### PR TITLE
build(devtools-browser-extension): Remove unnecessary file copy step

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -14,8 +14,7 @@
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build-and-test": "npm run build && npm run test",
-		"build:compile": "concurrently npm:tsc npm:build:copy-resources npm:build:webpack",
-		"build:copy-resources": "copyfiles -u 1 \"src/**/*.{css,json,html}\" dist",
+		"build:compile": "concurrently npm:tsc npm:build:webpack",
 		"build:full": "npm run build",
 		"build:full:compile": "npm run build:compile",
 		"build:webpack": "npm run webpack",


### PR DESCRIPTION
The TSC build is only used to enable Mocha testing in the package, so the build script that copied json, html, and css assets is not necessary. Additionally, it was copying the `fence.json` files we use to enforce directory-wise dependency invariants into the build output, which was not intended.