### PR TITLE
build(devtools-browser-extension): Update package build to isolate TSC output from Webpack bundle

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -14,8 +14,7 @@
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build-and-test": "npm run build && npm run test",
-		"build:compile": "concurrently npm:tsc npm:build:copy-resources npm:build:webpack",
-		"build:copy-resources": "copyfiles -u 1 \"src/**/*.{css,json,html}\" dist",
+		"build:compile": "concurrently npm:tsc npm:build:webpack",
 		"build:full": "npm run build",
 		"build:full:compile": "npm run build:compile",
 		"build:webpack": "npm run webpack",

--- a/packages/tools/devtools/devtools-browser-extension/tsconfig.json
+++ b/packages/tools/devtools/devtools-browser-extension/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist",
+		"outDir": "dist/tsc",
 		"composite": true,
 		"types": ["chai", "chrome", "mocha", "node"],
 		"jsx": "react-jsx",


### PR DESCRIPTION
Moves the TSC output (which is strictly used for testing) from `dist` to `dist/tsc`. For context, the Webpack output (the actual extension build) goes under `dist/bundle`. This makes it a bit easier to differentiate the two builds at the file-system level.