### PR TITLE
Better error message and fix couple of task definitions

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -257,12 +257,25 @@ export class BuildGraph {
 		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
 		getDepFilter: (pkg: Package) => (dep: Package) => boolean,
 	) {
-		packages.forEach((value) =>
-			this.buildPackages.set(
-				value.name,
-				new BuildPackage(this.buildContext, value, buildTaskNames, globalTaskDefinitions),
-			),
-		);
+		packages.forEach((value) => {
+			try {
+				this.buildPackages.set(
+					value.name,
+					new BuildPackage(
+						this.buildContext,
+						value,
+						buildTaskNames,
+						globalTaskDefinitions,
+					),
+				);
+			} catch (e: unknown) {
+				throw new Error(
+					`${value.nameColored}: Failed to load build package in ${value.directory}\n\t${
+						(e as Error).message
+					}`,
+				);
+			}
+		});
 
 		traceGraph("package initialized");
 

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -10,7 +10,7 @@ import { getResolvedFluidRoot } from "../common/fluidUtils";
 import { defaultLogger } from "../common/logging";
 import { Timer } from "../common/timer";
 import { existsSync } from "../common/utils";
-import { BuildResult } from "./buildGraph";
+import { BuildGraph, BuildResult } from "./buildGraph";
 import { FluidRepoBuild } from "./fluidRepoBuild";
 import { options, parseOptions } from "./options";
 
@@ -106,7 +106,13 @@ async function main() {
 		);
 
 		// build the graph
-		const buildGraph = repo.createBuildGraph(options, options.buildTaskNames);
+		let buildGraph: BuildGraph;
+		try {
+			buildGraph = repo.createBuildGraph(options, options.buildTaskNames);
+		} catch (e: unknown) {
+			error((e as Error).message);
+			process.exit(-11);
+		}
 		timer.time("Build graph creation completed");
 
 		// Check install

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -116,13 +116,13 @@
 			"compile": {
 				"dependsOn": [
 					"...",
-					"webpack",
-					"build:copy-resources"
+					"webpack"
 				],
 				"script": false
 			},
 			"webpack": [
-				"@fluid-tools/client-debugger-view#tsc"
+				"@fluid-experimental/devtools-core#tsc",
+				"@fluid-experimental/devtools-view#tsc"
 			]
 		}
 	},

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -131,7 +131,6 @@
 			},
 			"tsc": [
 				"^tsc",
-				"build:genver",
 				"@fluid-example/collaborative-textarea#build:esnext"
 			]
 		}

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -93,12 +93,5 @@
 		"rimraf": "^5.0.0",
 		"typescript": "~5.0.4"
 	},
-	"packageManager": "pnpm@7.32.3+sha512.c28d73f0d82a6c4712a40b91aa43d7397e119b16f35e5e75fe9b7e8fd4f2fc6dfbb68bb3ffac3473a958bbafa7888b79ec384ad122537378089a3a2a19b9900e",
-	"fluidBuild": {
-		"tasks": {
-			"build:tsc": [
-				"build:genver"
-			]
-		}
-	}
+	"packageManager": "pnpm@7.32.3+sha512.c28d73f0d82a6c4712a40b91aa43d7397e119b16f35e5e75fe9b7e8fd4f2fc6dfbb68bb3ffac3473a958bbafa7888b79ec384ad122537378089a3a2a19b9900e"
 }


### PR DESCRIPTION
A couple of package build rules has changed.  Fix the task definitions to reflect.
This won't happen once we make `fluid-build` the default way to build and validate in the CI.