### PR TITLE
fix(ci): Remove env variable in CI step to install pnpm

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -36,8 +36,6 @@ steps:
 
 - task: Bash@3
   displayName: Install and configure pnpm
-  env:
-    COREPACK_DEFAULT_TO_LATEST: 0
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}


### PR DESCRIPTION
## Description

While fixing the build-docs pipeline in #15582 I moved this to a place where it would start applying (instead of causing a syntax error) but @tylerbutler suggested to instead keep it out if it wasn't having an effect anyway. Missed adding the change to that PR, so removing it here.
