### PR TITLE
Add token cache support in alfred

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -17,6 +17,8 @@ import {
 	IThrottleMiddlewareOptions,
 	getParam,
 	getCorrelationId,
+	getBooleanFromConfig,
+	verifyToken,
 } from "@fluidframework/server-services-utils";
 import { validateRequestParams, handleResponse } from "@fluidframework/server-services";
 import { Request, Router } from "express";
@@ -40,6 +42,7 @@ export function create(
 	tenantManager: core.ITenantManager,
 	storage: core.IDocumentStorage,
 	tenantThrottlers: Map<string, core.IThrottler>,
+	jwtTokenCache?: core.ICache,
 	tokenManager?: core.ITokenRevocationManager,
 ): Router {
 	const router: Router = Router();
@@ -49,6 +52,12 @@ export function create(
 		throttleIdSuffix: Constants.alfredRestThrottleIdSuffix,
 	};
 	const generalTenantThrottler = tenantThrottlers.get(Constants.generalRestCallThrottleIdPrefix);
+
+	// Jwt token cache
+	const enableJwtTokenCache: boolean = getBooleanFromConfig(
+		"alfred:jwtTokenCache:enable",
+		config,
+	);
 
 	function handlePatchRootSuccess(request: Request, opBuilder: (request: Request) => any[]) {
 		const tenantId = getParam(request.params, "tenantId");
@@ -83,6 +92,8 @@ export function create(
 				storage,
 				maxTokenLifetimeSec,
 				isTokenExpiryEnabled,
+				enableJwtTokenCache,
+				jwtTokenCache,
 				tokenManager,
 			);
 			handleResponse(
@@ -200,24 +211,30 @@ const verifyRequest = async (
 	storage: core.IDocumentStorage,
 	maxTokenLifetimeSec: number,
 	isTokenExpiryEnabled: boolean,
+	tokenCacheEnabled: boolean,
+	tokenCache?: core.ICache,
 	tokenManager?: core.ITokenRevocationManager,
 ) =>
 	Promise.all([
-		verifyToken(
+		verifyTokenWrapper(
 			request,
 			tenantManager,
 			maxTokenLifetimeSec,
 			isTokenExpiryEnabled,
+			tokenCacheEnabled,
+			tokenCache,
 			tokenManager,
 		),
 		checkDocumentExistence(request, storage),
 	]);
 
-async function verifyToken(
+async function verifyTokenWrapper(
 	request: Request,
 	tenantManager: core.ITenantManager,
 	maxTokenLifetimeSec: number,
 	isTokenExpiryEnabled: boolean,
+	tokenCacheEnabled: boolean,
+	tokenCache?: core.ICache,
 	tokenManager?: core.ITokenRevocationManager,
 ): Promise<void> {
 	const token = request.headers["access-token"] as string;
@@ -236,6 +253,19 @@ async function verifyToken(
 		if (tokenRevoked) {
 			return Promise.reject(new Error("Permission denied. Token is revoked."));
 		}
+	}
+
+	if (tokenCacheEnabled && tokenCache) {
+		const options = {
+			requireDocumentId: true,
+			requireTokenExpiryCheck: isTokenExpiryEnabled,
+			maxTokenLifetimeSec,
+			ensureSingleUseToken: false,
+			singleUseTokenCache: undefined,
+			enableTokenCache: true,
+			tokenCache,
+		};
+		return verifyToken(tenantId, documentId, token, tenantManager, options);
 	}
 
 	return tenantManager.verifyToken(claims.tenantId, token);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -239,10 +239,16 @@ async function verifyTokenWrapper(
 ): Promise<void> {
 	const token = request.headers["access-token"] as string;
 	if (!token) {
-		return Promise.reject(new Error("Missing access token"));
+		return Promise.reject(new Error("Missing access token in request header."));
 	}
 	const tenantId = getParam(request.params, "tenantId");
+	if (!tenantId) {
+		return Promise.reject(new Error("Missing tenantId in request."));
+	}
 	const documentId = getParam(request.params, "id");
+	if (!documentId) {
+		return Promise.reject(new Error("Missing documentId in request."));
+	}
 	const claims = validateTokenClaims(token, documentId, tenantId);
 	if (isTokenExpiryEnabled) {
 		validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+	ICache,
 	IDeltaService,
 	ITenantManager,
 	IThrottler,
@@ -14,6 +15,7 @@ import {
 	throttle,
 	IThrottleMiddlewareOptions,
 	getParam,
+	getBooleanFromConfig,
 } from "@fluidframework/server-services-utils";
 import { validateRequestParams, handleResponse } from "@fluidframework/server-services";
 import { Router } from "express";
@@ -30,6 +32,7 @@ export function create(
 	tenantThrottlers: Map<string, IThrottler>,
 	clusterThrottlers: Map<string, IThrottler>,
 	tokenManager?: ITokenRevocationManager,
+	jwtTokenCache?: ICache,
 ): Router {
 	const deltasCollectionName = config.get("mongo:collectionNames:deltas");
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");
@@ -51,6 +54,12 @@ export function create(
 		throttleIdSuffix: Constants.alfredRestThrottleIdSuffix,
 	};
 
+	// Jwt token cache
+	const enableJwtTokenCache: boolean = getBooleanFromConfig(
+		"alfred:jwtTokenCache:enable",
+		config,
+	);
+
 	function stringToSequenceNumber(value: any): number {
 		if (typeof value !== "string") {
 			return undefined;
@@ -66,7 +75,13 @@ export function create(
 	router.get(
 		["/v1/:tenantId/:id", "/:tenantId/:id/v1"],
 		validateRequestParams("tenantId", "id"),
-		verifyStorageToken(tenantManager, config, tokenManager),
+		verifyStorageToken(tenantManager, config, tokenManager, {
+			requireDocumentId: true,
+			ensureSingleUseToken: false,
+			singleUseTokenCache: undefined,
+			enableTokenCache: enableJwtTokenCache,
+			tokenCache: jwtTokenCache,
+		}),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
@@ -92,7 +107,13 @@ export function create(
 	router.get(
 		"/raw/:tenantId/:id",
 		validateRequestParams("tenantId", "id"),
-		verifyStorageToken(tenantManager, config, tokenManager),
+		verifyStorageToken(tenantManager, config, tokenManager, {
+			requireDocumentId: true,
+			ensureSingleUseToken: false,
+			singleUseTokenCache: undefined,
+			enableTokenCache: enableJwtTokenCache,
+			tokenCache: jwtTokenCache,
+		}),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		(request, response, next) => {
 			const tenantId = getParam(request.params, "tenantId") || appTenants[0].id;
@@ -124,7 +145,13 @@ export function create(
 			winston,
 			getDeltasTenantThrottleOptions,
 		),
-		verifyStorageToken(tenantManager, config, tokenManager),
+		verifyStorageToken(tenantManager, config, tokenManager, {
+			requireDocumentId: true,
+			ensureSingleUseToken: false,
+			singleUseTokenCache: undefined,
+			enableTokenCache: enableJwtTokenCache,
+			tokenCache: jwtTokenCache,
+		}),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
 			const to = stringToSequenceNumber(request.query.to);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -31,8 +31,8 @@ export function create(
 	appTenants: IAlfredTenant[],
 	tenantThrottlers: Map<string, IThrottler>,
 	clusterThrottlers: Map<string, IThrottler>,
-	tokenManager?: ITokenRevocationManager,
 	jwtTokenCache?: ICache,
+	tokenManager?: ITokenRevocationManager,
 ): Router {
 	const deltasCollectionName = config.get("mongo:collectionNames:deltas");
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -60,6 +60,14 @@ export function create(
 		config,
 	);
 
+	const defaultTokenValidationOptions = {
+		requireDocumentId: true,
+		ensureSingleUseToken: false,
+		singleUseTokenCache: undefined,
+		enableTokenCache: enableJwtTokenCache,
+		tokenCache: jwtTokenCache,
+	};
+
 	function stringToSequenceNumber(value: any): number {
 		if (typeof value !== "string") {
 			return undefined;
@@ -75,13 +83,7 @@ export function create(
 	router.get(
 		["/v1/:tenantId/:id", "/:tenantId/:id/v1"],
 		validateRequestParams("tenantId", "id"),
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: jwtTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
@@ -107,13 +109,7 @@ export function create(
 	router.get(
 		"/raw/:tenantId/:id",
 		validateRequestParams("tenantId", "id"),
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: jwtTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		(request, response, next) => {
 			const tenantId = getParam(request.params, "tenantId") || appTenants[0].id;
@@ -145,13 +141,7 @@ export function create(
 			winston,
 			getDeltasTenantThrottleOptions,
 		),
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: jwtTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
 			const to = stringToSequenceNumber(request.query.to);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -93,16 +93,18 @@ export function create(
 		config,
 	);
 
+	const defaultTokenValidationOptions = {
+		requireDocumentId: true,
+		ensureSingleUseToken: false,
+		singleUseTokenCache: undefined,
+		enableTokenCache: enableJwtTokenCache,
+		tokenCache: singleUseTokenCache,
+	};
+
 	router.get(
 		"/:tenantId/:id",
 		validateRequestParams("tenantId", "id"),
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: singleUseTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		(request, response, next) => {
 			const documentP = storage.getDocument(
@@ -225,13 +227,7 @@ export function create(
 	 */
 	router.get(
 		"/:tenantId/session/:id",
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: singleUseTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		throttle(
 			clusterThrottlers.get(Constants.getSessionThrottleIdPrefix),
 			winston,
@@ -265,13 +261,7 @@ export function create(
 		"/:tenantId/document/:id",
 		validateRequestParams("tenantId", "id"),
 		validateTokenScopeClaims(DocDeleteScopeType),
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: singleUseTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		async (request, response, next) => {
 			const documentId = getParam(request.params, "id");
 			const tenantId = getParam(request.params, "tenantId");
@@ -290,13 +280,7 @@ export function create(
 		"/:tenantId/document/:id/revokeToken",
 		validateRequestParams("tenantId", "id"),
 		validateTokenScopeClaims(TokenRevokeScopeType),
-		verifyStorageToken(tenantManager, config, tokenManager, {
-			requireDocumentId: true,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: enableJwtTokenCache,
-			tokenCache: singleUseTokenCache,
-		}),
+		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		async (request, response, next) => {
 			const documentId = getParam(request.params, "id");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -44,6 +44,7 @@ export function create(
 		appTenants,
 		tenantThrottlers,
 		clusterThrottlers,
+		singleUseTokenCache,
 		tokenManager,
 	);
 	const documentsRoute = documents.create(
@@ -64,6 +65,7 @@ export function create(
 		tenantManager,
 		storage,
 		tenantThrottlers,
+		singleUseTokenCache,
 		tokenManager,
 	);
 

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -104,6 +104,9 @@
 		"enforceServerGeneratedDocumentId": false,
 		"socketIo": {
 			"perMessageDeflate": true
+		},
+		"jwtTokenCache": {
+			"enable": true
 		}
 	},
 	"client": {

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -179,8 +179,7 @@ export async function verifyToken(
 
 		// Check token cache first
 		if ((options.enableTokenCache || options.ensureSingleUseToken) && options.tokenCache) {
-			const tokenCacheKey = token;
-			const cachedToken = await options.tokenCache.get(tokenCacheKey).catch((error) => {
+			const cachedToken = await options.tokenCache.get(token).catch((error) => {
 				Lumberjack.error("Unable to retrieve cached JWT", logProperties, error);
 				return false;
 			});

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -195,10 +195,9 @@ export async function verifyToken(
 
 		await tenantManager.verifyToken(claims.tenantId, token);
 
-		Lumberjack.info("Token cache miss", logProperties);
-
 		// Update token cache
 		if ((options.enableTokenCache || options.ensureSingleUseToken) && options.tokenCache) {
+			Lumberjack.info("Token cache miss", logProperties);
 			const tokenCacheKey = token;
 			options.tokenCache
 				.set(

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -174,7 +174,7 @@ export async function verifyToken(
 			tokenLifetimeMs = validateTokenClaimsExpiration(claims, options.maxTokenLifetimeSec);
 		}
 
-		// Check token cache first
+		// TODO: what about token revocation check?
 		if (options.enableTokenCache && options.tokenCache) {
 			const tokenCacheKey = token;
 			const cachedToken = await options.tokenCache.get(tokenCacheKey).catch((error) => {
@@ -273,7 +273,7 @@ export function verifyStorageToken(
 			);
 		}
 
-		// TODO: remove this check and code after this block after testing
+		// TODO: remove this check and code after this block after validation
 		if (options.enableTokenCache) {
 			const moreOptions: IVerifyTokenOptions = options;
 			moreOptions.maxTokenLifetimeSec = maxTokenLifetimeSec;

--- a/server/routerlicious/packages/services-utils/src/configUtils.ts
+++ b/server/routerlicious/packages/services-utils/src/configUtils.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import nconf from "nconf";
+
+export function getBooleanFromConfig(name: string, config: nconf.Provider): boolean {
+	const rawValue = config.get(name);
+
+	if (typeof rawValue === "boolean") {
+		return rawValue;
+	} else if (typeof rawValue === "string") {
+		return rawValue.toLowerCase() === "true";
+	} else {
+		return false;
+	}
+}

--- a/server/routerlicious/packages/services-utils/src/configUtils.ts
+++ b/server/routerlicious/packages/services-utils/src/configUtils.ts
@@ -16,3 +16,14 @@ export function getBooleanFromConfig(name: string, config: nconf.Provider): bool
 		return false;
 	}
 }
+
+export function getNumberFromConfig(name: string, config: nconf.Provider): number {
+	const rawValue = config.get(name);
+	if (typeof rawValue === "number") {
+		return rawValue;
+	} else if (typeof rawValue === "string") {
+		return Number(rawValue);
+	} else {
+		return NaN;
+	}
+}

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -41,4 +41,4 @@ export { IThrottleConfig, ISimpleThrottleConfig, getThrottleConfig } from "./thr
 export { IThrottleMiddlewareOptions, throttle } from "./throttlerMiddleware";
 export { WinstonLumberjackEngine } from "./winstonLumberjackEngine";
 export { WebSocketTracker, DummyTokenRevocationManager } from "./tokenRevocationManager";
-export { getBooleanFromConfig } from "./configUtils";
+export { getBooleanFromConfig, getNumberFromConfig } from "./configUtils";

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -17,6 +17,7 @@ export {
 	validateTokenClaims,
 	verifyStorageToken,
 	validateTokenScopeClaims,
+	verifyToken,
 } from "./auth";
 export { parseBoolean } from "./conversion";
 export { deleteSummarizedOps } from "./deleteSummarizedOps";

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -40,3 +40,4 @@ export { IThrottleConfig, ISimpleThrottleConfig, getThrottleConfig } from "./thr
 export { IThrottleMiddlewareOptions, throttle } from "./throttlerMiddleware";
 export { WinstonLumberjackEngine } from "./winstonLumberjackEngine";
 export { WebSocketTracker, DummyTokenRevocationManager } from "./tokenRevocationManager";
+export { getBooleanFromConfig } from "./configUtils";


### PR DESCRIPTION
This PR includes changes below:
1. Add token cache in Alfred. It reuse the single token cache as the cache for all tokens. And there is no need to have a separate single token use cache if token cache is enabled
2. Add a new function verifyToken with taken cache and refactor verifyStorageToken to use this new function. It should be used in other places where we need to verify token.