### PR TITLE
Fix odsp webpack fluid loader fluid document creation

### DIFF
--- a/packages/tools/webpack-fluid-loader/src/odspUrlResolver.ts
+++ b/packages/tools/webpack-fluid-loader/src/odspUrlResolver.ts
@@ -7,6 +7,7 @@ import { IRequest } from "@fluidframework/core-interfaces";
 import { IUrlResolver, IResolvedUrl } from "@fluidframework/driver-definitions";
 import {
 	IOdspAuthRequestInfo,
+	getDriveId,
 	getDriveItemByRootFileName,
 } from "@fluidframework/odsp-doclib-utils";
 import {
@@ -38,7 +39,7 @@ export class OdspUrlResolver implements IUrlResolver {
 
 		const { driveId, itemId } = await getDriveItemByRootFileName(
 			this.server,
-			"",
+			undefined,
 			filePath,
 			this.authRequestInfo,
 			true,
@@ -55,7 +56,8 @@ export class OdspUrlResolver implements IUrlResolver {
 	}
 
 	private formFilePath(documentId: string): string {
-		const encoded = encodeURIComponent(`${documentId}.fluid`);
+		// Using .fluid will make ODSP think that it's a Loop document
+		const encoded = encodeURIComponent(`${documentId}.testFluid`);
 		return `/r11s/${encoded}`;
 	}
 
@@ -65,18 +67,13 @@ export class OdspUrlResolver implements IUrlResolver {
 
 	public async createCreateNewRequest(fileName: string): Promise<IRequest> {
 		const filePath = "/r11s/";
-		const driveItem = await getDriveItemByRootFileName(
-			this.server,
-			"",
-			filePath,
-			this.authRequestInfo,
-			false,
-		);
+		const driveId = await getDriveId(this.server, "", undefined, this.authRequestInfo);
+
 		return createOdspCreateContainerRequest(
 			`https://${this.server}`,
-			driveItem.driveId,
+			driveId,
 			filePath,
-			`${fileName}.fluid`,
+			`${fileName}.testFluid`,
 		);
 	}
 }


### PR DESCRIPTION
During FHL I noticed that the create new container flow would fail. 
What I found was that ODSP-df would actually create the file twice (I'm not exactly sure, but something like this). The first file would be `filename.fluid` and the second file after attach had been called would be `filename 1.fluid` or `filename 2.fluid`. Either way, this would mean the file was wrong and we could not load the container correctly.

This fix allows us to create the file with no errors. The fileName change was because ODSP uses `.fluid` files as Loop files. getDriveItemByRootFileName creates the file
