### PR TITLE
fix: fluid-build select precise dependencies

### DIFF
--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -86,7 +86,6 @@ export class Package {
 	private _packageJson: PackageJson;
 	private readonly packageId = Package.packageCount++;
 	private _matched: boolean = false;
-	private _markForBuild: boolean = false;
 
 	private _indent: string;
 	public readonly packageManager: PackageManager;
@@ -149,15 +148,6 @@ export class Package {
 
 	public setMatched() {
 		this._matched = true;
-		this._markForBuild = true;
-	}
-
-	public get markForBuild() {
-		return this._markForBuild;
-	}
-
-	public setMarkForBuild() {
-		this._markForBuild = true;
 	}
 
 	public get dependencies() {

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -387,6 +387,7 @@ export class BuildGraph {
 		traceGraph("package created");
 
 		// Create all the dependent packages
+		// eslint-disable-next-line no-constant-condition
 		while (true) {
 			const node = pendingInitDep.pop();
 			if (node === undefined) {

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -26,7 +26,7 @@ const traceBuildPackageCreate = registerDebug("fluid-build:package:create");
 const traceTaskDepTask = registerDebug("fluid-build:task:dep:task");
 const traceGraph = registerDebug("fluid-build:graph");
 
-const { info, verbose } = defaultLogger;
+const { info } = defaultLogger;
 
 export enum BuildResult {
 	Success,
@@ -64,7 +64,6 @@ class BuildContext {
 
 export class BuildPackage {
 	private tasks = new Map<string, Task>();
-	public readonly parents = new Array<BuildPackage>();
 	public readonly dependentPackages = new Array<BuildPackage>();
 	public level: number = -1;
 	private buildP?: Promise<BuildResult>;
@@ -73,7 +72,6 @@ export class BuildPackage {
 	constructor(
 		public readonly buildContext: BuildContext,
 		public readonly pkg: Package,
-		private readonly buildTaskNames: string[],
 		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
 	) {
 		this.taskDefinitions = getTaskDefinitions(this.pkg.packageJson, globalTaskDefinitions);
@@ -86,8 +84,12 @@ export class BuildPackage {
 		);
 	}
 
-	public createTasks() {
-		const taskNames = this.buildTaskNames;
+	public get taskCount() {
+		return this.tasks.size;
+	}
+
+	public createTasks(buildTaskNames: string[]) {
+		const taskNames = buildTaskNames;
 		if (taskNames.length === 0) {
 			return undefined;
 		}
@@ -244,7 +246,8 @@ export class BuildPackage {
 }
 
 export class BuildGraph {
-	public readonly buildPackages = new Map<string, BuildPackage>();
+	private matchedPackages = 0;
+	private readonly buildPackages = new Map<Package, BuildPackage>();
 	private readonly buildContext = new BuildContext(
 		options.worker
 			? new WorkerPool(options.workerThreads, options.workerMemoryLimit)
@@ -252,37 +255,14 @@ export class BuildGraph {
 	);
 
 	public constructor(
-		packages: Package[],
+		packages: Map<string, Package>,
 		private readonly buildTaskNames: string[],
 		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
 		getDepFilter: (pkg: Package) => (dep: Package) => boolean,
 	) {
-		packages.forEach((value) => {
-			try {
-				this.buildPackages.set(
-					value.name,
-					new BuildPackage(
-						this.buildContext,
-						value,
-						buildTaskNames,
-						globalTaskDefinitions,
-					),
-				);
-			} catch (e: unknown) {
-				throw new Error(
-					`${value.nameColored}: Failed to load build package in ${value.directory}\n\t${
-						(e as Error).message
-					}`,
-				);
-			}
-		});
-
-		traceGraph("package initialized");
-
-		const needPropagate = this.buildDependencies(getDepFilter);
+		this.initializePackages(packages, globalTaskDefinitions, getDepFilter);
 		this.populateLevel();
-		this.propagateMarkForBuild(needPropagate);
-		this.filterPackagesAndInitializeTasks();
+		this.initializeTasks(buildTaskNames);
 	}
 
 	private async isUpToDate() {
@@ -310,9 +290,11 @@ export class BuildGraph {
 		if (timer) timer.time(`Check up to date completed`);
 
 		info(
-			`Starting build tasks "${chalk.cyanBright(this.buildTaskNames.join(" && "))}" for ${
+			`Start tasks '${chalk.cyanBright(this.buildTaskNames.join("', '"))}' in ${
+				this.matchedPackages
+			} matched packages (${this.buildContext.taskStats.leafTotalCount} total tasks in ${
 				this.buildPackages.size
-			} packages, ${this.buildContext.taskStats.leafTotalCount} tasks`,
+			} packages)`,
 		);
 		if (isUpToDate) {
 			return BuildResult.UpToDate;
@@ -367,42 +349,79 @@ export class BuildGraph {
 		return summaryLines.join("\n");
 	}
 
-	private buildDependencies(getDepFilter: (pkg: Package) => (dep: Package) => boolean) {
-		const needPropagate: BuildPackage[] = [];
-		this.buildPackages.forEach((node) => {
-			if (node.pkg.markForBuild) {
-				needPropagate.push(node);
+	private getBuildPackage(
+		pkg: Package,
+		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
+		pendingInitDep: BuildPackage[],
+	) {
+		let buildPackage = this.buildPackages.get(pkg);
+		if (buildPackage === undefined) {
+			try {
+				buildPackage = new BuildPackage(this.buildContext, pkg, globalTaskDefinitions);
+			} catch (e: unknown) {
+				throw new Error(
+					`${pkg.nameColored}: Failed to load build package in ${pkg.directory}\n\t${
+						(e as Error).message
+					}`,
+				);
+			}
+			this.buildPackages.set(pkg, buildPackage);
+			pendingInitDep.push(buildPackage);
+		}
+		return buildPackage;
+	}
+
+	private initializePackages(
+		packages: Map<string, Package>,
+		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
+		getDepFilter: (pkg: Package) => (dep: Package) => boolean,
+	) {
+		const pendingInitDep: BuildPackage[] = [];
+		for (const pkg of packages.values()) {
+			// Start with only matched packages
+			if (pkg.matched) {
+				this.getBuildPackage(pkg, globalTaskDefinitions, pendingInitDep);
+			}
+		}
+
+		traceGraph("package created");
+
+		// Create all the dependent packages
+		while (true) {
+			const node = pendingInitDep.pop();
+			if (node === undefined) {
+				break;
 			}
 			const depFilter = getDepFilter(node.pkg);
 			for (const { name, version } of node.pkg.combinedDependencies) {
-				const child = this.buildPackages.get(name);
-				if (child) {
+				const dep = packages.get(name);
+				if (dep) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					const satisfied =
 						version!.startsWith("workspace:") ||
-						semver.satisfies(child.pkg.version, version!);
+						semver.satisfies(dep.version, version!);
 					if (satisfied) {
-						if (depFilter(child.pkg)) {
+						if (depFilter(dep)) {
 							traceGraph(
-								`Package dependency: ${node.pkg.nameColored} => ${child.pkg.nameColored}`,
+								`Package dependency: ${node.pkg.nameColored} => ${dep.nameColored}`,
 							);
-							node.dependentPackages.push(child);
-							child.parents.push(node);
+							node.dependentPackages.push(
+								this.getBuildPackage(dep, globalTaskDefinitions, pendingInitDep),
+							);
 						} else {
 							traceGraph(
-								`Package dependency skipped: ${node.pkg.nameColored} => ${child.pkg.nameColored}`,
+								`Package dependency skipped: ${node.pkg.nameColored} => ${dep.nameColored}`,
 							);
 						}
 					} else {
 						traceGraph(
-							`Package dependency version mismatch: ${node.pkg.nameColored} => ${child.pkg.nameColored}`,
+							`Package dependency version mismatch: ${node.pkg.nameColored} => ${dep.nameColored}`,
 						);
 					}
 				}
 			}
-		});
+		}
 		traceGraph("package dependencies initialized");
-		return needPropagate;
 	}
 
 	private populateLevel() {
@@ -433,34 +452,18 @@ export class BuildGraph {
 		traceGraph("package dependency level initialized");
 	}
 
-	private propagateMarkForBuild(needPropagate: BuildPackage[]) {
-		// eslint-disable-next-line no-constant-condition
-		while (true) {
-			const node = needPropagate.pop();
-			if (!node) {
-				break;
-			}
-			node.dependentPackages.forEach((child) => {
-				if (!child.pkg.markForBuild) {
-					child.pkg.setMarkForBuild();
-					needPropagate.push(child);
-				}
-			});
-		}
-		traceGraph("package mark for build");
-	}
-
-	private filterPackagesAndInitializeTasks() {
+	private initializeTasks(buildTaskNames: string[]) {
 		let hasTask = false;
-		this.buildPackages.forEach((node, name) => {
-			if (!node.pkg.markForBuild) {
-				verbose(`${node.pkg.nameColored}: Not marked for build`);
-				this.buildPackages.delete(name);
+		this.buildPackages.forEach((node) => {
+			if (options.matchedOnly && !node.pkg.matched) {
+				// Don't initialize task on package that wasn't matched in matchedOnly mode
 				return;
 			}
 
+			this.matchedPackages++;
+
 			// Initialize tasks
-			if (node.createTasks()) {
+			if (node.createTasks(buildTaskNames)) {
 				hasTask = true;
 			}
 		});
@@ -469,7 +472,7 @@ export class BuildGraph {
 			throw new Error(`No task(s) found for '${this.buildTaskNames.join()}'`);
 		}
 
-		traceGraph("package filtered and task initialize");
+		traceGraph("package task initialized");
 
 		// All the task has been created, initialize the dependent tasks
 		this.buildPackages.forEach((node) => {

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -194,7 +194,7 @@ export class FluidRepoBuild extends FluidRepo {
 
 	public createBuildGraph(options: ISymlinkOptions, buildTargetNames: string[]) {
 		return new BuildGraph(
-			this.packages.packages,
+			this.createPackageMap(),
 			buildTargetNames,
 			getFluidBuildConfig(this.resolvedRoot)?.tasks,
 			(pkg: Package) => {

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -30,7 +30,6 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 	nohoist: boolean;
 	uninstall: boolean;
 	concurrency: number;
-	samples: boolean;
 	fix: boolean;
 	services: boolean;
 	worker: boolean;
@@ -57,7 +56,6 @@ export const options: FastBuildOptions = {
 	nohoist: false,
 	uninstall: false,
 	concurrency: os.cpus().length, // TODO: argument?
-	samples: true,
 	fix: false,
 	all: false,
 	server: false,
@@ -171,11 +169,6 @@ export function parseOptions(argv: string[]) {
 
 		if (arg === "-f" || arg === "--force") {
 			options.force = true;
-			continue;
-		}
-
-		if (arg === "--nosamples") {
-			options.samples = false;
 			continue;
 		}
 


### PR DESCRIPTION
With PR #15589, we have a more accurate task-based dependencies graph.  So we can be more precise when packages is specified on the command line to filter, to run only tasks in those packages and also trigger the minimum set of dependent tasks.  Before this change, we would trigger based on the task name on all the dependent packages of the specified package.  This old behavior can can still be done with the `--dep` switch.

For example, `fluid-build packages/dds/sequence -t build` would pick up 180 tasks before, where now it only needs to run 60 tasks, whereas `fluid-build packages/dds/sequence -t build --dep` would run the `build` task on `sequence` and all of its dependent packages like before.