### PR TITLE
refactor(Tree): Make skip marks objects

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -34,7 +34,7 @@ import {
 import {
 	getInputLength,
 	getOutputLength,
-	isSkipMark,
+	isNoopMark,
 	getOffsetAtRevision,
 	cloneMark,
 	isDeleteMark,
@@ -169,9 +169,9 @@ function composeMarks<TNodeChange>(
 	);
 
 	if (!markHasCellEffect(baseMark) && !markHasCellEffect(newMark)) {
-		if (isSkipMark(baseMark)) {
+		if (isNoopMark(baseMark)) {
 			return withNodeChange(newMark, nodeChange);
-		} else if (isSkipMark(newMark)) {
+		} else if (isNoopMark(newMark)) {
 			return withNodeChange(baseMark, nodeChange);
 		}
 		return createModifyMark(getMarkLength(newMark), nodeChange, getCellId(baseMark, undefined));
@@ -298,12 +298,12 @@ function composeMark<TNodeChange, TMark extends Mark<TNodeChange>>(
 	revision: RevisionTag | undefined,
 	composeChild: NodeChangeComposer<TNodeChange>,
 ): TMark {
-	if (isSkipMark(mark)) {
+	if (isNoopMark(mark)) {
 		return mark;
 	}
 
 	const cloned = cloneMark(mark);
-	assert(!isSkipMark(cloned), 0x4de /* Cloned should be same type as input mark */);
+	assert(!isNoopMark(cloned), 0x4de /* Cloned should be same type as input mark */);
 	if (revision !== undefined && cloned.type !== "Modify" && cloned.revision === undefined) {
 		cloned.revision = revision;
 	}

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -16,14 +16,14 @@ export type NodeCount = number;
 /**
  * Left undefined for terseness.
  */
-export const SkipType = undefined;
+export const NoopMarkType = undefined;
 
-export interface Skip extends CellTargetingMark {
+export interface NoopMark extends CellTargetingMark {
 	/**
 	 * Declared for consistency with other marks.
 	 * Left undefined for terseness.
 	 */
-	type?: typeof SkipType;
+	type?: typeof NoopMarkType;
 
 	/**
 	 * The number of nodes being skipped.
@@ -271,7 +271,7 @@ export interface Modify<TNodeChange = NodeChangeType> extends CellTargetingMark 
  * A mark which extends `CellTargetingMark`.
  */
 export type ExistingCellMark<TNodeChange> =
-	| Skip
+	| NoopMark
 	| Delete<TNodeChange>
 	| MoveOut<TNodeChange>
 	| ReturnFrom<TNodeChange>
@@ -284,7 +284,7 @@ export type EmptyInputCellMark<TNodeChange> =
 	| (DetachedCellMark & ExistingCellMark<TNodeChange>);
 
 export type Mark<TNodeChange = NodeChangeType> =
-	| Skip
+	| NoopMark
 	| Modify<TNodeChange>
 	| Attach<TNodeChange>
 	| Detach<TNodeChange>;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -12,7 +12,24 @@ import { ChangesetLocalId, NodeChangeset } from "../modular-schema";
 export type ProtoNode = JsonableTree;
 
 export type NodeCount = number;
-export type Skip = number;
+
+/**
+ * Left undefined for terseness.
+ */
+export const SkipType = undefined;
+
+export interface Skip extends CellTargetingMark {
+	/**
+	 * Declared for consistency with other marks.
+	 * Left undefined for terseness.
+	 */
+	type?: typeof SkipType;
+
+	/**
+	 * The number of nodes being skipped.
+	 */
+	count: NodeCount;
+}
 
 /**
  * A monotonically increasing positive integer assigned to an individual mark within the changeset.
@@ -252,9 +269,9 @@ export interface Modify<TNodeChange = NodeChangeType> extends CellTargetingMark 
 
 /**
  * A mark which extends `CellTargetingMark`.
- * Conceptually `Skip` marks also target existing cells, but are not included because they do not have the `CellTargetingMark` fields.
  */
 export type ExistingCellMark<TNodeChange> =
+	| Skip
 	| Delete<TNodeChange>
 	| MoveOut<TNodeChange>
 	| ReturnFrom<TNodeChange>
@@ -275,8 +292,6 @@ export type Mark<TNodeChange = NodeChangeType> =
 export type MarkList<TNodeChange = NodeChangeType, TMark = Mark<TNodeChange>> = TMark[];
 
 export type Changeset<TNodeChange = NodeChangeType> = MarkList<TNodeChange>;
-
-export type ObjectMark<TNodeChange = NodeChangeType> = Exclude<Mark<TNodeChange>, Skip>;
 
 /**
  * A mark that spans one or more cells.

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
@@ -24,7 +24,6 @@ export {
 	NodeChangeType,
 	NodeCount,
 	MoveId,
-	ObjectMark,
 	ProtoNode,
 	RangeType,
 	Reattach,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
@@ -31,7 +31,7 @@ export {
 	ReturnTo,
 	Revive,
 	Tiebreak,
-	Skip,
+	NoopMark,
 	LineageEvent,
 	HasReattachFields,
 	CellSpanningMark,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -7,15 +7,13 @@ import { assert } from "@fluidframework/common-utils";
 import { RevisionTag, TaggedChange } from "../../core";
 import { fail } from "../../util";
 import { CrossFieldManager, CrossFieldTarget, IdAllocator, NodeReviver } from "../modular-schema";
-import { Changeset, DetachEvent, Mark, MarkList, Modify, ReturnFrom } from "./format";
+import { Changeset, DetachEvent, Mark, MarkList, Modify, ReturnFrom, SkipType } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {
 	areInputCellsEmpty,
 	getInputLength,
 	isConflictedReattach,
-	isObjMark,
 	isReattachConflicted,
-	isSkipMark,
 	withNodeChange,
 } from "./utils";
 
@@ -97,138 +95,137 @@ function invertMark<TNodeChange>(
 	invertChild: NodeChangeInverter<TNodeChange>,
 	crossFieldManager: CrossFieldManager<TNodeChange>,
 ): Mark<TNodeChange>[] {
-	if (isSkipMark(mark)) {
-		return [mark];
-	} else {
-		switch (mark.type) {
-			case "Insert": {
+	switch (mark.type) {
+		case SkipType: {
+			return [mark];
+		}
+		case "Insert": {
+			const inverse = withNodeChange(
+				{ type: "Delete", count: mark.content.length },
+				invertNodeChange(mark.changes, inputIndex, invertChild),
+			);
+			return [inverse];
+		}
+		case "Delete": {
+			assert(revision !== undefined, 0x5a1 /* Unable to revert to undefined revision */);
+			if (mark.detachEvent === undefined) {
 				const inverse = withNodeChange(
-					{ type: "Delete", count: mark.content.length },
+					{
+						type: "Revive",
+						detachEvent: { revision: mark.revision ?? revision, index: inputIndex },
+						content: reviver(revision, inputIndex, mark.count),
+						count: mark.count,
+						inverseOf: mark.revision ?? revision,
+					},
+					invertNodeChange(mark.changes, inputIndex, invertChild),
+				);
+
+				return [inverse];
+			}
+			// TODO: preserve modifications to the removed nodes.
+			return [];
+		}
+		case "Revive": {
+			if (!isReattachConflicted(mark)) {
+				const inverse = withNodeChange(
+					{
+						type: "Delete",
+						count: mark.count,
+					},
 					invertNodeChange(mark.changes, inputIndex, invertChild),
 				);
 				return [inverse];
 			}
-			case "Delete": {
-				assert(revision !== undefined, 0x5a1 /* Unable to revert to undefined revision */);
-				if (mark.detachEvent === undefined) {
-					const inverse = withNodeChange(
-						{
-							type: "Revive",
-							detachEvent: { revision: mark.revision ?? revision, index: inputIndex },
-							content: reviver(revision, inputIndex, mark.count),
-							count: mark.count,
-							inverseOf: mark.revision ?? revision,
-						},
-						invertNodeChange(mark.changes, inputIndex, invertChild),
-					);
-
-					return [inverse];
-				}
-				// TODO: preserve modifications to the removed nodes.
-				return [];
-			}
-			case "Revive": {
-				if (!isReattachConflicted(mark)) {
-					const inverse = withNodeChange(
-						{
-							type: "Delete",
-							count: mark.count,
-						},
-						invertNodeChange(mark.changes, inputIndex, invertChild),
-					);
-					return [inverse];
-				}
-				return [
-					invertModifyOrSkip(
-						mark.count,
-						mark.changes,
-						inputIndex,
-						invertChild,
-						mark.detachEvent,
-					),
-				];
-			}
-			case "Modify": {
-				if (mark.detachEvent === undefined) {
-					return [
-						{
-							type: "Modify",
-							changes: invertChild(mark.changes, inputIndex),
-						},
-					];
-				}
-				// TODO: preserve modifications to the removed nodes.
-				return [];
-			}
-			case "MoveOut":
-			case "ReturnFrom": {
-				if (areInputCellsEmpty(mark)) {
-					// TODO: preserve modifications to the removed nodes.
-					return [];
-				}
-				if (mark.type === "ReturnFrom" && mark.isDstConflicted) {
-					// The nodes were present but the destination was conflicted, the mark had no effect on the nodes.
-					return [invertModifyOrSkip(mark.count, mark.changes, inputIndex, invertChild)];
-				}
-				if (mark.changes !== undefined) {
-					crossFieldManager.getOrCreate(
-						CrossFieldTarget.Destination,
-						mark.revision ?? revision,
-						mark.id,
-						invertChild(mark.changes, inputIndex),
-						true,
-					);
-				}
+			return [
+				invertModifyOrSkip(
+					mark.count,
+					mark.changes,
+					inputIndex,
+					invertChild,
+					mark.detachEvent,
+				),
+			];
+		}
+		case "Modify": {
+			if (mark.detachEvent === undefined) {
 				return [
 					{
-						type: "ReturnTo",
-						id: mark.id,
-						count: mark.count,
-						detachEvent: {
-							revision: mark.revision ?? revision ?? fail("Revision must be defined"),
-							index: inputIndex,
-						},
+						type: "Modify",
+						changes: invertChild(mark.changes, inputIndex),
 					},
 				];
 			}
-			case "MoveIn":
-			case "ReturnTo": {
-				if (mark.isSrcConflicted) {
-					return mark.type === "ReturnTo" && mark.detachEvent === undefined
-						? [mark.count]
-						: [];
-				}
-				if (mark.type === "ReturnTo") {
-					if (mark.detachEvent === undefined) {
-						// The nodes were already attached, so the mark did not affect them.
-						return [mark.count];
-					} else if (isConflictedReattach(mark)) {
-						// The nodes were not attached and could not be attached.
-						return [];
-					}
-				}
-
-				const invertedMark: ReturnFrom<TNodeChange> = {
-					type: "ReturnFrom",
-					id: mark.id,
-					count: mark.count,
-				};
-
-				const movedChanges = crossFieldManager.get(
+			// TODO: preserve modifications to the removed nodes.
+			return [];
+		}
+		case "MoveOut":
+		case "ReturnFrom": {
+			if (areInputCellsEmpty(mark)) {
+				// TODO: preserve modifications to the removed nodes.
+				return [];
+			}
+			if (mark.type === "ReturnFrom" && mark.isDstConflicted) {
+				// The nodes were present but the destination was conflicted, the mark had no effect on the nodes.
+				return [invertModifyOrSkip(mark.count, mark.changes, inputIndex, invertChild)];
+			}
+			if (mark.changes !== undefined) {
+				crossFieldManager.getOrCreate(
 					CrossFieldTarget.Destination,
 					mark.revision ?? revision,
 					mark.id,
+					invertChild(mark.changes, inputIndex),
 					true,
 				);
-
-				if (movedChanges !== undefined) {
-					invertedMark.changes = movedChanges;
-				}
-				return [invertedMark];
 			}
-			default:
-				fail("Not implemented");
+			return [
+				{
+					type: "ReturnTo",
+					id: mark.id,
+					count: mark.count,
+					detachEvent: {
+						revision: mark.revision ?? revision ?? fail("Revision must be defined"),
+						index: inputIndex,
+					},
+				},
+			];
 		}
+		case "MoveIn":
+		case "ReturnTo": {
+			if (mark.isSrcConflicted) {
+				return mark.type === "ReturnTo" && mark.detachEvent === undefined
+					? [{ count: mark.count }]
+					: [];
+			}
+			if (mark.type === "ReturnTo") {
+				if (mark.detachEvent === undefined) {
+					// The nodes were already attached, so the mark did not affect them.
+					return [{ count: mark.count }];
+				} else if (isConflictedReattach(mark)) {
+					// The nodes were not attached and could not be attached.
+					return [];
+				}
+			}
+
+			const invertedMark: ReturnFrom<TNodeChange> = {
+				type: "ReturnFrom",
+				id: mark.id,
+				count: mark.count,
+			};
+
+			const movedChanges = crossFieldManager.get(
+				CrossFieldTarget.Destination,
+				mark.revision ?? revision,
+				mark.id,
+				true,
+			);
+
+			if (movedChanges !== undefined) {
+				invertedMark.changes = movedChanges;
+			}
+			return [invertedMark];
+		}
+		default:
+			fail("Not implemented");
 	}
 }
 
@@ -238,7 +235,7 @@ function transferMovedChanges<TNodeChange>(
 	crossFieldManager: CrossFieldManager<TNodeChange>,
 ): void {
 	for (const mark of marks) {
-		if (isObjMark(mark) && (mark.type === "MoveOut" || mark.type === "ReturnFrom")) {
+		if (mark.type === "MoveOut" || mark.type === "ReturnFrom") {
 			const change = crossFieldManager.get(
 				CrossFieldTarget.Destination,
 				mark.revision ?? revision,
@@ -269,7 +266,7 @@ function invertModifyOrSkip<TNodeChange>(
 		return modify;
 	}
 
-	return detachEvent === undefined ? length : 0;
+	return { count: detachEvent === undefined ? length : 0 };
 }
 
 function invertNodeChange<TNodeChange>(

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/common-utils";
 import { RevisionTag, TaggedChange } from "../../core";
 import { fail } from "../../util";
 import { CrossFieldManager, CrossFieldTarget, IdAllocator, NodeReviver } from "../modular-schema";
-import { Changeset, DetachEvent, Mark, MarkList, Modify, ReturnFrom, SkipType } from "./format";
+import { Changeset, DetachEvent, Mark, MarkList, Modify, ReturnFrom, NoopMarkType } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {
 	areInputCellsEmpty,
@@ -96,7 +96,7 @@ function invertMark<TNodeChange>(
 	crossFieldManager: CrossFieldManager<TNodeChange>,
 ): Mark<TNodeChange>[] {
 	switch (mark.type) {
-		case SkipType: {
+		case NoopMarkType: {
 			return [mark];
 		}
 		case "Insert": {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/markListFactory.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/markListFactory.ts
@@ -4,9 +4,9 @@
  */
 
 import { RevisionTag } from "../../core";
-import { Mark, MarkList, ObjectMark, Skip } from "./format";
+import { Mark, MarkList, Skip } from "./format";
 import { MoveEffectTable } from "./moveEffectTable";
-import { isObjMark, isSkipMark, tryExtendMark } from "./utils";
+import { isSkipMark, tryExtendMark } from "./utils";
 
 /**
  * Helper class for constructing an offset list of marks that...
@@ -29,24 +29,24 @@ export class MarkListFactory<TNodeChange> {
 	public push(...marks: Mark<TNodeChange>[]): void {
 		for (const item of marks) {
 			if (isSkipMark(item)) {
-				this.pushOffset(item);
+				this.pushOffset(item.count);
 			} else {
 				this.pushContent(item);
 			}
 		}
 	}
 
-	public pushOffset(offset: Skip): void {
+	public pushOffset(offset: number): void {
 		this.offset += offset;
 	}
 
-	public pushContent(mark: ObjectMark<TNodeChange>): void {
+	public pushContent(mark: Exclude<Mark<TNodeChange>, Skip>): void {
 		if (this.offset > 0) {
-			this.list.push(this.offset);
+			this.list.push({ count: this.offset });
 			this.offset = 0;
 		}
 		const prev = this.list[this.list.length - 1];
-		if (isObjMark(prev) && prev.type === mark.type) {
+		if (prev !== undefined && prev.type === mark.type) {
 			if (tryExtendMark(prev, mark, this.revision, this.moveEffects, this.recordMerges)) {
 				return;
 			}

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/markListFactory.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/markListFactory.ts
@@ -4,9 +4,9 @@
  */
 
 import { RevisionTag } from "../../core";
-import { Mark, MarkList, Skip } from "./format";
+import { Mark, MarkList, NoopMark } from "./format";
 import { MoveEffectTable } from "./moveEffectTable";
-import { isSkipMark, tryExtendMark } from "./utils";
+import { isNoopMark, tryExtendMark } from "./utils";
 
 /**
  * Helper class for constructing an offset list of marks that...
@@ -28,7 +28,7 @@ export class MarkListFactory<TNodeChange> {
 
 	public push(...marks: Mark<TNodeChange>[]): void {
 		for (const item of marks) {
-			if (isSkipMark(item)) {
+			if (isNoopMark(item)) {
 				this.pushOffset(item.count);
 			} else {
 				this.pushContent(item);
@@ -40,7 +40,7 @@ export class MarkListFactory<TNodeChange> {
 		this.offset += offset;
 	}
 
-	public pushContent(mark: Exclude<Mark<TNodeChange>, Skip>): void {
+	public pushContent(mark: Exclude<Mark<TNodeChange>, NoopMark>): void {
 		if (this.offset > 0) {
 			this.list.push({ count: this.offset });
 			this.offset = 0;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -7,7 +7,7 @@ import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { RevisionTag } from "../../core";
 import { CrossFieldManager, CrossFieldTarget } from "../modular-schema";
 import { Mark, MoveId, MoveIn, MoveOut, ReturnFrom, ReturnTo } from "./format";
-import { cloneMark, isSkipMark } from "./utils";
+import { cloneMark } from "./utils";
 
 export type MoveEffectTable<T> = CrossFieldManager<MoveEffect<T>>;
 
@@ -175,9 +175,6 @@ export function makeMergeable<T>(
 export type MoveMark<T> = MoveOut<T> | MoveIn | ReturnFrom<T> | ReturnTo;
 
 export function isMoveMark<T>(mark: Mark<T>): mark is MoveMark<T> {
-	if (isSkipMark(mark)) {
-		return false;
-	}
 	switch (mark.type) {
 		case "MoveIn":
 		case "MoveOut":

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -31,7 +31,7 @@ import {
 	getNodeChange,
 	withNodeChange,
 	getMarkMoveId,
-	isSkipMark,
+	isNoopMark,
 } from "./utils";
 import {
 	Attach,
@@ -40,11 +40,11 @@ import {
 	MarkList,
 	CellSpanningMark,
 	ExistingCellMark,
-	Skip,
+	NoopMark,
 	MoveId,
 	Modify,
 	EmptyInputCellMark,
-	SkipType,
+	NoopMarkType,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import { ComposeQueue } from "./compose";
@@ -415,7 +415,7 @@ function markFollowsMoves(mark: Mark<unknown>): boolean {
 		case "MoveOut":
 		case "Revive":
 			return true;
-		case SkipType:
+		case NoopMarkType:
 		case "ReturnFrom":
 		case "Insert":
 		case "MoveIn":
@@ -453,11 +453,11 @@ function rebaseNodeChange<TNodeChange>(
 }
 
 function makeDetachedMark<T>(
-	mark: Skip | ExistingCellMark<T>,
+	mark: NoopMark | ExistingCellMark<T>,
 	detachIntention: RevisionTag,
 	offset: number,
 ): Mark<T> {
-	if (isSkipMark(mark)) {
+	if (isNoopMark(mark)) {
 		return { count: 0 };
 	}
 
@@ -536,7 +536,7 @@ function amendRebaseI<TNodeChange>(
 			// TODO: Handle all pairings of base and new mark types.
 			if (baseMark !== undefined && isModify(baseMark)) {
 				switch (newMark.type) {
-					case SkipType: {
+					case NoopMarkType: {
 						const childChange = rebaseChild(undefined, baseMark.changes);
 						if (childChange !== undefined) {
 							rebasedMark = { type: "Modify", changes: childChange };

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -19,8 +19,6 @@ import {
 	isDetachMark,
 	isModify,
 	isNewAttach,
-	isSkipMark,
-	isObjMark,
 	cloneMark,
 	areInputCellsEmpty,
 	getMarkLength,
@@ -33,6 +31,7 @@ import {
 	getNodeChange,
 	withNodeChange,
 	getMarkMoveId,
+	isSkipMark,
 } from "./utils";
 import {
 	Attach,
@@ -45,6 +44,7 @@ import {
 	MoveId,
 	Modify,
 	EmptyInputCellMark,
+	SkipType,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import { ComposeQueue } from "./compose";
@@ -131,7 +131,7 @@ function rebaseMarkList<TNodeChange>(
 	let baseInputIndex = 0;
 	while (!queue.isEmpty()) {
 		const { baseMark, newMark: currMark } = queue.pop();
-		if (isObjMark(baseMark) && baseMark.type !== "Modify" && baseMark.revision !== undefined) {
+		if (baseMark !== undefined && "revision" in baseMark) {
 			// TODO support rebasing over composite changeset
 			assert(
 				baseMark.revision === baseRevision,
@@ -256,7 +256,7 @@ class RebaseQueue<T> {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const length = getInputLength(newMark!);
 			return {
-				baseMark: length > 0 ? length : undefined,
+				baseMark: length > 0 ? { count: length } : undefined,
 				newMark: this.newMarks.tryDequeue(),
 			};
 		} else if (newMark === undefined) {
@@ -266,7 +266,7 @@ class RebaseQueue<T> {
 			}
 			return {
 				baseMark: this.baseMarks.tryDequeue(),
-				newMark: length > 0 ? length : undefined,
+				newMark: length > 0 ? { count: length } : undefined,
 			};
 		} else if (areInputCellsEmpty(baseMark) && areInputCellsEmpty(newMark)) {
 			const cmp = compareCellPositions(
@@ -346,7 +346,7 @@ function rebaseMark<TNodeChange>(
 		if (moveId !== undefined) {
 			if (markFollowsMoves(rebasedMark)) {
 				sendMarkToDest(rebasedMark, moveEffects, baseRevision, moveId);
-				return 0;
+				return { count: 0 };
 			}
 
 			const nodeChange = getNodeChange(rebasedMark);
@@ -408,10 +408,6 @@ function rebaseMark<TNodeChange>(
 }
 
 function markFollowsMoves(mark: Mark<unknown>): boolean {
-	if (isSkipMark(mark)) {
-		return false;
-	}
-
 	const type = mark.type;
 	switch (type) {
 		case "Delete":
@@ -419,6 +415,7 @@ function markFollowsMoves(mark: Mark<unknown>): boolean {
 		case "MoveOut":
 		case "Revive":
 			return true;
+		case SkipType:
 		case "ReturnFrom":
 		case "Insert":
 		case "MoveIn":
@@ -461,7 +458,7 @@ function makeDetachedMark<T>(
 	offset: number,
 ): Mark<T> {
 	if (isSkipMark(mark)) {
-		return 0;
+		return { count: 0 };
 	}
 
 	assert(mark.detachEvent === undefined, "Expected mark to be attached");
@@ -516,7 +513,10 @@ function amendRebaseI<TNodeChange>(
 
 	while (!queue.isEmpty()) {
 		const { baseMark, newMark } = queue.pop();
-		if (isObjMark(baseMark) && (baseMark.type === "MoveIn" || baseMark.type === "ReturnTo")) {
+		if (
+			baseMark !== undefined &&
+			(baseMark.type === "MoveIn" || baseMark.type === "ReturnTo")
+		) {
 			const effect = getMoveEffect(
 				moveEffects,
 				CrossFieldTarget.Destination,
@@ -535,24 +535,25 @@ function amendRebaseI<TNodeChange>(
 
 			// TODO: Handle all pairings of base and new mark types.
 			if (baseMark !== undefined && isModify(baseMark)) {
-				if (isSkipMark(newMark)) {
-					const childChange = rebaseChild(undefined, baseMark.changes);
-					if (childChange !== undefined) {
-						rebasedMark = { type: "Modify", changes: childChange };
-					}
-				} else {
-					switch (newMark.type) {
-						case "Modify": {
-							const childChange = rebaseChild(newMark.changes, baseMark.changes);
-							if (childChange === undefined) {
-								rebasedMark = 1;
-							} else {
-								newMark.changes = childChange;
-							}
+				switch (newMark.type) {
+					case SkipType: {
+						const childChange = rebaseChild(undefined, baseMark.changes);
+						if (childChange !== undefined) {
+							rebasedMark = { type: "Modify", changes: childChange };
 						}
-						default:
-							break;
+						break;
 					}
+					case "Modify": {
+						const childChange = rebaseChild(newMark.changes, baseMark.changes);
+						if (childChange === undefined) {
+							rebasedMark = { count: 1 };
+						} else {
+							newMark.changes = childChange;
+						}
+						break;
+					}
+					default:
+						break;
 				}
 			}
 			factory.push(rebasedMark);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
@@ -7,7 +7,7 @@ import { unreachableCase } from "@fluidframework/common-utils";
 import { JsonCompatible, JsonCompatibleReadOnly } from "../../util";
 import { IJsonCodec, makeCodecFamily } from "../../codec";
 import { jsonableTreeFromCursor, singleTextCursor } from "../treeTextCursor";
-import { Changeset, Mark, SkipType } from "./format";
+import { Changeset, Mark, NoopMarkType } from "./format";
 
 export const sequenceFieldChangeCodecFactory = <TNodeChange>(childCodec: IJsonCodec<TNodeChange>) =>
 	makeCodecFamily<Changeset<TNodeChange>>([
@@ -64,7 +64,7 @@ function encodeForJson<TNodeChange>(
 					changes: childCodec.encode(mark.changes),
 				} as unknown as JsonCompatible);
 				break;
-			case SkipType:
+			case NoopMarkType:
 			case "MoveIn":
 			case "ReturnTo":
 				jsonMarks.push(mark as unknown as JsonCompatible);
@@ -122,7 +122,7 @@ function decodeJson<TNodeChange>(
 				}
 				break;
 			}
-			case SkipType:
+			case NoopMarkType:
 			case "MoveIn":
 			case "ReturnTo":
 				marks.push(mark);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
@@ -7,8 +7,7 @@ import { unreachableCase } from "@fluidframework/common-utils";
 import { JsonCompatible, JsonCompatibleReadOnly } from "../../util";
 import { IJsonCodec, makeCodecFamily } from "../../codec";
 import { jsonableTreeFromCursor, singleTextCursor } from "../treeTextCursor";
-import { Changeset, Mark } from "./format";
-import { isSkipMark } from "./utils";
+import { Changeset, Mark, SkipType } from "./format";
 
 export const sequenceFieldChangeCodecFactory = <TNodeChange>(childCodec: IJsonCodec<TNodeChange>) =>
 	makeCodecFamily<Changeset<TNodeChange>>([
@@ -27,54 +26,51 @@ function encodeForJson<TNodeChange>(
 ): JsonCompatibleReadOnly {
 	const jsonMarks: JsonCompatible[] = [];
 	for (const mark of markList) {
-		if (isSkipMark(mark)) {
-			jsonMarks.push(mark);
-		} else {
-			const type = mark.type;
-			switch (type) {
-				case "Insert":
-				case "Delete":
-				case "MoveOut":
-				case "ReturnFrom":
-					if (mark.changes !== undefined) {
-						jsonMarks.push({
-							...mark,
-							changes: childCodec.encode(mark.changes),
-						} as unknown as JsonCompatible);
-					} else {
-						jsonMarks.push(mark as Mark<TNodeChange> & JsonCompatible);
-					}
-
-					break;
-				case "Revive": {
-					const content = mark.content.map(jsonableTreeFromCursor);
-					if (mark.changes !== undefined) {
-						jsonMarks.push({
-							...mark,
-							content,
-							changes: childCodec.encode(mark.changes),
-						} as unknown as JsonCompatible);
-					} else {
-						jsonMarks.push({
-							...mark,
-							content,
-						} as unknown as JsonCompatible);
-					}
-					break;
-				}
-				case "Modify":
+		const type = mark.type;
+		switch (type) {
+			case "Insert":
+			case "Delete":
+			case "MoveOut":
+			case "ReturnFrom":
+				if (mark.changes !== undefined) {
 					jsonMarks.push({
 						...mark,
 						changes: childCodec.encode(mark.changes),
 					} as unknown as JsonCompatible);
-					break;
-				case "MoveIn":
-				case "ReturnTo":
-					jsonMarks.push(mark as unknown as JsonCompatible);
-					break;
-				default:
-					unreachableCase(type);
+				} else {
+					jsonMarks.push(mark as Mark<TNodeChange> & JsonCompatible);
+				}
+
+				break;
+			case "Revive": {
+				const content = mark.content.map(jsonableTreeFromCursor);
+				if (mark.changes !== undefined) {
+					jsonMarks.push({
+						...mark,
+						content,
+						changes: childCodec.encode(mark.changes),
+					} as unknown as JsonCompatible);
+				} else {
+					jsonMarks.push({
+						...mark,
+						content,
+					} as unknown as JsonCompatible);
+				}
+				break;
 			}
+			case "Modify":
+				jsonMarks.push({
+					...mark,
+					changes: childCodec.encode(mark.changes),
+				} as unknown as JsonCompatible);
+				break;
+			case SkipType:
+			case "MoveIn":
+			case "ReturnTo":
+				jsonMarks.push(mark as unknown as JsonCompatible);
+				break;
+			default:
+				unreachableCase(type);
 		}
 	}
 	return jsonMarks;
@@ -85,57 +81,54 @@ function decodeJson<TNodeChange>(
 	childCodec: IJsonCodec<TNodeChange>,
 ): Changeset<TNodeChange> {
 	const marks: Changeset<TNodeChange> = [];
-	const array = change as Changeset<JsonCompatibleReadOnly>;
+	const array = change as unknown as Changeset<JsonCompatibleReadOnly>;
 	for (const mark of array) {
-		if (isSkipMark(mark)) {
-			marks.push(mark);
-		} else {
-			const type = mark.type;
-			switch (type) {
-				case "Modify": {
+		const type = mark.type;
+		switch (type) {
+			case "Modify": {
+				marks.push({
+					...mark,
+					changes: childCodec.decode(mark.changes),
+				});
+				break;
+			}
+			case "Insert":
+			case "Delete":
+			case "MoveOut":
+			case "ReturnFrom": {
+				if (mark.changes !== undefined) {
 					marks.push({
 						...mark,
 						changes: childCodec.decode(mark.changes),
 					});
-					break;
+				} else {
+					marks.push(mark as Mark<TNodeChange>);
 				}
-				case "Insert":
-				case "Delete":
-				case "MoveOut":
-				case "ReturnFrom": {
-					if (mark.changes !== undefined) {
-						marks.push({
-							...mark,
-							changes: childCodec.decode(mark.changes),
-						});
-					} else {
-						marks.push(mark as Mark<TNodeChange>);
-					}
-					break;
-				}
-				case "Revive": {
-					const content = mark.content.map(singleTextCursor);
-					if (mark.changes !== undefined) {
-						marks.push({
-							...mark,
-							content,
-							changes: childCodec.decode(mark.changes),
-						});
-					} else {
-						marks.push({
-							...mark,
-							content,
-						} as unknown as Mark<TNodeChange>);
-					}
-					break;
-				}
-				case "MoveIn":
-				case "ReturnTo":
-					marks.push(mark);
-					break;
-				default:
-					unreachableCase(type);
+				break;
 			}
+			case "Revive": {
+				const content = mark.content.map(singleTextCursor);
+				if (mark.changes !== undefined) {
+					marks.push({
+						...mark,
+						content,
+						changes: childCodec.decode(mark.changes),
+					});
+				} else {
+					marks.push({
+						...mark,
+						content,
+					} as unknown as Mark<TNodeChange>);
+				}
+				break;
+			}
+			case SkipType:
+			case "MoveIn":
+			case "ReturnTo":
+				marks.push(mark);
+				break;
+			default:
+				unreachableCase(type);
 		}
 	}
 	return marks;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -158,5 +158,5 @@ export const sequenceFieldEditor = {
 };
 
 function markAtIndex<TNodeChange>(index: number, mark: Mark<TNodeChange>): Changeset<TNodeChange> {
-	return index === 0 ? [mark] : [index, mark];
+	return index === 0 ? [mark] : [{ count: index }, mark];
 }

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -8,7 +8,7 @@ import { brandOpaque, Mutable, OffsetListFactory } from "../../util";
 import { Delta } from "../../core";
 import { populateChildModifications } from "../deltaUtils";
 import { singleTextCursor } from "../treeTextCursor";
-import { MarkList, SkipType } from "./format";
+import { MarkList, NoopMarkType } from "./format";
 import { areInputCellsEmpty, areOutputCellsEmpty, getMarkLength, getNodeChange } from "./utils";
 
 export type ToDelta<TNodeChange> = (child: TNodeChange) => Delta.Modify;
@@ -25,7 +25,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 		} else {
 			// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 			const type = mark.type;
-			assert(type !== SkipType, "Cell changing mark must be an ObjMark");
+			assert(type !== NoopMarkType, "Cell changing mark must no be a NoopMark");
 			switch (type) {
 				case "Insert": {
 					const cursors = mark.content.map(singleTextCursor);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -8,14 +8,8 @@ import { brandOpaque, Mutable, OffsetListFactory } from "../../util";
 import { Delta } from "../../core";
 import { populateChildModifications } from "../deltaUtils";
 import { singleTextCursor } from "../treeTextCursor";
-import { MarkList } from "./format";
-import {
-	areInputCellsEmpty,
-	areOutputCellsEmpty,
-	getMarkLength,
-	getNodeChange,
-	isObjMark,
-} from "./utils";
+import { MarkList, SkipType } from "./format";
+import { areInputCellsEmpty, areOutputCellsEmpty, getMarkLength, getNodeChange } from "./utils";
 
 export type ToDelta<TNodeChange> = (child: TNodeChange) => Delta.Modify;
 
@@ -29,9 +23,9 @@ export function sequenceFieldToDelta<TNodeChange>(
 			out.push(deltaFromNodeChange(getNodeChange(mark), getMarkLength(mark), deltaFromChild));
 		} else if (areInputCellsEmpty(mark) && areOutputCellsEmpty(mark)) {
 		} else {
-			assert(isObjMark(mark), "Cell changing mark must be an ObjMark");
 			// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 			const type = mark.type;
+			assert(type !== SkipType, "Cell changing mark must be an ObjMark");
 			switch (type) {
 				case "Insert": {
 					const cursors = mark.content.map(singleTextCursor);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/tracker.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/tracker.ts
@@ -13,7 +13,7 @@ import {
 	isAttach,
 	isDetachMark,
 	isModify,
-	isSkipMark,
+	isNoopMark,
 	markHasCellEffect,
 } from "./utils";
 
@@ -31,7 +31,7 @@ export class IndexTracker {
 			return;
 		}
 
-		assert(!isSkipMark(mark) && !isModify(mark), "These marks have no cell effects");
+		assert(!isNoopMark(mark) && !isModify(mark), "These marks have no cell effects");
 
 		const netLength = outLength - inLength;
 		// If you hit this assert, then you probably need to add a check for it in `isNetZeroNodeCountChange`.
@@ -87,7 +87,7 @@ export class GapTracker {
 		if (!markHasCellEffect(mark)) {
 			this.map.clear();
 		} else {
-			assert(!isSkipMark(mark) && !isModify(mark), "These marks have no cell effects");
+			assert(!isNoopMark(mark) && !isModify(mark), "These marks have no cell effects");
 			const revision = mark.revision;
 			// TODO: Remove this early return. It is only needed because some tests use anonymous changes.
 			// These tests will fail (i.e., produce the wrong result) if they rely the index tracking performed here.

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -37,7 +37,7 @@ import {
 	Reattach,
 	ReturnFrom,
 	ReturnTo,
-	Skip,
+	NoopMark,
 	Changeset,
 	MoveId,
 	Revive,
@@ -45,7 +45,7 @@ import {
 	DetachEvent,
 	EmptyInputCellMark,
 	ExistingCellMark,
-	SkipType,
+	NoopMarkType,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {
@@ -194,7 +194,7 @@ export function markHasCellEffect(mark: Mark<unknown>): boolean {
 export function isExistingCellMark<T>(mark: Mark<T>): mark is ExistingCellMark<T> {
 	const type = mark.type;
 	switch (type) {
-		case SkipType:
+		case NoopMarkType:
 		case "Delete":
 		case "Modify":
 		case "MoveOut":
@@ -221,7 +221,7 @@ export function areInputCellsEmpty<T>(mark: Mark<T>): mark is EmptyInputCellMark
 export function areOutputCellsEmpty(mark: Mark<unknown>): boolean {
 	const type = mark.type;
 	switch (type) {
-		case SkipType:
+		case NoopMarkType:
 		case "Insert":
 			return false;
 		case "MoveIn":
@@ -252,7 +252,7 @@ export function getMarkLength(mark: Mark<unknown>): number {
 			return mark.content.length;
 		case "Modify":
 			return 1;
-		case SkipType:
+		case NoopMarkType:
 		case "Delete":
 		case "MoveIn":
 		case "MoveOut":
@@ -265,8 +265,8 @@ export function getMarkLength(mark: Mark<unknown>): number {
 	}
 }
 
-export function isSkipMark(mark: Mark<unknown>): mark is Skip {
-	return mark.type === SkipType;
+export function isNoopMark(mark: Mark<unknown>): mark is NoopMark {
+	return mark.type === NoopMarkType;
 }
 
 export function getOffsetAtRevision(
@@ -317,8 +317,8 @@ export function tryExtendMark<T>(
 		return false;
 	}
 	const type = rhs.type;
-	if (type === SkipType) {
-		(lhs as Skip).count += rhs.count;
+	if (type === NoopMarkType) {
+		(lhs as NoopMark).count += rhs.count;
 		return true;
 	}
 	if (type !== "Modify" && rhs.revision !== (lhs as HasRevisionTag).revision) {
@@ -877,7 +877,7 @@ export function splitMark<T, TMark extends Mark<T>>(
 	}
 	const type = mark.type;
 	switch (type) {
-		case SkipType:
+		case NoopMarkType:
 			return [{ count: length }, { count: remainder }] as [TMark, TMark];
 		case "Modify":
 			fail("Unable to split Modify mark of length 1");
@@ -1026,7 +1026,7 @@ export function compareLineages(
 export function getNodeChange<TNodeChange>(mark: Mark<TNodeChange>): TNodeChange | undefined {
 	const type = mark.type;
 	switch (type) {
-		case SkipType:
+		case NoopMarkType:
 		case "MoveIn":
 		case "ReturnTo":
 			return undefined;
@@ -1048,7 +1048,7 @@ export function withNodeChange<TNodeChange>(
 ): Mark<TNodeChange> {
 	const type = mark.type;
 	switch (type) {
-		case SkipType:
+		case NoopMarkType:
 			return changes !== undefined ? { type: "Modify", changes } : mark;
 		case "MoveIn":
 		case "ReturnTo":
@@ -1081,7 +1081,7 @@ export function withRevision<TMark extends Mark<unknown>>(
 		return mark;
 	}
 
-	if (isSkipMark(mark)) {
+	if (isNoopMark(mark)) {
 		return mark;
 	}
 
@@ -1090,7 +1090,7 @@ export function withRevision<TMark extends Mark<unknown>>(
 	}
 
 	const cloned = cloneMark(mark);
-	(cloned as Exclude<Mark<unknown>, Skip | Modify<unknown>>).revision = revision;
+	(cloned as Exclude<Mark<unknown>, NoopMark | Modify<unknown>>).revision = revision;
 	return cloned;
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -34,7 +34,6 @@ import {
 	MoveIn,
 	NewAttach,
 	MoveOut,
-	ObjectMark,
 	Reattach,
 	ReturnFrom,
 	ReturnTo,
@@ -46,6 +45,7 @@ import {
 	DetachEvent,
 	EmptyInputCellMark,
 	ExistingCellMark,
+	SkipType,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {
@@ -59,11 +59,11 @@ import {
 } from "./moveEffectTable";
 
 export function isModify<TNodeChange>(mark: Mark<TNodeChange>): mark is Modify<TNodeChange> {
-	return isObjMark(mark) && mark.type === "Modify";
+	return mark.type === "Modify";
 }
 
 export function isNewAttach<TNodeChange>(mark: Mark<TNodeChange>): mark is NewAttach<TNodeChange> {
-	return isObjMark(mark) && (mark.type === "Insert" || mark.type === "MoveIn");
+	return mark.type === "Insert" || mark.type === "MoveIn";
 }
 
 export function isAttach<TNodeChange>(mark: Mark<TNodeChange>): mark is Attach<TNodeChange> {
@@ -71,7 +71,7 @@ export function isAttach<TNodeChange>(mark: Mark<TNodeChange>): mark is Attach<T
 }
 
 export function isReattach<TNodeChange>(mark: Mark<TNodeChange>): mark is Reattach<TNodeChange> {
-	return isObjMark(mark) && (mark.type === "Revive" || mark.type === "ReturnTo");
+	return mark.type === "Revive" || mark.type === "ReturnTo";
 }
 
 export function isActiveReattach<TNodeChange>(
@@ -108,9 +108,6 @@ export function getCellId(
 	mark: Mark<unknown>,
 	revision: RevisionTag | undefined,
 ): DetachEvent | undefined {
-	if (isSkipMark(mark)) {
-		return undefined;
-	}
 	if (isNewAttach(mark)) {
 		const rev = mark.revision ?? revision;
 		if (rev !== undefined) {
@@ -124,11 +121,7 @@ export function getCellId(
 }
 
 export function cloneMark<TMark extends Mark<TNodeChange>, TNodeChange>(mark: TMark): TMark {
-	if (isSkipMark(mark)) {
-		return mark;
-	}
-	const objMark = mark as Exclude<TMark, Skip>;
-	const clone = { ...objMark };
+	const clone = { ...mark };
 	if (clone.type === "Insert" || clone.type === "Revive") {
 		clone.content = [...clone.content];
 	}
@@ -199,12 +192,9 @@ export function markHasCellEffect(mark: Mark<unknown>): boolean {
 }
 
 export function isExistingCellMark<T>(mark: Mark<T>): mark is ExistingCellMark<T> {
-	if (isSkipMark(mark)) {
-		return false;
-	}
-
 	const type = mark.type;
 	switch (type) {
+		case SkipType:
 		case "Delete":
 		case "Modify":
 		case "MoveOut":
@@ -221,10 +211,6 @@ export function isExistingCellMark<T>(mark: Mark<T>): mark is ExistingCellMark<T
 }
 
 export function areInputCellsEmpty<T>(mark: Mark<T>): mark is EmptyInputCellMark<T> {
-	if (isSkipMark(mark)) {
-		return false;
-	}
-
 	if (isNewAttach(mark)) {
 		return true;
 	}
@@ -233,12 +219,9 @@ export function areInputCellsEmpty<T>(mark: Mark<T>): mark is EmptyInputCellMark
 }
 
 export function areOutputCellsEmpty(mark: Mark<unknown>): boolean {
-	if (isSkipMark(mark)) {
-		return false;
-	}
-
 	const type = mark.type;
 	switch (type) {
+		case SkipType:
 		case "Insert":
 			return false;
 		case "MoveIn":
@@ -263,16 +246,13 @@ export function areOutputCellsEmpty(mark: Mark<unknown>): boolean {
 }
 
 export function getMarkLength(mark: Mark<unknown>): number {
-	if (isSkipMark(mark)) {
-		return mark;
-	}
-
 	const type = mark.type;
 	switch (type) {
 		case "Insert":
 			return mark.content.length;
 		case "Modify":
 			return 1;
+		case SkipType:
 		case "Delete":
 		case "MoveIn":
 		case "MoveOut":
@@ -286,7 +266,7 @@ export function getMarkLength(mark: Mark<unknown>): number {
 }
 
 export function isSkipMark(mark: Mark<unknown>): mark is Skip {
-	return typeof mark === "number";
+	return mark.type === SkipType;
 }
 
 export function getOffsetAtRevision(
@@ -309,23 +289,14 @@ export function getOffsetAtRevision(
 export function isDetachMark<TNodeChange>(
 	mark: Mark<TNodeChange> | undefined,
 ): mark is Detach<TNodeChange> {
-	if (isObjMark(mark)) {
-		const type = mark.type;
-		return type === "Delete" || type === "MoveOut" || type === "ReturnFrom";
-	}
-	return false;
+	const type = mark?.type;
+	return type === "Delete" || type === "MoveOut" || type === "ReturnFrom";
 }
 
 export function isDeleteMark<TNodeChange>(
 	mark: Mark<TNodeChange> | undefined,
 ): mark is Delete<TNodeChange> {
-	return isObjMark(mark) && mark.type === "Delete";
-}
-
-export function isObjMark<TNodeChange>(
-	mark: Mark<TNodeChange> | undefined,
-): mark is ObjectMark<TNodeChange> {
-	return typeof mark === "object";
+	return mark?.type === "Delete";
 }
 
 /**
@@ -336,8 +307,8 @@ export function isObjMark<TNodeChange>(
  * When `false` is returned, `lhs` is left untouched.
  */
 export function tryExtendMark<T>(
-	lhs: ObjectMark<T>,
-	rhs: Readonly<ObjectMark<T>>,
+	lhs: Mark<T>,
+	rhs: Readonly<Mark<T>>,
 	revision: RevisionTag | undefined,
 	moveEffects: MoveEffectTable<T> | undefined,
 	recordMerges: boolean,
@@ -346,6 +317,10 @@ export function tryExtendMark<T>(
 		return false;
 	}
 	const type = rhs.type;
+	if (type === SkipType) {
+		(lhs as Skip).count += rhs.count;
+		return true;
+	}
 	if (type !== "Modify" && rhs.revision !== (lhs as HasRevisionTag).revision) {
 		return false;
 	}
@@ -900,21 +875,19 @@ export function splitMark<T, TMark extends Mark<T>>(
 	if (length < 1 || remainder < 1) {
 		fail("Unable to split mark due to lengths");
 	}
-	if (isSkipMark(mark)) {
-		return [length, remainder] as [TMark, TMark];
-	}
-	const markObj = mark as Exclude<TMark, Skip>;
-	const type = markObj.type;
+	const type = mark.type;
 	switch (type) {
+		case SkipType:
+			return [{ count: length }, { count: remainder }] as [TMark, TMark];
 		case "Modify":
 			fail("Unable to split Modify mark of length 1");
 		case "Insert":
 			return [
-				{ ...markObj, content: markObj.content.slice(0, length) },
+				{ ...mark, content: mark.content.slice(0, length) },
 				{
-					...markObj,
-					content: markObj.content.slice(length),
-					id: (markObj.id as number) + length,
+					...mark,
+					content: mark.content.slice(length),
+					id: (mark.id as number) + length,
 				},
 			];
 		case "MoveIn":
@@ -923,8 +896,8 @@ export function splitMark<T, TMark extends Mark<T>>(
 			splitMove(
 				moveEffects,
 				CrossFieldTarget.Source,
-				markObj.revision ?? revision,
-				markObj.id,
+				mark.revision ?? revision,
+				mark.id,
 				newId,
 				length,
 				remainder,
@@ -933,18 +906,18 @@ export function splitMark<T, TMark extends Mark<T>>(
 				splitMove(
 					moveEffects,
 					CrossFieldTarget.Destination,
-					markObj.revision ?? revision,
-					markObj.id,
+					mark.revision ?? revision,
+					mark.id,
 					newId,
 					length,
 					remainder,
 				);
 			}
-			const mark1: TMark = { ...markObj, count: length };
-			const mark2: TMark = { ...markObj, id: newId, count: remainder };
-			if (markObj.type === "ReturnTo") {
-				if (markObj.detachEvent !== undefined) {
-					(mark2 as ReturnTo).detachEvent = splitDetachEvent(markObj.detachEvent, length);
+			const mark1: TMark = { ...mark, count: length };
+			const mark2: TMark = { ...mark, id: newId, count: remainder };
+			if (mark.type === "ReturnTo") {
+				if (mark.detachEvent !== undefined) {
+					(mark2 as ReturnTo).detachEvent = splitDetachEvent(mark.detachEvent, length);
 				}
 
 				return [mark1, mark2];
@@ -952,28 +925,28 @@ export function splitMark<T, TMark extends Mark<T>>(
 			return [mark1, mark2];
 		}
 		case "Revive": {
-			const mark1 = { ...markObj, content: markObj.content.slice(0, length), count: length };
+			const mark1 = { ...mark, content: mark.content.slice(0, length), count: length };
 			const mark2 = {
-				...markObj,
-				content: markObj.content.slice(length),
+				...mark,
+				content: mark.content.slice(length),
 				count: remainder,
 			};
 
-			if (markObj.detachEvent !== undefined) {
-				(mark2 as Revive).detachEvent = splitDetachEvent(markObj.detachEvent, length);
+			if (mark.detachEvent !== undefined) {
+				(mark2 as Revive).detachEvent = splitDetachEvent(mark.detachEvent, length);
 			}
 
 			return [mark1, mark2];
 		}
 		case "Delete": {
-			const mark1 = { ...markObj, count: length };
+			const mark1 = { ...mark, count: length };
 			const mark2 = {
-				...markObj,
+				...mark,
 				count: remainder,
 			};
 
-			if (markObj.detachEvent !== undefined) {
-				(mark2 as Delete).detachEvent = splitDetachEvent(markObj.detachEvent, length);
+			if (mark.detachEvent !== undefined) {
+				(mark2 as Delete).detachEvent = splitDetachEvent(mark.detachEvent, length);
 			}
 
 			return [mark1, mark2];
@@ -985,8 +958,8 @@ export function splitMark<T, TMark extends Mark<T>>(
 			splitMove(
 				moveEffects,
 				CrossFieldTarget.Destination,
-				markObj.revision ?? revision,
-				markObj.id,
+				mark.revision ?? revision,
+				mark.id,
 				newId,
 				length,
 				remainder,
@@ -995,21 +968,21 @@ export function splitMark<T, TMark extends Mark<T>>(
 				splitMove(
 					moveEffects,
 					CrossFieldTarget.Source,
-					markObj.revision ?? revision,
-					markObj.id,
+					mark.revision ?? revision,
+					mark.id,
 					newId,
 					length,
 					remainder,
 				);
 			}
-			const mark1 = { ...markObj, count: length };
+			const mark1 = { ...mark, count: length };
 			const mark2 = {
-				...markObj,
+				...mark,
 				id: newId,
 				count: remainder,
 			};
-			if (markObj.detachEvent !== undefined) {
-				(mark2 as Detach).detachEvent = splitDetachEvent(markObj.detachEvent, length);
+			if (mark.detachEvent !== undefined) {
+				(mark2 as Detach).detachEvent = splitDetachEvent(mark.detachEvent, length);
 			}
 			return [mark1, mark2];
 		}
@@ -1051,12 +1024,9 @@ export function compareLineages(
 }
 
 export function getNodeChange<TNodeChange>(mark: Mark<TNodeChange>): TNodeChange | undefined {
-	if (isSkipMark(mark)) {
-		return undefined;
-	}
-
 	const type = mark.type;
 	switch (type) {
+		case SkipType:
 		case "MoveIn":
 		case "ReturnTo":
 			return undefined;
@@ -1076,12 +1046,10 @@ export function withNodeChange<TNodeChange>(
 	mark: Mark<TNodeChange>,
 	changes: TNodeChange | undefined,
 ): Mark<TNodeChange> {
-	if (isSkipMark(mark)) {
-		return changes !== undefined ? { type: "Modify", changes } : mark;
-	}
-
 	const type = mark.type;
 	switch (type) {
+		case SkipType:
+			return changes !== undefined ? { type: "Modify", changes } : mark;
 		case "MoveIn":
 		case "ReturnTo":
 			assert(changes === undefined, "Cannot have a node change on a MoveIn or ReturnTo mark");

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -397,13 +397,13 @@ describe("SequenceField - Compose", () => {
 		// Deletes ABC-----IJKLM
 		const deleteA: SF.Changeset = [
 			{ type: "Delete", count: 3 },
-			5,
+			{ count: 5 },
 			{ type: "Delete", count: 5 },
 		];
 		// Deletes DEFG--OP
 		const deleteB: SF.Changeset = [
 			{ type: "Delete", count: 4 },
-			2,
+			{ count: 2 },
 			{ type: "Delete", count: 2 },
 		];
 		const actual = shallowCompose([tagChange(deleteA, tag1), tagChange(deleteB, tag2)]);
@@ -411,9 +411,9 @@ describe("SequenceField - Compose", () => {
 		const expected: SF.Changeset = [
 			{ type: "Delete", revision: tag1, count: 3 },
 			{ type: "Delete", revision: tag2, count: 4 },
-			1,
+			{ count: 1 },
 			{ type: "Delete", revision: tag1, count: 5 },
-			1,
+			{ count: 1 },
 			{ type: "Delete", revision: tag2, count: 2 },
 		];
 		assert.deepEqual(actual, expected);
@@ -422,9 +422,9 @@ describe("SequenceField - Compose", () => {
 	it("revive ○ delete", () => {
 		const revive = Change.revive(0, 5, tag1, 0);
 		const deletion: SF.Changeset = [
-			1,
+			{ count: 1 },
 			{ type: "Delete", count: 1 },
-			1,
+			{ count: 1 },
 			{ type: "Delete", count: 3 },
 		];
 		const actual = shallowCompose([makeAnonChange(revive), makeAnonChange(deletion)]);
@@ -514,7 +514,7 @@ describe("SequenceField - Compose", () => {
 	it("insert ○ insert", () => {
 		const insertA: SF.Changeset = [
 			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
-			2,
+			{ count: 2 },
 			{
 				type: "Insert",
 				revision: tag2,
@@ -528,14 +528,14 @@ describe("SequenceField - Compose", () => {
 
 		const insertB: SF.Changeset = [
 			{ type: "Insert", revision: tag3, content: [{ type, value: 4 }], id: brand(4) },
-			4,
+			{ count: 4 },
 			{ type: "Insert", revision: tag4, content: [{ type, value: 5 }], id: brand(5) },
 		];
 		const actual = shallowCompose([makeAnonChange(insertA), makeAnonChange(insertB)], revInfos);
 		const expected: SF.Changeset = [
 			{ type: "Insert", revision: tag3, content: [{ type, value: 4 }], id: brand(4) },
 			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
-			2,
+			{ count: 2 },
 			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }], id: brand(2) },
 			{ type: "Insert", revision: tag4, content: [{ type, value: 5 }], id: brand(5) },
 			{ type: "Insert", revision: tag2, content: [{ type, value: 3 }], id: brand(3) },
@@ -633,7 +633,7 @@ describe("SequenceField - Compose", () => {
 		const expected: SF.Changeset = [
 			{ type: "Delete", count: 1, revision: tag2 },
 			{ type: "Delete", count: 1, revision: tag1 },
-			1,
+			{ count: 1 },
 			{ type: "Delete", count: 1, revision: tag1 },
 			{ type: "Delete", count: 1, revision: tag2 },
 		];
@@ -649,7 +649,7 @@ describe("SequenceField - Compose", () => {
 		const delete1 = Change.delete(1, 3);
 		const delete2 = Change.delete(0, 2);
 		const revive = Change.revive(0, 2, tag2, 0);
-		const expected: SF.Changeset = [1, { type: "Delete", count: 3, revision: tag1 }];
+		const expected: SF.Changeset = [{ count: 1 }, { type: "Delete", count: 3, revision: tag1 }];
 		const actual = shallowCompose([
 			tagChange(delete1, tag1),
 			tagChange(delete2, tag2),
@@ -762,7 +762,7 @@ describe("SequenceField - Compose", () => {
 	it("insert ○ revive", () => {
 		const insert: SF.Changeset = [
 			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
-			2,
+			{ count: 2 },
 			{
 				type: "Insert",
 				revision: tag2,
@@ -781,7 +781,7 @@ describe("SequenceField - Compose", () => {
 				count: 1,
 				detachEvent: { revision: tag1, index: 0 },
 			},
-			4,
+			{ count: 4 },
 			{
 				type: "Revive",
 				revision: tag4,
@@ -800,7 +800,7 @@ describe("SequenceField - Compose", () => {
 				detachEvent: { revision: tag1, index: 0 },
 			},
 			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
-			2,
+			{ count: 2 },
 			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }], id: brand(2) },
 			{
 				type: "Revive",
@@ -820,7 +820,7 @@ describe("SequenceField - Compose", () => {
 		const modify = Change.modify(1, nodeChange);
 		const expected: SF.Changeset<TestChange> = [
 			{ type: "MoveOut", id: brand(0), count: 1, changes: nodeChange },
-			1,
+			{ count: 1 },
 			{ type: "MoveIn", id: brand(0), count: 1 },
 		];
 		const actual = shallowCompose([makeAnonChange(move), makeAnonChange(modify)]);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -18,7 +18,7 @@ describe("SequenceField - MarkListFactory", () => {
 		const factory = new SF.MarkListFactory();
 		factory.pushOffset(42);
 		factory.pushContent(dummyMark);
-		assert.deepStrictEqual(factory.list, [42, dummyMark]);
+		assert.deepStrictEqual(factory.list, [{ count: 42 }, dummyMark]);
 	});
 
 	it("Does not insert 0-length offsets", () => {
@@ -33,7 +33,7 @@ describe("SequenceField - MarkListFactory", () => {
 		factory.pushOffset(42);
 		factory.pushOffset(42);
 		factory.pushContent(dummyMark);
-		assert.deepStrictEqual(factory.list, [84, dummyMark]);
+		assert.deepStrictEqual(factory.list, [{ count: 84 }, dummyMark]);
 	});
 
 	it("Does not insert an offset when there is no content after the offset", () => {
@@ -93,7 +93,7 @@ describe("SequenceField - MarkListFactory", () => {
 
 		assert.deepStrictEqual(factory2.list, [
 			{ type: "MoveOut", id: 0, count: 2 },
-			3,
+			{ count: 3 },
 			{ type: "MoveIn", id: 0, count: 2 },
 		]);
 	});
@@ -122,7 +122,7 @@ describe("SequenceField - MarkListFactory", () => {
 
 		assert.deepStrictEqual(factory2.list, [
 			{ type: "MoveOut", id: 0, count: 3 },
-			3,
+			{ count: 3 },
 			{ type: "MoveIn", id: 0, count: 3 },
 		]);
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/randomChangeGenerator.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/randomChangeGenerator.spec.ts
@@ -26,7 +26,7 @@ describe("SequenceField - generateRandomChange", () => {
 
 	it("Generates a change", () => {
 		const change = generateRandomChange(testSeed, maxIndex, childGen);
-		const expected = [2, { type: "Delete", count: 5 }];
+		const expected = [{ count: 2 }, { type: "Delete", count: 5 }];
 		assert.deepStrictEqual(change, expected);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -257,7 +257,7 @@ describe("SequenceField - Rebase", () => {
 		const actual = rebase(deleteA, deleteB, tag1);
 		// Deletes --E-G
 		const expected: SF.Changeset<never> = [
-			2,
+			{ count: 2 },
 			{ type: "Delete", count: 1, detachEvent: { revision: tag1, index: 3 } },
 			{ type: "Delete", count: 1 },
 			{ type: "Delete", count: 1, detachEvent: { revision: tag1, index: 5 } },
@@ -306,7 +306,7 @@ describe("SequenceField - Rebase", () => {
 			{ type: "MoveIn", count: 1, id: brand(2), isSrcConflicted: true },
 			{ type: "MoveIn", count: 1, id: brand(3) },
 			{ type: "MoveIn", count: 1, id: brand(4), isSrcConflicted: true },
-			2,
+			{ count: 2 },
 			{ type: "MoveOut", count: 1, id: brand(0), detachEvent: { revision: tag1, index: 3 } },
 			{ type: "MoveOut", count: 1, id: brand(1) },
 			{ type: "MoveOut", count: 1, id: brand(2), detachEvent: { revision: tag1, index: 5 } },

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
@@ -25,25 +25,28 @@ describe("SequenceField - Editor", () => {
 		const childChange: NodeChangeset = { valueChange: { value: 1 } };
 		deepFreeze(childChange);
 		const actual = SF.sequenceFieldEditor.buildChildChange(42, childChange);
-		const expected: SF.Changeset = [42, { type: "Modify", changes: childChange }];
+		const expected: SF.Changeset = [{ count: 42 }, { type: "Modify", changes: childChange }];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("insert one node", () => {
 		const actual = SF.sequenceFieldEditor.insert(42, content[0], id);
-		const expected: SF.Changeset = [42, { type: "Insert", content: [nodeX], id }];
+		const expected: SF.Changeset = [{ count: 42 }, { type: "Insert", content: [nodeX], id }];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("insert multiple nodes", () => {
 		const actual = SF.sequenceFieldEditor.insert(42, content, id);
-		const expected: SF.Changeset = [42, { type: "Insert", content: [nodeX, nodeY], id }];
+		const expected: SF.Changeset = [
+			{ count: 42 },
+			{ type: "Insert", content: [nodeX, nodeY], id },
+		];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("delete", () => {
 		const actual = SF.sequenceFieldEditor.delete(42, 3);
-		const expected: SF.Changeset = [42, { type: "Delete", count: 3 }];
+		const expected: SF.Changeset = [{ count: 42 }, { type: "Delete", count: 3 }];
 		assert.deepEqual(actual, expected);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -151,13 +151,13 @@ describe("SequenceField - toDelta", () => {
 
 	it("move", () => {
 		const changeset: TestChangeset = [
-			42,
+			{ count: 42 },
 			{
 				type: "MoveOut",
 				id: moveId,
 				count: 10,
 			},
-			8,
+			{ count: 8 },
 			{
 				type: "MoveIn",
 				id: moveId,
@@ -307,7 +307,7 @@ describe("SequenceField - toDelta", () => {
 		it("move", () => {
 			const move: TestChangeset = [
 				{ type: "MoveIn", id: brand(0), count: 1, isSrcConflicted: true },
-				1,
+				{ count: 1 },
 				{ type: "MoveOut", id: brand(0), count: 1, detachEvent },
 			];
 


### PR DESCRIPTION
Refactors the marks that represent skipped nodes so that they are more similar to the other types of marks.
This makes the format more homogenous, which reduces code clutter and avoids type kludges (see the changes to `isExistingCellMark`).