### PR TITLE
Fix imports and module publishing in local driver

### DIFF
--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
+	"module": "lib/index.js",
 	"browser": {
 		"moniker": "@fluidframework/server-services-client/dist/generateNames.js"
 	},

--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -16,11 +16,10 @@ import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 import { GitManager } from "@fluidframework/server-services-client";
 import { TestHistorian } from "@fluidframework/server-test-utils";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import {
-	LocalDeltaStorageService,
-	LocalDocumentDeltaConnection,
-	LocalDocumentStorageService,
-} from ".";
+import { LocalDocumentStorageService } from "./localDocumentStorageService";
+import { LocalDocumentDeltaConnection } from "./localDocumentDeltaConnection";
+import { LocalDeltaStorageService } from "./localDeltaStorageService";
+
 /**
  * Basic implementation of a document service for local use.
  */


### PR DESCRIPTION
## Description

Do two of the fixes suggested by https://github.com/microsoft/FluidFramework/issues/14312

Note that this does not solve the general problem that we have no validation of non-cyclic imports or proper esm exports: it just fixes on case which was pointed out.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

