### PR TITLE
[Testing] Remove condition for bundle size test

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"ci:test:realsvc:local": "pnpm run -r --no-sort --stream --no-bail test:realsvc:local:report",
 		"ci:test:realsvc:local:coverage": "c8 --no-clean pnpm recursive --no-sort --stream --no-bail run test:realsvc:local:report",
 		"ci:test:realsvc:tinylicious": "pnpm run -r --no-sort --stream --no-bail test:realsvc:tinylicious:report",
-		"ci:test:realsvc:tinylicious:coverage": "controlledTest c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:realsvc:tinylicious:report ",
+		"ci:test:realsvc:tinylicious:coverage": "c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:realsvc:tinylicious:report ",
 		"ci:test:stress:tinylicious": "pnpm run -r --no-sort --stream --no-bail test:stress:tinylicious:report ",
 		"ci:test:stress:tinylicious:coverage": "c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:stress:tinylicious:report ",
 		"clean": "pnpm run -r --no-sort --stream clean && npm run clean:docs && npm run clean:nyc",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"ci:test:realsvc:local": "pnpm run -r --no-sort --stream --no-bail test:realsvc:local:report",
 		"ci:test:realsvc:local:coverage": "c8 --no-clean pnpm recursive --no-sort --stream --no-bail run test:realsvc:local:report",
 		"ci:test:realsvc:tinylicious": "pnpm run -r --no-sort --stream --no-bail test:realsvc:tinylicious:report",
-		"ci:test:realsvc:tinylicious:coverage": "c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:realsvc:tinylicious:report ",
+		"ci:test:realsvc:tinylicious:coverage": "controlledTest c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:realsvc:tinylicious:report ",
 		"ci:test:stress:tinylicious": "pnpm run -r --no-sort --stream --no-bail test:stress:tinylicious:report ",
 		"ci:test:stress:tinylicious:coverage": "c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:stress:tinylicious:report ",
 		"clean": "pnpm run -r --no-sort --stream clean && npm run clean:docs && npm run clean:nyc",

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -517,7 +517,6 @@ stages:
 
             - task: Bash@3
               displayName: Write bundle sizes measurements to Aria/Kusto
-              condition: succeededOrFailed()
               inputs:
                 targetType: 'inline'
                 workingDirectory: ${{ variables.toolAbsolutePath }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -301,7 +301,7 @@ stages:
                 inputs:
                   command: 'custom'
                   workingDir: ${{ parameters.buildDirectory }}
-                  customCommand: 'exit 2' # deliberately fail the test 
+                  customCommand: 'run ${{ taskTestStep }}:coverage'
                 condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
             # Test - No coverage
             - ${{ if or(eq(variables['testCoverage'], false), eq(startsWith(taskTestStep, 'ci:test'), false)) }}:
@@ -310,7 +310,7 @@ stages:
                   inputs:
                     command: 'custom'
                     workingDir: ${{ parameters.buildDirectory }}
-                    customCommand: 'exit 2' # deliberately fail the test 
+                    customCommand: 'run ${{ taskTestStep }}'
                   condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
           # Test - Upload coverage results

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -301,7 +301,7 @@ stages:
                 inputs:
                   command: 'custom'
                   workingDir: ${{ parameters.buildDirectory }}
-                  customCommand: 'run ${{ taskTestStep }}:coverage'
+                  customCommand: 'exit 2' # deliberately fail the test 
                 condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
             # Test - No coverage
             - ${{ if or(eq(variables['testCoverage'], false), eq(startsWith(taskTestStep, 'ci:test'), false)) }}:
@@ -310,7 +310,7 @@ stages:
                   inputs:
                     command: 'custom'
                     workingDir: ${{ parameters.buildDirectory }}
-                    customCommand: 'run ${{ taskTestStep }}'
+                    customCommand: 'exit 2' # deliberately fail the test 
                   condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
           # Test - Upload coverage results


### PR DESCRIPTION
- Work in Progress

#### Description (OCE)

https://dev.azure.com/fluidframework/internal/_build/results?buildId=160673&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3


As shown in the build pipeline above, `Write bundle sizes measurements to Aria/Kusto` should be skipped after the build fails in `npm run ci:test:realsvc:tinylicious:coverage`. This PR removes the condition inside the `build-npm-package.yml` file. 