### PR TITLE
Revert "Remove retry for 400/404 push error (#15039)"

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -295,8 +295,30 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			enableMultiplexing,
 		);
 
-		await deltaConnection.initialize(connectMessage, timeoutMs);
-		await epochTracker.validateEpoch(deltaConnection.details.epoch, "push");
+		try {
+			await deltaConnection.initialize(connectMessage, timeoutMs);
+			await epochTracker.validateEpoch(deltaConnection.details.epoch, "push");
+		} catch (errorObject: any) {
+			if (errorObject !== null && typeof errorObject === "object") {
+				// We have to special-case error types here in terms of what is re-triable.
+				// These errors have to re-retried, we just need new joinSession result to connect to right server:
+				//    400: Invalid tenant or document id. The WebSocket is connected to a different document
+				//         Document is full (with retryAfter)
+				//    404: Invalid document. The document \"local/w1-...\" does not exist
+				// But this has to stay not-retriable:
+				//    406: Unsupported client protocol. This path is the only gatekeeper, have to fail!
+				//    409: Epoch Version Mismatch. Client epoch and server epoch does not match, so app needs
+				//         to be refreshed.
+				// This one is fine either way
+				//    401/403: Code will retry once with new token either way, then it becomes fatal - on this path
+				//         and on join Session path.
+				//    501: (Fluid not enabled): this is fine either way, as joinSession is gatekeeper
+				if (errorObject.statusCode === 400 || errorObject.statusCode === 404) {
+					errorObject.canRetry = true;
+				}
+			}
+			throw errorObject;
+		}
 
 		return deltaConnection;
 	}


### PR DESCRIPTION
## Description

This reverts commit de1f61f291cf0d0f27578c409344ecca69e00c89.
This change seems to cause issues where 404 happens due to session inactivity for long time and we get 404 and where join session cache needs to be cleared. We will be working on this in future where push can provide us more info beside the status code telling client whether we want to retry or not.
This also caused a problem where on session restore in loop app, we got 404 error due to old join session response in cache.