### PR TITLE
Fix unwrapping in useTree, and related fixes

### DIFF
--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
@@ -41,5 +41,4 @@ export type FlexClient = SchemaAware.TypedNode<typeof clientSchema, SchemaAware.
 
 // TODO: experiment with this interface pattern. Maybe it makes better intellisense and errors?
 // TODO: Intellisense is pretty bad here if not using interface.
-export interface ClientsField
-	extends SchemaAware.TypedField<SchemaAware.ApiMode.Editable, typeof rootAppStateSchema> {}
+export interface ClientsField extends SchemaAware.TypedField<typeof rootAppStateSchema> {}

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -23,6 +23,7 @@ export const inventory = builder.object("Contoso:Inventory-1.0.0", {
 });
 
 export const rootField = SchemaBuilder.field(FieldKinds.value, inventory);
+export type RootField = SchemaAware.TypedField<typeof rootField>;
 
 export const schema = builder.intoDocumentSchema(rootField);
 

--- a/examples/data-objects/inventory-app/src/view/inventoryList.tsx
+++ b/examples/data-objects/inventory-app/src/view/inventoryList.tsx
@@ -6,7 +6,7 @@
 import * as React from "react";
 import { AllowedUpdateType, ISharedTree } from "@fluid-experimental/tree2";
 import { useTree } from "@fluid-experimental/tree-react-api";
-import { Inventory, schema } from "../schema";
+import { Inventory, RootField, schema } from "../schema";
 import { Counter } from "./counter";
 
 const schemaPolicy = {
@@ -27,7 +27,9 @@ const schemaPolicy = {
 };
 
 export const MainView: React.FC<{ tree: ISharedTree }> = ({ tree }) => {
-	const inventory: Inventory = useTree(tree, schemaPolicy);
+	const root: RootField = useTree(tree, schemaPolicy);
+	// TODO: value fields like `root` which always contain exactly one value should have a nicer API for accessing that child, like `.child`.
+	const inventory: Inventory = root[0];
 
 	const counters: JSX.Element[] = [];
 

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -400,7 +400,7 @@ export function cursorsFromContextualData(
 export function cursorsForTypedFieldData<T extends FieldSchema>(
 	schemaData: SchemaDataAndPolicy,
 	schema: T,
-	data: TypedField<ApiMode.Simple, T>,
+	data: TypedField<T, ApiMode.Simple>,
 ): ITreeCursorSynchronous {
 	return cursorFromContextualData(schemaData, schema.types, data as ContextuallyTypedNodeData);
 }

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/internal.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/internal.ts
@@ -12,6 +12,8 @@ export {
 	ValuePropertyFromSchema,
 	FlexibleObject,
 	EditableSequenceField,
+	EditableValueField,
+	EditableOptionalField,
 	TypedField,
 	UnbrandedName,
 	TypeArrayToTypedTreeArray,
@@ -21,4 +23,4 @@ export {
 
 export { ValuesOf, TypedValue, PrimitiveValueSchema } from "./schemaAwareUtil";
 
-export { UntypedSequenceField } from "./partlyTyped";
+export { UntypedSequenceField, UntypedOptionalField, UntypedValueField } from "./partlyTyped";

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/partlyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/partlyTyped.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKey, FieldStoredSchema, ITreeCursor } from "../../core";
-import { FieldEditor, FieldKind, Multiplicity } from "../modular-schema";
-import { UntypedField, UntypedTree, UntypedTreeContext } from "../untypedTree";
+import { FieldStoredSchema, ITreeCursor } from "../../core";
+import { Optional, Sequence, ValueFieldKind } from "../defaultFieldKinds";
+import { UntypedField } from "../untypedTree";
 
 /**
  * A sequence field in an {@link UntypedTree}.
@@ -20,30 +20,8 @@ export interface UntypedSequenceField extends UntypedField {
 	 * The `FieldStoredSchema` of this field.
 	 */
 	readonly fieldSchema: FieldStoredSchema & {
-		readonly kind: FieldKind<FieldEditor<any>, Multiplicity.Sequence>;
+		readonly kind: Sequence;
 	};
-
-	/**
-	 * The `FieldKey` of this field.
-	 */
-	readonly fieldKey: FieldKey;
-
-	/**
-	 * The node which has this field on it under `fieldKey`.
-	 * `undefined` iff this field is a detached field.
-	 */
-	readonly parent?: UntypedTree;
-
-	/**
-	 * A common context of a "forest" of EditableTrees.
-	 */
-	readonly context: UntypedTreeContext;
-
-	/**
-	 * Gets a node of this field by its index without unwrapping.
-	 * Note that the node must exists at the given index.
-	 */
-	getNode(index: number): UntypedTree;
 
 	/**
 	 * Inserts new nodes into this field.
@@ -70,4 +48,36 @@ export interface UntypedSequenceField extends UntypedField {
 	 * all the insertions will be preserved.
 	 */
 	replaceNodes(index: number, newContent: ITreeCursor | ITreeCursor[], count?: number): void;
+}
+
+/**
+ * A value field in an {@link UntypedTree}.
+ * @alpha
+ */
+export interface UntypedValueField extends UntypedField {
+	/**
+	 * The `FieldStoredSchema` of this field.
+	 */
+	readonly fieldSchema: FieldStoredSchema & {
+		readonly kind: ValueFieldKind;
+	};
+
+	// TODO: add editing APIs
+	// TODO: add friendly .child getter
+}
+
+/**
+ * A value field in an {@link UntypedTree}.
+ * @alpha
+ */
+export interface UntypedOptionalField extends UntypedField {
+	/**
+	 * The `FieldStoredSchema` of this field.
+	 */
+	readonly fieldSchema: FieldStoredSchema & {
+		readonly kind: Optional;
+	};
+
+	// TODO: add editing APIs
+	// TODO: add friendly .child getter
 }

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -22,7 +22,7 @@ import {
 import { UntypedField, UntypedTree, UntypedTreeCore } from "../untypedTree";
 import { contextSymbol, typeSymbol } from "../editable-tree";
 import { Assume } from "../../util";
-import { UntypedSequenceField } from "./partlyTyped";
+import { UntypedOptionalField, UntypedSequenceField, UntypedValueField } from "./partlyTyped";
 import { PrimitiveValueSchema, TypedValue } from "./schemaAwareUtil";
 
 /**
@@ -147,6 +147,8 @@ export type UnbrandedName<TName> = [
 /**
  * `{ [key: string]: FieldSchemaTypeInfo }` to `{ [key: string]: TypedTree }`
  *
+ * In Editable mode, unwraps the fields.
+ *
  * TODO:
  * Extend this to support global fields.
  * @alpha
@@ -157,20 +159,23 @@ export type TypedFields<
 > = [
 	TFields extends { [key: string]: FieldSchema }
 		? {
-				[key in keyof TFields]: TypedField<Mode, TFields[key]>;
+				[key in keyof TFields]: TypedField<
+					TFields[key],
+					Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode
+				>;
 		  }
 		: EmptyObject,
 ][InternalTypedSchemaTypes._InlineTrick];
 
 /**
- * `FieldSchemaTypeInfo` to `TypedTree`
+ * `FieldSchema` to `TypedField`. May unwrap to child depending on Mode and FieldKind.
  * @alpha
  */
-export type TypedField<Mode extends ApiMode, TField extends FieldSchema> = [
+export type TypedField<TField extends FieldSchema, Mode extends ApiMode = ApiMode.Editable> = [
 	ApplyMultiplicity<
 		TField["kind"]["multiplicity"],
 		AllowedTypesToTypedTrees<Mode, TField["allowedTypes"]>,
-		Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode
+		Mode
 	>,
 ][InternalTypedSchemaTypes._InlineTrick];
 
@@ -184,11 +189,15 @@ export type ApplyMultiplicity<
 	Mode extends ApiMode,
 > = {
 	[Multiplicity.Forbidden]: undefined;
-	[Multiplicity.Optional]: undefined | TypedChild;
+	[Multiplicity.Optional]: Mode extends ApiMode.Editable
+		? EditableOptionalField<TypedChild>
+		: undefined | TypedChild;
 	[Multiplicity.Sequence]: Mode extends ApiMode.Editable | ApiMode.EditableUnwrapped
 		? EditableSequenceField<TypedChild>
 		: TypedChild[];
-	[Multiplicity.Value]: TypedChild;
+	[Multiplicity.Value]: Mode extends ApiMode.Editable
+		? EditableValueField<TypedChild>
+		: TypedChild;
 }[TMultiplicity];
 
 // TODO: add strong typed `getNode`.
@@ -198,7 +207,23 @@ export type EditableField<TypedChild> = UntypedField & MarkedArrayLike<TypedChil
 /**
  * @alpha
  */
-export type EditableSequenceField<TypedChild> = UntypedSequenceField & MarkedArrayLike<TypedChild>;
+export type EditableSequenceField<TypedChild> = [
+	UntypedSequenceField & MarkedArrayLike<TypedChild>,
+][InternalTypedSchemaTypes._InlineTrick];
+
+/**
+ * @alpha
+ */
+export type EditableValueField<TypedChild> = [
+	UntypedValueField & MarkedArrayLike<TypedChild>,
+][InternalTypedSchemaTypes._InlineTrick];
+
+/**
+ * @alpha
+ */
+export type EditableOptionalField<TypedChild> = [
+	UntypedOptionalField & MarkedArrayLike<TypedChild>,
+][InternalTypedSchemaTypes._InlineTrick];
 
 /**
  * Takes in `AllowedTypes` and returns a TypedTree union.
@@ -278,6 +303,7 @@ export type NodeDataFor<Mode extends ApiMode, TSchema extends TreeSchema> = Type
  * Provided schema must be included in the schema for the tree being viewed (getting this wrong will error).
  * @alpha
  */
+// TODO: tests
 export function downCast<TSchema extends TreeSchema>(
 	schema: TSchema,
 	tree: UntypedTreeCore,

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -251,6 +251,7 @@ export {
 	GlobalFieldSchema,
 	Any,
 	Sourced,
+	cursorForTypedTreeData,
 } from "./feature-libraries";
 
 export {

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -176,5 +176,5 @@ export interface SchematizeConfiguration<TRoot extends GlobalFieldSchema = Globa
 	 * Default tree content to initialize the tree with iff the tree is uninitialized
 	 * (meaning it does not even have any schema set at all).
 	 */
-	readonly initialTree: SchemaAware.TypedField<SchemaAware.ApiMode.Simple, TRoot["schema"]>;
+	readonly initialTree: SchemaAware.TypedField<TRoot["schema"], SchemaAware.ApiMode.Simple>;
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -131,7 +131,7 @@ const b7: BallTree = { [typeNameSymbol]: ballSchema.name, x: 1 };
 {
 	type XField = typeof ballSchema["localFieldsObject"]["x"];
 	type XMultiplicity = XField["kind"]["multiplicity"];
-	type XContent = TypedField<ApiMode.Simple, XField>;
+	type XContent = TypedField<XField, ApiMode.Simple>;
 	type XChild = XField["allowedTypes"];
 	type _check = requireAssignableTo<XContent, number>;
 }
@@ -258,7 +258,7 @@ type SimpleBall = {
 		type _check5 = requireAssignableTo<FlexBool, ChildTypes>;
 		type _check6 = requireAssignableTo<FlexStr, ChildTypes>;
 		type _check7 = requireAssignableTo<ChildTypes, FlexBool | FlexStr>;
-		type Field = TypedField<ApiMode.Flexible, ChildSchema>;
+		type Field = TypedField<ChildSchema, ApiMode.Flexible>;
 	}
 
 	{
@@ -324,7 +324,7 @@ type SimpleBall = {
 				ApiMode.Simple,
 				RecFieldSchema["allowedTypes"]
 			>;
-			type SimpleField = TypedField<ApiMode.Simple, RecFieldSchema>;
+			type SimpleField = TypedField<RecFieldSchema, ApiMode.Simple>;
 		}
 
 		// Overall integration tests
@@ -387,8 +387,8 @@ type SimpleBall = {
 				>;
 
 				type BoxChildTypeField = TypedField<
-					ApiMode.Flexible,
-					typeof boxSchema.localFieldsObject.children
+					typeof boxSchema.localFieldsObject.children,
+					ApiMode.Flexible
 				>;
 			}
 			type _check8 = requireAssignableTo<ChildTypeArray[0], FlexBall>;
@@ -399,7 +399,7 @@ type SimpleBall = {
 			type _check6 = requireAssignableTo<FlexBall, ChildTypes>;
 			type _check7 = requireAssignableTo<ChildTypes, FlexBall | FlexBox>;
 		}
-		type Field = TypedField<ApiMode.Flexible, ChildSchema>;
+		type Field = TypedField<ChildSchema, ApiMode.Flexible>;
 	}
 
 	type _check1 = requireTrue<areSafelyAssignable<F, FlexBox>>;

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@fluid-experimental/tree-react-api",
 	"version": "2.0.0-internal.4.4.0",
-	"private": true,
 	"description": "Experimental SharedTree API for React integration.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/tree-react-api/src/test/useTree.spec.ts
+++ b/experimental/framework/tree-react-api/src/test/useTree.spec.ts
@@ -4,13 +4,19 @@
  */
 
 import { strict as assert } from "assert";
-import { AllowedUpdateType, ISharedTreeView, SharedTreeFactory } from "@fluid-experimental/tree2";
+import {
+	AllowedUpdateType,
+	ISharedTreeView,
+	SchemaAware,
+	SharedTreeFactory,
+} from "@fluid-experimental/tree2";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import React from "react";
 import { SinonSandbox, createSandbox } from "sinon";
 import { useTree } from "..";
-import { schema } from "./schema";
+import { rootField, schema } from "./schema";
 
+// TODO: why do failing tests in this suite not cause CI to fail?
 describe("useTree()", () => {
 	function createLocalTree(id: string): ISharedTreeView {
 		const factory = new SharedTreeFactory();
@@ -31,6 +37,11 @@ describe("useTree()", () => {
 	// Mock 'React.useEffect()'
 	function mockUseEffect(effect: React.EffectCallback, deps?: React.DependencyList): void {}
 
+	// Mock 'React.useMemo()'
+	function mockUseMemo<T>(factory: () => T, deps: React.DependencyList | undefined): T {
+		return factory();
+	}
+
 	let sandbox: SinonSandbox;
 
 	before(() => {
@@ -40,6 +51,7 @@ describe("useTree()", () => {
 	beforeEach(() => {
 		sandbox.stub(React, "useState").callsFake(mockUseState as any);
 		sandbox.stub(React, "useEffect").callsFake(mockUseEffect);
+		sandbox.stub(React, "useMemo").callsFake(mockUseMemo);
 	});
 
 	afterEach(() => {
@@ -48,7 +60,7 @@ describe("useTree()", () => {
 
 	it("works", () => {
 		const tree = createLocalTree("tree");
-		const inventory = useTree(tree, {
+		const root: SchemaAware.TypedField<typeof rootField> = useTree(tree, {
 			schema,
 			initialTree: {
 				nuts: 0,
@@ -57,6 +69,6 @@ describe("useTree()", () => {
 			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 		});
 
-		assert.deepEqual(JSON.parse(JSON.stringify(inventory)), { nuts: 0, bolts: 0 });
+		assert.deepEqual(JSON.parse(JSON.stringify(root[0])), { nuts: 0, bolts: 0 });
 	});
 });

--- a/experimental/framework/tree-react-api/src/useTree.ts
+++ b/experimental/framework/tree-react-api/src/useTree.ts
@@ -23,7 +23,7 @@ import React from "react";
 export function useTree<TRoot extends GlobalFieldSchema>(
 	tree: ISharedTreeView,
 	config: SchematizeConfiguration<TRoot>,
-): SchemaAware.TypedField<SchemaAware.ApiMode.Editable, TRoot["schema"]> {
+): SchemaAware.TypedField<TRoot["schema"]> {
 	// TODO: reconsider where this belongs. Consider error handling from schema changes.
 	const typedTree = React.useMemo<ISharedTreeView>(() => tree.schematize(config), [tree]);
 
@@ -39,8 +39,5 @@ export function useTree<TRoot extends GlobalFieldSchema>(
 		});
 	});
 
-	return typedTree.context.unwrappedRoot as unknown as SchemaAware.TypedField<
-		SchemaAware.ApiMode.Editable,
-		TRoot["schema"]
-	>;
+	return typedTree.context.root as unknown as SchemaAware.TypedField<TRoot["schema"]>;
 }


### PR DESCRIPTION
## Description

useTree incorrectly unwrapped the root.

TypedField incorrectly unwrapped itself.

useTree's tests did not mock useMemo and thus were failing. Why this did not break CI is not known: a TODO was added for this.

Make react-tree-api package not private as two separate projects (from the hackathon) had expressed interest in using it but couldn't.

Cleanup schema aware types a bit.

Export cursorForTypedTreeData which is quite useful for use with the current editable tree APIs.

## Breaking Changes

Several type changes were name to TypedField, including reversing its argument order to a default could be added.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

