### PR TITLE
build(devtools-browser-extension): Update extension manifest in preparation for publishing

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -7,7 +7,7 @@
 		"default_icon": "images/Icon.png",
 		"default_popup": "popup/popup.html"
 	},
-	"permissions": ["activeTab", "scripting", "storage"],
+	"permissions": ["activeTab", "scripting"],
 	"devtools_page": "devtools/devtools.html",
 	"background": {
 		"service_worker": "background/BackgroundScript.js"

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -2,6 +2,7 @@
 	"manifest_version": 3,
 	"name": "Fluid Framework Devtools",
 	"description": "Devtools extension for viewing live data about your Fluid application.",
+	"author": "Microsoft",
 	"version": "0.0.1",
 	"action": {
 		"default_icon": "images/Icon.png",

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Fluid Framework Devtools",
-	"description": "DevTools extension providing live Fluid Client debug data.",
+	"description": "Devtools extension for viewing live data about your Fluid application.",
 	"version": "0.1",
 	"action": {
 		"default_icon": "images/Icon.png",

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Fluid Framework Devtools",
 	"description": "Devtools extension for viewing live data about your Fluid application.",
-	"version": "0.1",
+	"version": "0.0.1",
 	"action": {
 		"default_icon": "images/Icon.png",
 		"default_popup": "popup/popup.html"


### PR DESCRIPTION
Makes the following changes:
* Reduces the version number to `0.0.1` to give us more flexibility prior to actually "releasing".
* Removes unnecessary permission to access browser storage
* Updates extension description
* Adds missing `author` property (set to `Microsoft`)