### PR TITLE
fix(tree): trunk undo-redo manager bug after summary load

### DIFF
--- a/experimental/dds/tree2/src/core/undo/undoRedoManager.ts
+++ b/experimental/dds/tree2/src/core/undo/undoRedoManager.ts
@@ -35,7 +35,7 @@ export class UndoRedoManager<TChange, TEditor extends ChangeFamilyEditor> {
 	}
 
 	private constructor(
-		public readonly repairDataStoreProvider: IRepairDataStoreProvider,
+		public repairDataStoreProvider: IRepairDataStoreProvider,
 		private readonly changeFamily: ChangeFamily<TEditor, TChange>,
 		private headUndoableCommit?: ReversibleCommit<TChange>,
 		private headRedoableCommit?: ReversibleCommit<TChange>,

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -396,8 +396,13 @@ export class EditManager<
 		);
 	}
 
+	/**
+	 * Needs to be called after a summary is loaded.
+	 * @remarks This is a temporary workaround until UndoRedoManager is better managed.
+	 */
 	public afterSummaryLoad(): void {
-		this.trunkUndoRedoManager = this.localBranchUndoRedoManager.clone();
+		this.trunkUndoRedoManager.repairDataStoreProvider =
+			this.localBranchUndoRedoManager.clone().repairDataStoreProvider;
 	}
 
 	public addSequencedChange(

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -402,7 +402,7 @@ export class EditManager<
 	 */
 	public afterSummaryLoad(): void {
 		this.trunkUndoRedoManager.repairDataStoreProvider =
-			this.localBranchUndoRedoManager.clone().repairDataStoreProvider;
+			this.localBranchUndoRedoManager.repairDataStoreProvider.clone();
 	}
 
 	public addSequencedChange(

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -76,7 +76,7 @@ export class EditManager<
 	private readonly sequenceMap = new BTree<SeqNumber, GraphCommit<TChangeset>>();
 
 	/** The {@link UndoRedoManager} associated with the trunk */
-	private readonly trunkUndoRedoManager: UndoRedoManager<TChangeset, TEditor>;
+	private trunkUndoRedoManager: UndoRedoManager<TChangeset, TEditor>;
 
 	/**
 	 * Branches are maintained to represent the local change list that the issuing client had
@@ -362,9 +362,6 @@ export class EditManager<
 		this.trunk.setHead(
 			data.trunk.reduce((base, c) => {
 				const commit = mintCommit(base, c);
-				this.trunkUndoRedoManager.repairDataStoreProvider.applyDelta(
-					this.changeFamily.intoDelta(commit.change),
-				);
 				this.sequenceMap.set(c.sequenceNumber, commit);
 				this.trunkMetadata.set(c.revision, {
 					sequenceNumber: c.sequenceNumber,
@@ -397,6 +394,10 @@ export class EditManager<
 		return getPathFromBase(this.localBranch.getHead(), this.trunk.getHead()).map(
 			(c) => c.change,
 		);
+	}
+
+	public afterSummaryLoad(): void {
+		this.trunkUndoRedoManager = this.localBranchUndoRedoManager.clone();
 	}
 
 	public addSequencedChange(

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -76,7 +76,7 @@ export class EditManager<
 	private readonly sequenceMap = new BTree<SeqNumber, GraphCommit<TChangeset>>();
 
 	/** The {@link UndoRedoManager} associated with the trunk */
-	private trunkUndoRedoManager: UndoRedoManager<TChangeset, TEditor>;
+	private readonly trunkUndoRedoManager: UndoRedoManager<TChangeset, TEditor>;
 
 	/**
 	 * Branches are maintained to represent the local change list that the issuing client had

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -238,6 +238,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		);
 
 		await Promise.all(loadSummaries);
+		// this.editManager.afterSummaryLoad();
 	}
 
 	/**

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -238,7 +238,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		);
 
 		await Promise.all(loadSummaries);
-		// this.editManager.afterSummaryLoad();
+		this.editManager.afterSummaryLoad();
 	}
 
 	/**


### PR DESCRIPTION
Fixes a bug where invalid changes were being applied to the forest maintained by the undo redo manager for the trunk.
The current fix is a bit kludgey. That code will be refactored away soon, the only reason we're pushing the fix before the refactor is to unblock @nmsimons  for demo purposes.