### PR TITLE
Pending blob entry not found for uploaded blob assert

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -470,9 +470,10 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 
 	private onUploadResolve(localId: string, response: ICreateBlobResponseWithTTL) {
 		const entry = this.pendingBlobs.get(localId);
+		assert(entry !== undefined, "pending blob entry not found for uploaded blob");
 		assert(
-			entry?.status === PendingBlobStatus.OnlinePendingUpload ||
-				entry?.status === PendingBlobStatus.OfflinePendingUpload,
+			entry.status === PendingBlobStatus.OnlinePendingUpload ||
+				entry.status === PendingBlobStatus.OfflinePendingUpload,
 			0x386 /* Must have pending blob entry for uploaded blob */,
 		);
 		entry.storageId = response.id;


### PR DESCRIPTION
Assert 0x386 is failing in test "not expired stashed blobs", which makes difficult to know if the test is failing due to the pending blob being in a forbidden status or it's not there at all. Just adding a different assert for debugging and clarity reasons.