### PR TITLE
Remove op reentry enforcement at the shared object level.

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -356,6 +356,7 @@ export interface IContainerRuntimeOptions {
     readonly chunkSizeInBytes?: number;
     readonly compressionOptions?: ICompressionRuntimeOptions;
     readonly enableGroupedBatching?: boolean;
+    // @deprecated
     readonly enableOpReentryCheck?: boolean;
     readonly enableRuntimeIdCompressor?: boolean;
     readonly flushMode?: FlushMode;

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -548,21 +548,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 	 * @returns `true` if the event had listeners, `false` otherwise.
 	 */
 	public emit(event: EventEmitterEventType, ...args: any[]): boolean {
-		return this.callbacksHelper.measure(() => {
-			// Creating ops while handling a DDS event can lead
-			// to undefined behavior and events observed in the wrong order.
-			// For example, we have two callbacks registered for a DDS, A and B.
-			// Then if on change #1 callback A creates change #2, the invocation flow will be:
-			//
-			// A because of #1
-			// A because of #2
-			// B because of #2
-			// B because of #1
-			//
-			// The runtime must enforce op coherence by not allowing any ops to be created during
-			// the event handler
-			return this.runtime.ensureNoDataModelChanges(() => super.emit(event, ...args));
-		});
+		return this.callbacksHelper.measure(() => super.emit(event, ...args));
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -267,34 +267,7 @@ describe("Runtime", () => {
 		describe("Op reentry enforcement", () => {
 			let containerRuntime: ContainerRuntime;
 
-			it("By default, don't enforce the op reentry check", async () => {
-				containerRuntime = await ContainerRuntime.load(
-					getMockContext() as IContainerContext,
-					[],
-					undefined, // requestHandler
-					{}, // runtimeOptions
-				);
-
-				assert.ok(
-					containerRuntime.ensureNoDataModelChanges(() => {
-						containerRuntime.submitDataStoreOp("id", "test");
-						return true;
-					}),
-				);
-
-				assert.ok(
-					containerRuntime.ensureNoDataModelChanges(() =>
-						containerRuntime.ensureNoDataModelChanges(() =>
-							containerRuntime.ensureNoDataModelChanges(() => {
-								containerRuntime.submitDataStoreOp("id", "test");
-								return true;
-							}),
-						),
-					),
-				);
-			});
-
-			it("If option enabled, enforce the op reentry check", async () => {
+			it("Enforce the op reentry check", async () => {
 				containerRuntime = await ContainerRuntime.load(
 					getMockContext() as IContainerContext,
 					[],
@@ -316,31 +289,6 @@ describe("Runtime", () => {
 							containerRuntime.ensureNoDataModelChanges(() =>
 								containerRuntime.submitDataStoreOp("id", "test"),
 							),
-						),
-					),
-				);
-			});
-
-			it("If option enabled but disabled via feature gate, don't enforce the op reentry check", async () => {
-				containerRuntime = await ContainerRuntime.load(
-					getMockContext({
-						"Fluid.ContainerRuntime.DisableOpReentryCheck": true,
-					}) as IContainerContext,
-					[],
-					undefined, // requestHandler
-					{
-						enableOpReentryCheck: true,
-					}, // runtimeOptions
-				);
-
-				containerRuntime.ensureNoDataModelChanges(() =>
-					containerRuntime.submitDataStoreOp("id", "test"),
-				);
-
-				containerRuntime.ensureNoDataModelChanges(() =>
-					containerRuntime.ensureNoDataModelChanges(() =>
-						containerRuntime.ensureNoDataModelChanges(() =>
-							containerRuntime.submitDataStoreOp("id", "test"),
 						),
 					),
 				);

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1011,6 +1011,7 @@ describe("Runtime", () => {
 				maxBatchSizeInBytes: 700 * 1024,
 				chunkSizeInBytes: 204800,
 				enableRuntimeIdCompressor: false,
+				enableOpReentryCheck: true,
 				enableGroupedBatching: false,
 			};
 			const mergedRuntimeOptions = { ...defaultRuntimeOptions, ...runtimeOptions };
@@ -1037,7 +1038,6 @@ describe("Runtime", () => {
 				const featureGates = {
 					"Fluid.ContainerRuntime.CompressionDisabled": true,
 					"Fluid.ContainerRuntime.CompressionChunkingDisabled": true,
-					"Fluid.ContainerRuntime.DisableOpReentryCheck": false,
 					"Fluid.ContainerRuntime.IdCompressorEnabled": true,
 				};
 				await ContainerRuntime.loadRuntime({
@@ -1054,7 +1054,6 @@ describe("Runtime", () => {
 						options: JSON.stringify(mergedRuntimeOptions),
 						featureGates: JSON.stringify({
 							disableCompression: true,
-							disableOpReentryCheck: false,
 							disableChunking: true,
 							idCompressorEnabled: true,
 						}),

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -272,9 +272,6 @@ describe("Runtime", () => {
 					getMockContext() as IContainerContext,
 					[],
 					undefined, // requestHandler
-					{
-						enableOpReentryCheck: true,
-					}, // runtimeOptions
 				);
 
 				assert.throws(() =>
@@ -291,31 +288,6 @@ describe("Runtime", () => {
 							),
 						),
 					),
-				);
-			});
-
-			it("Report at most 5 reentrant ops", async () => {
-				const mockLogger = new MockLogger();
-				containerRuntime = await ContainerRuntime.load(
-					getMockContext({}, mockLogger) as IContainerContext,
-					[],
-					undefined, // requestHandler
-					{}, // runtimeOptions
-				);
-
-				mockLogger.clear();
-				containerRuntime.ensureNoDataModelChanges(() => {
-					for (let i = 0; i < 10; i++) {
-						containerRuntime.submitDataStoreOp("id", "test");
-					}
-				});
-
-				// We expect only 5 events
-				mockLogger.assertMatchStrict(
-					Array.from(Array(5).keys()).map(() => ({
-						eventName: "ContainerRuntime:OpReentry",
-						error: "Op was submitted from within a `ensureNoDataModelChanges` callback",
-					})),
 				);
 			});
 		});
@@ -1039,7 +1011,6 @@ describe("Runtime", () => {
 				maxBatchSizeInBytes: 700 * 1024,
 				chunkSizeInBytes: 204800,
 				enableRuntimeIdCompressor: false,
-				enableOpReentryCheck: false,
 				enableGroupedBatching: false,
 			};
 			const mergedRuntimeOptions = { ...defaultRuntimeOptions, ...runtimeOptions };

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -82,8 +82,6 @@ export interface IFluidDataStoreRuntime
 	 * Invokes the given callback and expects that no ops are submitted
 	 * until execution finishes. If an op is submitted, an error will be raised.
 	 *
-	 * Can be disabled by feature gate `Fluid.ContainerRuntime.DisableOpReentryCheck`
-	 *
 	 * @param callback - the callback to be invoked
 	 */
 	ensureNoDataModelChanges<T>(callback: () => T): T;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -221,15 +221,10 @@ export class FluidDataStoreRuntime
 	 * Invokes the given callback and expects that no ops are submitted
 	 * until execution finishes. If an op is submitted, an error will be raised.
 	 *
-	 * Can be disabled by feature gate `Fluid.ContainerRuntime.DisableOpReentryCheck`
-	 *
 	 * @param callback - the callback to be invoked
 	 */
 	public ensureNoDataModelChanges<T>(callback: () => T): T {
-		// back-compat ADO:2309
-		return this.dataStoreContext.ensureNoDataModelChanges === undefined
-			? callback()
-			: this.dataStoreContext.ensureNoDataModelChanges(callback);
+		return this.dataStoreContext.ensureNoDataModelChanges(callback);
 	}
 
 	/**

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -410,8 +410,6 @@ export interface IFluidDataStoreContext
 	 * Invokes the given callback and expects that no ops are submitted
 	 * until execution finishes. If an op is submitted, an error will be raised.
 	 *
-	 * Can be disabled by feature gate `Fluid.ContainerRuntime.DisableOpReentryCheck`
-	 *
 	 * @param callback - the callback to be invoked
 	 */
 	ensureNoDataModelChanges<T>(callback: () => T): T;

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -96,7 +96,7 @@ export function generateRuntimeOptions(
 			{ minimumBatchSizeInBytes: 500, compressionAlgorithm: CompressionAlgorithms.lz4 },
 		],
 		maxBatchSizeInBytes: [716800],
-		enableOpReentryCheck: [true],
+		enableOpReentryCheck: [undefined],
 		// Compressed payloads exceeding this size will be chunked into messages of exactly this size
 		chunkSizeInBytes: [204800],
 		enableRuntimeIdCompressor: [undefined, true],


### PR DESCRIPTION
## Description

The `ensureNoDataModelChanges` API will stay at least for now. Nobody will actually be using it after this PR is merged. If someone is going to be using it, it will throw an exception regardless of feature gates or options.