### PR TITLE
Remove root lerna.json

### DIFF
--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -142,6 +142,9 @@ export class MonoRepo {
 			if (this._packageJson.workspaces instanceof Array) {
 				this.workspaceGlobs = this._packageJson.workspaces;
 			} else {
+				// TODO: make this not crash when using pnpm without lerna.
+				// Maybe restore logic from https://github.com/microsoft/FluidFramework/commit/2f162b61705aa6395298a7adb32c86f4e5590d78 ?
+				// There seems to be only one use of `this.workspaceGlobs` (npmCheckUpdates): maybe it can be removed?
 				this.workspaceGlobs = (this._packageJson.workspaces as any).packages;
 			}
 		}

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,0 @@
-{
-	"version": "2.0.0-internal.4.4.0",
-	"npmClient": "pnpm",
-	"useWorkspaces": true
-}


### PR DESCRIPTION
## Description

Remove lerna.json for the client release group.
This release group no longer uses lerna, so this file should be unneeded.

TODO: update build tools before merging this so version bump still works.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
