### PR TITLE
Fixed incrementalSummaryViolation error logged due to GC state updated DS count reset

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2791,8 +2791,7 @@ export class ContainerRuntime
 			const summaryStats: IGeneratedSummaryStats = {
 				dataStoreCount: this.dataStores.size,
 				summarizedDataStoreCount: this.dataStores.size - handleCount,
-				gcStateUpdatedDataStoreCount:
-					this.garbageCollector.stateUpdatedDSCountSinceLastSummary,
+				gcStateUpdatedDataStoreCount: this.garbageCollector.updatedDSCountSinceLastSummary,
 				gcBlobNodeCount: gcSummaryTreeStats?.blobNodeCount,
 				gcTotalBlobsSize: gcSummaryTreeStats?.totalBlobSize,
 				summaryNumber,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2791,7 +2791,8 @@ export class ContainerRuntime
 			const summaryStats: IGeneratedSummaryStats = {
 				dataStoreCount: this.dataStores.size,
 				summarizedDataStoreCount: this.dataStores.size - handleCount,
-				gcStateUpdatedDataStoreCount: summarizeResult.gcStats?.updatedDataStoreCount,
+				gcStateUpdatedDataStoreCount:
+					this.garbageCollector.stateUpdatedDSCountSinceLastSummary,
 				gcBlobNodeCount: gcSummaryTreeStats?.blobNodeCount,
 				gcTotalBlobsSize: gcSummaryTreeStats?.totalBlobSize,
 				summaryNumber,

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -122,8 +122,8 @@ export class GarbageCollector implements IGarbageCollector {
 	}
 
 	/** Returns the count of data stores whose GC state updated since the last summary. */
-	public get stateUpdatedDSCountSinceLastSummary(): number {
-		return this.summaryStateTracker.stateUpdatedDSCountSinceLastSummary;
+	public get updatedDSCountSinceLastSummary(): number {
+		return this.summaryStateTracker.updatedDSCountSinceLastSummary;
 	}
 
 	protected constructor(createParams: IGarbageCollectorCreateParams) {
@@ -510,9 +510,8 @@ export class GarbageCollector implements IGarbageCollector {
 				// updates its state so that we don't send false positives based on intermediate state. For example, we may get
 				// reference to an unreferenced node from another unreferenced node which means the node wasn't revived.
 				await this.telemetryTracker.logPendingEvents(logger);
-				// Update the count of data stores whose state changed in this GC run. This is used by the runtime to validate
-				// that data stores are summarizer incrementally.
-				this.summaryStateTracker.updateStateUpdatedDSCount(gcStats.updatedDataStoreCount);
+				// Update the state of summary state tracker from this run's stats.
+				this.summaryStateTracker.updateStateFromGCRunStats(gcStats);
 				this.newReferencesSinceLastRun.clear();
 				this.completedRuns++;
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -121,6 +121,11 @@ export class GarbageCollector implements IGarbageCollector {
 		return this.summaryStateTracker.doesSummaryStateNeedReset;
 	}
 
+	/** Returns the count of data stores whose GC state updated since the last summary. */
+	public get stateUpdatedDSCountSinceLastSummary(): number {
+		return this.summaryStateTracker.stateUpdatedDSCountSinceLastSummary;
+	}
+
 	protected constructor(createParams: IGarbageCollectorCreateParams) {
 		this.runtime = createParams.runtime;
 		this.isSummarizerClient = createParams.isSummarizerClient;
@@ -505,6 +510,9 @@ export class GarbageCollector implements IGarbageCollector {
 				// updates its state so that we don't send false positives based on intermediate state. For example, we may get
 				// reference to an unreferenced node from another unreferenced node which means the node wasn't revived.
 				await this.telemetryTracker.logPendingEvents(logger);
+				// Update the count of data stores whose state changed in this GC run. This is used by the runtime to validate
+				// that data stores are summarizer incrementally.
+				this.summaryStateTracker.updateStateUpdatedDSCount(gcStats.updatedDataStoreCount);
 				this.newReferencesSinceLastRun.clear();
 				this.completedRuns++;
 

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -205,7 +205,7 @@ export interface IGarbageCollector {
 	/** Tells whether the GC state in summary needs to be reset in the next summary. */
 	readonly summaryStateNeedsReset: boolean;
 	/** The count of data stores whose GC state updated since the last summary. */
-	readonly stateUpdatedDSCountSinceLastSummary: number;
+	readonly updatedDSCountSinceLastSummary: number;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -204,6 +204,8 @@ export interface IGarbageCollector {
 	readonly shouldRunGC: boolean;
 	/** Tells whether the GC state in summary needs to be reset in the next summary. */
 	readonly summaryStateNeedsReset: boolean;
+	/** The count of data stores whose GC state updated since the last summary. */
+	readonly stateUpdatedDSCountSinceLastSummary: number;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { mergeStats, ReadAndParseBlob, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { IContainerRuntimeMetadata, metadataBlobName, RefreshSummaryResult } from "../summary";
-import { GCVersion } from "./gcDefinitions";
+import { GCVersion, IGCStats } from "./gcDefinitions";
 import { getGCDataFromSnapshot, generateSortedGCState, getGCVersion } from "./gcHelpers";
 import { IGarbageCollectionSnapshotData, IGarbageCollectionState } from "./gcSummaryDefinitions";
 import { IGarbageCollectorConfigs } from ".";
@@ -52,7 +52,7 @@ export class GCSummaryStateTracker {
 
 	// Tracks the count of data stores whose state updated since the last summary, i.e., they went from referenced
 	// to unreferenced or vice-versa.
-	public stateUpdatedDSCountSinceLastSummary: number = 0;
+	public updatedDSCountSinceLastSummary: number = 0;
 
 	constructor(
 		// Tells whether GC should run or not.
@@ -290,7 +290,7 @@ export class GCSummaryStateTracker {
 			this.latestSummaryGCVersion = this.currentGCVersion;
 			this.latestSummaryData = this.pendingSummaryData;
 			this.pendingSummaryData = undefined;
-			this.stateUpdatedDSCountSinceLastSummary = 0;
+			this.updatedDSCountSinceLastSummary = 0;
 			return undefined;
 		}
 
@@ -333,9 +333,9 @@ export class GCSummaryStateTracker {
 	}
 
 	/**
-	 * Called to update the stats of a GC run. Used to update the count of data stores whose state updated.
+	 * Called to update the state from a GC run's stats. Used to update the count of data stores whose state updated.
 	 */
-	public updateStateUpdatedDSCount(stateUpdatedDataStoreCount: number) {
-		this.stateUpdatedDSCountSinceLastSummary += stateUpdatedDataStoreCount;
+	public updateStateFromGCRunStats(stats: IGCStats) {
+		this.updatedDSCountSinceLastSummary += stats.updatedDataStoreCount;
 	}
 }

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -50,6 +50,10 @@ export class GCSummaryStateTracker {
 	// Tracks whether there was GC was run in latest summary being tracked.
 	private wasGCRunInLatestSummary: boolean;
 
+	// Tracks the count of data stores whose state updated since the last summary, i.e., they went from referenced
+	// to unreferenced or vice-versa.
+	public stateUpdatedDSCountSinceLastSummary: number = 0;
+
 	constructor(
 		// Tells whether GC should run or not.
 		private readonly configs: Pick<
@@ -286,6 +290,7 @@ export class GCSummaryStateTracker {
 			this.latestSummaryGCVersion = this.currentGCVersion;
 			this.latestSummaryData = this.pendingSummaryData;
 			this.pendingSummaryData = undefined;
+			this.stateUpdatedDSCountSinceLastSummary = 0;
 			return undefined;
 		}
 
@@ -325,5 +330,12 @@ export class GCSummaryStateTracker {
 			serializedDeletedNodes: JSON.stringify(snapshotData.deletedNodes),
 		};
 		return snapshotData;
+	}
+
+	/**
+	 * Called to update the stats of a GC run. Used to update the count of data stores whose state updated.
+	 */
+	public updateStateUpdatedDSCount(stateUpdatedDataStoreCount: number) {
+		this.stateUpdatedDSCountSinceLastSummary += stateUpdatedDataStoreCount;
 	}
 }

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -61,6 +61,12 @@ export const configProvider = (settings: Record<string, ConfigTypes>): IConfigPr
 	getRawConfig: (name: string): ConfigTypes => settings[name],
 });
 
+export const parseNothing: ReadAndParseBlob = async <T>() => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	const x: T = {} as T;
+	return x;
+};
+
 type GcWithPrivates = IGarbageCollector & {
 	readonly configs: IGarbageCollectorConfigs;
 	readonly summaryStateTracker: Omit<
@@ -100,12 +106,6 @@ describe("Garbage Collection Tests", () => {
 			blobs: {},
 			trees: {},
 		};
-	};
-
-	const parseNothing: ReadAndParseBlob = async <T>() => {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-		const x: T = {} as T;
-		return x;
 	};
 
 	function createGarbageCollector(

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -13,208 +13,269 @@ import {
 	GCVersion,
 	IGarbageCollectionState,
 } from "../../gc";
+import { RefreshSummaryResult } from "../../summary";
+import { parseNothing } from "./garbageCollection.spec";
 
 type GCSummaryStateTrackerWithPrivates = Omit<GCSummaryStateTracker, "latestSummaryGCVersion"> & {
 	latestSummaryGCVersion: GCVersion;
 };
 
-describe("Garbage Collection Tests", () => {
-	describe("GCSummaryStateTracker", () => {
-		describe("latestSummaryGCVersion", () => {
-			it("Persisted < Current: Do Need Reset", () => {
-				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
-					{
-						shouldRunGC: true,
-						tombstoneMode: false,
-						gcVersionInBaseSnapshot: 0,
-						gcVersionInEffect: 1,
-					},
-					true /* wasGCRunInBaseSnapshot */,
-				) as any;
-				assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
-				assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
-				assert.equal(
-					tracker.doesSummaryStateNeedReset,
-					true,
-					"Should need reset: Persisted GC Version was old",
-				);
-			});
+describe("GCSummaryStateTracker tests", () => {
+	describe("latestSummaryGCVersion", () => {
+		it("Persisted < Current: Do Need Reset", () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: true,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 0,
+					gcVersionInEffect: 1,
+				},
+				true /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
+			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
+			assert.equal(
+				tracker.doesSummaryStateNeedReset,
+				true,
+				"Should need reset: Persisted GC Version was old",
+			);
+		});
 
-			it("Persisted === Current: Don't Need Reset", () => {
-				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
-					{
-						shouldRunGC: true,
-						tombstoneMode: false,
-						gcVersionInBaseSnapshot: 1,
-						gcVersionInEffect: 1,
-					},
-					true /* wasGCRunInBaseSnapshot */,
-				) as any;
-				assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
-				assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
-				assert.equal(
-					tracker.doesSummaryStateNeedReset,
-					false,
-					"Shouldn't need reset: GC Versions match",
-				);
-			});
+		it("Persisted === Current: Don't Need Reset", () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: true,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 1,
+					gcVersionInEffect: 1,
+				},
+				true /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
+			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
+			assert.equal(
+				tracker.doesSummaryStateNeedReset,
+				false,
+				"Shouldn't need reset: GC Versions match",
+			);
+		});
 
-			it("Persisted > Current: Do Need Reset", () => {
-				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
-					{
-						shouldRunGC: true,
-						tombstoneMode: false,
-						gcVersionInBaseSnapshot: 2,
-						gcVersionInEffect: 1,
-					},
-					true /* wasGCRunInBaseSnapshot */,
-				) as any;
-				assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
-				assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
+		it("Persisted > Current: Do Need Reset", () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: true,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 2,
+					gcVersionInEffect: 1,
+				},
+				true /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
+			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
 
-				// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset) shouldn't need to do it again.
-				assert.equal(
-					tracker.doesSummaryStateNeedReset,
-					true,
-					"Should need reset: Persisted GC Version is not old",
-				);
+			// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset) shouldn't need to do it again.
+			assert.equal(
+				tracker.doesSummaryStateNeedReset,
+				true,
+				"Should need reset: Persisted GC Version is not old",
+			);
+		});
+	});
+
+	/**
+	 * These tests validate that the GC data is written in summary incrementally. Basically, only parts of the GC
+	 * data that has changed since the last successful summary is re-written, rest is written as SummaryHandle.
+	 */
+	describe("Incremental summary of GC data", () => {
+		const nodes = ["node1", "node2", "node3"];
+		const initialGCState: IGarbageCollectionState = {
+			gcNodes: {
+				"/": { outboundRoutes: [] },
+				[nodes[0]]: { outboundRoutes: [] },
+				[nodes[1]]: { outboundRoutes: [] },
+			},
+		};
+		const initialTombstones: string[] = [nodes[0], nodes[1]];
+		const initialDeletedNodes: Set<string> = new Set([nodes[1]]);
+		let summaryStateTracker: GCSummaryStateTracker;
+
+		beforeEach(async () => {
+			// Creates a summary state tracker and initialize it.
+			summaryStateTracker = new GCSummaryStateTracker(
+				{
+					shouldRunGC: true,
+					tombstoneMode: true,
+					gcVersionInBaseSnapshot: currentGCVersion,
+					gcVersionInEffect: currentGCVersion,
+				},
+				false /* wasGCRunInBaseSnapshot */,
+			);
+
+			summaryStateTracker.initializeBaseState({
+				gcState: initialGCState,
+				tombstones: initialTombstones,
+				deletedNodes: Array.from(initialDeletedNodes),
 			});
 		});
 
-		/**
-		 * These tests validate that the GC data is written in summary incrementally. Basically, only parts of the GC
-		 * data that has changed since the last successful summary is re-written, rest is written as SummaryHandle.
-		 */
-		describe("Incremental summary of GC data", () => {
-			const nodes = ["node1", "node2", "node3"];
-			const initialGCState: IGarbageCollectionState = {
+		it("does incremental summary when nothing changes", async () => {
+			// Summarize with the same GC state, tombstone state and deleted nodes as in the initial state.
+			// The GC data should be summarized as a summary handle.
+			const summary = summaryStateTracker.summarize(
+				false /* fullTree */,
+				true /* trackState */,
+				initialGCState,
+				initialDeletedNodes,
+				initialTombstones,
+			);
+			assert(summary?.summary.type === SummaryType.Handle, "GC summary should be a handle");
+		});
+
+		it("does incremental summary when only GC state changes", async () => {
+			// Summarize with the same tombstone state and deleted nodes but different GC state as in the initial.
+			// state. The GC state should be summarized as a summary handle.
+			const newGCState: IGarbageCollectionState = {
 				gcNodes: {
-					"/": { outboundRoutes: [] },
-					[nodes[0]]: { outboundRoutes: [] },
-					[nodes[1]]: { outboundRoutes: [] },
+					...initialGCState.gcNodes,
+					[nodes[2]]: { outboundRoutes: [] },
 				},
 			};
-			const initialTombstones: string[] = [nodes[0], nodes[1]];
-			const initialDeletedNodes: Set<string> = new Set([nodes[1]]);
-			let summaryStateTracker: GCSummaryStateTracker;
-
-			beforeEach(async () => {
-				// Creates a summary state tracker and initialize it.
-				summaryStateTracker = new GCSummaryStateTracker(
-					{
-						shouldRunGC: true,
-						tombstoneMode: true,
-						gcVersionInBaseSnapshot: currentGCVersion,
-						gcVersionInEffect: currentGCVersion,
-					},
-					false,
-				);
-
-				summaryStateTracker.initializeBaseState({
-					gcState: initialGCState,
-					tombstones: initialTombstones,
-					deletedNodes: Array.from(initialDeletedNodes),
-				});
-			});
-
-			it("does incremental summary when nothing changes", async () => {
-				// Summarize with the same GC state, tombstone state and deleted nodes as in the initial state.
-				// The GC data should be summarized as a summary handle.
-				const summary = summaryStateTracker.summarize(
-					false /* fullTree */,
-					true /* trackState */,
-					initialGCState,
-					initialDeletedNodes,
-					initialTombstones,
-				);
-				assert(
-					summary?.summary.type === SummaryType.Handle,
-					"GC summary should be a handle",
-				);
-			});
-
-			it("does incremental summary when only GC state changes", async () => {
-				// Summarize with the same tombstone state and deleted nodes but different GC state as in the initial.
-				// state. The GC state should be summarized as a summary handle.
-				const newGCState: IGarbageCollectionState = {
-					gcNodes: {
-						...initialGCState.gcNodes,
-						[nodes[2]]: { outboundRoutes: [] },
-					},
-				};
-				const summary = summaryStateTracker.summarize(
-					false /* fullTree */,
-					true /* trackState */,
-					newGCState,
-					initialDeletedNodes,
-					initialTombstones,
-				);
-				assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
-				assert(
-					summary.summary.tree[gcStateBlobKey].type === SummaryType.Blob,
-					"GC state should be written as a blob",
-				);
-				assert(
-					summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Handle,
-					"Tombstone state should be written as handle",
-				);
-				assert(
-					summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Handle,
-					"Deleted nodes should be written as handle",
-				);
-			});
-
-			it("does incremental summary when only tombstone state changes", async () => {
-				// Summarize with the same GC state and deleted nodes but different tombstone state as in the initial.
-				// state. The tombstone state should be summarized as a summary handle.
-				const newTombstones: string[] = Array.from([...initialTombstones, nodes[2]]);
-				const summary = summaryStateTracker.summarize(
-					false /* fullTree */,
-					true /* trackState */,
-					initialGCState,
-					initialDeletedNodes,
-					newTombstones,
-				);
-				assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
-				assert(
-					summary.summary.tree[gcStateBlobKey].type === SummaryType.Handle,
-					"GC state should be written as handle",
-				);
-				assert(
-					summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Blob,
-					"Tombstone state should be written as a blob",
-				);
-				assert(
-					summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Handle,
-					"Deleted nodes should be written as handle",
-				);
-			});
-
-			it("does incremental summary when only deleted nodes change", async () => {
-				// Summarize with the same GC state and tombstone state but different deleted nodes as in the initial.
-				// state. The deleted nodes should be summarized as a summary handle.
-				const newDeletedNodes: Set<string> = new Set(...initialDeletedNodes, nodes[2]);
-				const summary = summaryStateTracker.summarize(
-					false /* fullTree */,
-					true /* trackState */,
-					initialGCState,
-					newDeletedNodes,
-					initialTombstones,
-				);
-				assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
-				assert(
-					summary.summary.tree[gcStateBlobKey].type === SummaryType.Handle,
-					"GC state should be written as handle",
-				);
-				assert(
-					summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Handle,
-					"Tombstone state should be written as handle",
-				);
-				assert(
-					summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Blob,
-					"Deleted nodes should be written as a blob",
-				);
-			});
+			const summary = summaryStateTracker.summarize(
+				false /* fullTree */,
+				true /* trackState */,
+				newGCState,
+				initialDeletedNodes,
+				initialTombstones,
+			);
+			assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
+			assert(
+				summary.summary.tree[gcStateBlobKey].type === SummaryType.Blob,
+				"GC state should be written as a blob",
+			);
+			assert(
+				summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Handle,
+				"Tombstone state should be written as handle",
+			);
+			assert(
+				summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Handle,
+				"Deleted nodes should be written as handle",
+			);
 		});
+
+		it("does incremental summary when only tombstone state changes", async () => {
+			// Summarize with the same GC state and deleted nodes but different tombstone state as in the initial.
+			// state. The tombstone state should be summarized as a summary handle.
+			const newTombstones: string[] = Array.from([...initialTombstones, nodes[2]]);
+			const summary = summaryStateTracker.summarize(
+				false /* fullTree */,
+				true /* trackState */,
+				initialGCState,
+				initialDeletedNodes,
+				newTombstones,
+			);
+			assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
+			assert(
+				summary.summary.tree[gcStateBlobKey].type === SummaryType.Handle,
+				"GC state should be written as handle",
+			);
+			assert(
+				summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Blob,
+				"Tombstone state should be written as a blob",
+			);
+			assert(
+				summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Handle,
+				"Deleted nodes should be written as handle",
+			);
+		});
+
+		it("does incremental summary when only deleted nodes change", async () => {
+			// Summarize with the same GC state and tombstone state but different deleted nodes as in the initial.
+			// state. The deleted nodes should be summarized as a summary handle.
+			const newDeletedNodes: Set<string> = new Set(...initialDeletedNodes, nodes[2]);
+			const summary = summaryStateTracker.summarize(
+				false /* fullTree */,
+				true /* trackState */,
+				initialGCState,
+				newDeletedNodes,
+				initialTombstones,
+			);
+			assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
+			assert(
+				summary.summary.tree[gcStateBlobKey].type === SummaryType.Handle,
+				"GC state should be written as handle",
+			);
+			assert(
+				summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Handle,
+				"Tombstone state should be written as handle",
+			);
+			assert(
+				summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Blob,
+				"Deleted nodes should be written as a blob",
+			);
+		});
+	});
+
+	it("updates state updated data store count correctly", async () => {
+		const summaryStateTracker = new GCSummaryStateTracker(
+			{
+				shouldRunGC: true,
+				tombstoneMode: true,
+				gcVersionInBaseSnapshot: currentGCVersion,
+				gcVersionInEffect: currentGCVersion,
+			},
+			false /* wasGCRunInBaseSnapshot */,
+		);
+
+		// Update the count of data stores whose state updated. This happens when GC runs.
+		summaryStateTracker.updateStateUpdatedDSCount(10);
+		// Validate that the count is 10.
+		assert.strictEqual(
+			summaryStateTracker.stateUpdatedDSCountSinceLastSummary,
+			10,
+			"Updated DS count is not correct",
+		);
+
+		// Call summarize. This happens after GC runs.
+		summaryStateTracker.summarize(
+			false /* fullTree */,
+			true /* trackState */,
+			{ gcNodes: {} },
+			new Set(),
+			[],
+		);
+
+		// Update the count again and validate that the count is aggregate of previous and this count.
+		summaryStateTracker.updateStateUpdatedDSCount(10);
+		assert.strictEqual(
+			summaryStateTracker.stateUpdatedDSCountSinceLastSummary,
+			20,
+			"Updated DS count should be aggregated",
+		);
+
+		// Call summarize again. This happens after GC runs.
+		summaryStateTracker.summarize(
+			false /* fullTree */,
+			true /* trackState */,
+			{ gcNodes: {} },
+			new Set(),
+			[],
+		);
+
+		// Refresh latest summary and validate that the count is reset.
+		const refreshSummaryResult: RefreshSummaryResult = {
+			latestSummaryUpdated: true,
+			wasSummaryTracked: true,
+			summaryRefSeq: 0,
+		};
+		await summaryStateTracker.refreshLatestSummary(
+			undefined /* proposalHandle */,
+			refreshSummaryResult,
+			parseNothing,
+		);
+		assert.strictEqual(
+			summaryStateTracker.stateUpdatedDSCountSinceLastSummary,
+			0,
+			"Updated DS count should be reset after refresh latest summary",
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -5,9 +5,10 @@
 
 import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
-import { ISummarizer } from "@fluidframework/container-runtime";
+import { ContainerRuntime, ISummarizer } from "@fluidframework/container-runtime";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import {
 	ITestObjectProvider,
 	createSummarizer,
@@ -17,6 +18,7 @@ import {
 import {
 	describeNoCompat,
 	ITestDataObject,
+	itExpects,
 	TestDataObjectType,
 } from "@fluid-internal/test-version-utils";
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
@@ -218,4 +220,70 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 		dataStoreSummaryTypesMap.set(dataStoreB._context.id, SummaryType.Handle);
 		await validateIncrementalSummary(summarizer3, dataStoreSummaryTypesMap);
 	});
+
+	itExpects.only(
+		"does not log incrementalSummaryViolation when summary fails with gc state updated data stores",
+		[
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				error: "Summary failed simulation",
+			},
+		],
+		async () => {
+			const mockLogger = new MockLogger();
+			const { summarizer: summarizer1 } = await createSummarizer(
+				provider,
+				mainContainer,
+				undefined /* summaryVersion */,
+				undefined /* gcOptions */,
+				undefined /* configProvider */,
+				mockLogger,
+			);
+
+			// Create data stores B and C, and mark them as referenced.
+			const dataStoreB = await requestFluidObject<ITestDataObject>(
+				await dataStoreA._context.containerRuntime.createDataStore(TestDataObjectType),
+				"",
+			);
+			dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+			for (let i = 1; i < 10; i++) {
+				const newDataStore = await requestFluidObject<ITestDataObject>(
+					await dataStoreA._context.containerRuntime.createDataStore(TestDataObjectType),
+					"",
+				);
+				dataStoreB._root.set(`dataStoreB-${i}`, newDataStore.handle);
+			}
+			await provider.ensureSynchronized();
+			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed");
+
+			const containerRuntime = (summarizer1 as any).runtime as ContainerRuntime;
+			const uploadSummaryWithContextFunc = containerRuntime.storage.uploadSummaryWithContext;
+			const uploadSummaryWithContextOverride = async () => {
+				throw new Error("Summary failed simulation");
+			};
+			containerRuntime.storage.uploadSummaryWithContext = uploadSummaryWithContextOverride;
+
+			dataStoreA._root.delete("dataStoreB");
+			await provider.ensureSynchronized();
+			const errorFn = (error: Error): boolean => {
+				assert.strictEqual(
+					error.message,
+					"Summary failed simulation",
+					"unexpected summary failures",
+				);
+				return true;
+			};
+			await assert.rejects(
+				summarizeNow(summarizer1),
+				errorFn,
+				"Summarize should have failed",
+			);
+			mockLogger.assertMatchNone([{ eventName: "IncrementalSummaryViolation" }]);
+			containerRuntime.storage.uploadSummaryWithContext = uploadSummaryWithContextFunc;
+
+			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed");
+			mockLogger.assertMatchNone([{ eventName: "IncrementalSummaryViolation" }]);
+		},
+	);
 });

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -168,7 +168,9 @@ export async function summarizeNow(summarizer: ISummarizer, reason: string = "en
 	const result = summarizer.summarizeOnDemand({ reason });
 
 	const submitResult = await timeoutAwait(result.summarySubmitted);
-	assert(submitResult.success, "on-demand summary should submit");
+	if (!submitResult.success) {
+		throw submitResult.error;
+	}
 	assert(
 		submitResult.data.stage === "submit",
 		"on-demand summary submitted data stage should be submit",
@@ -176,10 +178,14 @@ export async function summarizeNow(summarizer: ISummarizer, reason: string = "en
 	assert(submitResult.data.summaryTree !== undefined, "summary tree should exist");
 
 	const broadcastResult = await timeoutAwait(result.summaryOpBroadcasted);
-	assert(broadcastResult.success, "summary op should be broadcast");
+	if (!broadcastResult.success) {
+		throw broadcastResult.error;
+	}
 
 	const ackNackResult = await timeoutAwait(result.receivedSummaryAckOrNack);
-	assert(ackNackResult.success, "summary op should be acked");
+	if (!ackNackResult.success) {
+		throw ackNackResult.error;
+	}
 
 	await new Promise((resolve) => process.nextTick(resolve));
 


### PR DESCRIPTION
## Bug
This error is logged when the number of datas store summarized in a summary is greater than ops since last summary + number of data stores whose GC state updated.
Basically, `summarizedDataStoreCount <= opsSinceLastSummary + gcStateUpdatedDataStoreCount`.

GC updates its state on every GC run / summarize, i.e, `gcStateUpdatedDataStoreCount` will be reset when GC ran and then the summary failed.
Whereas, `summarizedDataStoreCount` and `opsSinceLastSummary` are updated on every successful summary, i.e., when a summary is ack'd.
So, when a summary fails, GC has already updated its state whereas the other two states are not updated. So, we may see this error logged in the next summary if `gcStateUpdatedDataStoreCount` is non-zero.

## Fix
The fix is that GC tracks `gcStateUpdatedDataStoreCount` across successful summaries and exposes it in the `IGarbageCollector` interface. This is okay because the interace is internal (not public).

## Alternatives considered
- Another approach was to add a new property to `IGCStats` called `gcStateUpdatedDataStoreCountSinceLastSummary` and use that. But that would make the stats inconsistent - Currently, they all indicate stats between GC runs (and not successful summary runs). It also makes this a breaking change because `IGCStats` is public (this isn't a big deal but contributed to the decision).
- I also considered fixing this in `SummaryGenerator` by tracking the count across summary attempts. So, on failure, it would cache the count and use it in the next attempt. But, the problem is attemps are managed by `RunningSummarizer` and so, it would have to track that which would make the code very complicated. Moreover, GC code seems like the right place for this.

Note: With this change, `IRootSummaryTreeWithStats` is no longer required. I didn't change that in this PR because it's a breaking change - [AB#4421](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4421)

[AB#4260](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4260)