### PR TITLE
Update blobs cache when getting a whole snapshot in the wholeSummaryDocumentStorageService

### DIFF
--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -196,6 +196,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 			return cachedBlob;
 		}
 
+		// Note: AFR does not support readBlobs, but potentially other r11s like servers do
 		const blob = await PerformanceEvent.timedExecAsync(
 			this.logger,
 			{

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -170,14 +170,24 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 			requestVersion = versions[0];
 		}
 
-		const normalizedWholeSnapshot = await this.snapshotTreeCache.get(
+		let normalizedWholeSnapshot = await this.snapshotTreeCache.get(
 			this.getCacheKey(requestVersion.id),
 		);
 		if (normalizedWholeSnapshot !== undefined) {
 			return normalizedWholeSnapshot.snapshotTree;
 		}
-		return (await this.fetchSnapshotTree(requestVersion.id, undefined, "getSnapshotTree"))
-			.snapshotTree;
+
+		normalizedWholeSnapshot = await this.fetchSnapshotTree(
+			requestVersion.id,
+			undefined,
+			"getSnapshotTree",
+		);
+
+		// Currently retrieving blobs from network is not supported by AFR for WholeSummaryDocumentStorageService
+		// Blobs are expected to be put in the cache
+		await this.updateBlobsCache(normalizedWholeSnapshot.blobs);
+
+		return normalizedWholeSnapshot.snapshotTree;
 	}
 
 	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
@@ -328,7 +338,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		assert(snapshotId !== undefined, 0x275 /* "Root tree should contain the id" */);
 		const cachePs: Promise<any>[] = [
 			this.snapshotTreeCache.put(this.getCacheKey(snapshotId), normalizedWholeSummary),
-			this.initBlobCache(normalizedWholeSummary.blobs),
+			this.updateBlobsCache(normalizedWholeSummary.blobs),
 		];
 
 		await Promise.all(cachePs);
@@ -336,7 +346,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		return snapshotId;
 	}
 
-	private async initBlobCache(blobs: Map<string, ArrayBuffer>): Promise<void> {
+	private async updateBlobsCache(blobs: Map<string, ArrayBuffer>): Promise<void> {
 		const blobCachePutPs: Promise<void>[] = [];
 		blobs.forEach((value, id) => {
 			const cacheKey = this.getCacheKey(id);

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRefreshLatestSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRefreshLatestSummary.spec.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import {
+	ITestContainerConfig,
+	mockConfigProvider,
+	ITestObjectProvider,
+	createSummarizer,
+	summarizeNow,
+} from "@fluidframework/test-utils";
+
+describeNoCompat("Summarizer can refresh a snapshot from the server", (getTestObjectProvider) => {
+	const settings = {};
+	const testContainerConfig: ITestContainerConfig = {
+		runtimeOptions: {
+			summaryOptions: {
+				summaryConfigOverrides: { state: "disabled" },
+			},
+		},
+		loaderProps: { configProvider: mockConfigProvider(settings) },
+	};
+
+	let provider: ITestObjectProvider;
+	const createContainer = async (): Promise<IContainer> => {
+		return provider.makeTestContainer(testContainerConfig);
+	};
+
+	beforeEach(async () => {
+		provider = getTestObjectProvider({ syncSummarizer: true });
+	});
+
+	it("The summarizing client can refresh from an unexpected ack", async () => {
+		const container = await createContainer();
+		const { container: summarizingContainer, summarizer } = await createSummarizer(
+			provider,
+			container,
+			undefined,
+			undefined,
+			mockConfigProvider(settings),
+		);
+
+		await provider.ensureSynchronized();
+		const { summaryVersion } = await summarizeNow(summarizer);
+		assert(!summarizingContainer.closed, "Refreshing acks should not close the summarizer");
+		assert(!container.closed, "Original container should not be closed");
+
+		await summarizeNow(summarizer);
+		summarizer.stop("summarizerClientDisconnected");
+		summarizer.close();
+		await createSummarizer(provider, container, summaryVersion);
+		await provider.ensureSynchronized();
+	});
+});


### PR DESCRIPTION
[AB#4270](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4270)

In our service load tests, we were noticing `refreshLatestSummary_cancel` events for the AFR endpoints. After looking at the error stack, we determined that we were fetching the snapshot, and then trying to read the blob, but the `readBlob` endpoint does not work for AFR and the blobs weren't cached. Since the blobs are in the snapshot of the `wholeSummaryDocumentStorageService`. We want to cache those blobs. 

We opted to cache the blobs in the `wholeDocumentSummary/Snapshot` in the cache.