### PR TITLE
Fix empty fields of contextually typed data

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { brand, fail } from "../util";
+import { fail } from "../util";
 import {
 	EmptyKey,
 	FieldKey,

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -459,16 +459,16 @@ export function applyTypesFromContext(
 		const children = applyFieldTypesFromContext(schemaData, primary.schema, data);
 		return { value: undefined, type, fields: new Map([[primary.key, children]]) };
 	} else {
-		const fields: Map<FieldKey, MapTree[]> = new Map(
-			fieldKeysFromData(data).map((key) => {
-				const childKey: FieldKey = brand(key);
-				const childSchema = getFieldSchema(childKey, schemaData, schema);
-				return [
-					childKey,
-					applyFieldTypesFromContext(schemaData, childSchema, data[childKey]),
-				];
-			}),
-		);
+		const fields: Map<FieldKey, MapTree[]> = new Map();
+		for (const key of fieldKeysFromData(data)) {
+			assert(!fields.has(key), "Keys should not be duplicated");
+			const childSchema = getFieldSchema(key, schemaData, schema);
+			const children = applyFieldTypesFromContext(schemaData, childSchema, data[key]);
+			if (children.length > 0) {
+				fields.set(key, children);
+			}
+		}
+
 		const value = data[valueSymbol];
 		assert(
 			allowsValue(schema.value, value),


### PR DESCRIPTION
## Description

Fix bug in applyTypesFromContext which added empty fields to MapTree.

This could result in errors elsewhere processing the data when assuming only nonempty fields would be enumerated.

MapTree explicitly documents that empty fields should not be stored on it, so the bug is in applyTypesFromContext.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

