### PR TITLE
Add props from disconnect error to telemetry

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -7,6 +7,7 @@
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { EventEmitter } from 'events';
 import { FluidObject } from '@fluidframework/core-interfaces';
+import { IAnyDriverError } from '@fluidframework/driver-definitions';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
@@ -280,7 +281,7 @@ export interface IDeltaManagerEvents extends IEvent {
     // @deprecated (undocumented)
     (event: "processTime", listener: (latency: number) => void): any;
     (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void): any;
-    (event: "disconnect", listener: (reason: string, props?: ITelemetryProperties) => void): any;
+    (event: "disconnect", listener: (reason: string, error?: IAnyDriverError) => void): any;
     (event: "readonly", listener: (readonly: boolean) => void): any;
 }
 

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -280,7 +280,7 @@ export interface IDeltaManagerEvents extends IEvent {
     // @deprecated (undocumented)
     (event: "processTime", listener: (latency: number) => void): any;
     (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void): any;
-    (event: "disconnect", listener: (reason: string) => void): any;
+    (event: "disconnect", listener: (reason: string, props?: ITelemetryProperties) => void): any;
     (event: "readonly", listener: (readonly: boolean) => void): any;
 }
 

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -8,6 +8,7 @@ import {
 	IEventProvider,
 	IEvent,
 	IErrorEvent,
+	ITelemetryProperties,
 } from "@fluidframework/common-definitions";
 import {
 	ConnectionMode,
@@ -144,7 +145,7 @@ export interface IDeltaManagerEvents extends IEvent {
 	 *
 	 * - `reason`: Describes the reason for which the delta manager was disconnected.
 	 */
-	(event: "disconnect", listener: (reason: string) => void);
+	(event: "disconnect", listener: (reason: string, props?: ITelemetryProperties) => void);
 
 	/**
 	 * Emitted when read/write permissions change.

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -8,8 +8,8 @@ import {
 	IEventProvider,
 	IEvent,
 	IErrorEvent,
-	ITelemetryProperties,
 } from "@fluidframework/common-definitions";
+import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import {
 	ConnectionMode,
 	IClientConfiguration,
@@ -144,8 +144,9 @@ export interface IDeltaManagerEvents extends IEvent {
 	 * @remarks Listener parameters:
 	 *
 	 * - `reason`: Describes the reason for which the delta manager was disconnected.
+	 * - `error` : error if any for the disconnect.
 	 */
-	(event: "disconnect", listener: (reason: string, props?: ITelemetryProperties) => void);
+	(event: "disconnect", listener: (reason: string, error?: IAnyDriverError) => void);
 
 	/**
 	 * Emitted when read/write permissions change.

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -48,7 +48,7 @@ import {
 	ScopeType,
 	ISequencedDocumentSystemMessage,
 } from "@fluidframework/protocol-definitions";
-import { TelemetryLogger, normalizeError } from "@fluidframework/telemetry-utils";
+import { TelemetryLogger, isILoggingError, normalizeError } from "@fluidframework/telemetry-utils";
 import { ReconnectMode, IConnectionManager, IConnectionManagerFactoryArgs } from "./contracts";
 import { DeltaQueue } from "./deltaQueue";
 import { SignalType } from "./protocol";
@@ -664,9 +664,10 @@ export class ConnectionManager implements IConnectionManager {
 	/**
 	 * Disconnect the current connection.
 	 * @param reason - Text description of disconnect reason to emit with disconnect event
+	 * @param error - Error causing the disconnect if any.
 	 * @returns A boolean that indicates if there was an existing connection (or pending connection) to disconnect
 	 */
-	private disconnectFromDeltaStream(reason: string): boolean {
+	private disconnectFromDeltaStream(reason: string, error?: IAnyDriverError): boolean {
 		this.pendingReconnect = false;
 
 		if (this.connection === undefined) {
@@ -699,7 +700,10 @@ export class ConnectionManager implements IConnectionManager {
 		this._outbound.clear();
 		connection.dispose();
 
-		this.props.disconnectHandler(reason);
+		this.props.disconnectHandler(
+			reason,
+			error !== undefined && isILoggingError(error) ? error.getTelemetryProperties() : {},
+		);
 
 		this._connectionVerboseProps = {};
 
@@ -894,7 +898,7 @@ export class ConnectionManager implements IConnectionManager {
 		// If we're already disconnected/disconnecting it's not appropriate to call this again.
 		assert(this.connection !== undefined, 0x0eb /* "Missing connection for reconnect" */);
 
-		this.disconnectFromDeltaStream(disconnectMessage);
+		this.disconnectFromDeltaStream(disconnectMessage, error);
 
 		// We will always trigger reconnect, even if canRetry is false.
 		// Any truly fatal error state will result in container close upon attempted reconnect,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -48,7 +48,7 @@ import {
 	ScopeType,
 	ISequencedDocumentSystemMessage,
 } from "@fluidframework/protocol-definitions";
-import { TelemetryLogger, isILoggingError, normalizeError } from "@fluidframework/telemetry-utils";
+import { TelemetryLogger, normalizeError } from "@fluidframework/telemetry-utils";
 import { ReconnectMode, IConnectionManager, IConnectionManagerFactoryArgs } from "./contracts";
 import { DeltaQueue } from "./deltaQueue";
 import { SignalType } from "./protocol";
@@ -700,10 +700,7 @@ export class ConnectionManager implements IConnectionManager {
 		this._outbound.clear();
 		connection.dispose();
 
-		this.props.disconnectHandler(
-			reason,
-			error !== undefined && isILoggingError(error) ? error.getTelemetryProperties() : {},
-		);
+		this.props.disconnectHandler(reason, error);
 
 		this._connectionVerboseProps = {};
 

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -10,6 +10,7 @@ import {
 } from "@fluidframework/common-definitions";
 import { assert, Timer } from "@fluidframework/common-utils";
 import { IConnectionDetailsInternal, IDeltaManager } from "@fluidframework/container-definitions";
+import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import { ISequencedClient, IClient } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent, loggerToMonitoringContext } from "@fluidframework/telemetry-utils";
 import { ConnectionState } from "./connectionState";
@@ -32,7 +33,7 @@ export interface IConnectionStateHandlerInputs {
 		value: ConnectionState,
 		oldState: ConnectionState,
 		reason?: string | undefined,
-		props?: ITelemetryProperties,
+		error?: IAnyDriverError,
 	) => void;
 	/** Whether to expect the client to join in write mode on next connection */
 	shouldClientJoinWrite: () => boolean;
@@ -57,7 +58,7 @@ export interface IConnectionStateHandler {
 	dispose(): void;
 	initProtocol(protocol: IProtocolHandler): void;
 	receivedConnectEvent(details: IConnectionDetailsInternal): void;
-	receivedDisconnectEvent(reason: string, props?: ITelemetryProperties): void;
+	receivedDisconnectEvent(reason: string, error?: IAnyDriverError): void;
 }
 
 export function createConnectionStateHandler(
@@ -139,8 +140,8 @@ class ConnectionStateHandlerPassThrough
 	public initProtocol(protocol: IProtocolHandler) {
 		return this.pimpl.initProtocol(protocol);
 	}
-	public receivedDisconnectEvent(reason: string, props?: ITelemetryProperties) {
-		return this.pimpl.receivedDisconnectEvent(reason, props);
+	public receivedDisconnectEvent(reason: string, error?: IAnyDriverError) {
+		return this.pimpl.receivedDisconnectEvent(reason, error);
 	}
 
 	public receivedConnectEvent(details: IConnectionDetailsInternal) {
@@ -158,9 +159,9 @@ class ConnectionStateHandlerPassThrough
 		value: ConnectionState,
 		oldState: ConnectionState,
 		reason?: string | undefined,
-		props?: ITelemetryProperties,
+		error?: IAnyDriverError,
 	) {
-		return this.inputs.connectionStateChanged(value, oldState, reason, props);
+		return this.inputs.connectionStateChanged(value, oldState, reason, error);
 	}
 	public shouldClientJoinWrite() {
 		return this.inputs.shouldClientJoinWrite();
@@ -202,7 +203,7 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
 		value: ConnectionState,
 		oldState: ConnectionState,
 		reason?: string | undefined,
-		props?: ITelemetryProperties,
+		error?: IAnyDriverError,
 	) {
 		switch (value) {
 			case ConnectionState.Connected:
@@ -238,7 +239,7 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
 			default:
 		}
 		this._connectionState = value;
-		this.inputs.connectionStateChanged(value, oldState, reason);
+		this.inputs.connectionStateChanged(value, oldState, reason, error);
 	}
 
 	private readonly transitionToConnectedState = () => {
@@ -465,9 +466,9 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 		}
 	}
 
-	public receivedDisconnectEvent(reason: string, props?: ITelemetryProperties) {
+	public receivedDisconnectEvent(reason: string, error?: IAnyDriverError) {
 		this.connection = undefined;
-		this.setConnectionState(ConnectionState.Disconnected, reason, props);
+		this.setConnectionState(ConnectionState.Disconnected, reason, error);
 	}
 
 	private shouldWaitForJoinSignal() {
@@ -533,13 +534,13 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 	private setConnectionState(
 		value: ConnectionState.Disconnected,
 		reason: string,
-		props?: ITelemetryProperties,
+		error?: IAnyDriverError,
 	): void;
 	private setConnectionState(value: ConnectionState.Connected): void;
 	private setConnectionState(
 		value: ConnectionState.Disconnected | ConnectionState.Connected,
 		reason?: string,
-		props?: ITelemetryProperties,
+		error?: IAnyDriverError,
 	): void {
 		if (this.connectionState === value) {
 			// Already in the desired state - exit early
@@ -600,7 +601,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 		}
 
 		// Report transition before we propagate event across layers
-		this.handler.connectionStateChanged(this._connectionState, oldState, reason, props);
+		this.handler.connectionStateChanged(this._connectionState, oldState, reason, error);
 	}
 
 	// Helper method to switch between quorum and audience.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -758,11 +758,11 @@ export class Container
 		this.connectionStateHandler = createConnectionStateHandler(
 			{
 				logger: this.mc.logger,
-				connectionStateChanged: (value, oldState, reason) => {
+				connectionStateChanged: (value, oldState, reason, props) => {
 					if (value === ConnectionState.Connected) {
 						this._clientId = this.connectionStateHandler.pendingClientId;
 					}
-					this.logConnectionStateChangeTelemetry(value, oldState, reason);
+					this.logConnectionStateChangeTelemetry(value, oldState, reason, props);
 					if (this._lifecycleState === "loaded") {
 						this.propagateConnectionState(
 							false /* initial transition */,
@@ -1843,10 +1843,10 @@ export class Container
 			this.connectionStateHandler.receivedConnectEvent(details);
 		});
 
-		deltaManager.on("disconnect", (reason: string) => {
+		deltaManager.on("disconnect", (reason: string, props?: ITelemetryProperties) => {
 			this.collabWindowTracker?.stopSequenceNumberUpdate();
 			if (!this.closed) {
-				this.connectionStateHandler.receivedDisconnectEvent(reason);
+				this.connectionStateHandler.receivedDisconnectEvent(reason, props);
 			}
 		});
 
@@ -1900,6 +1900,7 @@ export class Container
 		value: ConnectionState,
 		oldState: ConnectionState,
 		reason?: string,
+		props?: ITelemetryProperties,
 	) {
 		// Log actual event
 		const time = performance.now();
@@ -1930,6 +1931,7 @@ export class Container
 
 		this.mc.logger.sendPerformanceEvent({
 			eventName: `ConnectionStateChange_${ConnectionState[value]}`,
+			...props,
 			from: ConnectionState[oldState],
 			duration,
 			durationFromDisconnected,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -32,6 +32,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { GenericError, UsageError } from "@fluidframework/container-utils";
 import {
+	IAnyDriverError,
 	IDocumentService,
 	IDocumentStorageService,
 	IFluidResolvedUrl,
@@ -758,11 +759,11 @@ export class Container
 		this.connectionStateHandler = createConnectionStateHandler(
 			{
 				logger: this.mc.logger,
-				connectionStateChanged: (value, oldState, reason, props) => {
+				connectionStateChanged: (value, oldState, reason, error) => {
 					if (value === ConnectionState.Connected) {
 						this._clientId = this.connectionStateHandler.pendingClientId;
 					}
-					this.logConnectionStateChangeTelemetry(value, oldState, reason, props);
+					this.logConnectionStateChangeTelemetry(value, oldState, reason, error);
 					if (this._lifecycleState === "loaded") {
 						this.propagateConnectionState(
 							false /* initial transition */,
@@ -1843,10 +1844,10 @@ export class Container
 			this.connectionStateHandler.receivedConnectEvent(details);
 		});
 
-		deltaManager.on("disconnect", (reason: string, props?: ITelemetryProperties) => {
+		deltaManager.on("disconnect", (reason: string, error?: IAnyDriverError) => {
 			this.collabWindowTracker?.stopSequenceNumberUpdate();
 			if (!this.closed) {
-				this.connectionStateHandler.receivedDisconnectEvent(reason, props);
+				this.connectionStateHandler.receivedDisconnectEvent(reason, error);
 			}
 		});
 
@@ -1900,7 +1901,7 @@ export class Container
 		value: ConnectionState,
 		oldState: ConnectionState,
 		reason?: string,
-		props?: ITelemetryProperties,
+		error?: IAnyDriverError,
 	) {
 		// Log actual event
 		const time = performance.now();
@@ -1929,25 +1930,29 @@ export class Container
 			connectionInitiationReason = this.firstConnection ? "InitialConnect" : "AutoReconnect";
 		}
 
-		this.mc.logger.sendPerformanceEvent({
-			eventName: `ConnectionStateChange_${ConnectionState[value]}`,
-			...props,
-			from: ConnectionState[oldState],
-			duration,
-			durationFromDisconnected,
-			reason,
-			connectionInitiationReason,
-			pendingClientId: this.connectionStateHandler.pendingClientId,
-			clientId: this.clientId,
-			autoReconnect,
-			opsBehind,
-			online: OnlineStatus[isOnline()],
-			lastVisible:
-				this.lastVisible !== undefined ? performance.now() - this.lastVisible : undefined,
-			checkpointSequenceNumber,
-			quorumSize: this._protocolHandler?.quorum.getMembers().size,
-			...this._deltaManager.connectionProps,
-		});
+		this.mc.logger.sendPerformanceEvent(
+			{
+				eventName: `ConnectionStateChange_${ConnectionState[value]}`,
+				from: ConnectionState[oldState],
+				duration,
+				durationFromDisconnected,
+				reason,
+				connectionInitiationReason,
+				pendingClientId: this.connectionStateHandler.pendingClientId,
+				clientId: this.clientId,
+				autoReconnect,
+				opsBehind,
+				online: OnlineStatus[isOnline()],
+				lastVisible:
+					this.lastVisible !== undefined
+						? performance.now() - this.lastVisible
+						: undefined,
+				checkpointSequenceNumber,
+				quorumSize: this._protocolHandler?.quorum.getMembers().size,
+				...this._deltaManager.connectionProps,
+			},
+			error,
+		);
 
 		if (value === ConnectionState.Connected) {
 			this.firstConnection = false;

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -139,7 +139,7 @@ export interface IConnectionManagerFactoryArgs {
 	/**
 	 * Called whenever connection to relay service is lost.
 	 */
-	readonly disconnectHandler: (reason: string) => void;
+	readonly disconnectHandler: (reason: string, props?: ITelemetryProperties) => void;
 
 	/**
 	 * Called whenever new connection to rely service is established

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -20,7 +20,7 @@ import {
 	IClientDetails,
 	ISignalMessage,
 } from "@fluidframework/protocol-definitions";
-import { IContainerPackageInfo } from "@fluidframework/driver-definitions";
+import { IAnyDriverError, IContainerPackageInfo } from "@fluidframework/driver-definitions";
 
 export enum ReconnectMode {
 	Never = "Never",
@@ -139,7 +139,7 @@ export interface IConnectionManagerFactoryArgs {
 	/**
 	 * Called whenever connection to relay service is lost.
 	 */
-	readonly disconnectHandler: (reason: string, props?: ITelemetryProperties) => void;
+	readonly disconnectHandler: (reason: string, error?: IAnyDriverError) => void;
 
 	/**
 	 * Called whenever new connection to rely service is established

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -26,6 +26,7 @@ import {
 	IDocumentDeltaStorageService,
 	IDocumentService,
 	DriverErrorType,
+	IAnyDriverError,
 } from "@fluidframework/driver-definitions";
 import {
 	IDocumentMessage,
@@ -357,8 +358,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			reconnectionDelayHandler: (delayMs: number, error: unknown) =>
 				this.emitDelayInfo(this.deltaStreamDelayId, delayMs, error),
 			closeHandler: (error: any) => this.close(error),
-			disconnectHandler: (reason: string, telemetryProps?: ITelemetryProperties) =>
-				this.disconnectHandler(reason, telemetryProps),
+			disconnectHandler: (reason: string, error?: IAnyDriverError) =>
+				this.disconnectHandler(reason, error),
 			connectHandler: (connection: IConnectionDetailsInternal) =>
 				this.connectHandler(connection),
 			pongHandler: (latency: number) => this.emit("pong", latency),
@@ -701,9 +702,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		}
 	}
 
-	private disconnectHandler(reason: string, props?: ITelemetryProperties) {
+	private disconnectHandler(reason: string, error?: IAnyDriverError) {
 		this.messageBuffer.length = 0;
-		this.emit("disconnect", reason, props);
+		this.emit("disconnect", reason, error);
 	}
 
 	/**

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -357,7 +357,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			reconnectionDelayHandler: (delayMs: number, error: unknown) =>
 				this.emitDelayInfo(this.deltaStreamDelayId, delayMs, error),
 			closeHandler: (error: any) => this.close(error),
-			disconnectHandler: (reason: string) => this.disconnectHandler(reason),
+			disconnectHandler: (reason: string, telemetryProps?: ITelemetryProperties) =>
+				this.disconnectHandler(reason, telemetryProps),
 			connectHandler: (connection: IConnectionDetailsInternal) =>
 				this.connectHandler(connection),
 			pongHandler: (latency: number) => this.emit("pong", latency),
@@ -700,9 +701,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		}
 	}
 
-	private disconnectHandler(reason: string) {
+	private disconnectHandler(reason: string, props?: ITelemetryProperties) {
 		this.messageBuffer.length = 0;
-		this.emit("disconnect", reason);
+		this.emit("disconnect", reason, props);
 	}
 
 	/**


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/3481
Add props from disconnect error to disconnect telemetry so that we can know what kind of disconnect it was.