### PR TITLE
Add performance benchmarks for SharedTree's identifier index

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/identifierIndex.bench.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/identifierIndex.bench.ts
@@ -1,0 +1,195 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { benchmark, BenchmarkTimer, BenchmarkType } from "@fluid-tools/benchmark";
+import { makeRandom } from "@fluid-internal/stochastic-test-utils";
+import { IsoBuffer } from "@fluidframework/common-utils";
+import { identifierKeySymbol, identifierKey, ISharedTree } from "../../shared-tree";
+import { TestTreeProviderLite } from "../utils";
+import {
+	Identifier,
+	identifierSchema,
+	SequenceFieldEditBuilder,
+	singleTextCursor,
+} from "../../feature-libraries";
+import { rootFieldKeySymbol, ITreeCursor, moveToDetachedField, JsonableTree } from "../../core";
+import { nodeSchema, nodeSchemaData } from "./identifierIndex.spec";
+
+describe.only("Identifiers", () => {
+	// TODO: Increase these numbers when the identifier index is more efficient
+	for (const nodeCount of [50, 100]) {
+		describe(`In a tree with ${nodeCount} nodes`, () => {
+			function makeTree(): [ISharedTree, SequenceFieldEditBuilder, TestTreeProviderLite] {
+				const provider = new TestTreeProviderLite(1);
+				const [tree] = provider.trees;
+				tree.storedSchema.update(nodeSchemaData);
+				const field = tree.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
+				return [tree, field, provider];
+			}
+
+			function createNode(identifier?: Identifier): ITreeCursor {
+				const jsonTree: JsonableTree = {
+					type: nodeSchema.name,
+				};
+				if (identifier !== undefined) {
+					jsonTree.globalFields = {
+						[identifierKey]: [{ type: identifierSchema.name, value: identifier }],
+					};
+				}
+				return singleTextCursor(jsonTree);
+			}
+
+			for (const identifierDensityPercentage of [5, 50, 100]) {
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Insert ${nodeCount} nodes, ${identifierDensityPercentage}% of which have identifiers`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						const period = Math.round(100 / identifierDensityPercentage);
+						let duration: number;
+						do {
+							assert.equal(state.iterationsPerBatch, 1);
+							const [tree, field] = makeTree();
+							const cursors: ITreeCursor[] = [];
+							for (let i = 0; i < nodeCount; i++) {
+								const identifier = i % period === 0 ? i : undefined;
+								cursors.push(createNode(identifier));
+							}
+
+							// Measure how long it takes to insert a node with an identifier
+							const before = state.timer.now();
+							for (let i = 0; i < nodeCount; i++) {
+								field.insert(i, cursors[i]);
+							}
+							duration = state.timer.toSeconds(before, state.timer.now());
+
+							// Validate that the tree is as we expect
+							const cursor = tree.forest.allocateCursor();
+							moveToDetachedField(tree.forest, cursor);
+							cursor.firstNode();
+							for (let i = 0; i < nodeCount; i++) {
+								if (i % period === 0) {
+									cursor.enterField(identifierKeySymbol);
+									cursor.enterNode(0);
+									assert.equal(cursor.value, i);
+									cursor.exitNode();
+									cursor.exitField();
+
+									const node = tree.identifiedNodes.get(i);
+									assert(node !== undefined);
+									assert.equal(node[identifierKeySymbol], i);
+								}
+								cursor.nextNode();
+							}
+							cursor.free();
+						} while (state.recordBatch(duration));
+					},
+					minBatchDurationSeconds: 0, // Force batch size of 1
+				});
+			}
+
+			for (const identifierDensityPercentage of [5, 50, 100]) {
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Lookup a node by identifier in a tree of size ${nodeCount} where ${identifierDensityPercentage}% of the tree has identifiers`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						const period = Math.round(100 / identifierDensityPercentage);
+						const random = makeRandom(0);
+						let duration: number;
+						do {
+							assert.equal(state.iterationsPerBatch, 1);
+							const [tree, field] = makeTree();
+							const ids: number[] = [];
+							for (let i = 0; i < nodeCount; i++) {
+								if (i % period === 0) {
+									field.insert(i, createNode(i));
+									ids.push(i);
+								} else {
+									field.insert(i, createNode());
+								}
+							}
+
+							const id = random.pick(ids);
+
+							// Measure how long it takes to lookup a randomly selected ID that is known to be in the document
+							const before = state.timer.now();
+							const node = tree.identifiedNodes.get(id);
+							duration = state.timer.toSeconds(before, state.timer.now());
+
+							assert(node !== undefined);
+							assert.equal(node[identifierKeySymbol], id);
+						} while (state.recordBatch(duration));
+					},
+					minBatchDurationSeconds: 0, // Force batch size of 1
+				});
+			}
+
+			for (const identifierDensityPercentage of [5, 50, 100]) {
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Lookup a non-existent identifier in a tree of size ${nodeCount} where ${identifierDensityPercentage}% of the tree has identifiers`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						const period = Math.round(100 / identifierDensityPercentage);
+						let duration: number;
+						do {
+							assert.equal(state.iterationsPerBatch, 1);
+							const [tree, field] = makeTree();
+							for (let i = 0; i < nodeCount; i++) {
+								const identifier = i % period === 0 ? i : undefined;
+								field.insert(i, createNode(identifier));
+							}
+
+							// Measure how long it takes to lookup an ID that is not in the document
+							const before = state.timer.now();
+							const node = tree.identifiedNodes.get(-1);
+							duration = state.timer.toSeconds(before, state.timer.now());
+
+							assert(node === undefined);
+						} while (state.recordBatch(duration));
+					},
+					minBatchDurationSeconds: 0, // Force batch size of 1
+				});
+			}
+
+			for (const identifierDensityPercentage of [5, 50, 100]) {
+				const period = Math.round(100 / identifierDensityPercentage);
+				it(`increase the summary size (when ${identifierDensityPercentage}% of nodes have identifiers)`, () => {
+					// Create a baseline tree with no identifiers
+					const [treeBaseline, fieldBaseline, providerBaseline] = makeTree();
+					for (let i = 0; i < nodeCount; i++) {
+						fieldBaseline.insert(i, createNode());
+					}
+					providerBaseline.processMessages();
+					// Create a tree of the same size as the baseline, but with some identifiers
+					const [treeWithIds, fieldWithIds, providerWithIds] = makeTree();
+					for (let i = 0; i < nodeCount; i++) {
+						const identifier = i % period === 0 ? i : undefined;
+						fieldWithIds.insert(i, createNode(identifier));
+					}
+					providerWithIds.processMessages();
+
+					// Summarize both trees and measure their summary sizes
+					const { summary: summaryBaseline } = treeBaseline.getAttachSummary(true);
+					const sizeBaseline = IsoBuffer.from(JSON.stringify(summaryBaseline)).byteLength;
+					const { summary: summaryWithIds } = treeWithIds.getAttachSummary(true);
+					const sizeWithIds = IsoBuffer.from(JSON.stringify(summaryWithIds)).byteLength;
+					// TODO: report these sizes as benchmark output which can be tracked over time.
+					const sizeDelta = sizeWithIds - sizeBaseline;
+					const relativeDelta = sizeDelta / sizeBaseline;
+					// Arbitrary limit of 10% increase. Re-adjust when identifier index is more performant.
+					assert(
+						relativeDelta < 0.1,
+						`Increased summary size by ${sizeDelta} bytes (${(
+							relativeDelta * 100
+						).toFixed(2)}% increase)`,
+					);
+				});
+			}
+		});
+	}
+});

--- a/experimental/dds/tree2/src/test/feature-libraries/identifierIndex.bench.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/identifierIndex.bench.ts
@@ -18,7 +18,7 @@ import {
 import { rootFieldKeySymbol, ITreeCursor, moveToDetachedField, JsonableTree } from "../../core";
 import { nodeSchema, nodeSchemaData } from "./identifierIndex.spec";
 
-describe.only("Identifiers", () => {
+describe("Identifiers", () => {
 	// TODO: Increase these numbers when the identifier index is more efficient
 	for (const nodeCount of [50, 100]) {
 		describe(`In a tree with ${nodeCount} nodes`, () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/identifierIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/identifierIndex.spec.ts
@@ -31,11 +31,11 @@ import {
 } from "../../feature-libraries";
 
 const builder = new SchemaBuilder("identifier index tests", identifierFieldSchemaLibrary);
-const nodeSchema = builder.objectRecursive("node", {
+export const nodeSchema = builder.objectRecursive("node", {
 	local: { child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchema) },
 	global: [identifierFieldSchema] as const,
 });
-const nodeSchemaData = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(nodeSchema));
+export const nodeSchemaData = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(nodeSchema));
 
 describe("Node Identifier Index", () => {
 	let nextId: Identifier = 42;


### PR DESCRIPTION
## Description

These benchmarks measure the following scenarios:

* The time it takes to insert _n_ nodes with an identifier
* The time it takes to lookup _n_ identifiers that exists in the tree
* The time it takes to lookup an identifier that does not exist in the tree
* The summary size increase caused by having identifiers in the tree

Each of these scenarios is run with different "saturations" of identifiers in the tree (e.g. a tree where only 5% of its nodes have identifiers vs. a tree where 75% of its nodes have identifiers) which determines the value of _n_.

The identifier index is currently un-optimized and has perfomance characteristics that are probably unacceptable for any real world use, so the current perf data from these benchmarks is probably also not of much use. However, they should allow us to measure performance improvements as the identifier index is optimized (currently a work in progress).