### PR TITLE
fix(Tree): fix rebase of field changes over no-op in base change

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -601,7 +601,7 @@ export class ModularChangeFamily
 				(child, baseChild) =>
 					this.rebaseNodeChange(
 						child,
-						baseChild !== undefined ? tagChange(baseChild, baseRevision) : undefined,
+						tagChange(baseChild, baseRevision),
 						genId,
 						crossFieldTable,
 						undefined,
@@ -670,7 +670,7 @@ export class ModularChangeFamily
 				(child, baseChild, deleted) =>
 					this.rebaseNodeChange(
 						child,
-						baseChild !== undefined ? { revision, change: baseChild } : undefined,
+						{ revision, change: baseChild },
 						genId,
 						crossFieldTable,
 						baseChanges,
@@ -725,7 +725,7 @@ export class ModularChangeFamily
 						);
 						return this.rebaseNodeChange(
 							child,
-							undefined,
+							tagChange(undefined, over.revision),
 							genId,
 							crossFieldTable,
 							baseChanges,
@@ -752,7 +752,7 @@ export class ModularChangeFamily
 
 	private rebaseNodeChange(
 		change: NodeChangeset | undefined,
-		over: TaggedChange<NodeChangeset> | undefined,
+		over: TaggedChange<NodeChangeset | undefined>,
 		genId: IdAllocator,
 		crossFieldTable: RebaseTable,
 		parentField: FieldChange | undefined,
@@ -761,21 +761,21 @@ export class ModularChangeFamily
 		constraintState: ConstraintState,
 		deletedByBase: boolean = false,
 	): NodeChangeset | undefined {
-		if (change === undefined && over?.change?.fieldChanges === undefined) {
+		if (change === undefined && over.change?.fieldChanges === undefined) {
 			return undefined;
 		}
 
-		if (over?.change?.fieldChanges !== undefined && parentField !== undefined) {
+		if (over.change?.fieldChanges !== undefined && parentField !== undefined) {
 			crossFieldTable.baseMapToParentField.set(over.change.fieldChanges, parentField);
 		}
 
 		const baseMap: TaggedChange<FieldChangeMap> =
-			over?.change?.fieldChanges !== undefined
+			over.change?.fieldChanges !== undefined
 				? {
 						...over,
 						change: over.change.fieldChanges,
 				  }
-				: makeAnonChange(new Map());
+				: tagChange(new Map(), over.revision);
 
 		const fieldChanges = this.rebaseFieldMap(
 			change?.fieldChanges ?? new Map(),
@@ -806,7 +806,7 @@ export class ModularChangeFamily
 
 		// We only care if a violated constraint is fixed or if a non-violated
 		// constraint becomes violated
-		if (rebasedChange.valueConstraint !== undefined && over?.change.valueChange !== undefined) {
+		if (rebasedChange.valueConstraint !== undefined && over.change?.valueChange !== undefined) {
 			const violatedByOver =
 				over.change.valueChange.value !== rebasedChange.valueConstraint.value;
 

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -297,6 +297,43 @@ describe("Editing", () => {
 
 			expectJsonTree(tree1, ["x", { foo: ["b", "a"] }]);
 		});
+
+		it("rebase changes to field untouched by base", () => {
+			const tree = makeTreeFromJson({ foo: [{ bar: "A" }, "B"] });
+			const tree1 = tree.fork();
+			const tree2 = tree.fork();
+
+			const rootNode: UpPath = {
+				parent: undefined,
+				parentField: rootFieldKeySymbol,
+				parentIndex: 0,
+			};
+			const fooList: UpPath = {
+				parent: rootNode,
+				parentField: brand("foo"),
+				parentIndex: 0,
+			};
+			const foo1: UpPath = {
+				parent: fooList,
+				parentField: brand(""),
+				parentIndex: 0,
+			};
+			const nodeB: UpPath = {
+				parent: fooList,
+				parentField: brand(""),
+				parentIndex: 1,
+			};
+
+			tree1.editor.setValue(nodeB, "b");
+			tree2.editor.sequenceField({ parent: foo1, field: brand("bar") }).delete(0, 1);
+
+			tree.merge(tree1);
+			tree.merge(tree2);
+			tree1.rebaseOnto(tree);
+			tree2.rebaseOnto(tree);
+
+			expectJsonTree([tree, tree1, tree2], [{ foo: [{}, "b"] }]);
+		});
 	});
 
 	describe("Optional Field", () => {


### PR DESCRIPTION
Fixes a bug in the `ModularChangeFamily` rebase logic: the rebasing of changes to fields that are untouched by the base changeset were delegated to the field-kind-specific rebase code but without passing the appropriate revision information for the base change. The revision information is now properly passed through.