### PR TITLE
Update checkpointManager to swallow errors that dont require a restart

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -23,9 +23,19 @@ export class CheckpointManager {
 	 */
 	public async checkpoint(queuedMessage: IQueuedMessage) {
 		// Checkpoint calls should always be of increasing or equal value
-		assert(
-			this.lastCheckpoint === undefined || queuedMessage.offset >= this.lastCheckpoint.offset,
-		);
+		// Exit early if already checkpointed a higher offset
+		if (this.lastCheckpoint && queuedMessage.offset < this.lastCheckpoint.offset) {
+			Lumberjack.info(
+				"Skipping checkpoint since kafka already checkpointed a higher offset",
+				{
+					lastCheckpointOffset: this.lastCheckpoint.offset,
+					queuedMessageOffset: queuedMessage.offset,
+					lastCheckpointPartition: this.lastCheckpoint.partition,
+					queuedMessagePartition: queuedMessage.partition,
+				},
+			);
+			return;
+		}
 
 		// Exit early if the manager has been closed
 		if (this.closed) {
@@ -80,7 +90,15 @@ export class CheckpointManager {
 			},
 			// eslint-disable-next-line @typescript-eslint/promise-function-async
 			(error) => {
-				// Enter an error state on any commit error
+				if (error.name === "PendingCommitError") {
+					Lumberjack.info(`Skipping checkpoint since ${error.message}`, {
+						queuedMessageOffset: queuedMessage.offset,
+						queuedMessagePartition: queuedMessage.partition,
+					});
+					this.checkpointing = false;
+					return;
+				}
+				// Enter an error state on any other commit error
 				this.error = error;
 				if (this.pendingCheckpoint) {
 					this.pendingCheckpoint.reject(this.error);

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -23,10 +23,10 @@ export class CheckpointManager {
 	 */
 	public async checkpoint(queuedMessage: IQueuedMessage) {
 		// Checkpoint calls should always be of increasing or equal value
-		// Exit early if already checkpointed a higher offset
+		// Exit early if already requested checkpoint for a higher offset
 		if (this.lastCheckpoint && queuedMessage.offset < this.lastCheckpoint.offset) {
 			Lumberjack.info(
-				"Skipping checkpoint since kafka already checkpointed a higher offset",
+				"Skipping checkpoint since a request for checkpointing a higher offset has already been made",
 				{
 					lastCheckpointOffset: this.lastCheckpoint.offset,
 					queuedMessageOffset: queuedMessage.offset,

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -350,7 +350,11 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			}
 
 			if (this.pendingCommits.has(partitionId)) {
-				throw new Error(`There is already a pending commit for partition ${partitionId}`);
+				const pendingCommitError = new Error(
+					`There is already a pending commit for partition ${partitionId}`,
+				);
+				pendingCommitError.name = "PendingCommitError";
+				throw pendingCommitError;
 			}
 
 			// this will be resolved in the "offset.commit" event


### PR DESCRIPTION
## Description

Recently we have been seeing checkpointing errors like "ERR_ASSERTION" and "There is already a pending commit for partition 2". These errors unnecessarily restart the services and cause other issues due to re-processing of messages.

These errors do not mean a failure, and hence this PR changes the code to not throw an exception in these cases. 

## Reviewer Guidance

This will affect all services talking to kafka like deli, scribe and scriptorium.
