### PR TITLE
Tree: add readonly marked array like

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -988,9 +988,6 @@ export interface ISubscribable<E extends Events<E>> {
 }
 
 // @alpha
-export function isWritableArrayLike(data: ContextuallyTypedFieldData): data is MarkedArrayLike<ContextuallyTypedNodeData>;
-
-// @alpha
 export interface ITreeCursor {
     readonly [CursorMarker]: true;
     readonly chunkLength: number;

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -188,6 +188,15 @@ export interface MarkedArrayLike<TGet, TSet extends TGet = TGet> extends ArrayLi
 }
 
 /**
+ * Can be used to mark a type which works like an array, but is not compatible with `Array.isArray`.
+ * @alpha
+ */
+export interface ReadonlyMarkedArrayLike<T> extends ArrayLike<T> {
+	readonly [arrayLikeMarkerSymbol]: true;
+	[Symbol.iterator](): IterableIterator<T>;
+}
+
+/**
  * `ArrayLike` numeric indexed access, but writable.
  *
  * @remarks
@@ -230,23 +239,15 @@ export type ContextuallyTypedFieldData = ContextuallyTypedNodeData | undefined;
  */
 export function isArrayLike(
 	data: ContextuallyTypedFieldData,
-): data is readonly ContextuallyTypedNodeData[] | MarkedArrayLike<ContextuallyTypedNodeData> {
-	return isWritableArrayLike(data) || Array.isArray(data);
-}
-
-/**
- * Checks the type of a `ContextuallyTypedNodeData`.
- * @alpha
- */
-export function isWritableArrayLike(
-	data: ContextuallyTypedFieldData,
-): data is MarkedArrayLike<ContextuallyTypedNodeData> {
+): data is
+	| readonly ContextuallyTypedNodeData[]
+	| ReadonlyMarkedArrayLike<ContextuallyTypedNodeData> {
 	if (typeof data !== "object") {
 		return false;
 	}
 	return (
 		(data as Partial<MarkedArrayLike<ContextuallyTypedNodeData>>)[arrayLikeMarkerSymbol] ===
-		true
+			true || Array.isArray(data)
 	);
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -42,7 +42,6 @@ export {
 	ContextuallyTypedNodeDataObject,
 	ContextuallyTypedNodeData,
 	MarkedArrayLike,
-	isWritableArrayLike,
 	isContextuallyTypedNodeDataObject,
 	getFieldKind,
 	getFieldSchema,

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -195,7 +195,6 @@ export {
 	ContextuallyTypedNodeDataObject,
 	ContextuallyTypedNodeData,
 	MarkedArrayLike,
-	isWritableArrayLike,
 	isContextuallyTypedNodeDataObject,
 	defaultSchemaPolicy,
 	jsonableTreeFromCursor,


### PR DESCRIPTION
## Description

Make MarkedArrayLike work better with readonly, and remove isWritableArrayLike

## Breaking Changes

Users of editable field should use the more specific method, isEditableField instead of isWritableArrayLike. No other usecase for isWritableArrayLike is known.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
