### PR TITLE
Don't run GC and reset GC data if the GC version is older that the GC version in base snapshot

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -202,10 +202,7 @@ export class GarbageCollector implements IGarbageCollector {
 					// in the snapshot cannot be interpreted correctly. Set everything to undefined except for
 					// deletedNodes because irrespective of GC versions, these nodes have been deleted and cannot be
 					// brought back. The deletedNodes info is needed to identify when these nodes are used.
-					if (
-						this.configs.gcVersionInBaseSnapshot !==
-						this.summaryStateTracker.currentGCVersion
-					) {
+					if (this.configs.gcVersionInEffect !== this.configs.gcVersionInBaseSnapshot) {
 						return {
 							gcState: undefined,
 							tombstones: undefined,

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -820,10 +820,10 @@ export class GarbageCollector implements IGarbageCollector {
 	public getMetadata(): IGCMetadata {
 		return {
 			/**
-			 * If GC is enabled, the GC data is written using the current GC version and that is the gcFeature that goes
+			 * If GC is enabled, the GC data is written using the GC version in effect and that is the gcFeature that goes
 			 * into the metadata blob. If GC is disabled, the gcFeature is 0.
 			 */
-			gcFeature: this.configs.gcEnabled ? this.summaryStateTracker.currentGCVersion : 0,
+			gcFeature: this.configs.gcEnabled ? this.configs.gcVersionInEffect : 0,
 			gcFeatureMatrix: this.configs.persistedGcFeatureMatrix,
 			sessionExpiryTimeoutMs: this.configs.sessionExpiryTimeoutMs,
 			sweepEnabled: false, // DEPRECATED - to be removed

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -110,9 +110,9 @@ export function generateGCConfigs(
 	const gcVersionInEffect =
 		mc.config.getBoolean(gcVersionUpgradeToV3Key) === true ? currentGCVersion : stableGCVersion;
 
-	// The GC version is up-to-date if the GC version in effect is not less than the GC version in base snapshot.
-	// If it is not up-to-date, there is a newer version of GC out there which is more reliable than this. So,
-	// GC should not be run as it may produce incorrect / unreliable GC state.
+	// The GC version is up-to-date if the GC version in effect is at least equal to the GC version in base snapshot.
+	// If it is not up-to-date, there is a newer version of GC out there which is more reliable than this. So, GC
+	// should not run as it may produce incorrect / unreliable state.
 	const isGCVersionUpToDate =
 		gcVersionInBaseSnapshot === undefined || gcVersionInEffect >= gcVersionInBaseSnapshot;
 

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -106,21 +106,24 @@ export function generateGCConfigs(
 		createParams.gcOptions[gcSweepGenerationOptionName] /* currentGeneration */,
 	);
 
+	// If version upgrade is not enabled, fall back to the stable GC version.
+	const gcVersionInEffect =
+		mc.config.getBoolean(gcVersionUpgradeToV3Key) === true ? currentGCVersion : stableGCVersion;
+	// If the GC version in effect is older than the GC version in base snapshot, the GC version is outdated. If so,
+	// we should not run GC as there is a newer version out there which is more reliable than this.
+	const outdatedGCVersion =
+		gcVersionInBaseSnapshot && gcVersionInEffect < gcVersionInBaseSnapshot;
+
 	/**
 	 * Whether GC should run or not. The following conditions have to be met to run sweep:
-	 *
 	 * 1. GC should be enabled for this container.
-	 *
 	 * 2. GC should not be disabled via disableGC GC option.
-	 *
+	 * 3. The current GC version should be greater of equal to the GC version in the base snapshot.
 	 * These conditions can be overridden via runGCKey feature flag.
 	 */
 	const shouldRunGC =
 		mc.config.getBoolean(runGCKey) ??
-		// GC must be enabled for the document.
-		(gcEnabled &&
-			// GC must not be disabled via GC options.
-			!createParams.gcOptions.disableGC);
+		(gcEnabled && !createParams.gcOptions.disableGC && !outdatedGCVersion);
 
 	/**
 	 * Whether sweep should run or not. The following conditions have to be met to run sweep:
@@ -155,10 +158,6 @@ export function generateGCConfigs(
 	// via feature flags.
 	const tombstoneMode = !shouldRunSweep && mc.config.getBoolean(disableTombstoneKey) !== true;
 	const runFullGC = createParams.gcOptions.runFullGC;
-
-	// If version upgrade is not enabled, fall back to the stable GC version.
-	const gcVersionInEffect =
-		mc.config.getBoolean(gcVersionUpgradeToV3Key) === true ? currentGCVersion : stableGCVersion;
 
 	return {
 		gcEnabled,

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -22,11 +22,9 @@ import {
 import {
 	MockLogger,
 	ConfigTypes,
-	IConfigProviderBase,
 	mixinMonitoringContext,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils";
-import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 import { Timer } from "@fluidframework/common-utils";
 import {
 	concatGarbageCollectionStates,
@@ -56,16 +54,7 @@ import {
 	RefreshSummaryResult,
 } from "../../summary";
 import { pkgVersion } from "../../packageVersion";
-
-export const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-	getRawConfig: (name: string): ConfigTypes => settings[name],
-});
-
-export const parseNothing: ReadAndParseBlob = async <T>() => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-	const x: T = {} as T;
-	return x;
-};
+import { configProvider, parseNothing } from "./gcUnitTestHelpers";
 
 type GcWithPrivates = IGarbageCollector & {
 	readonly configs: IGarbageCollectorConfigs;

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -44,7 +44,7 @@ import {
 } from "../../gc";
 import { IContainerRuntimeMetadata } from "../../summary";
 import { pkgVersion } from "../../packageVersion";
-import { configProvider } from "./garbageCollection.spec";
+import { configProvider } from "./gcUnitTestHelpers";
 
 type GcWithPrivates = IGarbageCollector & {
 	readonly configs: IGarbageCollectorConfigs;
@@ -691,6 +691,30 @@ describe("Garbage Collection configurations", () => {
 						"shouldRunGC not set as expected",
 					);
 				});
+			});
+
+			it("shouldRunGC should be true when gcVersionInEffect is newer than gcVersionInBaseSnapshot", () => {
+				const gcVersionInBaseSnapshot = stableGCVersion - 1;
+				gc = createGcWithPrivateMembers({ gcFeature: gcVersionInBaseSnapshot });
+				assert.equal(gc.configs.gcEnabled, true, "PRECONDITION: gcEnabled set incorrectly");
+				assert.equal(gc.configs.shouldRunGC, true, "shouldRunGC should be true");
+				assert.equal(
+					gc.configs.gcVersionInBaseSnapshot,
+					gcVersionInBaseSnapshot,
+					"gcVersionInBaseSnapshot set incorrectly",
+				);
+			});
+
+			it("shouldRunGC should be false when gcVersionInEffect is older than gcVersionInBaseSnapshot", () => {
+				const gcVersionInBaseSnapshot = currentGCVersion + 1;
+				gc = createGcWithPrivateMembers({ gcFeature: gcVersionInBaseSnapshot });
+				assert.equal(gc.configs.gcEnabled, true, "PRECONDITION: gcEnabled set incorrectly");
+				assert.equal(gc.configs.shouldRunGC, false, "shouldRunGC should be false");
+				assert.equal(
+					gc.configs.gcVersionInBaseSnapshot,
+					gcVersionInBaseSnapshot,
+					"gcVersionInBaseSnapshot set incorrectly",
+				);
 			});
 		});
 		describe("shouldRunSweep", () => {

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -35,7 +35,6 @@ describe("GCSummaryStateTracker tests", () => {
 				true /* wasGCRunInBaseSnapshot */,
 			) as any;
 			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
-			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
 				true,
@@ -72,7 +71,6 @@ describe("GCSummaryStateTracker tests", () => {
 				true /* wasGCRunInBaseSnapshot */,
 			) as any;
 			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
-			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
 				false,
@@ -91,7 +89,6 @@ describe("GCSummaryStateTracker tests", () => {
 				true /* wasGCRunInBaseSnapshot */,
 			) as any;
 			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
-			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
 
 			// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset)
 			// shouldn't need to do it again.

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -15,15 +15,16 @@ import {
 	IGCStats,
 } from "../../gc";
 import { RefreshSummaryResult } from "../../summary";
-import { parseNothing } from "./garbageCollection.spec";
+import { parseNothing } from "./gcUnitTestHelpers";
 
 type GCSummaryStateTrackerWithPrivates = Omit<GCSummaryStateTracker, "latestSummaryGCVersion"> & {
 	latestSummaryGCVersion: GCVersion;
 };
 
 describe("GCSummaryStateTracker tests", () => {
-	describe("latestSummaryGCVersion", () => {
-		it("Persisted < Current: Do Need Reset", () => {
+	describe("Summary state reset", () => {
+		// In these tests, Persisted = gcVersionInBaseSnapshot. Current = gcVersionInEffect.
+		it("Persisted < Current: Do Need Reset", async () => {
 			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
 				{
 					shouldRunGC: true,
@@ -39,6 +40,24 @@ describe("GCSummaryStateTracker tests", () => {
 				tracker.doesSummaryStateNeedReset,
 				true,
 				"Should need reset: Persisted GC Version was old",
+			);
+
+			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
+			const refreshSummaryResult: RefreshSummaryResult = {
+				latestSummaryUpdated: true,
+				wasSummaryTracked: true,
+				summaryRefSeq: 0,
+			};
+			await tracker.refreshLatestSummary(
+				undefined /* proposalHandle */,
+				refreshSummaryResult,
+				parseNothing,
+			);
+
+			assert.equal(
+				tracker.doesSummaryStateNeedReset,
+				false,
+				"Shouldn't need reset after first summary",
 			);
 		});
 
@@ -61,7 +80,7 @@ describe("GCSummaryStateTracker tests", () => {
 			);
 		});
 
-		it("Persisted > Current: Do Need Reset", () => {
+		it("Persisted > Current: Do Need Reset", async () => {
 			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
 				{
 					shouldRunGC: true,
@@ -74,12 +93,119 @@ describe("GCSummaryStateTracker tests", () => {
 			assert.equal(tracker.doesGCStateNeedReset, false, "Precondition 1");
 			assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
 
-			// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset) shouldn't need to do it again.
+			// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset)
+			// shouldn't need to do it again.
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
 				true,
 				"Should need reset: Persisted GC Version is not old",
 			);
+
+			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
+			const refreshSummaryResult: RefreshSummaryResult = {
+				latestSummaryUpdated: true,
+				wasSummaryTracked: true,
+				summaryRefSeq: 0,
+			};
+			await tracker.refreshLatestSummary(
+				undefined /* proposalHandle */,
+				refreshSummaryResult,
+				parseNothing,
+			);
+			assert.equal(
+				tracker.doesSummaryStateNeedReset,
+				false,
+				"Shouldn't need reset after first summary",
+			);
+		});
+	});
+
+	describe("GC state reset", () => {
+		it("wasGCRunInBaseSnapshot = false, shouldRunGC = false: Don't Need Reset", () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: false,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 1,
+					gcVersionInEffect: 1,
+				},
+				false /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, false, "Shouldn't need reset");
+		});
+
+		it("wasGCRunInBaseSnapshot = true, shouldRunGC = false: Do Need Reset", async () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: false,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 1,
+					gcVersionInEffect: 1,
+				},
+				true /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, true, "Should need reset");
+
+			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
+			const refreshSummaryResult: RefreshSummaryResult = {
+				latestSummaryUpdated: true,
+				wasSummaryTracked: true,
+				summaryRefSeq: 0,
+			};
+			await tracker.refreshLatestSummary(
+				undefined /* proposalHandle */,
+				refreshSummaryResult,
+				parseNothing,
+			);
+			assert.equal(
+				tracker.doesGCStateNeedReset,
+				false,
+				"Shouldn't need reset after first summary",
+			);
+		});
+
+		it("wasGCRunInBaseSnapshot = false, shouldRunGC = true: Do Need Reset", async () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: true,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 1,
+					gcVersionInEffect: 1,
+				},
+				false /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, true, "Should need reset");
+
+			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
+			const refreshSummaryResult: RefreshSummaryResult = {
+				latestSummaryUpdated: true,
+				wasSummaryTracked: true,
+				summaryRefSeq: 0,
+			};
+			await tracker.refreshLatestSummary(
+				undefined /* proposalHandle */,
+				refreshSummaryResult,
+				parseNothing,
+			);
+
+			assert.equal(
+				tracker.doesGCStateNeedReset,
+				false,
+				"Shouldn't need reset after first summary",
+			);
+		});
+
+		it("wasGCRunInBaseSnapshot = true, shouldRunGC = true: Don't Need Reset", () => {
+			const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+				{
+					shouldRunGC: true,
+					tombstoneMode: false,
+					gcVersionInBaseSnapshot: 1,
+					gcVersionInEffect: 1,
+				},
+				true /* wasGCRunInBaseSnapshot */,
+			) as any;
+			assert.equal(tracker.doesGCStateNeedReset, false, "Shouldn't need reset");
 		});
 	});
 

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -11,7 +11,6 @@ import {
 	MockLogger,
 	TelemetryDataTag,
 	ConfigTypes,
-	IConfigProviderBase,
 	mixinMonitoringContext,
 	MonitoringContext,
 	ChildLogger,
@@ -28,10 +27,7 @@ import {
 } from "../../gc";
 import { pkgVersion } from "../../packageVersion";
 import { BlobManager } from "../../blobManager";
-
-export const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-	getRawConfig: (name: string): ConfigTypes => settings[name],
-});
+import { configProvider } from "./gcUnitTestHelpers";
 
 describe("GC Telemetry Tracker", () => {
 	const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;

--- a/packages/runtime/container-runtime/src/test/gc/gcUnitTestHelpers.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcUnitTestHelpers.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
+
+export const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+	getRawConfig: (name: string): ConfigTypes => settings[name],
+});
+
+export const parseNothing: ReadAndParseBlob = async <T>() => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	const x: T = {} as T;
+	return x;
+};

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
@@ -9,7 +9,11 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
-import { channelsTreeName, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import {
+	channelsTreeName,
+	gcTreeKey,
+	IContainerRuntimeBase,
+} from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	ITestFluidObject,
@@ -22,36 +26,21 @@ import {
 import { describeNoCompat } from "@fluid-internal/test-version-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
-	GCSummaryStateTracker,
+	IGCMetadata,
 	IGarbageCollector,
 	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/container-runtime/dist/gc";
 
-// Type that is used to increment the GC version of garbage collector which is private property.
+// IContainerRuntime type that exposes garbage collector which is a private property.
 type IContainerRuntimeWithPrivates = IContainerRuntime & {
-	readonly garbageCollector: IGarbageCollector & {
-		summaryStateTracker: Omit<GCSummaryStateTracker, "currentGCVersion"> & {
-			currentGCVersion: number;
-		};
-	};
+	readonly garbageCollector: IGarbageCollector;
 };
 
 /**
- * Runtime dataObjectFactory that increments the current GC version of the container runtime it creates. This is used
- * to simulate scenario where the GC version upgrades and we have to regenerate the GC data and summary.
+ * Validates that when the runtime GC version changes, we reset GC state and regenerate summary. Basically, when we
+ * update the GC version due to bugs, newer versions re-run GC and older versions stop running GC.
  */
-class ContainerRuntimeFactoryWithGC extends ContainerRuntimeFactoryWithDefaultDataStore {
-	protected async containerHasInitialized(runtime: IContainerRuntimeWithPrivates) {
-		runtime.garbageCollector.summaryStateTracker.currentGCVersion += 1;
-	}
-}
-
-/**
- * Validates that when the runtime GC version changes, we re-run GC and summary. Basically, when we update the GC
- * version due to either bugs or changes in the implementation, we re-run GC and regenerate summary based on the
- * new GC code.
- */
-describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
+describeNoCompat("GC version update", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	const dataObjectFactory = new TestFluidObjectFactory([]);
 	const runtimeOptions: IContainerRuntimeOptions = {
@@ -87,9 +76,13 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
 	async function summarizeAndValidateDataStoreState(
 		summarizer: ISummarizer,
 		dataStoresAsHandles: string[],
+		gcEnabled: boolean,
 	) {
 		await provider.ensureSynchronized();
 		const summaryResult = await summarizeNow(summarizer);
+
+		const gcTreeExists = summaryResult.summaryTree.tree[gcTreeKey] !== undefined;
+		assert.strictEqual(gcTreeExists, gcEnabled, "GC tree in summary is not as expected.");
 
 		const dataStoreTrees = (summaryResult.summaryTree.tree[channelsTreeName] as ISummaryTree)
 			.tree;
@@ -107,6 +100,31 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
 			}
 		}
 		return summaryResult.summaryVersion;
+	}
+
+	/**
+	 * Function that sets up a container such that the GC version is the metadata blob in summary is updated as per
+	 * gcVersionDiff param. It either increments or decrements the version to provide the ability to test clients
+	 * running different GC versions.
+	 */
+	async function setupGCVersionUpdateInMetadata(container: IContainer, gcVersionDiff: number) {
+		const ds = await requestFluidObject<ITestFluidObject>(container, "default");
+
+		// Override the getMetadata function in GarbageCollector to update the gcFeature property.
+		const containerRuntime = ds.context.containerRuntime as IContainerRuntimeWithPrivates;
+		let getMetadataFunc = containerRuntime.garbageCollector.getMetadata;
+		const getMetadataOverride = () => {
+			getMetadataFunc = getMetadataFunc.bind(containerRuntime.garbageCollector);
+			const metadata = getMetadataFunc();
+			const gcFeature = metadata.gcFeature;
+			assert(gcFeature !== undefined, "gcFeature not found in GC metadata");
+			const updatedMetadata: IGCMetadata = {
+				...metadata,
+				gcFeature: gcFeature + gcVersionDiff,
+			};
+			return updatedMetadata;
+		};
+		containerRuntime.garbageCollector.getMetadata = getMetadataOverride;
 	}
 
 	beforeEach(async () => {
@@ -132,40 +150,94 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
 		await waitForContainerConnection(mainContainer);
 	});
 
-	it("should regenerate summary and GC data when GC version updates", async () => {
+	it("should regenerate summary and GC data when GC version is newer that the one in base snapshot", async () => {
 		// Stores the ids of data stores whose summary tree should be handles.
 		let dataStoresAsHandles: string[] = [];
 
 		// Create a summarizer client.
-		const { summarizer: summarizer1 } = await createSummarizerFromFactory(
-			provider,
-			mainContainer,
-			dataObjectFactory,
-		);
+		const { summarizer: summarizer1, container: container1 } =
+			await createSummarizerFromFactory(provider, mainContainer, dataObjectFactory);
+		// Setup the summarizer container's GC version in summary to be decremented by 1. Containers that load from
+		// this summary will have newer GC version.
+		await setupGCVersionUpdateInMetadata(container1, -1 /* gcVersionDiff */);
 
 		// Generate a summary and validate that all data store summaries are trees.
-		await summarizeAndValidateDataStoreState(summarizer1, dataStoresAsHandles);
+		await summarizeAndValidateDataStoreState(
+			summarizer1,
+			dataStoresAsHandles,
+			true /* gcEnabled */,
+		);
 
 		// Generate another summary in which the summaries for all data stores are handles.
 		dataStoresAsHandles.push(dataStore1Id, dataStore2Id, dataStore3Id);
 		const summaryVersion = await summarizeAndValidateDataStoreState(
 			summarizer1,
 			dataStoresAsHandles,
+			true /* gcEnabled */,
 		);
 
-		// Create a new summarizer with a new GC version and the latest summary that has been generated.
+		// Create a new summarizer. It will have newer GC version that the above container.
 		summarizer1.close();
 		const { summarizer: summarizer2 } = await createSummarizerFromFactory(
 			provider,
 			mainContainer,
 			dataObjectFactory,
 			summaryVersion,
-			ContainerRuntimeFactoryWithGC,
 		);
 
 		// Validate that there aren't any handles in the summary generated by the new mainContainer runtime since the
 		// GC version got updated.
 		dataStoresAsHandles = [];
-		await summarizeAndValidateDataStoreState(summarizer2, dataStoresAsHandles);
+		await summarizeAndValidateDataStoreState(
+			summarizer2,
+			dataStoresAsHandles,
+			true /* gcEnabled */,
+		);
+	});
+
+	it("should disable GC and regenerate state when GC version is older than the one in base snapshot", async () => {
+		// Stores the ids of data stores whose summary tree should be handles.
+		let dataStoresAsHandles: string[] = [];
+
+		// Create a summarizer client.
+		const { summarizer: summarizer1, container: container1 } =
+			await createSummarizerFromFactory(provider, mainContainer, dataObjectFactory);
+		// Setup the summarizer container's GC version in summary to be incremented by 1. Containers that load from
+		// this summary will have older GC version.
+		await setupGCVersionUpdateInMetadata(container1, 1 /* gcVersionDiff */);
+
+		// Generate a summary and validate that all data store summaries are trees.
+		await summarizeAndValidateDataStoreState(
+			summarizer1,
+			dataStoresAsHandles,
+			true /* gcEnabled */,
+		);
+
+		// Generate another summary in which the summaries for all data stores are handles.
+		dataStoresAsHandles.push(dataStore1Id, dataStore2Id, dataStore3Id);
+		const summaryVersion = await summarizeAndValidateDataStoreState(
+			summarizer1,
+			dataStoresAsHandles,
+			true /* gcEnabled */,
+		);
+
+		// Create a new summarizer. It will have older GC version that the above container.
+		summarizer1.close();
+		const { summarizer: summarizer2 } = await createSummarizerFromFactory(
+			provider,
+			mainContainer,
+			dataObjectFactory,
+			summaryVersion,
+		);
+
+		// Validate that there aren't any handles in the summary generated by the new mainContainer runtime since the
+		// GC version got updated.
+		// Also, GC should not have run since this summarizer's GC version is older than the one it loaded from.
+		dataStoresAsHandles = [];
+		await summarizeAndValidateDataStoreState(
+			summarizer2,
+			dataStoresAsHandles,
+			false /* gcEnabled */,
+		);
 	});
 });


### PR DESCRIPTION
Currently, if the GC versions changes, the GC state is reset, summary is regenerated and GC runs again with the GC version of the current container.
This change updates this behavior to the following:
- If the GC version of a container is same or newer than the one in the base snapshot it loads from, it will reset GC state, regenerate summary and run GC with the current container's GC version.
- If the GC version of a container is older than the one in the base snapshot, it will reset GC state and regenerate summary but it will not run GC anymore.
The reason behind this is that we will typically increment the GC version when we find a bug in the GC code which can lead to incorrect GC state. If a container learns that there is a newer GC version out there, if it continues to run GC with an older version, it may be generating incorrect GC state and re-introducing bugs fixed by the newer GC version. So, it should stop running GC to prevent further damage.


[AB#3947](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3947)
