### PR TITLE
Tree: clarify move API and fix bounds checking of it

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -773,8 +773,7 @@ export interface IDefaultEditBuilder {
     addNodeExistsConstraint(path: UpPath): void;
     // (undocumented)
     addValueConstraint(path: UpPath, value: Value): void;
-    // (undocumented)
-    move(sourceField: FieldUpPath, sourceIndex: number, count: number, destinationField: FieldUpPath, destIndex: number): void;
+    move(sourceField: FieldUpPath, sourceIndex: number, count: number, destinationField: FieldUpPath, destinationIndex: number): void;
     // (undocumented)
     optionalField(field: FieldUpPath): OptionalFieldEditBuilder;
     // (undocumented)

--- a/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
@@ -100,13 +100,19 @@ export interface IDefaultEditBuilder {
 	 */
 	sequenceField(field: FieldUpPath): SequenceFieldEditBuilder;
 
-	// TODO: document
+	/**
+	 * Moves a subsequence from one sequence field to another sequence.
+	 *
+	 * Note that in the case where the source and destination are the same, the `destinationIndex` is the final index the first node moved would end up at.
+	 * Thus if moving nodes from a lower to a higher index withing the same field, the `destinationIndex` must be computed as if the subsequence being moved has already been removed.
+	 * See {@link SequenceFieldEditBuilder.move} for details.
+	 */
 	move(
 		sourceField: FieldUpPath,
 		sourceIndex: number,
 		count: number,
 		destinationField: FieldUpPath,
-		destIndex: number,
+		destinationIndex: number,
 	): void;
 
 	// TODO: document

--- a/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
@@ -101,9 +101,9 @@ export interface IDefaultEditBuilder {
 	sequenceField(field: FieldUpPath): SequenceFieldEditBuilder;
 
 	/**
-	 * Moves a subsequence from one sequence field to another sequence.
+	 * Moves a subsequence from one sequence field to another sequence field.
 	 *
-	 * Note that in the case where the source and destination are the same, the `destinationIndex` is the final index the first node moved would end up at.
+	 * Note that the `destinationIndex` is the final index the first node moved should end up at.
 	 * Thus if moving nodes from a lower to a higher index within the same field, the `destinationIndex` must be computed as if the subsequence being moved has already been removed.
 	 * See {@link SequenceFieldEditBuilder.move} for details.
 	 */

--- a/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
@@ -104,7 +104,7 @@ export interface IDefaultEditBuilder {
 	 * Moves a subsequence from one sequence field to another sequence.
 	 *
 	 * Note that in the case where the source and destination are the same, the `destinationIndex` is the final index the first node moved would end up at.
-	 * Thus if moving nodes from a lower to a higher index withing the same field, the `destinationIndex` must be computed as if the subsequence being moved has already been removed.
+	 * Thus if moving nodes from a lower to a higher index within the same field, the `destinationIndex` must be computed as if the subsequence being moved has already been removed.
 	 * See {@link SequenceFieldEditBuilder.move} for details.
 	 */
 	move(

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -114,13 +114,13 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 
 	/**
 	 * Check if this field is the same as a different field.
-	 * This is defined to mean that both are in the same editable tree, and are the same failed on the same node.
+	 * This is defined to mean that both are in the same editable tree, and are the same field on the same node.
 	 * This is more than just a reference comparison because unlike EditableTree nodes, fields are not cached on anchors and can be duplicated.
 	 */
 	private isSameAs(other: FieldProxyTarget): boolean {
 		assert(
 			other.context === this.context,
-			"Content from different editable trees should not bew used together",
+			"Content from different editable trees should not be used together",
 		);
 		return this.fieldKey === other.fieldKey && this.parent === other.parent;
 	}
@@ -366,7 +366,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		assert(destination.kind === FieldKinds.sequence, "Move destination must be a sequence.");
 
 		assertNonNegativeSafeInteger(count);
-		// This permits a move of 0 noted starting at this.length, which does seem like it should be allowed.
+		// This permits a move of 0 nodes starting at this.length, which does seem like it should be allowed.
 		assertValidIndex(sourceIndex + count, this, true);
 
 		let destinationLength = destination.length;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -32,7 +32,7 @@ import {
 	cursorsFromContextualData,
 } from "../contextuallyTyped";
 import { FieldKinds } from "../defaultFieldKinds";
-import { assertValidIndex, fail, isReadonlyArray } from "../../util";
+import { assertValidIndex, fail, isReadonlyArray, assertNonNegativeSafeInteger } from "../../util";
 import {
 	OptionalFieldEditBuilder,
 	SequenceFieldEditBuilder,
@@ -110,6 +110,19 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		this.fieldKey = cursor.getFieldKey();
 		this[arrayLikeMarkerSymbol] = true;
 		this.kind = getFieldKind(this.fieldSchema);
+	}
+
+	/**
+	 * Check if this field is the same as a different field.
+	 * This is defined to mean that both are in the same editable tree, and are the same failed on the same node.
+	 * This is more than just a reference comparison because unlike EditableTree nodes, fields are not cached on anchors and can be duplicated.
+	 */
+	private isSameAs(other: FieldProxyTarget): boolean {
+		assert(
+			other.context === this.context,
+			"Content from different editable trees should not bew used together",
+		);
+		return this.fieldKey === other.fieldKey && this.parent === other.parent;
 	}
 
 	public normalizeNewContent(content: NewFieldContent): readonly ITreeCursor[] {
@@ -338,26 +351,31 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		destinationField?: EditableField,
 	): void {
 		const sourceFieldPath = this.cursor.getFieldPath();
-		const destinationFieldKindIdentifier =
-			destinationField?.fieldSchema.kind.identifier ?? this.kind.identifier;
 
-		assert(this.kind === FieldKinds.sequence, "Move source field must be a sequence field.");
+		const destination =
+			destinationField === undefined
+				? this
+				: (destinationField?.[proxyTargetSymbol] as ProxyTarget<Anchor | FieldAnchor>);
+
 		assert(
-			destinationFieldKindIdentifier === FieldKinds.sequence.identifier,
-			"Move destination field must be a sequence field.",
+			isFieldProxyTarget(destination),
+			0x684 /* destination must be a field proxy target */,
 		);
 
-		const destinationFieldProxy =
-			destinationField !== undefined
-				? (destinationField[proxyTargetSymbol] as ProxyTarget<Anchor | FieldAnchor>)
-				: this;
-		assert(
-			isFieldProxyTarget(destinationFieldProxy),
-			0x684 /* destination field proxy must be a field proxy target */,
-		);
-		assertValidIndex(destinationIndex, destinationFieldProxy, true);
+		assert(this.kind === FieldKinds.sequence, "Move source must be a sequence.");
+		assert(destination.kind === FieldKinds.sequence, "Move destination must be a sequence.");
 
-		const destinationFieldPath = destinationFieldProxy.cursor.getFieldPath();
+		assertNonNegativeSafeInteger(count);
+		// This permits a move of 0 noted starting at this.length, which does seem like it should be allowed.
+		assertValidIndex(sourceIndex + count, this, true);
+
+		let destinationLength = destination.length;
+		if (this.isSameAs(destination)) {
+			destinationLength -= count;
+		}
+		assertValidIndex(destinationIndex, { length: destinationLength }, true);
+
+		const destinationFieldPath = destination.cursor.getFieldPath();
 
 		this.context.editor.move(
 			sourceFieldPath,

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -66,5 +66,6 @@ export {
 	zipIterables,
 	Assume,
 	assertValidIndex,
+	assertNonNegativeSafeInteger,
 } from "./utils";
 export { ReferenceCountedBase, ReferenceCounted } from "./referenceCounting";

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -239,13 +239,17 @@ export function assertValidIndex(
 	array: { readonly length: number },
 	allowOnePastEnd: boolean = false,
 ) {
-	assert(Number.isInteger(index), 0x376 /* index must be an integer */);
-	assert(index >= 0, 0x377 /* index must be non-negative */);
+	assertNonNegativeSafeInteger(index);
 	if (allowOnePastEnd) {
 		assert(index <= array.length, 0x378 /* index must be less than or equal to length */);
 	} else {
 		assert(index < array.length, 0x379 /* index must be less than length */);
 	}
+}
+
+export function assertNonNegativeSafeInteger(index: number) {
+	assert(Number.isSafeInteger(index), 0x376 /* index must be an integer */);
+	assert(index >= 0, 0x377 /* index must be non-negative */);
 }
 
 /**


### PR DESCRIPTION
## Description

Clarify moveNodes API and fix bounds checking of it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

