### PR TITLE
FF.com Add underline to cta banner

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -32,6 +32,7 @@ footer {
     color: #f3f5f7;
     transition: 0.1s ease-in;
     background: #404049;
+    text-decoration: underline;
 }
 
 .cta svg {


### PR DESCRIPTION
requirements from [AB#1442](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1442) to add underlines to CTA banner

<img width="761" alt="image" src="https://github.com/microsoft/FluidFramework/assets/107130183/62a1daf4-9925-44d0-a08e-390c2d02afbb">

<img width="765" alt="image" src="https://github.com/microsoft/FluidFramework/assets/107130183/0f9d0404-3d33-443d-af3d-159f1251bc2c">
