### PR TITLE
Update token

### DIFF
--- a/.github/workflows/merge-commits.yml
+++ b/.github/workflows/merge-commits.yml
@@ -116,7 +116,7 @@ jobs:
           token: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
           script: |
             const { Octokit } = require("@octokit/core");
-            const token = `${{ secrets.FLUIDBOTPAT }}`;
+            const token = `${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}`;
             const sha = 'main-next-${{needs.dequeue.outputs.SHA}}';
             const author = '${{needs.dequeue.outputs.AUTHOR}}';
             const description = `


### PR DESCRIPTION
The main/next workflow has been failing at the generate `pull request` step due to `Bad credentials`. Updating the PAT token is an attempt to get the workflow working. 