### PR TITLE
Add attachIndex/detachIndex API for Interval Collection Querying

### DIFF
--- a/.changeset/unlucky-falcons-breathe.md
+++ b/.changeset/unlucky-falcons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@fluidframework/sequence": major
+---
+
+Add attachIndex/detachIndex API to IntervalCollection for interval querying

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -158,6 +158,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     get attached(): boolean;
     // @internal (undocumented)
     attachGraph(client: Client, label: string): void;
+    attachIndex(index: IntervalIndex<TInterval>): void;
     change(id: string, start?: number, end?: number): TInterval | undefined;
     changeProperties(id: string, props: PropertySet): void;
     // (undocumented)
@@ -168,6 +169,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     CreateForwardIteratorWithEndPosition(endPosition: number): IntervalCollectionIterator<TInterval>;
     // (undocumented)
     CreateForwardIteratorWithStartPosition(startPosition: number): IntervalCollectionIterator<TInterval>;
+    detachIndex(index: IntervalIndex<TInterval>): boolean;
     // (undocumented)
     findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[];
     gatherIterationResults(results: TInterval[], iteratesForward: boolean, start?: number, end?: number): void;
@@ -194,6 +196,12 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 
 // @public @deprecated (undocumented)
 export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) => TInterval;
+
+// @public
+export interface IntervalIndex<TInterval extends ISerializableInterval> {
+    add(interval: TInterval): void;
+    remove(interval: TInterval): void;
+}
 
 // @public
 export interface IntervalLocator {

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -127,6 +127,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_IntervalCollection": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -21,6 +21,7 @@ export {
 	IIntervalCollectionEvent,
 	IIntervalHelpers,
 	Interval,
+	IntervalIndex,
 	IntervalCollection,
 	IntervalCollectionIterator,
 	IntervalLocator,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1575,6 +1575,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	 * Detaches an index from this collection.
 	 * All intervals which are part of this collection will be removed from the index, and updates to this collection
 	 * due to local or remote changes will no longer incur updates to the index.
+	 *
+	 * @returns - Return false if the target index cannot be found in the indexes, otherwise remove all intervals in the index and return true
 	 */
 	public detachIndex(index: IntervalIndex<TInterval>): boolean {
 		if (!this.attached) {

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1112,10 +1112,6 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 		return this.indexes.delete(index);
 	}
 
-	public hasIndex(index: IntervalIndex<TInterval>): boolean {
-		return this.indexes.has(index);
-	}
-
 	public removeExistingInterval(interval: TInterval) {
 		this.removeIntervalFromIndexes(interval);
 		this.removeIntervalListeners(interval);
@@ -1586,7 +1582,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		}
 
 		// Avoid removing intervals if the index does not exist
-		if (!this.localCollection?.hasIndex(index)) {
+		if (!this.localCollection?.removeIndex(index)) {
 			return false;
 		}
 
@@ -1594,7 +1590,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 			index.remove(interval);
 		}
 
-		return this.localCollection.removeIndex(index);
+		return true;
 	}
 
 	private rebasePositionWithSegmentSlide(

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1041,7 +1041,7 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 	public readonly overlappingIntervalsIndex: OverlappingIntervalsIndex<TInterval>;
 	public readonly idIntervalIndex: IdIntervalIndex<TInterval>;
 	public readonly endIntervalIndex: EndpointIndex<TInterval>;
-	private readonly indexes: IntervalIndex<TInterval>[];
+	private readonly indexes: Set<IntervalIndex<TInterval>>;
 
 	constructor(
 		private readonly client: Client,
@@ -1056,11 +1056,11 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 		this.overlappingIntervalsIndex = new OverlappingIntervalsIndex(client, helpers);
 		this.idIntervalIndex = new IdIntervalIndex();
 		this.endIntervalIndex = new EndpointIndex(client, helpers);
-		this.indexes = [
+		this.indexes = new Set([
 			this.overlappingIntervalsIndex,
 			this.idIntervalIndex,
 			this.endIntervalIndex,
-		];
+		]);
 	}
 
 	public createLegacyId(start: number, end: number): string {
@@ -1105,16 +1105,11 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 	}
 
 	public appendIndex(index: IntervalIndex<TInterval>) {
-		this.indexes.push(index);
+		this.indexes.add(index);
 	}
 
 	public removeIndex(index: IntervalIndex<TInterval>): boolean {
-		const indexToRemove = this.indexes.indexOf(index);
-		if (indexToRemove !== -1) {
-			this.indexes.splice(indexToRemove, 1);
-			return true; // Index removed successfully
-		}
-		return false; // Index not found in this.indexes
+		return this.indexes.delete(index);
 	}
 
 	public removeExistingInterval(interval: TInterval) {
@@ -1589,6 +1584,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 			index.remove(interval);
 		}
 
+		// Avoid removing intervals from the index if it was not present
 		return this.localCollection?.removeIndex(index) ?? false;
 	}
 

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1112,6 +1112,10 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 		return this.indexes.delete(index);
 	}
 
+	public hasIndex(index: IntervalIndex<TInterval>): boolean {
+		return this.indexes.has(index);
+	}
+
 	public removeExistingInterval(interval: TInterval) {
 		this.removeIntervalFromIndexes(interval);
 		this.removeIntervalListeners(interval);
@@ -1580,12 +1584,17 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		if (!this.attached) {
 			throw new LoggingError("The local interval collection must exist");
 		}
+
+		// Avoid removing intervals if the index does not exist
+		if (!this.localCollection?.hasIndex(index)) {
+			return false;
+		}
+
 		for (const interval of this) {
 			index.remove(interval);
 		}
 
-		// Avoid removing intervals from the index if it was not present
-		return this.localCollection?.removeIndex(index) ?? false;
+		return this.localCollection.removeIndex(index);
 	}
 
 	private rebasePositionWithSegmentSlide(

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1560,14 +1560,11 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		if (!this.attached) {
 			throw new LoggingError("The local interval collection must exist");
 		}
-		this.localCollection?.appendIndex(index);
-		const iterator = this[Symbol.iterator]();
-		let iteratorResult = iterator.next();
-		while (!iteratorResult.done) {
-			const interval = iteratorResult.value;
+		for (const interval of this) {
 			this.localCollection?.add(interval);
-			iteratorResult = iterator.next();
 		}
+
+		this.localCollection?.appendIndex(index);
 	}
 
 	private rebasePositionWithSegmentSlide(

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1108,6 +1108,15 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 		this.indexes.push(index);
 	}
 
+	public removeIndex(index: IntervalIndex<TInterval>): boolean {
+		const indexToRemove = this.indexes.indexOf(index);
+		if (indexToRemove !== -1) {
+			this.indexes.splice(indexToRemove, 1);
+			return true; // Index removed successfully
+		}
+		return false; // Index not found in this.indexes
+	}
+
 	public removeExistingInterval(interval: TInterval) {
 		this.removeIntervalFromIndexes(interval);
 		this.removeIntervalListeners(interval);
@@ -1561,10 +1570,26 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 			throw new LoggingError("The local interval collection must exist");
 		}
 		for (const interval of this) {
-			this.localCollection?.add(interval);
+			index.add(interval);
 		}
 
 		this.localCollection?.appendIndex(index);
+	}
+
+	/**
+	 * Detaches an index from this collection.
+	 * All intervals which are part of this collection will be removed from the index, and updates to this collection
+	 * due to local or remote changes will no longer incur updates to the index.
+	 */
+	public detachIndex(index: IntervalIndex<TInterval>): boolean {
+		if (!this.attached) {
+			throw new LoggingError("The local interval collection must exist");
+		}
+		for (const interval of this) {
+			index.remove(interval);
+		}
+
+		return this.localCollection?.removeIndex(index) ?? false;
 	}
 
 	private rebasePositionWithSegmentSlide(

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1104,6 +1104,10 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 		}
 	}
 
+	public appendIndex(index: IntervalIndex<TInterval>) {
+		this.indexes.push(index);
+	}
+
 	public removeExistingInterval(interval: TInterval) {
 		this.removeIntervalFromIndexes(interval);
 		this.removeIntervalListeners(interval);
@@ -1542,6 +1546,28 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 			: serializedIntervals.intervals.map((i) =>
 					decompressInterval(i, serializedIntervals.label),
 			  );
+	}
+
+	/**
+	 * Attaches an index to this collection.
+	 * All intervals which are part of this collection will be added to the index, and the index will automatically
+	 * be updated when this collection updates due to local or remote changes.
+	 *
+	 * @remarks - After attaching an index to an interval collection, applications should typically store this
+	 * index somewhere in their in-memory data model for future reference and querying.
+	 */
+	public attachIndex(index: IntervalIndex<TInterval>): void {
+		if (!this.attached) {
+			throw new LoggingError("The local interval collection must exist");
+		}
+		this.localCollection?.appendIndex(index);
+		const iterator = this[Symbol.iterator]();
+		let iteratorResult = iterator.next();
+		while (!iteratorResult.done) {
+			const interval = iteratorResult.value;
+			this.localCollection?.add(interval);
+			iteratorResult = iterator.next();
+		}
 	}
 
 	private rebasePositionWithSegmentSlide(

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -1469,6 +1469,11 @@ describe("SharedString interval collections", () => {
 					end: 3,
 				});
 			});
+
+			it("can not detach the index does not exist", () => {
+				assert.equal(collection.detachIndex(mockIntervalIndex), true);
+				assert.equal(collection.detachIndex(mockIntervalIndex), false);
+			});
 		});
 	});
 });

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -407,6 +407,7 @@ declare function get_old_ClassDeclaration_IntervalCollection():
 declare function use_current_ClassDeclaration_IntervalCollection(
     use: TypeOnly<current.IntervalCollection<any>>);
 use_current_ClassDeclaration_IntervalCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_IntervalCollection());
 
 /*


### PR DESCRIPTION
## Description

Add `attachIndex/detachIndex` API (and related test suites) to make supported indexes customizable

[AB#4152](https://dev.azure.com/fluidframework/internal/_workitems/edit/4152)