### PR TITLE
Performance improvement around token fetching for AFR driver

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -16,7 +16,11 @@ import { DocumentStorageService } from "./documentStorageService";
 import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
 import { NullBlobStorageService } from "./nullBlobStorageService";
 import { ITokenProvider } from "./tokens";
-import { RouterliciousOrdererRestWrapper, RouterliciousStorageRestWrapper } from "./restWrapper";
+import {
+	RouterliciousOrdererRestWrapper,
+	RouterliciousStorageRestWrapper,
+	TokenFetcher,
+} from "./restWrapper";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ICache } from "./cache";
 import { ISnapshotTreeVersion } from "./definitions";
@@ -68,6 +72,8 @@ export class DocumentService implements api.IDocumentService {
 		private readonly shreddedSummaryTreeCache: ICache<ISnapshotTreeVersion>,
 		private readonly discoverFluidResolvedUrl: () => Promise<api.IFluidResolvedUrl>,
 		private storageRestWrapper: RouterliciousStorageRestWrapper,
+		private readonly storageTokenFetcher: TokenFetcher,
+		private readonly ordererTokenFetcher: TokenFetcher,
 	) {}
 
 	private documentStorageService: DocumentStorageService | undefined;
@@ -104,8 +110,7 @@ export class DocumentService implements api.IDocumentService {
 					);
 					this.storageRestWrapper = await RouterliciousStorageRestWrapper.load(
 						this.tenantId,
-						this.documentId,
-						this.tokenProvider,
+						this.storageTokenFetcher,
 						this.logger,
 						rateLimiter,
 						this.driverPolicies.enableRestLess,
@@ -156,9 +161,7 @@ export class DocumentService implements api.IDocumentService {
 					this.driverPolicies.maxConcurrentOrdererRequests,
 				);
 				this.ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
-					this.tenantId,
-					this.documentId,
-					this.tokenProvider,
+					this.ordererTokenFetcher,
 					this.logger,
 					rateLimiter,
 					this.driverPolicies.enableRestLess,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -32,6 +32,7 @@ import {
 	RouterliciousOrdererRestWrapper,
 	RouterliciousStorageRestWrapper,
 	toInstrumentedR11sOrdererTokenFetcher,
+	toInstrumentedR11sStorageTokenFetcher,
 } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
 import { parseFluidUrl, replaceDocumentIdInPath, getDiscoveredFluidResolvedUrl } from "./urlUtils";
@@ -259,7 +260,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			this.tokenProvider,
 			logger2,
 		);
-		const storageTokenFetcher = toInstrumentedR11sOrdererTokenFetcher(
+		const storageTokenFetcher = toInstrumentedR11sStorageTokenFetcher(
 			tenantId,
 			documentId,
 			this.tokenProvider,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -28,7 +28,7 @@ import { ISession } from "@fluidframework/server-services-client";
 import { DocumentService } from "./documentService";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
-import { RouterliciousOrdererRestWrapper } from "./restWrapper";
+import { RouterliciousOrdererRestWrapper, RouterliciousStorageRestWrapper } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
 import { parseFluidUrl, replaceDocumentIdInPath, getDiscoveredFluidResolvedUrl } from "./urlUtils";
 import { ICache, InMemoryCache, NullCache } from "./cache";
@@ -295,6 +295,16 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			);
 		}
 
+		const storageRestWrapper = await RouterliciousStorageRestWrapper.load(
+			tenantId,
+			documentId,
+			this.tokenProvider,
+			logger2,
+			new RateLimiter(this.driverPolicies.maxConcurrentStorageRequests),
+			this.driverPolicies.enableRestLess,
+			storageUrl,
+		);
+
 		const documentStorageServicePolicies: IDocumentStorageServicePolicies = {
 			caching: this.driverPolicies.enablePrefetch
 				? LoaderCachingPolicy.Prefetch
@@ -320,6 +330,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			this.wholeSnapshotTreeCache,
 			this.shreddedSummaryTreeCache,
 			discoverFluidResolvedUrl,
+			storageRestWrapper,
 		);
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -354,6 +354,8 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			this.shreddedSummaryTreeCache,
 			discoverFluidResolvedUrl,
 			storageRestWrapper,
+			storageTokenFetcher,
+			ordererTokenFetcher,
 		);
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -28,7 +28,11 @@ import { ISession } from "@fluidframework/server-services-client";
 import { DocumentService } from "./documentService";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
-import { RouterliciousOrdererRestWrapper, RouterliciousStorageRestWrapper } from "./restWrapper";
+import {
+	RouterliciousOrdererRestWrapper,
+	RouterliciousStorageRestWrapper,
+	toInstrumentedR11sOrdererTokenFetcher,
+} from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
 import { parseFluidUrl, replaceDocumentIdInPath, getDiscoveredFluidResolvedUrl } from "./urlUtils";
 import { ICache, InMemoryCache, NullCache } from "./cache";
@@ -117,11 +121,15 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 		const quorumValues = getQuorumValuesFromProtocolSummary(protocolSummary);
 
 		const logger2 = ChildLogger.create(logger, "RouterliciousDriver");
+		const ordererTokenFetcher = toInstrumentedR11sOrdererTokenFetcher(
+			tenantId,
+			undefined /* documentId */,
+			this.tokenProvider,
+			logger2,
+		);
 		const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
 		const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
-			tenantId,
-			undefined,
-			this.tokenProvider,
+			ordererTokenFetcher,
 			logger2,
 			rateLimiter,
 			this.driverPolicies.enableRestLess,
@@ -245,14 +253,29 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			all: { driverVersion },
 		});
 
-		const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
-		const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
+		const ordererTokenFetcher = toInstrumentedR11sOrdererTokenFetcher(
 			tenantId,
 			documentId,
 			this.tokenProvider,
 			logger2,
+		);
+		const storageTokenFetcher = toInstrumentedR11sOrdererTokenFetcher(
+			tenantId,
+			documentId,
+			this.tokenProvider,
+			logger2,
+		);
+		const ordererTokenP = ordererTokenFetcher();
+		const storageTokenP = storageTokenFetcher();
+
+		const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
+		const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
+			ordererTokenFetcher,
+			logger2,
 			rateLimiter,
 			this.driverPolicies.enableRestLess,
+			undefined /* baseUrl */,
+			ordererTokenP,
 		);
 
 		const discoverFluidResolvedUrl = async (): Promise<IFluidResolvedUrl> => {
@@ -297,12 +320,12 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 
 		const storageRestWrapper = await RouterliciousStorageRestWrapper.load(
 			tenantId,
-			documentId,
-			this.tokenProvider,
+			storageTokenFetcher,
 			logger2,
 			new RateLimiter(this.driverPolicies.maxConcurrentStorageRequests),
 			this.driverPolicies.enableRestLess,
 			storageUrl,
+			storageTokenP,
 		);
 
 		const documentStorageServicePolicies: IDocumentStorageServicePolicies = {

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -100,6 +100,7 @@ export function getPropsToLogFromResponse(headers: {
 export class RouterliciousRestWrapper extends RestWrapper {
 	private readonly restLess = new RestLessClient();
 	private token: ITokenResponse | undefined;
+	private tokenP: Promise<ITokenResponse> | undefined;
 
 	constructor(
 		logger: ITelemetryLogger,
@@ -111,6 +112,8 @@ export class RouterliciousRestWrapper extends RestWrapper {
 		defaultQueryString: QueryStringType = {},
 	) {
 		super(baseurl, defaultQueryString);
+		// Initiate the token fetch.
+		this.tokenP = this.fetchRefreshedToken();
 	}
 
 	protected async request<T>(
@@ -221,8 +224,9 @@ export class RouterliciousRestWrapper extends RestWrapper {
 		if (this.token !== undefined) {
 			return this.token;
 		}
-		const token = await this.fetchRefreshedToken();
+		const token = await (this.tokenP ?? this.fetchRefreshedToken());
 		this.setToken(token);
+		this.tokenP = undefined;
 		return token;
 	}
 

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -8,7 +8,10 @@ import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter } from "@fluidframework/driver-utils";
 import nock from "nock";
-import { RouterliciousOrdererRestWrapper } from "../restWrapper";
+import {
+	RouterliciousOrdererRestWrapper,
+	toInstrumentedR11sOrdererTokenFetcher,
+} from "../restWrapper";
 import { RouterliciousErrorType } from "../errorUtils";
 import { DefaultTokenProvider } from "../defaultTokenProvider";
 import { ITokenResponse } from "../tokens";
@@ -57,11 +60,15 @@ describe("RouterliciousDriverRestWrapper", () => {
 			return newToken;
 		};
 
+		const logger = new TelemetryUTLogger();
 		restWrapper = await RouterliciousOrdererRestWrapper.load(
-			"dummytenantid",
-			"dummydocumentid",
-			tokenProvider,
-			new TelemetryUTLogger(),
+			toInstrumentedR11sOrdererTokenFetcher(
+				"dummytenantid",
+				"dummydocumentid",
+				tokenProvider,
+				logger,
+			),
+			logger,
 			rateLimiter,
 			false,
 		);


### PR DESCRIPTION
## Description

Performance improvement around token fetching for AFR driver. Based on learnings from ODSP driver where token fetching does take time, we want to initiate the token fetch as early as possible for AFR driver. So soon as the rest wrappers are created, initiate the token fetch so that they can be used later.