### PR TITLE
Adds LazyPromise wrapper on DependencyContainer resolver in order to ensure lazy loading of dependencies

### DIFF
--- a/api-report/synthesize.api.md
+++ b/api-report/synthesize.api.md
@@ -51,7 +51,6 @@ export interface IProvideFluidDependencySynthesizer {
     IFluidDependencySynthesizer: IFluidDependencySynthesizer;
 }
 
-
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -65,6 +65,9 @@
 		],
 		"temp-directory": "nyc/.nyc_output"
 	},
+	"dependencies": {
+		"@fluidframework/common-utils": "^1.1.1"
+	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { LazyPromise } from "@fluidframework/common-utils";
 import {
 	AsyncFluidObjectProvider,
 	FluidObjectSymbolProvider,
@@ -176,10 +177,12 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
 		return {
 			get() {
 				if (provider) {
-					return Promise.resolve(provider).then((p) => {
-						if (p) {
-							return p[t];
-						}
+					return new LazyPromise(async () => {
+						return Promise.resolve(provider).then((p) => {
+							if (p) {
+								return p[t];
+							}
+						});
 					});
 				}
 			},

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -135,7 +135,7 @@ describe("Routerlicious", () => {
 				const s = dc.synthesize<IFluidLoadable>({ IFluidLoadable }, undefined);
 				const loadable_promise = s.IFluidLoadable;
 				// This stacking of promises is done in order to make sure that the loadable_promise would have been executed by the time the assertion is done
-				void Promise.resolve().then(async () => {
+				await Promise.resolve().then(async () => {
 					assert(!lazyPromiseFlag, "Optional IFluidLoadable was correctly lazy loaded");
 					const loadable = await loadable_promise;
 					assert(loadable, "Optional IFluidLoadable was registered");
@@ -232,7 +232,7 @@ describe("Routerlicious", () => {
 				});
 				const loadable_promise = s.IFluidLoadable;
 				// This stacking of promises is done in order to make sure that the loadable_promise would have been executed by the time the assertion is done
-				void Promise.resolve().then(async () => {
+				await Promise.resolve().then(async () => {
 					assert(!lazyPromiseFlag, "Required IFluidLoadable was correctly lazy loaded");
 					const loadable = await loadable_promise;
 					assert(loadable, "Required IFluidLoadable was registered");

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -17,6 +17,7 @@ import {
 } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle } from "@fluidframework/datastore";
 
+import { LazyPromise } from "@fluidframework/common-utils";
 import { DependencyContainer } from "..";
 import { IFluidDependencySynthesizer } from "../IFluidDependencySynthesizer";
 import { AsyncFluidObjectProvider, FluidObjectProvider, FluidObjectSymbolProvider } from "../types";
@@ -121,6 +122,31 @@ describe("Routerlicious", () => {
 				);
 			});
 
+			it(`One Optional Provider registered via LazyPromise factory`, async () => {
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable>>();
+				const mock = new MockLoadable();
+				let lazyPromiseFlag = false;
+				const lazyFactory = new LazyPromise(async () => {
+					lazyPromiseFlag = true;
+					return mock;
+				});
+				dc.register(IFluidLoadable, lazyFactory);
+
+				const s = dc.synthesize<IFluidLoadable>({ IFluidLoadable }, undefined);
+				const loadable_promise = s.IFluidLoadable;
+				// This stacking of promises is done in order to make sure that the loadable_promise would have been executed by the time the assertion is done
+				void Promise.resolve().then(async () => {
+					assert(!lazyPromiseFlag, "Optional IFluidLoadable was correctly lazy loaded");
+					const loadable = await loadable_promise;
+					assert(loadable, "Optional IFluidLoadable was registered");
+					assert(loadable === mock, "IFluidLoadable is expected");
+					assert(
+						loadable?.handle.absolutePath === mock.handle.absolutePath,
+						"IFluidLoadable is valid",
+					);
+				});
+			});
+
 			it(`One Required Provider registered via value`, async () => {
 				const dc = new DependencyContainer<FluidObject<IFluidLoadable>>();
 				const mock = new MockLoadable();
@@ -189,6 +215,33 @@ describe("Routerlicious", () => {
 					loadable?.handle.absolutePath === mock.handle.absolutePath,
 					"IFluidLoadable is valid",
 				);
+			});
+
+			it(`One Required Provider registered via LazyPromise factory`, async () => {
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable>>();
+				const mock = new MockLoadable();
+				let lazyPromiseFlag = false;
+				const lazyFactory = new LazyPromise(async () => {
+					lazyPromiseFlag = true;
+					return mock;
+				});
+				dc.register(IFluidLoadable, lazyFactory);
+
+				const s = dc.synthesize<undefined, IProvideFluidLoadable>(undefined, {
+					IFluidLoadable,
+				});
+				const loadable_promise = s.IFluidLoadable;
+				// This stacking of promises is done in order to make sure that the loadable_promise would have been executed by the time the assertion is done
+				void Promise.resolve().then(async () => {
+					assert(!lazyPromiseFlag, "Required IFluidLoadable was correctly lazy loaded");
+					const loadable = await loadable_promise;
+					assert(loadable, "Required IFluidLoadable was registered");
+					assert(loadable === mock, "IFluidLoadable is expected");
+					assert(
+						loadable?.handle.absolutePath === mock.handle.absolutePath,
+						"IFluidLoadable is valid",
+					);
+				});
 			});
 
 			it(`Two Optional Modules all registered`, async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12038,6 +12038,10 @@ importers:
         version: 4.5.5
 
   packages/framework/synthesize:
+    dependencies:
+      '@fluidframework/common-utils':
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: ^0.17.0
@@ -18191,7 +18195,7 @@ packages:
     resolution: {integrity: sha512-2FdUL/10qOjXzPTt/2dcjQPHDcsI+svvdU3KERGZaUvH5IwDdzE+nGLAx1+ICxhr6cqU29zvWR6GHGOFp+fbWA==}
     engines: {node: '>=10'}
     peerDependencies:
-      webpack: ^4.30.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.30.0 || ^5.0.0 || 5.83.0
     dependencies:
       chalk: 4.1.2
       find-root: 1.1.0
@@ -25457,7 +25461,7 @@ packages:
       react-refresh: '>=0.10.0 <1.0.0'
       sockjs-client: ^1.4.0
       type-fest: '>=0.17.0 <4.0.0'
-      webpack: '>=4.43.0 <6.0.0 || 5.82.1'
+      webpack: '>=4.43.0 <6.0.0 || 5.83.0'
       webpack-dev-server: 3.x || 4.x
       webpack-hot-middleware: 2.x
       webpack-plugin-serve: 0.x || 1.x
@@ -26882,7 +26886,7 @@ packages:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
-      webpack: '>= 4 || 5.82.1'
+      webpack: '>= 4 || 5.83.0'
     dependencies:
       debug: 4.3.4
       endent: 2.1.0
@@ -28655,7 +28659,7 @@ packages:
   /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.83.0):
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
     peerDependencies:
-      webpack: 4.x.x || 5.x.x || 5.82.1
+      webpack: 4.x.x || 5.x.x || 5.83.0
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.83.0(webpack-cli@4.10.0)
@@ -29691,7 +29695,7 @@ packages:
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
-      webpack: '>=2 || 5.82.1'
+      webpack: '>=2 || 5.83.0'
     dependencies:
       '@babel/core': 7.21.8
       find-cache-dir: 3.3.2
@@ -29706,7 +29710,7 @@ packages:
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
-      webpack: '>=2 || 5.82.1'
+      webpack: '>=2 || 5.83.0'
     dependencies:
       '@babel/core': 7.21.8
       find-cache-dir: 3.3.2
@@ -31203,7 +31207,7 @@ packages:
     resolution: {integrity: sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
-      webpack: '>=4.0.0 <6.0.0 || 5.82.1'
+      webpack: '>=4.0.0 <6.0.0 || 5.83.0'
     dependencies:
       del: 4.1.1
       webpack: 5.83.0(webpack-cli@4.10.0)
@@ -31835,7 +31839,7 @@ packages:
     resolution: {integrity: sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      webpack: ^5.1.0 || 5.82.1
+      webpack: ^5.1.0 || 5.83.0
     dependencies:
       fast-glob: 3.2.12
       glob-parent: 6.0.2
@@ -32136,7 +32140,7 @@ packages:
     resolution: {integrity: sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==}
     engines: {node: '>= 6.9.0 <7.0.0 || >= 8.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || 5.82.1
+      webpack: ^4.0.0 || 5.83.0
     dependencies:
       babel-code-frame: 6.26.0
       css-selector-tokenizer: 0.7.3
@@ -32156,7 +32160,7 @@ packages:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       camelcase: 5.3.1
       cssesc: 3.0.0
@@ -32178,7 +32182,7 @@ packages:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.27.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.27.0 || ^5.0.0 || 5.83.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.23)
       loader-utils: 2.0.4
@@ -34661,7 +34665,7 @@ packages:
     resolution: {integrity: sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==}
     engines: {node: '>= 6.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || 5.82.1
+      webpack: ^4.0.0 || 5.83.0
     dependencies:
       loader-utils: 1.4.2
       schema-utils: 1.0.0
@@ -34672,7 +34676,7 @@ packages:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
@@ -35006,7 +35010,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '>= 4 || 5.82.1'
+      webpack: '>= 4 || 5.83.0'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -35034,7 +35038,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '>= 4 || 5.82.1'
+      webpack: '>= 4 || 5.83.0'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -35066,7 +35070,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '>= 4 || 5.82.1'
+      webpack: '>= 4 || 5.83.0'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -36275,7 +36279,7 @@ packages:
     resolution: {integrity: sha512-9WQlLiAV5N9fCna4MUmBW/ifaUbuFZ2r7IZmtXzhyfyi4zgPEjXsmsYCKs+yT873MzRj+f1WMjuAiPNA7C6Tcw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^5.0.0 || 5.82.1
+      webpack: ^5.0.0 || 5.83.0
     dependencies:
       html-minifier-terser: 6.1.0
       parse5: 6.0.1
@@ -36323,7 +36327,7 @@ packages:
     resolution: {integrity: sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==}
     engines: {node: '>=6.9'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       '@types/html-minifier-terser': 5.1.2
       '@types/tapable': 1.0.8
@@ -36341,7 +36345,7 @@ packages:
     resolution: {integrity: sha512-cTUzZ1+NqjGEKjmVgZKLMdiFg3m9MdRXkZW2OEe69WYVi5ONLMmlnSZdXzGGMOq0C8jGDrL6EWyEDDUioHO/pA==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      webpack: ^5.20.0 || 5.82.1
+      webpack: ^5.20.0 || 5.83.0
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -37684,7 +37688,7 @@ packages:
     resolution: {integrity: sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==}
     engines: {node: '>= 4.8 < 5.0.0 || >= 5.10'}
     peerDependencies:
-      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || 5.82.1
+      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || 5.83.0
     dependencies:
       convert-source-map: 1.9.0
       istanbul-lib-instrument: 1.10.2
@@ -39042,7 +39046,7 @@ packages:
     engines: {node: '>= 4.8 < 5.0.0 || >= 5.10'}
     peerDependencies:
       less: ^2.3.1 || ^3.0.0
-      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || 5.82.1
+      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || 5.83.0
     dependencies:
       clone: 2.1.2
       less: 3.9.0
@@ -40621,7 +40625,7 @@ packages:
     resolution: {integrity: sha512-vC886Mzpd2AkSM35XLkfQMjH+Ohz6RISVwhAejDUzZDheJAiz6G34lky1vyO8fZ702v7IrcKmsGwL1rRFnwvUA==}
     peerDependencies:
       monaco-editor: 0.30.x
-      webpack: ^4.5.0 || 5.x || 5.82.1
+      webpack: ^4.5.0 || 5.x || 5.83.0
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.30.1
@@ -42507,7 +42511,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
@@ -43405,7 +43409,7 @@ packages:
     resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
@@ -44651,7 +44655,7 @@ packages:
     resolution: {integrity: sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==}
     engines: {node: '>= 6.9.0'}
     peerDependencies:
-      webpack: ^3.0.0 || ^4.0.0 || 5.82.1
+      webpack: ^3.0.0 || ^4.0.0 || 5.83.0
     dependencies:
       clone-deep: 4.0.1
       loader-utils: 1.4.2
@@ -45352,7 +45356,7 @@ packages:
     resolution: {integrity: sha512-yIYkFOsKn+OdOirRJUPQpnZiMkF74raDVQjj5ni3SzbOiA57SabeX80R5zyMQAKpvKySA3Z4a85vFX3bvpC6KQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^5.0.0 || 5.82.1
+      webpack: ^5.0.0 || 5.83.0
     dependencies:
       abab: 2.0.6
       iconv-lite: 0.6.3
@@ -45960,7 +45964,7 @@ packages:
     resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
@@ -45971,7 +45975,7 @@ packages:
     resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
@@ -45981,7 +45985,7 @@ packages:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
@@ -46362,7 +46366,7 @@ packages:
     resolution: {integrity: sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==}
     engines: {node: '>= 6.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || 5.82.1
+      webpack: ^4.0.0 || 5.83.0
     dependencies:
       cacache: 12.0.4
       find-cache-dir: 2.1.0
@@ -46380,7 +46384,7 @@ packages:
     resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       cacache: 15.3.0
       find-cache-dir: 3.3.2
@@ -46403,7 +46407,7 @@ packages:
       '@swc/core': '*'
       esbuild: '*'
       uglify-js: '*'
-      webpack: ^5.1.0 || 5.82.1
+      webpack: ^5.1.0 || 5.83.0
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -46791,7 +46795,7 @@ packages:
     engines: {node: '>=12.0.0'}
     peerDependencies:
       typescript: '*'
-      webpack: ^5.0.0 || 5.82.1
+      webpack: ^5.0.0 || 5.83.0
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.14.0
@@ -47500,7 +47504,7 @@ packages:
     engines: {node: '>= 8.9.0'}
     peerDependencies:
       file-loader: '*'
-      webpack: ^4.0.0 || 5.82.1
+      webpack: ^4.0.0 || 5.83.0
     peerDependenciesMeta:
       file-loader:
         optional: true
@@ -47517,7 +47521,7 @@ packages:
     engines: {node: '>= 8.9.0'}
     peerDependencies:
       file-loader: '*'
-      webpack: ^4.0.0 || 5.82.1
+      webpack: ^4.0.0 || 5.83.0
     peerDependenciesMeta:
       file-loader:
         optional: true
@@ -47533,7 +47537,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       file-loader: '*'
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     peerDependenciesMeta:
       file-loader:
         optional: true
@@ -48032,7 +48036,7 @@ packages:
     peerDependencies:
       '@webpack-cli/generators': '*'
       '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x || 5.82.1
+      webpack: 4.x.x || 5.x.x || 5.83.0
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -48069,7 +48073,7 @@ packages:
     peerDependencies:
       '@webpack-cli/generators': '*'
       '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x || 5.82.1
+      webpack: 4.x.x || 5.x.x || 5.83.0
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -48105,7 +48109,7 @@ packages:
     peerDependencies:
       '@webpack-cli/generators': '*'
       '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x || 5.82.1
+      webpack: 4.x.x || 5.x.x || 5.83.0
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -48140,7 +48144,7 @@ packages:
     peerDependencies:
       '@webpack-cli/generators': '*'
       '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x || 5.82.1
+      webpack: 4.x.x || 5.x.x || 5.83.0
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -48172,7 +48176,7 @@ packages:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
     engines: {node: '>= 6'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       memory-fs: 0.4.1
       mime: 2.6.0
@@ -48186,7 +48190,7 @@ packages:
     resolution: {integrity: sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==}
     engines: {node: '>= v10.23.3'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       colorette: 1.4.0
       mem: 8.1.1
@@ -48201,7 +48205,7 @@ packages:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.0.0 || ^5.0.0 || 5.83.0
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -48215,7 +48219,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.37.0 || ^5.0.0 || 5.83.0
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
@@ -48260,7 +48264,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.37.0 || ^5.0.0 || 5.83.0
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
@@ -48306,7 +48310,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0 || 5.82.1
+      webpack: ^4.37.0 || ^5.0.0 || 5.83.0
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
@@ -48350,7 +48354,7 @@ packages:
     resolution: {integrity: sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==}
     engines: {node: '>= 4.3 < 5.0.0 || >= 5.10'}
     peerDependencies:
-      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || 5.82.1
+      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || 5.83.0
     dependencies:
       webpack: 4.46.0(webpack-cli@4.10.0)
     dev: true


### PR DESCRIPTION
## Description

This PR solves this [bug](https://office.visualstudio.com/OC/_workitems/edit/7872230) by enabling DependencyContainer to work well with LazyPromises, allowing for delayed loading of expensive dependencies.

## The Problem

Sometimes in loop-app, specific dependencies get mentioned in order to be passed down the chain, triggering their getter from the DepenencyContainer, which would end up triggering the LazyPromise without the use of an await keyword. This invalidates the lazy loading of these dependencies, causing performance issues in direct nav and workspace creation flows.

## Testing

Testing was done by reverting loop-app to the [original attempted fix ](https://office.visualstudio.com/OC/_git/office-bohemia/commit/8aa90c748ce4f532a8c8303a719ddcdd8f27cfbf?refName=refs%2Fheads%2Fu%2Fmbeardmore%2Fciq-service-startup-changes) for [this issue](https://office.visualstudio.com/OC/_workitems/edit/7799911), while substituting the ff/synthesize package locally to verify that it would lazy load correctly. Originally, the bug was not fixed by this commit and additional work was required to work around the DC/LazyPromise interaction. Running the tests again with the changes that are on this PR injected locally, this initial fix does solve the problem (lazy loading works as expected, only triggering the promise after an await keyword is used).

A specific example of this pattern happening can be seen in the new unit tests that were added with this PR as well.