### PR TITLE
[r11s] Adding more logs when service restarts

### DIFF
--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -70,7 +70,7 @@
 		"nconf": "^0.12.0",
 		"notepack.io": "^2.3.0",
 		"querystring": "^0.2.0",
-    "serialize-error": "^8.1.0",
+		"serialize-error": "^8.1.0",
 		"socket.io": "^4.5.3",
 		"socket.io-adapter": "^2.4.0",
 		"socket.io-parser": "^4.2.1",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -70,6 +70,7 @@
 		"nconf": "^0.12.0",
 		"notepack.io": "^2.3.0",
 		"querystring": "^0.2.0",
+    "serialize-error": "^8.1.0",
 		"socket.io": "^4.5.3",
 		"socket.io-adapter": "^2.4.0",
 		"socket.io-parser": "^4.2.1",

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { inspect } from "util";
 import nconf from "nconf";
+import { serializeError } from "serialize-error";
 import {
 	ILogger,
 	IResources,
@@ -30,6 +30,8 @@ export async function run<T extends IResources>(
 
 	// Start the runner and then listen for the message to stop it
 	const runningP = runner.start(logger).catch(async (error) => {
+        logger?.error(`Encountered exception while running service: ${serializeError(error)}`);
+		Lumberjack.error(`Encountered exception while running service`, undefined, error);
 		await runner.stop().catch((innerError) => {
 			logger?.error(`Could not stop runner due to error: ${innerError}`);
 			Lumberjack.error(`Could not stop runner due to error`, undefined, innerError);
@@ -39,8 +41,11 @@ export async function run<T extends IResources>(
 	});
 
 	process.on("SIGTERM", () => {
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		runner.stop();
+        Lumberjack.info(`Received SIGTERM request to stop the service.`);
+		runner.stop().catch((error) => {
+			logger?.error(`Could not stop runner after SIGTERM due to error: ${error}`);
+			Lumberjack.error(`Could not stop runner after SIGTERM due to error`, undefined, error);
+		});
 	});
 
 	try {
@@ -88,7 +93,7 @@ export function runService<T extends IResources>(
 		async (error) => {
 			await executeAndWait(() => {
 				logger?.error(`${group} service exiting due to error`);
-				logger?.error(inspect(error));
+				logger?.error(serializeError(error));
 				runnerMetric.error(`${group} service exiting due to error`, error);
 			}, waitInMs);
 			if (error.forceKill) {

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -30,7 +30,7 @@ export async function run<T extends IResources>(
 
 	// Start the runner and then listen for the message to stop it
 	const runningP = runner.start(logger).catch(async (error) => {
-        logger?.error(`Encountered exception while running service: ${serializeError(error)}`);
+		logger?.error(`Encountered exception while running service: ${serializeError(error)}`);
 		Lumberjack.error(`Encountered exception while running service`, undefined, error);
 		await runner.stop().catch((innerError) => {
 			logger?.error(`Could not stop runner due to error: ${innerError}`);
@@ -41,7 +41,7 @@ export async function run<T extends IResources>(
 	});
 
 	process.on("SIGTERM", () => {
-        Lumberjack.info(`Received SIGTERM request to stop the service.`);
+		Lumberjack.info(`Received SIGTERM request to stop the service.`);
 		runner.stop().catch((error) => {
 			logger?.error(`Could not stop runner after SIGTERM due to error: ${error}`);
 			Lumberjack.error(`Could not stop runner after SIGTERM due to error`, undefined, error);


### PR DESCRIPTION
## Description

RunService is a metric that is used to track reasons for service restarts, when those are restarts initiated within the Fluid server (e.g. an error in Kafka or similar, instead of kubernetes controller (external to Fluid) kiiling the service).

In AFR, we noticed that occasionally, the RunService metric does not get emitted/logged, even though the service restart reason was not kubernetes-initiated. We also ruled out the possibility of our telemetry pipeline being the issue, as we don't even see RunService console logs for the affected pod/containers.

In this PR, I add a few more auxiliary log statements that might help obtain more information about service restarts. I validated this by forcing errors in two conditions: service runner `start()` and also service runner `stop()` methods.

I am also using [serialize-error](https://www.npmjs.com/package/serialize-error) to log error objects in runner.ts, as it might provide better features than `util.inspect()`.

## Breaking Changes
None.

## Reviewer Guidance

Note, for future reference: I also noticed that the problem of missing metrics seem to be related not to our telemetry infra, but instead into the handling of exceptions. This is not something being addressed in this PR as it requires additional investigation. I am referring to the fact that we might have unhandled errors/promise rejections in some situations - possibly, due to some errors being thrown, while others are promise rejections - and also due to how we catch those in runner.ts. The reason I say that: when testing these changes and forcing errors in service runner `start()` and `stop()`, I noticed the metric is correctly emitted when the errors were generated with `Promise.reject(error)`. But the metric would not be available when using `throw error`.