### PR TITLE
Tree: fix empty primary fields of contextually typed data

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -458,7 +458,9 @@ export function applyTypesFromContext(
 			0x4d6 /* array data reported comparable with the schema without a primary field */,
 		);
 		const children = applyFieldTypesFromContext(schemaData, primary.schema, data);
-		return { value: undefined, type, fields: new Map([[primary.key, children]]) };
+		return children.length > 0
+			? { value: undefined, type, fields: new Map([[primary.key, children]]) }
+			: { value: undefined, type, fields: new Map() };
 	} else {
 		const fields: Map<FieldKey, MapTree[]> = new Map();
 		for (const key of fieldKeysFromData(data)) {

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -458,9 +458,11 @@ export function applyTypesFromContext(
 			0x4d6 /* array data reported comparable with the schema without a primary field */,
 		);
 		const children = applyFieldTypesFromContext(schemaData, primary.schema, data);
-		return children.length > 0
-			? { value: undefined, type, fields: new Map([[primary.key, children]]) }
-			: { value: undefined, type, fields: new Map() };
+		return {
+			value: undefined,
+			type,
+			fields: new Map(children.length > 0 ? [[primary.key, children]] : []),
+		};
 	} else {
 		const fields: Map<FieldKey, MapTree[]> = new Map();
 		for (const key of fieldKeysFromData(data)) {

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { MapTree, ValueSchema } from "../../core";
+import { EmptyKey, MapTree, ValueSchema } from "../../core";
 
 import {
 	allowsValue,
@@ -72,6 +72,17 @@ describe("ContextuallyTyped", () => {
 			numbers: [],
 		});
 		const expected: MapTree = { fields: new Map(), type: numbersObject.name, value: undefined };
+		assert.deepEqual(mapTree, expected);
+	});
+
+	it("applyTypesFromContext omits empty primary fields", () => {
+		const builder = new SchemaBuilder("applyTypesFromContext");
+		const numberSchema = builder.primitive("number", ValueSchema.Number);
+		const numberSequence = SchemaBuilder.fieldSequence(numberSchema);
+		const primaryObject = builder.object("numbers", { local: { [EmptyKey]: numberSequence } });
+		const schema = builder.intoDocumentSchema(numberSequence);
+		const mapTree = applyTypesFromContext(schema, new Set([primaryObject.name]), []);
+		const expected: MapTree = { fields: new Map(), type: primaryObject.name, value: undefined };
 		assert.deepEqual(mapTree, expected);
 	});
 


### PR DESCRIPTION
## Description

This fixes an issue setting an empty primary field of contextually typed data.

### Some concerns

It might be arguable, that, in contrast to the sequence fields, for which `root.foo = []` makes `foo` to be "really" non-existent, doing same for the primary fields should not make them to be non-existent, as primary fields have a special meaning.

If not fixed, an issue occurs while creating the chunk tree out of a corresponding delta, since `chunkField` requires the fields to have at least one node, which is not the case for primary fields set via contextually typed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
