### PR TITLE
Fix non-escaped quotes in examples.md

### DIFF
--- a/docs/content/docs/start/examples.md
+++ b/docs/content/docs/start/examples.md
@@ -55,6 +55,6 @@ that don't have an HTTP canvas can participate in the Fluid Framework collaborat
 
 ## Fluid in a Microsoft 365 Teams tab
 
-The [Teams and Fluid /"Hello World/" app](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world)
+The [Teams and Fluid "Hello World" app](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world)
 shows you how to integrate a Fluid Framework application into a custom Microsoft 365 Teams tab. See
 also [Using Fluid with Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/using-fluid-msteam).

--- a/docs/content/docs/start/examples.md
+++ b/docs/content/docs/start/examples.md
@@ -55,6 +55,6 @@ that don't have an HTTP canvas can participate in the Fluid Framework collaborat
 
 ## Fluid in a Microsoft 365 Teams tab
 
-The [Teams and Fluid "Hello World" app](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world)
+The [Teams and Fluid /"Hello World/" app](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world)
 shows you how to integrate a Fluid Framework application into a custom Microsoft 365 Teams tab. See
 also [Using Fluid with Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/using-fluid-msteam).

--- a/docs/skipped-urls.txt
+++ b/docs/skipped-urls.txt
@@ -7,6 +7,7 @@ https://aka.ms/fluentui/
 https://github.com/microsoft/FluidFramework/edit/*
 https://twitter.com/intent/follow*
 https://twitter.com/intent/tweet*
+https://twitter.com/fluidframework
 https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/*
 
 # These URLs have false positives with their anchors. Linkcheck thinks the anchors are missing.

--- a/docs/themes/thxvscode/layouts/_default/_markup/render-link.html
+++ b/docs/themes/thxvscode/layouts/_default/_markup/render-link.html
@@ -1,4 +1,4 @@
 {{ $link := .Destination }}
 {{- with .Page.GetPage .Destination }}{{ $link = .RelPermalink }}{{ end -}}
 <a href="{{ $link | safeURL }}" {{ with .Title}} title="{{ . }}" {{ end }}{{ if strings.HasPrefix .Destination "http" }}
-    target="_blank" {{ end }}>{{ .Text }}</a>
+    target="_blank" {{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


## Description
Before:
  
<img width="460" alt="Screenshot 2023-05-24 at 2 00 11 PM" src="https://github.com/microsoft/FluidFramework/assets/89981/603f4820-9967-4eea-82af-50f4d3112ac0">

Fixes the non-escapes quotes in the link. I'm not 100% if this fixes it as the Github preview doesn't render the same.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
