### PR TITLE
fix(devtool): Extension crashes on webpage reload

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/BackgroundConnection.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/BackgroundConnection.ts
@@ -59,7 +59,7 @@ export class BackgroundConnection
 	/**
 	 * Port connection to the Background Script
 	 */
-	private readonly backgroundServiceConnection: TypedPortConnection;
+	private backgroundServiceConnection!: TypedPortConnection;
 
 	public static async Initialize(): Promise<BackgroundConnection> {
 		const connection = new BackgroundConnection(extensionMessageSource);
@@ -82,32 +82,7 @@ export class BackgroundConnection
 	) {
 		super();
 
-		console.log(formatDevtoolsScriptMessageForLogging("Connecting to Background script..."));
-
-		// Create a connection to the background page
-		this.backgroundServiceConnection = browser.runtime.connect({
-			name: "Background Script",
-		});
-
-		// Relay the tab ID to the background service worker.
-		const initMessage: DevToolsInitMessage = {
-			source: this.messageSource,
-			type: devToolsInitMessageType,
-			data: {
-				tabId: browser.devtools.inspectedWindow.tabId,
-			},
-		};
-		postMessageToPort(
-			initMessage,
-			this.backgroundServiceConnection,
-			devtoolsScriptMessageLoggingOptions,
-		);
-
-		// Bind listeners
-		this.backgroundServiceConnection.onMessage.addListener(this.onBackgroundServiceMessage);
-		this.backgroundServiceConnection.onDisconnect.addListener(
-			this.onBackgroundServiceDisconnect,
-		);
+		this.connectToBackgroundService();
 	}
 
 	/**
@@ -164,13 +139,50 @@ export class BackgroundConnection
 
 	/**
 	 * Handler for a disconnect event coming from the background service.
-	 * Immediately throws, since this type is currently not capable of recovering from this state.
+	 * Log the disconnection and re-establish the connection.
 	 */
 	private readonly onBackgroundServiceDisconnect = (): void => {
-		throw new Error(
+		console.log(
 			formatDevtoolsScriptMessageForLogging(
-				"The Background Script disconnected. Further use of the message relay is not allowed.",
+				"Disconnected from Background script. Attempting to reconnect.",
 			),
+		);
+		/**
+		 * No need to clean up the disconnected event listener here since if the event emitter is not accessible,
+		 * even if it has listeners attached to it, it will be garbage collected.
+		 */
+		this.connectToBackgroundService();
+	};
+
+	/**
+	 * Connects to the Background Script.
+	 */
+	private readonly connectToBackgroundService = (): void => {
+		console.log(formatDevtoolsScriptMessageForLogging("Connecting to Background script..."));
+
+		// Create a connection to the background page
+		this.backgroundServiceConnection = browser.runtime.connect({
+			name: "Background Script",
+		});
+
+		// Relay the tab ID to the background service worker.
+		const initMessage: DevToolsInitMessage = {
+			source: this.messageSource,
+			type: devToolsInitMessageType,
+			data: {
+				tabId: browser.devtools.inspectedWindow.tabId,
+			},
+		};
+		postMessageToPort(
+			initMessage,
+			this.backgroundServiceConnection,
+			devtoolsScriptMessageLoggingOptions,
+		);
+
+		// Bind listeners
+		this.backgroundServiceConnection.onMessage.addListener(this.onBackgroundServiceMessage);
+		this.backgroundServiceConnection.onDisconnect.addListener(
+			this.onBackgroundServiceDisconnect,
 		);
 	};
 }


### PR DESCRIPTION
## Description

Initially, whatever view you were looking at in the devtools will remain unchanged (it will be stale), and the Containers menu options will not have reloaded either. Attempting to click any other option in the menu will immediately crash the extension.

## Example

https://github.com/microsoft/FluidFramework/assets/114451900/dd413a03-588d-4f7f-a5ee-cb37b7b049e3

