### PR TITLE
Fix peer rebase branch bug

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -257,7 +257,7 @@ export class EditManager<
 		const searchResult = this.sequenceMap.getPairOrNextHigher(trunkTailSearchKey);
 		if (searchResult !== undefined) {
 			const [_, newTrunkTail] = searchResult;
-			// Only work if the commit found by the search is farther than the current tail of the trunk
+			// Don't do any work if the commit found by the search is already the tail of the trunk
 			if (newTrunkTail.parent !== this.trunkBase) {
 				// The minimum sequence number informs us that all peer branches are at least caught up to the tail commit,
 				// so rebase them accordingly. This is necessary to prevent peer branches from referencing any evicted commits.

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -257,8 +257,20 @@ export class EditManager<
 		const searchResult = this.sequenceMap.getPairOrNextHigher(trunkTailSearchKey);
 		if (searchResult !== undefined) {
 			const [_, newTrunkTail] = searchResult;
-			// Don't do any work if the commit found by the search is already the tail of the trunk
+			// Only work if the commit found by the search is farther than the current tail of the trunk
 			if (newTrunkTail.parent !== this.trunkBase) {
+				// The minimum sequence number informs us that all peer branches are at least caught up to the tail commit,
+				// so rebase them accordingly. This is necessary to prevent peer branches from referencing any evicted commits.
+				for (const [sessionId, branch] of this.peerLocalBranches) {
+					const [rebasedBranch] = rebaseBranch(
+						this.changeFamily.rebaser,
+						branch,
+						newTrunkTail,
+						this.trunk.getHead(),
+					);
+					this.peerLocalBranches.set(sessionId, rebasedBranch);
+				}
+
 				// This is dangerous. Commits ought to be immutable, but if they are then changing the trunk tail requires
 				// regenerating the entire commit graph. It is, in general, safe to chop off the tail like this if we know
 				// that there are no outstanding references to any of the commits being removed. For example, there must be
@@ -283,14 +295,6 @@ export class EditManager<
 					sequenceNumber,
 					false,
 				);
-
-				for (const [sessionId, branch] of this.peerLocalBranches) {
-					// If a session branch falls behind the min sequence number, then we know that its session has been abandoned by Fluid
-					// (because otherwise, it would have already been updated) and we expect not to receive any more updates for it.
-					if (findCommonAncestor(branch, newTrunkTail) === undefined) {
-						this.peerLocalBranches.delete(sessionId);
-					}
-				}
 			}
 		} else {
 			// If no trunk commit is found, it means that all trunk commits are below the search key, so evict them all

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -238,87 +238,101 @@ describe("EditManager", () => {
 			{ seq: 3, type: "Pull", ref: 2, from: peer1 },
 		]);
 
-		it("Evicts trunk commits according to a provided minimum sequence number", () => {
-			const { manager } = editManagerFactory({});
-			for (let i = 0; i < 10; ++i) {
-				manager.addSequencedChange(
-					{
-						change: TestChange.mint([], []),
-						revision: mintRevisionTag(),
-						sessionId: peer1,
-					},
-					brand(i),
-					brand(i - 1),
+		describe("Trunk eviction", () => {
+			function localCommit(
+				manager: EditManager<
+					ChangeFamilyEditor,
+					TestChange,
+					ChangeFamily<ChangeFamilyEditor, TestChange>
+				>,
+				inputContext: readonly number[] = [],
+				intention: number | number[] = [],
+			): Commit<TestChange> {
+				const [_, commit] = manager.localBranch.apply(
+					TestChange.mint(inputContext, intention),
+					mintRevisionTag(),
 				);
+				return {
+					change: commit.change,
+					revision: commit.revision,
+					sessionId: localSessionId,
+				};
 			}
 
-			assert.equal(manager.getTrunkChanges().length, 10);
-			manager.advanceMinimumSequenceNumber(brand(5));
-			assert.equal(manager.getTrunkChanges().length, 5);
-			manager.advanceMinimumSequenceNumber(brand(10));
-			assert.equal(manager.getTrunkChanges().length, 0);
-
-			for (let i = 10; i < 20; ++i) {
-				manager.addSequencedChange(
-					{
-						change: TestChange.mint([], []),
-						revision: mintRevisionTag(),
-						sessionId: peer1,
-					},
-					brand(i),
-					brand(i - 1),
-				);
+			function peerCommit(
+				peer = localSessionId,
+				inputContext: readonly number[] = [],
+				intention: number | number[] = [],
+			): Commit<TestChange> {
+				return {
+					change: TestChange.mint(inputContext, intention),
+					revision: mintRevisionTag(),
+					sessionId: peer,
+				};
 			}
 
-			assert.equal(manager.getTrunkChanges().length, 10);
-			manager.advanceMinimumSequenceNumber(brand(15));
-			assert.equal(manager.getTrunkChanges().length, 5);
-			manager.advanceMinimumSequenceNumber(brand(20));
-			assert.equal(manager.getTrunkChanges().length, 0);
-		});
+			it("Evicts trunk commits according to a provided minimum sequence number", () => {
+				const { manager } = editManagerFactory({});
+				for (let i = 0; i < 10; ++i) {
+					manager.addSequencedChange(localCommit(manager), brand(i), brand(i - 1));
+				}
 
-		it("Evicts trunk commits after but not exactly at the minimum sequence number", () => {
-			const { manager } = editManagerFactory({});
-			manager.addSequencedChange(
-				{
-					change: TestChange.mint([], []),
-					revision: mintRevisionTag(),
-					sessionId: peer1,
-				},
-				brand(1),
-				brand(0),
-			);
+				assert.equal(manager.getTrunkChanges().length, 10);
+				manager.advanceMinimumSequenceNumber(brand(5));
+				assert.equal(manager.getTrunkChanges().length, 5);
+				manager.advanceMinimumSequenceNumber(brand(10));
+				assert.equal(manager.getTrunkChanges().length, 0);
+				for (let i = 10; i < 20; ++i) {
+					manager.addSequencedChange(localCommit(manager), brand(i), brand(i - 1));
+				}
 
-			assert.equal(manager.getTrunkChanges().length, 1);
-			manager.addSequencedChange(
-				{
-					change: TestChange.mint([], []),
-					revision: mintRevisionTag(),
-					sessionId: peer1,
-				},
-				brand(2),
-				brand(1),
-			);
+				assert.equal(manager.getTrunkChanges().length, 10);
+				manager.advanceMinimumSequenceNumber(brand(15));
+				assert.equal(manager.getTrunkChanges().length, 5);
+				manager.advanceMinimumSequenceNumber(brand(20));
+				assert.equal(manager.getTrunkChanges().length, 0);
+			});
 
-			assert.equal(manager.getTrunkChanges().length, 2);
-			manager.advanceMinimumSequenceNumber(brand(1));
-			assert.equal(manager.getTrunkChanges().length, 2);
+			it("Evicts trunk commits after but not exactly at the minimum sequence number", () => {
+				const { manager } = editManagerFactory({});
+				manager.addSequencedChange(localCommit(manager), brand(1), brand(0));
+				assert.equal(manager.getTrunkChanges().length, 1);
+				manager.addSequencedChange(localCommit(manager), brand(2), brand(1));
+				assert.equal(manager.getTrunkChanges().length, 2);
+				manager.advanceMinimumSequenceNumber(brand(1));
+				assert.equal(manager.getTrunkChanges().length, 2);
 
-			// If a change's sequence number is also the minimum sequence number,
-			// it should not be evicted
-			manager.addSequencedChange(
-				{
-					change: TestChange.mint([], []),
-					revision: mintRevisionTag(),
-					sessionId: peer1,
-				},
-				brand(3),
-				brand(3),
-			);
+				// If a change's sequence number is also the minimum sequence number,
+				// it should not be evicted
+				manager.addSequencedChange(localCommit(manager), brand(3), brand(3));
+				assert.equal(manager.getTrunkChanges().length, 3);
+				manager.advanceMinimumSequenceNumber(brand(3));
+				assert.equal(manager.getTrunkChanges().length, 1);
+			});
 
-			assert.equal(manager.getTrunkChanges().length, 3);
-			manager.advanceMinimumSequenceNumber(brand(3));
-			assert.equal(manager.getTrunkChanges().length, 1);
+			it("Rebases peer branches during trunk eviction", () => {
+				// This is a regression test that ensures peer branches are rebased up to at least the new tail of the trunk after trunk commits are evicted.
+				const { manager } = editManagerFactory({});
+				// We receive a commit from a peer.
+				manager.addSequencedChange(peerCommit(peer1, [], 1), brand(1), brand(0));
+				// We submit and ack a local commit.
+				// This prevents the upcoming rebase of the peer branch from hitting an eager fast-path that keeps it on the head of the trunk.
+				manager.addSequencedChange(localCommit(manager, [1], 2), brand(2), brand(1));
+				// We receive a second commit from the peer.
+				// Based on the ref seq number, we know that the peer is lagging "behind" by two commits,
+				// i.e. it has sent a second op without receiving its first op or our local op just above.
+				manager.addSequencedChange(peerCommit(peer1, [1], 3), brand(3), brand(0));
+				// Suppose that the peer catches up, and we are informed of the new minimum sequence number via some means (e.g. an op).
+				manager.advanceMinimumSequenceNumber(brand(3));
+				// We expect the trunk to now contain commits "3" and "4" (the first two commits "1" and "2" have been evicted)...
+				checkChangeList(manager, [3]);
+				// ...and we also expect our copy of the peer's local branch to be updated,
+				// even though we have not received any new commits from that peer since commit "3".
+				// We can check this by receiving another commit from our peer.
+				// The rebase will fail if the branch was not updated and was left referencing evicted commits.
+				manager.addSequencedChange(peerCommit(peer1, [1, 2, 3], 4), brand(4), brand(3));
+				checkChangeList(manager, [3, 4]);
+			});
 		});
 
 		it("Rebases anchors over local changes", () => {


### PR DESCRIPTION
## Description

This fixes a bug in during `EditManager`'s trunk commit eviction. Peer branches, which currently track the last-known local state of other clients' local branches, could be left referencing evicted commits after a pass of `trimTrunk()`. All peer branches are now rebased up to the tail of the trunk when eviction happens.

This PR also factors out some test helpers for the trunk eviction tests.