### PR TITLE
Add caching for checking on invalid docs/sessions.

### DIFF
--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -72,6 +72,7 @@
 		"events": "^3.1.0",
 		"json-stringify-safe": "^5.0.1",
 		"lodash": "^4.17.21",
+		"lru-cache": "^6.0.0",
 		"nconf": "^0.12.0",
 		"semver": "^6.3.0",
 		"sha.js": "^2.4.11",

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -54,6 +54,11 @@ export async function deliCreate(
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
 
+	const invalidDocumentOrSessionCacheEnabled = config.get("deli:invalidDocumentOrSessionCacheEnabled") ?? false;
+	const invalidDocumentCacheExpiryInMs = config.get("deli:invalidDocumentCacheExpiryInMs") ?? 1000 * 60 * 60 * 12;
+	const invalidSessionCacheExpiryInMs = config.get("deli:invalidSessionCacheExpiryInMs") ?? 1000 * 10;
+	const invalidDocumentOrSessionMaxCacheSize = config.get("deli:invalidDocumentOrSessionMaxCacheSize") ?? 10000;
+
 	const checkpointHeuristics = config.get(
 		"deli:checkpointHeuristics",
 	) as core.ICheckpointHeuristicsServerConfiguration;
@@ -167,6 +172,10 @@ export async function deliCreate(
 		serviceConfiguration,
 		restartOnCheckpointFailure,
 		kafkaCheckpointOnReprocessingOp,
+		invalidDocumentOrSessionCacheEnabled,
+		invalidDocumentCacheExpiryInMs,
+		invalidSessionCacheExpiryInMs,
+		invalidDocumentOrSessionMaxCacheSize,
 	);
 }
 

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -65,6 +65,11 @@ export async function scribeCreate(
 	const deltaManager = new DeltaManager(authEndpoint, internalAlfredUrl);
 	const factory = await getDbFactory(config);
 
+	const invalidDocumentOrSessionCacheEnabled = config.get("scribe:invalidDocumentOrSessionCacheEnabled") ?? false;
+	const invalidDocumentCacheExpiryInMs = config.get("scribe:invalidDocumentCacheExpiryInMs") ?? 1000 * 60 * 60 * 12;
+	const invalidSessionCacheExpiryInMs = config.get("scribe:invalidSessionCacheExpiryInMs") ?? 1000 * 10;
+	const invalidDocumentOrSessionMaxCacheSize = config.get("scribe:invalidDocumentOrSessionMaxCacheSize") ?? 10000;
+
 	const checkpointHeuristics = config.get(
 		"scribe:checkpointHeuristics",
 	) as ICheckpointHeuristicsServerConfiguration;
@@ -159,6 +164,10 @@ export async function scribeCreate(
 		checkpointService,
 		restartOnCheckpointFailure,
 		kafkaCheckpointOnReprocessingOp,
+		invalidDocumentOrSessionCacheEnabled,
+		invalidDocumentCacheExpiryInMs,
+		invalidSessionCacheExpiryInMs,
+		invalidDocumentOrSessionMaxCacheSize,
 	);
 }
 

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      lru-cache:
+        specifier: ^6.0.0
+        version: 6.0.0
       nconf:
         specifier: ^0.12.0
         version: 0.12.0


### PR DESCRIPTION
## Description
Adding caching for checking on invalid documents and sessions in Deli and Scribe. This would help to avoid the extra MongoDB call to load the document.