### PR TITLE
build(docs): Don't generate API docs for `@fluid-internal` packages

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,85 +1,86 @@
 {
-  "name": "fluidframework-docs",
-  "version": "0.25.0",
-  "private": true,
-  "description": "Fluid Framework documentation",
-  "homepage": "https://fluidframework.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/FluidFramework.git",
-    "directory": "docs"
-  },
-  "license": "MIT",
-  "author": "Microsoft and contributors",
-  "scripts": {
-    "build": "npm run build:api && npm run build:md-magic && npm run hugo",
-    "build:api": "npm run build:api-rollup && npm run build:api-documentation",
-    "build:api-documentation": "node ./api-markdown-documenter/index.js",
-    "build:api-rollup": "rimraf ./_api-extractor-temp && node ./rollup-api-json.js ../_api-extractor-temp/doc-models/ ./_api-extractor-temp/",
-    "build:md-magic": "concurrently npm:build:md-magic:code npm:build:md-magic:website",
-    "build:md-magic:code": "markdown-magic --files \"**/*.md\" \"!docs\" --workingDirectory ..",
-    "build:md-magic:website": "markdown-magic",
-    "build:repo-docs": "npm run build:md-magic:code",
-    "build:website": "npm run build:api-rollup && npm run build:md-magic:website && npm run build:api-documentation && npm run hugo",
-    "ci:build": "npm run download && npm run build",
-    "ci:linkcheck": "start-server-and-test ci:start http://localhost:1313 linkcheck:full",
-    "ci:start": "http-server ./public --port 1313 --silent",
-    "clean": "rimraf public content/docs/apis _api-extractor-temp",
-    "download": "npm run download:api && npm run build:api",
-    "download:api": "download --extract --out ../_api-extractor-temp/doc-models/ https://fluidframework.blob.core.windows.net/api-extractor-json/latest.tar.gz",
-    "hugo": "hugo",
-    "linkcheck": "start-server-and-test start http://localhost:1313 linkcheck:full",
-    "linkcheck:fast": "linkcheck http://localhost:1313 --skip-file skipped-urls.txt",
-    "linkcheck:full": "npm run linkcheck:fast -- --external",
-    "lint": "markdownlint-cli2",
-    "lint:fix": "markdownlint-cli2-fix",
-    "start": "hugo server"
-  },
-  "dependencies": {
-    "@fluid-tools/api-markdown-documenter": "^0.6.0",
-    "@fluid-tools/markdown-magic": "file:../tools/markdown-magic",
-    "@microsoft/api-extractor-model": "^7.26.4",
-    "@tylerbu/dl-cli": "1.1.2-tylerbu-0",
-    "@vscode/codicons": "0.0.32",
-    "chalk": "^4.1.2",
-    "concurrently": "^7.6.0",
-    "cpy": "^8.1.2",
-    "deepdash": "^5.3.9",
-    "fs-extra": "^11.1.1",
-    "glob": "^7.2.3",
-    "http-server": "^14.1.1",
-    "hugo-extended": "^0.111.3",
-    "linkcheck-bin": "3.0.0-0",
-    "markdown-magic": "npm:@tylerbu/markdown-magic@2.4.0-tylerbu-1",
-    "markdown-magic-package-json": "^2.0.2",
-    "markdown-magic-package-scripts": "^1.2.2",
-    "markdown-magic-template": "^1.0.1",
-    "markdownlint-cli2": "^0.6.0",
-    "markdownlint-rule-emphasis-style": "^1.0.1",
-    "markdownlint-rule-github-internal-links": "^0.1.0",
-    "markdownlint-rule-helpers": "^0.18.0",
-    "node-fetch": "^2.6.9",
-    "replace-in-file": "^6.3.5",
-    "rimraf": "^4.4.1",
-    "start-server-and-test": "^2.0.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "qs": "^6.11.0"
-    },
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "eslint",
-        "typescript"
-      ]
-    },
-    "updateConfig": {
-      "ignoreDependencies": [
-        "chalk",
-        "cpy",
-        "glob",
-        "node-fetch"
-      ]
-    }
-  }
+	"name": "fluidframework-docs",
+	"version": "0.25.0",
+	"private": true,
+	"description": "Fluid Framework documentation",
+	"homepage": "https://fluidframework.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/FluidFramework.git",
+		"directory": "docs"
+	},
+	"license": "MIT",
+	"author": "Microsoft and contributors",
+	"scripts": {
+		"build": "npm run build:api && npm run build:md-magic && npm run hugo",
+		"build:api": "npm run build:api-rollup && npm run build:api-documentation",
+		"build:api-documentation": "node ./api-markdown-documenter/index.js",
+		"build:api-rollup": "rimraf ./_api-extractor-temp && node ./rollup-api-json.js ../_api-extractor-temp/doc-models/ ./_api-extractor-temp/",
+		"build:md-magic": "concurrently npm:build:md-magic:code npm:build:md-magic:website",
+		"build:md-magic:code": "markdown-magic --files \"**/*.md\" \"!docs\" --workingDirectory ..",
+		"build:md-magic:website": "markdown-magic",
+		"build:repo-docs": "npm run build:md-magic:code",
+		"build:website": "npm run build:api-rollup && npm run build:md-magic:website && npm run build:api-documentation && npm run hugo",
+		"ci:build": "npm run download && npm run build",
+		"ci:linkcheck": "start-server-and-test ci:start http://localhost:1313 linkcheck:full",
+		"ci:start": "http-server ./public --port 1313 --silent",
+		"clean": "rimraf public content/docs/apis _api-extractor-temp",
+		"download": "npm run download:api && npm run build:api",
+		"download:api": "download --extract --out ../_api-extractor-temp/doc-models/ https://fluidframework.blob.core.windows.net/api-extractor-json/latest.tar.gz",
+		"hugo": "hugo",
+		"linkcheck": "start-server-and-test start http://localhost:1313 linkcheck:full",
+		"linkcheck:fast": "linkcheck http://localhost:1313 --skip-file skipped-urls.txt",
+		"linkcheck:full": "npm run linkcheck:fast -- --external",
+		"lint": "markdownlint-cli2",
+		"lint:fix": "markdownlint-cli2-fix",
+		"start": "hugo server"
+	},
+	"dependencies": {
+		"@fluid-tools/api-markdown-documenter": "^0.6.0",
+		"@fluid-tools/markdown-magic": "file:../tools/markdown-magic",
+		"@microsoft/api-extractor-model": "^7.26.4",
+		"@rushstack/node-core-library": "^3.55.2",
+		"@tylerbu/dl-cli": "1.1.2-tylerbu-0",
+		"@vscode/codicons": "0.0.32",
+		"chalk": "^4.1.2",
+		"concurrently": "^7.6.0",
+		"cpy": "^8.1.2",
+		"deepdash": "^5.3.9",
+		"fs-extra": "^11.1.1",
+		"glob": "^7.2.3",
+		"http-server": "^14.1.1",
+		"hugo-extended": "^0.111.3",
+		"linkcheck-bin": "3.0.0-0",
+		"markdown-magic": "npm:@tylerbu/markdown-magic@2.4.0-tylerbu-1",
+		"markdown-magic-package-json": "^2.0.2",
+		"markdown-magic-package-scripts": "^1.2.2",
+		"markdown-magic-template": "^1.0.1",
+		"markdownlint-cli2": "^0.6.0",
+		"markdownlint-rule-emphasis-style": "^1.0.1",
+		"markdownlint-rule-github-internal-links": "^0.1.0",
+		"markdownlint-rule-helpers": "^0.18.0",
+		"node-fetch": "^2.6.9",
+		"replace-in-file": "^6.3.5",
+		"rimraf": "^4.4.1",
+		"start-server-and-test": "^2.0.0"
+	},
+	"pnpm": {
+		"overrides": {
+			"qs": "^6.11.0"
+		},
+		"peerDependencyRules": {
+			"ignoreMissing": [
+				"eslint",
+				"typescript"
+			]
+		},
+		"updateConfig": {
+			"ignoreDependencies": [
+				"chalk",
+				"cpy",
+				"glob",
+				"node-fetch"
+			]
+		}
+	}
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -10,6 +10,7 @@ importers:
       '@fluid-tools/api-markdown-documenter': ^0.6.0
       '@fluid-tools/markdown-magic': file:../tools/markdown-magic
       '@microsoft/api-extractor-model': ^7.26.4
+      '@rushstack/node-core-library': ^3.55.2
       '@tylerbu/dl-cli': 1.1.2-tylerbu-0
       '@vscode/codicons': 0.0.32
       chalk: ^4.1.2
@@ -37,6 +38,7 @@ importers:
       '@fluid-tools/api-markdown-documenter': 0.6.0
       '@fluid-tools/markdown-magic': file:../tools/markdown-magic_bfrwj6ys6wock6p526xv5vf35u
       '@microsoft/api-extractor-model': 7.26.4
+      '@rushstack/node-core-library': 3.55.2
       '@tylerbu/dl-cli': 1.1.2-tylerbu-0
       '@vscode/codicons': 0.0.32
       chalk: 4.1.2


### PR DESCRIPTION
Omits `@fluid-internal` packages, which are only intended for consumption within this repo (see [here](https://github.com/microsoft/FluidFramework/wiki/npm-package-scopes#fluid-internal)), from the API docs generated for the public website build.