### PR TITLE
Tree: fix import cycle in anchorSet

### DIFF
--- a/experimental/dds/tree2/src/core/tree/anchorSet.ts
+++ b/experimental/dds/tree2/src/core/tree/anchorSet.ts
@@ -10,7 +10,7 @@ import { UpPath } from "./pathTree";
 import { Value, detachedFieldAsKey, DetachedField, FieldKey, EmptyKey } from "./types";
 import { PathVisitor } from "./visitPath";
 import { visitDelta, DeltaVisitor } from "./visitDelta";
-import type { Delta } from ".";
+import * as Delta from "./delta";
 
 /**
  * A way to refer to a particular tree location within an {@link AnchorSet}.

--- a/experimental/dds/tree2/src/core/tree/anchorSet.ts
+++ b/experimental/dds/tree2/src/core/tree/anchorSet.ts
@@ -6,10 +6,11 @@
 import { assert } from "@fluidframework/common-utils";
 import { createEmitter, ISubscribable } from "../../events";
 import { brand, Brand, fail, Invariant, Opaque, ReferenceCountedBase } from "../../util";
-import { FieldKey, EmptyKey, Delta, visitDelta, DeltaVisitor } from "../tree";
 import { UpPath } from "./pathTree";
-import { Value, detachedFieldAsKey, DetachedField } from "./types";
+import { Value, detachedFieldAsKey, DetachedField, FieldKey, EmptyKey } from "./types";
 import { PathVisitor } from "./visitPath";
+import { visitDelta, DeltaVisitor } from "./visitDelta";
+import type { Delta } from ".";
 
 /**
  * A way to refer to a particular tree location within an {@link AnchorSet}.


### PR DESCRIPTION
## Description

Avoid importing `../tree` (which is the same as `.` in this case).
This fixes a cycle detected with dependency-cruiser.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


