### PR TITLE
fix: (fluid devtools) Bugs in Container Summary View when container i…

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -108,13 +108,13 @@ function ContainerStatusRow(statusComponents: string[]): React.ReactElement {
 				<TableCellLayout
 					media={((): JSX.Element => {
 						switch (statusComponents[0]) {
-							case "attaching":
+							case AttachState.Attaching:
 								return (
 									<Badge shape="rounded" color="warning">
 										{statusComponents[0]}
 									</Badge>
 								);
-							case "detached":
+							case AttachState.Detached:
 								return (
 									<Badge shape="rounded" color="danger">
 										{statusComponents[0]}


### PR DESCRIPTION
## Description

When a container is not attached, the Container Summary View has a few issues:
The "Detached" box is green instead of red.
The box for the connected/disconnected status is empty instead of saying "Disconnected".
The box for the connected/disconnected status is misaligned from the attached/detached one.

## Example
<img width="935" alt="Screenshot 2023-05-25 154042" src="https://github.com/microsoft/FluidFramework/assets/114451900/83e4b62c-464e-4782-8ecc-340ba58c047a">

