### PR TITLE
fix(devtools-example): Add missing key prop to fix React errors

### DIFF
--- a/packages/tools/devtools/devtools-example/src/widgets/EmojiGrid.tsx
+++ b/packages/tools/devtools/devtools-example/src/widgets/EmojiGrid.tsx
@@ -34,7 +34,7 @@ export function EmojiGrid(props: EmojiGridProps): React.ReactElement {
 		for (let col = 0; col < colCount; col++) {
 			const cellHandle = emojiMatrix.getCell(row, col) as IFluidHandle<SharedCell<boolean>>;
 			renderedCells.push(
-				<Stack.Item>
+				<Stack.Item key={`emoji-grid-cell-${row}-${col}`}>
 					<CellView cellHandle={cellHandle} />
 				</Stack.Item>,
 			);


### PR DESCRIPTION
Errors were being reported in the console due to missing `key` prop at the cell level for the `EmojiGrid` component.