### PR TITLE
Fixing log properties in Scribe LambdaFactory.

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -108,7 +108,7 @@ export class ScribeLambdaFactory
 			this.serviceConfiguration,
 		);
 
-		const lumberProperties = getLumberBaseProperties(tenantId, documentId);
+		const lumberProperties = getLumberBaseProperties(documentId, tenantId);
 
 		try {
 			document = await this.documentRepository.readOne({ documentId, tenantId });


### PR DESCRIPTION
## Description

Fixing the order of passing the tenantId and documentId for log properties in Scribe LambdaFactory.