### PR TITLE
Trigger another checkpoint only if new offset is greater than committed offset

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -65,7 +65,11 @@ export class CheckpointManager {
 
 				// Trigger another checkpoint round if the offset has moved since the checkpoint finished and
 				// resolve any pending checkpoints to it.
-				if (this.lastCheckpoint && this.lastCheckpoint !== this.commitedCheckpoint) {
+				if (
+					this.lastCheckpoint &&
+					(this.lastCheckpoint.partition !== this.commitedCheckpoint.partition ||
+						this.lastCheckpoint.offset > this.commitedCheckpoint.offset)
+				) {
 					assert(
 						this.pendingCheckpoint,
 						"Differing offsets will always result in pendingCheckpoint",


### PR DESCRIPTION
## Description

In deli/scribe, during shutdown/draining triggered by restart, sometimes we see logs for checkpointing offsets smaller than the last committed checkpoint. Which fails with exceptions like "unknown member" or "Partition for commit was unassigned". 

The fix is to trigger another checkpoint only if the new checkpoint request is for offset greater than whats already committed.