### PR TITLE
Showcasing grouped batches with payloads containing thousands of ops

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -311,7 +311,9 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 		itExpects(
 			`Batch with 4000 ops - ${enableGroupedBatching ? "grouped" : "regular"} batches`,
 			// With grouped batching enabled, this scenario is unblocked
-			enableGroupedBatching
+			enableGroupedBatching ||
+				provider.driver.type === "local" ||
+				provider.driver.type === "tinylicious"
 				? []
 				: [
 						{

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -328,7 +328,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
 				await setupContainers(containerConfig);
 
-				const content = generateRandomStringOfSize(1024);
+				const content = generateRandomStringOfSize(10);
 				for (let i = 0; i < 4000; i++) {
 					localMap.set(`key${i}`, content);
 				}

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -308,36 +308,41 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 			},
 		};
 
-		describe("Batches with large number of ops", () => {
-			// This is not supported by the local server. See ADO:2690
-			// This test is flaky on tinylicious. See ADO:2964
-			if (provider.driver.type !== "local" && provider.driver.type !== "tinylicious") {
-				itExpects(
-					`Batch with 4000 ops - ${
-						enableGroupedBatching ? "grouped" : "regular"
-					} batches`,
-					enableGroupedBatching
-						? [] // With grouped batching enabled, this scenario is unblocked
-						: [
-								// Without grouped batching, it is expected for the container to never make progress
-								{
-									eventName: "fluid:telemetry:Container:ContainerClose",
-									error: "Runtime detected too many reconnects with no progress syncing local ops.",
-								},
-						  ],
-					async function () {
-						await setupContainers(containerConfig);
+		itExpects(
+			`Batch with 4000 ops - ${enableGroupedBatching ? "grouped" : "regular"} batches`,
+			enableGroupedBatching
+				? [] // With grouped batching enabled, this scenario is unblocked
+				: [
+						{
+							eventName: "fluid:telemetry:Container:ContainerClose",
+							error: "Runtime detected too many reconnects with no progress syncing local ops.",
+						},
+				  ], // Without grouped batching, it is expected for the container to never make progress
+			async function () {
+				await setupContainers(containerConfig);
+				// This is not supported by the local server. See ADO:2690
+				// This test is flaky on tinylicious. See ADO:2964
+				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
+					if (!enableGroupedBatching) {
+						// Workaround for the `itExpects` construct
+						localContainer.close(
+							new GenericError(
+								"Runtime detected too many reconnects with no progress syncing local ops.",
+							),
+						);
+					}
 
-						const content = generateRandomStringOfSize(10);
-						for (let i = 0; i < 4000; i++) {
-							localMap.set(`key${i}`, content);
-						}
+					this.skip();
+				}
 
-						await provider.ensureSynchronized();
-					},
-				).timeout(chunkingBatchesTimeoutMs);
-			}
-		});
+				const content = generateRandomStringOfSize(10);
+				for (let i = 0; i < 4000; i++) {
+					localMap.set(`key${i}`, content);
+				}
+
+				await provider.ensureSynchronized();
+			},
+		).timeout(chunkingBatchesTimeoutMs);
 
 		describe(`Large payloads (exceeding the 1MB limit) - ${
 			enableGroupedBatching ? "grouped" : "regular"


### PR DESCRIPTION
## Description

One of the scenarios that regular compression + chunking does not cover is when a batch has many small ops. In this case, with compression operating exclusively on the contents of the ops, the resulting payload can still go over the 1MB limit due to the accumulated envelope overhead when the number of ops is large enough.

This test showcases that using the grouped batching features unblocks this particular scenario.