### PR TITLE
Ignore chunked ops when accounting for container progress

### DIFF
--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -767,7 +767,7 @@ describe("Runtime", () => {
 
 			it(
 				`No progress for ${maxReconnects} connection state changes, with pending state, successfully ` +
-					"processing remote op, should generate telemetry event and throw an error that closes the container",
+					"processing remote op and local chunked op, should generate telemetry event and throw an error that closes the container",
 				async () => {
 					const pendingStateManager = getMockPendingStateManager();
 					patchRuntime(pendingStateManager);
@@ -785,6 +785,22 @@ describe("Runtime", () => {
 								},
 							} as any as ISequencedDocumentMessage,
 							false /* local */,
+						);
+						containerRuntime.process(
+							{
+								type: "op",
+								clientId: "clientId",
+								sequenceNumber: 0,
+								contents: {
+									address: "address",
+									contents: {
+										chunkId: i + 1,
+										totalChunks: maxReconnects + 1,
+									},
+									type: "chunkedOp",
+								},
+							} as any as ISequencedDocumentMessage,
+							true /* local */,
 						);
 					}
 


### PR DESCRIPTION
## Description

Chunking adds the possibility of a runaway container when the payload size is too large due to the large number of ops in a batch.

### Context
- There is a mechanism to catch a container which keeps reconnecting due to server errors and close it after 7 attempts if we detect that the container is not making progress.
- We track the container progress by resetting the number of reconnects whenever the container processes its own local op received from the server.
- When chunking is used, the batch is split into 2: first we send the chunks for the large op in their own batches, then we send the (possibly large) rest of the batch, comprised of empty ops.

The rest of the batch might fail due to the overhead from the op envelope. If the number of ops surpasses ~2k, this is very likely to happen. 

If it fails, the container will disconnect and try to send the original batch again (this means it will be re-split into chunks, batch separated, etc..). However, at this point, the container is already receiving the initial chunks it sent to the server, so the reconnect counter is reset, but the container is not actually making progress. This can lead to a situation in which the container keeps resending the batch, re-creating a storm of chunks forever (or until it gets throttled).