### PR TITLE
test(tree): Exhaustive delete/move & undo test

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -355,7 +355,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree1, tree2], [{ foo: [{}, "b"] }]);
 		});
 
-		describe("Exhaustive removal tests", () => {
+		describe.skip("Exhaustive removal tests", () => {
 			// Toggle the constant below to run each scenario as a separate test.
 			// This is useful to debug a specific scenario but makes CI and the test browser slower.
 			// Note that if the numbers of nodes and peers are too high (more than 3 nodes and 3 peers),

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -431,7 +431,7 @@ describe("Editing", () => {
 				/**
 				 * Generates all permutations with prefix `scenario`
 				 */
-				function* buildScenariosImpl(
+				function* buildScenariosWithPrefix(
 					scenario: ScenarioStep[] = [],
 				): Generator<readonly ScenarioStep[]> {
 					let done = true;
@@ -440,7 +440,7 @@ describe("Editing", () => {
 							if (!buildState.removed[i]) {
 								buildState.removed[i] = true;
 								buildState.peerUndoStack[p] += 1;
-								yield* buildScenariosImpl([
+								yield* buildScenariosWithPrefix([
 									...scenario,
 									{ type: StepType.Remove, index: i, peer: p },
 								]);
@@ -451,7 +451,7 @@ describe("Editing", () => {
 						}
 						if (buildState.peerUndoStack[p] > 0) {
 							buildState.peerUndoStack[p] -= 1;
-							yield* buildScenariosImpl([
+							yield* buildScenariosWithPrefix([
 								...scenario,
 								{ type: StepType.Undo, peer: p },
 							]);
@@ -463,7 +463,7 @@ describe("Editing", () => {
 						yield scenario;
 					}
 				}
-				return buildScenariosImpl();
+				return buildScenariosWithPrefix();
 			}
 
 			const delAction = (peer: SharedTreeView, idx: number) => remove(peer, idx, 1);


### PR DESCRIPTION
This PR add a battery of tests that remove (either through deletion or move) nodes from a field and bring them back through undo.

Since it is trivial to check the validity of the outcome for any possible permutation of such operations (the final state should be the same as the starting state), these tests provide a good "bang for buck" ratio: for equivalent test coverage, it doesn't take much to write an exhaustive generator for them (compared to writing tests individually).

The battery of test is committed as skipped since it detects some errors.