### PR TITLE
Fixes for running Routerlicious on Apple silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ docs/resources/_gen/
 
 # documentation tool artifact
 tsdoc-metadata.json
+
+# PNPM store (when opening local file system in dev container)
+.pnpm-store/

--- a/server/README.md
+++ b/server/README.md
@@ -49,6 +49,7 @@ docker compose restart gitrest
 ### Common Issues
 * Port already allocated
   * This can happen if you have a process already running on a port the docker-compose file expects to have available
+  * On MacOS, Disable AirPlay Receiver to free port 5000 (System Settings -> General -> AirDrop & Handoff -> AirPlay Receiver)
 * Drive Share Failure
   * An intermittent failure most frequent on Windows, best solved by reinstalling
 * Not Enough RAM

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -8,6 +8,7 @@ services:
             - "3003:3003"
             - "3001:3001"
     alfred:
+        platform: linux/amd64
         build:
             context: .
             target: runner
@@ -20,6 +21,7 @@ services:
             - IS_FLUID_SERVER=true
         restart: always
     deli:
+        platform: linux/amd64
         build:
             context: .
             target: runner
@@ -30,6 +32,7 @@ services:
             - IS_FLUID_SERVER=true
         restart: always
     scriptorium:
+        platform: linux/amd64
         build:
             context: .
             target: runner
@@ -40,6 +43,7 @@ services:
             - IS_FLUID_SERVER=true
         restart: always
     copier:
+        platform: linux/amd64
         build:
             context: .
             target: runner
@@ -50,6 +54,7 @@ services:
             - IS_FLUID_SERVER=true
         restart: always
     scribe:
+        platform: linux/amd64
         build:
             context: .
             target: runner
@@ -60,6 +65,7 @@ services:
             - IS_FLUID_SERVER=true
         restart: always
     riddler:
+        platform: linux/amd64
         build:
             context: .
             target: runner

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1531,6 +1531,9 @@ importers:
       querystring:
         specifier: ^0.2.0
         version: 0.2.0
+      serialize-error:
+        specifier: ^8.1.0
+        version: 8.1.0
       socket.io:
         specifier: ^4.5.3
         version: 4.5.4


### PR DESCRIPTION
Alfred, Deli, Scriptorium, Copier, Scribe, and Riddler need to specify platform 'linux/amd64'.

All MacOS users will need to disable 'Airplay Receiver' to free port 5000 for Riddler (added to README.md)