### PR TITLE
Fix EditManager serialization bug

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/nodeIdentifierIndex.bench.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/nodeIdentifierIndex.bench.ts
@@ -205,9 +205,9 @@ describe("Node Identifiers", () => {
 					// TODO: report these sizes as benchmark output which can be tracked over time.
 					const sizeDelta = sizeWithIds - sizeBaseline;
 					const relativeDelta = sizeDelta / sizeBaseline;
-					// Arbitrary limit of 10% increase. Re-adjust when identifier index is more performant.
+					// Arbitrary limit. Re-adjust when identifier index is more performant.
 					assert(
-						relativeDelta < 0.1,
+						relativeDelta < identifierDensityPercentage / 100,
 						`Increased summary size by ${sizeDelta} bytes (${(
 							relativeDelta * 100
 						).toFixed(2)}% increase)`,

--- a/experimental/dds/tree2/src/test/shared-tree/summary.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/summary.bench.ts
@@ -46,7 +46,7 @@ describe("Summary benchmarks", () => {
 			const { summary } = tree.getAttachSummary(true);
 			const summaryString = JSON.stringify(summary);
 			const summarySize = IsoBuffer.from(summaryString).byteLength;
-			assert(summarySize < 1000);
+			assert(summarySize < 500);
 		});
 		it("a tree with 1 node.", async () => {
 			const summaryTree = getInsertsSummaryTree(1, TreeShape.Wide);
@@ -60,35 +60,35 @@ describe("Summary benchmarks", () => {
 			const summaryString = JSON.stringify(summaryTree);
 			const summarySize = IsoBuffer.from(summaryString).byteLength;
 			assert(summarySize > 1000);
-			assert(summarySize < 20000);
+			assert(summarySize < 10000);
 		});
 		it("a wide tree with 100 nodes", async () => {
 			const summaryTree = getInsertsSummaryTree(100, TreeShape.Wide);
 			const summaryString = JSON.stringify(summaryTree);
 			const summarySize = IsoBuffer.from(summaryString).byteLength;
 			assert(summarySize > 1000);
-			assert(summarySize < 1000000);
+			assert(summarySize < 500000);
 		});
 		it("a deep tree with 10 nodes", async () => {
 			const summaryTree = getInsertsSummaryTree(10, TreeShape.Deep);
 			const summaryString = JSON.stringify(summaryTree);
 			const summarySize = IsoBuffer.from(summaryString).byteLength;
 			assert(summarySize > 1000);
-			assert(summarySize < 50000);
+			assert(summarySize < 25000);
 		});
 		it("a deep tree with 100 nodes.", async () => {
 			const summaryTree = getInsertsSummaryTree(100, TreeShape.Deep);
 			const summaryString = JSON.stringify(summaryTree);
 			const summarySize = IsoBuffer.from(summaryString).byteLength;
 			assert(summarySize > 1000);
-			assert(summarySize < 2000000);
+			assert(summarySize < 1000000);
 		});
 		it("a deep tree with 200 nodes.", async () => {
 			const summaryTree = getInsertsSummaryTree(200, TreeShape.Deep);
 			const summaryString = JSON.stringify(summaryTree);
 			const summarySize = IsoBuffer.from(summaryString).byteLength;
 			assert(summarySize > 1000);
-			assert(summarySize < 10000000);
+			assert(summarySize < 5000000);
 		});
 	});
 


### PR DESCRIPTION
## Description

`EditManager` currently serializes the `parent` properties of commits in the commit graph because of a unfortunate property spread. Remove the spread and `parent` property and add explicit types for better type safety. Update tests that measure summary size to be stricter.

Thank you @jenn-le for the diagnosis.