### PR TITLE
Deprecate IntervalCollection

### DIFF
--- a/.changeset/itchy-pets-tap.md
+++ b/.changeset/itchy-pets-tap.md
@@ -1,0 +1,5 @@
+---
+"@fluidframework/sequence": patch
+---
+
+Deprecate IntervalCollection and related classes

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,17 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   Avoid using code formatting in the title (it's fine to use in the body).
 -   To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.4.4.0
+
+## 2.0.0-internal.4.3.0 Upcoming changes
+
+-   [IntervalCollection public export deprecated](#intervalCollection-public-export-deprecated)
+
+### IntervalCollection public export deprecated
+
+`IntervalCollection` has been deprecated in favor of an interface (`IIntervalCollection`) containing its public API.
+Several types transitively referenced by `IntervalCollection` implementation details have also been deprecated: `CompressedSerializedInterval`, `IntervalCollectionIterator`, and `ISerializedIntervalCollectionV2`.
+
 # 2.0.0-internal.4.3.0
 
 ## 2.0.0-internal.4.3.0 Breaking changes

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -49,7 +49,7 @@ import { SummarySerializer } from '@fluidframework/shared-object-base';
 import { TextSegment } from '@fluidframework/merge-tree';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
-// @public
+// @public @deprecated
 export type CompressedSerializedInterval = [number, number, number, IntervalType, PropertySet, IntervalStickiness] | [number, number, number, IntervalType, PropertySet];
 
 // @public (undocumented)
@@ -74,6 +74,40 @@ export interface IInterval {
     overlaps(b: IInterval): boolean;
     // @internal
     union(b: IInterval): IInterval;
+}
+
+// @public
+export interface IIntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
+    // (undocumented)
+    [Symbol.iterator](): Iterator<TInterval>;
+    add(start: number, end: number, intervalType: IntervalType, props?: PropertySet): TInterval;
+    // (undocumented)
+    attachDeserializer(onDeserialize: DeserializeCallback): void;
+    // (undocumented)
+    readonly attached: boolean;
+    attachIndex(index: IntervalIndex<TInterval>): void;
+    change(id: string, start?: number, end?: number): TInterval | undefined;
+    changeProperties(id: string, props: PropertySet): any;
+    // (undocumented)
+    CreateBackwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
+    // (undocumented)
+    CreateBackwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
+    // (undocumented)
+    CreateForwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
+    // (undocumented)
+    CreateForwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
+    detachIndex(index: IntervalIndex<TInterval>): boolean;
+    // (undocumented)
+    findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[];
+    gatherIterationResults(results: TInterval[], iteratesForward: boolean, start?: number, end?: number): void;
+    // (undocumented)
+    getIntervalById(id: string): TInterval | undefined;
+    map(fn: (interval: TInterval) => void): void;
+    // (undocumented)
+    nextInterval(pos: number): TInterval | undefined;
+    // (undocumented)
+    previousInterval(pos: number): TInterval | undefined;
+    removeIntervalById(id: string): TInterval | undefined;
 }
 
 // @public
@@ -138,8 +172,8 @@ export class Interval implements ISerializableInterval {
     union(b: Interval): Interval;
 }
 
-// @public
-export class IntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
+// @public @deprecated (undocumented)
+export class IntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> implements IIntervalCollection<TInterval> {
     // (undocumented)
     [Symbol.iterator](): IntervalCollectionIterator<TInterval>;
     // @internal
@@ -188,7 +222,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     serializeInternal(): ISerializedIntervalCollectionV2;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class IntervalCollectionIterator<TInterval extends ISerializableInterval> implements Iterator<TInterval> {
     constructor(collection: IntervalCollection<TInterval>, iteratesForward?: boolean, start?: number, end?: number);
     // (undocumented)
@@ -266,7 +300,7 @@ export interface ISerializedInterval {
     stickiness?: IntervalStickiness;
 }
 
-// @internal (undocumented)
+// @internal @deprecated (undocumented)
 export interface ISerializedIntervalCollectionV2 {
     // (undocumented)
     intervals: CompressedSerializedInterval[];

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -280,6 +280,30 @@ use_old_InterfaceDeclaration_IAttributionCollectionSerializer(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IAttributionCollectionSpec": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IAttributionCollectionSpec():
+    TypeOnly<old.IAttributionCollectionSpec<any>>;
+declare function use_current_InterfaceDeclaration_IAttributionCollectionSpec(
+    use: TypeOnly<current.IAttributionCollectionSpec<any>>);
+use_current_InterfaceDeclaration_IAttributionCollectionSpec(
+    get_old_InterfaceDeclaration_IAttributionCollectionSpec());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IAttributionCollectionSpec": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IAttributionCollectionSpec():
+    TypeOnly<current.IAttributionCollectionSpec<any>>;
+declare function use_old_InterfaceDeclaration_IAttributionCollectionSpec(
+    use: TypeOnly<old.IAttributionCollectionSpec<any>>);
+use_old_InterfaceDeclaration_IAttributionCollectionSpec(
+    get_current_InterfaceDeclaration_IAttributionCollectionSpec());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ICombiningOp": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ICombiningOp():
@@ -1116,6 +1140,30 @@ declare function use_old_InterfaceDeclaration_ISegmentChanges(
     use: TypeOnly<old.ISegmentChanges>);
 use_old_InterfaceDeclaration_ISegmentChanges(
     get_current_InterfaceDeclaration_ISegmentChanges());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITrackingGroup": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITrackingGroup():
+    TypeOnly<old.ITrackingGroup>;
+declare function use_current_InterfaceDeclaration_ITrackingGroup(
+    use: TypeOnly<current.ITrackingGroup>);
+use_current_InterfaceDeclaration_ITrackingGroup(
+    get_old_InterfaceDeclaration_ITrackingGroup());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITrackingGroup": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITrackingGroup():
+    TypeOnly<current.ITrackingGroup>;
+declare function use_old_InterfaceDeclaration_ITrackingGroup(
+    use: TypeOnly<old.ITrackingGroup>);
+use_old_InterfaceDeclaration_ITrackingGroup(
+    get_current_InterfaceDeclaration_ITrackingGroup());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -2244,6 +2292,30 @@ declare function use_old_ClassDeclaration_SegmentGroupCollection(
     use: TypeOnly<old.SegmentGroupCollection>);
 use_old_ClassDeclaration_SegmentGroupCollection(
     get_current_ClassDeclaration_SegmentGroupCollection());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_SequenceOffsets": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_SequenceOffsets():
+    TypeOnly<old.SequenceOffsets>;
+declare function use_current_InterfaceDeclaration_SequenceOffsets(
+    use: TypeOnly<current.SequenceOffsets>);
+use_current_InterfaceDeclaration_SequenceOffsets(
+    get_old_InterfaceDeclaration_SequenceOffsets());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_SequenceOffsets": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_SequenceOffsets():
+    TypeOnly<current.SequenceOffsets>;
+declare function use_old_InterfaceDeclaration_SequenceOffsets(
+    use: TypeOnly<old.SequenceOffsets>);
+use_old_InterfaceDeclaration_SequenceOffsets(
+    get_current_InterfaceDeclaration_SequenceOffsets());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -280,30 +280,6 @@ use_old_InterfaceDeclaration_IAttributionCollectionSerializer(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IAttributionCollectionSpec": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_IAttributionCollectionSpec():
-    TypeOnly<old.IAttributionCollectionSpec<any>>;
-declare function use_current_InterfaceDeclaration_IAttributionCollectionSpec(
-    use: TypeOnly<current.IAttributionCollectionSpec<any>>);
-use_current_InterfaceDeclaration_IAttributionCollectionSpec(
-    get_old_InterfaceDeclaration_IAttributionCollectionSpec());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IAttributionCollectionSpec": {"backCompat": false}
-*/
-declare function get_current_InterfaceDeclaration_IAttributionCollectionSpec():
-    TypeOnly<current.IAttributionCollectionSpec<any>>;
-declare function use_old_InterfaceDeclaration_IAttributionCollectionSpec(
-    use: TypeOnly<old.IAttributionCollectionSpec<any>>);
-use_old_InterfaceDeclaration_IAttributionCollectionSpec(
-    get_current_InterfaceDeclaration_IAttributionCollectionSpec());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ICombiningOp": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ICombiningOp():
@@ -1140,30 +1116,6 @@ declare function use_old_InterfaceDeclaration_ISegmentChanges(
     use: TypeOnly<old.ISegmentChanges>);
 use_old_InterfaceDeclaration_ISegmentChanges(
     get_current_InterfaceDeclaration_ISegmentChanges());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ITrackingGroup": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_ITrackingGroup():
-    TypeOnly<old.ITrackingGroup>;
-declare function use_current_InterfaceDeclaration_ITrackingGroup(
-    use: TypeOnly<current.ITrackingGroup>);
-use_current_InterfaceDeclaration_ITrackingGroup(
-    get_old_InterfaceDeclaration_ITrackingGroup());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ITrackingGroup": {"backCompat": false}
-*/
-declare function get_current_InterfaceDeclaration_ITrackingGroup():
-    TypeOnly<current.ITrackingGroup>;
-declare function use_old_InterfaceDeclaration_ITrackingGroup(
-    use: TypeOnly<old.ITrackingGroup>);
-use_old_InterfaceDeclaration_ITrackingGroup(
-    get_current_InterfaceDeclaration_ITrackingGroup());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -2292,30 +2244,6 @@ declare function use_old_ClassDeclaration_SegmentGroupCollection(
     use: TypeOnly<old.SegmentGroupCollection>);
 use_old_ClassDeclaration_SegmentGroupCollection(
     get_current_ClassDeclaration_SegmentGroupCollection());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_SequenceOffsets": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_SequenceOffsets():
-    TypeOnly<old.SequenceOffsets>;
-declare function use_current_InterfaceDeclaration_SequenceOffsets(
-    use: TypeOnly<current.SequenceOffsets>);
-use_current_InterfaceDeclaration_SequenceOffsets(
-    get_old_InterfaceDeclaration_SequenceOffsets());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_SequenceOffsets": {"backCompat": false}
-*/
-declare function get_current_InterfaceDeclaration_SequenceOffsets():
-    TypeOnly<current.SequenceOffsets>;
-declare function use_old_InterfaceDeclaration_SequenceOffsets(
-    use: TypeOnly<old.SequenceOffsets>);
-use_old_InterfaceDeclaration_SequenceOffsets(
-    get_current_InterfaceDeclaration_SequenceOffsets());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -22,6 +22,7 @@ export {
 	IIntervalHelpers,
 	Interval,
 	IntervalIndex,
+	IIntervalCollection,
 	IntervalCollection,
 	IntervalCollectionIterator,
 	IntervalLocator,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -105,6 +105,8 @@ export type SerializedIntervalDelta = Omit<ISerializedInterval, "start" | "end" 
  * Intervals are of the format:
  *
  * [start, end, sequenceNumber, intervalType, properties, stickiness?]
+ *
+ * @deprecated - Public export was never intended and will be removed.
  */
 export type CompressedSerializedInterval =
 	| [number, number, number, IntervalType, PropertySet, IntervalStickiness]
@@ -112,6 +114,7 @@ export type CompressedSerializedInterval =
 
 /**
  * @internal
+ * @deprecated - Public export will be removed.
  */
 export interface ISerializedIntervalCollectionV2 {
 	label: string;
@@ -1543,6 +1546,10 @@ export function makeOpsMap<T extends ISerializableInterval>(): Map<
 
 export type DeserializeCallback = (properties: PropertySet) => void;
 
+/**
+ * @deprecated - Public export will be removed. Use an appropriate iterator creation method on
+ * {@link IIntervalCollection} to iterate intervals instead.
+ */
 export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 	implements Iterator<TInterval>
 {
@@ -1641,9 +1648,128 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
  * This aligns with its usage in `SharedSegmentSequence`, which allows associating intervals to positions in the
  * sequence DDS which are broadcast to all other clients in an eventually consistent fashion.
  */
-export class IntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<
-	IIntervalCollectionEvent<TInterval>
-> {
+export interface IIntervalCollection<TInterval extends ISerializableInterval>
+	extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
+	readonly attached: boolean;
+	/**
+	 * Attaches an index to this collection.
+	 * All intervals which are part of this collection will be added to the index, and the index will automatically
+	 * be updated when this collection updates due to local or remote changes.
+	 *
+	 * @remarks - After attaching an index to an interval collection, applications should typically store this
+	 * index somewhere in their in-memory data model for future reference and querying.
+	 */
+	attachIndex(index: IntervalIndex<TInterval>): void;
+	/**
+	 * Detaches an index from this collection.
+	 * All intervals which are part of this collection will be removed from the index, and updates to this collection
+	 * due to local or remote changes will no longer incur updates to the index.
+	 *
+	 * @returns - Return false if the target index cannot be found in the indexes, otherwise remove all intervals in the index and return true
+	 */
+	detachIndex(index: IntervalIndex<TInterval>): boolean;
+	/**
+	 * @returns the interval in this collection that has the provided `id`.
+	 * If no interval in the collection has this `id`, returns `undefined`.
+	 */
+	getIntervalById(id: string): TInterval | undefined;
+	/**
+	 * Creates a new interval and add it to the collection.
+	 * @param start - interval start position (inclusive)
+	 * @param end - interval end position (exclusive)
+	 * @param intervalType - type of the interval. All intervals are SlideOnRemove. Intervals may not be Transient.
+	 * @param props - properties of the interval
+	 * @returns - the created interval
+	 * @remarks - See documentation on {@link SequenceInterval} for comments on interval endpoint semantics: there are subtleties
+	 * with how the current half-open behavior is represented.
+	 */
+	add(start: number, end: number, intervalType: IntervalType, props?: PropertySet): TInterval;
+	/**
+	 * Removes an interval from the collection.
+	 * @param id - Id of the interval to remove
+	 * @returns the removed interval
+	 */
+	removeIntervalById(id: string): TInterval | undefined;
+	/**
+	 * Changes the properties on an existing interval.
+	 * @param id - Id of the interval whose properties should be changed
+	 * @param props - Property set to apply to the interval. Shallow merging is used between any existing properties
+	 * and `prop`, i.e. the interval will end up with a property object equivalent to `{ ...oldProps, ...props }`.
+	 */
+	changeProperties(id: string, props: PropertySet);
+	/**
+	 * Changes the endpoints of an existing interval.
+	 * @param id - Id of the interval to change
+	 * @param start - New start value, if defined. `undefined` signifies this endpoint should be left unchanged.
+	 * @param end - New end value, if defined. `undefined` signifies this endpoint should be left unchanged.
+	 * @returns the interval that was changed, if it existed in the collection.
+	 */
+	change(id: string, start?: number, end?: number): TInterval | undefined;
+
+	attachDeserializer(onDeserialize: DeserializeCallback): void;
+	/**
+	 * @returns an iterator over all intervals in this collection.
+	 */
+	[Symbol.iterator](): Iterator<TInterval>;
+
+	/**
+	 * @returns a forward iterator over all intervals in this collection with start point equal to `startPosition`.
+	 */
+	CreateForwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
+
+	/**
+	 * @returns a backward iterator over all intervals in this collection with start point equal to `startPosition`.
+	 */
+	CreateBackwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
+
+	/**
+	 * @returns a forward iterator over all intervals in this collection with end point equal to `endPosition`.
+	 */
+	CreateForwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
+
+	/**
+	 * @returns a backward iterator over all intervals in this collection with end point equal to `endPosition`.
+	 */
+	CreateBackwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
+
+	/**
+	 * Gathers iteration results that optionally match a start/end criteria into the provided array.
+	 * @param results - Array to gather the results into. In lieu of a return value, this array will be populated with
+	 * intervals matching the query upon edit.
+	 * @param iteratesForward - whether or not iteration should be in the forward direction
+	 * @param start - If provided, only match intervals whose start point is equal to `start`.
+	 * @param end - If provided, only match intervals whose end point is equal to `end`.
+	 */
+	gatherIterationResults(
+		results: TInterval[],
+		iteratesForward: boolean,
+		start?: number,
+		end?: number,
+	): void;
+
+	/**
+	 * @returns an array of all intervals in this collection that overlap with the interval
+	 * `[startPosition, endPosition]`.
+	 */
+	findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[];
+
+	/**
+	 * Applies a function to each interval in this collection.
+	 */
+	map(fn: (interval: TInterval) => void): void;
+
+	previousInterval(pos: number): TInterval | undefined;
+
+	nextInterval(pos: number): TInterval | undefined;
+}
+
+/**
+ * @deprecated - Use {@link IIntervalCollection} instead.
+ */
+export class IntervalCollection<TInterval extends ISerializableInterval>
+	extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>>
+	implements IIntervalCollection<TInterval>
+{
 	private savedSerializedIntervals?: ISerializedInterval[];
 	private localCollection: LocalIntervalCollection<TInterval> | undefined;
 	private onDeserialize: DeserializeCallback | undefined;
@@ -1687,12 +1813,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Attaches an index to this collection.
-	 * All intervals which are part of this collection will be added to the index, and the index will automatically
-	 * be updated when this collection updates due to local or remote changes.
-	 *
-	 * @remarks - After attaching an index to an interval collection, applications should typically store this
-	 * index somewhere in their in-memory data model for future reference and querying.
+	 * {@inheritdoc IIntervalCollection.attachIndex}
 	 */
 	public attachIndex(index: IntervalIndex<TInterval>): void {
 		if (!this.attached) {
@@ -1706,11 +1827,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Detaches an index from this collection.
-	 * All intervals which are part of this collection will be removed from the index, and updates to this collection
-	 * due to local or remote changes will no longer incur updates to the index.
-	 *
-	 * @returns - Return false if the target index cannot be found in the indexes, otherwise remove all intervals in the index and return true
+	 * {@inheritdoc IIntervalCollection.detachIndex}
 	 */
 	public detachIndex(index: IntervalIndex<TInterval>): boolean {
 		if (!this.attached) {
@@ -1875,8 +1992,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * @returns the interval in this collection that has the provided `id`.
-	 * If no interval in the collection has this `id`, returns `undefined`.
+	 * {@inheritdoc IIntervalCollection.getIntervalById}
 	 */
 	public getIntervalById(id: string) {
 		if (!this.localCollection) {
@@ -1886,14 +2002,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Creates a new interval and add it to the collection.
-	 * @param start - interval start position (inclusive)
-	 * @param end - interval end position (exclusive)
-	 * @param intervalType - type of the interval. All intervals are SlideOnRemove. Intervals may not be Transient.
-	 * @param props - properties of the interval
-	 * @returns - the created interval
-	 * @remarks - See documentation on {@link SequenceInterval} for comments on interval endpoint semantics: there are subtleties
-	 * with how the current half-open behavior is represented.
+	 * {@inheritdoc IIntervalCollection.add}
 	 */
 	public add(
 		start: number,
@@ -1971,9 +2080,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Removes an interval from the collection.
-	 * @param id - Id of the interval to remove
-	 * @returns the removed interval
+	 * {@inheritdoc IIntervalCollection.removeIntervalById}
 	 */
 	public removeIntervalById(id: string) {
 		if (!this.localCollection) {
@@ -1987,10 +2094,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Changes the properties on an existing interval.
-	 * @param id - Id of the interval whose properties should be changed
-	 * @param props - Property set to apply to the interval. Shallow merging is used between any existing properties
-	 * and `prop`, i.e. the interval will end up with a property object equivalent to `{ ...oldProps, ...props }`.
+	 * {@inheritdoc IIntervalCollection.changeProperties}
 	 */
 	public changeProperties(id: string, props: PropertySet) {
 		if (!this.attached) {
@@ -2024,11 +2128,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Changes the endpoints of an existing interval.
-	 * @param id - Id of the interval to change
-	 * @param start - New start value, if defined. `undefined` signifies this endpoint should be left unchanged.
-	 * @param end - New end value, if defined. `undefined` signifies this endpoint should be left unchanged.
-	 * @returns the interval that was changed, if it existed in the collection.
+	 * {@inheritdoc IIntervalCollection.change}
 	 */
 	public change(id: string, start?: number, end?: number): TInterval | undefined {
 		if (!this.localCollection) {
@@ -2216,6 +2316,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		}
 	}
 
+	/**
+	 * {@inheritdoc IIntervalCollection.attachDeserializer}
+	 */
 	public attachDeserializer(onDeserialize: DeserializeCallback): void {
 		// If no deserializer is specified can skip all processing work
 		if (!onDeserialize) {
@@ -2508,7 +2611,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * @returns a forward iterator over all intervals in this collection with start point equal to `startPosition`.
+	 * {@inheritdoc IIntervalCollection.CreateForwardIteratorWithStartPosition}
 	 */
 	public CreateForwardIteratorWithStartPosition(
 		startPosition: number,
@@ -2518,7 +2621,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * @returns a backward iterator over all intervals in this collection with start point equal to `startPosition`.
+	 * {@inheritdoc IIntervalCollection.CreateBackwardIteratorWithStartPosition}
 	 */
 	public CreateBackwardIteratorWithStartPosition(
 		startPosition: number,
@@ -2528,7 +2631,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * @returns a forward iterator over all intervals in this collection with end point equal to `endPosition`.
+	 * {@inheritdoc IIntervalCollection.CreateForwardIteratorWithEndPosition}
 	 */
 	public CreateForwardIteratorWithEndPosition(
 		endPosition: number,
@@ -2543,7 +2646,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * @returns a backward iterator over all intervals in this collection with end point equal to `endPosition`.
+	 * {@inheritdoc IIntervalCollection.CreateBackwardIteratorWithEndPosition}
 	 */
 	public CreateBackwardIteratorWithEndPosition(
 		endPosition: number,
@@ -2558,12 +2661,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Gathers iteration results that optionally match a start/end criteria into the provided array.
-	 * @param results - Array to gather the results into. In lieu of a return value, this array will be populated with
-	 * intervals matching the query upon edit.
-	 * @param iteratesForward - whether or not iteration should be in the forward direction
-	 * @param start - If provided, only match intervals whose start point is equal to `start`.
-	 * @param end - If provided, only match intervals whose end point is equal to `end`.
+	 * {@inheritdoc IIntervalCollection.gatherIterationResults}
 	 */
 	public gatherIterationResults(
 		results: TInterval[],
@@ -2584,8 +2682,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * @returns an array of all intervals in this collection that overlap with the interval
-	 * `[startPosition, endPosition]`.
+	 * {@inheritdoc IIntervalCollection.findOverlappingIntervals}
 	 */
 	public findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[] {
 		if (!this.localCollection) {
@@ -2599,7 +2696,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 	}
 
 	/**
-	 * Applies a function to each interval in this collection.
+	 * {@inheritdoc IIntervalCollection.map}
 	 */
 	public map(fn: (interval: TInterval) => void) {
 		if (!this.localCollection) {
@@ -2611,6 +2708,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		}
 	}
 
+	/**
+	 * {@inheritdoc IIntervalCollection.previousInterval}
+	 */
 	public previousInterval(pos: number): TInterval | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("attachSequence must be called");
@@ -2619,6 +2719,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		return this.localCollection.endIntervalIndex.previousInterval(pos);
 	}
 
+	/**
+	 * {@inheritdoc IIntervalCollection.nextInterval}
+	 */
 	public nextInterval(pos: number): TInterval | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("attachSequence must be called");


### PR DESCRIPTION
## Description

Deprecates `IntervalCollection` and stages an interface containing its public API to export instead. This allows cleanup of some other undesirable exports in sequence's public API--see #15773.
