### PR TITLE
build: Correct allowed webpack peer dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
 			"allowedVersions": {
 				"react": "17.0.2",
 				"react-dom": "17.0.2",
-				"webpack": "5.83.0"
+				"webpack": "^5.82.0"
 			},
 			"ignoreMissing": [
 				"fluid-framework"


### PR DESCRIPTION
Corrects problems like these that are reported by pnpm:

```shell
experimental/PropertyDDS/examples/property-inspector
├─┬ css-loader 1.0.1
│ └── ✕ unmet peer webpack@"^4.0.0 || 5.83.0": found 5.82.0
└─┬ sass-loader 7.3.1
  └── ✕ unmet peer webpack@"^3.0.0 || ^4.0.0 || 5.83.0": found 5.82.0

experimental/PropertyDDS/packages/property-inspector-table
└─┬ istanbul-instrumenter-loader 3.0.1
  └── ✕ unmet peer webpack@"^2.0.0 || ^3.0.0 || ^4.0.0 || 5.83.0": found 5.82.0
```