### PR TITLE
fix(devtools-example): Remove invalid objects from test app, which were breaking data view

### DIFF
--- a/packages/tools/devtools/devtools-example/src/App.tsx
+++ b/packages/tools/devtools/devtools-example/src/App.tsx
@@ -22,11 +22,9 @@ import { SharedCell } from "@fluidframework/cell";
 import { SharedMap } from "@fluidframework/map";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { SharedString } from "@fluidframework/sequence";
-import { MockHandle } from "@fluidframework/test-runtime-utils";
 
 import { ContainerInfo, createFluidContainer, loadExistingFluidContainer } from "./ClientUtilities";
 import { CounterWidget, EmojiGrid } from "./widgets";
-import { createMockSharedObject } from "./MockSharedObject";
 
 const sharedContainerKey: ContainerKey = "Shared Container";
 const privateContainerKey: ContainerKey = "Private Container";
@@ -45,16 +43,6 @@ const sharedCounterKey = "shared-counter";
  * Key in the app's `rootMap` under which the SharedCell object is stored.
  */
 const emojiMatrixKey = "emoji-matrix";
-
-/**
- * Key in the app's `rootMap` under which an unknown (to the devtools) kind of data will be recorded for testing purposes.
- */
-const unknownDataKey = "unknown-data";
-
-/**
- * Key in the app's `rootMap` under which an unknown (to the devtools) kind of Shared Object will be recorded for testing purposes.
- */
-const unknownSharedObjectKey = "unknown-shared-object";
 
 /**
  * Schema used by the app.
@@ -116,12 +104,6 @@ async function populateRootMap(container: IFluidContainer): Promise<void> {
 			b: "b",
 		},
 	});
-
-	// Add some unrecognizable data to test devtools handling
-	rootMap.set(unknownDataKey, new MockHandle("Unknown data"));
-
-	const unknownSharedObject = createMockSharedObject("unknown-shared-object-id");
-	rootMap.set(unknownSharedObjectKey, unknownSharedObject.handle);
 }
 
 /**


### PR DESCRIPTION
We were using `MockHandle` (directly, and transitively through `MockSharedObject`) when setting up our Container. This is fine for a local-only, transient session. But when attempting to reload the container (as we can do for the "Shared Container" in the example), the runtime fails to resolve the handles. This was causing subsequent views of the Shared Container's data to spin forever awaiting data.

The temporary fix is to remove usages of `MockHandle` from the test app. In the future, it may be worth adding more legitimate examples of data the visualizer doesn't understand, but that will require further investigation.

We also probably need to update our handling of cases like this to give a better UX experience. 