### PR TITLE
Better understand what happens in refresh latest ack scenarios

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -314,7 +314,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 			referenceSequenceNumber: number;
 			latestSummaryUpdated?: boolean;
 			wasSummaryTracked?: boolean;
-			refreshScenario?: string;
+			refreshScenario?: number;
 		} = {
 			proposalHandle,
 			summaryRefSeq,
@@ -350,8 +350,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 							latestSummaryUpdated: true,
 							wasSummaryTracked: true,
 							summaryRefSeq,
-							refreshScenario:
-								"Successfully refreshed summary ack for tracked summary",
+							refreshScenario: 0, // Successfully refreshed summary ack for tracked summary
 						};
 					}
 				}
@@ -361,8 +360,8 @@ export class SummarizerNode implements IRootSummarizerNode {
 					eventProps.latestSummaryUpdated = false;
 					eventProps.refreshScenario =
 						this.referenceSequenceNumber === summaryRefSeq
-							? "Received ack matching the current referenceSequenceNumber without a tracked summary"
-							: "Received ack older than the current referenceSequenceNumber, potentially a server problem";
+							? 1 // Received ack matching the current referenceSequenceNumber without a tracked summary
+							: 2; // Received ack older than the current referenceSequenceNumber, potentially a server problem
 					event.end(eventProps);
 					return { latestSummaryUpdated: false };
 				}
@@ -376,8 +375,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 				// snapshot is older than the latest tracked summary, ignore it.
 				if (this.referenceSequenceNumber >= fetchedSnapshotRefSeq) {
 					eventProps.latestSummaryUpdated = false;
-					eventProps.refreshScenario =
-						"Received an ack for a summary with a referenceSequenceNumber greater than currently tracked, and fetched a snapshot older than currently tracked!";
+					eventProps.refreshScenario = 3; // Received an ack for a summary with a referenceSequenceNumber greater than currently tracked, and fetched a snapshot older than currently tracked
 					event.end(eventProps);
 					return { latestSummaryUpdated: false };
 				}
@@ -396,10 +394,10 @@ export class SummarizerNode implements IRootSummarizerNode {
 				eventProps.summaryRefSeq = fetchedSnapshotRefSeq;
 				eventProps.refreshScenario =
 					fetchedSnapshotRefSeq === summaryRefSeq
-						? "Refreshed summary ack with matching server snapshot"
-						: `Refreshed summary ack with server snapshot referenceSequenceNumber ${
-								fetchedSnapshotRefSeq > summaryRefSeq ? ">" : "<"
-						  } the ack's referenceSequenceNumber`;
+						? 4 // Refreshed summary ack with matching server snapshot
+						: fetchedSnapshotRefSeq > summaryRefSeq
+						? 5 // Refreshed summary ack with server snapshot referenceSequenceNumber > the ack's referenceSequenceNumber
+						: 6; // Refreshed summary ack with server snapshot referenceSequenceNumber < the ack's referenceSequenceNumber
 				event.end(eventProps);
 				return {
 					latestSummaryUpdated: true,


### PR DESCRIPTION
[AB#4180](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4180)

This allows us to better understand what happenes when we refresh from an ack. Improves telemetry so that it is more human readable.