### PR TITLE
chore(tree): Remove forest provider pattern from ForestRepairDataStore

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -132,11 +132,7 @@ export {
 
 export { mapFieldMarks, mapMark, mapMarkList, populateChildModifications } from "./deltaUtils";
 
-export {
-	ForestRepairDataStore,
-	ForestRepairDataStoreProvider,
-	repairDataStoreFromForest,
-} from "./forestRepairDataStore";
+export { ForestRepairDataStore, ForestRepairDataStoreProvider } from "./forestRepairDataStore";
 export { dummyRepairDataStore } from "./fakeRepairDataStore";
 
 export { mapFromNamed, namedTreeSchema } from "./viewSchemaUtil";

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -32,10 +32,10 @@ import {
 	defaultChangeFamily,
 	defaultSchemaPolicy,
 	getEditableTreeContext,
-	repairDataStoreFromForest,
 	ForestRepairDataStoreProvider,
 	DefaultEditBuilder,
 	NewFieldContent,
+	ForestRepairDataStore,
 } from "../feature-libraries";
 import { SharedTreeBranch } from "../shared-tree-core";
 import { TransactionResult, brand } from "../util";
@@ -328,7 +328,7 @@ export class SharedTreeView implements ISharedTreeView {
 
 	public readonly transaction: ISharedTreeView["transaction"] = {
 		start: () => {
-			this.branch.startTransaction(repairDataStoreFromForest(this.forest));
+			this.branch.startTransaction(new ForestRepairDataStore(this.forest));
 			this.branch.editor.enterTransaction();
 		},
 		commit: () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -29,10 +29,10 @@ import {
 } from "../../../core";
 import { jsonSchema } from "../../../domains";
 import {
+	ForestRepairDataStore,
 	defaultSchemaPolicy,
 	jsonableTreeFromCursor,
 	singleTextCursor,
-	repairDataStoreFromForest,
 } from "../../../feature-libraries";
 import { testForest } from "../../forestTestSuite";
 import { brand } from "../../../util";
@@ -64,7 +64,7 @@ describe("ChunkedForest", () => {
 		assert(!chunk.isShared());
 		compareForest(forest, [initialState]);
 
-		const repairStore = repairDataStoreFromForest(forest);
+		const repairStore = new ForestRepairDataStore(forest);
 		const delta: Delta.Root = new Map([
 			[rootFieldKeySymbol, [{ type: Delta.MarkType.Delete, count: 1 }]],
 		]);

--- a/experimental/dds/tree2/src/test/feature-libraries/defaultChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/defaultChangeFamily.spec.ts
@@ -17,7 +17,6 @@ import {
 	mapCursorField,
 	moveToDetachedField,
 	ReadonlyRepairDataStore,
-	RevisionTag,
 	rootFieldKeySymbol,
 	TaggedChange,
 	UpPath,
@@ -84,13 +83,7 @@ function initializeEditableForest(data?: JsonableTree): {
 		initializeForest(forest, [singleTextCursor(data)]);
 	}
 	let currentRevision = mintRevisionTag();
-	const repairStore = new ForestRepairDataStore((revision: RevisionTag) => {
-		assert(
-			revision === currentRevision,
-			"The repair data store should only ask for the current forest state",
-		);
-		return forest;
-	});
+	const repairStore = new ForestRepairDataStore(forest);
 	const changes: TaggedChange<DefaultChangeset>[] = [];
 	const deltas: Delta.Root[] = [];
 	const builder = new DefaultEditBuilder(

--- a/experimental/dds/tree2/src/test/feature-libraries/forestRepairDataStore.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/forestRepairDataStore.spec.ts
@@ -38,12 +38,7 @@ describe("ForestRepairDataStore", () => {
 	it("Captures deleted nodes", () => {
 		const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
 		const forest = buildForest(schema);
-		let revision = revision1;
-		const store = new ForestRepairDataStore((rev) => {
-			assert.equal(rev, revision);
-			revision = revision2;
-			return forest;
-		});
+		const store = new ForestRepairDataStore(forest);
 		const capture1 = [
 			{ type: jsonNumber.name, value: 1 },
 			{
@@ -121,10 +116,7 @@ describe("ForestRepairDataStore", () => {
 	it("Captures overwritten values", () => {
 		const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
 		const forest = buildForest(schema);
-		const store = new ForestRepairDataStore((rev) => {
-			assert.equal(rev, revision1);
-			return forest;
-		});
+		const store = new ForestRepairDataStore(forest);
 		const data = {
 			type: jsonObject.name,
 			fields: {


### PR DESCRIPTION
This pattern is currently not being used and is replaced by the pattern of having a RepairDataStore per commit.