### PR TITLE
refactor(devtools-core): Remove `postMessagesToWindow` from public API surface

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -403,9 +403,6 @@ export interface MessageLoggingOptions {
     context?: string;
 }
 
-// @internal
-export function postMessagesToWindow<TMessage extends IDevtoolsMessage>(loggingOptions?: MessageLoggingOptions, ...messages: TMessage[]): void;
-
 // @public
 export type Primitive = bigint | number | boolean | null | string | symbol | undefined;
 

--- a/packages/tools/devtools/devtools-core/src/index.ts
+++ b/packages/tools/devtools/devtools-core/src/index.ts
@@ -91,7 +91,6 @@ export {
 	InboundHandlers,
 	isDevtoolsMessage,
 	MessageLoggingOptions,
-	postMessagesToWindow,
 	RootDataVisualizations,
 	TelemetryEvent,
 	TelemetryHistory,

--- a/packages/tools/devtools/devtools-core/src/messaging/Utilities.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/Utilities.ts
@@ -14,8 +14,6 @@ import { IDevtoolsMessage, ISourcedDevtoolsMessage } from "./Messages";
  * If not passed, this function won't log to console before posting the message.
  *
  * @remarks Thin wrapper to provide some message-wise type-safety.
- *
- * @internal
  */
 export function postMessagesToWindow<TMessage extends IDevtoolsMessage>(
 	loggingOptions?: MessageLoggingOptions,


### PR DESCRIPTION
The function implicitly injects the message source into messages it sends, marking them as being from the devtools library, so it is fundamentally not usable externally.

### Breaking Change

Note: this is a breaking change, in that it removes an API member.