### PR TITLE
Make sure we wait for FRS before upload time info

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -619,6 +619,7 @@ stages:
       - perf_unit_tests_memory
       - perf_e2e_tests_local
       - perf_e2e_tests_odsp
+      - perf_e2e_tests_frs
 
     jobs:
       - template: templates/include-test-perf-benchmarks.yml


### PR DESCRIPTION

## Description
Make sure we only upload the perf benchmark pipeline info after FRS has run. 