### PR TITLE
Make some type utilities not specific to the schema code

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -26,7 +26,7 @@ export type AllowedTypes = [Any] | readonly LazyItem<TreeSchema>[];
 // @alpha
 type AllowedTypesToTypedTrees<Mode extends ApiMode, T extends AllowedTypes> = [
 T extends InternalTypedSchemaTypes.FlexList<TreeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray<Mode, Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<T>, readonly TreeSchema[]>>> : UntypedApi<Mode>
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha
 export enum AllowedUpdateType {
@@ -128,7 +128,7 @@ export interface ArrayLikeMut<TGet, TSet extends TGet = TGet> extends ArrayLike<
 type ArrayToUnion<T extends readonly unknown[]> = T extends readonly (infer TValue)[] ? TValue : never;
 
 // @alpha
-export type Assume<TInput, TAssumeToBe> = TInput extends TAssumeToBe ? TInput : TAssumeToBe;
+type Assume<TInput, TAssumeToBe> = TInput extends TAssumeToBe ? TInput : TAssumeToBe;
 
 // @alpha
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
@@ -160,7 +160,7 @@ export interface BrandedMapSubset<K extends BrandedKey<unknown, any>> {
 }
 
 // @alpha @sealed
-export abstract class BrandedType<ValueType, Name extends string> {
+abstract class BrandedType<ValueType, Name extends string> {
     protected readonly _type_brand: Name;
     // (undocumented)
     protected _typeCheck?: Invariant<ValueType>;
@@ -257,13 +257,13 @@ export interface ContextuallyTypedNodeDataObject {
 }
 
 // @alpha
-export interface Contravariant<T> {
+interface Contravariant<T> {
     // (undocumented)
     _removeCovariance?: (_: T) => void;
 }
 
 // @alpha
-export interface Covariant<T> {
+interface Covariant<T> {
     // (undocumented)
     _removeContravariance?: T;
 }
@@ -386,12 +386,12 @@ export interface EditableField extends MarkedArrayLike<UnwrappedEditableTree> {
 // @alpha (undocumented)
 type EditableOptionalField<TypedChild> = [
 UntypedOptionalField & MarkedArrayLike<TypedChild>
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha (undocumented)
 type EditableSequenceField<TypedChild> = [
 UntypedSequenceField & MarkedArrayLike<TypedChild>
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha
 export interface EditableTree extends Iterable<EditableField>, ContextuallyTypedNodeDataObject {
@@ -434,7 +434,7 @@ export type EditableTreeOrPrimitive = EditableTree | PrimitiveValue;
 // @alpha (undocumented)
 type EditableValueField<TypedChild> = [
 UntypedValueField & MarkedArrayLike<TypedChild>
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha (undocumented)
 export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
@@ -474,7 +474,7 @@ export type Events<E> = {
 };
 
 // @alpha
-export type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> = TOpaque extends BrandedType<infer ValueType, infer Name> ? isAny<ValueType> extends true ? unknown : Brand<ValueType, Name> : never;
+type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> = TOpaque extends BrandedType<infer ValueType, infer Name> ? isAny<ValueType> extends true ? unknown : Brand<ValueType, Name> : never;
 
 // @alpha
 export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(value: TOpaque): ExtractFromOpaque<TOpaque>;
@@ -655,10 +655,10 @@ type FlattenKeys<T> = [{
 
 // @alpha
 type FlexibleObject<TValueSchema extends ValueSchema, TName> = [
-InternalTypedSchemaTypes.FlattenKeys<{
+FlattenKeys<{
     [typeNameSymbol]?: UnbrandedName<TName>;
-} & InternalTypedSchemaTypes.AllowOptional<ValuePropertyFromSchema<TValueSchema>>>
-][InternalTypedSchemaTypes._InlineTrick];
+} & AllowOptional<ValuePropertyFromSchema<TValueSchema>>>
+][_InlineTrick];
 
 // @alpha
 type FlexList<Item = unknown> = readonly LazyItem<Item>[];
@@ -850,15 +850,8 @@ declare namespace InternalTypedSchemaTypes {
         RecursiveTreeSchema,
         ObjectToMap,
         WithDefault,
-        AllowOptional,
-        RequiredFields,
-        OptionalFields,
         Unbrand,
         UnbrandList,
-        _InlineTrick,
-        _RecursiveTrick,
-        FlattenKeys,
-        AllowOptionalNotFlattened,
         ArrayToUnion,
         TreeSchemaSpecification,
         NormalizeLocalFieldsInner,
@@ -878,6 +871,27 @@ declare namespace InternalTypedSchemaTypes {
 export { InternalTypedSchemaTypes }
 
 declare namespace InternalTypes {
+    export {
+        MakeNominal,
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny
+    }
+}
+export { InternalTypes }
+
+declare namespace InternalTypes_2 {
     export {
         AllowedTypesToTypedTrees,
         CollectOptions,
@@ -914,11 +928,11 @@ export class InvalidationToken {
 }
 
 // @alpha
-export interface Invariant<T> extends Contravariant<T>, Covariant<T> {
+interface Invariant<T> extends Contravariant<T>, Covariant<T> {
 }
 
 // @alpha
-export type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
+type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
 
 // @alpha
 export function isContextuallyTypedNodeDataObject(data: ContextuallyTypedNodeData | undefined): data is ContextuallyTypedNodeDataObject;
@@ -1132,7 +1146,7 @@ interface LocalFields {
 }
 
 // @alpha
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @alpha
@@ -1515,7 +1529,7 @@ declare namespace SchemaAware {
         TypedNode,
         TypedField,
         AllowedTypesToTypedTrees,
-        InternalTypes
+        InternalTypes_2 as InternalTypes
     }
 }
 export { SchemaAware }
@@ -1536,7 +1550,7 @@ export class SchemaBuilder {
     readonly name: string;
     object<Name extends string, T extends TreeSchemaSpecification>(name: Name, t: T): TreeSchema<Name, T>;
     objectRecursive<Name extends string, T extends RecursiveTreeSchemaSpecification>(name: Name, t: T): TreeSchema<Name, T>;
-    primitive<Name extends string, T extends InternalTypes.PrimitiveValueSchema>(name: Name, t: T): TreeSchema<Name, {
+    primitive<Name extends string, T extends InternalTypes_2.PrimitiveValueSchema>(name: Name, t: T): TreeSchema<Name, {
         value: T;
     }>;
 }
@@ -1834,12 +1848,12 @@ T extends readonly [infer Head, ...infer Tail] ? [
 TypedNode<Assume<Head, TreeSchema>, Mode>,
 ...TypeArrayToTypedTreeArray<Mode, Assume<Tail, readonly TreeSchema[]>>
 ] : []
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha
 type TypedField<TField extends FieldSchema, Mode extends ApiMode = ApiMode.Editable> = [
 ApplyMultiplicity<TField["kind"]["multiplicity"], AllowedTypesToTypedTrees<Mode, TField["allowedTypes"]>, Mode>
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha
 type TypedFields<Mode extends ApiMode, TFields extends undefined | {
@@ -1850,10 +1864,10 @@ TFields extends {
 } ? {
     [key in keyof TFields]: TypedField<TFields[key], Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode>;
 } : EmptyObject
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha
-type TypedNode<TSchema extends TreeSchema, Mode extends ApiMode = ApiMode.Editable> = InternalTypedSchemaTypes.FlattenKeys<CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["localFieldsObject"]>, TSchema["value"], TSchema["name"]>>;
+type TypedNode<TSchema extends TreeSchema, Mode extends ApiMode = ApiMode.Editable> = FlattenKeys<CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["localFieldsObject"]>, TSchema["value"], TSchema["name"]>>;
 
 // @alpha (undocumented)
 export interface TypedSchemaCollection<T extends GlobalFieldSchema> extends SchemaCollection {
@@ -1881,7 +1895,7 @@ type Unbrand<T, B> = T extends infer S & B ? S : T;
 // @alpha
 type UnbrandedName<TName> = [
 TName extends infer S & TreeSchemaIdentifier ? S : string
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // @alpha
 type UnbrandList<T extends unknown[], B> = T extends [infer Head, ...infer Tail] ? [Unbrand<Head, B>, ...UnbrandList<Tail, B>] : [];

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/internal.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/internal.ts
@@ -6,20 +6,7 @@
 // Used by public types, but not part of the desired API surface
 export { RecursiveTreeSchemaSpecification, RecursiveTreeSchema } from "./schemaBuilder";
 
-export {
-	ObjectToMap,
-	WithDefault,
-	AllowOptional,
-	RequiredFields,
-	OptionalFields,
-	Unbrand,
-	UnbrandList,
-	_InlineTrick,
-	_RecursiveTrick,
-	FlattenKeys,
-	AllowOptionalNotFlattened,
-	ArrayToUnion,
-} from "./typeUtils";
+export { ObjectToMap, WithDefault, Unbrand, UnbrandList, ArrayToUnion } from "./typeUtils";
 
 export {
 	TreeSchemaSpecification,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/typeUtils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/typeUtils.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { objectToMap } from "../../../util";
+
 /**
  * Utilities for manipulating types.
  */
@@ -19,18 +21,12 @@ export type ObjectToMap<ObjectMap, MapKey extends number | string, MapValue> = R
 };
 
 // TODO: test + document
-export function objectToMap<
+export function objectToMapTyped<
 	ObjectMap extends Record<MapKey, MapValue>,
 	MapKey extends string,
 	MapValue,
 >(objectMap: ObjectMap): ObjectToMap<ObjectMap, MapKey, MapValue> {
-	const map = new Map<MapKey, MapValue>();
-	// This function must only be used with objects specifically intended to encode map like information.
-	for (const key of Object.keys(objectMap)) {
-		const element = objectMap[key as MapKey];
-		map.set(key as MapKey, element);
-	}
-	return map as unknown as ObjectToMap<ObjectMap, MapKey, MapValue>;
+	return objectToMap(objectMap) as unknown as ObjectToMap<ObjectMap, MapKey, MapValue>;
 }
 
 /**
@@ -68,150 +64,3 @@ export type Unbrand<T, B> = T extends infer S & B ? S : T;
 export type UnbrandList<T extends unknown[], B> = T extends [infer Head, ...infer Tail]
 	? [Unbrand<Head, B>, ...UnbrandList<Tail, B>]
 	: [];
-
-/**
- * Return a type thats equivalent to the input, but with different IntelliSense.
- * This tends to convert unions and intersections into objects.
- * @alpha
- */
-export type FlattenKeys<T> = [{ [Property in keyof T]: T[Property] }][_InlineTrick];
-
-/**
- * Remove all fields which permit undefined from `T`.
- * @alpha
- */
-export type RequiredFields<T> = [
-	{
-		[P in keyof T as undefined extends T[P] ? never : P]: T[P];
-	},
-][_InlineTrick];
-
-/**
- * Extract fields which permit undefined but can also hold other types.
- * @alpha
- */
-export type OptionalFields<T> = [
-	{
-		[P in keyof T as undefined extends T[P]
-			? T[P] extends undefined
-				? never
-				: P
-			: never]?: T[P];
-	},
-][_InlineTrick];
-
-/**
- * Converts properties of an object which permit undefined into optional properties.
- * Removes fields which only allow undefined.
- *
- * @remarks
- * This version does not flatten the resulting type.
- * This version exists because some cases recursive types need to avoid this
- * flattening since it causes complication issues.
- *
- * See also `AllowOptional`.
- * @alpha
- */
-// export type AllowOptionalNotFlattened<T> = [RequiredFields<T> & OptionalFields<T>][_InlineTrick];
-export type AllowOptionalNotFlattened<T> = [RequiredFields<T> & OptionalFields<T>][_InlineTrick];
-
-/**
- * Converts properties of an object which permit undefined into optional properties.
- * Removes fields which only allow undefined.
- * @alpha
- */
-export type AllowOptional<T> = [FlattenKeys<RequiredFields<T> & OptionalFields<T>>][_InlineTrick];
-
-/**
- * Use for trick to "inline" generic types.
- *
- * @remarks
- * The TypeScript compiler can be convinced to inline a generic type
- * (so the result of evaluating the generic type show up in IntelliSense and error messages instead of just the invocation of the generic type)
- * by creating an object with a field, and returning the type of that field.
- *
- * For example:
- * ```typescript
- * type MyGeneric<T1, T2> = {x: T1 extends [] ? T1 : T2 };
- * type MyGenericExpanded<T1, T2> = [{x: T1 extends [] ? T1 : T2 }][_InlineTrick]
- *
- * // Type is MyGeneric<5, string>
- * const foo: MyGeneric<5, string> = {x: "x"}
- * // Type is {x: "x"}
- * const foo2: MyGenericExpanded<5, string> = {x: "x"}
- * ```
- *
- * This constant is defined to provide a way to find this documentation from types which use this pattern,
- * and to locate types which use this pattern in case they need updating for compiler changes.
- * @alpha
- */
-export type _InlineTrick = 0;
-
-/**
- * Use for trick to prevent self reference error `ts(2456)`.
- *
- * Prefix a type expression with `K extends _RecursiveTrick ? _RecursiveTrick : ` for some K to break the cycle.
- *
- * @remarks
- * The TypeScript compiler handles some cases of recursive types, but not others.
- * Sometimes adding an otherwise needless conditional can make a type compile.
- * Use this type in such cases.
- *
- *For example:
- * ```typescript
- * // The TypeScript compiler can't handle this case
- * type Broken<T> = FlattenKeys<
- *	{
- * 		[K in keyof T]: 0;
- * 	} & {
- * 		[K in keyof T]: Broken<T[K]>;
- * 	}
- * >;
- *
- * // Adding `K extends _RecursiveTrick ? _RecursiveTrick :` makes it compile, and has no effect on the type produced.
- * type Works<T> = FlattenKeys<
- * 	{
- * 		[K in keyof T]: 0;
- * 	} & {
- * 		// Trick added here. Since `k` never extends `never`, the second conditional option is always taken,
- * 		// making this equivalent to the broken version, except this one compiles.
- * 		[K in keyof T]: K extends _RecursiveTrick ? _RecursiveTrick : Works<T[K]>;
- * 	}
- * >;
- * ```
- *
- * This trick appears to start working in TypeScript 4.1 and is confirmed to still work in 5.0.4.
- *
- * This constant is defined to provide a way to find this documentation from types which use this pattern,
- * and to locate types which use this pattern in case they need updating for compiler changes.
- * @alpha
- */
-export type _RecursiveTrick = never;
-
-// This block is kept here to ensure the above example behaves as documented, and can be copied into the example to update it as needed.
-{
-	/* eslint-disable @typescript-eslint/no-unused-vars */
-
-	// @ts-expect-error The TypeScript compiler can't handle this case
-	type Broken<T> = FlattenKeys<
-		{
-			[K in keyof T]: 0;
-		} & {
-			// @ts-expect-error Same error as above.
-			[K in keyof T]: Broken<T[K]>;
-		}
-	>;
-
-	// Adding `K extends _RecursiveTrick ? _RecursiveTrick:` OR `T extends _RecursiveTrick ? _RecursiveTrick :` makes it compile and has no effect on the type produced.
-	type Works<T> = FlattenKeys<
-		{
-			[K in keyof T]: 0;
-		} & {
-			// Trick added here. Since `K` never extends `never`, the second conditional option is always taken,
-			// making this equivalent to the broken version, except this one compiles.
-			[K in keyof T]: T extends _RecursiveTrick ? _RecursiveTrick : Works<T[K]>;
-		}
-	>;
-
-	/* eslint-enable @typescript-eslint/no-unused-vars */
-}

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/typedTreeSchema.ts
@@ -18,7 +18,7 @@ import {
 import { MakeNominal, Assume } from "../../../util";
 import { FieldKindTypes, FieldKinds } from "../../defaultFieldKinds";
 import { FlexList, LazyItem, normalizeFlexList } from "./flexList";
-import { ObjectToMap, WithDefault, objectToMap } from "./typeUtils";
+import { ObjectToMap, WithDefault, objectToMapTyped } from "./typeUtils";
 import { RecursiveTreeSchemaSpecification } from "./schemaBuilder";
 
 // TODO: tests for this file
@@ -83,7 +83,7 @@ export class TreeSchema<
 		this.localFieldsObject = normalizeLocalFields<Assume<T, TreeSchemaSpecification>["local"]>(
 			this.info.local,
 		);
-		this.localFields = objectToMap(this.localFieldsObject);
+		this.localFields = objectToMapTyped(this.localFieldsObject);
 		this.extraLocalFields = normalizeField(this.info.extraLocalFields);
 		this.extraGlobalFields = this.info.extraGlobalFields ?? false;
 		this.value = (this.info.value ?? ValueSchema.Nothing) as WithDefault<

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -21,7 +21,7 @@ import {
 } from "../modular-schema";
 import { UntypedField, UntypedTree, UntypedTreeCore } from "../untypedTree";
 import { contextSymbol, typeSymbol } from "../editable-tree";
-import { Assume } from "../../util";
+import { AllowOptional, Assume, FlattenKeys, _InlineTrick } from "../../util";
 import { UntypedOptionalField, UntypedSequenceField, UntypedValueField } from "./partlyTyped";
 import { PrimitiveValueSchema, TypedValue } from "./schemaAwareUtil";
 
@@ -129,12 +129,12 @@ export type CollectOptions<
  * @alpha
  */
 export type FlexibleObject<TValueSchema extends ValueSchema, TName> = [
-	InternalTypedSchemaTypes.FlattenKeys<
-		{ [typeNameSymbol]?: UnbrandedName<TName> } & InternalTypedSchemaTypes.AllowOptional<
+	FlattenKeys<
+		{ [typeNameSymbol]?: UnbrandedName<TName> } & AllowOptional<
 			ValuePropertyFromSchema<TValueSchema>
 		>
 	>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Remove type brand from name.
@@ -142,7 +142,7 @@ export type FlexibleObject<TValueSchema extends ValueSchema, TName> = [
  */
 export type UnbrandedName<TName> = [
 	TName extends infer S & TreeSchemaIdentifier ? S : string,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * `{ [key: string]: FieldSchemaTypeInfo }` to `{ [key: string]: TypedTree }`
@@ -165,7 +165,7 @@ export type TypedFields<
 				>;
 		  }
 		: EmptyObject,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * `FieldSchema` to `TypedField`. May unwrap to child depending on Mode and FieldKind.
@@ -177,7 +177,7 @@ export type TypedField<TField extends FieldSchema, Mode extends ApiMode = ApiMod
 		AllowedTypesToTypedTrees<Mode, TField["allowedTypes"]>,
 		Mode
 	>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Adjusts the API for a field based on its Multiplicity.
@@ -209,21 +209,21 @@ export type EditableField<TypedChild> = UntypedField & MarkedArrayLike<TypedChil
  */
 export type EditableSequenceField<TypedChild> = [
 	UntypedSequenceField & MarkedArrayLike<TypedChild>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * @alpha
  */
 export type EditableValueField<TypedChild> = [
 	UntypedValueField & MarkedArrayLike<TypedChild>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * @alpha
  */
 export type EditableOptionalField<TypedChild> = [
 	UntypedOptionalField & MarkedArrayLike<TypedChild>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Takes in `AllowedTypes` and returns a TypedTree union.
@@ -241,7 +241,7 @@ export type AllowedTypesToTypedTrees<Mode extends ApiMode, T extends AllowedType
 				>
 		  >
 		: UntypedApi<Mode>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Takes in `TreeSchema[]` and returns a TypedTree union.
@@ -254,7 +254,7 @@ export type TypeArrayToTypedTreeArray<Mode extends ApiMode, T extends readonly T
 				...TypeArrayToTypedTreeArray<Mode, Assume<Tail, readonly TreeSchema[]>>,
 		  ]
 		: [],
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 // TODO: make these more accurate
 /**
@@ -276,7 +276,7 @@ export type UntypedApi<Mode extends ApiMode> = {
 export type TypedNode<
 	TSchema extends TreeSchema,
 	Mode extends ApiMode = ApiMode.Editable,
-> = InternalTypedSchemaTypes.FlattenKeys<
+> = FlattenKeys<
 	CollectOptions<
 		Mode,
 		TypedFields<

--- a/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
@@ -30,29 +30,6 @@ import {
 } from "../core";
 import { brand, fail } from "../util";
 
-const Baz = Type.Recursive((Baz2) =>
-	Type.Object({
-		child: Type.Optional(Baz2),
-	}),
-);
-
-type Baz = Static<typeof Baz>;
-
-const _baz: Baz = { child: { child: {} } };
-
-const Foo = Type.Recursive((Foo2) =>
-	Type.Object({
-		child1: Type.Object({
-			child2: Type.Optional(Foo2),
-		}),
-	}),
-);
-
-type Foo = Static<typeof Foo>;
-type Bar = Required<Foo>["child1"];
-
-const _bar: Bar = { child2: { child1: {} } };
-
 const version = "1.0.0" as const;
 
 const FieldSchemaFormatBase = Type.Object({

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -99,15 +99,8 @@ export {
 
 export {
 	Brand,
-	BrandedType,
 	Opaque,
 	extractFromOpaque,
-	MakeNominal,
-	Invariant,
-	Contravariant,
-	Covariant,
-	ExtractFromOpaque,
-	isAny,
 	brand,
 	brandOpaque,
 	ValueFromBranded,
@@ -118,7 +111,6 @@ export {
 	NestedMap,
 	fail,
 	TransactionResult,
-	Assume,
 } from "./util";
 
 export {
@@ -275,3 +267,7 @@ export type {
 	IJsonCodec,
 	IMultiFormatCodec,
 } from "./codec";
+
+// Below here are things that are used by the above, but not part of the desired API surface.
+import * as InternalTypes from "./internal";
+export { InternalTypes };

--- a/experimental/dds/tree2/src/internal.ts
+++ b/experimental/dds/tree2/src/internal.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Used by public types, but not part of the desired API surface
+export {
+	MakeNominal,
+	Invariant,
+	Contravariant,
+	Covariant,
+	BrandedType,
+	ExtractFromOpaque,
+	Assume,
+	AllowOptional,
+	RequiredFields,
+	OptionalFields,
+	_InlineTrick,
+	_RecursiveTrick,
+	FlattenKeys,
+	AllowOptionalNotFlattened,
+	isAny,
+} from "./util";

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/typedSchema/typeUtils.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/typedSchema/typeUtils.spec.ts
@@ -5,11 +5,7 @@
 
 import { TreeSchemaIdentifier } from "../../../../core";
 import {
-	AllowOptional,
-	AllowOptionalNotFlattened,
 	ArrayToUnion,
-	OptionalFields,
-	RequiredFields,
 	Unbrand,
 	WithDefault,
 	// Allow importing from this specific file which is being tested:
@@ -39,34 +35,6 @@ import {
 	type check1_ = requireTrue<areSafelyAssignable<ArrayToUnion<[1]>, 1>>;
 	type Case2 = ArrayToUnion<[1, 2]>;
 	type check2_ = requireTrue<areSafelyAssignable<Case2, 1 | 2>>;
-}
-
-// Test RemoveOptionalFields
-{
-	type a = OptionalFields<{ a: 5; b: undefined | 5; c: undefined }>;
-	type check1_ = requireAssignableTo<a, { b?: 5 }>;
-	type check2_ = requireAssignableTo<{ b?: 5 }, a>;
-}
-
-// Test PartialWithoutUndefined
-{
-	type a = RequiredFields<{ a: 5; b: undefined | 5; c: undefined }>;
-	type check1_ = requireAssignableTo<a, { a: 5 }>;
-	type check2_ = requireAssignableTo<{ a: 5 }, a>;
-}
-
-// Test AllowOptional
-{
-	type a = AllowOptional<{ a: 5; b: undefined | 5; c: undefined }>;
-	type check1_ = requireAssignableTo<a, { a: 5; b?: 5 }>;
-	type check2_ = requireAssignableTo<{ a: 5; b?: 5 }, a>;
-}
-
-// Test AllowOptionalNotFlattened
-{
-	type a = AllowOptionalNotFlattened<{ a: 5; b: undefined | 5; c: undefined }>;
-	type check1_ = requireAssignableTo<a, { a: 5; b?: 5 }>;
-	type check2_ = requireAssignableTo<{ a: 5; b?: 5 }, a>;
 }
 
 // Test Unbrand

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAwareSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAwareSimple.ts
@@ -20,7 +20,7 @@ import { ValueSchema } from "../../../core";
 import { UntypedSequenceField } from "../../../feature-libraries/schema-aware/partlyTyped";
 // eslint-disable-next-line import/no-internal-modules
 import { TypedValue } from "../../../feature-libraries/schema-aware/schemaAwareUtil";
-import { Assume } from "../../../util";
+import { Assume, _InlineTrick } from "../../../util";
 
 /**
  * @alpha
@@ -54,7 +54,7 @@ export type TypedFields<TFields extends undefined | { [key: string]: FieldSchema
 				[key in keyof TFields]: TypedField<TFields[key]>;
 		  }
 		: Record<string, never>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * `FieldSchemaTypeInfo` to `TypedTree`
@@ -65,7 +65,7 @@ export type TypedField<TField extends FieldSchema> = [
 		TField["kind"]["multiplicity"],
 		AllowedTypesToTypedTrees<TField["allowedTypes"]>
 	>,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Adjusts the API for a field based on its Multiplicity.
@@ -102,7 +102,7 @@ export type AllowedTypesToTypedTrees<T extends AllowedTypes> = [
 				>
 		  >
 		: unknown,
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Takes in `TreeSchema[]` and returns a TypedTree union.
@@ -115,7 +115,7 @@ export type TypeArrayToTypedTreeArray<T extends readonly TreeSchema[]> = [
 				...TypeArrayToTypedTreeArray<Assume<Tail, readonly TreeSchema[]>>,
 		  ]
 		: [],
-][InternalTypedSchemaTypes._InlineTrick];
+][_InlineTrick];
 
 /**
  * Generate a schema aware API for a list of types.

--- a/experimental/dds/tree2/src/test/util/typeUtils.spec.ts
+++ b/experimental/dds/tree2/src/test/util/typeUtils.spec.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	AllowOptional,
+	AllowOptionalNotFlattened,
+	OptionalFields,
+	RequiredFields,
+	// Allow importing from this specific file which is being tested:
+	/* eslint-disable-next-line import/no-internal-modules */
+} from "../../util/typeUtils";
+import { requireAssignableTo } from "../../util";
+
+// These tests currently just cover the type checking, so its all compile time.
+
+// Test OptionalFields
+{
+	type a = OptionalFields<{ a: 5; b: undefined | 5; c: undefined }>;
+	type check1_ = requireAssignableTo<a, { b?: 5 }>;
+	type check2_ = requireAssignableTo<{ b?: 5 }, a>;
+}
+
+// Test RequiredFields
+{
+	type a = RequiredFields<{ a: 5; b: undefined | 5; c: undefined }>;
+	type check1_ = requireAssignableTo<a, { a: 5 }>;
+	type check2_ = requireAssignableTo<{ a: 5 }, a>;
+}
+
+// Test AllowOptional
+{
+	type a = AllowOptional<{ a: 5; b: undefined | 5; c: undefined }>;
+	type check1_ = requireAssignableTo<a, { a: 5; b?: 5 }>;
+	type check2_ = requireAssignableTo<{ a: 5; b?: 5 }, a>;
+}
+
+// Test AllowOptionalNotFlattened
+{
+	type a = AllowOptionalNotFlattened<{ a: 5; b: undefined | 5; c: undefined }>;
+	type check1_ = requireAssignableTo<a, { a: 5; b?: 5 }>;
+	type check2_ = requireAssignableTo<{ a: 5; b?: 5 }, a>;
+}

--- a/experimental/dds/tree2/src/util/brand.ts
+++ b/experimental/dds/tree2/src/util/brand.ts
@@ -28,7 +28,7 @@ export type Brand<ValueType, Name extends string> = ValueType & BrandedType<Valu
  * - get nominal typing (so types produced without using this class can never be assignable to it).
  * - allow use as {@link Opaque} branded type (not assignable to `ValueType`, but captures `ValueType`).
  *
- * See {@link MakeNominal} for some more details.
+ * See {@link InternalTypes#MakeNominal} for some more details.
  *
  * Do not use this class with `instanceof`: this will always be false at runtime,
  * but the compiler may think its true in some cases.

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -67,5 +67,16 @@ export {
 	Assume,
 	assertValidIndex,
 	assertNonNegativeSafeInteger,
+	objectToMap,
 } from "./utils";
 export { ReferenceCountedBase, ReferenceCounted } from "./referenceCounting";
+
+export {
+	AllowOptional,
+	RequiredFields,
+	OptionalFields,
+	_InlineTrick,
+	_RecursiveTrick,
+	FlattenKeys,
+	AllowOptionalNotFlattened,
+} from "./typeUtils";

--- a/experimental/dds/tree2/src/util/typeUtils.ts
+++ b/experimental/dds/tree2/src/util/typeUtils.ts
@@ -1,0 +1,155 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Utilities for manipulating types.
+ */
+
+/**
+ * Return a type thats equivalent to the input, but with different IntelliSense.
+ * This tends to convert unions and intersections into objects.
+ * @alpha
+ */
+export type FlattenKeys<T> = [{ [Property in keyof T]: T[Property] }][_InlineTrick];
+
+/**
+ * Remove all fields which permit undefined from `T`.
+ * @alpha
+ */
+export type RequiredFields<T> = [
+	{
+		[P in keyof T as undefined extends T[P] ? never : P]: T[P];
+	},
+][_InlineTrick];
+
+/**
+ * Extract fields which permit undefined but can also hold other types.
+ * @alpha
+ */
+export type OptionalFields<T> = [
+	{
+		[P in keyof T as undefined extends T[P]
+			? T[P] extends undefined
+				? never
+				: P
+			: never]?: T[P];
+	},
+][_InlineTrick];
+
+/**
+ * Converts properties of an object which permit undefined into optional properties.
+ * Removes fields which only allow undefined.
+ *
+ * @remarks
+ * This version does not flatten the resulting type.
+ * This version exists because some cases recursive types need to avoid this
+ * flattening since it causes complication issues.
+ *
+ * See also `AllowOptional`.
+ * @alpha
+ */
+// export type AllowOptionalNotFlattened<T> = [RequiredFields<T> & OptionalFields<T>][_InlineTrick];
+export type AllowOptionalNotFlattened<T> = [RequiredFields<T> & OptionalFields<T>][_InlineTrick];
+
+/**
+ * Converts properties of an object which permit undefined into optional properties.
+ * Removes fields which only allow undefined.
+ * @alpha
+ */
+export type AllowOptional<T> = [FlattenKeys<RequiredFields<T> & OptionalFields<T>>][_InlineTrick];
+
+/**
+ * Use for trick to "inline" generic types.
+ *
+ * @remarks
+ * The TypeScript compiler can be convinced to inline a generic type
+ * (so the result of evaluating the generic type show up in IntelliSense and error messages instead of just the invocation of the generic type)
+ * by creating an object with a field, and returning the type of that field.
+ *
+ * For example:
+ * ```typescript
+ * type MyGeneric<T1, T2> = {x: T1 extends [] ? T1 : T2 };
+ * type MyGenericExpanded<T1, T2> = [{x: T1 extends [] ? T1 : T2 }][_InlineTrick]
+ *
+ * // Type is MyGeneric<5, string>
+ * const foo: MyGeneric<5, string> = {x: "x"}
+ * // Type is {x: "x"}
+ * const foo2: MyGenericExpanded<5, string> = {x: "x"}
+ * ```
+ *
+ * This constant is defined to provide a way to find this documentation from types which use this pattern,
+ * and to locate types which use this pattern in case they need updating for compiler changes.
+ * @alpha
+ */
+export type _InlineTrick = 0;
+
+/**
+ * Use for trick to prevent self reference error `ts(2456)`.
+ *
+ * Prefix a type expression with `K extends _RecursiveTrick ? _RecursiveTrick : ` for some K to break the cycle.
+ *
+ * @remarks
+ * The TypeScript compiler handles some cases of recursive types, but not others.
+ * Sometimes adding an otherwise needless conditional can make a type compile.
+ * Use this type in such cases.
+ *
+ *For example:
+ * ```typescript
+ * // The TypeScript compiler can't handle this case
+ * type Broken<T> = FlattenKeys<
+ *	{
+ * 		[K in keyof T]: 0;
+ * 	} & {
+ * 		[K in keyof T]: Broken<T[K]>;
+ * 	}
+ * >;
+ *
+ * // Adding `K extends _RecursiveTrick ? _RecursiveTrick :` makes it compile, and has no effect on the type produced.
+ * type Works<T> = FlattenKeys<
+ * 	{
+ * 		[K in keyof T]: 0;
+ * 	} & {
+ * 		// Trick added here. Since `k` never extends `never`, the second conditional option is always taken,
+ * 		// making this equivalent to the broken version, except this one compiles.
+ * 		[K in keyof T]: K extends _RecursiveTrick ? _RecursiveTrick : Works<T[K]>;
+ * 	}
+ * >;
+ * ```
+ *
+ * This trick appears to start working in TypeScript 4.1 and is confirmed to still work in 5.0.4.
+ *
+ * This constant is defined to provide a way to find this documentation from types which use this pattern,
+ * and to locate types which use this pattern in case they need updating for compiler changes.
+ * @alpha
+ */
+export type _RecursiveTrick = never;
+
+// This block is kept here to ensure the above example behaves as documented, and can be copied into the example to update it as needed.
+{
+	/* eslint-disable @typescript-eslint/no-unused-vars */
+
+	// @ts-expect-error The TypeScript compiler can't handle this case
+	type Broken<T> = FlattenKeys<
+		{
+			[K in keyof T]: 0;
+		} & {
+			// @ts-expect-error Same error as above.
+			[K in keyof T]: Broken<T[K]>;
+		}
+	>;
+
+	// Adding `K extends _RecursiveTrick ? _RecursiveTrick:` OR `T extends _RecursiveTrick ? _RecursiveTrick :` makes it compile and has no effect on the type produced.
+	type Works<T> = FlattenKeys<
+		{
+			[K in keyof T]: 0;
+		} & {
+			// Trick added here. Since `K` never extends `never`, the second conditional option is always taken,
+			// making this equivalent to the broken version, except this one compiles.
+			[K in keyof T]: T extends _RecursiveTrick ? _RecursiveTrick : Works<T[K]>;
+		}
+	>;
+
+	/* eslint-enable @typescript-eslint/no-unused-vars */
+}

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -265,3 +265,24 @@ export function assertNonNegativeSafeInteger(index: number) {
  * @alpha
  */
 export type Assume<TInput, TAssumeToBe> = TInput extends TAssumeToBe ? TInput : TAssumeToBe;
+
+/**
+ * Convert an object into a Map.
+ *
+ * This function must only be used with objects specifically intended to encode map like information.
+ * The only time such objects should be used is for encoding maps as object literals to allow for developer ergonomics or JSON compatibility.
+ * Even those two use-cases need to be carefully considered as using objects as maps can have a lot of issues
+ * (including but not limited to unintended access to __proto__ and other non-owned keys).
+ * This function helps these few cases get into using an actual map in as safe of was as is practical.
+ */
+export function objectToMap<MapKey extends string | number | symbol, MapValue>(
+	objectMap: Record<MapKey, MapValue>,
+): Map<MapKey, MapValue> {
+	const map = new Map<MapKey, MapValue>();
+	// This function must only be used with objects specifically intended to encode map like information.
+	for (const key of Object.keys(objectMap)) {
+		const element = objectMap[key as MapKey];
+		map.set(key as MapKey, element);
+	}
+	return map;
+}


### PR DESCRIPTION
## Description

Remove some experimental schema code from schemaIndexFormat.ts and split out some generally useful logic from TypeSchema's type utils into the package type utils.

## Breaking Changes

Some internal types were moved. Code which did not refer to these directly will not be impacted. Code which did use them can find them at their new location, "InternalTypes" at the package root.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

