### PR TITLE
refactor(devtools-core): Make message handlers async

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -367,7 +367,7 @@ export interface IMessageRelayEvents<TMessage extends ISourcedDevtoolsMessage = 
 
 // @internal
 export interface InboundHandlers {
-    [type: string]: (message: ISourcedDevtoolsMessage) => boolean;
+    [type: string]: (message: ISourcedDevtoolsMessage) => Promise<boolean>;
 }
 
 // @public

--- a/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
@@ -272,7 +272,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 	 * Handlers for inbound messages related to the debugger.
 	 */
 	private readonly inboundMessageHandlers: InboundHandlers = {
-		[GetContainerDevtoolsFeatures.MessageType]: (untypedMessage) => {
+		[GetContainerDevtoolsFeatures.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as GetContainerDevtoolsFeatures.Message;
 			if (message.data.containerKey === this.containerKey) {
 				this.postSupportedFeatures();
@@ -280,7 +280,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			}
 			return false;
 		},
-		[GetContainerState.MessageType]: (untypedMessage) => {
+		[GetContainerState.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as GetContainerState.Message;
 			if (message.data.containerKey === this.containerKey) {
 				this.postContainerStateChange();
@@ -288,7 +288,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			}
 			return false;
 		},
-		[ConnectContainer.MessageType]: (untypedMessage) => {
+		[ConnectContainer.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as ConnectContainer.Message;
 			if (message.data.containerKey === this.containerKey) {
 				this.container.connect();
@@ -296,7 +296,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			}
 			return false;
 		},
-		[DisconnectContainer.MessageType]: (untypedMessage) => {
+		[DisconnectContainer.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as DisconnectContainer.Message;
 			if (message.data.containerKey === this.containerKey) {
 				this.container.disconnect(/* TODO: Specify debugger reason here once it is supported */);
@@ -304,7 +304,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			}
 			return false;
 		},
-		[CloseContainer.MessageType]: (untypedMessage) => {
+		[CloseContainer.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as CloseContainer.Message;
 			if (message.data.containerKey === this.containerKey) {
 				this.container.close(/* TODO: Specify debugger reason here once it is supported */);
@@ -312,7 +312,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			}
 			return false;
 		},
-		[GetAudienceSummary.MessageType]: (untypedMessage) => {
+		[GetAudienceSummary.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as GetAudienceSummary.Message;
 			if (message.data.containerKey === this.containerKey) {
 				this.postAudienceStateChange();
@@ -320,22 +320,20 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			}
 			return false;
 		},
-		[GetRootDataVisualizations.MessageType]: (untypedMessage) => {
+		[GetRootDataVisualizations.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as GetRootDataVisualizations.Message;
 			if (message.data.containerKey === this.containerKey) {
-				this.getRootDataVisualizations().then((visualizations) => {
-					this.postRootDataVisualizations(visualizations);
-				}, console.error);
+				const visualizations = await this.getRootDataVisualizations();
+				this.postRootDataVisualizations(visualizations);
 				return true;
 			}
 			return false;
 		},
-		[GetDataVisualization.MessageType]: (untypedMessage) => {
+		[GetDataVisualization.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as GetDataVisualization.Message;
 			if (message.data.containerKey === this.containerKey) {
-				this.getDataVisualization(message.data.fluidObjectId).then((visualization) => {
-					this.postDataVisualization(message.data.fluidObjectId, visualization);
-				}, console.error);
+				const visualization = await this.getDataVisualization(message.data.fluidObjectId);
+				this.postDataVisualization(message.data.fluidObjectId, visualization);
 				return true;
 			}
 			return false;

--- a/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
+++ b/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
@@ -66,7 +66,7 @@ export class DevtoolsLogger extends TelemetryLogger {
 	 * Handlers for inbound messages related to the logger.
 	 */
 	private readonly inboundMessageHandlers: InboundHandlers = {
-		[GetTelemetryHistory.MessageType]: (untypedMessage) => {
+		[GetTelemetryHistory.MessageType]: async (untypedMessage) => {
 			this.postLogHistory();
 			return true;
 		},

--- a/packages/tools/devtools/devtools-core/src/FluidDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/FluidDevtools.ts
@@ -156,11 +156,11 @@ export class FluidDevtools implements IFluidDevtools {
 	 * Handlers for inbound messages specific to FluidDevTools.
 	 */
 	private readonly inboundMessageHandlers: InboundHandlers = {
-		[GetDevtoolsFeatures.MessageType]: () => {
+		[GetDevtoolsFeatures.MessageType]: async () => {
 			this.postSupportedFeatures();
 			return true;
 		},
-		[GetContainerList.MessageType]: () => {
+		[GetContainerList.MessageType]: async () => {
 			this.postContainerList();
 			return true;
 		},

--- a/packages/tools/devtools/devtools-core/src/messaging/Utilities.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/Utilities.ts
@@ -46,9 +46,10 @@ export function postMessagesToWindow<TMessage extends IDevtoolsMessage>(
 export interface InboundHandlers {
 	/**
 	 * Mapping from {@link IDevtoolsMessage."type"}s to a handler callback for that message type.
-	 * @returns Whether or not the message was actually handled.
+	 *
+	 * @returns A promise that resolves to a flag indicating if the message was handled (`true`) or not (`false`).
 	 */
-	[type: string]: (message: ISourcedDevtoolsMessage) => boolean;
+	[type: string]: (message: ISourcedDevtoolsMessage) => Promise<boolean>;
 }
 
 /**
@@ -115,14 +116,14 @@ export function handleIncomingMessage(
 		return;
 	}
 
-	const handled = handlers[message.type](message);
-
-	// Only log if the message was actually handled by the recipient.
-	if (handled && loggingOptions !== undefined) {
-		const loggingPreamble =
-			loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
-		console.debug(`${loggingPreamble} message handled:`, message);
-	}
+	handlers[message.type](message).then((wasMessageHandled) => {
+		// Only log if the message was actually handled by the recipient.
+		if (wasMessageHandled && loggingOptions !== undefined) {
+			const loggingPreamble =
+				loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
+			console.debug(`${loggingPreamble} message handled:`, message);
+		}
+	}, console.error);
 }
 
 /**

--- a/packages/tools/devtools/devtools-core/src/messaging/Utilities.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/Utilities.ts
@@ -116,14 +116,23 @@ export function handleIncomingMessage(
 		return;
 	}
 
-	handlers[message.type](message).then((wasMessageHandled) => {
-		// Only log if the message was actually handled by the recipient.
-		if (wasMessageHandled && loggingOptions !== undefined) {
-			const loggingPreamble =
-				loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
-			console.debug(`${loggingPreamble} message handled:`, message);
-		}
-	}, console.error);
+	const loggingPreamble =
+		loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
+
+	handlers[message.type](message).then(
+		(wasMessageHandled) => {
+			// Only log if the message was actually handled by the recipient.
+			if (wasMessageHandled && loggingOptions !== undefined) {
+				console.debug(`${loggingPreamble} Message handled.`, message);
+			}
+		},
+		(error) => {
+			console.error(
+				`${loggingPreamble} Message could not be handled due to an error:`,
+				error,
+			);
+		},
+	);
 }
 
 /**

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -155,7 +155,7 @@ export function DevtoolsView(): React.ReactElement {
 		 * Handlers for inbound messages related to the registry.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[DevtoolsFeatures.MessageType]: (untypedMessage) => {
+			[DevtoolsFeatures.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as DevtoolsFeatures.Message;
 				setSupportedFeatures(message.data.features);
 				return true;
@@ -243,7 +243,7 @@ function _DevtoolsView(props: _DevtoolsViewProps): React.ReactElement {
 		 * Handlers for inbound messages related to the registry.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[ContainerList.MessageType]: (untypedMessage) => {
+			[ContainerList.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as ContainerList.Message;
 				setContainers(message.data.containers);
 				return true;

--- a/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
@@ -45,7 +45,7 @@ export function AudienceView(props: AudienceViewProps): React.ReactElement {
 		 * Handlers for inbound messages related to Audience
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[AudienceSummary.MessageType]: (untypedMessage) => {
+			[AudienceSummary.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as AudienceSummary.Message;
 
 				setAudienceData(message.data);

--- a/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
@@ -95,7 +95,7 @@ export function ContainerDevtoolsView(props: ContainerDevtoolsViewProps): React.
 		 * Handlers for inbound messages related to the registry.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[ContainerDevtoolsFeatures.MessageType]: (untypedMessage) => {
+			[ContainerDevtoolsFeatures.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as ContainerDevtoolsFeatures.Message;
 				if (message.data.containerKey === containerKey) {
 					setSupportedFeatures(message.data.features);

--- a/packages/tools/devtools/devtools-view/src/components/ContainerHistoryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerHistoryView.tsx
@@ -40,7 +40,7 @@ export function ContainerHistoryView(props: ContainerHistoryProps): React.ReactE
 		 * Handlers for inbound messages related to the registry.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[ContainerStateHistory.MessageType]: (untypedMessage) => {
+			[ContainerStateHistory.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as ContainerStateHistory.Message;
 				if (message.data.containerKey === containerKey) {
 					setContainerHistory(message.data.history);

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -204,7 +204,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 		 * Handlers for inbound messages related to the registry.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[ContainerStateChange.MessageType]: (untypedMessage) => {
+			[ContainerStateChange.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as ContainerStateChange.Message;
 				if (message.data.containerKey === containerKey) {
 					setContainerState(message.data.containerState);

--- a/packages/tools/devtools/devtools-view/src/components/DataObjectsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/DataObjectsView.tsx
@@ -44,7 +44,7 @@ export function DataObjectsView(props: DataObjectsViewProps): React.ReactElement
 
 	React.useEffect(() => {
 		const inboundMessageHandlers: InboundHandlers = {
-			[RootDataVisualizations.MessageType]: (untypedMessage) => {
+			[RootDataVisualizations.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as RootDataVisualizations.Message;
 
 				if (message.data.containerKey === containerKey) {

--- a/packages/tools/devtools/devtools-view/src/components/TelemetryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TelemetryView.tsx
@@ -76,7 +76,7 @@ export function TelemetryView(): React.ReactElement {
 		 * Handlers for inbound messages related to telemetry.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[TelemetryEvent.MessageType]: (untypedMessage) => {
+			[TelemetryEvent.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as TelemetryEvent.Message;
 				setBufferedEvents((currentBuffer) => [
 					message.data.event,
@@ -84,7 +84,7 @@ export function TelemetryView(): React.ReactElement {
 				]);
 				return true;
 			},
-			[TelemetryHistory.MessageType]: (untypedMessage) => {
+			[TelemetryHistory.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as TelemetryHistory.Message;
 				setTelemetryEvents(message.data.contents);
 				return true;

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
@@ -43,7 +43,7 @@ export function FluidHandleView(props: FluidHandleViewProps): React.ReactElement
 		 * Handlers for inbound message related to Data View.
 		 */
 		const inboundMessageHandlers: InboundHandlers = {
-			[DataVisualization.MessageType]: (untypedMessage) => {
+			[DataVisualization.MessageType]: async (untypedMessage) => {
 				const message = untypedMessage as DataVisualization.Message;
 				if (
 					message.data.containerKey === containerKey &&


### PR DESCRIPTION
Updates our message handler infra to make handlers async. The current motivation for this is to allow the data visualization code to run to completion before we report whether or not the message was handled.

### Breaking Change

This PR changes the message handler interface, which is exported and used by the view.