### PR TITLE
Tree: set followSymlinks false

### DIFF
--- a/experimental/dds/tree2/.vscode/Tree.code-workspace
+++ b/experimental/dds/tree2/.vscode/Tree.code-workspace
@@ -9,5 +9,7 @@
 			"path": ".."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"search.followSymlinks": false
+	}
 }


### PR DESCRIPTION
## Description

This prevents vscode from making an "rg" process which keeps several cores 100% loaded for no apparent reason when launched.

Its not clear to me why rg (ripgrep, the file search utility vs-code uses) is launched when I open the workspace, or why this instance of it runs forever.

Previously I just manually killed the process, but https://github.com/microsoft/vscode/issues/98594#issuecomment-643871783 suggested this setting change and it fixes the issue for me.

To test this: in vs-code with the workspace open, run the "reload window" command. For me, with this setting added, it no longer spawns a "rg" process easting tons of CPU.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
