### PR TITLE
Add ci:build to target config

### DIFF
--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -14,10 +14,9 @@
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
+		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run build:test",
 		"build:compile": "concurrently npm:build:commonjs npm:build:esnext",
-		"build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
 		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:full": "npm run build",
 		"build:full:compile": "npm run build:compile",

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -14,6 +14,10 @@ const tscDependsOn = ["^tsc", "build:genver", "typetests:gen"];
  */
 module.exports = {
 	tasks: {
+		"ci:build": {
+			dependsOn: ["compile", "lint", "ci:build:docs"],
+			script: false,
+		},
 		"full": {
 			dependsOn: ["build", "webpack"],
 			script: false,
@@ -41,6 +45,7 @@ module.exports = {
 		"build:esnext": tscDependsOn,
 		"build:test": [...tscDependsOn, "tsc"],
 		"build:docs": [...tscDependsOn, "tsc"],
+		"ci:build:docs": [...tscDependsOn, "tsc"],
 		"eslint": [...tscDependsOn, "commonjs"],
 		"good-fences": [],
 		"prettier": [],


### PR DESCRIPTION
Add `ci:build` and `ci:build:docs` to the `fluid-build` target config in preparation to switch over to use `fluid-build` by default.

Also clean up unused docs generation scripts from PropertyDDS.

With this change, the output between the old `npm run ci:build` + `npm run ci:build:docs` is exactly the same as `fluid-build -t ci:build` (except for extra incremental build log generated by `fluid-build`)