### PR TITLE
[bump] build-tools: 0.18.0 => 0.19.0 (minor)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"npmClient": "pnpm",
 	"useWorkspaces": true
 }

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "root",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version|-V)
-@fluid-tools/build-cli/0.18.0
+@fluid-tools/build-cli/0.19.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/bundle-size-tools",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"description": "Utility for analyzing bundle size regressions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/readme-command/README.md
+++ b/build-tools/packages/readme-command/README.md
@@ -20,7 +20,7 @@ $ npm install -g @fluid-internal/readme-command
 $ fluid-readme COMMAND
 running command...
 $ fluid-readme (--version|-V)
-@fluid-internal/readme-command/0.18.0
+@fluid-internal/readme-command/0.19.0
 $ fluid-readme --help [COMMAND]
 USAGE
   $ fluid-readme COMMAND

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/readme-command",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"private": true,
 	"description": "CLI to generate readmes for Fluid build-tools",
 	"homepage": "https://fluidframework.com",

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -78,7 +78,7 @@ $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
 running command...
 $ fluv (--version|-V)
-@fluid-tools/version-tools/0.18.0
+@fluid-tools/version-tools/0.19.0
 $ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped build-tools from 0.18.0 to 0.19.0 in preparation for release.