### PR TITLE
Log the exceptions from checkpoint.flush call and add a config to ignore those exceptions

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -61,7 +61,8 @@
 		"assert": "^2.0.0",
 		"async": "^3.2.2",
 		"events": "^3.1.0",
-		"lodash": "^4.17.21"
+		"lodash": "^4.17.21",
+		"nconf": "^0.12.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.16.1",

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -157,6 +157,17 @@ export class Partition extends EventEmitter {
 		await drainedP;
 
 		// Checkpoint at the latest offset
-		await this.checkpointManager.flush();
+		try {
+			await this.checkpointManager.flush();
+		} catch (err) {
+			// dont throw the error so that the service continues to shut down gracefully
+			Lumberjack.error(
+				"Error during checkpointManager.flush call",
+				{
+					partition: this.id,
+				},
+				err,
+			);
+		}
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -15,6 +15,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { QueueObject, queue } from "async";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { Provider } from "nconf";
 import { CheckpointManager } from "./checkpointManager";
 import { Context } from "./context";
 
@@ -35,6 +36,7 @@ export class Partition extends EventEmitter {
 		factory: IPartitionLambdaFactory,
 		consumer: IConsumer,
 		private readonly logger?: ILogger,
+		private readonly config?: Provider,
 	) {
 		super();
 
@@ -160,7 +162,6 @@ export class Partition extends EventEmitter {
 		try {
 			await this.checkpointManager.flush();
 		} catch (err) {
-			// dont throw the error so that the service continues to shut down gracefully
 			Lumberjack.error(
 				"Error during checkpointManager.flush call",
 				{
@@ -168,6 +169,9 @@ export class Partition extends EventEmitter {
 				},
 				err,
 			);
+			if (!this.config?.get("checkpoints:ignoreCheckpointFlushException")) {
+				throw err;
+			} // else, dont throw the error so that the service continues to shut down gracefully
 		}
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -14,6 +14,7 @@ import {
 	IContextErrorData,
 } from "@fluidframework/server-services-core";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { Provider } from "nconf";
 import { Partition } from "./partition";
 
 /**
@@ -31,6 +32,7 @@ export class PartitionManager extends EventEmitter {
 		private readonly factory: IPartitionLambdaFactory,
 		private readonly consumer: IConsumer,
 		private readonly logger?: ILogger,
+		private readonly config?: Provider,
 		listenForConsumerErrors = true,
 	) {
 		super();
@@ -209,6 +211,7 @@ export class PartitionManager extends EventEmitter {
 				this.factory,
 				this.consumer,
 				this.logger,
+				this.config,
 			);
 
 			// Listen for error events to know when the partition has stopped processing due to an error

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runnerFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runnerFactory.ts
@@ -10,16 +10,19 @@ import {
 	IRunner,
 	IRunnerFactory,
 } from "@fluidframework/server-services-core";
+import { Provider } from "nconf";
 import { KafkaRunner } from "./runner";
 
 export interface IKafkaResources extends IResources {
 	lambdaFactory: IPartitionLambdaFactory;
 
 	consumer: IConsumer;
+
+	config?: Provider;
 }
 
 export class KafkaRunnerFactory implements IRunnerFactory<IKafkaResources> {
 	public async create(resources: IKafkaResources): Promise<IRunner> {
-		return new KafkaRunner(resources.lambdaFactory, resources.consumer);
+		return new KafkaRunner(resources.lambdaFactory, resources.consumer, resources.config);
 	}
 }

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -52,7 +52,8 @@
 	},
 	"checkpoints": {
 		"localCheckpointEnabled": true,
-		"kafkaCheckpointOnReprocessingOp": false
+		"kafkaCheckpointOnReprocessingOp": false,
+		"ignoreCheckpointFlushException": false
 	},
 	"alfred": {
 		"kafkaClientId": "alfred",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      nconf:
+        specifier: ^0.12.0
+        version: 0.12.0
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: ^0.16.1


### PR DESCRIPTION
## Description

We make a call to [checkpointManager.flush](https://github.com/microsoft/FluidFramework/blob/main/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts#L160) during service shutdown process (i.e. during restart) and it sometimes fails with a kafka checkpointing exception, and thus other shutdown methods arent processed. Eventually, we get "Could not stop runner" error and the [process is killed with a SIGKILL.](https://github.com/microsoft/FluidFramework/blob/main/server/routerlicious/packages/services-shared/src/runner.ts#L100)

In case of such checkpointing errors during restart/shutdown, we should just ignore that exception and continue with further steps in the shutdown process. This will reduce the no. of non-graceful restarts.

Added a flag `ignoreCheckpointFlushException` to control whether to throw or ignore the exception.

Tested by manually triggering a restart and throwing an exception from checkpointManager flush method.