### PR TITLE
feat(devtools-view): Added icons to "joined and "left" message in audience view

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
@@ -13,7 +13,13 @@ import {
 	TableHeader,
 	TableHeaderCell,
 } from "@fluentui/react-components";
-import { DoorArrowLeftRegular, Clock12Regular, Person12Regular } from "@fluentui/react-icons";
+import {
+	DoorArrowLeftRegular,
+	Clock12Regular,
+	Person12Regular,
+	ArrowJoinRegular,
+	ArrowExitRegular,
+} from "@fluentui/react-icons";
 
 import { clientIdTooltipText } from "./TooltipTexts";
 import { TransformedAudienceHistoryData } from "./AudienceView";
@@ -83,7 +89,19 @@ export function AudienceHistoryTable(props: AudienceHistoryTableProps): React.Re
 									: tokens.colorPaletteRedBorder1,
 						}}
 					>
-						<TableCell>{item.changeKind}</TableCell>
+						<TableCell>
+							<LabelCellLayout
+								icon={
+									item.changeKind === "joined" ? (
+										<ArrowJoinRegular />
+									) : (
+										<ArrowExitRegular />
+									)
+								}
+							>
+								{item.changeKind}
+							</LabelCellLayout>
+						</TableCell>
 						<TableCell>{item.clientId}</TableCell>
 						<TableCell>{item.time}</TableCell>
 					</TableRow>


### PR DESCRIPTION
In the Audience view there are now icons which are display along with "joined" and "left". 
