### PR TITLE
missing start:frs:canary

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -37,6 +37,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"start": "node ./dist/nodeStressTest.js",
 		"start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs --profile ci_frs",
+		"start:frs:canary": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frsCanary --profile ci_frs",
 		"start:mini": "node ./dist/nodeStressTest.js  --profile mini",
 		"start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
 		"start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",


### PR DESCRIPTION
Noticed start:frs:canary was missing, adding it back in