### PR TITLE
Add support for logging flat objects (e.g. details) to reduce number of unique columns in telemetry

### DIFF
--- a/.changeset/wild-items-beam.md
+++ b/.changeset/wild-items-beam.md
@@ -1,0 +1,5 @@
+---
+"@fluidframework/telemetry-utils": major
+---
+
+Adding support to log a flat object, which will be JSON.stringified.

--- a/.changeset/wild-items-beam.md
+++ b/.changeset/wild-items-beam.md
@@ -2,4 +2,5 @@
 "@fluidframework/telemetry-utils": major
 ---
 
-Adding support to log a flat object, which will be JSON.stringified.
+The logger interface now supports logging a flat object, which will be JSON.stringified before being sent to the host's base logger.
+This is technically a breaking change but based on typical logger configuration, should not require any changes to accommodate.

--- a/.changeset/wild-items-beam.md
+++ b/.changeset/wild-items-beam.md
@@ -2,5 +2,6 @@
 "@fluidframework/telemetry-utils": major
 ---
 
-The logger interface now supports logging a flat object, which will be JSON.stringified before being sent to the host's base logger.
+The internal logger interface used when instrumenting the code now supports logging a flat object,
+which will be JSON.stringified before being sent to the host's base logger.
 This is technically a breaking change but based on typical logger configuration, should not require any changes to accommodate.

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -323,7 +323,10 @@ export enum TelemetryDataTag {
 }
 
 // @public
-export type TelemetryEventPropertyTypeExt = string | number | boolean | undefined | (string | number | boolean)[];
+export type TelemetryEventPropertyTypeExt = string | number | boolean | undefined | (string | number | boolean)[] | {
+    [key: string]: // Flat objects can have the same properties as the event itself
+    string | number | boolean | undefined | (string | number | boolean)[];
+};
 
 // @public (undocumented)
 export type TelemetryEventPropertyTypes = TelemetryEventPropertyType | ITaggedTelemetryPropertyType;

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -102,6 +102,28 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITelemetryErrorEventExt": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITelemetryEventExt": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITelemetryGenericEventExt": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITelemetryPerformanceEventExt": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITelemetryPropertiesExt": {
+				"backCompat": false
+			},
+			"TypeAliasDeclaration_TelemetryEventPropertyTypeExt": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -645,7 +645,7 @@ function convertToBasePropertyTypeUntagged(
 		case "undefined":
 			return x;
 		case "object":
-			// We assume this is an array based on the input types
+			// We assume this is an array or flat object based on the input types
 			return JSON.stringify(x);
 		default:
 			// should never reach this case based on the input types

--- a/packages/utils/telemetry-utils/src/telemetryTypes.ts
+++ b/packages/utils/telemetry-utils/src/telemetryTypes.ts
@@ -14,7 +14,11 @@ export type TelemetryEventPropertyTypeExt =
 	| number
 	| boolean
 	| undefined
-	| (string | number | boolean)[];
+	| (string | number | boolean)[]
+	| {
+			[key: string]: // Flat objects can have the same properties as the event itself
+			string | number | boolean | undefined | (string | number | boolean)[];
+	  };
 
 /**
  * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -241,6 +241,24 @@ describe("convertToBasePropertyType", () => {
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
+		it("tagged flat object", () => {
+			const value: TelemetryEventPropertyTypeExt = {
+				a: 1,
+				b: "two",
+				c: true,
+				d: [false, "okay"],
+			};
+			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+				value,
+				tag: "tag",
+			};
+			const converted = convertToBasePropertyType(taggedProperty);
+			const expected: ITaggedTelemetryPropertyTypeExt = {
+				value: JSON.stringify(value),
+				tag: "tag",
+			};
+			assert.deepStrictEqual(converted, expected);
+		});
 	});
 	describe("untagged properties", () => {
 		it("number", () => {
@@ -261,10 +279,27 @@ describe("convertToBasePropertyType", () => {
 			const expected: TelemetryEventPropertyTypeExt = true;
 			assert.deepStrictEqual(converted, expected);
 		});
+		it("undefined", () => {
+			const property: TelemetryEventPropertyTypeExt = undefined;
+			const converted = convertToBasePropertyType(property);
+			const expected: TelemetryEventPropertyTypeExt = undefined;
+			assert.deepStrictEqual(converted, expected);
+		});
 		it("array", () => {
 			const property: TelemetryEventPropertyTypeExt = [true, "test"];
 			const converted = convertToBasePropertyType(property);
 			const expected: TelemetryEventPropertyTypeExt = JSON.stringify([true, "test"]);
+			assert.deepStrictEqual(converted, expected);
+		});
+		it("flat object", () => {
+			const property: TelemetryEventPropertyTypeExt = {
+				a: 1,
+				b: "two",
+				c: true,
+				d: [false, "okay"],
+			};
+			const converted = convertToBasePropertyType(property);
+			const expected: TelemetryEventPropertyTypeExt = JSON.stringify(property);
 			assert.deepStrictEqual(converted, expected);
 		});
 	});
@@ -286,12 +321,12 @@ describe("convertToBasePropertyType", () => {
 		});
 		it("nested non ITaggedTelemetryPropertyTypeExt", () => {
 			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
-				value: { foo: 3 } as any,
+				value: { foo: 3, bar: { x: 5 } as any },
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
 			const expected: ITaggedTelemetryPropertyTypeExt = {
-				value: '{"foo":3}' as any,
+				value: '{"foo":3,"bar":{"x":5}}',
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -297,9 +297,18 @@ describe("convertToBasePropertyType", () => {
 				b: "two",
 				c: true,
 				d: [false, "okay"],
+				e: undefined,
 			};
 			const converted = convertToBasePropertyType(property);
 			const expected: TelemetryEventPropertyTypeExt = JSON.stringify(property);
+			assert.deepStrictEqual(converted, expected);
+		});
+		it("flat object with only undefined", () => {
+			const property: TelemetryEventPropertyTypeExt = {
+				e: undefined,
+			};
+			const converted = convertToBasePropertyType(property);
+			const expected: TelemetryEventPropertyTypeExt = "{}";
 			assert.deepStrictEqual(converted, expected);
 		});
 	});

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -275,6 +275,7 @@ declare function get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeEx
 declare function use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
     use: TypeOnly<old.ITaggedTelemetryPropertyTypeExt>);
 use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt());
 
 /*
@@ -299,6 +300,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryErrorEventExt():
 declare function use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
     use: TypeOnly<old.ITelemetryErrorEventExt>);
 use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryErrorEventExt());
 
 /*
@@ -323,6 +325,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryEventExt():
 declare function use_old_InterfaceDeclaration_ITelemetryEventExt(
     use: TypeOnly<old.ITelemetryEventExt>);
 use_old_InterfaceDeclaration_ITelemetryEventExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryEventExt());
 
 /*
@@ -347,6 +350,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryGenericEventExt():
 declare function use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
     use: TypeOnly<old.ITelemetryGenericEventExt>);
 use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryGenericEventExt());
 
 /*
@@ -443,6 +447,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt(
 declare function use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
     use: TypeOnly<old.ITelemetryPerformanceEventExt>);
 use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt());
 
 /*
@@ -467,6 +472,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryPropertiesExt():
 declare function use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
     use: TypeOnly<old.ITelemetryPropertiesExt>);
 use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryPropertiesExt());
 
 /*
@@ -707,6 +713,7 @@ declare function get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
 declare function use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
     use: TypeOnly<old.TelemetryEventPropertyTypeExt>);
 use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt());
 
 /*


### PR DESCRIPTION
## Description

Precursors:
* PR https://github.com/microsoft/FluidFramework/pull/12863 moved the typings for our internal loggers to telemetry-utils package and added support for arrays.
* PR #15667 upgraded the client release group to use the new types

This PR updates that type further to add support for flat objects.  This has become a more common practice to consolidate event-specific properties, e.g. in a `details` object.  Today instrumentation does the JSON.stringify itself, but this is not ideal.  It's proven the utility of logging properties like this, so this PR adds first-class support for this.

## Breaking Changes

Yes, this is a breaking change.  If a logger implements the existing logger contracts based on the existing type, it will not necessarily be equipped to handle a flat object.

In practice, there shouldn't be any follow-up required.  These types are only used for our internal logging contracts, which are always fulfilled by a class derived from `TelemetryLogger`, which actually handles this case just fine without any changes.

The API surface we expect partners to use always speaks in `ITelemetryBaseLogger` which is unchanged here.
