### PR TITLE
fix: Use correct assert function in tests

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import * as crypto from "crypto";
+import { strict as assert } from "assert";
 import { expect } from "chai";
 import {
 	IContainer,
@@ -35,7 +36,6 @@ import {
 	NamedProperty,
 	Int32Property,
 } from "@fluid-experimental/property-properties";
-import { assert } from "@fluidframework/common-utils";
 import { SharedPropertyTree } from "../propertyTree";
 
 function createLocalLoader(

--- a/packages/dds/merge-tree/src/test/attributionCollection.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/attributionCollection.perf.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/common-utils";
+import { strict as assert } from "assert";
 import { benchmark, BenchmarkType } from "@fluid-tools/benchmark";
 import { AttributionKey } from "@fluidframework/runtime-definitions";
 import {
@@ -138,7 +138,7 @@ function runAttributionCollectionSuite(
 }
 
 // Note: channel functionality is left unimplemented.
-export class TreeAttributionCollection implements IAttributionCollection<AttributionKey> {
+class TreeAttributionCollection implements IAttributionCollection<AttributionKey> {
 	private readonly entries: RedBlackTree<number, AttributionKey | null> = new RedBlackTree(
 		compareNumbers,
 	);
@@ -154,9 +154,9 @@ export class TreeAttributionCollection implements IAttributionCollection<Attribu
 	}
 
 	public getAtOffset(offset: number): AttributionKey | undefined {
-		assert(offset >= 0 && offset < this._length, 0x443 /* Requested offset should be valid */);
+		assert(offset >= 0 && offset < this._length, "Requested offset should be valid");
 		const node = this.entries.floor(offset);
-		assert(node !== undefined, 0x444 /* Collection should have at least one entry */);
+		assert(node !== undefined, "Collection should have at least one entry");
 		return node.data === null ? undefined : node.data;
 	}
 
@@ -224,7 +224,7 @@ export class TreeAttributionCollection implements IAttributionCollection<Attribu
 		const { seqs, posBreakpoints } = summary;
 		assert(
 			seqs.length === posBreakpoints.length && seqs.length > 0,
-			0x445 /* Invalid attribution summary blob provided */,
+			"Invalid attribution summary blob provided",
 		);
 		let curIndex = 0;
 		let cumulativeSegPos = 0;
@@ -295,7 +295,7 @@ export class TreeAttributionCollection implements IAttributionCollection<Attribu
 
 		assert(
 			segmentsWithAttribution === 0 || segmentsWithoutAttribution === 0,
-			0x446 /* Expected either all segments or no segments to have attribution information. */,
+			"Expected either all segments or no segments to have attribution information.",
 		);
 
 		const blobContents: SerializedAttributionCollection = {

--- a/packages/utils/telemetry-utils/src/test/childLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/childLogger.spec.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
 import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { assert } from "@fluidframework/common-utils";
 import { ChildLogger } from "../logger";
 
 describe("ChildLogger", () => {

--- a/packages/utils/telemetry-utils/src/test/performanceEvent.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/performanceEvent.spec.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
-import { assert } from "@fluidframework/common-utils";
 import { TelemetryLogger, PerformanceEvent } from "../logger";
 import { ITelemetryLoggerExt } from "../telemetryTypes";
 
@@ -45,6 +45,6 @@ describe("PerformanceEvent", () => {
 		};
 
 		await PerformanceEvent.timedExecAsync(logger, { eventName: "Testing" }, callback);
-		assert(logger.errorsLogged === 0, "Shouldn't have logged any errors");
+		assert.equal(logger.errorsLogged, 0, "Shouldn't have logged any errors");
 	});
 });


### PR DESCRIPTION
## Description

Found some test files using our custom assert function instead of node's assert, which was probably unintended, so replaced those uses with node's assert.

Also removed export from class that lives in a test file and isn't referenced anywhere outside of it.

I'm curious why the asserts in property-dds and in telemetry-utils were never tagged in our releases... they've been there for a while. @tylerbutler FYI, in case you have thoughts. I'll try to investigate it too.