### PR TITLE
docs(devtools-view): Change sandbox app instruction in README

### DIFF
--- a/packages/tools/devtools/devtools-core/src/messaging/Messages.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/Messages.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * Structure of a message used for communication from/to the Fluid Client Debugger.
+ * Structure of a message used for communication from/to the Fluid Devtools.
  *
  * @internal
  */
@@ -23,7 +23,7 @@ export interface IDevtoolsMessage<TData = unknown> {
 }
 
 /**
- * Message structure expected for window event listeners used by the Fluid Client Debugger.
+ * Message structure expected for window event listeners used by the Fluid Devtools.
  *
  * @internal
  */

--- a/packages/tools/devtools/devtools-view/README.md
+++ b/packages/tools/devtools/devtools-view/README.md
@@ -47,7 +47,7 @@ Next, run `npm run test` from a terminal within this directory.
 
 This package has a simple testing app that sets up a Container with some simple data for testing the debug view, as well as some interactive controls for testing live editing / collaboration scenarios.
 
-To run the app, navigate to the root of this package and run `npm run start:test-app`.
+To run the app, navigate to the root of `@fluid-example/devtools-example` package and run `npm run start`.
 
 -   This will launch a local [Tinylicious](https://fluidframework.com/docs/testing/tinylicious/) service and serve the app at <http://localhost:8080/>.
 


### PR DESCRIPTION
#### Description

`npm run start:test-app` script no longer exists in `devtools-view` package. 