### PR TITLE
ci: Remove colorization from t9s logs for build-npm-package template

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -295,7 +295,7 @@ stages:
 
           - ${{ each taskTestStep in parameters.taskTest }}:
             # Test - With coverage
-            - ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
+            ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
               - task: Npm@1
                 displayName: npm run ${{ taskTestStep }}:coverage
                 inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -303,8 +303,14 @@ stages:
                   workingDir: ${{ parameters.buildDirectory }}
                   customCommand: 'run ${{ taskTestStep }}:coverage'
                 condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                env:
+                  ${{ if contains(taskTestStep, 'tinylicious') }}:
+                    # Disable colorization for tinylicious logs (not useful when printing to a file)
+                    logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+                    logger__morganFormat: tiny
+
             # Test - No coverage
-            - ${{ if or(eq(variables['testCoverage'], false), eq(startsWith(taskTestStep, 'ci:test'), false)) }}:
+              ${{ else }}:
                 - task: Npm@1
                   displayName: npm run ${{ taskTestStep }}
                   inputs:
@@ -312,6 +318,11 @@ stages:
                     workingDir: ${{ parameters.buildDirectory }}
                     customCommand: 'run ${{ taskTestStep }}'
                   condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                  env:
+                    ${{ if contains(taskTestStep, 'tinylicious') }}:
+                      # Disable colorization for tinylicious logs (not useful when printing to a file)
+                      logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+                      logger__morganFormat: tiny
 
           # Test - Upload coverage results
           # Some webpacked file using externals introduce file name with quotes in them

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -295,7 +295,7 @@ stages:
 
           - ${{ each taskTestStep in parameters.taskTest }}:
             # Test - With coverage
-            ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
+            - ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
               - task: Npm@1
                 displayName: npm run ${{ taskTestStep }}:coverage
                 inputs:
@@ -309,8 +309,8 @@ stages:
                     logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
                     logger__morganFormat: tiny
 
-            # Test - No coverage
-            ${{ else }}:
+              # Test - No coverage
+            - ${{ else }}:
               - task: Npm@1
                 displayName: npm run ${{ taskTestStep }}
                 inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -310,19 +310,19 @@ stages:
                     logger__morganFormat: tiny
 
             # Test - No coverage
-              ${{ else }}:
-                - task: Npm@1
-                  displayName: npm run ${{ taskTestStep }}
-                  inputs:
-                    command: 'custom'
-                    workingDir: ${{ parameters.buildDirectory }}
-                    customCommand: 'run ${{ taskTestStep }}'
-                  condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-                  env:
-                    ${{ if contains(taskTestStep, 'tinylicious') }}:
-                      # Disable colorization for tinylicious logs (not useful when printing to a file)
-                      logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
-                      logger__morganFormat: tiny
+            ${{ else }}:
+              - task: Npm@1
+                displayName: npm run ${{ taskTestStep }}
+                inputs:
+                  command: 'custom'
+                  workingDir: ${{ parameters.buildDirectory }}
+                  customCommand: 'run ${{ taskTestStep }}'
+                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                env:
+                  ${{ if contains(taskTestStep, 'tinylicious') }}:
+                    # Disable colorization for tinylicious logs (not useful when printing to a file)
+                    logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+                    logger__morganFormat: tiny
 
           # Test - Upload coverage results
           # Some webpacked file using externals introduce file name with quotes in them


### PR DESCRIPTION
## Description

Several previous PRs have worked towards this; I think this is the last bit so all tinylicious log files generated in our pipeline runs are plaintext, with no TTY-colorization codes that make them harder to read.

Also simplified from 

```ado
{{ if <condition-is-true> }}
  // Something
{{ if <condition-is-not-true> }}
  // Something else
```

to

```ado
{{ if <condition-is-true> }}
  // Something
{{ else }}
  // Something else
```