### PR TITLE
fix(release): Handle independent packages with release branches

### DIFF
--- a/build-tools/packages/build-cli/src/commands/release.ts
+++ b/build-tools/packages/build-cli/src/commands/release.ts
@@ -4,7 +4,10 @@
  */
 import { VersionBumpType, detectVersionScheme } from "@fluid-tools/version-tools";
 import { Config } from "@oclif/core";
+import { MonoRepoKind } from "@fluidframework/build-tools";
+import chalk from "chalk";
 
+import { findPackageOrReleaseGroup } from "../args";
 import {
 	bumpTypeFlag,
 	checkFlags,
@@ -17,8 +20,6 @@ import { PromptWriter } from "../instructionalPromptWriter";
 import { FluidReleaseMachine } from "../machines";
 import { getRunPolicyCheckDefault } from "../repoConfig";
 import { StateMachineCommand } from "../stateMachineCommand";
-import { MonoRepoKind } from "@fluidframework/build-tools";
-import chalk from "chalk";
 
 /**
  * Releases a package or release group. This command is mostly scaffolding and setting up the state machine, handlers,
@@ -68,7 +69,14 @@ export default class ReleaseCommand extends StateMachineCommand<typeof ReleaseCo
 
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const releaseGroup = flags.releaseGroup ?? flags.package!;
-		const releaseVersion = context.getVersion(releaseGroup);
+		const packageOrReleaseGroup = findPackageOrReleaseGroup(releaseGroup, context);
+		if (packageOrReleaseGroup === undefined) {
+			this.error(`Could not find release group or package: ${releaseGroup}`, {
+				exit: 1,
+			});
+		}
+
+		const releaseVersion = packageOrReleaseGroup.version;
 
 		// eslint-disable-next-line no-warning-comments
 		// TODO: can be removed once server team owns server releases

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -314,9 +314,16 @@ export const checkOnReleaseBranch: StateHandlerFunction = async (
 
 	const { context, releaseGroup, releaseVersion, shouldCheckBranch } = data;
 	assert(context !== undefined, "Context is undefined.");
-	assert(isReleaseGroup(releaseGroup), `Not a release group: ${releaseGroup}`);
 
 	const currentBranch = await context.gitRepo.getCurrentBranchName();
+	if (!isReleaseGroup(releaseGroup)) {
+		// must be a package
+		assert(
+			context.fullPackageMap.has(releaseGroup),
+			`Package ${releaseGroup} not found in context.`,
+		);
+	}
+
 	const releaseBranch = generateReleaseBranchName(releaseGroup, releaseVersion);
 
 	if (shouldCheckBranch) {

--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -107,7 +107,7 @@ export function generateBumpDepsBranchName(
 /**
  * Generates the correct branch name for the release branch of a given release group and branch.
  *
- * @param releaseGroup - The release group for which to generate a branch name.
+ * @param releaseGroup - The release group or package for which to generate a branch name.
  * @param version - The version for the release branch. Typically this is a major.minor version, but for release groups
  * using the Fluid internal or virtualPatch version schemes the versions may differ.
  * @returns The generated branch name.
@@ -118,7 +118,10 @@ export function generateBumpDepsBranchName(
  *
  * @internal
  */
-export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: string): string {
+export function generateReleaseBranchName(
+	releaseGroup: ReleaseGroup | ReleasePackage,
+	version: string,
+): string {
 	// An array of all the sections of a "path" branch -- a branch with slashes in the name.
 	const branchPath = ["release"];
 
@@ -134,12 +137,16 @@ export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: s
 		branchVersion = version;
 	}
 
-	if (releaseGroup === "client") {
-		if (schemeIsInternal) {
-			branchPath.push("v2int");
+	if (isReleaseGroup(releaseGroup)) {
+		if (releaseGroup === "client") {
+			if (schemeIsInternal) {
+				branchPath.push("v2int");
+			}
+		} else {
+			branchPath.push(releaseGroup);
 		}
 	} else {
-		branchPath.push(releaseGroup);
+		branchPath.push(PackageName.getUnscopedName(releaseGroup));
 	}
 
 	const releaseBranchVersion =

--- a/build-tools/packages/build-cli/test/lib/branches.test.ts
+++ b/build-tools/packages/build-cli/test/lib/branches.test.ts
@@ -127,6 +127,12 @@ describe("generateReleaseBranchName", () => {
 		const expected = "release/v2int/1.0";
 		assert.equal(actual, expected);
 	});
+
+  it("Independent package with standard semver", () => {
+		const actual = generateReleaseBranchName("@fluidframework/build-common", "1.2.1");
+		const expected = "release/build-common/1.2";
+		assert.equal(actual, expected);
+	});
 });
 
 describe("getDefaultBumpTypeForBranch", () => {


### PR DESCRIPTION
Independent packages were causing the release command to throw an exception. The problem was an assertion in the release branch handler that the argument was a release group and not a package.

This change removes that assertion and looks up the package/release group name in the context to confirm it's valid. As a side effect, the release command now works with unscoped package names.