### PR TITLE
fix(devtools-browser-extension): Fix globals stubbing infra with regards to the `window` object

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/Globals.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/Globals.ts
@@ -9,7 +9,8 @@ declare const browser: typeof chrome;
 const _browser: typeof chrome = typeof browser !== "undefined" ? browser : chrome;
 
 // Include references to web browser globals to facilitate mocks during testing.
-const _window = window;
+// Note: this will always be `undefined` in the BackgroundScript, but we expect it to be defined elsewhere.
+const _window = typeof window === "undefined" ? undefined : window;
 
 export {
 	_browser as browser,

--- a/packages/tools/devtools/devtools-browser-extension/src/content/ContentScript.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/content/ContentScript.ts
@@ -9,7 +9,7 @@ import {
 	isDevtoolsMessage,
 } from "@fluid-experimental/devtools-core";
 
-import { browser, window } from "../Globals";
+import { browser, window as maybeWindow } from "../Globals";
 import { extensionMessageSource, relayMessageToPort } from "../messaging";
 import {
 	contentScriptMessageLoggingOptions,
@@ -17,6 +17,9 @@ import {
 } from "./Logging";
 
 type Port = chrome.runtime.Port;
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const window = maybeWindow!;
 
 /**
  * This module is the extension's Content Script.

--- a/packages/tools/devtools/devtools-browser-extension/src/content/ContentScript.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/content/ContentScript.ts
@@ -18,6 +18,7 @@ import {
 
 type Port = chrome.runtime.Port;
 
+// `window` should always be defined in the Content script context.
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const window = maybeWindow!;
 


### PR DESCRIPTION
#15829 Added new globals stubbing infra for use with the `window` object for testing the Content script. It inadvertently broke the extension build (verified when you attempt to install it in the browser), due to the `window` object not being defined in the BackgroundScript context. This is expected per Google's documentation.

This PR adds handling to support the case where `window` is not defined.