### PR TITLE
Change logger type to ITelemetryBaseLogger

### DIFF
--- a/api-report/location-redirection-utils.api.md
+++ b/api-report/location-redirection-utils.api.md
@@ -6,14 +6,14 @@
 
 import { ILocationRedirectionError } from '@fluidframework/driver-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
+import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 
 // @public
 export function isLocationRedirectionError(error: any): error is ILocationRedirectionError;
 
 // @public
-export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, logger?: ITelemetryLoggerExt): Promise<T>;
+export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, baseLogger?: ITelemetryBaseLogger): Promise<T>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/loader/location-redirection-utils/src/resolveWithLocationRedirection.ts
+++ b/packages/loader/location-redirection-utils/src/resolveWithLocationRedirection.ts
@@ -3,13 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
 	DriverErrorType,
 	ILocationRedirectionError,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 /**
  * Checks if the error is location redirection error.
@@ -29,15 +30,17 @@ export function isLocationRedirectionError(error: any): error is ILocationRedire
  * @param api - Callback in which user can wrap the loader.resolve or loader.request call.
  * @param request - request to be resolved.
  * @param urlResolver - resolver used to resolve the url.
+ * @param baseLogger - logger to send events.
  * @returns - Response from the api call.
  */
 export async function resolveWithLocationRedirectionHandling<T>(
 	api: (request: IRequest) => Promise<T>,
 	request: IRequest,
 	urlResolver: IUrlResolver,
-	logger?: ITelemetryLoggerExt,
+	baseLogger?: ITelemetryBaseLogger,
 ): Promise<T> {
 	let req: IRequest = request;
+	const logger = ChildLogger.create(baseLogger, "LocationRedirection");
 	for (;;) {
 		try {
 			return await api(req);
@@ -45,7 +48,7 @@ export async function resolveWithLocationRedirectionHandling<T>(
 			if (!isLocationRedirectionError(error)) {
 				throw error;
 			}
-			logger?.sendTelemetryEvent({ eventName: "LocationRedirectionError" });
+			logger.sendTelemetryEvent({ eventName: "LocationRedirectionError" });
 			const resolvedUrl = error.redirectUrl;
 			// Generate the new request with new location details from the resolved url. For datastore/relative path,
 			// we don't need to pass "/" as host could have asked for a specific data store. So driver need to


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4456
Change logger type to ITelemetryBaseLogger from ItelemetryLogger as hosts/apps provides type base logger only.