### PR TITLE
build(routerlicious): Remove unused dependencies

### DIFF
--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -63,8 +63,7 @@
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/gitresources": "workspace:*",
 		"@fluidframework/protocol-definitions": "^1.1.0",
-		"events": "^3.1.0",
-		"lodash": "^4.17.21"
+    "events": "^3.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.16.1",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -577,9 +577,6 @@ importers:
       events:
         specifier: ^3.1.0
         version: 3.3.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: ^0.16.1


### PR DESCRIPTION
Removes lodash from the protocol-base package. It was previously removed in #13746 but was re-added due to an incorrect merge resolution.