### PR TITLE
ci: Run checks in server pipelines

### DIFF
--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -20,6 +20,7 @@
 		"build:gendocs": "api-documenter markdown -i _api-extractor-temp/doc-models -o docs/api",
 		"build:genver": "lerna run build:genver --stream --parallel",
 		"bump-version": "lerna version minor --no-push --no-git-tag-version && npm run build:genver",
+    "check:versions": "flub check buildVersion -g server --path .",
 		"ci:build": "npm run build:genver && lerna run build:compile --stream",
 		"ci:build:docs": "lerna run ci:build:docs --stream --parallel",
 		"ci:eslint": "lerna run eslint --no-sort --stream",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -20,7 +20,7 @@
 		"build:gendocs": "api-documenter markdown -i _api-extractor-temp/doc-models -o docs/api",
 		"build:genver": "lerna run build:genver --stream --parallel",
 		"bump-version": "lerna version minor --no-push --no-git-tag-version && npm run build:genver",
-    "check:versions": "flub check buildVersion -g server --path .",
+		"check:versions": "flub check buildVersion -g server --path .",
 		"ci:build": "npm run build:genver && lerna run build:compile --stream",
 		"ci:build:docs": "lerna run ci:build:docs --stream --parallel",
 		"ci:eslint": "lerna run eslint --no-sort --stream",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/gitresources": "workspace:*",
 		"@fluidframework/protocol-definitions": "^1.1.0",
-    "events": "^3.1.0"
+		"events": "^3.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.18.0",

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -90,3 +90,5 @@ extends:
     tagName: gitrest
     lint: true
     pack: true
+    checks:
+    - prettier

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -92,3 +92,5 @@ extends:
     tagName: historian
     lint: true
     pack: true
+    checks:
+    - prettier

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -101,3 +101,6 @@ extends:
     test: ci:test
     docs: true
     containerBaseDir: /usr/src/server
+    checks:
+    - prettier
+    - check:versions

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -80,6 +80,12 @@ parameters:
   type: string
   default: "^"
 
+# A list of scripts that execute checks of the release group, e.g. prettier, syncpack, etc. These will be run serially
+# in a pipeline stage separate from the build stage.
+- name: checks
+  type: object
+  default: []
+
 trigger: none
 
 variables:
@@ -128,6 +134,12 @@ variables:
     value: ${{ parameters.tagName }}
 
 stages:
+- ${{ if ne(convertToJson(parameters.checks), '[]') }}:
+  - template: include-policy-check.yml
+    parameters:
+      buildDirectory: ${{ parameters.buildDirectory }}
+      checks: ${{ parameters.checks }}
+
 - stage: build
   displayName: Build Stage
   jobs:


### PR DESCRIPTION
The server CI pipelines now support running "checks" in a separate stage like the client pipeline already does. The primary check that's run is `prettier`; this should prevent unformatted server changes from sneaking in.

Example failing CI due to prettier failures: https://dev.azure.com/fluidframework/public/_build/results?buildId=164758&view=logs&jobId=eefa678c-f484-5837-78d3-627f1635913b&j=eefa678c-f484-5837-78d3-627f1635913b&t=f0aa30c6-6319-5149-37ef-972f8438220b