### PR TITLE
build(docs): Fix some known broken links

### DIFF
--- a/docs/content/docs/concepts/signals.md
+++ b/docs/content/docs/concepts/signals.md
@@ -63,7 +63,7 @@ For more information on using `ContainerSchema` to create objects please see [Da
 
 #### Signal request
 
-When a client joins a collaboration session, they may need to receive information about the current state immediately after connecting the container.  To support this, they can request a specific signal be sent to them from other connected clients. For example, in the [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker) example we define a "focusRequest" signal type that a newly joining client uses to request the focus-state of each currently connected client:
+When a client joins a collaboration session, they may need to receive information about the current state immediately after connecting the container.  To support this, they can request a specific signal be sent to them from other connected clients. For example, in the [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/apps/presence-tracker) example we define a "focusRequest" signal type that a newly joining client uses to request the focus-state of each currently connected client:
 
 ```typescript
 private static readonly focusRequestType = "focusRequest";
@@ -83,7 +83,7 @@ this.signalManager.onSignal(FocusTracker.focusRequestType, () => {
 });
 ```
 
-This pattern adds cost however, as it forces every connected client to generate a signal.  Consider whether your scenario can be satisfied by receiving the signals naturally over time instead of requesting the information up-front. The mouse tracking in [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker) is an example where a newly connecting client does not request current state. Since mouse movements are frequent, the newly connecting client can instead simply wait to receive other users' mouse positions on their next mousemove event.
+This pattern adds cost however, as it forces every connected client to generate a signal.  Consider whether your scenario can be satisfied by receiving the signals naturally over time instead of requesting the information up-front. The mouse tracking in [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/apps/presence-tracker) is an example where a newly connecting client does not request current state. Since mouse movements are frequent, the newly connecting client can instead simply wait to receive other users' mouse positions on their next mousemove event.
 
 #### Grouping signal types
 

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -4,7 +4,7 @@ menuPosition: 5
 draft: true
 ---
 
-In this article, we will go over the `PresenceTracker` example to learn how the [Signaler](https://github.com/microsoft/FluidFramework/tree/main/experimental/framework/data-objects/src/signaler) DataObject is used in a Fluid application to share user presence information between collaborators. We'll cover how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to share mouse position and focus state. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
+In this article, we will go over the `PresenceTracker` example to learn how the [Signaler](https://github.com/microsoft/FluidFramework/tree/main/experimental/framework/data-objects/src/signaler) DataObject is used in a Fluid application to share user presence information between collaborators. We'll cover how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to share mouse position and focus state. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/apps/presence-tracker).
 
 ## Creation
 
@@ -364,6 +364,6 @@ function renderMousePresence(mouseTracker: MouseTracker, focusTracker: FocusTrac
 
 ## Next Steps
 
--   You can find the completed code for this example in the Fluid GitHub repository [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
+-   You can find the completed code for this example in the Fluid GitHub repository [here](https://github.com/microsoft/FluidFramework/tree/main/examples/apps/presence-tracker).
 -   Try extending the `PresenceTracker` to track some other form of presence using signals!
 

--- a/docs/content/docs/start/examples.md
+++ b/docs/content/docs/start/examples.md
@@ -55,6 +55,5 @@ that don't have an HTTP canvas can participate in the Fluid Framework collaborat
 
 ## Fluid in a Microsoft 365 Teams tab
 
-The [Teams and Fluid "Hello World" app](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world)
-shows you how to integrate a Fluid Framework application into a custom Microsoft 365 Teams tab. See
-also [Using Fluid with Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/using-fluid-msteam).
+The [Using Fluid with Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/using-fluid-msteam)
+article shows you how to integrate a Fluid Framework application into a custom Microsoft 365 Teams tab.

--- a/docs/skipped-urls.txt
+++ b/docs/skipped-urls.txt
@@ -7,6 +7,7 @@ https://aka.ms/fluentui/
 https://github.com/microsoft/FluidFramework/edit/*
 https://twitter.com/intent/follow*
 https://twitter.com/intent/tweet*
+https://twitter.com/fluidframework
 https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/*
 
 # These URLs have false positives with their anchors. Linkcheck thinks the anchors are missing.

--- a/docs/themes/thxvscode/layouts/_default/_markup/render-link.html
+++ b/docs/themes/thxvscode/layouts/_default/_markup/render-link.html
@@ -1,4 +1,4 @@
 {{ $link := .Destination }}
 {{- with .Page.GetPage .Destination }}{{ $link = .RelPermalink }}{{ end -}}
 <a href="{{ $link | safeURL }}" {{ with .Title}} title="{{ . }}" {{ end }}{{ if strings.HasPrefix .Destination "http" }}
-    target="_blank" {{ end }}>{{ .Text }}</a>
+    target="_blank" {{ end }}>{{ .Text | safeHTML }}</a>

--- a/experimental/framework/data-objects/src/signaler/README.md
+++ b/experimental/framework/data-objects/src/signaler/README.md
@@ -40,7 +40,7 @@ For more information on using `ContainerSchema` to create objects please see [Da
 
 ### Signal Request
 
-When a client joins a collaboration session, they may need to receive pertinent information immediately after connecting the container. To support this, they can request a specific signal be sent to them from other connected clients within the application. For example, in the [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker) we define a "focusRequest" signal type that a newly joining client uses to request the focus-state of each currently connected client:
+When a client joins a collaboration session, they may need to receive pertinent information immediately after connecting the container. To support this, they can request a specific signal be sent to them from other connected clients within the application. For example, in the [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/apps/presence-tracker) we define a "focusRequest" signal type that a newly joining client uses to request the focus-state of each currently connected client:
 
 ```typescript
 private static readonly focusRequestType = "focusRequest";
@@ -60,7 +60,7 @@ this.signaler.onSignal(FocusTracker.focusRequestType, () => {
 });
 ```
 
-When there are a lot of connected clients, usage of this request pattern can lead to high signal costs incurred from large amounts of signals being submitted all at the same time. While this pattern is helpful when a client is in need of relevant information, to limit signal costs it would be beneficial to examine whether or not the requested data will be quickly avaiable from other events being listened to within the application. The mouse tracking in [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker) is an example where a newly connecting client is not required to request a signal to receive every current mouse position on the document. Since mouse movements are frequent, the newly connecting client can simply wait to recieve other users mouse positions on their mousemove events.
+When there are a lot of connected clients, usage of this request pattern can lead to high signal costs incurred from large amounts of signals being submitted all at the same time. While this pattern is helpful when a client is in need of relevant information, to limit signal costs it would be beneficial to examine whether or not the requested data will be quickly avaiable from other events being listened to within the application. The mouse tracking in [PresenceTracker](https://github.com/microsoft/FluidFramework/tree/main/examples/apps/presence-tracker) is an example where a newly connecting client is not required to request a signal to receive every current mouse position on the document. Since mouse movements are frequent, the newly connecting client can simply wait to recieve other users mouse positions on their mousemove events.
 
 ### Grouping Signal Types
 


### PR DESCRIPTION
Also fixes escaped HTML entities in external links that was noted in #15698.

The remaining broken links are in the TSDocs so they'll have to be fixed separately.