### PR TITLE
build(devtools-browser-extension): Remove unneeded "scripting" permission from extension manifest

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -13,7 +13,7 @@
 		},
 		"default_popup": "popup/popup.html"
 	},
-	"permissions": ["activeTab", "scripting"],
+	"permissions": ["activeTab"],
 	"devtools_page": "devtools/devtools.html",
 	"background": {
 		"service_worker": "background/BackgroundScript.js"


### PR DESCRIPTION
Since our extension does not inject any scripting logic into the webpage, we do not need the ["scripting"](https://developer.chrome.com/docs/extensions/reference/scripting/) permission in our manifest. This permission was a leftover from early prototypes, but is no longer needed.

Removing this will also make the browser store audit process faster.