### PR TITLE
[fluid-runner] Disable fetch calls explicitly

### DIFF
--- a/packages/tools/fluid-runner/src/exportFile.ts
+++ b/packages/tools/fluid-runner/src/exportFile.ts
@@ -43,6 +43,7 @@ export async function exportFile(
 	options?: string,
 	telemetryOptions?: ITelemetryOptions,
 	timeout?: number,
+	disableNetworkFetch?: boolean,
 ): Promise<IExportFileResponse> {
 	const telemetryArgError = getTelemetryFileValidationError(telemetryFile);
 	if (telemetryArgError) {
@@ -71,6 +72,7 @@ export async function exportFile(
 						logger,
 						options,
 						timeout,
+						disableNetworkFetch,
 					),
 				);
 
@@ -96,8 +98,15 @@ export async function createContainerAndExecute(
 	logger: ITelemetryLogger,
 	options?: string,
 	timeout?: number,
+	disableNetworkFetch: boolean = false,
 ): Promise<string> {
 	const fn = async () => {
+		if (disableNetworkFetch) {
+			global.fetch = async () => {
+				throw new Error("Network fetch is not allowed");
+			};
+		}
+
 		const loader = new Loader({
 			urlResolver: new FakeUrlResolver(),
 			documentServiceFactory: createLocalOdspDocumentServiceFactory(localOdspSnapshot),

--- a/packages/tools/fluid-runner/src/fluidRunner.ts
+++ b/packages/tools/fluid-runner/src/fluidRunner.ts
@@ -76,6 +76,12 @@ export function fluidRunner(fluidFileConverter?: IFluidFileConverter) {
 						describe: "Allowed timeout in ms before process is automatically cancelled",
 						type: "number",
 						demandOption: false,
+					})
+					.option("disableNetworkFetch", {
+						describe: "Should network fetch calls be explicitly disabled?",
+						type: "boolean",
+						demandOption: false,
+						default: false,
 					}),
 			// eslint-disable-next-line @typescript-eslint/no-misused-promises
 			async (argv) => {
@@ -103,6 +109,7 @@ export function fluidRunner(fluidFileConverter?: IFluidFileConverter) {
 							argv.options,
 							telemetryOptionsResult.telemetryOptions,
 							argv.timeout,
+							argv.disableNetworkFetch,
 					  )
 					: exportFile(
 							fluidFileConverter!,
@@ -112,6 +119,7 @@ export function fluidRunner(fluidFileConverter?: IFluidFileConverter) {
 							argv.options,
 							telemetryOptionsResult.telemetryOptions,
 							argv.timeout,
+							argv.disableNetworkFetch,
 					  ));
 
 				if (!result.success) {

--- a/packages/tools/fluid-runner/src/parseBundleAndExportFile.ts
+++ b/packages/tools/fluid-runner/src/parseBundleAndExportFile.ts
@@ -27,6 +27,7 @@ export async function parseBundleAndExportFile(
 	options?: string,
 	telemetryOptions?: ITelemetryOptions,
 	timeout?: number,
+	disableNetworkFetch?: boolean,
 ): Promise<IExportFileResponse> {
 	const telemetryArgError = getTelemetryFileValidationError(telemetryFile);
 	if (telemetryArgError) {
@@ -73,6 +74,7 @@ export async function parseBundleAndExportFile(
 						logger,
 						options,
 						timeout,
+						disableNetworkFetch,
 					),
 				);
 

--- a/packages/tools/fluid-runner/src/test/exportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/exportFile.spec.ts
@@ -99,7 +99,7 @@ describe("exportFile", () => {
 		assert(!result.success, "result should not be successful");
 		assert(
 			result.error?.message.toLowerCase().includes("network fetch"),
-			`error message does not contain "timed out" [${result.error?.message}]`,
+			`error message does not contain "network fetch" [${result.error?.message}]`,
 		);
 	});
 

--- a/packages/tools/fluid-runner/src/test/exportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/exportFile.spec.ts
@@ -12,6 +12,7 @@ import { getSnapshotFileContent } from "../utils";
 /* eslint-disable import/no-internal-modules */
 import { executeResult, fluidExport } from "./sampleCodeLoaders/sampleCodeLoader";
 import { fluidExport as timeoutFluidExport } from "./sampleCodeLoaders/timeoutCodeLoader";
+import { fluidExport as networkFetchFluidExport } from "./sampleCodeLoaders/networkFetchCodeLoader";
 /* eslint-enable import/no-internal-modules */
 
 describe("exportFile", () => {
@@ -23,6 +24,9 @@ describe("exportFile", () => {
 
 	beforeEach(() => {
 		fs.mkdirSync(outputFolder);
+		global.fetch = (async () => {
+			return undefined;
+		}) as any;
 	});
 
 	afterEach(() => {
@@ -78,6 +82,40 @@ describe("exportFile", () => {
 			result.error?.message.toLowerCase().includes("timed out"),
 			`error message does not contain "timed out" [${result.error?.message}]`,
 		);
+	});
+
+	it("fails on disallowed network fetch", async () => {
+		const result = await exportFile(
+			networkFetchFluidExport,
+			path.join(snapshotFolder, "odspSnapshot1.json"),
+			outputFilePath,
+			telemetryFile,
+			undefined,
+			undefined,
+			undefined,
+			true,
+		);
+
+		assert(!result.success, "result should not be successful");
+		assert(
+			result.error?.message.toLowerCase().includes("network fetch"),
+			`error message does not contain "timed out" [${result.error?.message}]`,
+		);
+	});
+
+	it("succeeds when allowed network fetch occurs", async () => {
+		const result = await exportFile(
+			networkFetchFluidExport,
+			path.join(snapshotFolder, "odspSnapshot1.json"),
+			outputFilePath,
+			telemetryFile,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		);
+
+		assert(result.success, "result should be successful");
 	});
 
 	describe("Validate arguments", () => {

--- a/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
+++ b/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
@@ -133,6 +133,61 @@ describe("fluid-runner from command line", () => {
 			);
 			assert.notStrictEqual(exportFile.stderr, "", "Expect some error output");
 		});
+
+		it("Process exits with code 1 when disallowed network call occurs", () => {
+			const networkFetchCodeLoader = path.join(
+				__dirname,
+				"sampleCodeLoaders",
+				"networkFetchCodeLoader.js",
+			);
+			const exportFile = spawnSync(
+				"node",
+				[
+					command,
+					"exportFile",
+					`--codeLoader=${networkFetchCodeLoader}`,
+					`--inputFile=${snapshot}`,
+					`--outputFile=${outputFilePath}`,
+					`--telemetryFile=${telemetryFile}`,
+					`--disableNetworkFetch=true`,
+				],
+				{ encoding: "utf-8" },
+			);
+
+			assert.strictEqual(
+				exportFile.status,
+				1,
+				`Process was not exited with code 1. Error: [${exportFile.stderr}]`,
+			);
+			assert.notStrictEqual(exportFile.stderr, "", "Expect some error output");
+		});
+
+		it("Process exits with code 0 when allowed network call occurs", () => {
+			const networkFetchCodeLoader = path.join(
+				__dirname,
+				"sampleCodeLoaders",
+				"networkFetchCodeLoader.js",
+			);
+			const exportFile = spawnSync(
+				"node",
+				[
+					command,
+					"exportFile",
+					`--codeLoader=${networkFetchCodeLoader}`,
+					`--inputFile=${snapshot}`,
+					`--outputFile=${outputFilePath}`,
+					`--telemetryFile=${telemetryFile}`,
+					`--disableNetworkFetch=false`,
+				],
+				{ encoding: "utf-8" },
+			);
+
+			assert.strictEqual(
+				exportFile.status,
+				0,
+				`Process was not exited with code 0. Error: [${exportFile.stderr}]`,
+			);
+		});
 	});
 });
 

--- a/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
@@ -20,6 +20,9 @@ describe("parseBundleAndExportFile", () => {
 
 	beforeEach(() => {
 		fs.mkdirSync(outputFolder);
+		global.fetch = (async () => {
+			return undefined;
+		}) as any;
 	});
 
 	afterEach(() => {
@@ -66,6 +69,40 @@ describe("parseBundleAndExportFile", () => {
 			result.error?.message.toLowerCase().includes("timed out"),
 			`error message does not contain "timed out" [${result.error?.message}]`,
 		);
+	});
+
+	it("fails on disallowed network fetch", async () => {
+		const result = await parseBundleAndExportFile(
+			path.join(sampleCodeLoadersFolder, "networkFetchCodeLoader.js"),
+			path.join(snapshotFolder, "odspSnapshot1.json"),
+			outputFilePath,
+			telemetryFile,
+			undefined,
+			undefined,
+			undefined,
+			true,
+		);
+
+		assert(!result.success, "result should not be successful");
+		assert(
+			result.error?.message.toLowerCase().includes("network fetch"),
+			`error message does not contain "timed out" [${result.error?.message}]`,
+		);
+	});
+
+	it("succeeds when allowed network fetch occurs", async () => {
+		const result = await parseBundleAndExportFile(
+			path.join(sampleCodeLoadersFolder, "networkFetchCodeLoader.js"),
+			path.join(snapshotFolder, "odspSnapshot1.json"),
+			outputFilePath,
+			telemetryFile,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		);
+
+		assert(result.success, "result should be successful");
 	});
 
 	describe("Validate arguments", () => {

--- a/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
@@ -86,7 +86,7 @@ describe("parseBundleAndExportFile", () => {
 		assert(!result.success, "result should not be successful");
 		assert(
 			result.error?.message.toLowerCase().includes("network fetch"),
-			`error message does not contain "timed out" [${result.error?.message}]`,
+			`error message does not contain "network fetch" [${result.error?.message}]`,
 		);
 	});
 

--- a/packages/tools/fluid-runner/src/test/sampleCodeLoaders/networkFetchCodeLoader.ts
+++ b/packages/tools/fluid-runner/src/test/sampleCodeLoaders/networkFetchCodeLoader.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	ICodeDetailsLoader,
+	IContainer,
+	IFluidModuleWithDetails,
+} from "@fluidframework/container-definitions";
+import { BaseContainerRuntimeFactory } from "@fluidframework/aqueduct";
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { IFluidFileConverter } from "../../codeLoaderBundle";
+
+async function getCodeLoader(_logger: ITelemetryBaseLogger): Promise<ICodeDetailsLoader> {
+	return {
+		load: async (): Promise<IFluidModuleWithDetails> => {
+			return {
+				module: { fluidExport: new BaseContainerRuntimeFactory(new Map()) },
+				details: { package: "no-dynamic-package", config: {} },
+			};
+		},
+	};
+}
+
+export const executeResult = "result";
+async function execute(_container: IContainer, _options?: string): Promise<string> {
+	// Make a network fetch call
+	await fetch("https://www.microsoft.com/");
+	return executeResult;
+}
+
+function getFluidExport(): IFluidFileConverter {
+	global.fetch = (async () => {
+		return undefined;
+	}) as any;
+	return {
+		getCodeLoader,
+		execute,
+	};
+}
+
+export const fluidExport = getFluidExport();


### PR DESCRIPTION
## Description

The `LocalOdspDocumentService` should prevent most `fetch` call cases, but it's better to explicitly disallow any calls by overriding it globally.
If we are not doing it, then we will see infinite retry loops (as that's runtime behavior).

[AB#4272](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4272)