### PR TITLE
fix(generate:changeset): Support entering changeset info in CLI

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -94,7 +94,7 @@
 		"npm-check-updates": "^16.0.0",
 		"oclif": "^3.7.0",
 		"prettier": "~2.6.2",
-		"prompts": "npm:prompts-ncu@^3.0.0",
+		"prompts": "^2.4.2",
 		"read-pkg-up": "^7.0.1",
 		"semver": "^7.3.7",
 		"semver-utils": "^1.1.4",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -117,6 +117,7 @@
 		"@types/inquirer": "^8.2.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
+		"@types/prompts": "^2.4.4",
 		"@types/semver": "^7.3.10",
 		"@types/semver-utils": "^1.1.1",
 		"@types/sort-json": "^2.0.1",

--- a/build-tools/packages/build-cli/src/commands/generate/changeset.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changeset.ts
@@ -223,7 +223,7 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 				onState: (state: any) => {
 					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 					if (state.aborted) {
-						process.nextTick(() => this.exit(1));
+						process.nextTick(() => this.exit(0));
 					}
 				},
 			} as any, // Typed as any because the typings don't include the optionsPerPage property.
@@ -234,7 +234,7 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 				onState: (state: any) => {
 					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 					if (state.aborted) {
-						process.nextTick(() => this.exit(1));
+						process.nextTick(() => this.exit(0));
 					}
 				},
 			},
@@ -245,7 +245,7 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 				onState: (state: any) => {
 					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 					if (state.aborted) {
-						process.nextTick(() => this.exit(1));
+						process.nextTick(() => this.exit(0));
 					}
 				},
 			},

--- a/build-tools/packages/build-cli/src/commands/generate/changeset.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changeset.ts
@@ -9,6 +9,7 @@ import chalk from "chalk";
 import humanId from "human-id";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+import { format as prettier } from "prettier";
 import prompts from "prompts";
 
 import { BaseCommand } from "../../base";
@@ -100,7 +101,6 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 		const { all, branch, empty, uiMode } = this.flags;
 
 		if (empty) {
-			// TODO: This only works for the root release group (client). Is that OK?
 			const emptyFile = await createChangesetFile(context.gitRepo.resolvedRoot, new Map());
 			// eslint-disable-next-line @typescript-eslint/no-shadow
 			const changesetPath = path.relative(context.gitRepo.resolvedRoot, emptyFile);
@@ -184,7 +184,7 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 			}
 			const changed = changedPackages.some((cp) => cp.name === pkg.name);
 			choices.push({
-				title: changed ? `${pkg.nameColored} ${chalk.red.bold("(changed)")}` : pkg.name,
+				title: changed ? `${pkg.name} ${chalk.red.bold("(changed)")}` : pkg.name,
 				value: pkg,
 				selected: changed,
 			});
@@ -211,27 +211,54 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 			}
 		}
 
-		const response = await prompts({
-			choices: [...choices, { title: " ", heading: true, disabled: true }],
-			instructions: INSTRUCTIONS,
-			message: "Choose which packages to include in the changeset. Type to filter the list.",
-			name: "selectedPackages",
-			optionsPerPage: 5,
-			type: uiMode === "default" ? "autocompleteMultiselect" : "multiselect",
-			onState: (state: any) => {
-				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-				if (state.aborted) {
-					process.nextTick(() => this.exit(1));
-				}
+		const questions: prompts.PromptObject[] = [
+			{
+				name: "selectedPackages",
+				type: uiMode === "default" ? "autocompleteMultiselect" : "multiselect",
+				choices: [...choices, { title: " ", heading: true, disabled: true }],
+				instructions: INSTRUCTIONS,
+				message:
+					"Choose which packages to include in the changeset. Type to filter the list.",
+				optionsPerPage: 5,
+				onState: (state: any) => {
+					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+					if (state.aborted) {
+						process.nextTick(() => this.exit(1));
+					}
+				},
+			} as any, // Typed as any because the typings don't include the optionsPerPage property.
+			{
+				name: "summary",
+				type: "text",
+				message: "Enter a summary of the change.",
+				onState: (state: any) => {
+					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+					if (state.aborted) {
+						process.nextTick(() => this.exit(1));
+					}
+				},
 			},
-		});
+			{
+				name: "description",
+				type: "text",
+				message: "Enter a longer description of the change.",
+				onState: (state: any) => {
+					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+					if (state.aborted) {
+						process.nextTick(() => this.exit(1));
+					}
+				},
+			},
+		];
 
+		const response = await prompts(questions);
 		const selectedPackages: Package[] = response.selectedPackages;
 		const bumpType = getDefaultBumpTypeForBranch(branch) ?? "minor";
 
 		const newFile = await createChangesetFile(
 			context.gitRepo.resolvedRoot,
 			new Map(selectedPackages.map((p) => [p, bumpType])),
+			`${response.summary.trim()}\n\n${response.description}`,
 		);
 		const changesetPath = path.relative(context.gitRepo.resolvedRoot, newFile);
 		this.logHr();
@@ -252,7 +279,10 @@ async function createChangesetFile(
 	const changesetID = humanId({ separator: "-", capitalize: false });
 	const changesetPath = path.join(rootPath, ".changeset", `${changesetID}.md`);
 	const changesetContent = await createChangesetContent(packages, body);
-	await writeFile(changesetPath, changesetContent);
+	await writeFile(
+		changesetPath,
+		prettier(changesetContent, { proseWrap: "never", parser: "markdown" }),
+	);
 	return changesetPath;
 }
 
@@ -264,7 +294,7 @@ async function createChangesetContent(
 	for (const [pkg, bump] of packages.entries()) {
 		lines.push(`"${pkg.name}": ${bump}`);
 	}
-	lines.push("---");
+	lines.push("---", "\n");
 	const frontMatter = lines.join("\n");
 	const changesetContents = [frontMatter, body].join("\n");
 	return changesetContents;

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       '@types/node':
         specifier: ^14.18.38
         version: 14.18.38
+      '@types/prompts':
+        specifier: ^2.4.4
+        version: 2.4.4
       '@types/semver':
         specifier: ^7.3.10
         version: 7.3.12
@@ -3368,6 +3371,13 @@ packages:
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: true
+
+  /@types/prompts@2.4.4:
+    resolution: {integrity: sha512-p5N9uoTH76lLvSAaYSZtBCdEXzpOOufsRjnhjVSrZGXikVGHX9+cc9ERtHRV4hvBKHyZb1bg4K+56Bd2TqUn4A==}
+    dependencies:
+      '@types/node': 14.18.38
+      kleur: 3.0.3
     dev: true
 
   /@types/responselike@1.0.0:
@@ -8181,6 +8191,11 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
     dev: true
 
   /kleur@4.1.5:

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ~2.6.2
         version: 2.6.2
       prompts:
-        specifier: npm:prompts-ncu@^3.0.0
-        version: /prompts-ncu@3.0.0
+        specifier: ^2.4.2
+        version: 2.4.2
       read-pkg-up:
         specifier: ^7.0.1
         version: 7.0.1
@@ -8196,7 +8196,6 @@ packages:
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: true
 
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -10076,11 +10075,11 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /prompts-ncu@3.0.0:
-    resolution: {integrity: sha512-qyz9UxZ5MlPKWVhWrCmSZ1ahm2GVYdjLb8og2sg0IPth1KRuhcggHGuijz0e41dkx35p1t1q3GRISGH7QGALFA==}
-    engines: {node: '>= 14'}
+  /prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
     dependencies:
-      kleur: 4.1.5
+      kleur: 3.0.3
       sisteransi: 1.0.5
     dev: false
 


### PR DESCRIPTION
The custom changeset CLI does not support entering the description of the changeset. This PR enables that by prompting the user to enter a summary and description of the change.