### PR TITLE
Move qualifiedTitle to Configuration.ts, export qualifiedTitle and runBenchmark from tools/benchmark/index

### DIFF
--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -418,7 +418,7 @@ export function benchmarkArgumentsIsCustom(
 /**
  * Tags and formats the provided Title from the supplied BenchmarkDescription to create a
  * tagged and formatted Title for the Reporter.
- * 
+ *
  * @param args - see {@link BenchmarkDescription} and {@link Titled}
  * @returns - a formatted tagged title from the supplied BenchmarkDescription
  */

--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -416,6 +416,24 @@ export function benchmarkArgumentsIsCustom(
 }
 
 /**
+ * Tags and formats the provided Title from the supplied BenchmarkDescription to create a
+ * tagged and formatted Title for the Reporter.
+ * 
+ * @param args - see {@link BenchmarkDescription} and {@link Titled}
+ * @returns - a formatted tagged title from the supplied BenchmarkDescription
+ */
+export function qualifiedTitle(args: BenchmarkDescription & Titled): string {
+	const benchmarkTypeTag = BenchmarkType[args.type ?? BenchmarkType.Measurement];
+	const testTypeTag = TestType[TestType.ExecutionTime];
+	let qualifiedTitle = `${performanceTestSuiteTag} @${benchmarkTypeTag} @${testTypeTag} ${args.title}`;
+
+	if (args.category !== "") {
+		qualifiedTitle = `${qualifiedTitle} ${userCategoriesSplitter} @${args.category}`;
+	}
+	return qualifiedTitle;
+}
+
+/**
  * Determines if we are in a mode where we actually want to run benchmarks and output data.
  *
  * When not in performanceTestingMode, performance tests should be run as correctness tests, and should be

--- a/tools/benchmark/src/ReporterUtilities.ts
+++ b/tools/benchmark/src/ReporterUtilities.ts
@@ -5,6 +5,10 @@
 
 import { assert } from "chai";
 import {
+	BenchmarkDescription,
+	BenchmarkType,
+	TestType,
+	Titled,
 	benchmarkTypes,
 	performanceTestSuiteTag,
 	testTypes,
@@ -38,6 +42,24 @@ export function getName(name: string): string {
 		s = s.slice(0, indexOfSplitter);
 	}
 	return s.trim();
+}
+
+/**
+ * Tags and formats the provided Title from the supplied BenchmarkDescription to create a
+ * tagged and formatted Title for the Reporter.
+ * 
+ * @param args - see {@link BenchmarkDescription} and {@link Titled}
+ * @returns - a formatted tagged title from the supplied BenchmarkDescription
+ */
+export function qualifiedTitle(args: BenchmarkDescription & Titled): string {
+	const benchmarkTypeTag = BenchmarkType[args.type ?? BenchmarkType.Measurement];
+	const testTypeTag = TestType[TestType.ExecutionTime];
+	let qualifiedTitle = `${performanceTestSuiteTag} @${benchmarkTypeTag} @${testTypeTag} ${args.title}`;
+
+	if (args.category !== "") {
+		qualifiedTitle = `${qualifiedTitle} ${userCategoriesSplitter} @${args.category}`;
+	}
+	return qualifiedTitle;
 }
 
 /**

--- a/tools/benchmark/src/ReporterUtilities.ts
+++ b/tools/benchmark/src/ReporterUtilities.ts
@@ -5,10 +5,6 @@
 
 import { assert } from "chai";
 import {
-	BenchmarkDescription,
-	BenchmarkType,
-	TestType,
-	Titled,
 	benchmarkTypes,
 	performanceTestSuiteTag,
 	testTypes,
@@ -42,24 +38,6 @@ export function getName(name: string): string {
 		s = s.slice(0, indexOfSplitter);
 	}
 	return s.trim();
-}
-
-/**
- * Tags and formats the provided Title from the supplied BenchmarkDescription to create a
- * tagged and formatted Title for the Reporter.
- * 
- * @param args - see {@link BenchmarkDescription} and {@link Titled}
- * @returns - a formatted tagged title from the supplied BenchmarkDescription
- */
-export function qualifiedTitle(args: BenchmarkDescription & Titled): string {
-	const benchmarkTypeTag = BenchmarkType[args.type ?? BenchmarkType.Measurement];
-	const testTypeTag = TestType[TestType.ExecutionTime];
-	let qualifiedTitle = `${performanceTestSuiteTag} @${benchmarkTypeTag} @${testTypeTag} ${args.title}`;
-
-	if (args.category !== "") {
-		qualifiedTitle = `${qualifiedTitle} ${userCategoriesSplitter} @${args.category}`;
-	}
-	return qualifiedTitle;
 }
 
 /**

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -47,6 +47,6 @@ export {
 	BenchmarkResult,
 	isResultError,
 	Phase,
-	runBenchmark
+	runBenchmark,
 } from "./runBenchmark";
 export { Timer } from "./timer";

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -26,6 +26,7 @@ export {
 	HookArguments,
 	isInPerformanceTestingMode,
 	validateBenchmarkArguments,
+	qualifiedTitle,
 	Titled,
 	BenchmarkTimingOptions,
 	BenchmarkRunningOptions,
@@ -38,7 +39,7 @@ export {
 	CustomBenchmarkArguments,
 } from "./Configuration";
 export { benchmark, benchmarkMemory, IMemoryTestObject, MemoryTestObjectProps } from "./mocha";
-export { prettyNumber, geometricMean, qualifiedTitle, Stats } from "./ReporterUtilities";
+export { prettyNumber, geometricMean, Stats } from "./ReporterUtilities";
 export { BenchmarkReporter } from "./Reporter";
 export {
 	BenchmarkData,

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -38,7 +38,7 @@ export {
 	CustomBenchmarkArguments,
 } from "./Configuration";
 export { benchmark, benchmarkMemory, IMemoryTestObject, MemoryTestObjectProps } from "./mocha";
-export { prettyNumber, geometricMean, Stats } from "./ReporterUtilities";
+export { prettyNumber, geometricMean, qualifiedTitle, Stats } from "./ReporterUtilities";
 export { BenchmarkReporter } from "./Reporter";
 export {
 	BenchmarkData,
@@ -46,5 +46,6 @@ export {
 	BenchmarkResult,
 	isResultError,
 	Phase,
+	runBenchmark
 } from "./runBenchmark";
 export { Timer } from "./timer";

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -6,29 +6,14 @@
 import { assert } from "chai";
 import { Test } from "mocha";
 import {
-	BenchmarkType,
 	BenchmarkArguments,
 	isParentProcess,
 	isInPerformanceTestingMode,
-	performanceTestSuiteTag,
-	userCategoriesSplitter,
-	TestType,
 	Titled,
 	MochaExclusiveOptions,
-	BenchmarkDescription,
 } from "../Configuration";
 import { BenchmarkResult, Phase, runBenchmark } from "../runBenchmark";
-
-export function qualifiedTitle(args: BenchmarkDescription & Titled): string {
-	const benchmarkTypeTag = BenchmarkType[args.type ?? BenchmarkType.Measurement];
-	const testTypeTag = TestType[TestType.ExecutionTime];
-	let qualifiedTitle = `${performanceTestSuiteTag} @${benchmarkTypeTag} @${testTypeTag} ${args.title}`;
-
-	if (args.category !== "") {
-		qualifiedTitle = `${qualifiedTitle} ${userCategoriesSplitter} @${args.category}`;
-	}
-	return qualifiedTitle;
-}
+import { qualifiedTitle } from "../ReporterUtilities";
 
 /**
  * This is wrapper for Mocha's it function that runs a performance benchmark.

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -11,9 +11,9 @@ import {
 	isInPerformanceTestingMode,
 	Titled,
 	MochaExclusiveOptions,
+	qualifiedTitle,
 } from "../Configuration";
 import { BenchmarkResult, Phase, runBenchmark } from "../runBenchmark";
-import { qualifiedTitle } from "../ReporterUtilities";
 
 /**
  * This is wrapper for Mocha's it function that runs a performance benchmark.


### PR DESCRIPTION
Needed to ease external implementations that use fluid-tools/benchmark.