### PR TITLE
docs(devtools-browser-extension): Add note to README about downloading build artifacts from Codespace

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/README.md
+++ b/packages/tools/devtools/devtools-browser-extension/README.md
@@ -18,8 +18,9 @@ To use this extension in your browser:
 1. Build this package and its dependencies.
    Your extension files should be generated under the build output directory (`dist/bundle`) in this package.
 2. Load the unpacked extension in the browser by following [these instructions](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).
-   For [WSL](https://learn.microsoft.com/en-us/windows/wsl/about) users, your Linux files should be at a \\wsl$ path.
-   In File Explorer or any other Windows application that can browse files, navigate to the path: \\wsl$.
+    - For [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/about) users, your Linux files should be at a \\wsl$ path.
+      In File Explorer or any other Windows application that can browse files, navigate to the path: \\wsl$.
+    - If you are working in a [Codespace](https://code.visualstudio.com/docs/remote/codespaces) with Visual Studio Code, you can download the build artifacts by right-clicking on `dist/bundle` in the `Explorer` view and clicking `download`. This will download the files to your local machine, which you can upload to the browser.
 
 ## Devtools Extensions
 


### PR DESCRIPTION
Discovered this option recently and figured it would be useful for folks working on the extension to be aware of.