### PR TITLE
fix(tree): Make the source RepairDataStoreProvider optional for peer branches

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -413,7 +413,10 @@ export class EditManager<
 	 * local's after a summary load.
 	 */
 	public afterSummaryLoad(): void {
-		assert(this.localBranch.repairDataStoreProvider !== undefined, "Local branch must maintain repair data");
+		assert(
+			this.localBranch.repairDataStoreProvider !== undefined,
+			"Local branch must maintain repair data",
+		);
 		this.trunk.repairDataStoreProvider = this.localBranch.repairDataStoreProvider.clone();
 	}
 

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -253,7 +253,9 @@ export class EditManager<
 				for (const [sessionId, branch] of this.peerLocalBranches) {
 					const [rebasedBranch] = rebaseBranch(
 						this.changeFamily.rebaser,
-						this.localBranch.repairDataStoreProvider,
+						// Peer branches do not need to track repair data, so passing undefined will skip the repair data update process
+						// TODO:#4593: Add test to ensure that peer branches don't pass in incorrect repairDataStoreProviders when rebasing
+						undefined,
 						branch,
 						newTrunkTail,
 						this.trunk.getHead(),
@@ -411,6 +413,7 @@ export class EditManager<
 	 * local's after a summary load.
 	 */
 	public afterSummaryLoad(): void {
+		assert(this.localBranch.repairDataStoreProvider !== undefined, "Local branch must maintain repair data");
 		this.trunk.repairDataStoreProvider = this.localBranch.repairDataStoreProvider.clone();
 	}
 
@@ -447,7 +450,9 @@ export class EditManager<
 		// This will be a no-op if the sending client has not advanced since the last time we received an edit from it
 		const [rebasedBranch] = rebaseBranch(
 			this.changeFamily.rebaser,
-			this.localBranch.repairDataStoreProvider,
+			// Peer branches do not need to track repair data, so passing undefined will skip the repair data update process
+			// TODO:#4593: Add test to ensure that peer branches don't pass in incorrect repairDataStoreProviders when rebasing
+			undefined,
 			getOrCreate(this.peerLocalBranches, newCommit.sessionId, () => baseRevisionInTrunk),
 			baseRevisionInTrunk,
 			this.trunk.getHead(),
@@ -502,7 +507,7 @@ export class EditManager<
 
 			this.trunkUndoRedoManager.trackCommit(trunkHead, type);
 		}
-		this.trunk.repairDataStoreProvider.applyChange(commit.change);
+		this.trunk.repairDataStoreProvider?.applyChange(commit.change);
 		this.sequenceMap.set(sequenceNumber, trunkHead);
 		this.trunkMetadata.set(trunkHead.revision, { sequenceNumber, sessionId: commit.sessionId });
 		this.events.emit("newTrunkHead", trunkHead);

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -347,6 +347,8 @@ describe("EditManager", () => {
 				manager.addSequencedChange(peerCommit(peer1, [1, 2, 3], 4), brand(4), brand(3));
 				checkChangeList(manager, [3, 4]);
 			});
+
+			// TODO:#4593: Add test to ensure that peer branches don't pass in incorrect repairDataStoreProviders when rebasing
 		});
 
 		it("Rebases anchors over local changes", () => {


### PR DESCRIPTION
The edit manager was previously passing in the local branch's `repairDataStoreProvider` when rebasing peer branches. This would have caused a crash due to `applyDelta` possibly applying invalid changes. There is currently no easy way to write a regression test for this so an item has been filed to write it once peer branches are represented as actual branches.