### PR TITLE
docs(tree): Replace usages of the term checkout with view

### DIFF
--- a/experimental/dds/tree2/README.md
+++ b/experimental/dds/tree2/README.md
@@ -34,7 +34,7 @@ The current feature focus is on:
     -   Transactionality.
     -   Support schema in a semantically robust way.
 -   Scalability:
-    -   Support for partial checkouts: allow efficiently viewing and editing parts of larger datasets without downloading the whole thing.
+    -   Support for partial views: allow efficiently viewing and editing parts of larger datasets without downloading the whole thing.
     -   Ability to easily (sharing code with client) spin up optional services to improve scalability further (ex: server side summaries, indexing, permissions etc.)
     -   Efficient data encodings.
 -   Expressiveness:
@@ -53,7 +53,7 @@ The current feature focus is on:
 `directory` and `map` can not provide merge resolution that guarantees well-formedness of trees while supporting the desired editing APIs (like subsequence move),
 and are missing (and cannot be practically extended to have) efficient ways to handle large data or schema.
 
-`sequence` does not capture the hierarchy or schema, and also does not handle partial checkouts.
+`sequence` does not capture the hierarchy or schema, and also does not handle partial views.
 Additionally its actual merge resolution leaves some things to be desired in some cases which `tree` aims to improve on.
 
 `experimental/tree` does not have a built in schema system reducing the data available to make semantically high quality merges.
@@ -71,7 +71,7 @@ For example, moving part of a sequence from one sequence DDS to another cannot b
 Cross DDS moves also currently can't be as efficient as moves withing a single DDS, and there isn't a good way to do cross DDS history or branching without major framework changes.
 There are also some significant per DDS performance and storage costs that make this approach much more costly than using a single DDS.
 
-One way to think about this new tree DDS is to try and mix some of the Fluid-Framework features (like the ability to checkout a subset of the data) with features from DDSes (ex: lower overhead per item, efficient moves of sub-sequences, transactions).
+One way to think about this new tree DDS is to try and mix some of the Fluid-Framework features (like the ability to view a subset of the data) with features from DDSes (ex: lower overhead per item, efficient moves of sub-sequences, transactions).
 If this effort is successful, it might reveal some improved abstractions for modularizing hierarchical collaborative data-structures (perhaps "field kinds"),
 which could make their way back into the framework, enabling some features specific to this tree (ex: history, branching, transactional moves, reduced overhead) to be framework features instead.
 
@@ -115,11 +115,11 @@ graph TD;
         shared-tree-core-."reads".->doc
         shared-tree-core-->EditManager-->X["collab window & branches"]
         shared-tree-core-->Indexes-->ForestIndex
-        shared-tree-->checkout["default checkout"]
-        transaction-."updates".->checkout
+        shared-tree-->view["default view"]
+        transaction-."updates".->view
         transaction-->EditBuilder
-        checkout-."reads".->ForestIndex
-        checkout-->transaction
+        view-."reads".->ForestIndex
+        view-->transaction
     end
 ```
 
@@ -131,8 +131,8 @@ The tree DDS itself, or more specifically [`shared-tree-core`](./src/shared-tree
 
 See [indexes and branches](./docs/indexes%20and%20branches.md) for details on how this works with branches.
 
-When applications want access to the `tree`'s data, they do so through a [`checkout`](./src/core/checkout/README.md) which abstracts the indexes into nice application facing APIs.
-Checkouts may also have state from the application, including:
+When applications want access to the `tree`'s data, they do so through a [`SharedTreeView`](./src/shared-tree/sharedTreeView.ts) which abstracts the indexes into nice application facing APIs.
+Views may also have state from the application, including:
 
 -   [`view-schema`](./src/core/schema-view/README.md)
 -   adapters for out-of-schema data
@@ -140,11 +140,11 @@ Checkouts may also have state from the application, including:
 -   pending transactions
 -   registrations for application callbacks / events.
 
-[`shared-tree`](./src/shared-tree/) provides a default checkout which it owns, but applications can create more if desired, which they will own.
-Since checkouts subscribe to events from `shared-tree`, explicitly disposing any additionally created ones of is required to avoid leaks.
+[`shared-tree`](./src/shared-tree/) provides a default view which it owns, but applications can create more if desired, which they will own.
+Since views subscribe to events from `shared-tree`, explicitly disposing any additionally created ones of is required to avoid leaks.
 
-[transactions](./src/core/transaction/README.md) are created from `checkouts` and are currently synchronous.
-Support for asynchronous transactions, with the application managing the lifetime and ensuring it does not exceed the lifetime of the checkout,
+[transactions](./src/core/transaction/README.md) are created from `SharedTreeView`s and are currently synchronous.
+Support for asynchronous transactions, with the application managing the lifetime and ensuring it does not exceed the lifetime of the view,
 could be added in the future.
 
 ### Data Flow
@@ -157,15 +157,15 @@ flowchart LR;
     subgraph "@fluid-experimental/tree2"
         shared-tree--"configures"-->shared-tree-core
         shared-tree-core--"Summary"-->Indexes--"Summary"-->ForestIndex;
-        ForestIndex--"Exposed by"-->checkout
+        ForestIndex--"Exposed by"-->SharedTreeView
     end
-    checkout--"viewed by"-->app
+    SharedTreeView--"viewed by"-->app
 ```
 
 [`shared-tree`](./src/shared-tree/) configures [`shared-tree-core`](./src/shared-tree-core/README.md) with a set of indexes.
 `shared-tree-core` downloads the summary data from the Fluid Container, feeding the summary data (and any future edits) into the indexes.
-`shared-tree` then constructs the default `checkout`.
-The application using the `shared-tree` can get the checkout from which it can read data (which the checkout internally gets from the indexes).
+`shared-tree` then constructs the default `SharedTreeView`.
+The application using the `shared-tree` can get the view from which it can read data (which the view internally gets from the indexes).
 For any given part of the application this will typically follow one of two patterns:
 
 -   read the tree data as needed to create the view.
@@ -188,7 +188,7 @@ this should usually be easier, but may incur some performance overhead in specif
 When views want to hold onto part of the tree (for the first pattern),
 they do so with "anchors" which have well defined behavior across edits.
 
-TODO: Note that as some point the application will want their [`view-schema`](./src/core/schema-view/README.md) applied to the tree from the checkout.
+TODO: Note that as some point the application will want their [`view-schema`](./src/core/schema-view/README.md) applied to the tree from the view.
 The system for doing this is called "schematize" and is currently not implemented.
 When it is more designed, some details for how it works belong in this section (as well as the section below).
 
@@ -205,7 +205,7 @@ flowchart RL
         transaction--"collects edits in"-->EditBuilder
         EditBuilder--"updates anchors"-->AnchorSet
         EditBuilder--"deltas for edits"-->transaction
-        transaction--"applies deltas to"-->forest["checkout's forest"]
+        transaction--"applies deltas to"-->forest["SharedTreeView's forest"]
     end
     command["App's command callback"]
     command--"Edits"-->transaction
@@ -213,7 +213,7 @@ flowchart RL
 ```
 
 The application can use their view to locate places they want to edit.
-The application passes a "command" to the checkout which create a transaction that runs the command.
+The application passes a "command" to the view which create a transaction that runs the command.
 This "command" can interactively edit the tree.
 Internally the transaction implements these edits by creating changes.
 Each change is processed in two ways:
@@ -223,10 +223,10 @@ Each change is processed in two ways:
 
 Once the command ends, the transaction is rolled back leaving the forest in a clean state.
 Then if the command did not error, a `changeset` is created from the changes applied to the `EditBuilder`, which is encoded into a Fluid Op.
-The checkout then rebases the op if any Ops came in while the transaction was pending (only possible for async transactions or if the checkout was behind due to it being async for some reason).
-Finally the checkout sends the op to `shared-tree-core` which submits it to Fluid.
+The view then rebases the op if any Ops came in while the transaction was pending (only possible for async transactions or if the view was behind due to it being async for some reason).
+Finally the view sends the op to `shared-tree-core` which submits it to Fluid.
 This submission results in the op becoming a local op, which `shared-tree-core` creates a delta for.
-This delta goes to the indexes, resulting in the ForestIndex and thus checkouts getting updated,
+This delta goes to the indexes, resulting in the ForestIndex and thus views getting updated,
 as well as anything else subscribing to deltas.
 
 This shows completion of a transaction.

--- a/experimental/dds/tree2/README.md
+++ b/experimental/dds/tree2/README.md
@@ -131,7 +131,7 @@ The tree DDS itself, or more specifically [`shared-tree-core`](./src/shared-tree
 
 See [indexes and branches](./docs/indexes%20and%20branches.md) for details on how this works with branches.
 
-When applications want access to the `tree`'s data, they do so through a [`SharedTreeView`](./src/shared-tree/sharedTreeView.ts) which abstracts the indexes into nice application facing APIs.
+When applications want access to the `tree`'s data, they do so through an [`ISharedTreeView`](./src/shared-tree/sharedTreeView.ts) which abstracts the indexes into nice application facing APIs.
 Views may also have state from the application, including:
 
 -   [`view-schema`](./src/core/schema-view/README.md)

--- a/experimental/dds/tree2/README.md
+++ b/experimental/dds/tree2/README.md
@@ -157,14 +157,14 @@ flowchart LR;
     subgraph "@fluid-experimental/tree2"
         shared-tree--"configures"-->shared-tree-core
         shared-tree-core--"Summary"-->Indexes--"Summary"-->ForestIndex;
-        ForestIndex--"Exposed by"-->SharedTreeView
+        ForestIndex--"Exposed by"-->ISharedTreeView
     end
-    SharedTreeView--"viewed by"-->app
+    ISharedTreeView--"viewed by"-->app
 ```
 
 [`shared-tree`](./src/shared-tree/) configures [`shared-tree-core`](./src/shared-tree-core/README.md) with a set of indexes.
 `shared-tree-core` downloads the summary data from the Fluid Container, feeding the summary data (and any future edits) into the indexes.
-`shared-tree` then constructs the default `SharedTreeView`.
+`shared-tree` then constructs the default view.
 The application using the `shared-tree` can get the view from which it can read data (which the view internally gets from the indexes).
 For any given part of the application this will typically follow one of two patterns:
 
@@ -205,7 +205,7 @@ flowchart RL
         transaction--"collects edits in"-->EditBuilder
         EditBuilder--"updates anchors"-->AnchorSet
         EditBuilder--"deltas for edits"-->transaction
-        transaction--"applies deltas to"-->forest["SharedTreeView's forest"]
+        transaction--"applies deltas to"-->forest["ISharedTreeView's forest"]
     end
     command["App's command callback"]
     command--"Edits"-->transaction

--- a/experimental/dds/tree2/README.md
+++ b/experimental/dds/tree2/README.md
@@ -115,7 +115,7 @@ graph TD;
         shared-tree-core-."reads".->doc
         shared-tree-core-->EditManager-->X["collab window & branches"]
         shared-tree-core-->Indexes-->ForestIndex
-        shared-tree-->view["default view"]
+        shared-tree-->view["SharedTreeView"]
         transaction-."updates".->view
         transaction-->EditBuilder
         view-."reads".->ForestIndex

--- a/experimental/dds/tree2/README.md
+++ b/experimental/dds/tree2/README.md
@@ -143,7 +143,7 @@ Views may also have state from the application, including:
 [`shared-tree`](./src/shared-tree/) provides a default view which it owns, but applications can create more if desired, which they will own.
 Since views subscribe to events from `shared-tree`, explicitly disposing any additionally created ones of is required to avoid leaks.
 
-[transactions](./src/core/transaction/README.md) are created from `SharedTreeView`s and are currently synchronous.
+[transactions](./src/core/transaction/README.md) are created by `ISharedTreeView`s and are currently synchronous.
 Support for asynchronous transactions, with the application managing the lifetime and ensuring it does not exceed the lifetime of the view,
 could be added in the future.
 

--- a/experimental/dds/tree2/docs/roadmap.md
+++ b/experimental/dds/tree2/docs/roadmap.md
@@ -398,7 +398,7 @@ For exceptionally large documents it is likely that the number of concurrently e
 This means that each client would receive, process, and ignore most edits—resulting in computational waste and bottlenecks.
 
 The [storage performance: incrementality and virtualization](#storage-performance-incrementality-and-virtualization) milestone ensures that document load times and summarization performance (both bandwidth and CPU time) are not limiting factors in these cases.
-This milestone introduces a _partial checkout_: a partial view of the tree registered with the server during document load.
+This milestone introduces a partial view of the tree registered with the server during document load.
 The view (a subset of the tree) is dynamic and can be expanded by navigating the tree.
 The server provides op filtering to ensure that a client only receives the edits that apply to the region of the tree that they are viewing.
 

--- a/experimental/dds/tree2/docs/undo/v1-undo.md
+++ b/experimental/dds/tree2/docs/undo/v1-undo.md
@@ -51,7 +51,7 @@ interface UndoableCommit<TChange> {
 }
 ```
 
-That tree is a sparse copy of the commit tree maintained by `EditManager` and `Checkout`s for branch management.
+That tree is a sparse copy of the commit tree maintained by `EditManager` and `SharedTreeView`s for branch management.
 
 The structure forms a tree as opposed to a linked-list because different local branches can share the same ancestor commits.
 Each branch however only ever sees a single spine of this tree, which therefore looks like a linked-list to said branch.

--- a/experimental/dds/tree2/docs/undo/v1-undo.md
+++ b/experimental/dds/tree2/docs/undo/v1-undo.md
@@ -51,7 +51,7 @@ interface UndoableCommit<TChange> {
 }
 ```
 
-That tree is a sparse copy of the commit tree maintained by `EditManager` and `SharedTreeView`s for branch management.
+That tree is a sparse copy of the commit tree maintained by `EditManager` and each view for branch management.
 
 The structure forms a tree as opposed to a linked-list because different local branches can share the same ancestor commits.
 Each branch however only ever sees a single spine of this tree, which therefore looks like a linked-list to said branch.

--- a/experimental/dds/tree2/src/core/schema-stored/Stored and View Schema Options.md
+++ b/experimental/dds/tree2/src/core/schema-stored/Stored and View Schema Options.md
@@ -117,4 +117,4 @@ and not about how to use those options to actually build a schema system.
 ## Ways to update existing schema:
 
 -   Could support op that changes a schema in a way where all data that was accepted by the old schema is accepted by the new one (ex: add optional fields (if compatible with extra fields), move required field into extraFields, add a type to a field).
--   Could even do things like apply a change to all nodes with a specific type to enable edits which modify a schema and update data atomically (ex: alter table like from sql). This does not work with partial checkouts well.
+-   Could even do things like apply a change to all nodes with a specific type to enable edits which modify a schema and update data atomically (ex: alter table like from sql). This does not work with partial views well.

--- a/experimental/dds/tree2/src/core/tree/visitDelta.ts
+++ b/experimental/dds/tree2/src/core/tree/visitDelta.ts
@@ -50,7 +50,7 @@ import * as Delta from "./delta";
  *
  * Future work:
  *
- * - Allow the visitor to ignore changes to regions of the tree that are not of interest to it (for partial checkouts).
+ * - Allow the visitor to ignore changes to regions of the tree that are not of interest to it (for partial views).
  *
  * - Avoid moving the visitor through parts of the document that do not need changing in the current pass.
  * This could be done by assigning IDs to nodes of interest and asking the visitor to jump to these nodes in order to edit them.

--- a/experimental/dds/tree2/src/feature-libraries/README.md
+++ b/experimental/dds/tree2/src/feature-libraries/README.md
@@ -77,7 +77,7 @@ There are a few different usage patterns for systems with existing data:
 
 ### Misc use-case
 
-Large documents, partial checkout, permissions
+Large documents, partial view, permissions
 
 indexing / external readonly copies: update them from deltas (or maybe from change sets?)
 
@@ -133,7 +133,7 @@ rest: document specific schema perf
 
 cross document schema caching: hash -> rest service
 
-rest: need partial checkout
+rest: need partial view
 
 rest: post vs put. Constraint to prevent concurrent edits. can express cancel of modified. Json patch. Reference identifier to diff against.
 


### PR DESCRIPTION
The checkout concept is implemented in v2 SharedTree as `SharedTreeView` so this removes the possibly misleading usages of the term 'checkout' from the documentation.