### PR TITLE
Fix publish docs and make client pipeline trigger if the `fluidBuild.config.cjs` is changed

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -114,6 +114,7 @@ extends:
     taskBundleAnalysis: true
     taskLint: false
     taskBuildDocs: false
+    publishBuildDocs: true
     taskTest:
     - webpack
     - ci:test:mocha

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -114,7 +114,7 @@ extends:
     taskBundleAnalysis: true
     taskLint: false
     taskBuildDocs: false
-    publishBuildDocs: true
+    publishDocs: true
     taskTest:
     - webpack
     - ci:test:mocha

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -88,6 +88,7 @@ pr:
     - package.json
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
+    - fluidBuild.config.cjs
     - tools/pipelines/build-client.yml
     - tools/pipelines/build-azure.yml
     - tools/pipelines/templates/build-npm-package.yml

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -555,7 +555,7 @@ stages:
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run ci:build:docs'
 
-        - ${{ if or(ne(parameters.publishDocs, false), ne(parameters.taskBuildDocs, false)) }}:
+        - ${{ if or(eq(parameters.publishDocs, true), eq(parameters.taskBuildDocs, true)) }}:
           - task: PublishPipelineArtifact@1
             displayName: Publish Artifact - _api-extractor-temp
             inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -15,6 +15,10 @@ parameters:
   type: boolean
   default: true
 
+- name: publishDocs
+  type: boolean
+  default: false
+
 - name: taskLint
   type: boolean
   default: true
@@ -178,6 +182,7 @@ stages:
                 LintName: ${{ parameters.taskLintName }}
                 Test=${{ convertToJson(parameters.taskTest) }}
                 BuildDoc=${{ parameters.taskBuildDocs }}
+                PublishDocs=${{ parameters.publishDocs }}
                 TestCoverage=$(testCoverage)
 
               Variables:
@@ -550,6 +555,7 @@ stages:
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run ci:build:docs'
 
+        - ${{ if or(ne(parameters.publishDocs, false), ne(parameters.taskBuildDocs, false)) }}:
           - task: PublishPipelineArtifact@1
             displayName: Publish Artifact - _api-extractor-temp
             inputs:


### PR DESCRIPTION
- Client pipeline will build the docs along with the build steps, need to add a separate flag to publish them.
- Make client pipeline trigger if the `fluidBuild.config.cjs` is changed