### PR TITLE
Turn on `fluid-build`'s worker mode in '*:fast' scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"build": "npm run policy-check && npm run layer-check && fluid-build --task build",
 		"build:compile": "fluid-build --task compile",
 		"build:docs": "fluid-build --task build:docs",
-		"build:fast": "fluid-build --task build",
+		"build:fast": "fluid-build --task build --worker",
 		"build:full": "fluid-build --task full",
 		"build:full:compile": "fluid-build --task compile --task webpack",
 		"build:gendocs": "copyfiles server/routerlicious/_api-extractor-temp/** ./_api-extractor-temp/doc-models/ -f -V && cd docs && npm run build",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"test:realsvc": "pnpm run -r --no-sort --stream --no-bail test:realsvc",
 		"test:stress": "pnpm run -r --no-sort --stream --no-bail test:stress",
 		"tsc": "fluid-build --root . --task tsc",
-		"tsc:fast": "fluid-build --root . --task tsc",
+		"tsc:fast": "fluid-build --root . --task tsc --worker",
 		"typetests:gen": "pnpm -r typetests:gen",
 		"typetests:prepare": "flub typetests -g client --reset --previous --normalize",
 		"watch": "concurrently \"npm run watch:tsc\" \"npm run watch:esnext\" \"npm run watch:webpack\"",


### PR DESCRIPTION
Worker mode in `fluid-build` will create worker process and execute some of the build task there, instead of invoking a new process every time, speeding up build time.  Currently, only `tsc` and `eslint` is integrated.

Build speed for `--task build` goes from ~7 minutes to ~5 minutes (~30% improvement)

Note that because there are some data can be shared across different invocation, the work task can consume quite a bit of memory. So expose it experimentally thru the '*:fast' scripts to see if that is a problem and root out any other problems.

