### PR TITLE
add build alias for back compat

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -52,6 +52,20 @@ module.exports = {
 		"webpack": ["^tsc", "^build:esnext"],
 		"webpack:profile": ["^tsc", "^build:esnext"],
 		"clean": [],
+
+		// alias for back compat
+		"build:full": {
+			dependsOn: ["full"],
+			script: false,
+		},
+		"build:compile": {
+			dependsOn: ["compile"],
+			script: false,
+		},
+		"build:commonjs": {
+			dependsOn: ["commonjs"],
+			script: false,
+		},
 	},
 	// This defines the layout of the repo for fluid-build. It applies to the whole repo.
 	repoPackages: {


### PR DESCRIPTION
There are some 'build:*' script name that people are used to.  Added that for now for usage back compat.
Will assess whether we want to deprecate them.