### PR TITLE
Delete tests which are both redundant and skipped

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -200,6 +200,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		});
 	};
 
+	// If these tests start failing due to "runtime is closed" errors try first adjusting `sweepTimeoutMs` above
 	describe("Using tombstone data stores not allowed (per config)", () => {
 		beforeEach(() => {
 			// Allow Loading but not Usage
@@ -207,7 +208,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
 		});
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
 			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
@@ -237,28 +237,22 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
 			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
 			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+				const { unreferencedId, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 
 				// The datastore should be tombstoned now
 				const { summaryVersion } = await summarize(summarizer);
+
 				const dataObject = await getTombstonedDataObjectFromSummary(
 					summaryVersion,
 					unreferencedId,
 				);
 
-				// Sending an op from a datastore substantiated from the request pattern should fail!
+				// Modifying a testDataObject substantiated from the request pattern should fail!
 				assert.throws(
 					() => dataObject._root.set("send", "op"),
 					(error) => {
@@ -272,7 +266,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Receive ops fails for tombstoned datastores in summarizing container loaded after sweep time",
 			[
@@ -327,7 +320,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
 			[
@@ -348,23 +340,18 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				},
 			],
 			async () => {
-				const { unreferencedId, summarizingContainer, summarizer, summaryVersion } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
+				const { unreferencedId, summarizer, summaryVersion, summarizingContainer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-				const sendingContainer = await loadContainer(summaryVersion);
+				const container = await loadContainer(summaryVersion);
 				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-				// production application. Causes an inactiveObject loaded error
-				const dataObject = await requestFluidObject<ITestDataObject>(
-					sendingContainer,
+				// production application
+				// This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+				// ready was set
+				const senderObject = await requestFluidObject<ITestDataObject>(
+					container,
 					unreferencedId,
 				);
-
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
 				// The datastore should be tombstoned now
 				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
@@ -375,14 +362,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
 				setupContainerCloseErrorValidation(receivingContainer, "process");
 
-				// Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep
-				// ready errors as it closes before the op is processed and the datastore is realized
-				dataObject._root.set("send an op to be received", "op");
+				// Receive an op - both the summarizer and the receiving client log a process error, only the receiving
+				// client closes
+				senderObject._root.set("send an op to be received", "op");
 				await provider.ensureSynchronized();
-				assert(
-					receivingContainer.closed === true,
-					`Container receiving messages to a tombstoned datastore should close.`,
-				);
+				assert(receivingContainer.closed === true, `Reading container should close.`);
 				assert(
 					summarizingContainer.closed !== true,
 					`Summarizing container should not close.`,
@@ -390,7 +374,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
 			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
@@ -419,7 +402,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
 			[
@@ -476,6 +458,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		);
 	});
 
+	// If these tests start failing due to "runtime is closed" errors try first adjusting `sweepTimeoutMs` above
 	describe("Loading tombstone data stores not allowed (per config)", () => {
 		const expectedHeadersLogged = {
 			request: "{}",
@@ -501,7 +484,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			return container.request(request);
 		}
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Requesting tombstoned datastores fails in interactive client loaded after sweep timeout",
 			[
@@ -587,7 +569,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Requesting tombstoned datastores succeeds for legacy document given gcTombtoneGeneration option is defined",
 			[
@@ -628,7 +609,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Requesting tombstoned datastores succeeds with when gcTombtoneGeneration differs from persisted value",
 			[
@@ -677,7 +657,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
 			[
@@ -762,7 +741,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		);
 
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Can un-tombstone datastores by storing a handle",
 			[


### PR DESCRIPTION
## Description

These tests are each part of a pair of tests which are identical except for whether the sweep timeout expires before or after load.  I skipped these tests months ago because they're redundant. SweepReady calculation/timers has coverage elsewhere, so this test file can focus only on the mechanics of Tombstone, regardless of when the Sweep timeout expires.