### PR TITLE
Log connectionId with clientId on connection attempt

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -230,7 +230,6 @@ export class DocumentDeltaConnection
 		assert(!this.disposed, 0x20c /* "connection disposed" */);
 	}
 
-
 	/**
 	 * Get messages sent during the connection
 	 *

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -230,6 +230,7 @@ export class DocumentDeltaConnection
 		assert(!this.disposed, 0x20c /* "connection disposed" */);
 	}
 
+
 	/**
 	 * Get messages sent during the connection
 	 *

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -83,15 +83,10 @@ export class DocumentDeltaConnection
 	}
 
 	public get disposed() {
-		try {
-			assert(
-				this._disposed || this.socket.connected,
-				0x244 /* "Socket is closed, but connection is not!" */,
-			);
-		} catch (error) {
-			const normalizedError = this.addPropsToError(error);
-			throw normalizedError;
-		}
+		assert(
+			this._disposed || this.socket.connected,
+			0x244 /* "Socket is closed, but connection is not!" */,
+		);
 		return this._disposed;
 	}
 
@@ -232,12 +227,7 @@ export class DocumentDeltaConnection
 	}
 
 	private checkNotDisposed() {
-		try {
-			assert(!this.disposed, 0x20c /* "connection disposed" */);
-		} catch (error) {
-			const normalizedError = this.addPropsToError(error);
-			throw normalizedError;
-		}
+		assert(!this.disposed, 0x20c /* "connection disposed" */);
 	}
 
 	/**

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -83,11 +83,7 @@ export class DocumentDeltaConnection
 	}
 
 	public get disposed() {
-		// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
-		// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
-		const originalStackTraceLimit = (Error as any).stackTraceLimit;
 		try {
-			(Error as any).stackTraceLimit = 50;
 			assert(
 				this._disposed || this.socket.connected,
 				0x244 /* "Socket is closed, but connection is not!" */,
@@ -95,8 +91,6 @@ export class DocumentDeltaConnection
 		} catch (error) {
 			const normalizedError = this.addPropsToError(error);
 			throw normalizedError;
-		} finally {
-			(Error as any).stackTraceLimit = originalStackTraceLimit;
 		}
 		return this._disposed;
 	}
@@ -136,6 +130,7 @@ export class DocumentDeltaConnection
 		protected readonly connectionId?: string,
 	) {
 		super((name, error) => {
+			this.addPropsToError(error);
 			logger.sendErrorEvent(
 				{
 					eventName: "DeltaConnection:EventException",
@@ -237,17 +232,11 @@ export class DocumentDeltaConnection
 	}
 
 	private checkNotDisposed() {
-		// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
-		// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
-		const originalStackTraceLimit = (Error as any).stackTraceLimit;
 		try {
-			(Error as any).stackTraceLimit = 50;
 			assert(!this.disposed, 0x20c /* "connection disposed" */);
 		} catch (error) {
 			const normalizedError = this.addPropsToError(error);
 			throw normalizedError;
-		} finally {
-			(Error as any).stackTraceLimit = originalStackTraceLimit;
 		}
 	}
 
@@ -342,17 +331,6 @@ export class DocumentDeltaConnection
 	private closeSocket(error: IAnyDriverError) {
 		if (this._disposed) {
 			// This would be rare situation due to complexity around socket emitting events.
-			this.logger.sendTelemetryEvent(
-				{
-					eventName: "SocketCloseOnDisposedConnection",
-					driverVersion,
-					details: JSON.stringify({
-						...this.getConnectionDetailsProps(),
-						trackedListenerCount: this.trackedListeners.size,
-					}),
-				},
-				error,
-			);
 			return;
 		}
 		this.closeSocketCore(error);
@@ -410,17 +388,6 @@ export class DocumentDeltaConnection
 
 		// Let user of connection object know about disconnect.
 		this.emit("disconnect", err);
-		this.logger.sendTelemetryEvent(
-			{
-				eventName: "AfterDisconnectEvent",
-				driverVersion,
-				details: JSON.stringify({
-					...this.getConnectionDetailsProps(),
-					disconnectListenerCount: this.listenerCount("disconnect"),
-				}),
-			},
-			err,
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Description

1.) Use nonce as connectioId to log on connection attempts. 
2.) Log connectionId with clientId on connection attempt so that it can be related to future events for a connection.
3.) Remove some extra telemetry events around connection.