### PR TITLE
hot-fix(dev-tools): Display disconnected when container is not attached

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -275,6 +275,13 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 		statusComponents.push(containerState.attachState);
 		if (containerState.attachState === AttachState.Attached) {
 			statusComponents.push(connectionStateToString(containerState.connectionState));
+		} else {
+			/*
+			 * If the container is not attached, it is not connected
+			 * TODO: If the container is detached, it is advisable to disable the action buttons
+			 * since Fluid will consistently fail to establish a connection with a detached container.
+			 */
+			statusComponents.push(connectionStateToString(ConnectionState.Disconnected));
 		}
 	}
 


### PR DESCRIPTION
## Description

The idea was to make the second box disappear entirely if the container is detached. Restore the "Disconnected" text for now as a quick fix.

## Sample
<img width="1138" alt="Screenshot 2023-06-07 173954" src="https://github.com/microsoft/FluidFramework/assets/114451900/06e571d6-59b6-4d19-9ae3-c7c02b481a19">

