### PR TITLE
fix: Remove unused import to fix build

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -8,7 +8,6 @@ import {
 	AllowTombstoneRequestHeaderKey,
 	ContainerRuntime,
 	ISummarizer,
-	RuntimeHeaders,
 	TombstoneResponseHeaderKey,
 } from "@fluidframework/container-runtime";
 import { requestFluidObject } from "@fluidframework/runtime-utils";


### PR DESCRIPTION
## Description

We missed removing an unused import in https://github.com/microsoft/FluidFramework/pull/15900, this removes it to fix the build.
