### PR TITLE
ci: Pin version downloaded by npx lerna

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -290,7 +290,7 @@ stages:
           displayName: Pack
           inputs:
             action: 'Run a Docker command'
-            customCommand: 'run -v $(System.DefaultWorkingDirectory)/pack/scoped:/usr/src/pack -t $(baseContainerTag) npx lerna exec --no-private -- mv `npm pack` /usr/src/pack'
+            customCommand: 'run -v $(System.DefaultWorkingDirectory)/pack/scoped:/usr/src/pack -t $(baseContainerTag) npx lerna@5.6.2 exec --no-private -- mv `npm pack` /usr/src/pack'
 
         - task: PublishPipelineArtifact@1
           displayName: Publish Artifact - pack

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -400,13 +400,13 @@ stages:
                   mkdir $(Build.ArtifactStagingDirectory)/pack/non-scoped/
                 fi
                 if [ -f "lerna.json" ]; then
-                  npx lerna exec --no-private --no-sort -- ${{ parameters.packageManager }} pack && \
-                  npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack/scoped/ ./*.tgz && \
-                  npx lerna exec --no-private --no-sort --parallel -- "[ ! -f ./*test-files.tar ] || (echo 'test files found' && mv -t $(Build.ArtifactStagingDirectory)/test-files/ ./*test-files.tar)"
+                  npx lerna@5.6.2 exec --no-private --no-sort -- ${{ parameters.packageManager }} pack && \
+                  npx lerna@5.6.2 exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack/scoped/ ./*.tgz && \
+                  npx lerna@5.6.2 exec --no-private --no-sort --parallel -- "[ ! -f ./*test-files.tar ] || (echo 'test files found' && mv -t $(Build.ArtifactStagingDirectory)/test-files/ ./*test-files.tar)"
 
                   # This saves a list of the packages in the working directory in topological order to a temporary file.
                   # Each package name is modified to match the packed tar files.
-                  npx lerna ls --toposort | sed 's/@//' | sed 's/\//-/' | head -c -1 > $(Build.ArtifactStagingDirectory)/pack/packagePublishOrder.txt
+                  npx lerna@5.6.2 ls --toposort | sed 's/@//' | sed 's/\//-/' | head -c -1 > $(Build.ArtifactStagingDirectory)/pack/packagePublishOrder.txt
                 else
                   ${{ parameters.packageManager }} pack && \
                   mv -t $(Build.ArtifactStagingDirectory)/pack/scoped/ ./*.tgz


### PR DESCRIPTION
## Description

Several pipelines and tool/scripts in our repo still do `npx lerna` for some things. The [release of Lerna 7.0.0](https://github.com/lerna/lerna/releases/tag/7.0.0) a few hours ago started causing issues in PR builds because of a breaking change dropping support for a property in our `lerna.json` files.

The issue might have been addressed by removing the property from that file too, since the new default behavior probably would do the right thing; but pinning package versions we "install dynamically" (npx) is still preferable and avoids any other surprises we might get from newer versions of Lerna.

Lerna ^5.6.2 is the last version specifier [we were using before removing it](https://github.com/microsoft/FluidFramework/pull/15531) so seems like the right call here.