### PR TITLE
fix: Pin version for npx lerna in build-tools

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -14,7 +14,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 	static flags = {
 		packageMetadataPath: Flags.file({
 			description:
-				"A path to a file containing JSON formatted package metadata. Used for testing. When not provided, the output of `npx lerna list --all --json` is used.",
+				"A path to a file containing JSON formatted package metadata. Used for testing. When not provided, the output of `npx lerna@5.6.2 list --all --json` is used.",
 			required: false,
 			hidden: true,
 		}),
@@ -30,7 +30,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 		const flags = this.flags;
 		const lernaOutput =
 			flags.packageMetadataPath ??
-			JSON.parse(execSync("npx lerna list --all --json").toString());
+			JSON.parse(execSync("npx lerna@5.6.2 list --all --json").toString());
 
 		if (!Array.isArray(lernaOutput)) {
 			this.error("failed to get package information");

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpVersion.ts
@@ -156,7 +156,7 @@ export async function bumpRepo(
 		monoRepo: MonoRepo,
 	) => {
 		return exec(
-			`npx lerna version ${repoVersionBump} --no-push --no-git-tag-version -y && npm run build:genver`,
+			`npx lerna@5.6.2 version ${repoVersionBump} --no-push --no-git-tag-version -y && npm run build:genver`,
 			monoRepo.repoPath,
 			"bump mono repo",
 		);

--- a/build-tools/packages/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
+++ b/build-tools/packages/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
@@ -14,7 +14,7 @@ const smallestAssetSize = 100;
 function main() {
 	// Get all the package locations
 	const lernaOutput = JSON.parse(
-		child_process.execSync("npx lerna list --all --json").toString(),
+		child_process.execSync("npx lerna@5.6.2 list --all --json").toString(),
 	);
 	if (!Array.isArray(lernaOutput)) {
 		throw new Error("failed to get package information");


### PR DESCRIPTION
## Description

Need to do it in build-tools only first, release a new version of it, then continue https://github.com/microsoft/FluidFramework/pull/15922 with the newer build-tools version.