### PR TITLE
fix: Pin version for npx lerna in build-tools (release branch)

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -14,7 +14,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 	static flags = {
 		packageMetadataPath: Flags.file({
 			description:
-				"A path to a file containing JSON formatted package metadata. Used for testing. When not provided, the output of `npx lerna list --all --json` is used.",
+				"A path to a file containing JSON formatted package metadata. Used for testing. When not provided, the output of `npx lerna@5.6.2 list --all --json` is used.",
 			required: false,
 			hidden: true,
 		}),
@@ -30,7 +30,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 		const flags = this.flags;
 		const lernaOutput =
 			flags.packageMetadataPath ??
-			JSON.parse(execSync("npx lerna list --all --json").toString());
+			JSON.parse(execSync("npx lerna@5.6.2 list --all --json").toString());
 
 		if (!Array.isArray(lernaOutput)) {
 			this.error("failed to get package information");

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpVersion.ts
@@ -156,7 +156,7 @@ export async function bumpRepo(
 		monoRepo: MonoRepo,
 	) => {
 		return exec(
-			`npx lerna version ${repoVersionBump} --no-push --no-git-tag-version -y && npm run build:genver`,
+			`npx lerna@5.6.2 version ${repoVersionBump} --no-push --no-git-tag-version -y && npm run build:genver`,
 			monoRepo.repoPath,
 			"bump mono repo",
 		);

--- a/build-tools/packages/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
+++ b/build-tools/packages/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
@@ -14,7 +14,7 @@ const smallestAssetSize = 100;
 function main() {
 	// Get all the package locations
 	const lernaOutput = JSON.parse(
-		child_process.execSync("npx lerna list --all --json").toString(),
+		child_process.execSync("npx lerna@5.6.2 list --all --json").toString(),
 	);
 	if (!Array.isArray(lernaOutput)) {
 		throw new Error("failed to get package information");


### PR DESCRIPTION
## Description

(Port of https://github.com/microsoft/FluidFramework/pull/15923 to the `release/build-tools/0.18` release branch).

Several pipelines and tool/scripts in our repo still do npx lerna for some things. The [release of Lerna 7.0.0](https://github.com/lerna/lerna/releases/tag/7.0.0) a few hours ago started causing issues in PR builds because of a breaking change dropping support for a property in our lerna.json files.

The issue might have been addressed by removing the property from that file too, since the new default behavior probably would do the right thing; but pinning package versions we "install dynamically" (npx) is still preferable and avoids any other surprises we might get from newer versions of Lerna.

Lerna ^5.6.2 is the last version specifier https://github.com/microsoft/FluidFramework/pull/15531 so seems like the right call here.