### PR TITLE
Exploring dice-roller initialization without aqueduct

### DIFF
--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -37,11 +37,15 @@
 	},
 	"dependencies": {
 		"@fluid-example/example-utils": "workspace:~",
-		"@fluidframework/aqueduct": "workspace:~",
+		"@fluidframework/cell": "workspace:~",
 		"@fluidframework/common-definitions": "^0.20.1",
+		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",
-		"@fluidframework/runtime-utils": "workspace:~",
+		"@fluidframework/core-interfaces": "workspace:~",
+		"@fluidframework/datastore": "workspace:~",
+		"@fluidframework/datastore-definitions": "workspace:~",
+		"@fluidframework/runtime-definitions": "workspace:~",
 		"css-loader": "^1.0.0",
 		"style-loader": "^1.0.0"
 	},

--- a/examples/view-integration/external-views/src/dataObject.ts
+++ b/examples/view-integration/external-views/src/dataObject.ts
@@ -3,13 +3,25 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitter } from "events";
-import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+import { ISharedCell, SharedCell } from "@fluidframework/cell";
+import { IEvent } from "@fluidframework/common-definitions";
+import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
+import { FluidDataStoreRuntime } from "@fluidframework/datastore";
+import { IChannelFactory, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import {
+	IFluidDataStoreContext,
+	IFluidDataStoreFactory,
+} from "@fluidframework/runtime-definitions";
+
+export interface IDiceRollerEvents extends IEvent {
+	(event: "diceRolled", listener: () => void);
+	(event: "disposed", listener: () => void);
+}
 
 /**
  * IDiceRoller describes the public API surface for our dice roller data object.
  */
-export interface IDiceRoller extends EventEmitter {
+export interface IDiceRoller extends TypedEventEmitter<IDiceRollerEvents> {
 	/**
 	 * Get the dice value as a number.
 	 */
@@ -21,57 +33,107 @@ export interface IDiceRoller extends EventEmitter {
 	roll: () => void;
 
 	/**
-	 * The diceRolled event will fire whenever someone rolls the device, either locally or remotely.
+	 * When the dice roller is disposed, it is no longer able to roll or receive updates from other clients.
 	 */
-	on(event: "diceRolled", listener: () => void): this;
+	readonly disposed: boolean;
 }
 
-// The root is map-like, so we'll use this key for storing the value.
-const diceValueKey = "diceValue";
+const diceCellId = "diceCell";
 
 /**
  * The DiceRoller is our data object that implements the IDiceRoller interface.
  */
-export class DiceRoller extends DataObject implements IDiceRoller {
-	/**
-	 * initializingFirstTime is run only once by the first client to create the DataObject.  Here we use it to
-	 * initialize the state of the DataObject.
-	 */
-	protected async initializingFirstTime() {
-		this.root.set(diceValueKey, 1);
+class DiceRoller extends TypedEventEmitter<IDiceRollerEvents> implements IDiceRoller {
+	private _disposed = false;
+
+	public get disposed() {
+		return this._disposed;
 	}
 
-	/**
-	 * hasInitialized is run by each client as they load the DataObject.  Here we use it to set up usage of the
-	 * DataObject, by registering an event listener for dice rolls.
-	 */
-	protected async hasInitialized() {
-		this.root.on("valueChanged", (changed) => {
-			if (changed.key === diceValueKey) {
-				// When we see the dice value change, we'll emit the diceRolled event we specified in our interface.
-				this.emit("diceRolled");
-			}
+	public get handle() {
+		// DiceRollerFactory already provides an entryPoint initialization function to the data store runtime,
+		// so this object should always have access to a non-null entryPoint.
+		assert(this.runtime.entryPoint !== undefined, "EntryPoint was undefined");
+		return this.runtime.entryPoint;
+	}
+
+	public constructor(
+		// Here I'm still passing through a full runtime, but really it would probably be better to just pass through
+		// the specific capabilities that the data object requires.
+		private readonly runtime: IFluidDataStoreRuntime,
+		private readonly diceCell: ISharedCell<number>,
+	) {
+		super();
+
+		if (this.runtime.disposed) {
+			this.dispose();
+		} else {
+			this.runtime.once("dispose", this.dispose);
+		}
+
+		this.diceCell.on("valueChanged", () => {
+			this.emit("diceRolled");
 		});
 	}
 
 	public get value() {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return this.root.get(diceValueKey);
+		// The cell is guaranteed to already be initialized with a value.
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		return this.diceCell.get()!;
 	}
 
 	public readonly roll = () => {
 		const rollValue = Math.floor(Math.random() * 6) + 1;
-		this.root.set(diceValueKey, rollValue);
+		this.diceCell.set(rollValue);
+	};
+
+	/**
+	 * Called when the host container closes and disposes itself
+	 */
+	private readonly dispose = (): void => {
+		this._disposed = true;
+		this.emit("disposed");
 	};
 }
 
-/**
- * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
- * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
- */
-export const DiceRollerInstantiationFactory = new DataObjectFactory(
-	"dice-roller",
-	DiceRoller,
-	[],
-	{},
-);
+const sharedCellFactory = SharedCell.getFactory();
+const diceRollerSharedObjectRegistry = new Map<string, IChannelFactory>([
+	[sharedCellFactory.type, sharedCellFactory],
+]);
+
+export class DiceRollerFactory implements IFluidDataStoreFactory {
+	public get type(): string {
+		throw new Error("Do not use the type on the data store factory");
+	}
+
+	public get IFluidDataStoreFactory() {
+		return this;
+	}
+
+	// Effectively, this pattern puts the factory in charge of "unpacking" the context, getting everything ready to assemble the DiceRoller
+	// As opposed to the DiceRoller instance having an initialize() method to be called after the fact that does the unpacking.
+	public async instantiateDataStore(context: IFluidDataStoreContext, existing: boolean) {
+		const runtime: FluidDataStoreRuntime = new FluidDataStoreRuntime(
+			context,
+			diceRollerSharedObjectRegistry,
+			existing,
+			// We have to provide a callback here to get an entryPoint, otherwise we would just omit it if we could always get an entryPoint.
+			async () => instance,
+		);
+
+		let diceCell: ISharedCell;
+		if (existing) {
+			diceCell = (await runtime.getChannel(diceCellId)) as ISharedCell;
+		} else {
+			diceCell = runtime.createChannel(diceCellId, sharedCellFactory.type) as SharedCell;
+			diceCell.bindToContext();
+			diceCell.set(1);
+		}
+
+		// By this point, we've performed any async work required to get the dependencies of the DiceRoller,
+		// so just a normal sync constructor will work fine (no followup async initialize()).
+		const instance = new DiceRoller(runtime, diceCell);
+
+		return runtime;
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5753,21 +5753,33 @@ importers:
       '@fluid-example/example-utils':
         specifier: workspace:~
         version: link:../../utils/example-utils
-      '@fluidframework/aqueduct':
+      '@fluidframework/cell':
         specifier: workspace:~
-        version: link:../../../packages/framework/aqueduct
+        version: link:../../../packages/dds/cell
       '@fluidframework/common-definitions':
         specifier: ^0.20.1
         version: 0.20.1
+      '@fluidframework/common-utils':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../../packages/common/container-definitions
       '@fluidframework/container-runtime-definitions':
         specifier: workspace:~
         version: link:../../../packages/runtime/container-runtime-definitions
-      '@fluidframework/runtime-utils':
+      '@fluidframework/core-interfaces':
         specifier: workspace:~
-        version: link:../../../packages/runtime/runtime-utils
+        version: link:../../../packages/common/core-interfaces
+      '@fluidframework/datastore':
+        specifier: workspace:~
+        version: link:../../../packages/runtime/datastore
+      '@fluidframework/datastore-definitions':
+        specifier: workspace:~
+        version: link:../../../packages/runtime/datastore-definitions
+      '@fluidframework/runtime-definitions':
+        specifier: workspace:~
+        version: link:../../../packages/runtime/runtime-definitions
       css-loader:
         specifier: ^1.0.0
         version: 1.0.1(webpack@5.83.0)


### PR DESCRIPTION
## Overview

I decided to explore the data store initialization flow and wanted to in particular understand what a more bare-bones data store might look like.  This draft PR is that - a dice roller that doesn't use aqueduct.

I especially wanted to explore other directions to take the async bits.  The current `PureDataObject` has a rather complex initialization flow, which bounces between the factory instantiateDataStore, the instance constructor, the entry point initialize callback, finishInitialization, various protected methods meant to be overridden, etc.  This draft PR instead has just a two-phase initialization flow:

1. The factory instantiateDataStore "unpacks" the context, pulling any async stuff down that it needs.  It then calls...
2. The data object constructor, which then has everything it needs available to it synchronously

## What I like about it

1. The data object class itself is free to be exactly whatever it wants to be - since it's no longer extending a base class it doesn't have to really conform to any rules, and it can just ask for whatever it wants in its constructor params.  It probably (but maybe not?) still wants to expose Fluid state up to its view (like `disposed`), but there's no real contract imposed on it.
2. The data object doesn't have to be bimodal, comprehending both its "pre-initialize" and "post-initialize" state.  For example, the typing of `DataObject.internalRoot` is `ISharedDirectory | undefined` - now it can instead just be `ISharedDirectory`.
3. I've got to imagine it's easier to mock/test the data object, since there's a single clear injection point for all of its dependencies.
4. This wouldn't preclude us from providing some different aqueduct-like helpers to pack this sort of flow up a little nicer.  In this draft I wanted to lay it all out on the table to get a good look at it.  Most likely this would look like helpers for just the factory, leaving the data object fully up to the customer.
5. Doesn't require class inheritance.

## What I'm not sure about

1. The first-time initialization of a new data object is externalized from the data object itself.  So the factory has intimate knowledge of the internal expectations that the data object has on its dependencies.  This might not be so bad - although split across two classes, the overall initialization is still encapsulated to the data object + factory combo.
    * I also considered static methods on the data object (or just freestanding helper methods) for `setUpNewDiceRoller(context): IDiceRollerConstructorParams` and `unpackExistingDiceRoller(context): IDiceRollerConstructorParams` or something - I think it's roughly equivalent to me.
2. I wasn't clear if there might be some lazy/deferred characteristic that I'm unintentionally breaking - AFAICT the important thing is just that instantiateDataStore doesn't get called until context.realize() is called (which should be true both here and in aqueduct).

## Ask for reviewers

I mostly just want your general thoughts on this - we've talked recently about how we currently handle async stuff generally, so curious for your likes/dislikes of this alternative as compared to the current state of things.  This PR is not intended to ever be checked in, I'm just using this as a proof of concept.