### PR TITLE
Cleanup SharedTreeView events

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1651,7 +1651,7 @@ export class SharedTreeView implements ISharedTreeView {
     // (undocumented)
     get editor(): IDefaultEditBuilder;
     // (undocumented)
-    readonly events: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>;
+    get events(): ISubscribable<ViewEvents>;
     // (undocumented)
     get forest(): IForestSubscription;
     // (undocumented)
@@ -1671,7 +1671,7 @@ export class SharedTreeView implements ISharedTreeView {
     redo(): void;
     // (undocumented)
     get root(): UnwrappedEditableField;
-    set root(data: ContextuallyTypedNodeData | undefined);
+    set root(data: NewFieldContent);
     // (undocumented)
     get rootEvents(): ISubscribable<AnchorSetRootEvents>;
     // (undocumented)

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -32,7 +32,6 @@ import {
 	UnwrappedEditableField,
 	DefaultChangeset,
 	buildForest,
-	ContextuallyTypedNodeData,
 	ForestRepairDataStoreProvider,
 	GlobalFieldSchema,
 	EditableTree,
@@ -40,8 +39,9 @@ import {
 	NodeIdentifierIndex,
 	NodeIdentifier,
 	defaultIntoDelta,
+	NewFieldContent,
 } from "../feature-libraries";
-import { IEmitter, ISubscribable, createEmitter } from "../events";
+import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
 import { JsonCompatibleReadOnly } from "../util";
 import { nodeIdentifierKey } from "../domains";
 import { SchematizeConfiguration } from "./schematizedTree";
@@ -71,7 +71,9 @@ export class SharedTree
 	extends SharedTreeCore<DefaultEditBuilder, DefaultChangeset>
 	implements ISharedTree
 {
-	public readonly events: ISubscribable<ViewEvents> & IEmitter<ViewEvents>;
+	private readonly _events: ISubscribable<ViewEvents> &
+		IEmitter<ViewEvents> &
+		HasListeners<ViewEvents>;
 	private readonly view: ISharedTreeView;
 	private readonly schema: SchemaEditor<InMemoryStoredSchemaRepository>;
 	private readonly identifierIndex: NodeIdentifierIndex<typeof nodeIdentifierKey>;
@@ -99,15 +101,19 @@ export class SharedTree
 		);
 		this.schema = new SchemaEditor(schema, (op) => this.submitLocalMessage(op));
 		this.identifierIndex = new NodeIdentifierIndex(nodeIdentifierKey);
+		this._events = createEmitter<ViewEvents>();
 		this.view = createSharedTreeView({
 			branch: this.getLocalBranch(),
 			schema,
 			forest,
 			repairProvider,
 			identifierIndex: this.identifierIndex,
+			events: this._events,
 		});
-		this.events = createEmitter<ViewEvents>();
-		this.getLocalBranch().on("change", () => this.finishBatch());
+	}
+
+	public get events(): ISubscribable<ViewEvents> {
+		return this._events;
 	}
 
 	public get rootEvents(): ISubscribable<AnchorSetRootEvents> {
@@ -130,7 +136,7 @@ export class SharedTree
 		return this.view.root;
 	}
 
-	public set root(data: ContextuallyTypedNodeData | undefined) {
+	public set root(data: NewFieldContent) {
 		this.view.root = data;
 	}
 
@@ -202,13 +208,10 @@ export class SharedTree
 
 	protected override async loadCore(services: IChannelStorageService): Promise<void> {
 		await super.loadCore(services);
-		this.finishBatch();
-	}
-
-	/** Finish a batch (see {@link ViewEvents}) */
-	private finishBatch(): void {
+		// The identifier index must be populated after both the schema and forest have loaded.
+		// TODO: Create an ISummarizer for the identifier index and ensure it loads after the other indexes.
 		this.identifierIndex.scanIdentifiers(this.context);
-		this.events.emit("afterBatch");
+		this._events.emit("afterBatch");
 	}
 }
 

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -17,10 +17,9 @@ import {
 	assertIsRevisionTag,
 	UndoRedoManager,
 } from "../core";
-import { ISubscribable, createEmitter } from "../events";
+import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
 import {
 	UnwrappedEditableField,
-	ContextuallyTypedNodeData,
 	EditableTreeContext,
 	IDefaultEditBuilder,
 	NodeIdentifier,
@@ -250,6 +249,7 @@ export function createSharedTreeView(args?: {
 	forest?: IEditableForest;
 	repairProvider?: ForestRepairDataStoreProvider<DefaultChangeset>;
 	identifierIndex?: NodeIdentifierIndex<typeof nodeIdentifierKey>;
+	events?: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>;
 }): ISharedTreeView {
 	const schema = args?.schema ?? new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
 	const forest = args?.forest ?? buildForest(schema, new AnchorSet());
@@ -270,7 +270,8 @@ export function createSharedTreeView(args?: {
 		);
 	const context = getEditableTreeContext(forest, branch.editor);
 	const identifierIndex = args?.identifierIndex ?? new NodeIdentifierIndex(nodeIdentifierKey);
-	return SharedTreeView[create](branch, schema, forest, context, identifierIndex);
+	const events = args?.events ?? createEmitter();
+	return SharedTreeView[create](branch, schema, forest, context, identifierIndex, events);
 }
 
 /**
@@ -278,21 +279,22 @@ export function createSharedTreeView(args?: {
  * @alpha
  */
 export class SharedTreeView implements ISharedTreeView {
-	public readonly events = createEmitter<ViewEvents>();
-
 	private constructor(
 		private readonly branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>,
 		private readonly _storedSchema: InMemoryStoredSchemaRepository,
 		private readonly _forest: IEditableForest,
 		public readonly context: EditableTreeContext,
 		private readonly _identifiedIndex: NodeIdentifierIndex<typeof nodeIdentifierKey>,
+		private readonly _events: ISubscribable<ViewEvents> &
+			IEmitter<ViewEvents> &
+			HasListeners<ViewEvents>,
 	) {
 		branch.on("change", ({ change }) => {
 			if (change !== undefined) {
 				const delta = defaultChangeFamily.intoDelta(change);
 				this._forest.applyDelta(delta);
 				this._identifiedIndex.scanIdentifiers(this.context);
-				this.events.emit("afterBatch");
+				this._events.emit("afterBatch");
 			}
 		});
 	}
@@ -304,8 +306,13 @@ export class SharedTreeView implements ISharedTreeView {
 		forest: IEditableForest,
 		context: EditableTreeContext,
 		identifiedIndex: NodeIdentifierIndex<typeof nodeIdentifierKey>,
+		events: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>,
 	): SharedTreeView {
-		return new SharedTreeView(branch, storedSchema, forest, context, identifiedIndex);
+		return new SharedTreeView(branch, storedSchema, forest, context, identifiedIndex, events);
+	}
+
+	public get events(): ISubscribable<ViewEvents> {
+		return this._events;
 	}
 
 	public get storedSchema(): StoredSchemaRepository {
@@ -386,6 +393,7 @@ export class SharedTreeView implements ISharedTreeView {
 			forest,
 			context,
 			this._identifiedIndex.clone(context),
+			createEmitter(),
 		);
 	}
 
@@ -409,7 +417,7 @@ export class SharedTreeView implements ISharedTreeView {
 		return this.context.unwrappedRoot;
 	}
 
-	public set root(data: ContextuallyTypedNodeData | undefined) {
+	public set root(data: NewFieldContent) {
 		this.context.unwrappedRoot = data;
 	}
 


### PR DESCRIPTION
## Description

This PR adds a private `_events` field to both `SharedTree` and `SharedTreeView`. 

* `SharedTreeView` no longer exposes the ability to emit events from outside the class
* `SharedTreeView` can have an optional event emitter passed into its constructor
* `SharedTree` uses the optional event emitter to shared an event emitter with its inner `view`. This removes the need to emit an `afterBatch` event on change, since the inner view already emits it, but still allows `SharedTree` to emit an additional `afterBatch` event on load.
* Updated the input type to the `root` setters for consistency

## Breaking Changes

`SharedTreeView`'s events API has been restricted to allow subscribing but not emitting. Allowing a client of `SharedTreeView` to cause the view to emit events was a mistake.
