### PR TITLE
Allow fractional weights in createWeightedGenerator

### DIFF
--- a/packages/test/stochastic-test-utils/src/generators.ts
+++ b/packages/test/stochastic-test-utils/src/generators.ts
@@ -55,7 +55,7 @@ export function createWeightedGenerator<T, TState extends BaseFuzzTestState>(
 	return (state) => {
 		const { random } = state;
 		const sample = () => {
-			const weightSelected = random.integer(1, totalWeight);
+			const weightSelected = random.real(0, totalWeight);
 
 			let opIndex = 0;
 			while (cumulativeSums[opIndex][1] < weightSelected) {
@@ -292,7 +292,7 @@ export function createWeightedAsyncGenerator<T, TState extends BaseFuzzTestState
 	return async (state) => {
 		const { random } = state;
 		const sample = () => {
-			const weightSelected = random.integer(1, totalWeight);
+			const weightSelected = random.real(0, totalWeight);
 
 			let opIndex = 0;
 			while (cumulativeSums[opIndex][1] < weightSelected) {

--- a/packages/test/stochastic-test-utils/src/test/generators.spec.ts
+++ b/packages/test/stochastic-test-utils/src/test/generators.spec.ts
@@ -381,6 +381,33 @@ describe("generators", () => {
 			["c", 1],
 			["d", 1],
 		],
+		[
+			["a", 0],
+			["b", 1],
+			["d", 1],
+		],
+		[
+			["a", 1],
+			["b", 0],
+			["d", 1],
+		],
+		[
+			["a", 1],
+			["b", 1],
+			["c", 0],
+		],
+		[
+			["a", 0],
+			["b", 1],
+			["c", 0],
+			["d", 1],
+			["e", 0],
+		],
+		[
+			["a", 0.5],
+			["b", 0.3],
+			["c", 1.4],
+		],
 	];
 
 	// The distribution produced by createWeightedGenerator is a multinomial distribution. See:

--- a/packages/test/stochastic-test-utils/src/test/utils.ts
+++ b/packages/test/stochastic-test-utils/src/test/utils.ts
@@ -37,7 +37,7 @@ export function computeChiSquared<T>(weights: [T, number][], sampleCounts: Count
 	const values = Array.from(sampleCounts.values());
 
 	assert.deepEqual(
-		new Set(weights.map(([value]) => value)),
+		new Set(weights.filter(([_, weight]) => weight > 0).map(([value]) => value)),
 		new Set(values),
 		"'weights' must include all choices and all choices must have at least occurrence in 'sampleCounts'.",
 	);
@@ -61,6 +61,10 @@ export function computeChiSquared<T>(weights: [T, number][], sampleCounts: Count
 
 	let chiSquared = 0;
 	for (const [value, weight] of weights) {
+		if (weight === 0) {
+			assert.equal(sampleCounts.get(value), 0, "weight 0 value generated");
+			continue;
+		}
 		const expectedFrequency = (numberOfSamples * weight) / totalWeight;
 		const actualFrequency = sampleCounts.get(value);
 


### PR DESCRIPTION
## Description

This is a small QoL improvement for weighted generators (or arguably fixes a bug that it didn't really work for non-integer weights, since that wasn't documented)
