### PR TITLE
fix: Temporary workaround to make the prettier extension work again

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,4 +59,7 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 	},
+
+	// Temporary workaround for https://github.com/prettier/prettier-vscode/issues/3000
+	"prettier.prettierPath": "./node_modules/prettier"
 }


### PR DESCRIPTION
## Description

There's an [issue with the Prettier extension for VSCode ](https://github.com/prettier/prettier-vscode/issues/3000) (says it's on VSCode Insiders but it made it to stable with v1.79.0) that causes it to not load. This applies a temporary workaround from the discussion in the linked issue to make it work again while the problem is fixed.

VSCode shows a red "Prettier" status label on the bottom right, and the Output panel shows an error:

<img width="1191" alt="image" src="https://github.com/microsoft/FluidFramework/assets/716334/087c4d93-ed5e-4c3b-95ee-037ed76d04e3">

Text version of the error in the collapsed details section:

<details>

```
["INFO" - 5:48:34 PM] Attempted to determine module path from package.json
["ERROR" - 5:48:34 PM] Failed to load module. If you have prettier or plugins referenced in package.json, ensure you have run `npm install`
["ERROR" - 5:48:34 PM] Cannot read properties of undefined (reading 'uid')
TypeError: Cannot read properties of undefined (reading 'uid')
    at Object.statSync (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/node_modules/graceful-fs/polyfills.js:313:17)
    at p (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:35221)
    at L (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:37052)
    at /home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:36677
    at Function.e.exports [as sync] (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:36723)
    at t.ModuleResolver.findPkg (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:7297)
    at t.ModuleResolver.getPrettierInstance (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:3251)
    at t.default.handleActiveTextEditorChanged (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:9781)
    at handleActiveTextEditorChangedSync (/home/node/.vscode-remote/extensions/esbenp.prettier-vscode-9.13.0/dist/extension.js:1:9383)
    at b.invoke (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:145)
    at deliver (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:2121)
    at n.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:1729)
    at /vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:104:17303
    at b.invoke (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:145)
    at deliver (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:2121)
    at n.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:1729)
    at e.ExtHostDocumentsAndEditors.acceptDocumentsAndEditorsDelta (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:102:14003)
    at e.ExtHostDocumentsAndEditors.$acceptDocumentsAndEditorsDelta (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:102:12318)
    at s.N (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:112:11717)
    at s.M (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:112:11435)
    at s.H (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:112:10516)
    at s.G (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:112:9494)
    at /vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:112:8282
    at b.invoke (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:145)
    at deliver (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:2121)
    at n.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:1729)
    at p.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:73:14783)
    at /vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:128:32461
    at b.invoke (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:145)
    at deliver (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:2121)
    at n.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:1729)
    at p.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:73:14783)
    at D.E (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:73:18830)
    at /vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:73:16818
    at b.invoke (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:145)
    at deliver (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:2121)
    at n.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:1729)
    at h.acceptChunk (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:73:12514)
    at /vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:73:11801
    at b.invoke (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:145)
    at deliver (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:2121)
    at n.fire (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:63:1729)
    at E.u (/vscode/bin/linux-x64/b380da4ef1ee00e224a15c1d4d9793e27c2b6302/out/vs/workbench/api/node/extensionHostProcess.js:128:20017)
```

</details>