### PR TITLE
Ensure we log ContainerClose event even if only Container.dispose is called

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -274,7 +274,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			 * is realized (loaded) after GC was run on it creating summarizer nodes for its DDSes. In this
 			 * case, the used routes of the parent should be passed on the child nodes and it should be fine.
 			 * 2. A new node was created but GC was never run on it. This can mean that the GC data generated
-			 * during summarize is incomplete. We should not continue, log and throw an error. This will help us
+			 * during summarize is complete . We should not continue, log and throw an error. This will help us
 			 * identify these cases and take appropriate action.
 			 */
 			if (wipSerializedUsedRoutes === undefined) {

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -274,7 +274,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			 * is realized (loaded) after GC was run on it creating summarizer nodes for its DDSes. In this
 			 * case, the used routes of the parent should be passed on the child nodes and it should be fine.
 			 * 2. A new node was created but GC was never run on it. This can mean that the GC data generated
-			 * during summarize is complete . We should not continue, log and throw an error. This will help us
+			 * during summarize is incomplete. We should not continue, log and throw an error. This will help us
 			 * identify these cases and take appropriate action.
 			 */
 			if (wipSerializedUsedRoutes === undefined) {

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -598,7 +598,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 		assert.strictEqual(run, 1, "DeltaManager should send readonly event on container close");
 	});
 
-	it.only("Disposing container should send dispose events", async () => {
+	it("Disposing container should send dispose events", async () => {
 		const container = await createConnectedContainer();
 		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 
@@ -650,7 +650,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 		]);
 	});
 
-	it.only("Closing then disposing container should send close and dispose events", async () => {
+	it("Closing then disposing container should send close and dispose events", async () => {
 		const container = await createConnectedContainer();
 		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 


### PR DESCRIPTION
## Description

A Container can be closed, closed-then-disposed, or only disposed.  Previously there was only Container.close, and we are used to looking for the ContainerClose event in telemetry as the single event corresponding to the "end" of a container session.

Now, it's possible the container would be disposed directly without closing first.  In this case, we should still log the ContainerClose event to keep the logs consistent - that can be the single event we monitor for most cases.  And we have the ContainerDispose event to get the full picture if it's present.

Inspired by https://github.com/microsoft/FluidFramework/pull/15192#discussion_r1223736189