### PR TITLE
Convert @fluid-example/table-document tests to use esnext modules

### DIFF
--- a/examples/data-objects/table-document/.eslintrc.js
+++ b/examples/data-objects/table-document/.eslintrc.js
@@ -11,4 +11,16 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 	},
+	overrides: [
+		{
+			// Rules only for test files
+			files: ["*.spec.ts", "src/test/**"],
+			rules: {
+				// ESLint's resolver doesn't resolve relative imports of ESNext modules correctly, since
+				// it resolves the path relative to the .ts file (and assumes a file with a .js extension
+				// should exist there)
+				"import/no-unresolved": ["error", { ignore: ["^\\.(.*)\\.js$"] }],
+			},
+		},
+	],
 };

--- a/examples/data-objects/table-document/README.md
+++ b/examples/data-objects/table-document/README.md
@@ -20,3 +20,4 @@ For example, to support a feature like simple user attribution, the app can appe
 
 Being an example, this package should have `private: true` in `package.json` but alas there's one consumer of Fluid
 taking a dependency on it, so we can't do that yet.
+Once it can be converted, or once that consumer confirms they don't need both ESNext and CommonJS modules, it should also drop the CommonJS build (this has already been done for the package's tests, but not its public API).

--- a/examples/data-objects/table-document/src/test/table.spec.mts
+++ b/examples/data-objects/table-document/src/test/table.spec.mts
@@ -7,9 +7,9 @@ import { strict as assert } from "assert";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeLoaderCompat } from "@fluid-internal/test-version-utils";
-import { TableDocument } from "../document";
-import { TableSlice } from "../slice";
-import { TableDocumentItem } from "../table";
+import { TableDocument } from "../document.js";
+import { TableSlice } from "../slice.js";
+import { TableDocumentItem } from "../table.js";
 
 describeLoaderCompat("TableDocument", (getTestObjectProvider) => {
 	let tableDocument: TableDocument;

--- a/examples/data-objects/table-document/src/test/tableWithInterception.spec.mts
+++ b/examples/data-objects/table-document/src/test/tableWithInterception.spec.mts
@@ -9,9 +9,9 @@ import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeLoaderCompat } from "@fluid-internal/test-version-utils";
-import { ITable } from "../table";
-import { TableDocument } from "../document";
-import { createTableWithInterception } from "../interception";
+import { ITable } from "../table.js";
+import { TableDocument } from "../document.js";
+import { createTableWithInterception } from "../interception/index.js";
 
 describeLoaderCompat("Table Document with Interception", (getTestObjectProvider) => {
 	describe("Simple User Attribution", () => {

--- a/examples/data-objects/table-document/src/test/tsconfig.json
+++ b/examples/data-objects/table-document/src/test/tsconfig.json
@@ -6,6 +6,7 @@
 		"types": ["node", "mocha"],
 		"declaration": false,
 		"declarationMap": false,
+		"module": "esnext",
 	},
 	"include": ["./**/*"],
 	"references": [


### PR DESCRIPTION
## Description

This makes progress toward #15917 by converting `@fluid-example/table-document`'s tests to run esnext modules only.

It's not yet feasible to convert the whole package to esnext, as despite being an example package it's currently used by some internal partners. I've therefore just converted the test config to use esnext.
