### PR TITLE
Preserve batch boundaries upon resubmit

### DIFF
--- a/experimental/dds/tree/src/test/Summary.tests.ts
+++ b/experimental/dds/tree/src/test/Summary.tests.ts
@@ -337,13 +337,6 @@ export function runSummaryTests(title: string): void {
 					await testObjectProvider.ensureSynchronized();
 					await expectSharedTreesEqual(resubmitTree, tree);
 					await expectSharedTreesEqual(tree, await createSummaryTestTree(WriteFormat.v0_1_1, true));
-
-					// https://dev.azure.com/fluidframework/internal/_workitems/edit/3347
-					const events = testObjectProvider.logger.reportAndClearTrackedEvents();
-					expect(events.unexpectedErrors.length).to.equal(1);
-					expect(events.unexpectedErrors[0].eventName).to.equal(
-						'fluid:telemetry:ContainerRuntime:Outbox:ReferenceSequenceNumberMismatch'
-					);
 				});
 
 				it('Normalizes a denormalized summary containing nodes with empty traits', async () => {

--- a/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
@@ -367,13 +367,6 @@ export function runSharedTreeVersioningTests(
 				expect(stableIds.has(tree.convertToStableNodeId(id))).to.be.false;
 			}
 			expect(tree.equals(tree)).to.be.true;
-
-			// https://dev.azure.com/fluidframework/internal/_workitems/edit/3347
-			const events = testObjectProvider.logger.reportAndClearTrackedEvents();
-			expect(events.unexpectedErrors.length).to.equal(1);
-			expect(events.unexpectedErrors[0].eventName).to.equal(
-				'fluid:telemetry:ContainerRuntime:Outbox:ReferenceSequenceNumberMismatch'
-			);
 		});
 
 		it('converts IDs correctly after upgrading from 0.0.2', async () => {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -113,7 +113,11 @@ import { v4 as uuid } from "uuid";
 import { ContainerFluidHandleContext } from "./containerHandleContext";
 import { FluidDataStoreRegistry } from "./dataStoreRegistry";
 import { ReportOpPerfTelemetry, IPerfSignalReport } from "./connectionTelemetry";
-import { IPendingLocalState, PendingStateManager } from "./pendingStateManager";
+import {
+	IPendingBatchMessage,
+	IPendingLocalState,
+	PendingStateManager,
+} from "./pendingStateManager";
 import { pkgVersion } from "./packageVersion";
 import { BlobManager, IBlobManagerLoadInfo, IPendingBlobs } from "./blobManager";
 import { DataStores, getSummaryForDatastores } from "./dataStores";
@@ -1299,7 +1303,7 @@ export class ContainerRuntime
 				close: this.closeFn,
 				connected: () => this.connected,
 				reSubmit: this.reSubmit.bind(this),
-				orderSequentially: this.orderSequentially.bind(this),
+				reSubmitBatch: this.reSubmitBatch.bind(this),
 			},
 			pendingRuntimeState?.pending,
 		);
@@ -3180,14 +3184,19 @@ export class ContainerRuntime
 		}
 	}
 
-	private reSubmit(
-		content: string,
-		localOpMetadata: unknown,
-		opMetadata: Record<string, unknown> | undefined,
-	) {
+	private reSubmitBatch(batch: IPendingBatchMessage[]) {
+		this.orderSequentially(() => {
+			for (const message of batch) {
+				this.reSubmit(message);
+			}
+		});
+		this.flush();
+	}
+
+	private reSubmit(message: IPendingBatchMessage) {
 		// Need to parse from string for back-compat
-		const { contents, type } = this.parseOpContent(content);
-		this.reSubmitCore(type, contents, localOpMetadata, opMetadata);
+		const { contents, type } = this.parseOpContent(message.content);
+		this.reSubmitCore(type, contents, message.localOpMetadata, message.opMetadata);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -111,9 +111,7 @@ describe("Pending State Manager", () => {
 					close: (error?: ICriticalContainerError) => (closeError = error),
 					connected: () => true,
 					reSubmit: () => {},
-					orderSequentially: (callback: () => void) => {
-						callback();
-					},
+					reSubmitBatch: () => {},
 				},
 				undefined,
 			);
@@ -287,7 +285,7 @@ describe("Pending State Manager", () => {
 					close: () => {},
 					connected: () => true,
 					reSubmit: () => {},
-					orderSequentially: () => {},
+					reSubmitBatch: () => {},
 				},
 				{ pendingStates },
 			);

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -70,12 +70,12 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 		localMap = await localDataObject.getSharedObject<SharedMap>(mapId);
 
 		// Load the Container that was created by the first client.
-		// remoteContainer = await provider.loadTestContainer(configWithFeatureGates);
-		// remoteDataObject = await requestFluidObject<ITestFluidObject>(remoteContainer, "default");
-		// remoteMap = await remoteDataObject.getSharedObject<SharedMap>(mapId);
+		remoteContainer = await provider.loadTestContainer(configWithFeatureGates);
+		remoteDataObject = await requestFluidObject<ITestFluidObject>(remoteContainer, "default");
+		remoteMap = await remoteDataObject.getSharedObject<SharedMap>(mapId);
 
 		await waitForContainerConnection(localContainer, true);
-		// await waitForContainerConnection(remoteContainer, true);
+		await waitForContainerConnection(remoteContainer, true);
 
 		// Force the local container into write-mode by sending a small op
 		localMap.set("test", "test");
@@ -106,17 +106,12 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 			}),
 		);
 
-	const disableCompressionConfig: ITestContainerConfig = {
+	const disableCompressionConfig = {
 		...testContainerConfig,
 		runtimeOptions: {
 			compressionOptions: {
 				minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
-			},
-			summaryOptions: {
-				summaryConfigOverrides: {
-					state: "disabled",
-				},
 			},
 		},
 	}; // Compression is enabled by default
@@ -159,7 +154,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 		assertMapValues(remoteMap, messageCount, largeString);
 	});
 
-	itExpects.only(
+	itExpects.skip(
 		"Small batches pass while disconnected, fail when the container connects and compression is disabled",
 		[{ eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" }],
 		async () => {

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -154,6 +154,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 		assertMapValues(remoteMap, messageCount, largeString);
 	});
 
+	// Blocked waiting on AB#2690
 	itExpects.skip(
 		"Small batches pass while disconnected, fail when the container connects and compression is disabled",
 		[{ eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" }],

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -70,12 +70,12 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 		localMap = await localDataObject.getSharedObject<SharedMap>(mapId);
 
 		// Load the Container that was created by the first client.
-		remoteContainer = await provider.loadTestContainer(configWithFeatureGates);
-		remoteDataObject = await requestFluidObject<ITestFluidObject>(remoteContainer, "default");
-		remoteMap = await remoteDataObject.getSharedObject<SharedMap>(mapId);
+		// remoteContainer = await provider.loadTestContainer(configWithFeatureGates);
+		// remoteDataObject = await requestFluidObject<ITestFluidObject>(remoteContainer, "default");
+		// remoteMap = await remoteDataObject.getSharedObject<SharedMap>(mapId);
 
 		await waitForContainerConnection(localContainer, true);
-		await waitForContainerConnection(remoteContainer, true);
+		// await waitForContainerConnection(remoteContainer, true);
 
 		// Force the local container into write-mode by sending a small op
 		localMap.set("test", "test");
@@ -106,12 +106,17 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 			}),
 		);
 
-	const disableCompressionConfig = {
+	const disableCompressionConfig: ITestContainerConfig = {
 		...testContainerConfig,
 		runtimeOptions: {
 			compressionOptions: {
 				minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
+			},
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
 			},
 		},
 	}; // Compression is enabled by default
@@ -154,7 +159,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 		assertMapValues(remoteMap, messageCount, largeString);
 	});
 
-	itExpects(
+	itExpects.only(
 		"Small batches pass while disconnected, fail when the container connects and compression is disabled",
 		[{ eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" }],
 		async () => {


### PR DESCRIPTION
## Description

On op resubmit, we drop the opMetadata (which is what holds the batch metadata). This can potentially cause problems with batches getting grouped together into one mega batch.

[AB#3217](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3217)