### PR TITLE
Log additional properties on restoreFromCheckpoint

### DIFF
--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -127,6 +127,9 @@ export class CheckpointService implements ICheckpointService {
 		let isLocalCheckpoint = false;
 		let localLogOffset;
 		let globalLogOffset;
+		let localSequenceNumber;
+		let globalSequenceNumber;
+
 		const restoreFromCheckpointMetric = Lumberjack.newLumberMetric(
 			LumberEventName.RestoreFromCheckpoint,
 		);
@@ -165,6 +168,8 @@ export class CheckpointService implements ICheckpointService {
 					}
 					localLogOffset = localCheckpoint.logOffset;
 					globalLogOffset = globalCheckpoint.logOffset;
+					localSequenceNumber = localCheckpoint.sequenceNumber;
+					globalSequenceNumber = globalCheckpoint.sequenceNumber;
 				} else {
 					// If checkpoint does not exist, use document
 					Lumberjack.info(
@@ -173,6 +178,8 @@ export class CheckpointService implements ICheckpointService {
 					);
 					checkpointSource = "notFoundInLocalCollection";
 					lastCheckpoint = JSON.parse(document[service]);
+					globalLogOffset = lastCheckpoint.logOffset;
+					globalSequenceNumber = lastCheckpoint.sequenceNumber;
 				}
 			}
 			restoreFromCheckpointMetric.setProperties({

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -190,6 +190,8 @@ export class CheckpointService implements ICheckpointService {
 				retrievedFromLocalDatabase: isLocalCheckpoint,
 				globalLogOffset,
 				localLogOffset,
+				globalSequenceNumber,
+				localSequenceNumber,
 			});
 		} catch (error) {
 			Lumberjack.error(

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -125,6 +125,8 @@ export class CheckpointService implements ICheckpointService {
 		let checkpoint;
 		let lastCheckpoint: IDeliState | IScribe;
 		let isLocalCheckpoint = false;
+		let localLogOffset;
+		let globalLogOffset;
 		const restoreFromCheckpointMetric = Lumberjack.newLumberMetric(
 			LumberEventName.RestoreFromCheckpoint,
 		);
@@ -161,6 +163,8 @@ export class CheckpointService implements ICheckpointService {
 						checkpointSource = "latestFoundInLocalCollection";
 						isLocalCheckpoint = true;
 					}
+					localLogOffset = localCheckpoint.logOffset;
+					globalLogOffset = globalCheckpoint.logOffset;
 				} else {
 					// If checkpoint does not exist, use document
 					Lumberjack.info(
@@ -177,6 +181,8 @@ export class CheckpointService implements ICheckpointService {
 				service,
 				checkpointSource,
 				retrievedFromLocalDatabase: isLocalCheckpoint,
+				globalLogOffset,
+				localLogOffset,
 			});
 		} catch (error) {
 			Lumberjack.error(


### PR DESCRIPTION
Adds logs for the local and global database checkpoint sequence numbers and log offsets in restoreFromCheckpoint