### PR TITLE
[GC Stress] Add multi client collaboration for attachment blobs

### DIFF
--- a/packages/test/test-service-load/src/gcDataStores.ts
+++ b/packages/test/test-service-load/src/gcDataStores.ts
@@ -428,7 +428,7 @@ export class SingleCollabDataObject extends BaseDataObject implements IGCActivit
 		this.dataObjectMap.on("valueChanged", (changed, local) => {
 			activityRunner(changed, local, this.dataObjectMap).catch((error) => {
 				config.logger.sendErrorEvent({
-					eventName: "ActivityRunFailedError",
+					eventName: "DSActivityRunFailedError",
 					id,
 					error,
 				});
@@ -439,7 +439,7 @@ export class SingleCollabDataObject extends BaseDataObject implements IGCActivit
 		this.blobMap.on("valueChanged", (changed, local) => {
 			activityRunner(changed, local, this.blobMap).catch((error) => {
 				config.logger.sendErrorEvent({
-					eventName: "ActivityRunFailedError",
+					eventName: "BlobActivityRunFailedError",
 					id,
 					error,
 				});
@@ -811,14 +811,7 @@ export class MultiCollabDataObject extends SingleCollabDataObject implements IGC
 			}
 
 			// Collaborate with the partners clients specified in partnerIds.
-			let collaborate: boolean = false;
-			for (const partnerId of partnerIds) {
-				if (changed.key.startsWith(partnerId)) {
-					collaborate = true;
-					break;
-				}
-			}
-			if (!collaborate) {
+			if (!partnerIds.some((partnerId) => changed.key.startsWith(partnerId))) {
 				return;
 			}
 
@@ -856,7 +849,7 @@ export class MultiCollabDataObject extends SingleCollabDataObject implements IGC
 				partnerId2,
 			]).catch((error) => {
 				config.logger.sendErrorEvent({
-					eventName: "PartnerActivityRunFailedError",
+					eventName: "PartnerDSActivityRunFailedError",
 					id,
 					error,
 				});
@@ -869,7 +862,7 @@ export class MultiCollabDataObject extends SingleCollabDataObject implements IGC
 		this.blobMap.on("valueChanged", (changed, local) => {
 			partnerActivityRunner(changed, local, this.blobMap, [partnerId1]).catch((error) => {
 				config.logger.sendErrorEvent({
-					eventName: "PartnerActivityRunFailedError",
+					eventName: "PartnerBlobActivityRunFailedError",
 					id,
 					error,
 				});

--- a/packages/test/test-service-load/src/gcDataStores.ts
+++ b/packages/test/test-service-load/src/gcDataStores.ts
@@ -794,30 +794,46 @@ export class MultiCollabDataObject extends SingleCollabDataObject implements IGC
 		const partnerRunId2 = ((myRunId + halfClients + 1) % config.testConfig.numClients) + 1;
 		const partnerId1 = `client${partnerRunId1}`;
 		const partnerId2 = `client${partnerRunId2}`;
+
 		/**
-		 * Set up an event handler that listens for changes in the data object map meaning that a child data object
-		 * was referenced or unreferenced by a client.
+		 * Set up an event listener that will run / stop activity based on the activities of the partner.
+		 * If a partner referenced a data store or attachment blob, run activity on the corresponding local object.
+		 * If a partner unreferenced a data store or attachment blob, stop activity on the corresponding local object.
 		 */
-		const partnerActivityRunner = async (changed: IValueChanged, local: boolean) => {
+		const partnerActivityRunner = async (
+			changed: IValueChanged,
+			local: boolean,
+			activityObjectMap: SharedMap,
+			partnerIds: string[],
+		) => {
 			if (local) {
 				return;
 			}
 
-			// Only collaborate with two other partner clients. If we collaborate with all clients, there would be too
-			// many ops and we might get throttled.
-			if (!changed.key.startsWith(partnerId1) && !changed.key.startsWith(partnerId2)) {
+			// Collaborate with the partners clients specified in partnerIds.
+			let collaborate: boolean = false;
+			for (const partnerId of partnerIds) {
+				if (changed.key.startsWith(partnerId)) {
+					collaborate = true;
+					break;
+				}
+			}
+			if (!collaborate) {
 				return;
 			}
 
-			// If a new data object was referenced, run our corresponding local data object.
-			// If a data object was unreferenced, stop running our corresponding local data object.
-			if (this.dataObjectMap.has(changed.key)) {
-				const dataObjectHandle = this.dataObjectMap.get<IFluidHandle<IGCActivityObject>>(
+			// If a new object was referenced, run our corresponding local data object.
+			// If an object was unreferenced, stop running our corresponding local data object.
+			if (activityObjectMap.has(changed.key)) {
+				const activityObjectHandle = activityObjectMap.get<IFluidHandle<IGCActivityObject>>(
 					changed.key,
 				);
-				assert(dataObjectHandle !== undefined, `Could not find handle for ${changed.key}`);
-				const dataObject = await dataObjectHandle.get();
-				const result = await dataObject.run(
+				assert(
+					activityObjectHandle !== undefined,
+					`Could not find handle for ${changed.key}`,
+				);
+				const activityObject = await activityObjectHandle.get();
+				const result = await activityObject.run(
 					this.childRunConfig,
 					`${this.nodeId}/${changed.key}`,
 				);
@@ -825,14 +841,33 @@ export class MultiCollabDataObject extends SingleCollabDataObject implements IGC
 					this.activityFailed = true;
 				}
 			} else {
-				const dataObjectHandle = changed.previousValue as IFluidHandle<IGCActivityObject>;
-				const dataObject = await dataObjectHandle.get();
-				dataObject.stop();
+				const activityObjectHandle =
+					changed.previousValue as IFluidHandle<IGCActivityObject>;
+				const activityObject = await activityObjectHandle.get();
+				activityObject.stop();
 			}
 		};
 
+		// For data stores, collaborate with two partner clients. This will keep the number of ops to a reasonable
+		// number so as to not get throttled.
 		this.dataObjectMap.on("valueChanged", (changed, local) => {
-			partnerActivityRunner(changed, local).catch((error) => {
+			partnerActivityRunner(changed, local, this.dataObjectMap, [
+				partnerId1,
+				partnerId2,
+			]).catch((error) => {
+				config.logger.sendErrorEvent({
+					eventName: "PartnerActivityRunFailedError",
+					id,
+					error,
+				});
+				this.activityFailed = true;
+			});
+		});
+
+		// For attachment blobs, collaborate with one partner client. Blob requests are more sensitive to being
+		// throttled. Collaborating with one client will keep the number of requests less while giving coverage.
+		this.blobMap.on("valueChanged", (changed, local) => {
+			partnerActivityRunner(changed, local, this.blobMap, [partnerId1]).catch((error) => {
 				config.logger.sendErrorEvent({
 					eventName: "PartnerActivityRunFailedError",
 					id,


### PR DESCRIPTION
## Description
Added multi client collab for attachment blobs. When a client references or unreferenced an attachment blob, one partner client will run or stop activity on its local copy respectively. This should give us coverage where multiple clients retrieve the same attachment blob, for e.g., an image.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.

[AB#2750](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2750)