### PR TITLE
Fix normalizeError function when retry properties are present

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -124,7 +124,7 @@ export function normalizeError(
 	// Anywhere they are set should be on a valid Fluid Error that would have been returned above,
 	// but we can't prove it with the types, so adding this defensive measure.
 	if (typeof error === "object" && error !== null) {
-		const maybeRetirable: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> = error;
+		const maybeRetriable: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> = error;
 		let retryProps: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> | undefined;
 		if ("canRetry" in error) {
 			retryProps ??= {};

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -124,15 +124,15 @@ export function normalizeError(
 	// Anywhere they are set should be on a valid Fluid Error that would have been returned above,
 	// but we can't prove it with the types, so adding this defensive measure.
 	if (typeof error === "object" && error !== null) {
-		const maybeRetriable: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> = error;
+		const maybeHasRetry: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> = error;
 		let retryProps: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> | undefined;
 		if ("canRetry" in error) {
 			retryProps ??= {};
-			retryProps.canRetry = maybeRetirable.canRetry;
+			retryProps.canRetry = maybeHasRetry.canRetry;
 		}
 		if ("retryAfterSeconds" in error) {
 			retryProps ??= {};
-			retryProps.retryAfterSeconds = maybeRetirable.retryAfterSeconds;
+			retryProps.retryAfterSeconds = maybeHasRetry.retryAfterSeconds;
 		}
 		if (retryProps !== undefined) {
 			Object.assign(fluidError, retryProps);

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -124,8 +124,19 @@ export function normalizeError(
 	// Anywhere they are set should be on a valid Fluid Error that would have been returned above,
 	// but we can't prove it with the types, so adding this defensive measure.
 	if (typeof error === "object" && error !== null) {
-		const { canRetry, retryAfterSeconds } = error as any;
-		Object.assign(normalizeError, { canRetry, retryAfterSeconds });
+		const maybeRetirable: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> = error;
+		let retryProps: Partial<Record<"canRetry" | "retryAfterSeconds", unknown>> | undefined;
+		if ("canRetry" in error) {
+			retryProps ??= {};
+			retryProps.canRetry = maybeRetirable.canRetry;
+		}
+		if ("retryAfterSeconds" in error) {
+			retryProps ??= {};
+			retryProps.retryAfterSeconds = maybeRetirable.retryAfterSeconds;
+		}
+		if (retryProps !== undefined) {
+			Object.assign(fluidError, retryProps);
+		}
 	}
 
 	if (typeof error !== "object") {

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -580,7 +580,7 @@ describe("Error Logging", () => {
 					"retryAfterSeconds not undefined",
 				);
 			});
-			it("missing properties are not set", () => {
+			it("existing retry properties are present in normalized error", () => {
 				const unknownError: { canRetry?: boolean; retryAfterSeconds?: number } & Error =
 					new Error();
 				unknownError.canRetry = true;

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -563,6 +563,39 @@ describe("Error Logging", () => {
 			);
 		});
 	});
+	describe("normalizeError", () => {
+		describe("preserves properties", () => {
+			it("missing properties are not set", () => {
+				const unknownError = new Error();
+
+				const newError: IFluidErrorBase & {
+					canRetry?: boolean;
+					retryAfterSeconds?: number;
+				} = normalizeError(unknownError);
+
+				assert.strictEqual(newError.canRetry, undefined, "canRetry not undefined");
+				assert.strictEqual(
+					newError.retryAfterSeconds,
+					undefined,
+					"retryAfterSeconds not undefined",
+				);
+			});
+			it("missing properties are not set", () => {
+				const unknownError: { canRetry?: boolean; retryAfterSeconds?: number } & Error =
+					new Error();
+				unknownError.canRetry = true;
+				unknownError.retryAfterSeconds = 100;
+
+				const newError: IFluidErrorBase & {
+					canRetry?: boolean;
+					retryAfterSeconds?: number;
+				} = normalizeError(unknownError);
+
+				assert.strictEqual(newError.canRetry, true, "canRetry not true");
+				assert.strictEqual(newError.retryAfterSeconds, 100, "retryAfterSeconds not 100");
+			});
+		});
+	});
 });
 
 class TestFluidError implements IFluidErrorBase {


### PR DESCRIPTION
Fix normalizeError function when retry properties are present. Previously these properties were being assigned to the normalizeError function, and not the new error object. Also added tests.