### PR TITLE
Keep track of blob handles in BlobManager

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -16,6 +16,7 @@ import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidDataStoreContextDetached } from '@fluidframework/runtime-definitions';
+import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
@@ -42,6 +43,8 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     readonly isDirty: boolean;
     // (undocumented)
     readonly options: ILoaderOptions;
+    // (undocumented)
+    proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void;
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
     readonly scope: FluidObject;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -187,6 +187,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     process(messageArg: ISequencedDocumentMessage, local: boolean): void;
     // (undocumented)
     processSignal(message: ISignalMessage, local: boolean): void;
+    // (undocumented)
+    proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void;
     refreshLatestSummaryAck(options: IRefreshSummaryAckOptions): Promise<void>;
     request(request: IRequest): Promise<IResponse>;
     resolveHandle(request: IRequest): Promise<IResponse>;

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -122,6 +122,8 @@ export interface IFluidDataStoreRuntime extends IFluidRouter, IEventProvider<IFl
     // (undocumented)
     readonly options: ILoaderOptions;
     // (undocumented)
+    proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): any;
+    // (undocumented)
     readonly rootRoutingContext: IFluidHandleContext;
     submitSignal(type: string, content: any): void;
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -107,6 +107,8 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     processSignal(message: IInboundSignalMessage, local: boolean): void;
     // (undocumented)
+    proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void;
+    // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -273,6 +273,8 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     // (undocumented)
     readonly options: ILoaderOptions;
     readonly packagePath: readonly string[];
+    // (undocumented)
+    proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void;
     readonly scope: FluidObject;
     setChannelDirty(address: string): void;
     // (undocumented)

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -15,6 +15,7 @@ import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtim
 import { readAndParse } from "@fluidframework/driver-utils";
 import { IFluidSerializer, SharedObject } from "@fluidframework/shared-object-base";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISharedMap, ISharedMapEvents } from "./interfaces";
 import { IMapDataObjectSerializable, IMapOperation, MapKernel } from "./mapKernel";
 import { pkgVersion } from "./packageVersion";
@@ -226,6 +227,9 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 */
 	public set(key: string, value: unknown): this {
 		this.kernel.set(key, value);
+		if (this.runtime.proneBlobHandle !== undefined) {
+			this.runtime.proneBlobHandle(value as IFluidHandle<ArrayBufferLike>);
+		}
 		return this;
 	}
 

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -5,7 +5,13 @@
 
 import { IEventProvider } from "@fluidframework/common-definitions";
 import { AttachState, IDeltaManager, ILoaderOptions } from "@fluidframework/container-definitions";
-import { IRequest, IResponse, IFluidRouter, FluidObject } from "@fluidframework/core-interfaces";
+import {
+	IRequest,
+	IResponse,
+	IFluidRouter,
+	FluidObject,
+	IFluidHandle,
+} from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
 	IClientDetails,
@@ -91,4 +97,6 @@ export interface IContainerRuntime
 	 * @param request - request to resolve
 	 */
 	resolveHandle(request: IRequest): Promise<IResponse>;
+
+	proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void;
 }

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -339,7 +339,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 
 	public proneBlobHandle(handle: IFluidHandle<ArrayBufferLike>) {
 		const index = this.pendingHandles.indexOf(handle);
-		if (index !== -1) {
+		if (index !== -1 && handle.isAttached) {
 			this.pendingHandles.splice(index, 1);
 		}
 	}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2963,6 +2963,11 @@ export class ContainerRuntime
 		return this.blobManager.createBlob(blob);
 	}
 
+	public proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>) {
+		this.verifyNotClosed();
+		this.blobManager.proneBlobHandle(handle);
+	}
+
 	private maybeSubmitIdAllocationOp(type: ContainerMessageType) {
 		if (type !== ContainerMessageType.IdAllocation) {
 			let idAllocationBatchMessage: BatchMessage | undefined;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -939,6 +939,12 @@ export abstract class FluidDataStoreContext
 	public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
 		return this.containerRuntime.uploadBlob(blob);
 	}
+
+	public proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void {
+		if (this.containerRuntime.proneBlobHandle !== undefined) {
+			this.containerRuntime.proneBlobHandle(handle);
+		}
+	}
 }
 
 export class RemoteFluidDataStoreContext extends FluidDataStoreContext {

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -108,6 +108,8 @@ export interface IFluidDataStoreRuntime
 	 */
 	uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
+	proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>);
+
 	/**
 	 * Submits the signal to be sent to other clients.
 	 * @param type - Type of the signal.

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -589,6 +589,13 @@ export class FluidDataStoreRuntime
 		return this.dataStoreContext.uploadBlob(blob);
 	}
 
+	public proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>) {
+		if (this.dataStoreContext.proneBlobHandle !== undefined) {
+			this.dataStoreContext.proneBlobHandle(handle);
+		}
+		return;
+	}
+
 	public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
 		this.verifyNotClosed();
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -474,6 +474,8 @@ export interface IFluidDataStoreContext
 
 	uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
+	proneBlobHandle?(handle: IFluidHandle<ArrayBufferLike>): void;
+
 	/**
 	 * @deprecated - The functionality to get base GC details has been moved to summarizer node.
 	 *


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_workitems/edit/4549

Detached blobs are being removed from the pendingBlobs map as soon as its op is round tripped. Blob manager should be able to keep track of such blobs until they become attached (they are set in an attached DDS). The reason for this is the need of a better mechanism around blobs when we go offline. Current code stashes blobs that aren't recovered and transitionToOffline does not resemble how we handle datastores. This is a first step to better handle blob uploading and eventually have a unified shutdown mechanism across all container layers.

This change stores the blob handles in the BlobManager using an array. Once the blob handle is used in a map or directory, it runs proneBlobHandle method to remove it from that array. 

This is a simple first approach, but it helps to outline issues that I found while thinking about the design and considerations for other posible solutions. 

1. IFluidHandle interface does not have an id property. When handle is used in the DDS during set, there is no way to quickly identify the handle, so I decided to use an array and this.pendingHandles.indexOf(handle) to be able to delete it. This is more of an optimization, but we could create something like a BlobHandle interface with the blob id and change the array for a map.
2. I considered re using pendingBlobs map instead of creating pendingHandles array, but I believe the distinction is going to be necessary later on and also a lot of its details are not needed once we have the handle. 
3. A lot of pendingBlob usage around stashing will be redirected to pendingHandles. 
4. Probably there are other moments where we could try to prone the pendingHandles array, but checking right after each map or directory set seems the best way for me. Another approach could be to prune the array after each op submission. 
5. I need to think about ways to unit test proneBlobHandle correctly.