### PR TITLE
Add DirectConnection Option in MongoDB SDK

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -25,6 +25,7 @@ data:
             "globalDbEnabled": {{ .Values.mongodb.globalDbEnabled }},
             "expireAfterSeconds": {{ .Values.mongodb.expireAfterSeconds }},
             "createCosmosDBIndexes": {{ .Values.mongodb.createCosmosDBIndexes }},
+            "directConnection": {{ .Values.mongodb.directConnection }},
             "softDeletionRetentionPeriodMs": {{ .Values.mongodb.softDeletionRetentionPeriodMs }},
             "offlineWindowMs": {{ .Values.mongodb.offlineWindowMs }},
             "softDeletionEnabled": {{ .Values.mongodb.softDeletionEnabled }},

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -117,6 +117,7 @@ mongodb:
   globalDbEnabled: false
   expireAfterSeconds: -1
   createCosmosDBIndexes: false
+  directConnection: true
   softDeletionRetentionPeriodMs: 2592000000
   offlineWindowMs: 86400000
   softDeletionEnabled: false

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -13,6 +13,7 @@
 		"globalDbEnabled": false,
 		"expireAfterSeconds": -1,
 		"createCosmosDBIndexes": false,
+		"directConnection": true,
 		"softDeletionRetentionPeriodMs": 2592000000,
 		"offlineWindowMs": 86400000,
 		"softDeletionEnabled": false,

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -464,7 +464,7 @@ export class MongoDbFactory implements core.IDbFactory {
 	private readonly globalDbEndpoint?: string;
 	private readonly connectionPoolMinSize?: number;
 	private readonly connectionPoolMaxSize?: number;
-	private readonly directConnection?: boolean;
+	private readonly directConnection: boolean;
 	private readonly retryEnabled: boolean = false;
 	private readonly telemetryEnabled: boolean = false;
 	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "ruleBehavior";
@@ -487,7 +487,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
 		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";
-		this.directConnection = directConnection || false;
+		this.directConnection = directConnection ?? false;
 		this.retryEnabled = config.facadeLevelRetry || false;
 		this.telemetryEnabled = config.facadeLevelTelemetry || false;
 		this.retryRuleOverride = config.facadeLevelRetryRuleOverride
@@ -503,7 +503,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		);
 		// Need to cast to any before MongoClientOptions due to missing properties in d.ts
 		const options: MongoClientOptions = {
-			directConnection: this.directConnection || false,
+			directConnection: this.directConnection ?? false,
 			keepAlive: true,
 			keepAliveInitialDelay: 180000,
 			socketTimeoutMS: 120000,

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -499,7 +499,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		);
 		// Need to cast to any before MongoClientOptions due to missing properties in d.ts
 		const options: MongoClientOptions = {
-            directConnection: true,
+			directConnection: true,
 			keepAlive: true,
 			keepAliveInitialDelay: 180000,
 			socketTimeoutMS: 120000,

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -499,6 +499,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		);
 		// Need to cast to any before MongoClientOptions due to missing properties in d.ts
 		const options: MongoClientOptions = {
+            directConnection: true,
 			keepAlive: true,
 			keepAliveInitialDelay: 180000,
 			socketTimeoutMS: 120000,

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -452,6 +452,7 @@ interface IMongoDBConfig {
 	globalDbEnabled?: boolean;
 	connectionPoolMinSize?: number;
 	connectionPoolMaxSize?: number;
+	directConnection?: boolean;
 	facadeLevelRetry?: boolean;
 	facadeLevelTelemetry?: boolean;
 	facadeLevelRetryRuleOverride?: any;
@@ -463,6 +464,7 @@ export class MongoDbFactory implements core.IDbFactory {
 	private readonly globalDbEndpoint?: string;
 	private readonly connectionPoolMinSize?: number;
 	private readonly connectionPoolMaxSize?: number;
+	private readonly directConnection?: boolean;
 	private readonly retryEnabled: boolean = false;
 	private readonly telemetryEnabled: boolean = false;
 	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "ruleBehavior";
@@ -474,6 +476,7 @@ export class MongoDbFactory implements core.IDbFactory {
 			globalDbEndpoint,
 			connectionPoolMinSize,
 			connectionPoolMaxSize,
+			directConnection,
 			connectionNotAvailableMode,
 		} = config;
 		if (globalDbEnabled) {
@@ -484,6 +487,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
 		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";
+		this.directConnection = directConnection || false;
 		this.retryEnabled = config.facadeLevelRetry || false;
 		this.telemetryEnabled = config.facadeLevelTelemetry || false;
 		this.retryRuleOverride = config.facadeLevelRetryRuleOverride
@@ -499,7 +503,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		);
 		// Need to cast to any before MongoClientOptions due to missing properties in d.ts
 		const options: MongoClientOptions = {
-			directConnection: true,
+			directConnection: this.directConnection || false,
 			keepAlive: true,
 			keepAliveInitialDelay: 180000,
 			socketTimeoutMS: 120000,


### PR DESCRIPTION
We currently have a ReplicaSetNoPrimary error caused by MongoServerSelectionError: connection timed out\n 
{"reason"=>{"type"=>"ReplicaSetNoPrimary", "servers"=>{}, "stale"=>"REDACTED", "compatible"=>"REDACTED", "heartbeatFrequencyMS"=>"REDACTED", "localThresholdMS"=>"REDACTED", "setName"=>"REDACTED", "maxElectionId"=>nil, "maxSetVersion"=>"REDACTED", "commonWireVersion"=>"REDACTED", "logicalSessionTimeoutMinutes"=>nil}, "name"=>"MongoServerSelectionError", "message"=>"connection timed out", "stack"=>"MongoServerSelectionError: connection timed out\n at Timeout._onTimeout (/usr/src/server/bundle/alfred/www.js:126365:34)\n at listOnTimeout (node:internal/timers:559:17)\n at processTimers (node:internal/timers:502:7)"}

From: https://stackoverflow.com/questions/59162342/mongodb-connection-error-mongotimeouterror-server-selection-timed-out-after-30, we can fix it by enabling directConnection flag as true.

Here is the definition for directConnection: https://mongodb.github.io/node-mongodb-native/4.14/interfaces/MongoClientOptions.html#directConnection