### PR TITLE
docs: Minor cleanup - typos, remove nonexistent params from docstrings, remove outdated comments

### DIFF
--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -58,7 +58,6 @@ export class DeltaQueue<T>
 
 	/**
 	 * @param worker - A callback to process a delta.
-	 * @param logger - For logging telemetry.
 	 */
 	constructor(private readonly worker: (delta: T) => void) {
 		super();

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -20,8 +20,8 @@ export class DeltaQueue<T>
 	private readonly q = new Deque<T>();
 
 	/**
-	 * Tracks the number of pause requests for the queue
-	 * The DeltaQueue is create initially paused.
+	 * Tracks the number of pause requests for the queue.
+	 * The DeltaQueue is created initially paused.
 	 */
 	private pauseCount = 1;
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -289,7 +289,6 @@ export class ChildLogger extends TelemetryLogger {
 	 * is created, but it does not send telemetry events anywhere.
 	 * @param namespace - Telemetry event name prefix to add to all events
 	 * @param properties - Base properties to add to all events
-	 * @param propertyGetters - Getters to add additional properties to all events
 	 */
 	public static create(
 		baseLogger?: ITelemetryBaseLogger,
@@ -360,7 +359,6 @@ export class ChildLogger extends TelemetryLogger {
 /**
  * Multi-sink logger
  * Takes multiple ITelemetryBaseLogger objects (sinks) and logs all events into each sink
- * Implements ITelemetryBaseLogger (through static create() method)
  */
 export class MultiSinkLogger extends TelemetryLogger {
 	protected loggers: ITelemetryBaseLogger[] = [];
@@ -369,7 +367,6 @@ export class MultiSinkLogger extends TelemetryLogger {
 	 * Create multiple sink logger (i.e. logger that sends events to multiple sinks)
 	 * @param namespace - Telemetry event name prefix to add to all events
 	 * @param properties - Base properties to add to all events
-	 * @param propertyGetters - Getters to add additional properties to all events
 	 */
 	constructor(namespace?: string, properties?: ITelemetryLoggerPropertyBags) {
 		super(namespace, properties);


### PR DESCRIPTION
## Description

Non-functional. Cleaning up docstrings, comments.
