### PR TITLE
feat(merge-tree): new merge tree length calculation follow-up

### DIFF
--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -141,7 +141,6 @@ export class PermutationVector extends Client {
 			{
 				...runtime.options,
 				newMergeTreeSnapshotFormat: true, // Temporarily force new snapshot format until it is the default.
-				mergeTreeUseNewLengthCalculations: true,
 			},
 		); // (See https://github.com/microsoft/FluidFramework/issues/84)
 

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1105,7 +1105,7 @@ export class MergeTree {
 			} else {
 				const segment = node;
 				const removalInfo = toRemovalInfo(segment);
-				if (this.options?.mergeTreeUseNewLengthCalculations === true) {
+				if (this.options?.mergeTreeUseNewLengthCalculations !== false) {
 					if (removalInfo !== undefined) {
 						if (seqLTE(removalInfo.removedSeq, this.collabWindow.minSeq)) {
 							return undefined;

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -380,12 +380,7 @@ describe("client.applyMsg", () => {
 	});
 
 	it("Local insert after acked local delete", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "ZZ", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-			"C",
-		);
+		const clients = createClientsAtInitialState({ initialState: "ZZ" }, "A", "B", "C");
 
 		const logger = new TestClientLogger(clients.all);
 
@@ -462,12 +457,7 @@ describe("client.applyMsg", () => {
 	});
 
 	it("Inconsistent shared string after pausing connection #9703", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "abcd", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-			"C",
-		);
+		const clients = createClientsAtInitialState({ initialState: "abcd" }, "A", "B", "C");
 
 		const logger = new TestClientLogger(clients.all);
 
@@ -595,13 +585,7 @@ describe("client.applyMsg", () => {
 	 * ```
 	 */
 	it("Concurrent insert into removed segment across block boundary", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-			"C",
-			"D",
-		);
+		const clients = createClientsAtInitialState({ initialState: "" }, "A", "B", "C", "D");
 
 		const logger = new TestClientLogger([clients.A, clients.C]);
 		let seq = 0;

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -74,9 +74,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 				testOpts.resultsFilePostfix += extraSeed;
 			}
 
-			const clients: TestClient[] = [
-				new TestClient({ mergeTreeUseNewLengthCalculations: true }),
-			];
+			const clients: TestClient[] = [new TestClient()];
 			clients.forEach((c, i) => c.startOrUpdateCollaboration(clientNames[i]));
 
 			let seq = 0;

--- a/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -90,9 +90,7 @@ function runReconnectFarmTests(opts: IReconnectFarmConfig, extraSeed?: number): 
 				testOpts.resultsFilePostfix += extraSeed;
 			}
 
-			const clients: TestClient[] = [
-				new TestClient({ mergeTreeUseNewLengthCalculations: true }),
-			];
+			const clients: TestClient[] = [new TestClient()];
 			clients.forEach((c, i) => c.startOrUpdateCollaboration(clientNames[i]));
 
 			let seq = 0;

--- a/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
@@ -49,7 +49,7 @@ describe("MergeTree.Client", () => {
 				const clients = createClientsAtInitialState(
 					{
 						initialState: "",
-						options: { mergeTreeUseNewLengthCalculations: true },
+						options: {},
 					},
 					"A",
 					"B",

--- a/packages/dds/merge-tree/src/test/revertibles.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibles.spec.ts
@@ -50,11 +50,7 @@ export function spyOnMethod(
 
 describe("MergeTree.Revertibles", () => {
 	it("revert insert", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "123", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-		);
+		const clients = createClientsAtInitialState({ initialState: "123", options: {} }, "A", "B");
 		const logger = new TestClientLogger(clients.all);
 		let seq = 0;
 		const ops: ISequencedDocumentMessage[] = [];
@@ -94,7 +90,7 @@ describe("MergeTree.Revertibles", () => {
 			const clients = createClientsAtInitialState(
 				{
 					initialState: "",
-					options: { mergeTreeUseNewLengthCalculations: true },
+					options: {},
 				},
 				"A",
 			);
@@ -151,11 +147,7 @@ describe("MergeTree.Revertibles", () => {
 	});
 
 	it("revert remove", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "123", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-		);
+		const clients = createClientsAtInitialState({ initialState: "123", options: {} }, "A", "B");
 		const logger = new TestClientLogger(clients.all);
 		let seq = 0;
 		const ops: ISequencedDocumentMessage[] = [];
@@ -195,7 +187,7 @@ describe("MergeTree.Revertibles", () => {
 	]) {
 		it(name, () => {
 			const clients = createClientsAtInitialState(
-				{ initialState: "1-23", options: { mergeTreeUseNewLengthCalculations: true } },
+				{ initialState: "1-23", options: {} },
 				"A",
 				"B",
 				"C",
@@ -231,7 +223,7 @@ describe("MergeTree.Revertibles", () => {
 
 	it("revert two overlapping removes", () => {
 		const clients = createClientsAtInitialState(
-			{ initialState: "123", options: { mergeTreeUseNewLengthCalculations: true } },
+			{ initialState: "123", options: {} },
 			"A",
 			"B",
 			"C",
@@ -272,11 +264,7 @@ describe("MergeTree.Revertibles", () => {
 	});
 
 	it("revert annotate", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "123", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-		);
+		const clients = createClientsAtInitialState({ initialState: "123", options: {} }, "A", "B");
 		const logger = new TestClientLogger(clients.all);
 		let seq = 0;
 		const ops: ISequencedDocumentMessage[] = [];
@@ -306,7 +294,7 @@ describe("MergeTree.Revertibles", () => {
 
 	it("Remove All Original Text and Insert then Revert", () => {
 		const clients = createClientsAtInitialState(
-			{ initialState: "1-2--", options: { mergeTreeUseNewLengthCalculations: true } },
+			{ initialState: "1-2--", options: {} },
 			"A",
 			"B",
 			"C",
@@ -343,7 +331,7 @@ describe("MergeTree.Revertibles", () => {
 
 	it("Re-Insert at position 0 in empty string", () => {
 		const clients = createClientsAtInitialState(
-			{ initialState: "BBC-", options: { mergeTreeUseNewLengthCalculations: true } },
+			{ initialState: "BBC-", options: {} },
 			"A",
 			"B",
 			"C",
@@ -379,7 +367,7 @@ describe("MergeTree.Revertibles", () => {
 
 	it("Revert remove to empty with annotate", () => {
 		const clients = createClientsAtInitialState(
-			{ initialState: "1-23--", options: { mergeTreeUseNewLengthCalculations: true } },
+			{ initialState: "1-23--", options: {} },
 			"A",
 			"B",
 			"C",
@@ -420,7 +408,7 @@ describe("MergeTree.Revertibles", () => {
 
 	it("Revert Local annotate and remove with intersecting remote annotate", () => {
 		const clients = createClientsAtInitialState(
-			{ initialState: "1234-----", options: { mergeTreeUseNewLengthCalculations: true } },
+			{ initialState: "1234-----", options: {} },
 			"A",
 			"B",
 			"C",
@@ -483,7 +471,7 @@ describe("MergeTree.Revertibles", () => {
 		}).forEach((options) => {
 			it(JSON.stringify(options), () => {
 				const clients = createClientsAtInitialState(
-					{ initialState: "", options: { mergeTreeUseNewLengthCalculations: true } },
+					{ initialState: "", options: {} },
 					"A",
 					"B",
 				);


### PR DESCRIPTION
Enables new merge-tree length calculations by default in `nodeLength`, which was missed in the previous PR. Additionally removes the now-redundant flag from tests.