### PR TITLE
Experiment - Enable unsampled telemetry, option 1

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -31,7 +31,7 @@ export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
 export class ChildLogger extends TelemetryLogger {
     // (undocumented)
     protected readonly baseLogger: ITelemetryBaseLogger;
-    static create(baseLogger?: ITelemetryBaseLogger, namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    static create(baseLogger?: ITelemetryBaseLogger, namespace?: string, properties?: ITelemetryLoggerPropertyBags, sampling?: Map<string, number>): TelemetryLogger;
     send(event: ITelemetryBaseEvent): void;
 }
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -15,7 +15,12 @@ import {
 	TelemetryEventCategory,
 } from "@fluidframework/common-definitions";
 import { performance } from "@fluidframework/common-utils";
-import { CachedConfigProvider, loggerIsMonitoringContext, mixinMonitoringContext } from "./config";
+import {
+	CachedConfigProvider,
+	loggerIsMonitoringContext,
+	loggerToMonitoringContext,
+	mixinMonitoringContext,
+} from "./config";
 import {
 	isILoggingError,
 	extractLogSafeErrorProperties,
@@ -295,6 +300,7 @@ export class ChildLogger extends TelemetryLogger {
 		baseLogger?: ITelemetryBaseLogger,
 		namespace?: string,
 		properties?: ITelemetryLoggerPropertyBags,
+		sampling?: Map<string, number>,
 	): TelemetryLogger {
 		// if we are creating a child of a child, rather than nest, which will increase
 		// the callstack overhead, just generate a new logger that includes everything from the previous
@@ -324,28 +330,45 @@ export class ChildLogger extends TelemetryLogger {
 					? baseLogger.namespace
 					: `${baseLogger.namespace}${TelemetryLogger.eventNamespaceSeparator}${namespace}`;
 
-			return new ChildLogger(baseLogger.baseLogger, combinedNamespace, combinedProperties);
+			return new ChildLogger(
+				baseLogger.baseLogger,
+				combinedNamespace,
+				combinedProperties,
+				sampling,
+			);
 		}
 
 		return new ChildLogger(
 			baseLogger ? baseLogger : new BaseTelemetryNullLogger(),
 			namespace,
 			properties,
+			sampling,
 		);
 	}
+
+	private readonly isSamplingDisabled: boolean = false;
 
 	private constructor(
 		protected readonly baseLogger: ITelemetryBaseLogger,
 		namespace: string | undefined,
 		properties: ITelemetryLoggerPropertyBags | undefined,
+		private readonly samplingParams?: Map<string, number>,
 	) {
 		super(namespace, properties);
 
 		// propagate the monitoring context
 		if (loggerIsMonitoringContext(baseLogger)) {
 			mixinMonitoringContext(this, new CachedConfigProvider(this, baseLogger.config));
+
+			// Read config flag only once, so we don't pay the price every time an event is logged.
+			const mc = loggerToMonitoringContext(this);
+			if (mc.config.getBoolean("Fluid.Telemetry.DisableSampling") === true) {
+				this.isSamplingDisabled = true;
+			}
 		}
 	}
+
+	private readonly actualSampling: { [key: string]: number } = {};
 
 	/**
 	 * Send an event with the logger
@@ -353,7 +376,23 @@ export class ChildLogger extends TelemetryLogger {
 	 * @param event - the event to send
 	 */
 	public send(event: ITelemetryBaseEvent): void {
-		this.baseLogger.send(this.prepareEvent(event));
+		if (this.isSamplingDisabled) {
+			this.baseLogger.send(this.prepareEvent(event));
+			return;
+		}
+		const params = this.samplingParams?.get(event.eventName);
+		if (params !== undefined) {
+			if (this.actualSampling[event.eventName] === undefined) {
+				this.actualSampling[event.eventName] = 0;
+			}
+			this.actualSampling[event.eventName]++;
+			if (this.actualSampling[event.eventName] % params === 1) {
+				this.baseLogger.send(this.prepareEvent(event));
+				this.actualSampling[event.eventName] = 1;
+			}
+		} else {
+			this.baseLogger.send(this.prepareEvent(event));
+		}
 	}
 }
 

--- a/packages/utils/telemetry-utils/src/test/childLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/childLogger.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ChildLogger } from "../logger";
+import { ConfigTypes, IConfigProviderBase, mixinMonitoringContext } from "../config";
 
 describe("ChildLogger", () => {
 	it("Properties & Getters Propagate", () => {
@@ -175,5 +176,81 @@ describe("ChildLogger", () => {
 
 		childLogger2.send({ category: "generic", eventName: "testEvent" });
 		assert(sent, "event should be sent");
+	});
+
+	describe("Sampling", () => {
+		let events: ITelemetryBaseEvent[] = [];
+		function getBaseLoggerWithConfig(
+			configDictionary?: Record<string, ConfigTypes>,
+		): ITelemetryBaseLogger {
+			const logger: ITelemetryBaseLogger = {
+				send(event: ITelemetryBaseEvent): void {
+					events.push(event);
+				},
+			};
+			const configProvider = (
+				settings: Record<string, ConfigTypes>,
+			): IConfigProviderBase => ({
+				getRawConfig: (name: string): ConfigTypes => settings[name],
+			});
+			return mixinMonitoringContext(logger, configProvider(configDictionary ?? {})).logger;
+		}
+
+		beforeEach(() => {
+			events = [];
+		});
+
+		it("Applies sampling when feature flag to force unsampled telemetry is not set", () => {
+			const samplingConfiguration = new Map<string, number>([
+				["oneEveryTwo", 2],
+				["oneEveryFive", 5],
+			]);
+			const logger = getBaseLoggerWithConfig();
+			const childLogger = ChildLogger.create(
+				logger,
+				undefined,
+				undefined,
+				samplingConfiguration,
+			);
+
+			for (let i = 0; i < 15; i++) {
+				childLogger.send({ category: "generic", eventName: "noSampling" });
+				childLogger.send({ category: "generic", eventName: "oneEveryTwo" });
+				childLogger.send({ category: "generic", eventName: "oneEveryFive" });
+			}
+
+			// These counts also validate that we issue sampled events the first time we see them, not only until the specified
+			// number of samples have been seen.
+			assert.equal(events.filter((event) => event.eventName === "noSampling").length, 15);
+			assert.equal(events.filter((event) => event.eventName === "oneEveryTwo").length, 8);
+			assert.equal(events.filter((event) => event.eventName === "oneEveryFive").length, 3);
+		});
+
+		it("Ignores sampling when feature flag to force unsampled telemetry is set", () => {
+			const samplingConfiguration = new Map<string, number>([
+				["oneEveryTwo", 2],
+				["oneEveryFive", 5],
+			]);
+			const injectedSettings = {
+				"Fluid.Telemetry.DisableSampling": true,
+			};
+			const logger = getBaseLoggerWithConfig(injectedSettings);
+			const childLogger = ChildLogger.create(
+				logger,
+				undefined,
+				undefined,
+				samplingConfiguration,
+			);
+
+			for (let i = 0; i < 15; i++) {
+				childLogger.send({ category: "generic", eventName: "noSampling" });
+				childLogger.send({ category: "generic", eventName: "oneEveryTwo" });
+				childLogger.send({ category: "generic", eventName: "oneEveryFive" });
+			}
+
+			assert.equal(events.filter((event) => event.eventName === "noSampling").length, 15);
+			assert.equal(events.filter((event) => event.eventName === "oneEveryTwo").length, 15);
+			assert.equal(events.filter((event) => event.eventName === "oneEveryFive").length, 15);
+		});
 	});
 });


### PR DESCRIPTION
## Description

This approach enables unsampled telemetry with the following changes:

- Update the creation logic for `ChildLogger` so it can receive an optional map from event names to sampling rates, and update the `send()` method to use said map to make decisions about when telemetry events are forwarded to the `ITelemetryBaseLogger` implementation the `ChildLogger` knows about (e.g. the one passed to the loader by the host application).
- Add a new feature flag "Fluid.Telemetry.DisableSampling" used by the new logic in `ChildLogger`, so that unsampled telemetry only flows to the `ITelemetryBaseLogger` if the feature flag is enabled.

## Reviewer guidance

Compare with https://github.com/microsoft/FluidFramework/pull/15979.

I really like the simplicity of this approach. No changes to public API surface, only to the way we create `ChildLogger` instances.

Also has the advantage that no updates to the loader are required for consumers to leverage this.

The particulars of how to do sampling (counter like in the current version of the PR, or random number generation) could be made part of the configuration given to `ChildLogger`. It might even work for the unusual approach we took [here](https://github.com/microsoft/FluidFramework/blob/fce757dbdbdac5f10e02be3ae13e43ed55190b6d/experimental/dds/tree/src/id-compressor/Logger.ts#L16-L22), where some sampling of _clients_ are given an actual logger and the rest are given a null one, so that we get all the messages from some clients and none from the rest. Configuration such as the following, could support tweaking how sampling is done in different places in the codebase:

```typescript
interface IWithCounterTelemetrySamplingConfig {
  type: "withCounter";
  sampling: Map<string, number>; // Map from event names to sampling rate (e.g. `"OpRoundtripTime" -> 100`, sample 1 in 100)
}

interface IWithRandomNumbersTelemetrySamplingConfig {
  type: "withRandomNumbers";
  sampling: Map<string, number>; // Map from event names to sampling rate (e.g. `"OpRoundtripTime" -> 0.10`, sample when random number in [0,1] < 0.10)
}

interface IPerClientTelemetrySamplingConfig {
  type: "perClient";
  percentage: <number>; // Percent of clients that get an actual logger
}

interface ITelemetrySamplingConfig = IWithCounterTelemetrySamplingConfig | IWithRandomNumbersTelemetrySamplingConfig | IPerClientTelemetrySamplingConfig;

// ChildLogger class
{
  ...
  constructor(..., samplingConfig?: ITelemetrySamplingConfig)
  ...
}
```

Regardless of how it's done, the feature flag could disable any approach to sampling.