### PR TITLE
send telemetry event when container becomes dirty while disconnected

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2230,6 +2230,11 @@ export class Container
 		if (this._dirtyContainer === dirty) {
 			return;
 		}
+		if (dirty && this.connectionState === ConnectionState.Disconnected) {
+			// If container is dirtied while disconnected, it should reconnect in write mode if possible.
+			// We expect a "DesiredConnectionModeMismatch" event from ConnectionManager to follow if and when we reconnect.
+			this.mc.logger.sendTelemetryEvent({ eventName: "ContainerDirtiedWhileDisconnected" });
+		}
 		this._dirtyContainer = dirty;
 		this.emit(dirty ? dirtyContainerEvent : savedContainerEvent);
 	}


### PR DESCRIPTION
[AB#4133](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4133)
Related to #14997

Send a telemetry event when a container transitions from clean to dirty state while disconnected. This will help diagnose DesiredConnectionModeMismatch events, which are expected when a container disconnects while clean and then becomes dirty before it reconnects, since runtime will not have submitted any ops to container layer while disconnected.