### PR TITLE
Populating sub directories correctly in Shared Directory

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -654,6 +654,8 @@ export class SharedDirectory
 					if (!newSubDir) {
 						const createInfo = subdirObject.ci;
 						newSubDir = new SubDirectory(
+							// If csn is -1, then initialize it with 0, otherwise we will never process ops for this
+							// sub directory.
 							createInfo !== undefined && createInfo.csn > -1 ? createInfo.csn : 0,
 							createInfo !== undefined
 								? new Set<string>(createInfo.ccIds)

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -654,7 +654,7 @@ export class SharedDirectory
 					if (!newSubDir) {
 						const createInfo = subdirObject.ci;
 						newSubDir = new SubDirectory(
-							createInfo !== undefined ? createInfo.csn : 0,
+							createInfo !== undefined && createInfo.csn > -1 ? createInfo.csn : 0,
 							createInfo !== undefined
 								? new Set<string>(createInfo.ccIds)
 								: new Set(),

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -655,7 +655,8 @@ export class SharedDirectory
 						const createInfo = subdirObject.ci;
 						newSubDir = new SubDirectory(
 							// If csn is -1, then initialize it with 0, otherwise we will never process ops for this
-							// sub directory.
+							// sub directory. This could be done at serialization time too, but we need to maintain
+							// back compat too and also we will actually know the state when it was serialized.
 							createInfo !== undefined && createInfo.csn > -1 ? createInfo.csn : 0,
 							createInfo !== undefined
 								? new Set<string>(createInfo.ccIds)

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -817,6 +817,7 @@ describe("Directory", () => {
 				);
 				await directory2.load(services2);
 
+				// Now connect the first SharedDirectory
 				dataStoreRuntime.local = false;
 				const containerRuntime1 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -730,6 +730,55 @@ describe("Directory", () => {
 				);
 			});
 
+			it("Should populate with csn as 0 and then process the create op", async () => {
+				directory.createSubDirectory("nested");
+				const serialized = serialize(directory);
+
+				// Now populate a new directory with contents of above to simulate processing of attach op
+				const containerRuntimeFactory = new MockContainerRuntimeFactory();
+				const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+				const containerRuntime2 =
+					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+				const services2 = MockSharedObjectServices.createFromSummary(
+					directory.getAttachSummary().summary,
+				);
+				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+
+				const directory2 = new SharedDirectory(
+					"directory2",
+					dataStoreRuntime2,
+					DirectoryFactory.Attributes,
+				);
+				await directory2.load(services2);
+
+				// Now load another directory to send op from that.
+				const dataStoreRuntime3 = new MockFluidDataStoreRuntime();
+				const containerRuntime3 =
+					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime3);
+				const services3 = MockSharedObjectServices.createFromSummary(
+					directory.getAttachSummary().summary,
+				);
+				services3.deltaConnection = containerRuntime3.createDeltaConnection();
+
+				const directory3 = new SharedDirectory(
+					"directory3",
+					dataStoreRuntime3,
+					DirectoryFactory.Attributes,
+				);
+				await directory3.load(services3);
+				containerRuntimeFactory.processAllMessages();
+
+				// Now send create op
+				directory3.getSubDirectory("nested")?.createSubDirectory("nested2");
+				containerRuntimeFactory.processAllMessages();
+
+				// Other directory should process the create op.
+				assert(
+					directory2.getSubDirectory("nested")?.getSubDirectory("nested2") !== undefined,
+					"/nested/nested2 should be present",
+				);
+			});
+
 			/**
 			 * These tests test the scenario found in the following bug:
 			 * {@link https://github.com/microsoft/FluidFramework/issues/2400}.
@@ -768,7 +817,6 @@ describe("Directory", () => {
 				);
 				await directory2.load(services2);
 
-				// Now connect the first SharedDirectory
 				dataStoreRuntime.local = false;
 				const containerRuntime1 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);


### PR DESCRIPTION
## Description

Populating sub directories correctly in Shared Directory.
When we serialize a new directory on attach and record the csn which is -1 for a newly create one, then on load, we load with -1 csn for that. Now there is no create op for this subdir. So when a new subdir is added in that dir and create op comes for that, it does not pass this check below and we don't process that op.
https://github.com/microsoft/FluidFramework/blob/a51cd2afc8fb11e11c083f9f62fa9e69727e6845/packages/dds/map/src/directory.ts#L2150