### PR TITLE
Fix fluid-build to detect added files in incremental builds

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -90,7 +90,7 @@ export class TscTask extends LeafTask {
 					return false;
 				}
 
-				// Remove files that we have build before
+				// Remove files that we have built before
 				configFileNames.delete(fullPath);
 			} catch (e: any) {
 				this.traceTrigger(`exception generating hash for ${fileName}\n\t${e.stack}`);

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -60,9 +60,9 @@ export class TscTask extends LeafTask {
 			return false;
 		}
 
-		// Keep a list of file that needs to be compiled based on the command line and config
-		// And remove the files that we sees from the tsBuildInfo.   The one that are left are
-		// new files and needs to be rebuild.
+		// Keep a list of files that need to be compiled based on the command line flags and config, and
+		// remove the files that we sees from the tsBuildInfo.  The remaining files are
+		// new files that need to be rebuilt.
 		const configFileNames = new Set(config.fileNames);
 
 		// Check dependencies file hashes

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -54,6 +54,17 @@ export class TscTask extends LeafTask {
 			this.traceTrigger("previous build error");
 			return false;
 		}
+
+		const config = this.readTsConfig();
+		if (!config) {
+			return false;
+		}
+
+		// Keep a list of file that needs to be compiled based on the command line and config
+		// And remove the files that we sees from the tsBuildInfo.   The one that are left are
+		// new files and needs to be rebuild.
+		const configFileNames = new Set(config.fileNames);
+
 		// Check dependencies file hashes
 		const fileNames = tsBuildInfo.program.fileNames;
 		const fileInfos = tsBuildInfo.program.fileInfos;
@@ -70,7 +81,7 @@ export class TscTask extends LeafTask {
 
 				// If we have project reference, see if this is in reference to one of the file, and map it to the d.ts file instead
 				if (this._projectReference) {
-					fullPath = this._projectReference.remapSrcDeclFile(fullPath);
+					fullPath = this._projectReference.remapSrcDeclFile(fullPath, config);
 				}
 				const hash = await this.node.buildContext.fileHashCache.getFileHash(fullPath);
 				const version = typeof fileInfo === "string" ? fileInfo : fileInfo.version;
@@ -78,38 +89,44 @@ export class TscTask extends LeafTask {
 					this.traceTrigger(`version mismatch for ${fileName}, ${hash}, ${version}`);
 					return false;
 				}
+
+				// Remove files that we have build before
+				configFileNames.delete(fullPath);
 			} catch (e: any) {
-				this.traceTrigger(`exception generating hash for ${fileName}`);
-				verbose(e.stack);
+				this.traceTrigger(`exception generating hash for ${fileName}\n\t${e.stack}`);
 				return false;
 			}
 		}
 
+		if (configFileNames.size !== 0) {
+			// New files that are not in the previous build, we are not up to date.
+			this.traceTrigger(`new file detected ${[...configFileNames.values()].join(",")}`);
+			return false;
+		}
+
 		// Check tsconfig.json
-		return this.checkTsConfig(tsBuildInfoFileDirectory, tsBuildInfo);
+		return this.checkTsConfig(tsBuildInfoFileDirectory, tsBuildInfo, config);
 	}
 
-	private remapSrcDeclFile(fullPath: string) {
+	private remapSrcDeclFile(fullPath: string, config: ts.ParsedCommandLine) {
 		if (!this._sourceStats) {
-			const config = this.readTsConfig();
 			this._sourceStats = config ? config.fileNames.map((v) => fs.lstatSync(v)) : [];
 		}
 
-		const parsed = path.parse(fullPath);
-		const directory = parsed.dir;
 		const stat = fs.lstatSync(fullPath);
 		if (this._sourceStats.some((value) => isEqual(value, stat))) {
-			return this.remapOutFile(this.readTsConfig()!, directory, `${parsed.name}.d.ts`);
+			const parsed = path.parse(fullPath);
+			const directory = parsed.dir;
+			return this.remapOutFile(config, directory, `${parsed.name}.d.ts`);
 		}
 		return fullPath;
 	}
 
-	private checkTsConfig(tsBuildInfoFileDirectory: string, tsBuildInfo: ITsBuildInfo) {
-		const options = this.readTsConfig();
-		if (!options) {
-			return false;
-		}
-
+	private checkTsConfig(
+		tsBuildInfoFileDirectory: string,
+		tsBuildInfo: ITsBuildInfo,
+		options: ts.ParsedCommandLine,
+	) {
 		const configFileFullPath = this.configFileFullPath;
 		if (!configFileFullPath) {
 			assert.fail();
@@ -128,11 +145,13 @@ export class TscTask extends LeafTask {
 		);
 
 		if (!isEqual(configOptions, tsBuildInfoOptions)) {
-			verbose(`${this.node.pkg.nameColored}: ts option changed ${configFileFullPath}`);
-			verbose("Config:");
-			verbose(JSON.stringify(configOptions, undefined, 2));
-			verbose("BuildInfo:");
-			verbose(JSON.stringify(tsBuildInfoOptions, undefined, 2));
+			this.traceTrigger(
+				`${this.node.pkg.nameColored}: ts option changed ${configFileFullPath}`,
+			);
+			this.traceTrigger("Config:");
+			this.traceTrigger(JSON.stringify(configOptions, undefined, 2));
+			this.traceTrigger("BuildInfo:");
+			this.traceTrigger(JSON.stringify(tsBuildInfoOptions, undefined, 2));
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Get the list of files from TSC and trigger the build if there are files that are not seen in previous build based on the tsBuildInfo.