### PR TITLE
tree: Add RestrictiveReadonlyRecord

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -889,7 +889,8 @@ declare namespace InternalTypes {
         _RecursiveTrick,
         FlattenKeys,
         AllowOptionalNotFlattened,
-        isAny
+        isAny,
+        RestrictiveReadonlyRecord
     }
 }
 export { InternalTypes }
@@ -1484,6 +1485,11 @@ type RequiredFields<T> = [
 ][_InlineTrick];
 
 // @alpha
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+    readonly [P in symbol | string]: P extends K ? T : never;
+};
+
+// @alpha
 export type RevisionIndexer = (tag: RevisionTag) => number;
 
 // @alpha (undocumented)
@@ -1819,9 +1825,7 @@ interface TreeSchemaSpecification {
     // (undocumented)
     readonly global?: FlexList<GlobalFieldSchema>;
     // (undocumented)
-    readonly local?: {
-        readonly [key: string]: FieldSchema;
-    };
+    readonly local?: RestrictiveReadonlyRecord<string, FieldSchema>;
     // (undocumented)
     readonly value?: ValueSchema;
 }

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/typedTreeSchema.ts
@@ -15,7 +15,7 @@ import {
 	ValueSchema,
 	symbolFromKey,
 } from "../../../core";
-import { MakeNominal, Assume } from "../../../util";
+import { MakeNominal, Assume, RestrictiveReadonlyRecord } from "../../../util";
 import { FieldKindTypes, FieldKinds } from "../../defaultFieldKinds";
 import { FlexList, LazyItem, normalizeFlexList } from "./flexList";
 import { ObjectToMap, WithDefault, objectToMapTyped } from "./typeUtils";
@@ -172,7 +172,7 @@ export function allowedTypesIsAny(t: AllowedTypes): t is [Any] {
  * @alpha
  */
 export interface TreeSchemaSpecification {
-	readonly local?: { readonly [key: string]: FieldSchema };
+	readonly local?: RestrictiveReadonlyRecord<string, FieldSchema>;
 	readonly global?: FlexList<GlobalFieldSchema>;
 	readonly extraLocalFields?: FieldSchema;
 	readonly extraGlobalFields?: boolean;

--- a/experimental/dds/tree2/src/internal.ts
+++ b/experimental/dds/tree2/src/internal.ts
@@ -20,4 +20,5 @@ export {
 	FlattenKeys,
 	AllowOptionalNotFlattened,
 	isAny,
+	RestrictiveReadonlyRecord,
 } from "./util";

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -81,4 +81,5 @@ export {
 	_RecursiveTrick,
 	FlattenKeys,
 	AllowOptionalNotFlattened,
+	RestrictiveReadonlyRecord,
 } from "./typeUtils";

--- a/experimental/dds/tree2/src/util/typeUtils.ts
+++ b/experimental/dds/tree2/src/util/typeUtils.ts
@@ -153,3 +153,18 @@ export type _RecursiveTrick = never;
 
 	/* eslint-enable @typescript-eslint/no-unused-vars */
 }
+
+/**
+ * Alternative to the built in Record type which does not permit unexpected members,
+ * and is readonly.
+ *
+ * @privateRemarks
+ * `number` is now allowed as a key here since doing so causes the compiler to reject recursive schema.
+ * The cause for this is unclear, but empirically it was the case when this comment was written.
+ *
+ *
+ * @alpha
+ */
+export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+	readonly [P in symbol | string]: P extends K ? T : never;
+};

--- a/experimental/dds/tree2/src/util/typeUtils.ts
+++ b/experimental/dds/tree2/src/util/typeUtils.ts
@@ -159,7 +159,7 @@ export type _RecursiveTrick = never;
  * and is readonly.
  *
  * @privateRemarks
- * `number` is now allowed as a key here since doing so causes the compiler to reject recursive schema.
+ * `number` is not allowed as a key here since doing so causes the compiler to reject recursive schema.
  * The cause for this is unclear, but empirically it was the case when this comment was written.
  *
  *


### PR DESCRIPTION
## Description

Most typescript types error if you define a literal with unexpected keys. Index signatures like records violate this. This change includes a workaround, and causes accidental use of symbols in local fields in schema to not compile.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
