### PR TITLE
Populating sub directories correctly in Shared Directory (#15982)

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -654,7 +654,10 @@ export class SharedDirectory
 					if (!newSubDir) {
 						const createInfo = subdirObject.ci;
 						newSubDir = new SubDirectory(
-							createInfo !== undefined ? createInfo.csn : 0,
+							// If csn is -1, then initialize it with 0, otherwise we will never process ops for this
+							// sub directory. This could be done at serialization time too, but we need to maintain
+							// back compat too and also we will actually know the state when it was serialized.
+							createInfo !== undefined && createInfo.csn > -1 ? createInfo.csn : 0,
 							createInfo !== undefined
 								? new Set<string>(createInfo.ccIds)
 								: new Set(),


### PR DESCRIPTION
## Description

Populating sub directories correctly in Shared Directory. When we serialize a new directory on attach and record the csn which is -1 for a newly create one, then on load, we load with -1 csn for that. Now there is no create op for this subdir. So when a new subdir is added in that dir and create op comes for that, it does not pass this check below and we don't process that op.

https://github.com/microsoft/FluidFramework/blob/a51cd2afc8fb11e11c083f9f62fa9e69727e6845/packages/dds/map/src/directory.ts#L2150