### PR TITLE
feat(tree): optional fields changes carry identifiers

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultChangeFamily.ts
@@ -173,8 +173,9 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public optionalField(field: FieldUpPath): OptionalFieldEditBuilder {
 		return {
 			set: (newContent: ITreeCursor | undefined, wasEmpty: boolean): void => {
+				const id = this.modularBuilder.generateId();
 				const change: FieldChangeset = brand(
-					optional.changeHandler.editor.set(newContent, wasEmpty),
+					optional.changeHandler.editor.set(newContent, wasEmpty, id),
 				);
 				this.modularBuilder.submitChange(field, optional.identifier, change);
 			},

--- a/experimental/dds/tree2/src/feature-libraries/defaultFieldChangeCodecs.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultFieldChangeCodecs.ts
@@ -70,7 +70,10 @@ function makeOptionalFieldCodec(
 		encode: (change: OptionalChangeset) => {
 			const encoded: EncodedOptionalChangeset<TAnySchema> = {};
 			if (change.fieldChange !== undefined) {
-				encoded.fieldChange = { wasEmpty: change.fieldChange.wasEmpty };
+				encoded.fieldChange = {
+					id: change.fieldChange.id,
+					wasEmpty: change.fieldChange.wasEmpty,
+				};
 				if (change.fieldChange.newContent !== undefined) {
 					encoded.fieldChange.newContent = nodeUpdateCodec.encode(
 						change.fieldChange.newContent,
@@ -89,6 +92,7 @@ function makeOptionalFieldCodec(
 			const decoded: OptionalChangeset = {};
 			if (encoded.fieldChange !== undefined) {
 				decoded.fieldChange = {
+					id: encoded.fieldChange.id,
 					wasEmpty: encoded.fieldChange.wasEmpty,
 				};
 

--- a/experimental/dds/tree2/src/feature-libraries/defaultFieldChangeFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultFieldChangeFormat.ts
@@ -5,6 +5,7 @@
 
 import { Static, TSchema, Type } from "@sinclair/typebox";
 import { EncodedJsonableTree, RevisionTagSchema } from "../core";
+import { ChangesetLocalIdSchema } from "./modular-schema";
 
 export const EncodedNodeUpdate = <Schema extends TSchema>(tNodeChange: Schema) =>
 	Type.Union([
@@ -60,6 +61,10 @@ export type EncodedValueChangeset<Schema extends TSchema> = Static<
 
 export const EncodedOptionalFieldChange = <Schema extends TSchema>(tNodeChange: Schema) =>
 	Type.Object({
+		/**
+		 * Uniquely identifies, in the scope of the changeset, the change made to the field.
+		 */
+		id: ChangesetLocalIdSchema,
 		/**
 		 * The new content for the trait. If undefined, the trait will be cleared.
 		 */

--- a/experimental/dds/tree2/src/feature-libraries/defaultFieldChangeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/defaultFieldChangeTypes.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITreeCursorSynchronous, JsonableTree, RevisionTag } from "../core";
-import { NodeChangeset } from "./modular-schema";
+import { ChangesetLocalId, NodeChangeset } from "./modular-schema";
 
 export type NodeUpdate =
 	| {
@@ -26,6 +26,19 @@ export interface ValueChangeset {
 }
 
 export interface OptionalFieldChange {
+	/**
+	 * Uniquely identifies, in the scope of the changeset, the change made to the field.
+	 * Globally unique across all changesets when paired with the changeset's revision tag.
+	 */
+	readonly id: ChangesetLocalId;
+
+	/**
+	 * When populated, indicates the revision that this field change is associated with.
+	 * Is left undefined when the revision is the same as that of the whole changeset
+	 * (which would also be undefined in the case of an anonymous changeset).
+	 */
+	readonly revision?: RevisionTag;
+
 	/**
 	 * The new content for the trait. If undefined, the trait will be cleared.
 	 */

--- a/experimental/dds/tree2/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -31,7 +31,7 @@ import {
 	tagChange,
 	tagRollbackInverse,
 } from "../../core";
-import { JsonCompatibleReadOnly } from "../../util";
+import { JsonCompatibleReadOnly, brand } from "../../util";
 import {
 	assertMarkListEqual,
 	defaultRevisionMetadataFromChanges,
@@ -293,19 +293,24 @@ describe("Optional field changesets", () => {
 
 	const change1: TaggedChange<FieldKindsTypes.OptionalChangeset> = tagChange(
 		{
-			fieldChange: { newContent: { set: tree1, changes: nodeChange1 }, wasEmpty: true },
+			fieldChange: {
+				id: brand(1),
+				newContent: { set: tree1, changes: nodeChange1 },
+				wasEmpty: true,
+			},
 		},
 		mintRevisionTag(),
 	);
 
 	const change2: TaggedChange<FieldKindsTypes.OptionalChangeset> = tagChange(
-		editor.set(singleTextCursor(tree2), false),
+		editor.set(singleTextCursor(tree2), false, brand(2)),
 		mintRevisionTag(),
 	);
 
 	const revertChange2: TaggedChange<FieldKindsTypes.OptionalChangeset> = tagChange(
 		{
 			fieldChange: {
+				id: brand(2),
 				newContent: { revert: singleTextCursor(tree1), revision: change2.revision },
 				wasEmpty: false,
 			},
@@ -313,19 +318,39 @@ describe("Optional field changesets", () => {
 		mintRevisionTag(),
 	);
 
-	const change3: TaggedChange<FieldKindsTypes.OptionalChangeset> = tagChange(
-		editor.set(singleTextCursor(tree2), true),
-		mintRevisionTag(),
+	/**
+	 * Represents what change2 would have been had it been concurrent with change1.
+	 */
+	const change2PreChange1: TaggedChange<FieldKindsTypes.OptionalChangeset> = tagChange(
+		editor.set(singleTextCursor(tree2), true, brand(2)),
+		change2.revision,
 	);
+
+	/**
+	 * Represents the outcome of composing change1 and change2.
+	 */
+	const change1And2: TaggedChange<FieldKindsTypes.OptionalChangeset> = makeAnonChange({
+		fieldChange: {
+			id: brand(2),
+			revision: change2.revision,
+			newContent: { set: tree2 },
+			wasEmpty: true,
+		},
+	});
+
 	const change4: TaggedChange<FieldKindsTypes.OptionalChangeset> = tagChange(
 		editor.buildChildChange(0, nodeChange2),
 		mintRevisionTag(),
 	);
 
 	it("can be created", () => {
-		const actual: FieldKindsTypes.OptionalChangeset = editor.set(singleTextCursor(tree1), true);
+		const actual: FieldKindsTypes.OptionalChangeset = editor.set(
+			singleTextCursor(tree1),
+			true,
+			brand(42),
+		);
 		const expected: FieldKindsTypes.OptionalChangeset = {
-			fieldChange: { newContent: { set: tree1 }, wasEmpty: true },
+			fieldChange: { id: brand(42), newContent: { set: tree1 }, wasEmpty: true },
 		};
 		assert.deepEqual(actual, expected);
 	});
@@ -340,12 +365,17 @@ describe("Optional field changesets", () => {
 			crossFieldManager,
 			defaultRevisionMetadataFromChanges([change1, change2]),
 		);
-		assert.deepEqual(composed, change3.change);
+		assert.deepEqual(composed, change1And2.change);
 	});
 
 	it("can compose child changes", () => {
 		const expected: FieldKindsTypes.OptionalChangeset = {
-			fieldChange: { wasEmpty: true, newContent: { set: tree1, changes: nodeChange3 } },
+			fieldChange: {
+				id: brand(1),
+				revision: change1.revision,
+				wasEmpty: true,
+				newContent: { set: tree1, changes: nodeChange3 },
+			},
 		};
 
 		assert.deepEqual(
@@ -367,7 +397,7 @@ describe("Optional field changesets", () => {
 		};
 
 		const expected: FieldKindsTypes.OptionalChangeset = {
-			fieldChange: { wasEmpty: false },
+			fieldChange: { id: brand(1), wasEmpty: false },
 			childChange: nodeChange2,
 		};
 
@@ -398,7 +428,7 @@ describe("Optional field changesets", () => {
 			) => assert.fail("Should not be called");
 			assert.deepEqual(
 				fieldHandler.rebaser.rebase(
-					change3.change,
+					change2PreChange1.change,
 					change1,
 					childRebaser,
 					idAllocator,
@@ -441,7 +471,7 @@ describe("Optional field changesets", () => {
 			const tag1 = mintRevisionTag();
 			const tag2 = mintRevisionTag();
 			const changeToRebase = editor.buildChildChange(0, nodeChange1);
-			const deletion = tagChange(editor.set(undefined, false), tag1);
+			const deletion = tagChange(editor.set(undefined, false, brand(1)), tag1);
 			const revive = tagRollbackInverse(
 				fieldHandler.rebaser.invert(
 					deletion,


### PR DESCRIPTION
Adds changeset-local identifiers to optional field changesets.

This facilitates the identification of the content being added/removed in such changesets, which will be leveraged by the new repair data lifecycle (see https://github.com/microsoft/FluidFramework/pull/15930)