### PR TITLE
Splay constructor props in the Loader and Container

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -352,7 +352,7 @@ export class Container
 	): Promise<Container> {
 		const { version, pendingLocalState, loadMode, resolvedUrl } = loadProps;
 
-		const container = new Container(createProps, pendingLocalState);
+		const container = new Container(createProps, loadProps);
 
 		return PerformanceEvent.timedExecAsync(
 			container.mc.logger,
@@ -714,7 +714,10 @@ export class Container
 	/**
 	 * @internal
 	 */
-	constructor(createProps: IContainerCreateProps, pendingLocalState?: IPendingContainerState) {
+	constructor(
+		createProps: IContainerCreateProps,
+		loadProps?: Pick<IContainerLoadProps, "pendingLocalState">,
+	) {
 		super((name, error) => {
 			this.mc.logger.sendErrorEvent(
 				{
@@ -737,6 +740,8 @@ export class Container
 			detachedBlobStorage,
 			protocolHandlerBuilder,
 		} = createProps;
+
+		const pendingLocalState = loadProps?.pendingLocalState;
 
 		this._canReconnect = canReconnect ?? true;
 		this.clientDetailsOverride = clientDetailsOverride;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -352,7 +352,7 @@ export class Container
 	): Promise<Container> {
 		const { version, pendingLocalState, loadMode, resolvedUrl } = loadProps;
 
-		const container = new Container(createProps, loadProps);
+		const container = new Container(createProps, pendingLocalState);
 
 		return PerformanceEvent.timedExecAsync(
 			container.mc.logger,
@@ -714,7 +714,7 @@ export class Container
 	/**
 	 * @internal
 	 */
-	constructor(createProps: IContainerCreateProps, loadProps?: IContainerLoadProps) {
+	constructor(createProps: IContainerCreateProps, pendingLocalState?: IPendingContainerState) {
 		super((name, error) => {
 			this.mc.logger.sendErrorEvent(
 				{
@@ -779,7 +779,7 @@ export class Container
 				containerAttachState: () => this._attachState,
 				containerLifecycleState: () => this._lifecycleState,
 				containerConnectionState: () => ConnectionState[this.connectionState],
-				serializedContainer: loadProps?.pendingLocalState !== undefined,
+				serializedContainer: pendingLocalState !== undefined,
 			},
 			// we need to be judicious with our logging here to avoid generating too much data
 			// all data logged here should be broadly applicable, and not specific to a
@@ -862,7 +862,7 @@ export class Container
 				},
 			},
 			this.deltaManager,
-			loadProps?.pendingLocalState?.clientId,
+			pendingLocalState?.clientId,
 		);
 
 		this.on(savedContainerEvent, () => {
@@ -886,7 +886,7 @@ export class Container
 		this.storageAdapter = new ContainerStorageAdapter(
 			detachedBlobStorage,
 			this.mc.logger,
-			loadProps?.pendingLocalState?.snapshotBlobs,
+			pendingLocalState?.snapshotBlobs,
 			addProtocolSummaryIfMissing,
 			forceEnableSummarizeProtocolTree,
 		);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -440,6 +440,21 @@ export class Container
 		);
 	}
 
+	// Tells if container can reconnect on losing fist connection
+	// If false, container gets closed on loss of connection.
+	private readonly _canReconnect: boolean;
+	private readonly clientDetailsOverride: IClientDetails | undefined;
+	private readonly urlResolver: IUrlResolver;
+	private readonly serviceFactory: IDocumentServiceFactory;
+	private readonly codeLoader: ICodeDetailsLoader;
+	public readonly options: ILoaderOptions;
+	private readonly scope: FluidObject;
+	public subLogger: TelemetryLogger;
+	private readonly detachedBlobStorage: IDetachedBlobStorage | undefined;
+	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder | undefined;
+
+	private readonly mc: MonitoringContext;
+
 	/**
 	 * Used by the RelativeLoader to spawn a new Container for the same document.  Used to create the summarizing client.
 	 * @internal
@@ -448,14 +463,6 @@ export class Container
 		loadProps: IContainerLoadProps,
 		createParamOverrides: Partial<IContainerCreateProps>,
 	) => Promise<Container>;
-
-	public subLogger: TelemetryLogger;
-
-	// Tells if container can reconnect on losing fist connection
-	// If false, container gets closed on loss of connection.
-	private readonly _canReconnect: boolean;
-
-	private readonly mc: MonitoringContext;
 
 	/**
 	 * Lifecycle state of the container, used mainly to prevent re-entrancy and telemetry
@@ -506,7 +513,6 @@ export class Container
 		return this.storageAdapter;
 	}
 
-	private readonly clientDetailsOverride: IClientDetails | undefined;
 	private readonly _deltaManager: DeltaManager<ConnectionManager>;
 	private service: IDocumentService | undefined;
 
@@ -536,7 +542,6 @@ export class Container
 	private readonly savedOps: ISequencedDocumentMessage[] = [];
 	private baseSnapshot?: ISnapshotTree;
 	private baseSnapshotBlobs?: ISerializableBlobContents;
-	private readonly detachedBlobStorage: IDetachedBlobStorage | undefined;
 
 	private lastVisible: number | undefined;
 	private readonly visibilityEventHandler: (() => void) | undefined;
@@ -671,13 +676,6 @@ export class Container
 		return this._dirtyContainer;
 	}
 
-	private readonly serviceFactory: IDocumentServiceFactory;
-	private readonly urlResolver: IUrlResolver;
-	public readonly options: ILoaderOptions;
-	private readonly scope: FluidObject;
-	private readonly codeLoader: ICodeDetailsLoader;
-	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder | undefined;
-
 	/**
 	 * {@inheritDoc @fluidframework/container-definitions#IContainer.entryPoint}
 	 */
@@ -753,7 +751,7 @@ export class Container
 		this.detachedBlobStorage = detachedBlobStorage;
 		this.protocolHandlerBuilder = protocolHandlerBuilder;
 
-		// Note that we capture the createProps here so we can replicate the creation call to clone.
+		// Note that we capture the createProps here so we can replicate the creation call when we want to clone.
 		this.clone = async (
 			_loadProps: IContainerLoadProps,
 			createParamOverrides: Partial<IContainerCreateProps>,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -451,7 +451,7 @@ export class Container
 	private readonly scope: FluidObject;
 	public subLogger: TelemetryLogger;
 	private readonly detachedBlobStorage: IDetachedBlobStorage | undefined;
-	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder | undefined;
+	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder;
 
 	private readonly mc: MonitoringContext;
 
@@ -749,7 +749,8 @@ export class Container
 		this.options = { ...options };
 		this.scope = scope;
 		this.detachedBlobStorage = detachedBlobStorage;
-		this.protocolHandlerBuilder = protocolHandlerBuilder;
+		this.protocolHandlerBuilder =
+			protocolHandlerBuilder ?? ((...args) => new ProtocolHandler(...args, new Audience()));
 
 		// Note that we capture the createProps here so we can replicate the creation call when we want to clone.
 		this.clone = async (
@@ -1725,10 +1726,7 @@ export class Container
 		attributes: IDocumentAttributes,
 		quorumSnapshot: IQuorumSnapshot,
 	): void {
-		const protocolHandlerBuilder =
-			this.protocolHandlerBuilder ??
-			((...args) => new ProtocolHandler(...args, new Audience()));
-		const protocol = protocolHandlerBuilder(attributes, quorumSnapshot, (key, value) =>
+		const protocol = this.protocolHandlerBuilder(attributes, quorumSnapshot, (key, value) =>
 			this.submitMessage(MessageType.Propose, JSON.stringify({ key, value })),
 		);
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -431,7 +431,8 @@ export class Loader implements IHostLoader {
 			}
 		}
 
-		const { canCache, fromSequenceNumber } = this.parseHeader(parsed, request);
+		const { fromSequenceNumber } = this.parseHeader(parsed, request);
+		const canCache = this.cachingEnabled && request.headers?.[LoaderHeader.cache] !== false;
 		const shouldCache = pendingLocalState !== undefined ? false : canCache;
 
 		let container: Container;
@@ -469,10 +470,6 @@ export class Loader implements IHostLoader {
 		return this.services.options.cache !== false;
 	}
 
-	private canCacheForRequest(headers: IRequestHeader): boolean {
-		return this.cachingEnabled && headers[LoaderHeader.cache] !== false;
-	}
-
 	private parseHeader(parsed: IParsedUrl, request: IRequest) {
 		let fromSequenceNumber = -1;
 
@@ -487,10 +484,7 @@ export class Loader implements IHostLoader {
 		request.headers[LoaderHeader.version] =
 			parsed.version ?? request.headers[LoaderHeader.version];
 
-		const canCache = this.canCacheForRequest(request.headers);
-
 		return {
-			canCache,
 			fromSequenceNumber,
 		};
 	}

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -308,28 +308,41 @@ export class Loader implements IHostLoader {
 	private readonly mc: MonitoringContext;
 
 	constructor(loaderProps: ILoaderProps) {
-		const scope: FluidObject<ILoader> = { ...loaderProps.scope };
-		if (loaderProps.options?.provideScopeLoader !== false) {
-			scope.ILoader = this;
-		}
+		const {
+			urlResolver,
+			documentServiceFactory,
+			codeLoader,
+			options,
+			scope,
+			logger,
+			detachedBlobStorage,
+			configProvider,
+			protocolHandlerBuilder,
+		} = loaderProps;
+
 		const telemetryProps = {
 			loaderId: uuid(),
 			loaderVersion: pkgVersion,
 		};
 
 		const subMc = mixinMonitoringContext(
-			DebugLogger.mixinDebugLogger("fluid:telemetry", loaderProps.logger, {
+			DebugLogger.mixinDebugLogger("fluid:telemetry", logger, {
 				all: telemetryProps,
 			}),
 			sessionStorageConfigProvider.value,
-			loaderProps.configProvider,
+			configProvider,
 		);
 
 		this.services = {
-			...loaderProps,
-			scope,
+			urlResolver,
+			documentServiceFactory,
+			codeLoader,
+			options: options ?? {},
+			scope:
+				options?.provideScopeLoader !== false ? { ...scope, ILoader: this } : { ...scope },
+			detachedBlobStorage,
+			protocolHandlerBuilder,
 			subLogger: subMc.logger,
-			options: loaderProps.options ?? {},
 		};
 		this.mc = loggerToMonitoringContext(ChildLogger.create(this.services.subLogger, "Loader"));
 	}

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -79,8 +79,7 @@ export class RelativeLoader implements ILoader {
 				return this.container;
 			} else {
 				ensureResolvedUrlDefined(this.container.resolvedUrl);
-				const container = await Container.clone(
-					this.container,
+				const container = await this.container.clone(
 					{
 						resolvedUrl: { ...this.container.resolvedUrl },
 						version: request.headers?.[LoaderHeader.version] ?? undefined,


### PR DESCRIPTION
The Container and Loader both take "props" args to their constructors.  This is generally a fine practice, but it's resulted in a couple negative patterns I'm seeing that this PR cleans up:

1. The Container retains a (private) reference to its createProps long after creation is done.  This keeps several objects alive and accessible long after they have stopped being relevant, making it hard to reason about lifecycle and mutation scenarios.
2. The Loader props get "spaghettid" through to the Loader services without critical inspection, violating its type.  ILoaderServices is not a superset of ILoaderProps, so this puts members on the services that don't belong.  Also, by enforcing specific opt-in of props to services, we can force the conversation about whether a new prop actually belongs on the services.
3. The Container.clone static method was accessing the private createProps member to perform its duty.  While this works, it's surprising to most folks that private members can be accessed outside of the class instance.  This change moves the clone method to the Container instance, and captures the props in an opaque manner to scope their visibility.

Semi-relatedly, the parseHeader method on the Loader was misleading (it only partially processed the header AND had side effects of writing to the header).  By collapsing this in to the callsite, we can simplify the logic a good bit.