### PR TITLE
Update exception handling logic for uncaughtException

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -60,7 +60,8 @@
 		"async": "^3.2.2",
 		"events": "^3.1.0",
 		"lodash": "^4.17.21",
-		"nconf": "^0.12.0"
+		"nconf": "^0.12.0",
+		"serialize-error": "^8.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.19.0-165129",

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -130,7 +130,7 @@ export class KafkaRunner implements IRunner {
 				this.deferred?.reject({
 					caller,
 					uncaughtException: serializeError(uncaughtException),
-				}); // so that the runService exits the process with exit(1)
+				}); // reject the promise so that the runService exits the process with exit(1)
 			} else {
 				this.deferred?.resolve();
 			}

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -126,7 +126,7 @@ export class KafkaRunner implements IRunner {
 			await promiseTimeout(30000, this.consumer.close());
 
 			// Mark ourselves done once the partition manager has stopped
-			if (caller === "sigterm" || caller === "uncaughtException") {
+			if (caller === "uncaughtException") {
 				this.deferred?.reject({
 					caller,
 					uncaughtException: serializeError(uncaughtException),

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -139,9 +139,9 @@ export class KafkaRunner implements IRunner {
 				this.runnerMetric.error("Kafka runner encountered an error during stop", error);
 			}
 			this.deferred?.reject({
-				error,
 				customMessage: `Kafka runner couldnt be stopped`,
 				caller,
+				error,
 				forceKill: true,
 			});
 			this.deferred = undefined;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -4,6 +4,7 @@
  */
 
 import { inspect } from "util";
+import { serializeError } from "serialize-error";
 import { Deferred } from "@fluidframework/common-utils";
 import { promiseTimeout } from "@fluidframework/server-services-client";
 import {
@@ -126,7 +127,7 @@ export class KafkaRunner implements IRunner {
 
 			// Mark ourselves done once the partition manager has stopped
 			if (caller === "sigterm" || caller === "uncaughtException") {
-				this.deferred?.reject({ customMessage: `Kafka runner stopped`, caller }); // so that the runService exits the process with exit(1)
+				this.deferred?.reject({ caller, customMessage: `Kafka runner stopped` }); // so that the runService exits the process with exit(1)
 			} else {
 				this.deferred?.resolve();
 			}
@@ -139,9 +140,9 @@ export class KafkaRunner implements IRunner {
 				this.runnerMetric.error("Kafka runner encountered an error during stop", error);
 			}
 			this.deferred?.reject({
-				customMessage: `Kafka runner couldnt be stopped`,
 				caller,
-				error,
+				customMessage: `Kafka runner couldnt be stopped`,
+				error: serializeError(error),
 				forceKill: true,
 			});
 			this.deferred = undefined;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -136,10 +136,7 @@ export class KafkaRunner implements IRunner {
 			}
 		} catch (error) {
 			if (!this.runnerMetric.isCompleted()) {
-				this.runnerMetric.error(
-					"Kafka runner encountered an error during server.close",
-					error,
-				);
+				this.runnerMetric.error("Kafka runner encountered an error during stop", error);
 			}
 			this.deferred?.reject({
 				error,

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -128,7 +128,6 @@ export class KafkaRunner implements IRunner {
 			// Mark ourselves done once the partition manager has stopped
 			if (caller === "uncaughtException") {
 				this.deferred?.reject({
-					caller,
 					uncaughtException: serializeError(uncaughtException),
 				}); // reject the promise so that the runService exits the process with exit(1)
 			} else {
@@ -142,12 +141,15 @@ export class KafkaRunner implements IRunner {
 			if (!this.runnerMetric.isCompleted()) {
 				this.runnerMetric.error("Kafka runner encountered an error during stop", error);
 			}
-			this.deferred?.reject({
-				forceKill: true,
-				caller,
-				uncaughtException: serializeError(uncaughtException),
-				runnerStopException: serializeError(error),
-			});
+			if (caller === "uncaughtException") {
+				this.deferred?.reject({
+					forceKill: true,
+					uncaughtException: serializeError(uncaughtException),
+					runnerStopException: serializeError(error),
+				});
+			} else {
+				this.deferred?.resolve();
+			}
 			this.deferred = undefined;
 			throw error;
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -141,7 +141,12 @@ export class KafkaRunner implements IRunner {
 					error,
 				);
 			}
-			this.deferred?.reject({error, customMessage: `Kafka runner couldnt be stopped`, caller, forceKill: true});
+			this.deferred?.reject({
+				error,
+				customMessage: `Kafka runner couldnt be stopped`,
+				caller,
+				forceKill: true,
+			});
 			this.deferred = undefined;
 			throw error;
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -124,7 +124,7 @@ export class KafkaRunner implements IRunner {
 			// Close the underlying consumer, but setting a timeout for safety
 			await promiseTimeout(30000, this.consumer.close());
 
-			// Mark ourselves done once the partition manager has stopped or failed to stop
+			// Mark ourselves done once the partition manager has stopped
 			if (caller === "sigterm" || caller === "uncaughtException") {
 				this.deferred?.reject({ customMessage: `Kafka runner stopped`, caller }); // so that the runService exits the process with exit(1)
 			} else {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -130,7 +130,6 @@ export class KafkaRunner implements IRunner {
 				this.deferred?.reject({
 					caller,
 					uncaughtException: serializeError(uncaughtException),
-					customMessage: `Kafka runner stopped`,
 				}); // so that the runService exits the process with exit(1)
 			} else {
 				this.deferred?.resolve();
@@ -147,7 +146,6 @@ export class KafkaRunner implements IRunner {
 				forceKill: true,
 				caller,
 				uncaughtException: serializeError(uncaughtException),
-				customMessage: "Kafka runner couldnt be stopped",
 				runnerStopException: serializeError(error),
 			});
 			this.deferred = undefined;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -134,17 +134,14 @@ export class KafkaRunner implements IRunner {
 			if (!this.runnerMetric.isCompleted()) {
 				this.runnerMetric.success("Kafka runner stopped");
 			}
-		} catch (error: any) {
+		} catch (error) {
 			if (!this.runnerMetric.isCompleted()) {
 				this.runnerMetric.error(
 					"Kafka runner encountered an error during server.close",
 					error,
 				);
 			}
-			error.customMessage = "Kafka runner couldnt be stopped";
-			error.caller = caller;
-			error.forceKill = true;
-			this.deferred?.reject(error);
+			this.deferred?.reject({error, customMessage: `Kafka runner couldnt be stopped`, caller, forceKill: true});
 			this.deferred = undefined;
 			throw error;
 		}

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -76,6 +76,7 @@
 		"jsonwebtoken": "^9.0.0",
 		"lodash": "^4.17.21",
 		"nconf": "^0.12.0",
+		"serialize-error": "^8.1.0",
 		"sillyname": "^0.1.0",
 		"uuid": "^8.3.1",
 		"winston": "^3.6.0",

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { serializeError } from "serialize-error";
 import { Deferred } from "@fluidframework/common-utils";
 import {
 	ICache,
@@ -159,8 +160,8 @@ export class AlfredRunner implements IRunner {
 			await this.server.close();
 			if (caller === "sigterm" || caller === "uncaughtException") {
 				this.runningDeferred?.reject({
-					customMessage: `Alfred runner stopped`,
 					caller,
+					customMessage: `Alfred runner stopped`,
 				}); // so that the runService exits the process with exit(1)
 			} else {
 				this.runningDeferred?.resolve();
@@ -174,9 +175,9 @@ export class AlfredRunner implements IRunner {
 				this.runnerMetric.error("Alfred runner encountered an error during stop", error);
 			}
 			this.runningDeferred?.reject({
-				customMessage: "Alfred runner couldnt be stopped",
 				caller,
-				error,
+				customMessage: "Alfred runner couldnt be stopped",
+				error: serializeError(error),
 				forceKill: true,
 			});
 			this.runningDeferred = undefined;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -173,14 +173,15 @@ export class AlfredRunner implements IRunner {
 			if (!this.runnerMetric.isCompleted()) {
 				this.runnerMetric.error("Alfred runner encountered an error during stop", error);
 			}
-			if (caller === "uncaughtException") {
+			if (caller === "sigterm") {
+				this.runningDeferred?.resolve();
+			} else {
+				// uncaughtException
 				this.runningDeferred?.reject({
 					forceKill: true,
 					uncaughtException: serializeError(uncaughtException),
 					runnerStopException: serializeError(error),
 				});
-			} else {
-				this.runningDeferred?.resolve();
 			}
 			this.runningDeferred = undefined;
 			throw error;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -177,10 +177,7 @@ export class AlfredRunner implements IRunner {
 						error,
 					);
 				}
-				error.customMessage = "Alfred runner couldnt be stopped";
-				error.caller = caller;
-				error.forceKill = true;
-				this.runningDeferred?.reject(error);
+				this.runningDeferred?.reject({error, customMessage: "Alfred runner couldnt be stopped", caller, forceKill: true});
 				this.runningDeferred = undefined;
 				throw error;
 			},

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -160,7 +160,6 @@ export class AlfredRunner implements IRunner {
 			await this.server.close();
 			if (caller === "uncaughtException") {
 				this.runningDeferred?.reject({
-					caller,
 					uncaughtException: serializeError(uncaughtException),
 				}); // reject the promise so that the runService exits the process with exit(1)
 			} else {
@@ -174,12 +173,15 @@ export class AlfredRunner implements IRunner {
 			if (!this.runnerMetric.isCompleted()) {
 				this.runnerMetric.error("Alfred runner encountered an error during stop", error);
 			}
-			this.runningDeferred?.reject({
-				forceKill: true,
-				caller,
-				uncaughtException: serializeError(uncaughtException),
-				runnerStopException: serializeError(error),
-			});
+			if (caller === "uncaughtException") {
+				this.runningDeferred?.reject({
+					forceKill: true,
+					uncaughtException: serializeError(uncaughtException),
+					runnerStopException: serializeError(error),
+				});
+			} else {
+				this.runningDeferred?.resolve();
+			}
 			this.runningDeferred = undefined;
 			throw error;
 		}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -177,7 +177,12 @@ export class AlfredRunner implements IRunner {
 						error,
 					);
 				}
-				this.runningDeferred?.reject({error, customMessage: "Alfred runner couldnt be stopped", caller, forceKill: true});
+				this.runningDeferred?.reject({
+					error,
+					customMessage: "Alfred runner couldnt be stopped",
+					caller,
+					forceKill: true,
+				});
 				this.runningDeferred = undefined;
 				throw error;
 			},

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -173,7 +173,7 @@ export class AlfredRunner implements IRunner {
 			(error) => {
 				if (!this.runnerMetric.isCompleted()) {
 					this.runnerMetric.error(
-						"Alfred runner encountered an error during server.close",
+						"Alfred runner encountered an error during stop",
 						error,
 					);
 				}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -162,7 +162,7 @@ export class AlfredRunner implements IRunner {
 				this.runningDeferred?.reject({
 					caller,
 					uncaughtException: serializeError(uncaughtException),
-				}); // so that the runService exits the process with exit(1)
+				}); // reject the promise so that the runService exits the process with exit(1)
 			} else {
 				this.runningDeferred?.resolve();
 			}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -162,7 +162,6 @@ export class AlfredRunner implements IRunner {
 				this.runningDeferred?.reject({
 					caller,
 					uncaughtException: serializeError(uncaughtException),
-					customMessage: `Alfred runner stopped`,
 				}); // so that the runService exits the process with exit(1)
 			} else {
 				this.runningDeferred?.resolve();
@@ -179,7 +178,6 @@ export class AlfredRunner implements IRunner {
 				forceKill: true,
 				caller,
 				uncaughtException: serializeError(uncaughtException),
-				customMessage: "Alfred runner couldnt be stopped",
 				runnerStopException: serializeError(error),
 			});
 			this.runningDeferred = undefined;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -158,7 +158,7 @@ export class AlfredRunner implements IRunner {
 		try {
 			// Close the underlying server and then resolve the runner once closed
 			await this.server.close();
-			if (caller === "sigterm" || caller === "uncaughtException") {
+			if (caller === "uncaughtException") {
 				this.runningDeferred?.reject({
 					caller,
 					uncaughtException: serializeError(uncaughtException),

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -149,7 +149,7 @@ export class AlfredRunner implements IRunner {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
-	public async stop(caller?: string): Promise<void> {
+	public async stop(caller?: string, uncaughtException?: any): Promise<void> {
 		if (this.stopped) {
 			return;
 		}
@@ -161,6 +161,7 @@ export class AlfredRunner implements IRunner {
 			if (caller === "sigterm" || caller === "uncaughtException") {
 				this.runningDeferred?.reject({
 					caller,
+					uncaughtException: serializeError(uncaughtException),
 					customMessage: `Alfred runner stopped`,
 				}); // so that the runService exits the process with exit(1)
 			} else {
@@ -175,10 +176,11 @@ export class AlfredRunner implements IRunner {
 				this.runnerMetric.error("Alfred runner encountered an error during stop", error);
 			}
 			this.runningDeferred?.reject({
-				caller,
-				customMessage: "Alfred runner couldnt be stopped",
-				error: serializeError(error),
 				forceKill: true,
+				caller,
+				uncaughtException: serializeError(uncaughtException),
+				customMessage: "Alfred runner couldnt be stopped",
+				runnerStopException: serializeError(error),
 			});
 			this.runningDeferred = undefined;
 			throw error;

--- a/server/routerlicious/packages/services-core/src/runner.ts
+++ b/server/routerlicious/packages/services-core/src/runner.ts
@@ -19,7 +19,7 @@ export interface IRunner {
 	/**
 	 * Stops the runner
 	 */
-	stop(): Promise<void>;
+	stop(caller?: string): Promise<void>;
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/runner.ts
+++ b/server/routerlicious/packages/services-core/src/runner.ts
@@ -19,7 +19,7 @@ export interface IRunner {
 	/**
 	 * Stops the runner
 	 */
-	stop(caller?: string): Promise<void>;
+	stop(caller?: string, uncaughtException?: any): Promise<void>;
 }
 
 /**

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -43,7 +43,7 @@ export async function run<T extends IResources>(
 
 	process.on("SIGTERM", () => {
 		Lumberjack.info(`Received SIGTERM request to stop the service.`);
-		runner.stop("sigterm").catch((error) => {
+		runner.stop().catch((error) => {
 			logger?.error(`Could not stop runner after SIGTERM due to error: ${error}`);
 			Lumberjack.error(`Could not stop runner after SIGTERM due to error`, undefined, error);
 		});

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -42,7 +42,7 @@ export async function run<T extends IResources>(
 
 	process.on("SIGTERM", () => {
 		Lumberjack.info(`Received SIGTERM request to stop the service.`);
-		runner.stop().catch((error) => {
+		runner.stop("sigterm").catch((error) => {
 			logger?.error(`Could not stop runner after SIGTERM due to error: ${error}`);
 			Lumberjack.error(`Could not stop runner after SIGTERM due to error`, undefined, error);
 		});
@@ -50,7 +50,7 @@ export async function run<T extends IResources>(
 
 	process.on("uncaughtException", (error, origin) => {
 		Lumberjack.error(`Encountered uncaughtException while running service`, { origin }, error);
-		runner.stop().catch((innerError) => {
+		runner.stop("uncaughtException").catch((innerError) => {
 			logger?.error(
 				`Could not stop runner after uncaughtException event due to error: ${innerError}`,
 			);

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -36,6 +36,7 @@ export async function run<T extends IResources>(
 			logger?.error(`Could not stop runner due to error: ${innerError}`);
 			Lumberjack.error(`Could not stop runner due to error`, undefined, innerError);
 			error.forceKill = true;
+			error.runnerStopException = innerError;
 		});
 		return Promise.reject(error);
 	});

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -43,7 +43,7 @@ export async function run<T extends IResources>(
 
 	process.on("SIGTERM", () => {
 		Lumberjack.info(`Received SIGTERM request to stop the service.`);
-		runner.stop().catch((error) => {
+		runner.stop("sigterm").catch((error) => {
 			logger?.error(`Could not stop runner after SIGTERM due to error: ${error}`);
 			Lumberjack.error(`Could not stop runner after SIGTERM due to error`, undefined, error);
 		});

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -48,9 +48,13 @@ export async function run<T extends IResources>(
 		});
 	});
 
-	process.on("uncaughtException", (error, origin) => {
-		Lumberjack.error(`Encountered uncaughtException while running service`, { origin }, error);
-		runner.stop("uncaughtException").catch((innerError) => {
+	process.on("uncaughtException", (uncaughtException, origin) => {
+		Lumberjack.error(
+			`Encountered uncaughtException while running service`,
+			{ origin },
+			uncaughtException,
+		);
+		runner.stop("uncaughtException", uncaughtException).catch((innerError) => {
 			logger?.error(
 				`Could not stop runner after uncaughtException event due to error: ${innerError}`,
 			);

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -17,6 +17,7 @@ export enum LumberEventName {
 	UnitTestEvent = "UnitTestEvent",
 
 	// Lambdas
+	AlfredRunner = "AlfredRunner",
 	ClientSummary = "ClientSummary",
 	DeliHandler = "DeliHandler",
 	KafkaRunner = "KafkaRunner",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -220,6 +220,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
+      serialize-error: ^8.1.0
       typescript: ~4.5.5
     dependencies:
       '@fluidframework/common-utils': 1.1.1
@@ -231,6 +232,7 @@ importers:
       events: 3.3.0
       lodash: 4.17.21
       nconf: 0.12.0
+      serialize-error: 8.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.19.0_fu6vecow5ai5c26swy67nv6dse
       '@fluidframework/build-common': 1.2.0
@@ -577,6 +579,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
+      serialize-error: ^8.1.0
       sillyname: ^0.1.0
       sinon: ^9.2.3
       supertest: ^3.1.0
@@ -611,6 +614,7 @@ importers:
       jsonwebtoken: 9.0.0
       lodash: 4.17.21
       nconf: 0.12.0
+      serialize-error: 8.1.0
       sillyname: 0.1.0
       uuid: 8.3.2
       winston: 3.9.0


### PR DESCRIPTION
## Description

Couple of updates in the runner logic (kafka runner and alfred runner) to improve exception handling and its logging:
1. uncaughtException events will trigger the runner's promise rejection, so that it is handled by runService's catch block and exits the process with exit code 1.
2. The above change will also ensure that "RunService" failure logs include restarts due to uncaughtExceptions.
3. Added try-catch block in runner's stop() method so that the deferred promise can be completed before throwing the error.
4. Improved logging and added an 'AlfredRunner' metric in alfred runner.
5. Return alfred runner.stop() early if it has already been stopped.

## Testing
- Tested by manually triggering an uncaught exception in scribe(for kafka runner) and alfred(for alfred runner), and validated the logs.
- Also tested the other restart scenarios like below and validated the logs.
    - Exception during a service which is caught by a catch block
    - SIGTERM restart

## Reviewer guidance

These changes will affect the number of restarts captured by RunService metric, i.e. it will include restarts due to uncaughtExceptions also. Currently it does not. So we might need to update the alert's thresholds.