### PR TITLE
[Draft] Prototype for fixing NodeDidNotRunGC by not creating summarizer node for local data stores

### DIFF
--- a/packages/runtime/container-runtime/src/noOpSummarizerNode.ts
+++ b/packages/runtime/container-runtime/src/noOpSummarizerNode.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/common-utils";
+import {
+	ISummarizeResult,
+	CreateChildSummarizerNodeParam,
+	SummarizeInternalFn,
+	ITelemetryContext,
+	ISummarizerNodeWithGC,
+	IGarbageCollectionData,
+	ISummarizerNodeConfigWithGC,
+} from "@fluidframework/runtime-definitions";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
+
+export class NoOpSummarizerNodeWithGc implements ISummarizerNodeWithGC {
+	public get referenceSequenceNumber() {
+		return 0;
+	}
+
+	protected readonly children = new Map<string, NoOpSummarizerNodeWithGc>();
+
+	// Set used routes to have self route by default. This makes the node referenced by default. This is done to ensure
+	// that this node is not marked as collected when running GC has been disabled. Once, the option to disable GC is
+	// removed (from runGC flag in IContainerRuntimeOptions), this should be changed to be have no routes by default.
+	private usedRoutes: string[] = [""];
+
+	public constructor(
+		private readonly summarizeInternalFn: SummarizeInternalFn,
+		private readonly getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
+		protected telemetryNodeId?: string,
+	) {}
+
+	public async summarize(
+		fullTree: boolean,
+		trackState: boolean = true,
+		telemetryContext?: ITelemetryContext,
+	): Promise<ISummarizeResult> {
+		return this.summarizeInternalFn(fullTree, trackState, telemetryContext);
+	}
+
+	public async getGCData(fullGC: boolean = false): Promise<IGarbageCollectionData> {
+		assert(
+			this.getGCDataFn !== undefined,
+			0x1b3 /* "GC data cannot be retrieved without getGCDataFn" */,
+		);
+		return this.getGCDataFn(fullGC);
+	}
+
+	public updateBaseSummaryState(snapshot: ISnapshotTree) {}
+
+	public recordChange(op: ISequencedDocumentMessage): void {}
+
+	public invalidate(sequenceNumber: number): void {}
+
+	public createChild(
+		summarizeInternalFn: SummarizeInternalFn,
+		id: string,
+		createParam: CreateChildSummarizerNodeParam,
+		config?: ISummarizerNodeConfigWithGC,
+		getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
+	): ISummarizerNodeWithGC {
+		assert(!this.children.has(id), 0x1ab /* "Create SummarizerNode child already exists" */);
+		const child = new NoOpSummarizerNodeWithGc(summarizeInternalFn, getGCDataFn, id);
+		this.children.set(id, child);
+		return child;
+	}
+
+	public getChild(id: string): ISummarizerNodeWithGC | undefined {
+		return this.children.get(id);
+	}
+
+	public deleteChild(id: string): void {
+		this.children.delete(id);
+	}
+
+	public isReferenced(): boolean {
+		return this.usedRoutes.includes("") || this.usedRoutes.includes("/");
+	}
+
+	public updateUsedRoutes(usedRoutes: string[]) {
+		this.usedRoutes = Array.from(usedRoutes);
+	}
+
+	public isSummaryInProgress(): boolean {
+		return false;
+	}
+}

--- a/packages/test/test-end-to-end-tests/src/test/nodeDidNotRunGc.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/nodeDidNotRunGc.spec.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	DataObject,
+	DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
+import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+	ITestObjectProvider,
+	waitForContainerConnection,
+	createSummarizerFromFactory,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+
+function createDataStoreRuntime(factory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime) {
+	return mixinSummaryHandler(async (runtime: FluidDataStoreRuntime) => {
+		await DataObject.getDataObject(runtime);
+		return undefined;
+	}, factory);
+}
+
+export const TestDataObjectType1 = "@fluid-example/test-dataStore1";
+export const TestDataObjectType2 = "@fluid-example/test-dataStore2";
+class TestDataObject2 extends DataObject {
+	public get _root() {
+		return this.root;
+	}
+	public get _context() {
+		return this.context;
+	}
+}
+class TestDataObject1 extends DataObject {
+	public get _root() {
+		return this.root;
+	}
+
+	public get _context() {
+		return this.context;
+	}
+
+	protected async initializingFirstTime() {}
+
+	protected async hasInitialized() {
+		const dsFactory2 = await requestFluidObject<TestDataObject2>(
+			await this._context.containerRuntime.createDataStore(TestDataObjectType2),
+			"",
+		);
+		assert(dsFactory2 !== undefined);
+	}
+}
+
+/**
+ * Validates whether or not a GC Tree Summary Handle should be written to the summary.
+ */
+describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	const dataStoreFactory1 = new DataObjectFactory(
+		TestDataObjectType1,
+		TestDataObject1,
+		[],
+		[],
+		[],
+		createDataStoreRuntime(),
+	);
+	const dataStoreFactory2 = new DataObjectFactory(
+		TestDataObjectType2,
+		TestDataObject2,
+		[],
+		[],
+		[],
+		createDataStoreRuntime(),
+	);
+	const runtimeOptions: IContainerRuntimeOptions = {
+		summaryOptions: {
+			summaryConfigOverrides: { state: "disabled" },
+		},
+	};
+	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+		runtime.IFluidHandleContext.resolveHandle(request);
+	const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
+		[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
+		[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],
+	]);
+	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+		dataStoreFactory1,
+		registryStoreEntries,
+		undefined,
+		[innerRequestHandler],
+		runtimeOptions,
+	);
+
+	let mainContainer: IContainer;
+	let mainDataStore: TestDataObject1;
+
+	const createContainer = async (): Promise<IContainer> => {
+		return provider.createContainer(runtimeFactory);
+	};
+
+	describe("Realize DataStore during Search while waiting for Summary Ack", () => {
+		beforeEach(async () => {
+			provider = getTestObjectProvider({ syncSummarizer: true });
+			mainContainer = await createContainer();
+			mainDataStore = await requestFluidObject<TestDataObject1>(mainContainer, "default");
+			mainDataStore._root.set("mode", "write");
+			await waitForContainerConnection(mainContainer);
+		});
+
+		it("fails summary on data store created during summarize", async () => {
+			const { summarizer } = await createSummarizerFromFactory(
+				provider,
+				mainContainer,
+				dataStoreFactory1,
+				undefined,
+				undefined,
+				registryStoreEntries,
+			);
+
+			const result = summarizer.summarizeOnDemand({ reason: "test" });
+			const submitResult = await result.summarySubmitted;
+			assert(submitResult.success, "The summary should have passed");
+		});
+	});
+});


### PR DESCRIPTION
Currently, there are hits for NodeDidNotRunGC errors which fails summaries. This happens because local data stores are created in summarizer which is not expected. However, these errors are avoidable because these are thrown for data stores that are detached and detached data stores aren't part of the summary anyway so there is no point in failing summary because of them.
The summary fails because even though we did not run GC or summarize for these nodes, the summarizer node for it exists and the complete summary step runs on it validating that GC / summarize ran on this node. Since, these did not run, it throws an error.

This prototype creates a mock summarizer node for local data stores which does not do incremental summary. It basically does full GC and full summary for local data stores every time. While this has a performance hit it's fine because its not a common scenario and it's a result of using incorrect patterns, i.e., creating local data stores in summarizer. Infact, the channel contexts (for DDS) already do this - LocalChannelContext does not even create a summarizer node.

Alternatives for fixing this issue
- Don't create a summarizer node for local data stores at all. This is equivalent but makes the data store context code quite complicated. Note that we still need to summarize / run GC on attached data stores.
- Add state to SummarizerNode about whether the node is attached or not. If not attached, skip the startSummary / completeSummary / clearSummary / refreshSummary steps for these nodes. Again, this makes the code complicated and the benefits aren't that great compared to the added complexity.