### PR TITLE
feat(dev-tools): Add metadata to data visualization

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidTreeView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidTreeView.tsx
@@ -28,7 +28,10 @@ export function FluidTreeView(props: FluidTreeViewProps): React.ReactElement {
 		<TreeDataView key={key} containerKey={containerKey} label={key} node={fluidObject} />
 	));
 
-	const header = <TreeHeader label={label} nodeTypeMetadata={node.typeMetadata} />;
+	const metadata = JSON.stringify(node.metadata);
+	const header = (
+		<TreeHeader label={label} nodeTypeMetadata={node.typeMetadata} metadata={metadata} />
+	);
 
 	return <TreeItem header={header}>{childNodes}</TreeItem>;
 }

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidValueView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidValueView.tsx
@@ -21,11 +21,13 @@ export type FluidValueViewProps = DataVisualizationTreeProps<FluidObjectValueNod
 export function FluidValueView(props: FluidValueViewProps): React.ReactElement {
 	const { label, node } = props;
 
+	const metadata = JSON.stringify(node.metadata);
 	const header = (
 		<TreeHeader
 			label={label}
 			nodeTypeMetadata={node.typeMetadata}
 			inlineValue={String(node.value)}
+			metadata={metadata}
 		/>
 	);
 

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
@@ -22,19 +22,29 @@ export interface TreeHeaderProps extends HasLabel {
 	inlineValue?: React.ReactElement | string;
 
 	// TODO: metadata
+	metadata?: string | undefined;
 }
 
 /**
  * Renders the header of the item.
  */
 export function TreeHeader(props: TreeHeaderProps): React.ReactElement {
-	const { label, nodeTypeMetadata, inlineValue } = props;
+	const { label, nodeTypeMetadata, inlineValue, metadata } = props;
 
 	return (
 		<div style={{ width: "auto" }}>
 			{`${label}`}
 			<span style={{ color: tokens.colorPaletteRedBorderActive, fontSize: "10px" }}>
 				{nodeTypeMetadata === undefined ? "" : ` (${nodeTypeMetadata})`}
+			</span>
+			<span
+				style={{
+					color: tokens.colorPalettePlatinumBorderActive,
+					fontStyle: "oblique",
+					fontSize: "10px",
+				}}
+			>
+				{metadata === undefined ? "" : ` ${metadata}`}
 			</span>
 			{inlineValue === undefined ? "" : ": "}
 			{inlineValue}

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeView.tsx
@@ -24,12 +24,15 @@ export interface TreeViewProps
  */
 export function TreeView(props: TreeViewProps): React.ReactElement {
 	const { containerKey, label, node } = props;
+	const metadata = JSON.stringify(node.metadata);
 
 	const childNodes = Object.entries(node.children).map(([key, fluidObject]) => (
 		<TreeDataView key={key} containerKey={containerKey} label={key} node={fluidObject} />
 	));
 
-	const header = <TreeHeader label={label} nodeTypeMetadata={node.typeMetadata} />;
+	const header = (
+		<TreeHeader label={label} nodeTypeMetadata={node.typeMetadata} metadata={metadata} />
+	);
 
 	return <TreeItem header={header}>{childNodes}</TreeItem>;
 }

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownDataView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownDataView.tsx
@@ -21,11 +21,13 @@ export type UnknownDataViewProps = DataVisualizationTreeProps<UnknownObjectNode>
 export function UnknownDataView(props: UnknownDataViewProps): React.ReactElement {
 	const { label, node } = props;
 
+	const metadata = JSON.stringify(node.metadata);
 	const header = (
 		<TreeHeader
 			label={label}
 			nodeTypeMetadata={node.typeMetadata}
 			inlineValue={<i>Unrecognized kind of data.</i>}
+			metadata={metadata}
 		/>
 	);
 	return <TreeItem header={header} />;

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownFluidObjectView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownFluidObjectView.tsx
@@ -21,11 +21,13 @@ export type UnknownFluidObjectViewProps = DataVisualizationTreeProps<FluidUnknow
 export function UnknownFluidObjectView(props: UnknownFluidObjectViewProps): React.ReactElement {
 	const { label, node } = props;
 
+	const metadata = JSON.stringify(node.metadata);
 	const header = (
 		<TreeHeader
 			label={label}
 			nodeTypeMetadata={node.typeMetadata}
 			inlineValue={<i>Unrecognized kind of Fluid Object.</i>}
+			metadata={metadata}
 		/>
 	);
 	return <TreeItem header={header} />;

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/ValueView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/ValueView.tsx
@@ -21,11 +21,13 @@ export type ValueViewProps = DataVisualizationTreeProps<ValueNodeBase>;
 export function ValueView(props: ValueViewProps): React.ReactElement {
 	const { label, node } = props;
 
+	const metadata = JSON.stringify(node.metadata);
 	const header = (
 		<TreeHeader
 			label={label}
 			nodeTypeMetadata={node.typeMetadata}
 			inlineValue={String(node.value)}
+			metadata={metadata}
 		/>
 	);
 	return <TreeItem header={header} />;


### PR DESCRIPTION
## Description

> For our SharedMatrix visualization, our root nodes and row-level nodes include metadata listing the number of rows / columns. We should display this information.

Other DDS visualizations (optionally) include metadata in their tree nodes that we should display as well.

## Sample
![Screenshot 2023-06-14 191842](https://github.com/microsoft/FluidFramework/assets/114451900/ade6ec0e-e32b-4263-afe6-4c7d0b556090)
