### PR TITLE
feat(dev-tools): Display client "scopes" as an unordered list

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
@@ -115,11 +115,11 @@ export function AudienceStateTable(props: AudienceStateTableProps): React.ReactE
 							</TableCell>
 							<TableCell>{item.mode}</TableCell>
 							<TableCell>
-								<span>
+								<ul>
 									{item.scopes.map((each_scope, index) => (
 										<li key={index}>{each_scope}</li>
 									))}
-								</span>
+								</ul>
 							</TableCell>
 						</TableRow>
 					);

--- a/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
@@ -115,7 +115,11 @@ export function AudienceStateTable(props: AudienceStateTableProps): React.ReactE
 							</TableCell>
 							<TableCell>{item.mode}</TableCell>
 							<TableCell>
-								<span>{item.scopes.join("\n")}</span>
+								<span>
+									{item.scopes.map((each_scope, index) => (
+										<li key={index}>{each_scope}</li>
+									))}
+								</span>
 							</TableCell>
 						</TableRow>
 					);


### PR DESCRIPTION
## Description

> We currently display the list of "scopes" a client has as a space-separated list. It would be nice to display these as an unordered list instead.

## Sample
![Screenshot 2023-06-15 131227](https://github.com/microsoft/FluidFramework/assets/114451900/fd291d63-9867-4b7e-b202-b0aa49b20883)

