### PR TITLE
Approach for handing off container ref to the migration tool

### DIFF
--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigratableModel.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigratableModel.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import type { IContainer } from "@fluidframework/container-definitions";
 import type { IImportExportModel, IVersionedModel } from "./migratableModel";
 import type { ISameContainerMigrationTool } from "./sameContainerMigrationTool";
 
@@ -24,6 +25,13 @@ export interface ISameContainerMigratableModel
 	 * Can we merge these interfaces later somehow?
 	 */
 	readonly migrationTool: ISameContainerMigrationTool;
+
+	/**
+	 * A reference to the container associated with this model.
+	 * TODO: Similar to the note on the migration tool, can we scope the required exposure here to just what the tool needs?
+	 * Exposing the whole IContainer makes it available to a larger audience than should have access to it.
+	 */
+	readonly container: IContainer;
 
 	/**
 	 * Returns if the runtime is currently connected.

--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
@@ -4,7 +4,7 @@
  */
 
 import type { IEvent, IEventProvider } from "@fluidframework/common-definitions";
-import { IContainer } from "@fluidframework/container-definitions";
+import type { IContainer } from "@fluidframework/container-definitions";
 
 /**
  * The collaboration session may be in one of these states:

--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IContainer } from "@fluidframework/container-definitions";
 
 /**
  * The collaboration session may be in one of these states:
@@ -81,5 +82,14 @@ export interface ISameContainerMigrationTool
 	 * Propose a new version to use.
 	 * @param newVersion - the version string
 	 */
-	proposeVersion: (newVersion: string) => void;
+	readonly proposeVersion: (newVersion: string) => void;
+
+	/**
+	 * Give a container reference to the migration tool.  The migration tool must have this reference in order to
+	 * complete the migration flow, otherwise it won't be able to progress past proposingV2Code state.
+	 * TODO: Later consider whether we can reduce the scope of what's provided to the tool.  Does it need the whole IContainer,
+	 * or could we just give it a callback to proposeCodeDetails()?
+	 * @param container - the reference to the IContainer associated with this migration tool
+	 */
+	readonly setContainerRef: (container: IContainer) => void;
 }

--- a/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
@@ -5,8 +5,10 @@
 
 import { IPactMap, PactMap } from "@fluid-experimental/pact-map";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+import type { IContainer } from "@fluidframework/container-definitions";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import type { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { MessageType } from "@fluidframework/protocol-definitions";
 
 import type { ISameContainerMigrationTool } from "../migrationInterfaces";
 
@@ -21,6 +23,14 @@ const newVersionKey = "newVersion";
 
 export class SameContainerMigrationTool extends DataObject implements ISameContainerMigrationTool {
 	private _pactMap: IPactMap<string> | undefined;
+	private readonly _containerP: Promise<IContainer>;
+	private _setContainerRef: ((container: IContainer) => void) | undefined;
+	public get setContainerRef(): (container: IContainer) => void {
+		if (this._setContainerRef === undefined) {
+			throw new Error("_setContainerRef did not initialize properly");
+		}
+		return this._setContainerRef;
+	}
 
 	/**
 	 * A promise that is only defined if the local client has made a proposal, and will resolve when any proposal goes pending.
@@ -100,6 +110,13 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		} else {
 			return "collaborating";
 		}
+	}
+
+	public constructor(props) {
+		super(props);
+		this._containerP = new Promise<IContainer>((resolve) => {
+			this._setContainerRef = (container: IContainer) => resolve(container);
+		});
 	}
 
 	// Once we have the v2 contents in hand, we can work on sending it as the next summary (which will look like a v2
@@ -226,12 +243,21 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		// TODO Here probably need to have the container reference on the providers, in order to make the proposal?
 		// Or at least a callback for it.
 		const version = this.pactMap.get(newVersionKey);
+		if (version === undefined) {
+			throw new Error("PactMap proposal not defined before proposing on the Quorum");
+		}
 		const quorumProposal = { package: version };
 		console.log(`Want to propose: ${JSON.stringify(quorumProposal)}`);
 		this.emit("proposingV2Code");
 		if (!this._anyQuorumProposalSeen) {
-			// TODO: This is where we would want to call container.proposeCodeDetails(quorumProposal).
-			// However, only do so if we are still in this state after fully catching up
+			const container = await this._containerP;
+			// Check again, since we might have seen a proposal while waiting on the container.
+			if (!this._anyQuorumProposalSeen) {
+				// TODO: we should only propose if we are still in this state after fully catching up
+				// TODO: awaiting here may await past an earlier proposal from someone else.  This is probably OK, since we would be waiting for our
+				// own proposal to accept anyway in _quorumApprovalCompleteP but maybe something to think about.
+				await container.proposeCodeDetails(quorumProposal);
+			}
 		}
 		await this._anyQuorumProposalSeenP;
 		this.emit("waitingForV2ProposalCompletion");

--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -63,6 +63,7 @@ export class SameContainerMigrator
 		super();
 		this._currentModel = initialMigratable;
 		this._currentModelId = initialId;
+		this._currentModel.migrationTool.setContainerRef(this._currentModel.container);
 		this.takeAppropriateActionForCurrentMigratable();
 	}
 

--- a/examples/version-migration/same-container/src/modelInterfaces.ts
+++ b/examples/version-migration/same-container/src/modelInterfaces.ts
@@ -10,7 +10,6 @@ import type {
 } from "@fluid-example/example-utils";
 import type { IEventProvider } from "@fluidframework/common-definitions";
 import { SharedString } from "@fluidframework/sequence";
-import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IInventoryListAppModelEvents extends ISameContainerMigratableModelEvents {}
@@ -26,8 +25,6 @@ export interface IInventoryListAppModel
 	 * An inventory tracker list.
 	 */
 	readonly inventoryList: IInventoryList;
-	// TODO: TEMPORARY debug API to advance past the code proposal phase, until we have a good way to get the container ref inside the MigrationTool.
-	readonly DEBUG_proposeCodeDetails: (codeDetails: IFluidCodeDetails) => Promise<void>;
 
 	// TODO: TEMPORARY debug API to trigger a summary - for now the demo disables automatic summarization entirely, so this allows it to advance past the stages that require a summary.
 	readonly DEBUG_summarizeOnDemand: () => void;

--- a/examples/version-migration/same-container/src/modelVersion1/appModel.ts
+++ b/examples/version-migration/same-container/src/modelVersion1/appModel.ts
@@ -5,7 +5,8 @@
 
 import type { ISameContainerMigrationTool } from "@fluid-example/example-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { AttachState, IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
+import type { IContainer } from "@fluidframework/container-definitions";
+import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
@@ -83,12 +84,6 @@ export class InventoryListAppModel
 	public close() {
 		this.container.close();
 	}
-
-	public readonly DEBUG_proposeCodeDetails = async (
-		codeDetails: IFluidCodeDetails,
-	): Promise<void> => {
-		await this.container.proposeCodeDetails(codeDetails);
-	};
 
 	public readonly DEBUG_summarizeOnDemand = () => {
 		(this.runtime as any) /* ContainerRuntime */

--- a/examples/version-migration/same-container/src/modelVersion1/appModel.ts
+++ b/examples/version-migration/same-container/src/modelVersion1/appModel.ts
@@ -35,7 +35,7 @@ export class InventoryListAppModel
 	public constructor(
 		public readonly inventoryList: IInventoryList,
 		public readonly migrationTool: ISameContainerMigrationTool,
-		private readonly container: IContainer,
+		public readonly container: IContainer,
 		private readonly runtime: IContainerRuntime,
 	) {
 		super();

--- a/examples/version-migration/same-container/src/modelVersion2/appModel.ts
+++ b/examples/version-migration/same-container/src/modelVersion2/appModel.ts
@@ -5,7 +5,8 @@
 
 import type { ISameContainerMigrationTool } from "@fluid-example/example-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { AttachState, IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
+import type { IContainer } from "@fluidframework/container-definitions";
+import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
@@ -83,12 +84,6 @@ export class InventoryListAppModel
 	public close() {
 		this.container.close();
 	}
-
-	public readonly DEBUG_proposeCodeDetails = async (
-		codeDetails: IFluidCodeDetails,
-	): Promise<void> => {
-		await this.container.proposeCodeDetails(codeDetails);
-	};
 
 	public readonly DEBUG_summarizeOnDemand = () => {
 		(this.runtime as any) /* ContainerRuntime */

--- a/examples/version-migration/same-container/src/modelVersion2/appModel.ts
+++ b/examples/version-migration/same-container/src/modelVersion2/appModel.ts
@@ -35,7 +35,7 @@ export class InventoryListAppModel
 	public constructor(
 		public readonly inventoryList: IInventoryList,
 		public readonly migrationTool: ISameContainerMigrationTool,
-		private readonly container: IContainer,
+		public readonly container: IContainer,
 		private readonly runtime: IContainerRuntime,
 	) {
 		super();

--- a/examples/version-migration/same-container/src/start.ts
+++ b/examples/version-migration/same-container/src/start.ts
@@ -49,7 +49,6 @@ const render = (model: IVersionedModel) => {
 		ReactDOM.render(
 			React.createElement(DebugView, {
 				model,
-				proposeCodeDetails: model.DEBUG_proposeCodeDetails,
 				summarizeOnDemand: model.DEBUG_summarizeOnDemand,
 				getUrlForContainerId,
 			}),

--- a/examples/version-migration/same-container/src/view/debugView.tsx
+++ b/examples/version-migration/same-container/src/view/debugView.tsx
@@ -9,18 +9,16 @@ import type {
 	ISameContainerMigratableModel,
 	SameContainerMigrationState,
 } from "@fluid-example/example-utils";
-import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import type { IInventoryListAppModel } from "../modelInterfaces";
 
 export interface IDebugViewProps {
 	readonly model: IInventoryListAppModel;
-	readonly proposeCodeDetails: (codeDetails: IFluidCodeDetails) => Promise<void>;
 	readonly summarizeOnDemand: () => void;
 	readonly getUrlForContainerId?: (containerId: string) => string;
 }
 
 export const DebugView: React.FC<IDebugViewProps> = (props: IDebugViewProps) => {
-	const { model, proposeCodeDetails, summarizeOnDemand, getUrlForContainerId } = props;
+	const { model, summarizeOnDemand, getUrlForContainerId } = props;
 
 	return (
 		<div>
@@ -28,7 +26,6 @@ export const DebugView: React.FC<IDebugViewProps> = (props: IDebugViewProps) => 
 			<MigrationStatusView model={model} getUrlForContainerId={getUrlForContainerId} />
 			<ControlsView
 				proposeVersion={model.migrationTool.proposeVersion}
-				proposeCodeDetails={proposeCodeDetails}
 				summarizeOnDemand={summarizeOnDemand}
 				addItem={model.inventoryList.addItem}
 			/>
@@ -118,13 +115,12 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 
 interface IControlsViewProps {
 	readonly proposeVersion: (version: string) => void;
-	readonly proposeCodeDetails: (codeDetails: IFluidCodeDetails) => Promise<void>;
 	readonly summarizeOnDemand: () => void;
 	readonly addItem: (name: string, quantity: number) => void;
 }
 
 const ControlsView: React.FC<IControlsViewProps> = (props: IControlsViewProps) => {
-	const { proposeVersion, proposeCodeDetails, summarizeOnDemand, addItem } = props;
+	const { proposeVersion, summarizeOnDemand, addItem } = props;
 
 	const addSampleItems = () => {
 		addItem("Alpha", 1);
@@ -151,27 +147,6 @@ const ControlsView: React.FC<IControlsViewProps> = (props: IControlsViewProps) =
 					}}
 				>
 					&quot;two&quot;
-				</button>
-			</div>
-			<div style={{ margin: "10px 0" }}>
-				The demo in its current state can't make a real code proposal to the Quorum. Use
-				these debug buttons to simulate that step.
-				<br />
-				Propose QuorumProposals code details:
-				<br />
-				<button
-					onClick={() => {
-						proposeCodeDetails({ package: "one" }).catch(console.error);
-					}}
-				>
-					{`{ package: "one" }`}
-				</button>
-				<button
-					onClick={() => {
-						proposeCodeDetails({ package: "two" }).catch(console.error);
-					}}
-				>
-					{`{ package: "two" }`}
 				</button>
 			</div>
 			<div style={{ margin: "10px 0" }}>

--- a/examples/version-migration/same-container/tests/index.tsx
+++ b/examples/version-migration/same-container/tests/index.tsx
@@ -75,7 +75,6 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement)
 			ReactDOM.render(
 				React.createElement(DebugView, {
 					model,
-					proposeCodeDetails: model.DEBUG_proposeCodeDetails,
 					summarizeOnDemand: model.DEBUG_summarizeOnDemand,
 					getUrlForContainerId,
 				}),


### PR DESCRIPTION
This change adds the ability for the SameContainerMigrator to hand a reference to the IContainer to the SameContainerMigrationTool.  This ref is expected to be provided by the author of the ISameContainerMigratableModel (the container author).

Since the model/container author is already able to access the container easily, this should be pretty minimal extra effort for them, and we can encapsulate the handoff in the objects we provide instead.  The main complication is that we aren't able to get a reference to the IContainer until the SameContainerMigration tool has been instantiated, so we have to accommodate late availability with a promise.

With this change, we no longer need the debug buttons for faking a proposal so they are removed.

Alternatives considered:
* Passing the reference via the scope (and/or DependencyContainer which does the same thing).  Same problem of late availability, plus the DependencyContainer/scope stuff should probably go away.
* Raise an event from the MigrationTool that we are ready for an external party to make the quorum proposal - harder to maintain control of the migration flow with more of it externalized from the tool itself, and still need either the Migrator or the AppModel to participate using its IContainer ref.
* Have the AppModel make the proposal when requested - puts more burden on the container author to implement, and more chance for them to do the wrong thing.