### PR TITLE
Remove chatty telemetry event for client election

### DIFF
--- a/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
@@ -372,7 +372,7 @@ export class OrderedClientElection
 			// Override the initially elected client with the initial state.
 			if (initialClient?.clientId !== initialState.electedClientId) {
 				// Cannot find initially elected client, so elect undefined.
-				logger.sendErrorEvent({
+				this.logger.sendErrorEvent({
 					eventName: "InitialElectedClientNotFound",
 					electionSequenceNumber: initialState.electionSequenceNumber,
 					expectedClientId: initialState.electedClientId,
@@ -382,7 +382,7 @@ export class OrderedClientElection
 			} else if (initialClient !== undefined && !isEligibleFn(initialClient)) {
 				// Initially elected client is ineligible, so elect next eligible client.
 				initialClient = initialParent = this.findFirstEligibleParent(initialParent);
-				logger.sendErrorEvent({
+				this.logger.sendErrorEvent({
 					eventName: "InitialElectedClientIneligible",
 					electionSequenceNumber: initialState.electionSequenceNumber,
 					expectedClientId: initialState.electedClientId,

--- a/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
@@ -416,13 +416,6 @@ export class OrderedClientElection
 			change = true;
 		}
 		if (change) {
-			this.logger.sendTelemetryEvent({
-				eventName: "SummarizerClientElected",
-				electedClientId: this._electedClient?.clientId,
-				electedParentId: this._electedParent?.clientId,
-				electionSequenceNumber: sequenceNumber,
-				isSummarizerClient,
-			});
 			this.emit("election", client, sequenceNumber, prevClient);
 		}
 	}
@@ -430,12 +423,6 @@ export class OrderedClientElection
 	private tryElectingParent(client: ILinkedClient | undefined, sequenceNumber: number): void {
 		if (this._electedParent !== client) {
 			this._electedParent = client;
-			this.logger.sendTelemetryEvent({
-				eventName: "SummarizerParentElected",
-				electedClientId: this._electedClient?.clientId,
-				electedParentId: this._electedParent?.clientId,
-				electionSequenceNumber: sequenceNumber,
-			});
 			this.emit("election", this._electedClient, sequenceNumber, this._electedClient);
 		}
 	}


### PR DESCRIPTION

## Description

The client election logging was initially designed to identify summarizers running at the same time. There is a problem with this logging. If we have a document stuck without being able to summarize, the join/ leave ops  the new client processes (catch up) will trigger a huge number of re-elections. This PR removes the logging.