### PR TITLE
Add note to e2e test tsconfig

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/tsconfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/tsconfig.json
@@ -4,10 +4,13 @@
 		"declaration": false,
 		"declarationMap": false,
 		"rootDir": "../",
+		// Note: despite being esnext, this publishes to "dist" over "lib" to keep root project settings' debug launch targets
+		// reasonable. If we convert the remaining group of client packages to use esnext modules only, we likely want to
+		// standardize the esnext build directory.
 		"outDir": "../../dist",
 		"types": ["mocha", "@fluidframework/test-driver-definitions"],
 		"noUnusedLocals": false, // Needed for memory tests to be able to declare local variables just for the purpose of keeping stuff in memory
-		"module": "ESNext",
+		"module": "esnext",
 	},
 	"include": ["./**/*"],
 }


### PR DESCRIPTION
## Description

Small improvement to #15976 to note why it's not consistent with other example packages we have that don't build cjs. See discussion [here](https://github.com/microsoft/FluidFramework/pull/15940#discussion_r1231636495)