### PR TITLE
Deprecate test-client-utils package and remove usage

### DIFF
--- a/.changeset/legal-breads-happen.md
+++ b/.changeset/legal-breads-happen.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/test-client-utils": minor
+---
+
+@fluidframework/test-client-utils package deprecated
+
+The @fluidframework/test-client-utils package is deprecated and will be removed in an upcoming release.

--- a/api-report/test-client-utils.api.md
+++ b/api-report/test-client-utils.api.md
@@ -7,12 +7,11 @@
 import { InsecureTokenProvider } from '@fluidframework/test-runtime-utils';
 import { IUser } from '@fluidframework/protocol-definitions';
 
-// @public
+// @public @deprecated
 export const generateTestUser: () => IUser & {
     name: string;
 };
 
 export { InsecureTokenProvider }
-
 
 ```

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -65,11 +65,12 @@
 		"@fluidframework/build-tools": "^0.19.0-166151",
 		"@fluidframework/counter": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-client-utils": "workspace:~",
+		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
+		"@types/uuid": "^8.3.0",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
@@ -80,7 +81,8 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^1.11.7",
-		"typescript": "~4.5.5"
+		"typescript": "~4.5.5",
+		"uuid": "^8.3.1"
 	},
 	"typeValidation": {
 		"broken": {}

--- a/azure/packages/azure-client/src/test/AzureClient.spec.ts
+++ b/azure/packages/azure-client/src/test/AzureClient.spec.ts
@@ -8,15 +8,24 @@ import { AttachState } from "@fluidframework/container-definitions";
 import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map";
 import { ConnectionMode, ScopeType } from "@fluidframework/protocol-definitions";
-import { InsecureTokenProvider, generateTestUser } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import { timeoutPromise } from "@fluidframework/test-utils";
+
+import { v4 as uuid } from "uuid";
 
 import { AzureClient } from "../AzureClient";
 import { AzureLocalConnectionConfig } from "../interfaces";
 
 function createAzureClient(scopes?: ScopeType[]): AzureClient {
 	const connectionProps: AzureLocalConnectionConfig = {
-		tokenProvider: new InsecureTokenProvider("fooBar", generateTestUser(), scopes),
+		tokenProvider: new InsecureTokenProvider(
+			"fooBar",
+			{
+				id: uuid(),
+				name: uuid(),
+			},
+			scopes,
+		),
 		endpoint: "http://localhost:7070",
 		type: "local",
 	};

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -49,7 +49,8 @@
 		"assert": "^2.0.0",
 		"axios": "^0.26.0",
 		"events": "^3.1.0",
-		"fluid-framework": "workspace:~"
+		"fluid-framework": "workspace:~",
+		"uuid": "^8.3.1"
 	},
 	"devDependencies": {
 		"@fluid-experimental/devtools": "workspace:~",
@@ -60,13 +61,14 @@
 		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/local-driver": "workspace:~",
 		"@fluidframework/server-local-server": "^0.1038.4000",
-		"@fluidframework/test-client-utils": "workspace:~",
+		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
 		"@types/node": "^14.18.38",
 		"@types/puppeteer": "1.3.0",
+		"@types/uuid": "^8.3.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"concurrently": "^7.6.0",
 		"cross-env": "^7.0.3",

--- a/azure/packages/external-controller/src/app.ts
+++ b/azure/packages/external-controller/src/app.ts
@@ -12,7 +12,9 @@ import {
 	AzureRemoteConnectionConfig,
 } from "@fluidframework/azure-client";
 import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
-import { InsecureTokenProvider, generateTestUser } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
+
+import { v4 as uuid } from "uuid";
 
 import { AzureFunctionTokenProvider } from "./AzureFunctionTokenProvider";
 import { DiceRollerController, DiceRollerControllerProps } from "./controller";
@@ -31,7 +33,10 @@ const userDetails: ICustomUserDetails = {
 // Define the server we will be using and initialize Fluid
 const useAzure = process.env.FLUID_CLIENT === "azure";
 
-const user = generateTestUser();
+const user = {
+	id: uuid(),
+	name: uuid(),
+};
 
 const azureUser = {
 	userId: user.id,

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -63,7 +63,6 @@
 		"@fluidframework/matrix": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"@fluidframework/test-client-utils": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
 		"cross-env": "^7.0.3",

--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -9,7 +9,7 @@ import {
 	AzureLocalConnectionConfig,
 	AzureRemoteConnectionConfig,
 } from "@fluidframework/azure-client";
-import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 
 import { IConfigProviderBase, MockLogger } from "@fluidframework/telemetry-utils";
 import { createAzureTokenProvider } from "./AzureTokenFactory";

--- a/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { ITokenProvider } from "@fluidframework/azure-client";
-import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 
 export function createAzureTokenProvider(userId: string, userName: string): ITokenProvider {
 	const key = process.env.azure__fluid__relay__service__key as string;

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -73,7 +73,6 @@
 		"@fluidframework/matrix": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"@fluidframework/test-client-utils": "workspace:~",
 		"@fluidframework/test-driver-definitions": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",

--- a/azure/packages/test/scenario-runner/src/utils.ts
+++ b/azure/packages/test/scenario-runner/src/utils.ts
@@ -12,7 +12,9 @@ import {
 import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map";
 import { TelemetryLogger } from "@fluidframework/telemetry-utils";
-import { InsecureTokenProvider, generateTestUser } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
+
+import { v4 as uuid } from "uuid";
 
 import { ContainerFactorySchema } from "./interface";
 
@@ -119,7 +121,10 @@ export async function createAzureClient(config: AzureClientConfig): Promise<Azur
 		}
 	} else {
 		connectionProps = {
-			tokenProvider: new InsecureTokenProvider("fooBar", generateTestUser()),
+			tokenProvider: new InsecureTokenProvider("fooBar", {
+				id: uuid(),
+				name: uuid(),
+			}),
 			endpoint: config.connEndpoint,
 			type: "local",
 		};

--- a/packages/framework/test-client-utils/README.md
+++ b/packages/framework/test-client-utils/README.md
@@ -1,5 +1,7 @@
 # @fluidframework/test-client-utils
 
+## WARNING: This package is deprecated as of 2.0.0-internal.5.1.0 and will be removed in an upcoming release.
+
 Utilities to use while developing and testing using the service-specific clients (i.e. `AzureClient`, `TinyliciousClient`) supplied by the FluidFramework.
 
 <!-- AUTO-GENERATED-CONTENT:START (README_DEPENDENCY_GUIDELINES_SECTION:includeHeading=TRUE) -->

--- a/packages/framework/test-client-utils/src/generateTestUser.ts
+++ b/packages/framework/test-client-utils/src/generateTestUser.ts
@@ -11,6 +11,8 @@ import { v4 as uuid } from "uuid";
  * ({@link https://en.wikipedia.org/wiki/Universally_unique_identifier | uuid}) and random name (FIRST LAST)
  *
  * @returns a user object with a name and id property
+ *
+ * @deprecated 2.0.0-internal.5.1.0 - Not recommended for general use.
  */
 export const generateTestUser = (): IUser & { name: string } => {
 	const user = {

--- a/packages/runtime/test-runtime-utils/README.md
+++ b/packages/runtime/test-runtime-utils/README.md
@@ -65,6 +65,38 @@ To write a unit test for these scenarios, follow these steps:
 
 Examples - [sharedString](../sequence/src/test/sharedString.spec.ts), [consensusOrderedCollection](../consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts), [consensusRegisterCollection](../consensus-register-collection/src/test/consensusRegisterCollection.spec.ts).
 
+## InsecureTokenProvider
+
+The `InsecureTokenProvider` provides a class for locally generating JWT tokens, signed using a tenant key, that can be sent to Fluid services. These tokens will be used to authenticate and identify which user is sending operations from the client.
+
+It takes in two parameters:
+
+-   `tenantKey` - Used for signing the token for use with the `tenantId` that we are attempting to connect to on the service
+-   `user` - Used to populate the current user's details in the audience currently editing the container
+
+The `AzureClient`, from the `@fluidframework/azure-client` package, takes in a `tokenProvider` parameter as part of its constructor. This parameter can be fulfilled by using the `InsecureTokenProvider` that is exported here. However, it is advised to only use this for development or testing purposes as it risks exposing your Azure Fluid Relay service tenant key secret on your client side code.
+
+### Usage for Development with Local Tinylicious Instance
+
+When using the `AzureClient`, you can configure it to run against a local Tinylicous instance. Please see the client's [documentation on local development](https://github.com/microsoft/FluidFramework/blob/main/packages/framework/azure-client/README.md#backed-locally) for more information on how to do so. In this scenario, the `InsecureTokenProvider` will take any value for its `tenantKey` parameter since we're working with a local Tinylicious instance that doesn't require any authentication. As such, we can create an instance of it like this:
+
+```javascript
+const tokenProvider = new InsecureTokenProvider("fooBar", { id: "123", name: "Test User" });
+```
+
+### Usage for Development with Azure Fluid Relay service
+
+The `AzureClient` can also be configured to a deployed Azure Fluid Relay service instance as described [here](https://github.com/microsoft/FluidFramework/blob/main/packages/framework/azure-client/README.md#backed-by-a-live-azure-fluid-relay-instance). Now, the configuration is using a real `tenantId` and the `InsecureTokenProvider` will need the matching `tenantKey` as provided during the service onboarding.
+
+```javascript
+const tokenProvider = new InsecureTokenProvider("YOUR-TENANT-KEY-HERE", {
+	id: "123",
+	name: "Test User",
+});
+```
+
+Again, this should ONLY be used for local development as including the tenant key in the client code risks allowing malicious users to sniff it from the client bundle. Please consider using the [AzureFunctionTokenProvider](https://github.com/microsoft/FluidFramework/blob/main/packages/framework/azure-client/src/AzureFunctionTokenProvider.ts) or your own implementation that fulfills the `ITokenProvider` interface as an alternative for production scenarios.
+
 <!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->

--- a/packages/runtime/test-runtime-utils/src/generateToken.ts
+++ b/packages/runtime/test-runtime-utils/src/generateToken.ts
@@ -88,9 +88,8 @@ export function generateToken(
 }
 
 /**
- * Generates an arbitrary ("random") {@link @fluidframework/test-client-utils#IInsecureUser} by generating a
- * random UUID for its {@link @fluidframework/test-client-utils#IInsecureUser.id}
- * and {@link @fluidframework/test-client-utils#IInsecureUser.name} properties.
+ * Generates an arbitrary ("random") {@link IInsecureUser} by generating a
+ * random UUID for its {@link @fluidframework/protocol-definitions#IUser.id | id} and {@link IInsecureUser.name | name} properties.
  */
 export function generateUser(): IInsecureUser {
 	const randomUser = {

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -42,7 +42,6 @@
 		"@fluidframework/routerlicious-driver": "workspace:~",
 		"@fluidframework/routerlicious-urlresolver": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
-		"@fluidframework/test-client-utils": "workspace:~",
 		"@fluidframework/tool-utils": "workspace:~"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,9 @@ importers:
       '@fluidframework/eslint-config-fluid':
         specifier: ^2.0.0
         version: 2.0.0(eslint@8.6.0)(typescript@4.5.5)
-      '@fluidframework/test-client-utils':
+      '@fluidframework/test-runtime-utils':
         specifier: workspace:~
-        version: link:../../../packages/framework/test-client-utils
+        version: link:../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils':
         specifier: workspace:~
         version: link:../../../packages/test/test-utils
@@ -173,6 +173,9 @@ importers:
       '@types/node':
         specifier: ^14.18.38
         version: 14.18.47
+      '@types/uuid':
+        specifier: ^8.3.0
+        version: 8.3.4
       concurrently:
         specifier: ^7.6.0
         version: 7.6.0
@@ -206,6 +209,9 @@ importers:
       typescript:
         specifier: ~4.5.5
         version: 4.5.5
+      uuid:
+        specifier: ^8.3.1
+        version: 8.3.2
 
   azure/packages/azure-local-service:
     dependencies:
@@ -334,6 +340,9 @@ importers:
       fluid-framework:
         specifier: workspace:~
         version: link:../../../packages/framework/fluid-framework
+      uuid:
+        specifier: ^8.3.1
+        version: 8.3.2
     devDependencies:
       '@fluid-experimental/devtools':
         specifier: workspace:~
@@ -359,9 +368,9 @@ importers:
       '@fluidframework/server-local-server':
         specifier: ^0.1038.4000
         version: 0.1038.4001
-      '@fluidframework/test-client-utils':
+      '@fluidframework/test-runtime-utils':
         specifier: workspace:~
-        version: link:../../../packages/framework/test-client-utils
+        version: link:../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-tools':
         specifier: ^0.2.158186
         version: 0.2.158186
@@ -380,6 +389,9 @@ importers:
       '@types/puppeteer':
         specifier: 1.3.0
         version: 1.3.0
+      '@types/uuid':
+        specifier: ^8.3.0
+        version: 8.3.4
       clean-webpack-plugin:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.83.0)
@@ -479,9 +491,6 @@ importers:
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../../../packages/utils/telemetry-utils
-      '@fluidframework/test-client-utils':
-        specifier: workspace:~
-        version: link:../../../../packages/framework/test-client-utils
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../../../packages/runtime/test-runtime-utils
@@ -591,9 +600,6 @@ importers:
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../../../packages/utils/telemetry-utils
-      '@fluidframework/test-client-utils':
-        specifier: workspace:~
-        version: link:../../../../packages/framework/test-client-utils
       '@fluidframework/test-driver-definitions':
         specifier: workspace:~
         version: link:../../../../packages/test/test-driver-definitions
@@ -15999,9 +16005,6 @@ importers:
       '@fluidframework/runtime-definitions':
         specifier: workspace:~
         version: link:../../runtime/runtime-definitions
-      '@fluidframework/test-client-utils':
-        specifier: workspace:~
-        version: link:../../framework/test-client-utils
       '@fluidframework/tool-utils':
         specifier: workspace:~
         version: link:../../utils/tool-utils


### PR DESCRIPTION
This package is almost empty anyway - it's re-exporting InsecureUrlResolver from test-runtime-utils and a trivial helper.  No need to keep it around.