### PR TITLE
Deprecate IChannel.owner

### DIFF
--- a/.changeset/spotty-bears-start.md
+++ b/.changeset/spotty-bears-start.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/datastore-definitions": minor
+---
+
+IChannel.owner deprecated
+
+The owner property on IChannel has been deprecated and will be removed in an upcoming release. This property does nothing.

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -37,7 +37,7 @@ export interface IChannel extends IFluidLoadable {
     getGCData(fullGC?: boolean): IGarbageCollectionData;
     readonly id: string;
     isAttached(): boolean;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly owner?: string;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
 }

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -20,6 +20,9 @@ export interface IChannel extends IFluidLoadable {
 	 */
 	readonly id: string;
 
+	/**
+	 * @deprecated 2.0.0-internal.5.1.0 - The owner property does nothing and is not recommended for use.
+	 */
 	readonly owner?: string;
 
 	readonly attributes: IChannelAttributes;


### PR DESCRIPTION
I believe this is leftover from way back when we had the "OwnedMap" DDS.  Deprecating here to remove later.