### PR TITLE
Remove IContainerContext.existing

### DIFF
--- a/.changeset/better-apes-fly.md
+++ b/.changeset/better-apes-fly.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/container-definitions": major
+"@fluidframework/container-loader": major
+"@fluidframework/container-runtime": major
+---
+
+Removed IContainerContext.existing
+
+The recommended means of checking for existing changed to the instantiateRuntime param in 2021, and the IContainerContext.existing member was formally deprecated in 2.0.0-internal.2.0.0. This member is now removed.

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -175,8 +175,6 @@ export interface IContainerContext extends IDisposable {
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     // (undocumented)
     readonly disposeFn?: (error?: ICriticalContainerError) => void;
-    // @deprecated (undocumented)
-    readonly existing: boolean | undefined;
     getAbsoluteUrl?(relativeUrl: string): Promise<string | undefined>;
     getEntryPoint?(): Promise<FluidObject | undefined>;
     // (undocumented)

--- a/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
+++ b/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
@@ -46,7 +46,7 @@ export abstract class ModelContainerRuntimeFactoryWithAttribution<ModelType>
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<IRuntime> {
-		const fromExisting = existing ?? context.existing ?? false;
+		const fromExisting = existing ?? false;
 		const attributor = createRuntimeAttributor();
 		const scope: FluidObject<IProvideRuntimeAttributor> = { IRuntimeAttributor: attributor };
 

--- a/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
+++ b/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
@@ -46,7 +46,6 @@ export abstract class ModelContainerRuntimeFactoryWithAttribution<ModelType>
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<IRuntime> {
-		const fromExisting = existing ?? false;
 		const attributor = createRuntimeAttributor();
 		const scope: FluidObject<IProvideRuntimeAttributor> = { IRuntimeAttributor: attributor };
 
@@ -59,7 +58,7 @@ export abstract class ModelContainerRuntimeFactoryWithAttribution<ModelType>
 			existing,
 		);
 
-		if (!fromExisting) {
+		if (!existing) {
 			await this.containerInitializingFirstTime(runtime);
 		}
 		await this.containerHasInitialized(runtime);

--- a/examples/utils/example-utils/src/modelLoader/modelContainerRuntimeFactory.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelContainerRuntimeFactory.ts
@@ -36,7 +36,7 @@ export abstract class ModelContainerRuntimeFactory<ModelType> implements IRuntim
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<IRuntime> {
-		const fromExisting = existing ?? context.existing ?? false;
+		const fromExisting = existing ?? false;
 		const runtime = await ContainerRuntime.load(
 			context,
 			this.registryEntries,

--- a/examples/utils/example-utils/src/modelLoader/modelContainerRuntimeFactory.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelContainerRuntimeFactory.ts
@@ -36,7 +36,6 @@ export abstract class ModelContainerRuntimeFactory<ModelType> implements IRuntim
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<IRuntime> {
-		const fromExisting = existing ?? false;
 		const runtime = await ContainerRuntime.load(
 			context,
 			this.registryEntries,
@@ -46,7 +45,7 @@ export abstract class ModelContainerRuntimeFactory<ModelType> implements IRuntim
 			existing,
 		);
 
-		if (!fromExisting) {
+		if (!existing) {
 			await this.containerInitializingFirstTime(runtime);
 		}
 		await this.containerHasInitialized(runtime);

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -61,6 +61,10 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IContainerContext": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -138,8 +138,6 @@ export interface IBatchMessage {
  * and the Container has created a new ContainerContext.
  */
 export interface IContainerContext extends IDisposable {
-	/** @deprecated Please pass in existing directly in instantiateRuntime */
-	readonly existing: boolean | undefined;
 	readonly options: ILoaderOptions;
 	readonly clientId: string | undefined;
 	readonly clientDetails: IClientDetails;

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -419,6 +419,7 @@ declare function get_current_InterfaceDeclaration_IContainerContext():
 declare function use_old_InterfaceDeclaration_IContainerContext(
     use: TypeOnly<old.IContainerContext>);
 use_old_InterfaceDeclaration_IContainerContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerContext());
 
 /*

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -92,7 +92,6 @@ export class ContainerContext implements IContainerContext {
 			closeFn,
 			version,
 			updateDirtyContainerState,
-			existing,
 			pendingLocalState,
 		);
 		await context.instantiateRuntime(existing);
@@ -238,7 +237,6 @@ export class ContainerContext implements IContainerContext {
 		public readonly closeFn: (error?: ICriticalContainerError) => void,
 		public readonly version: string,
 		public readonly updateDirtyContainerState: (dirty: boolean) => void,
-		public readonly existing: boolean,
 		public readonly pendingLocalState?: unknown,
 	) {
 		this._connected = this.container.connected;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -705,8 +705,6 @@ export class ContainerRuntime
 				tryFetchBlob<SerializedIdCompressorWithNoSession>(idCompressorBlobName),
 			]);
 
-		const loadExisting = existing === true || context.existing === true;
-
 		// read snapshot blobs needed for BlobManager to load
 		const blobManagerSnapshot = await BlobManager.load(
 			context.baseSnapshot?.trees[blobsTreeName],
@@ -780,7 +778,7 @@ export class ContainerRuntime
 			},
 			containerScope,
 			logger,
-			loadExisting,
+			existing,
 			blobManagerSnapshot,
 			context.storage,
 			idCompressor,


### PR DESCRIPTION
This member has been recommended against since 2021 with #6604, was formally deprecated in 2.0.0-internal.2.0.0 with #12224, and was going to be removed in #11699 but looks like that one got stale-closed.  This PR removes it.