### PR TITLE
Fix ops usage from snapshot in frs driver

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -104,6 +104,9 @@ export function promiseRaceWithWinner<T>(promises: Promise<T>[]): Promise<{
     value: T;
 }>;
 
+// @public (undocumented)
+export function validateMessages(reason: string, messages: ISequencedDocumentMessage[], from: number, logger: ITelemetryLoggerExt): void;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/drivers/driver-base/src/index.ts
+++ b/packages/drivers/driver-base/src/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { DocumentDeltaConnection } from "./documentDeltaConnection";
-export { getW3CData, promiseRaceWithWinner } from "./driverUtils";
+export { getW3CData, promiseRaceWithWinner, validateMessages } from "./driverUtils";

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDeltaStorageService.ts
@@ -7,7 +7,7 @@ import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { IDocumentDeltaStorageService, IStream } from "@fluidframework/driver-definitions";
 import { Queue, emptyMessageStream } from "@fluidframework/driver-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { validateMessages } from "../odspUtils";
+import { validateMessages } from "@fluidframework/driver-base";
 
 /**
  * Implementation of IDocumentDeltaStorageService that will return snapshot ops when fetching messages

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -6,6 +6,7 @@
 import { default as AbortController } from "abort-controller";
 import { v4 as uuid } from "uuid";
 import { ITelemetryProperties } from "@fluidframework/common-definitions";
+import { validateMessages } from "@fluidframework/driver-base";
 import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -17,7 +18,7 @@ import {
 import { requestOps, streamObserver } from "@fluidframework/driver-utils";
 import { IDeltaStorageGetResponse, ISequencedDeltaOpMessage } from "./contracts";
 import { EpochTracker } from "./epochTracker";
-import { getWithRetryForTokenRefresh, validateMessages } from "./odspUtils";
+import { getWithRetryForTokenRefresh } from "./odspUtils";
 
 /**
  * Provides access to the underlying delta storage on the server for sharepoint driver.
@@ -177,7 +178,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 				validateMessages("cached", messages, from, this.logger);
 				if (messages.length > 0 && messages[0].sequenceNumber === from) {
 					this.snapshotOps = this.snapshotOps.filter((op) => op.sequenceNumber >= to);
-					opsFromSnapshot = messages.length;
+					opsFromSnapshot += messages.length;
 					return { messages, partialResult: true };
 				}
 				this.snapshotOps = undefined;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -40,7 +40,6 @@ import {
 	InstrumentedStorageTokenFetcher,
 	IOdspUrlParts,
 } from "@fluidframework/odsp-driver-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { fetch } from "./fetch";
 import { pkgVersion as driverVersion } from "./packageVersion";
 import { IOdspSnapshot } from "./contracts";
@@ -445,40 +444,4 @@ export async function measureP<T>(callback: () => Promise<T>): Promise<[T, numbe
 	const result = await callback();
 	const time = performance.now() - start;
 	return [result, time];
-}
-
-export function validateMessages(
-	reason: string,
-	messages: ISequencedDocumentMessage[],
-	from: number,
-	logger: ITelemetryLoggerExt,
-) {
-	if (messages.length !== 0) {
-		const start = messages[0].sequenceNumber;
-		const length = messages.length;
-		const last = messages[length - 1].sequenceNumber;
-		if (start !== from) {
-			logger.sendErrorEvent({
-				eventName: "OpsFetchViolation",
-				reason,
-				from,
-				start,
-				last,
-				length,
-			});
-			messages.length = 0;
-		}
-		if (last + 1 !== from + length) {
-			logger.sendErrorEvent({
-				eventName: "OpsFetchViolation",
-				reason,
-				from,
-				start,
-				last,
-				length,
-			});
-			// we can do better here by finding consecutive sub-block and return it
-			messages.length = 0;
-		}
-	}
 }

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -316,6 +316,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 					trees,
 					blobs: numBlobs,
 					encodedBlobsSize,
+					sequenceNumber: snapshot.sequenceNumber,
 					...response.propsToLog,
 					snapshotConversionTime,
 					...getW3CData(response.requestUrl, "xmlhttprequest"),


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4579
Fix ops usage from snapshot in frs driver. We were only using once the ops from snapshot instead of what it could give us.
Also increase ops limit from 2k to 5K which are fetched in 1 get delta storage call. Also improve telemetry.