### PR TITLE
fix(build-tools): Don't include dynamic version in readmes

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version|-V)
-@fluid-tools/build-cli/0.19.0
+@fluid-tools/build-cli/1.0.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND

--- a/build-tools/packages/readme-command/README.md
+++ b/build-tools/packages/readme-command/README.md
@@ -20,7 +20,7 @@ $ npm install -g @fluid-internal/readme-command
 $ fluid-readme COMMAND
 running command...
 $ fluid-readme (--version|-V)
-@fluid-internal/readme-command/0.19.0
+@fluid-internal/readme-command/1.0.0
 $ fluid-readme --help [COMMAND]
 USAGE
   $ fluid-readme COMMAND

--- a/build-tools/packages/readme-command/src/commands/generate/readme.ts
+++ b/build-tools/packages/readme-command/src/commands/generate/readme.ts
@@ -4,7 +4,6 @@
  */
 import { Interfaces } from "@oclif/core";
 import { default as BaseReadme } from "oclif/lib/commands/readme";
-import * as semver from "semver";
 
 export default class Readme extends BaseReadme {
 	static summary = "Adds commands to README.md in current directory.";
@@ -26,15 +25,10 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 			...(config.pjson.oclif.additionalVersionFlags ?? []).sort(),
 		];
 		const versionFlagsString = `(${versionFlags.join("|")})`;
-		const version = semver.parse(config.version);
-
-		if (version === null) {
-			this.error(`Can't parse version: ${config.version}`);
-		}
 
 		// We change the version in CI, which causes the readmes to get updated during a CI build. Including the
-		// full version section in the readme isn't valuable, so we strip off the prerelease section here.
-		const versionString = `${version.major}.${version.minor}.${version.patch}`;
+		// full version section in the readme isn't valuable, so we just use a fixed string.
+		const versionString = `1.0.0`;
 
 		return [
 			`\`\`\`sh-session

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -78,7 +78,7 @@ $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
 running command...
 $ fluv (--version|-V)
-@fluid-tools/version-tools/0.19.0
+@fluid-tools/version-tools/1.0.0
 $ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND


### PR DESCRIPTION
Including the version numbers in the CLI readme causes issues in CI, and also means that a build is required after bumping the version, which is annoying. @alexvy86 has previously noted that the versions in the readme are not that useful, so I just updated the code to always output 1.0.0. We could use something else or omit it, but omitting it seems wrong since it's displayed in the examples using the `--version` flag. Omitting it when the command explicitly includes the `--version` flag is misleading and confusing.