### PR TITLE
[GC stress] Remove the FULL test scripts from package.json

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -37,7 +37,6 @@
 		"test:realsvc:frs:report": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:realsvc:frs --",
 		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local",
 		"test:realsvc:local:report": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:realsvc:local --",
-		"test:realsvc:local:report:full": "cross-env FLUID_TEST_MULTIREPORT=1 fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
 		"test:realsvc:odsp:report": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:realsvc:odsp --",
 		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=5s --use-openssl-ca",
@@ -47,7 +46,6 @@
 		"test:realsvc:t9s": "start-server-and-test start:tinylicious:test 7070 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious": "npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:realsvc:t9s",
-		"test:realsvc:tinylicious:report:full": "cross-env FLUID_TEST_MULTIREPORT=1 fluid__test__backCompat=FULL npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s --timeout=5s",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
 	},


### PR DESCRIPTION
## Description
After merging with latest main, the CI build is failing due to an error in how packages are installed for FULL back compat testing. See https://dev.azure.com/fluidframework/internal/_build/results?buildId=168030&view=logs&j=7e6a3fb7-dbfe-5169-4db8-92b72295ba6c&t=e38f86c1-b224-578d-726f-fe0e17267ef6 for details.
While that is fixed, this is a workaround that removes the scripts that run full compat tests.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.