### PR TITLE
Add telemetry for socket.io reqs

### DIFF
--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -44,6 +44,7 @@ export enum LumberEventName {
 	DisconnectDocument = "DisconnectDocument",
 	RiddlerFetchTenantKey = "RiddlerFetchTenantKey",
 	HttpRequest = "HttpRequest",
+	SocketIoRequest = "SocketIoRequest",
 	TotalConnectionCount = "TotalConnectionCount",
 	ConnectionCountPerNode = "ConnectionCountPerNode",
 	RestoreFromCheckpoint = "RestoreFromCheckpoint",


### PR DESCRIPTION
## Description

Currently, our only insight into Socket.io connection requests is through NGINX error logs.

