### PR TITLE
R11s: add config to disable long-polling

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -107,7 +107,8 @@ data:
             },
             "enforceServerGeneratedDocumentId": {{ .Values.alfred.enforceServerGeneratedDocumentId }},
             "socketIo" : {
-                "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
+                "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}},
+                "enableLongPolling": {{ .Values.alfred.socketIo.enableLongPolling }}
             }
         },
         "client": {

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -48,6 +48,7 @@ alfred:
   enforceServerGeneratedDocumentId: false
   socketIo:
     perMessageDeflate: true
+    enableLongPolling: true
 
 storage:
   enableWholeSummaryUpload: false

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -129,7 +129,8 @@ export function create(
 		// Indicates whether a connection should use compression
 		perMessageDeflate: socketIoConfig?.perMessageDeflate ?? true,
 		// Enable long-polling as a fallback
-		transports: ["websocket", "polling"],
+		transports:
+			socketIoConfig?.enableLongPolling ?? true ? ["websocket", "polling"] : ["websocket"],
 		cors: {
 			// Explicitly allow all origins by reflecting request origin.
 			// As a service that has potential to host countless different client apps,


### PR DESCRIPTION
## Description

If Long-Polling isn't working or supported, R11s should be able to disable it to help Client fail faster.
