### PR TITLE
Add connection_error telemetry in socketio server

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from "events";
 import * as http from "http";
 import * as util from "util";
 import * as core from "@fluidframework/server-services-core";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { clone } from "lodash";
 import * as Redis from "ioredis";
 import { Namespace, Server, Socket } from "socket.io";
@@ -48,6 +48,24 @@ class SocketIoSocket implements core.IWebSocket {
 	}
 }
 
+/**
+ * From https://socket.io/docs/v4/server-api/#event-connection_error
+ */
+interface ISocketIoConnectionError extends Error {
+	code: number;
+	message: string;
+	req: http.IncomingMessage;
+	context: any;
+}
+function isSocketIoConnectionError(error: unknown): error is ISocketIoConnectionError {
+	return (
+		error !== undefined &&
+		typeof (error as ISocketIoConnectionError).code == "number" &&
+		typeof (error as ISocketIoConnectionError).message == "string" &&
+		typeof (error as ISocketIoConnectionError).req == "object"
+	);
+}
+
 class SocketIoServer implements core.IWebSocketServer {
 	private readonly events = new EventEmitter();
 
@@ -59,6 +77,19 @@ class SocketIoServer implements core.IWebSocketServer {
 		this.io.on("connection", (socket: Socket) => {
 			const webSocket = new SocketIoSocket(socket);
 			this.events.emit("connection", webSocket);
+		});
+		this.io.engine.on("connection_error", (error) => {
+			if (isSocketIoConnectionError(error) && error.req.url !== undefined) {
+				const url = new URL(error.req.url);
+				const telemetryProperties = {
+					protocolVersion: url.searchParams.get("EIO"), // '2', '3', or '4'
+					transport: url.searchParams.get("transport"), // 'websocket' or 'polling'
+					reason: JSON.stringify({ code: error.code, message: error.message }), // e.g. { code: 1, message: "Session ID unknown" }
+					[BaseTelemetryProperties.tenantId]: url.searchParams.get("tenantId") ?? "",
+					[BaseTelemetryProperties.documentId]: url.searchParams.get("documentId") ?? "",
+				};
+				Lumberjack.error("Socket.io Connection Error", telemetryProperties, error);
+			}
 		});
 	}
 


### PR DESCRIPTION
## Description

Socket.io v4 added the ability to log `connection_error` event info from server.
https://socket.io/docs/v4/server-api/#event-connection_error

We should log on these errors for visibility into connection failures that do not make it to the normal `.on("connection")` handler.

