### PR TITLE
R11s-driver: Add driver policy for long-polling downgrade

### DIFF
--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -36,6 +36,7 @@ export interface IRouterliciousDriverPolicies {
     aggregateBlobsSmallerThanBytes: number | undefined;
     enableDiscovery?: boolean;
     enableInternalSummaryCaching: boolean;
+    enableLongPollingDowngrade: boolean;
     enablePrefetch: boolean;
     enableRestLess: boolean;
     enableWholeSummaryUpload: boolean;

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -108,6 +108,10 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IRouterliciousDriverPolicies": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -26,6 +26,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection {
 		url: string,
 		logger: ITelemetryLoggerExt,
 		timeoutMs = 20000,
+		enableLongPollingDowngrade = true,
 	): Promise<IDocumentDeltaConnection> {
 		const socket = io(url, {
 			query: {
@@ -50,13 +51,11 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection {
 			),
 		};
 
-		// TODO: expose to host at factory level
-		const enableLongPollingDowngrades = true;
 		const deltaConnection = new R11sDocumentDeltaConnection(
 			socket,
 			id,
 			logger,
-			enableLongPollingDowngrades,
+			enableLongPollingDowngrade,
 		);
 
 		await deltaConnection.initialize(connectMessage, timeoutMs);

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -247,6 +247,8 @@ export class DocumentService implements api.IDocumentService {
 						client,
 						this.deltaStreamUrl,
 						this.logger,
+						undefined /* timeoutMs */,
+						this.driverPolicies.enableLongPollingDowngrade,
 					);
 				},
 			);

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -50,6 +50,7 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
 	enableWholeSummaryUpload: false,
 	enableRestLess: true,
 	enableInternalSummaryCaching: true,
+	enableLongPollingDowngrade: true,
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -48,4 +48,10 @@ export interface IRouterliciousDriverPolicies {
 	 * Default: true
 	 */
 	enableInternalSummaryCaching: boolean;
+	/**
+	 * Enable downgrading socket connection to long-polling
+	 * when websocket connection cannot be established.
+	 * Default: true
+	 */
+	enableLongPollingDowngrade: boolean;
 }

--- a/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
+++ b/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
@@ -71,6 +71,7 @@ declare function get_old_InterfaceDeclaration_IRouterliciousDriverPolicies():
 declare function use_current_InterfaceDeclaration_IRouterliciousDriverPolicies(
     use: TypeOnly<current.IRouterliciousDriverPolicies>);
 use_current_InterfaceDeclaration_IRouterliciousDriverPolicies(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRouterliciousDriverPolicies());
 
 /*


### PR DESCRIPTION
## Description

Allow R11s-driver consumers to disable long-polling downgrade functionality.

## Breaking Changes

The type for R11sDriverPolicies is adding a new config, but the param in DocumentServiceFactory uses `Partial<>`, so it is not actually breaking the usability.