### PR TITLE
revert: Remove temp workaround for prettier VSCode extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,7 +59,4 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 	},
-
-	// Temporary workaround for https://github.com/prettier/prettier-vscode/issues/3000
-	"prettier.prettierPath": "./node_modules/prettier"
 }


### PR DESCRIPTION
## Description

We [had implemented a temporary workaround](https://github.com/microsoft/FluidFramework/pull/15936) for an issue with the VSCode Prettier extension, and the fix [is present in v9.14.0 of the extension](https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md), so removing temporary workaround.