### PR TITLE
Improve delta storage perf by avoiding 2 extra cache read on document load

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -194,8 +194,8 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 				validateMessages("cached", messagesFromCache, from, this.logger);
 				if (messagesFromCache.length !== 0) {
 					opsFromCache += messagesFromCache.length;
-					// Set the firstCacheMiss at seq number 1 greater than the fetched ops in case we didn't get all
-					// the ops. This will save an extra cache read.
+					// Set the firstCacheMiss at seq number = (fetched ops last seq number + 1) in case we didn't get
+					// all the ops. This will save an extra cache read.
 					if (from + messagesFromCache.length < to) {
 						this.firstCacheMiss = Math.min(
 							this.firstCacheMiss,

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -194,12 +194,13 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 				validateMessages("cached", messagesFromCache, from, this.logger);
 				if (messagesFromCache.length !== 0) {
 					opsFromCache += messagesFromCache.length;
-					// Set the firstCacheMiss at seq number = (fetched ops last seq number + 1) in case we didn't get
-					// all the ops. This will save an extra cache read.
+					// Set the firstCacheMiss at seq number = (fetched ops last seq number) in case we didn't get
+					// all the ops. This will save an extra cache read on "DocumentOpen" and 1 cache read on
+					// "PostDocumentOpen".
 					if (from + messagesFromCache.length < to) {
 						this.firstCacheMiss = Math.min(
 							this.firstCacheMiss,
-							from + messagesFromCache.length,
+							from + messagesFromCache.length - 1,
 						);
 					}
 					return {
@@ -207,7 +208,8 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 						partialResult: true,
 					};
 				}
-				this.firstCacheMiss = Math.min(this.firstCacheMiss, from);
+				// Set at from - 1 to avoid an extra cache read on "PostDocumentOpen".
+				this.firstCacheMiss = Math.min(this.firstCacheMiss, from - 1);
 			}
 
 			if (cachedOnly) {

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -192,19 +192,16 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 			if (!this.firstCacheMiss) {
 				const messagesFromCache = await this.getCached(from, to);
 				validateMessages("cached", messagesFromCache, from, this.logger);
+				// Set the firstCacheMiss as true in case we didn't get all the ops.
+				// This will save an extra cache read on "DocumentOpen" or "PostDocumentOpen".
+				this.firstCacheMiss = from + messagesFromCache.length < to
 				if (messagesFromCache.length !== 0) {
 					opsFromCache += messagesFromCache.length;
-					// Set the firstCacheMiss as true in case we didn't get all the ops.
-					// This will save an extra cache read on "DocumentOpen" or "PostDocumentOpen".
-					if (from + messagesFromCache.length < to) {
-						this.firstCacheMiss = true;
-					}
 					return {
 						messages: messagesFromCache,
 						partialResult: true,
 					};
 				}
-				this.firstCacheMiss = true;
 			}
 
 			if (cachedOnly) {

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -194,6 +194,14 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 				validateMessages("cached", messagesFromCache, from, this.logger);
 				if (messagesFromCache.length !== 0) {
 					opsFromCache += messagesFromCache.length;
+					// Set the firstCacheMiss at seq number 1 greater than the fetched ops in case we didn't get all
+					// the ops. This will save an extra cache read.
+					if (from + messagesFromCache.length < to) {
+						this.firstCacheMiss = Math.min(
+							this.firstCacheMiss,
+							from + messagesFromCache.length,
+						);
+					}
 					return {
 						messages: messagesFromCache,
 						partialResult: true,
@@ -238,6 +246,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 					opsFromSnapshot,
 					opsFromCache,
 					opsFromStorage,
+					reason: fetchReason,
 				});
 			}
 		});

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -194,7 +194,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 				validateMessages("cached", messagesFromCache, from, this.logger);
 				// Set the firstCacheMiss as true in case we didn't get all the ops.
 				// This will save an extra cache read on "DocumentOpen" or "PostDocumentOpen".
-				this.firstCacheMiss = from + messagesFromCache.length < to
+				this.firstCacheMiss = from + messagesFromCache.length < to;
 				if (messagesFromCache.length !== 0) {
 					opsFromCache += messagesFromCache.length;
 					return {

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -4,9 +4,11 @@
  */
 
 import { strict as assert } from "assert";
+import { IDeltasFetchResult } from "@fluidframework/driver-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
-import { OdspDeltaStorageService } from "../odspDeltaStorageService";
+import { OdspDeltaStorageService, OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { LocalPersistentCache } from "../odspCache";
 import { EpochTracker } from "../epochTracker";
 import { mockFetchOk } from "./mockFetch";
@@ -190,6 +192,55 @@ describe("DeltaStorageService", () => {
 				"noop",
 				"Second element of feed response has invalid op type",
 			);
+		});
+	});
+
+	describe("DeltaStorageServiceWith Cache Tests", () => {
+		const logger = new TelemetryUTLogger();
+
+		it("FirstCacheMiss should update to first miss op seq number correctly", async () => {
+			const deltasFetchResult: IDeltasFetchResult = { messages: [], partialResult: false };
+			let count = 0;
+			const getCached = async (
+				from: number,
+				to: number,
+			): Promise<ISequencedDocumentMessage[]> => {
+				if (count === 0) {
+					count += 1;
+					return [
+						{
+							clientId: "present-place",
+							clientSequenceNumber: 71,
+							contents: null,
+							minimumSequenceNumber: 1,
+							referenceSequenceNumber: 1,
+							sequenceNumber: from,
+							term: 1,
+							type: "dds",
+							timestamp: Date.now(),
+						},
+					];
+				}
+				count += 1;
+				assert.fail("Should not reach here");
+			};
+			const odspDeltaStorageServiceWithCache = new OdspDeltaStorageWithCache(
+				[],
+				logger,
+				1000,
+				1,
+				async (from, to, props, reason) => deltasFetchResult,
+				async (from, to) => getCached(from, to),
+				(from, to) => [],
+				(ops) => {},
+			);
+
+			const messages = odspDeltaStorageServiceWithCache.fetchMessages(1, undefined);
+			const batch1 = await messages.read();
+			const batch2 = await messages.read();
+			assert(count === 1, "There should be only 1 cache access");
+			assert(batch1.done === false, "Firt batch should have returned 1 op");
+			assert(batch2.done === true, "No ops should be present in second batch");
 		});
 	});
 });


### PR DESCRIPTION
## Description

We should set the first cache miss as soon as we miss the cache for what we requested. This would lead to early bailout and avoid 1 cache read on critical path on "DocumentOpen" and 1 on "PostDocumentOpen".