### PR TITLE
Deprecate IConnectionDetailsInternal and IDeltaHandlerStrategy

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -115,15 +115,15 @@ export interface IConnectionDetails {
     serviceConfiguration: IClientConfiguration;
 }
 
-// @public
+// @public @deprecated
 export interface IConnectionDetailsInternal extends IConnectionDetails {
-    // (undocumented)
+    // @deprecated (undocumented)
     initialClients: ISignalClient[];
-    // (undocumented)
+    // @deprecated (undocumented)
     mode: ConnectionMode;
-    // (undocumented)
+    // @deprecated (undocumented)
     reason: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     version: string;
 }
 
@@ -242,9 +242,11 @@ export interface IContainerLoadMode {
 // @public
 export type ICriticalContainerError = IErrorBase;
 
-// @public
+// @public @deprecated
 export interface IDeltaHandlerStrategy {
+    // @deprecated
     process: (message: ISequencedDocumentMessage) => void;
+    // @deprecated
     processSignal: (message: ISignalMessage) => void;
 }
 

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -44,25 +44,41 @@ export interface IConnectionDetails {
 
 /**
  * Internal version of IConnectionDetails with props are only exposed internally
+ * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
  */
 export interface IConnectionDetailsInternal extends IConnectionDetails {
+	/**
+	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
+	 */
 	mode: ConnectionMode;
+	/**
+	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
+	 */
 	version: string;
+	/**
+	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
+	 */
 	initialClients: ISignalClient[];
+	/**
+	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
+	 */
 	reason: string;
 }
 
 /**
  * Interface used to define a strategy for handling incoming delta messages
+ * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
  */
 export interface IDeltaHandlerStrategy {
 	/**
 	 * Processes the message.
+	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
 	 */
 	process: (message: ISequencedDocumentMessage) => void;
 
 	/**
 	 * Processes the signal.
+	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
 	 */
 	processSignal: (message: ISignalMessage) => void;
 }


### PR DESCRIPTION
`IConnectionDetailsInternal` is an enhancement to `IConnectionDetails` that is intended to only be known about by the container-loader package, not by external consumers (they should only use the `IConnectionDetails` interface).  Followup will be to move it into container-loader to hide it in `next`.

`IDeltaHandlerStrategy` is only visible on `attachOpHandler`, which is only visible on `DeltaManager` and not `IDeltaManager`, which is not exported.  So it also doesn't need to be exported, and can also be hidden inside container-loader in `next`.

Will add a changeset, currently hitting an issue with the command that I need to resolve.