### PR TITLE
Add perf tests for interval revertibles

### DIFF
--- a/packages/dds/sequence/src/test/revertibles.perf.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.perf.spec.ts
@@ -1,0 +1,122 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { BenchmarkType, benchmark } from "@fluid-tools/benchmark";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
+import { SharedString } from "../sharedString";
+import { SharedStringFactory } from "../sequenceFactory";
+import { IIntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
+import {
+	appendChangeIntervalToRevertibles,
+	appendSharedStringDeltaToRevertibles,
+	SharedStringRevertible,
+} from "../revertibles";
+
+describe("Interval revertible perf", () => {
+	describe("Move interval", () => {
+		let collection: IIntervalCollection<SequenceInterval>;
+		let interval: SequenceInterval;
+	
+		const setUp = (enableRevertibles: boolean) => {
+			const runtime = new MockFluidDataStoreRuntime();
+			runtime.options = { mergeTreeUseNewLengthCalculations: true };
+			const factory = new SharedStringFactory();
+			const sharedString = factory.create(runtime, "id");
+			sharedString.insertText(0, "a".repeat(100));
+			collection = sharedString.getIntervalCollection("test");
+			interval = collection.add(45, 77, IntervalType.SlideOnRemove);
+			if (enableRevertibles) {
+				collection.on("changeInterval", (i, previousInterval, local, op) => {
+					const revertibles: SharedStringRevertible[] = [];
+					appendChangeIntervalToRevertibles(sharedString, i, previousInterval, revertibles);
+				});
+			}
+		};
+
+		const execute = () => {
+			collection.change(interval.getIntervalId(), 1, 2);
+		};
+
+		benchmark({
+			beforeEachBatch: () => {
+				setUp(false);
+			},
+			type: BenchmarkType.Perspective,
+			title: "without revertible",
+			benchmarkFn: () => {
+				execute();
+			},
+		});
+
+		benchmark({
+			beforeEachBatch: () => {
+				setUp(true);
+			},
+			type: BenchmarkType.Measurement,
+			title: "with revertible",
+			benchmarkFn: () => {
+				execute();
+			},
+		});
+	});
+
+	describe("Add and remove range with interval and moved interval", () => {
+		let sharedString: SharedString;
+		let collection: IIntervalCollection<SequenceInterval>;
+		let interval: SequenceInterval;
+
+		const setUp = (enableRevertibles: boolean) => {
+			const runtime = new MockFluidDataStoreRuntime();
+			runtime.options = { mergeTreeUseNewLengthCalculations: true };
+			const factory = new SharedStringFactory();
+			sharedString = factory.create(runtime, "id");
+			sharedString.insertText(0, "abc");
+			collection = sharedString.getIntervalCollection("test");
+			interval = collection.add(1, 2, IntervalType.SlideOnRemove);
+			if (enableRevertibles) {
+				const revertibles: SharedStringRevertible[] = [];
+				collection.on("changeInterval", (i, previousInterval, local, op) => {
+					appendChangeIntervalToRevertibles(sharedString, i, previousInterval, revertibles);
+				});
+				sharedString.on("sequenceDelta", (op) => {
+					appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+				});
+			}
+		};
+
+		const execute = () => {
+			// add text to end
+			sharedString.insertText(3, "abc");
+			// create interval in segment to be removed
+			collection.add(1, 2, IntervalType.SlideOnRemove);
+			// move existing interval to cause local refs from move revertible
+			collection.change(interval.getIntervalId(), 4, 5);
+			// delete range
+			sharedString.removeRange(0, 3);
+		};
+
+		benchmark({
+			type: BenchmarkType.Perspective,
+			title: "without revertible",
+			beforeEachBatch: () => {
+				setUp(false);
+			},
+			benchmarkFn: () => {
+				execute();
+			},
+		});
+
+		benchmark({
+			type: BenchmarkType.Measurement,
+			title: "with revertible",
+			beforeEachBatch: () => {
+				setUp(true);
+			},
+			benchmarkFn: () => {
+				execute();
+			},
+		});
+	});
+});


### PR DESCRIPTION
This change adds a couple of tests for comparing the overhead of enabling revertibles to not having revertibles. This does not measure performance of actually reverting anything. I chose move interval and remove range containing intervals as interesting revertible types; delete interval overhead is similar to move and add interval is not interesting.

## Reviewer Guidance

How do I run a comparison where the only difference is revertibles being enabled? I made separate benchmarks with types Measurement and Perspective. It doesn't seem right because the iterations aren't the same between them so it's not comparable.

The second test is doing more work than I really want to measure since removing ranges is destructive, so I have to keep adding. Is there a better way to do this?

Would memory tests be useful?

## Output

For reference:

```
Interval revertible perf Move interval
status  name                period (ns/op)  relative margin of error  iterations per batch  batch count  total time (s)
------  ------------------  --------------  ------------------------  --------------------  -----------  --------------
    ✔   without revertible       13,982.05                    ±5.77%                 1,024          333            5.00
    ✔   with revertible          12,937.88                    ±5.95%                 2,048          180            5.01
Interval revertible perf Add and remove range with interval and moved interval
status  name                period (ns/op)  relative margin of error  iterations per batch  batch count  total time (s)
------  ------------------  --------------  ------------------------  --------------------  -----------  --------------
    ✔   without revertible       92,987.28                    ±3.72%                    64          786            5.00
    ✔   with revertible         255,170.94                    ±4.03%                    64          295            5.01
``` 