### PR TITLE
refactor(devtools): Clean up remaining "debugger" terminology

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/popup/PopupScript.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/popup/PopupScript.ts
@@ -25,7 +25,7 @@ browser.tabs.query({ active: true, currentWindow: true }, (tab) => {
 	popupElement.style.height = "100%";
 	popupElement.style.width = "100%";
 	popupElement.textContent =
-		'To use the Fluid Devtools, open the browser Devtools pane (F12) and click the "Fluid Client Debugger" tab.';
+		'To use the Fluid Devtools, open the browser Devtools pane (F12) and click the "Fluid Developer Tools" tab.';
 
 	document.body.append(popupElement);
 });

--- a/packages/tools/devtools/devtools-core/README.md
+++ b/packages/tools/devtools/devtools-core/README.md
@@ -28,7 +28,7 @@ The Devtools' API surface is designed to fit nicely into most application flows.
 
 ### Initialization
 
-To initialize a debugger session for your container, call `initializeDevtools`.
+To initialize a devtools session for your container, call `initializeDevtools`.
 This function accepts a `DevtoolsLogger` for recording and communicating telemetry data, a list of initial Fluid `Containers` to associate with the session, and (optionally) customized data visualization configurations for visualizing `Container` data.
 
 TODO: link to API docs once API shape has settled.

--- a/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
@@ -156,7 +156,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 	 *
 	 * @remarks
 	 *
-	 * This map is assumed to be immutable. The debugger will not make any modifications to its contents.
+	 * This map is assumed to be immutable. The devtools will not make any modifications to its contents.
 	 */
 	public readonly containerData?: Record<string, IFluidLoadable>;
 
@@ -177,7 +177,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 	/**
 	 * Manages state visualization for {@link ContainerDevtools.containerData}, if any was provided.
 	 *
-	 * @remarks Will only be `undefined` if `containerData` was not provided, or if the debugger has been disposed.
+	 * @remarks Will only be `undefined` if `containerData` was not provided, or if the devtools has been disposed.
 	 */
 	private dataVisualizer: DataVisualizerGraph | undefined;
 
@@ -269,7 +269,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 	// #region Window event handlers
 
 	/**
-	 * Handlers for inbound messages related to the debugger.
+	 * Handlers for inbound messages related to the devtools.
 	 */
 	private readonly inboundMessageHandlers: InboundHandlers = {
 		[GetContainerDevtoolsFeatures.MessageType]: async (untypedMessage) => {
@@ -299,7 +299,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 		[DisconnectContainer.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as DisconnectContainer.Message;
 			if (message.data.containerKey === this.containerKey) {
-				this.container.disconnect(/* TODO: Specify debugger reason here once it is supported */);
+				this.container.disconnect(/* TODO: Specify devtools reason here once it is supported */);
 				return true;
 			}
 			return false;
@@ -307,7 +307,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 		[CloseContainer.MessageType]: async (untypedMessage) => {
 			const message = untypedMessage as CloseContainer.Message;
 			if (message.data.containerKey === this.containerKey) {
-				this.container.close(/* TODO: Specify debugger reason here once it is supported */);
+				this.container.close(/* TODO: Specify devtools reason here once it is supported */);
 				return true;
 			}
 			return false;
@@ -433,7 +433,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 	// #endregion
 
 	/**
-	 * Message logging options used by the debugger.
+	 * Message logging options used by the devtools.
 	 */
 	private get messageLoggingOptions(): MessageLoggingOptions {
 		return { context: `Container Devtools (${this.containerKey})` };
@@ -453,7 +453,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 		this.containerData = props.containerData;
 		this.container = props.container;
 
-		// TODO: would it be useful to log the states (and timestamps) at time of debugger initialize?
+		// TODO: would it be useful to log the states (and timestamps) at time of devtools initialize?
 		this._connectionStateLog = [];
 		this._audienceChangeLog = [];
 

--- a/packages/tools/devtools/devtools-core/src/IContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/IContainerDevtools.ts
@@ -21,7 +21,7 @@ import { HasContainerKey } from "./CommonInterfaces";
  */
 export interface IContainerDevtools extends HasContainerKey, IDisposable {
 	/**
-	 * Gets the history of all ConnectionState changes since the debugger session was initialized.
+	 * Gets the history of all ConnectionState changes since the devtools session was initialized.
 	 *
 	 * @remarks
 	 *
@@ -41,7 +41,7 @@ export interface IContainerDevtools extends HasContainerKey, IDisposable {
 	getAudienceHistory(): readonly AudienceChangeLogEntry[];
 
 	/**
-	 * Disposes the debugger session.
+	 * Disposes the devtools session.
 	 * All data recording will stop, and no further state change events will be emitted.
 	 */
 	dispose(): void;

--- a/packages/tools/devtools/devtools-core/src/Logs.ts
+++ b/packages/tools/devtools/devtools-core/src/Logs.ts
@@ -6,7 +6,7 @@ import { IClient } from "@fluidframework/protocol-definitions";
 import { ContainerStateChangeKind } from "./Container";
 
 /**
- * Base interface for data logs, associating data with a timestamp at which the data was recorded by the debugger.
+ * Base interface for data logs, associating data with a timestamp at which the data was recorded by the devtools.
  *
  * @internal
  */

--- a/packages/tools/devtools/devtools-core/src/TelemetryMetadata.ts
+++ b/packages/tools/devtools/devtools-core/src/TelemetryMetadata.ts
@@ -6,7 +6,7 @@
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 
 /**
- * Interface for telemetry events with a timestamp. Specific to the Fluid Debugger.
+ * Interface for telemetry events with a timestamp. Specific to the Fluid Devtools.
  *
  * @internal
  */

--- a/packages/tools/devtools/devtools-core/src/data-visualization/README.md
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/README.md
@@ -2,22 +2,22 @@
 
 This directory contains a system for describing Fluid Distributed Data Structure (DDS) visuals in a declarative manner, and for communicating incremental updates to those visuals.
 
-This system is designed to be compatible with the message-passing-based approach taken by the debugger, such that consumers can process the visual descriptors however they wish.
+This system is designed to be compatible with the message-passing-based approach taken by the devtools, such that consumers can process the visual descriptors however they wish.
 
 -   In particular, this enables tooling that may live in another process; e.g. Chromium Browser Extensions.
 
 ## The Flow
 
-For the purpose of demonstrating the intended usage flow of the system, we will be looking at it from the context of the debugger, rather than viewing this system in isolation.
+For the purpose of demonstrating the intended usage flow of the system, we will be looking at it from the context of the devtools, rather than viewing this system in isolation.
 
 **Terms**:
 
--   "Application": The client application, which initializes the "debugger".
--   "Debugger": Represents the client-side debugger, which communicates application state updates via message passing to the "consumer".
--   "Consumer": External tooling which consumes data from the "debugger" via message passing (e.g. our [browser extension](https://github.com/microsoft/FluidFramework/tree/main/packages/tools/devtools/devtools-browser-extension)).
-    -   Note that multiple consumers may be associated with a single debugger instance.
+-   "Application": The client application, which initializes the "devtools".
+-   "Devtools": Represents the client-side devtools, which communicates application state updates via message passing to the "consumer".
+-   "Consumer": External tooling which consumes data from the "devtools" via message passing (e.g. our [browser extension](https://github.com/microsoft/FluidFramework/tree/main/packages/tools/devtools/devtools-browser-extension)).
+    -   Note that multiple consumers may be associated with a single devtools instance.
 
-When initializing the debugger, the initializing application may optionally provide a root DDS(s) they wish to have visualized by the tooling.
+When initializing the devtools, the initializing application may optionally provide a root DDS(s) they wish to have visualized by the tooling.
 If they do not specify this, then the tooling will not generate any visual descriptors.
 
 To initiate "rendering" (generating visual summary trees), the consumer passes the `GET_ROOT_DATA_VISUALIZATIONS` to request the "root" visual summary.
@@ -31,17 +31,17 @@ The flow looks something like the following:
 ```mermaid
 sequenceDiagram
 participant Application
-participant Debugger
+participant Devtools
 participant Consumer
 
-Application->>Debugger: Initialize debugger
-Consumer-->>Debugger: "GET_ROOT_DATA_VISUALIZATIONS"
-Debugger->>Consumer: "ROOT_DATA_VISUALIZATIONS" ({ key1: handle1, key2: handle2, ..., keyN: handleN })
+Application->>Devtools: Initialize devtools
+Consumer-->>Devtools: "GET_ROOT_DATA_VISUALIZATIONS"
+Devtools->>Consumer: "ROOT_DATA_VISUALIZATIONS" ({ key1: handle1, key2: handle2, ..., keyN: handleN })
 loop renderTrees
 	Consumer->>Consumer: renderTree(handle.id)
 end
-Consumer-->>Debugger: "GET_DATA_VISUALIZATION" (id)
-Debugger->>Consumer: "DATA_VISUALIZATION" (visualization)
+Consumer-->>Devtools: "GET_DATA_VISUALIZATION" (id)
+Devtools->>Consumer: "DATA_VISUALIZATION" (visualization)
 ```
 
 Additionally, once a given DDS has been "rendered" for the first time, it will continue to broadcast automatic updates each time its contents change (i.e. each time the "op" event is fired on the DDS object).
@@ -62,7 +62,7 @@ At a high level, the DDS trees contain:
 
 ### Example
 
-For an example, consider a relatively simple application "schema", which is provided to the debugger at initialization:
+For an example, consider a relatively simple application "schema", which is provided to the devtools at initialization:
 
 ```typescript
 {
@@ -77,20 +77,20 @@ To visualize the entire tree, the flow might look something like the following:
 ```mermaid
 sequenceDiagram
 participant Application
-participant Debugger
+participant Devtools
 participant Consumer
 
-Application->>Debugger: Initialize debugger
-Consumer-->>Debugger: "GET_ROOT_DATA_VISUALIZATIONS"
-Debugger->>Consumer: "ROOT_DATA_VISUALIZATIONS" ({ rootMap: rootMapHandle })
+Application->>Devtools: Initialize devtools
+Consumer-->>Devtools: "GET_ROOT_DATA_VISUALIZATIONS"
+Devtools->>Consumer: "ROOT_DATA_VISUALIZATIONS" ({ rootMap: rootMapHandle })
 loop renderTrees
 	Consumer->>Consumer: renderTree(rootMapID)
 end
-Consumer-->>Debugger: "GET_DATA_VISUALIZATION" (rootMapID)
-Debugger->>Consumer: "DATA_VISUALIZATION" (rootMapVisualTree)
+Consumer-->>Devtools: "GET_DATA_VISUALIZATION" (rootMapID)
+Devtools->>Consumer: "DATA_VISUALIZATION" (rootMapVisualTree)
 loop renderTree
-	Consumer-->>Debugger: "GET_DATA_VISUALIZATION" (childCounterId)
-	Debugger->>Consumer: "DATA_VISUALIZATION" (counterVisualTree)
+	Consumer-->>Devtools: "GET_DATA_VISUALIZATION" (childCounterId)
+	Devtools->>Consumer: "DATA_VISUALIZATION" (counterVisualTree)
 end
 ```
 
@@ -136,4 +136,4 @@ Other follow-up items:
     -   For DDSs receiving rapid updates, we may not wish to broadcast updates on every single edit ("op" event).
         It would likely be worth introducing some simple, minimal time threshold in which we will post updates.
 1.  Verify that the proposed flow is fast enough to prevent visual delays on the consumer side.
-    -   I.e. we don't want the devtools extension to be displaying lots of spinners while it and the debugger chat back and forth.
+    -   I.e. we don't want the devtools extension to be displaying lots of spinners while it and the devtools chat back and forth.

--- a/packages/tools/devtools/devtools-core/src/data-visualization/VisualTree.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/VisualTree.ts
@@ -7,7 +7,7 @@ import { FluidObjectId } from "../CommonInterfaces";
 
 /**
  * This module contains a type system for describing visual descriptors of data objects in a serializable
- * tree format that can be broadcast by the debugger for external tools to consume.
+ * tree format that can be broadcast by the devtools for external tools to consume.
  */
 
 /**
@@ -120,7 +120,7 @@ export interface VisualValueNode extends ValueNodeBase {
 }
 
 /**
- * Terminal node indicating the debugger encountered data of a kind it did not recognize.
+ * Terminal node indicating the devtools encountered data of a kind it did not recognize.
  *
  * @remarks I.e. it is not a {@link @fluidframework/shared-object-base#ISharedObject}.
  *
@@ -245,7 +245,7 @@ export type VisualChildNode =
 	| UnknownObjectNode;
 
 /**
- * A visual tree node representing a root data object provided to the debugger at initialization time.
+ * A visual tree node representing a root data object provided to the devtools at initialization time.
  *
  * @public
  */

--- a/packages/tools/devtools/devtools-core/src/messaging/Constants.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/Constants.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * The message {@link ISourcedDevtoolsMessage.source} for all messages posted by the Client Debugger.
+ * The message {@link ISourcedDevtoolsMessage.source} for all messages posted by the devtools.
  *
  * @internal
  */

--- a/packages/tools/devtools/devtools-core/src/messaging/Messages.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/Messages.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * Structure of a message used for communication from/to the Fluid Client Debugger.
+ * Structure of a message used for communication from/to the Fluid Devtools.
  *
  * @internal
  */
@@ -23,7 +23,7 @@ export interface IDevtoolsMessage<TData = unknown> {
 }
 
 /**
- * Message structure expected for window event listeners used by the Fluid Client Debugger.
+ * Message structure expected for window event listeners used by the Fluid Devtools
  *
  * @internal
  */

--- a/packages/tools/devtools/devtools-core/src/messaging/container-devtools-messages/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/container-devtools-messages/DataVisualization.ts
@@ -29,7 +29,7 @@ export namespace DataVisualization {
 		/**
 		 * A visual description tree for a particular DDS.
 		 *
-		 * Will be undefined only if the debugger has no data associated with the provided
+		 * Will be undefined only if the devtools has no data associated with the provided
 		 * {@link HasFluidObjectId.fluidObjectId | ID}.
 		 */
 		visualization: FluidObjectNode | undefined;

--- a/packages/tools/devtools/devtools-core/src/messaging/index.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/index.ts
@@ -6,11 +6,11 @@
 // TODOs:
 // - Better documentation terminology WRT "inbound" vs "outbound" events.
 //   - Since the types and utilities are re-used between the packages, these should be documented in
-//     explicit terms of the debugger to/from external consumer.
+//     explicit terms of the devtools to/from external consumer.
 
 /**
  * This directory contains types and utilities for use in window-based messaging, used
- * by the Fluid Client Debugger.
+ * by the Fluid Devtools.
  */
 
 export { devtoolsMessageSource } from "./Constants";

--- a/packages/tools/devtools/devtools-example/README.md
+++ b/packages/tools/devtools/devtools-example/README.md
@@ -28,20 +28,6 @@ You can run this example using the following steps:
 To run the tests, first ensure you have followed the [build](#build) steps above.
 Next, run `npm run test` from a terminal within this directory.
 
-<!-- AUTO-GENERATED-CONTENT:START (README_API_DOCS_SECTION:includeHeading=TRUE) -->
-
-<!-- prettier-ignore-start -->
-
-<!-- This section is automatically generated. To update it, make the appropriate changes to docs/md-magic.config.js or the embedded content, then run 'npm run build:md-magic' in the docs folder. -->
-
-## API Documentation
-
-API documentation for **@fluid-tools/client-debugger-view** is available at <https://fluidframework.com/docs/apis/client-debugger-view>.
-
-<!-- prettier-ignore-end -->
-
-<!-- AUTO-GENERATED-CONTENT:END -->
-
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->
@@ -108,4 +94,4 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 <!-- Links -->
 
-[@fluid-internal/devtools-browser-extension]: https://github.com/microsoft/FluidFramework/tree/main/packages/tools/client-debugger/devtools-browser-extension
+[@fluid-internal/devtools-browser-extension]: https://github.com/microsoft/FluidFramework/tree/main/packages/tools/devtools/devtools-browser-extension

--- a/packages/tools/devtools/devtools-example/src/App.tsx
+++ b/packages/tools/devtools/devtools-example/src/App.tsx
@@ -247,7 +247,7 @@ const useStyles = makeStyles({
  * Initializes the Fluid Container and displays app view once it is ready.
  */
 export function App(): React.ReactElement {
-	// Initialize the Fluid Debugger logger
+	// Initialize the Devtools logger
 	const logger = React.useMemo(() => new DevtoolsLogger(), []);
 
 	// Initialize Devtools

--- a/packages/tools/devtools/devtools-example/src/index.html
+++ b/packages/tools/devtools/devtools-example/src/index.html
@@ -6,7 +6,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
-		<title>Client-Debugger-View Test App</title>
+		<title>Fluid Devtools Example App</title>
 	</head>
 	<body>
 		<div id="content"></div>

--- a/packages/tools/devtools/devtools-example/src/index.tsx
+++ b/packages/tools/devtools/devtools-example/src/index.tsx
@@ -22,14 +22,14 @@ ReactDOM.render(
 	},
 );
 
-const debuggerElement = document.createElement("debugger");
-document.body.append(debuggerElement);
+const devtoolsElement = document.createElement("devtools");
+document.body.append(devtoolsElement);
 
-ReactDOM.render(<DevToolsView />, debuggerElement, () => {
-	console.log("Debugger UI rendered!");
+ReactDOM.render(<DevtoolsView />, devtoolsElement, () => {
+	console.log("Devtools UI rendered!");
 });
 
-function DevToolsView(): React.ReactElement {
+function DevtoolsView(): React.ReactElement {
 	return (
 		<Resizable
 			style={{

--- a/packages/tools/devtools/devtools-view/README.md
+++ b/packages/tools/devtools/devtools-view/README.md
@@ -51,20 +51,6 @@ To run the app, navigate to the root of this package and run `npm run start:test
 
 -   This will launch a local [Tinylicious](https://fluidframework.com/docs/testing/tinylicious/) service and serve the app at <http://localhost:8080/>.
 
-<!-- AUTO-GENERATED-CONTENT:START (README_API_DOCS_SECTION:includeHeading=TRUE) -->
-
-<!-- prettier-ignore-start -->
-
-<!-- This section is automatically generated. To update it, make the appropriate changes to docs/md-magic.config.js or the embedded content, then run 'npm run build:md-magic' in the docs folder. -->
-
-## API Documentation
-
-API documentation for **@fluid-tools/client-debugger-view** is available at <https://fluidframework.com/docs/apis/client-debugger-view>.
-
-<!-- prettier-ignore-end -->
-
-<!-- AUTO-GENERATED-CONTENT:END -->
-
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->
@@ -131,4 +117,4 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 <!-- Links -->
 
-[@fluid-internal/devtools-browser-extension]: https://github.com/microsoft/FluidFramework/tree/main/packages/tools/client-debugger/devtools-browser-extension
+[@fluid-internal/devtools-browser-extension]: https://github.com/microsoft/FluidFramework/tree/main/packages/tools/devtools/devtools-browser-extension

--- a/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
@@ -14,7 +14,7 @@ import { MessageRelayContext } from "./MessageRelayContext";
 export interface DevtoolsPanelProps {
 	/**
 	 * An instance of {@link @fluid-experimental/devtools-core#IMessageRelay} that can handle message passing between the
-	 * debugger's "brain" and its UI, in whatever context the latter is being rendered (e.g. in the same page as the
+	 * devtools's "brain" and its UI, in whatever context the latter is being rendered (e.g. in the same page as the
 	 * application, or in the browser's DevTools panel).
 	 */
 	messageRelay: IMessageRelay;

--- a/packages/tools/devtools/devtools-view/src/WindowMessageRelay.ts
+++ b/packages/tools/devtools/devtools-view/src/WindowMessageRelay.ts
@@ -14,15 +14,15 @@ import {
 } from "@fluid-experimental/devtools-core";
 
 /**
- * Message relay used by a debugger view rendered in the same page as the application to communicate with the
+ * Message relay used by a devtools view rendered in the same page as the application to communicate with the
  * {@link @fluid-tools/client-debuger#IFluidDevtools}.
  *
  * @remarks
  *
- * While a debugger view rendered in the same page as the application could technically communicate with the
+ * While a devtools view rendered in the same page as the application could technically communicate with the
  * {@link @fluid-tools/client-debuger#IFluidDevtools} directly, we put this abstraction in the middle to match the
- * way that a debugger view rendered outside the context of the application (e.g. the browser's DevTools panel) has
- * to communicate with the debugger registry.
+ * way that a devtools view rendered outside the context of the application (e.g. the browser's DevTools panel) has
+ * to communicate with the devtools registry.
  * This ensures that we don't "abuse" the power of local interaction to do things that might not be possible (or need
  * to be done differently) with a message passing mechanism that crosses the boundary of the window.
  *

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -185,7 +185,7 @@ const useContainerSummaryViewStyles = makeStyles({
 });
 
 /**
- * Debugger view displaying basic Container stats.
+ * View displaying a simple summary of the Container state.
  */
 export function ContainerSummaryView(props: ContainerSummaryViewProps): React.ReactElement {
 	const { containerKey } = props;
@@ -340,7 +340,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 }
 
 /**
- * Container actions supported by the debugger view.
+ * Container actions supported by the devtools view.
  */
 export interface IContainerActions {
 	/**

--- a/packages/tools/devtools/devtools-view/src/components/LandingView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/LandingView.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
 });
 
 /**
- * Landing page for the debugger
+ * Landing page for the devtools.
  */
 export function LandingView(): React.ReactElement {
 	const styles = useStyles();

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles({
 });
 
 /**
- * Settings page for the debugger
+ * Settings page for the devtools.
  */
 export function SettingsView(): React.ReactElement {
 	const { setTheme } = React.useContext(ThemeContext) ?? {};

--- a/packages/tools/devtools/devtools/README.md
+++ b/packages/tools/devtools/devtools/README.md
@@ -25,7 +25,7 @@ The Devtools' API surface is designed to fit nicely into most application flows.
 
 ### Initialization
 
-To initialize a debugger session for your container, call `initializeDevtools`.
+To initialize a devtools session for your container, call `initializeDevtools`.
 This function accepts a `DevtoolsLogger` for recording and communicating telemetry data, a list of initial Fluid `Containers` to associate with the session, and (optionally) customized data visualization configurations for visualizing `Container` data.
 
 TODO: link to API docs once API shape has settled.


### PR DESCRIPTION
Replaces lingering "Debugger" terminology with "Devtools"