### PR TITLE
Remove IRootSummaryTreeWithStats from ContainerRuntime

### DIFF
--- a/.changeset/nine-falcons-repeat.md
+++ b/.changeset/nine-falcons-repeat.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-runtime": major
+---
+
+`IRootSummaryTreeWithStats` removed
+
+`IRootSummaryTreeWithStats` was the return type of `summarize` method on `ContainerRuntime`. It was an internal interface used only in `ContainerRuntime` class to to access `gcStats` from a call site. `gcStats` is not needed in the call site anymore so this interface is removed.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 -   [FluidDataStoreRuntime.getChannel throws for channels that do not exist](#FluidDataStoreRuntime.getChannel-throws-for-channels-that-do-not-exist)
 -   [Upgraded Typescript target to ES2020](#Upgraded-Typescript-target-to-ES2020)
+-   [IRootSummaryTreeWithStats removed from container-runtime package](#IRootSummaryTreeWithStats-removed-from-container-runtime-package)
 
 ### FluidDataStoreRuntime.getChannel throws for channels that do not exist
 
@@ -32,6 +33,10 @@ Previously, calling `FluidDataStoreRuntime.getChannel(id)` for a channel that do
 
 Upgraded typescript transpilation target to ES2020. This is done in order to decrease the bundle sizes of Fluid Framework packages. This has provided size improvements across the board for ex. Loader, Driver, Runtime etc. Reduced bundle sizes helps to load lesser code in apps and hence also helps to improve the perf.
 If any app wants to target any older versions of browsers with which this target version is not compatible, then they can use packages like babel to transpile to a older target.
+
+### IRootSummaryTreeWithStats removed from container-runtime package
+
+`IRootSummaryTreeWithStats` was the return type of `summarize` method on `ContainerRuntime`. It was an internal interface used only in `ContainerRuntime` class to to access `gcStats` from a call site. `gcStats` is not needed in the call site anymore and so, it is now removed from the container-runtime package.
 
 # 2.0.0-internal.5.0.0
 

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -215,7 +215,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         runGC?: boolean;
         fullGC?: boolean;
         runSweep?: boolean;
-    }): Promise<IRootSummaryTreeWithStats>;
+    }): Promise<ISummaryTreeWithStats>;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
     get summarizerClientId(): string | undefined;
@@ -434,11 +434,6 @@ export interface IRefreshSummaryAckOptions {
     readonly proposalHandle: string | undefined;
     readonly summaryLogger: ITelemetryLoggerExt;
     readonly summaryRefSeq: number;
-}
-
-// @public
-export interface IRootSummaryTreeWithStats extends ISummaryTreeWithStats {
-    gcStats?: IGCStats;
 }
 
 // @public @deprecated (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -112,6 +112,11 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterfaceDeclaration_IRootSummaryTreeWithStats": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -435,14 +435,6 @@ export interface IContainerRuntimeOptions {
 }
 
 /**
- * The summary tree returned by the root node. It adds state relevant to the root of the tree.
- */
-export interface IRootSummaryTreeWithStats extends ISummaryTreeWithStats {
-	/** The garbage collection stats if GC ran, undefined otherwise. */
-	gcStats?: IGCStats;
-}
-
-/**
  * Accepted header keys for requests coming to the runtime.
  */
 export enum RuntimeHeaders {
@@ -2425,7 +2417,7 @@ export class ContainerRuntime
 		fullGC?: boolean;
 		/** True to run GC sweep phase after the mark phase */
 		runSweep?: boolean;
-	}): Promise<IRootSummaryTreeWithStats> {
+	}): Promise<ISummaryTreeWithStats> {
 		this.verifyNotClosed();
 
 		const {
@@ -2448,9 +2440,8 @@ export class ContainerRuntime
 		});
 
 		try {
-			let gcStats: IGCStats | undefined;
 			if (runGC) {
-				gcStats = await this.collectGarbage(
+				await this.collectGarbage(
 					{ logger: summaryLogger, runSweep, fullGC },
 					telemetryContext,
 				);
@@ -2467,7 +2458,7 @@ export class ContainerRuntime
 				0x12f /* "Container Runtime's summarize should always return a tree" */,
 			);
 
-			return { stats, summary, gcStats };
+			return { stats, summary };
 		} finally {
 			this.logger.sendTelemetryEvent({
 				eventName: "SummarizeTelemetry",
@@ -2760,7 +2751,7 @@ export class ContainerRuntime
 			}
 
 			const trace = Trace.start();
-			let summarizeResult: IRootSummaryTreeWithStats;
+			let summarizeResult: ISummaryTreeWithStats;
 			// If the GC state needs to be reset, we need to force a full tree summary and update the unreferenced
 			// state of all the nodes.
 			const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -12,7 +12,6 @@ export {
 	ISummaryConfigurationDisableSummarizer,
 	ISummaryConfigurationDisableHeuristics,
 	IContainerRuntimeOptions,
-	IRootSummaryTreeWithStats,
 	isRuntimeMessage,
 	RuntimeMessage,
 	agentSchedulerId,

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -664,26 +664,14 @@ use_old_InterfaceDeclaration_IRefreshSummaryAckOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IRootSummaryTreeWithStats": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IRootSummaryTreeWithStats": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IRootSummaryTreeWithStats():
-    TypeOnly<old.IRootSummaryTreeWithStats>;
-declare function use_current_InterfaceDeclaration_IRootSummaryTreeWithStats(
-    use: TypeOnly<current.IRootSummaryTreeWithStats>);
-use_current_InterfaceDeclaration_IRootSummaryTreeWithStats(
-    get_old_InterfaceDeclaration_IRootSummaryTreeWithStats());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IRootSummaryTreeWithStats": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IRootSummaryTreeWithStats": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IRootSummaryTreeWithStats():
-    TypeOnly<current.IRootSummaryTreeWithStats>;
-declare function use_old_InterfaceDeclaration_IRootSummaryTreeWithStats(
-    use: TypeOnly<old.IRootSummaryTreeWithStats>);
-use_old_InterfaceDeclaration_IRootSummaryTreeWithStats(
-    get_current_InterfaceDeclaration_IRootSummaryTreeWithStats());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
## Description
`IRootSummaryTreeWithStats` has been removed from container-runtime. This was added to access `gcStats` from the result of `summarize` in `submitSummary` method in `ContainerRuntime`. This is no longer the case after #15663 was merged.

## Breaking Changes
This is a breaking change because it removes exporting `IRootSummaryTreeWithStats`. However, this was only used within the `ContainterRuntime` class and no one should depend on this.
