### PR TITLE
updated start and commit weights to 0 in targeted fuzz test

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
@@ -123,8 +123,11 @@ describe("Fuzz - Targeted", () => {
 	const random = makeRandom(0);
 	const runsPerBatch = 20;
 	const opsPerRun = 20;
+	// "start" and "commit" opWeights set to 0 in case there are changes to the default weights.
 	const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
 		setPayload: 1,
+		start: 0,
+		commit: 0,
 	};
 	describe("Anchors are unaffected by aborted transaction", () => {
 		runFuzzBatch(


### PR DESCRIPTION
## Description

This PR updates the `start` and `commit` to 0 for the individual vs composed targeted fuzz test, in case the default op weights change in the future.
