### PR TITLE
updated start and commit weights to 0 for targeted fuzz test

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
@@ -98,10 +98,13 @@ describe("Fuzz - Targeted", () => {
 			emitter,
 		});
 	});
+	// "start" and "commit" opWeights set to 0 in case there are changes to the default weights.
 	const composeVsIndividualWeights: Partial<EditGeneratorOpWeights> = {
 		setPayload: 1,
 		insert: 1,
 		delete: 1,
+		start: 0,
+		commit: 0,
 	};
 	describe("Composed vs individual changes converge to the same tree", () => {
 		const generatorFactory = () =>


### PR DESCRIPTION
## Description

This PR updates the start and commit to 0 for the individual vs composed targeted fuzz test, in case the default op weights change in the future.
