### PR TITLE
Deprecate unnecessary exports and ISegment.parent

### DIFF
--- a/.changeset/gentle-sloths-tease.md
+++ b/.changeset/gentle-sloths-tease.md
@@ -2,6 +2,6 @@
 "@fluidframework/merge-tree": minor
 ---
 
-Deprecate unnecessary exports"
+Deprecate unnecessary exports
 
 This change deprecates a number of interfaces in the merge tree package that are not used in the exported apis surface and therefore should not be used.

--- a/.changeset/gentle-sloths-tease.md
+++ b/.changeset/gentle-sloths-tease.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/merge-tree": minor
+---
+
+Deprecate unnecessary exports"
+
+This change deprecates a number of interfaces in the merge tree package that are not used in the exported apis surface and therefore should not be used.

--- a/.changeset/thirty-chicken-ask.md
+++ b/.changeset/thirty-chicken-ask.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/merge-tree": minor
+---
+
+Deprecate ISegment.parent
+
+This change deprecates the parent property on the ISegment interface. The property will still exist, but should not generally be used by outside consumers.

--- a/.changeset/thirty-chicken-ask.md
+++ b/.changeset/thirty-chicken-ask.md
@@ -1,7 +1,12 @@
 ---
 "@fluidframework/merge-tree": minor
+"@fluidframework/sequence": minor
 ---
 
 Deprecate ISegment.parent
 
 This change deprecates the parent property on the ISegment interface. The property will still exist, but should not generally be used by outside consumers.
+
+There are some circumstances where a consumer may wish to know if a segment is still in the underling tree, and were using the parent property.
+
+Please change those checks to use the following `"parent" in segment && segment.parent !== undefined`

--- a/.changeset/thirty-chicken-ask.md
+++ b/.changeset/thirty-chicken-ask.md
@@ -7,6 +7,6 @@ Deprecate ISegment.parent
 
 This change deprecates the parent property on the ISegment interface. The property will still exist, but should not generally be used by outside consumers.
 
-There are some circumstances where a consumer may wish to know if a segment is still in the underling tree, and were using the parent property.
+There are some circumstances where a consumer may wish to know if a segment is still in the underlying tree and were using the parent property to determine that.
 
 Please change those checks to use the following `"parent" in segment && segment.parent !== undefined`

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -87,13 +87,13 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     abstract readonly type: string;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface BlockAction<TClientData> {
     // (undocumented)
     (block: IMergeBlock, pos: number, refSeq: number, clientId: number, start: number | undefined, end: number | undefined, accum: TClientData): boolean;
 }
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export interface BlockUpdateActions {
     // (undocumented)
     child: (block: IMergeBlock, index: number) => void;
@@ -371,7 +371,7 @@ export interface IConsensusValue {
     value: any;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface IHierBlock extends IMergeBlock {
     // (undocumented)
     hierToString(indentCount: number): string;
@@ -421,7 +421,7 @@ export interface IMarkerModifiedAction {
     (marker: Marker): void;
 }
 
-// @public
+// @internal @deprecated
 export interface IMergeBlock extends IMergeNodeCommon {
     // (undocumented)
     assignChild(child: IMergeNode, index: number, updateOrdinal?: boolean): void;
@@ -437,7 +437,7 @@ export interface IMergeBlock extends IMergeNodeCommon {
     setOrdinal(child: IMergeNode, index: number): void;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export type IMergeNode = IMergeBlock | ISegment;
 
 // @public
@@ -447,7 +447,7 @@ export interface IMergeNodeCommon {
     // (undocumented)
     isLeaf(): this is ISegment;
     ordinal: string;
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     parent?: IMergeBlock;
 }
 
@@ -580,13 +580,13 @@ export interface IMergeTreeTextHelper {
     getText(refSeq: number, clientId: number, placeholder: string, start?: number, end?: number): string;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface IncrementalBlockAction<TContext> {
     // (undocumented)
     (state: IncrementalMapState<TContext>): any;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export enum IncrementalExecOp {
     // (undocumented)
     Go = 0,
@@ -596,7 +596,7 @@ export enum IncrementalExecOp {
     Yield = 2
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export class IncrementalMapState<TContext> {
     constructor(block: IMergeBlock, actions: IncrementalSegmentActions<TContext>, pos: number, refSeq: number, clientId: number, context: TContext, start: number, end: number, childIndex?: number);
     // (undocumented)
@@ -621,13 +621,13 @@ export class IncrementalMapState<TContext> {
     start: number;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface IncrementalSegmentAction<TContext> {
     // (undocumented)
     (segment: ISegment, state: IncrementalMapState<TContext>): any;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface IncrementalSegmentActions<TContext> {
     // (undocumented)
     leaf: IncrementalSegmentAction<TContext>;
@@ -637,7 +637,7 @@ export interface IncrementalSegmentActions<TContext> {
     pre?: IncrementalBlockAction<TContext>;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface InsertContext {
     // (undocumented)
     candidateSegment?: ISegment;
@@ -720,7 +720,7 @@ export interface ISegmentAction<TClientData> {
     (segment: ISegment, pos: number, refSeq: number, clientId: number, start: number, end: number, accum: TClientData): boolean;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface ISegmentChanges {
     // (undocumented)
     next?: ISegment;
@@ -852,13 +852,13 @@ export class Marker extends BaseSegment implements ReferencePosition {
 // @public (undocumented)
 export function matchProperties(a: PropertySet | undefined, b: PropertySet | undefined): boolean;
 
-// @public (undocumented)
+// @internal @deprecated
 export const MaxNodesInBlock = 8;
 
 // @public (undocumented)
 export function maxReferencePosition<T extends ReferencePosition>(a: T, b: T): T;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export class MergeBlock extends MergeNode implements IMergeBlock {
     constructor(childCount: number);
     // (undocumented)
@@ -883,7 +883,7 @@ export class MergeNode implements IMergeNodeCommon {
     isLeaf(): boolean;
     // (undocumented)
     ordinal: string;
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     parent?: IMergeBlock;
 }
 
@@ -944,7 +944,7 @@ export interface MergeTreeRevertibleDriver {
     removeRange(start: number, end: number): any;
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface MinListener {
     // (undocumented)
     minRequired: number;
@@ -955,7 +955,7 @@ export interface MinListener {
 // @public (undocumented)
 export function minReferencePosition<T extends ReferencePosition>(a: T, b: T): T;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface NodeAction<TClientData> {
     // (undocumented)
     (node: IMergeNode, pos: number, refSeq: number, clientId: number, start: number | undefined, end: number | undefined, clientData: TClientData): boolean;
@@ -964,7 +964,7 @@ export interface NodeAction<TClientData> {
 // @public (undocumented)
 export const NonCollabClient = -2;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export function ordinalToArray(ord: string): number[];
 
 // @public (undocumented)
@@ -1163,7 +1163,7 @@ export const reservedTileLabelsKey = "referenceTileLabels";
 // @alpha
 export function revertMergeTreeDeltaRevertibles(driver: MergeTreeRevertibleDriver, revertibles: MergeTreeDeltaRevertible[]): void;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface SearchResult {
     // (undocumented)
     pos: number;
@@ -1177,7 +1177,7 @@ export interface SegmentAccumulator {
     segments: ISegment[];
 }
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export interface SegmentActions<TClientData> {
     // (undocumented)
     contains?: NodeAction<TClientData>;

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -32,6 +32,11 @@ import { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManage
  * Common properties for a node in a merge tree.
  */
 export interface IMergeNodeCommon {
+	/**
+	 *
+	 * @deprecated - In subsequent releases this will no longer be exported
+	 * @internal
+	 */
 	parent?: IMergeBlock;
 	/**
 	 * The length of the contents of the node.
@@ -49,10 +54,17 @@ export interface IMergeNodeCommon {
 	isLeaf(): this is ISegment;
 }
 
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export type IMergeNode = IMergeBlock | ISegment;
 
 /**
  * Internal (i.e. non-leaf) node in a merge tree.
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
  */
 export interface IMergeBlock extends IMergeNodeCommon {
 	needsScour?: boolean;
@@ -81,6 +93,10 @@ export interface IMergeBlock extends IMergeNodeCommon {
 	setOrdinal(child: IMergeNode, index: number): void;
 }
 
+/**
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface IHierBlock extends IMergeBlock {
 	hierToString(indentCount: number): string;
 	rightmostTiles: MapLike<ReferencePosition>;
@@ -225,12 +241,20 @@ export interface ISegmentAction<TClientData> {
 		accum: TClientData,
 	): boolean;
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface ISegmentChanges {
 	next?: ISegment;
 	replaceCurrent?: ISegment;
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface BlockAction<TClientData> {
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
 	(
@@ -244,6 +268,11 @@ export interface BlockAction<TClientData> {
 	): boolean;
 }
 
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface NodeAction<TClientData> {
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
 	(
@@ -256,21 +285,36 @@ export interface NodeAction<TClientData> {
 		clientData: TClientData,
 	): boolean;
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface IncrementalSegmentAction<TContext> {
 	(segment: ISegment, state: IncrementalMapState<TContext>);
 }
 
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface IncrementalBlockAction<TContext> {
 	(state: IncrementalMapState<TContext>);
 }
 /**
- * @deprecated - unused and will be removed
- */
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ * */
 export interface BlockUpdateActions {
 	child: (block: IMergeBlock, index: number) => void;
 }
 
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface InsertContext {
 	candidateSegment?: ISegment;
 	prepareEvents?: boolean;
@@ -279,6 +323,11 @@ export interface InsertContext {
 	continuePredicate?: (continueFromBlock: IMergeBlock) => boolean;
 }
 
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface SegmentActions<TClientData> {
 	leaf?: ISegmentAction<TClientData>;
 	shift?: NodeAction<TClientData>;
@@ -286,13 +335,22 @@ export interface SegmentActions<TClientData> {
 	pre?: BlockAction<TClientData>;
 	post?: BlockAction<TClientData>;
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface IncrementalSegmentActions<TContext> {
 	leaf: IncrementalSegmentAction<TContext>;
 	pre?: IncrementalBlockAction<TContext>;
 	post?: IncrementalBlockAction<TContext>;
 }
 
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface SearchResult {
 	text: string;
 	pos: number;
@@ -308,6 +366,11 @@ export interface SegmentGroup {
 export class MergeNode implements IMergeNodeCommon {
 	index: number = 0;
 	ordinal: string = "";
+	/**
+	 *
+	 * @deprecated - In subsequent releases this will no longer be exported
+	 * @internal
+	 */
 	parent?: IMergeBlock;
 	cachedLength: number = 0;
 
@@ -315,6 +378,11 @@ export class MergeNode implements IMergeNodeCommon {
 		return false;
 	}
 }
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export function ordinalToArray(ord: string) {
 	const a: number[] = [];
 	if (ord) {
@@ -324,13 +392,20 @@ export function ordinalToArray(ord: string) {
 	}
 	return a;
 }
-
-// Note that the actual branching factor of the MergeTree is `MaxNodesInBlock - 1`.  This is because
-// the MergeTree always inserts first, then checks for overflow and splits if the child count equals
-// `MaxNodesInBlock`.  (i.e., `MaxNodesInBlock` contains 1 extra slot for temporary storage to
-// facilitate splits.)
+/**
+ * Note that the actual branching factor of the MergeTree is `MaxNodesInBlock - 1`.  This is because
+ * the MergeTree always inserts first, then checks for overflow and splits if the child count equals
+ * `MaxNodesInBlock`.  (i.e., `MaxNodesInBlock` contains 1 extra slot for temporary storage to
+ * facilitate splits.)
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export const MaxNodesInBlock = 8;
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export class MergeBlock extends MergeNode implements IMergeBlock {
 	public children: IMergeNode[];
 	public constructor(public childCount: number) {
@@ -637,13 +712,21 @@ export class Marker extends BaseSegment implements ReferencePosition {
 		throw new Error("Can not append to marker");
 	}
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export enum IncrementalExecOp {
 	Go,
 	Stop,
 	Yield,
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export class IncrementalMapState<TContext> {
 	op = IncrementalExecOp.Go;
 	constructor(
@@ -701,7 +784,11 @@ export interface IConsensusInfo {
 export interface SegmentAccumulator {
 	segments: ISegment[];
 }
-
+/**
+ *
+ * @deprecated - In subsequent releases this internal interface will no longer be exported
+ * @internal
+ */
 export interface MinListener {
 	minRequired: number;
 	onMinGE(minSeq: number): void;


### PR DESCRIPTION
## Deprecate unnecessary exports

This change deprecates a number of interfaces in the merge tree package that are not used in the exported apis surface and therefore should not be used.

## Deprecate ISegment.parent

This change deprecates the parent property on the ISegment interface. The property will still exist but should not generally be used by outside consumers.

There are some circumstances where a consumer may wish to know if a segment is still in the underlying tree and were using the parent property to determine that.

Please change those checks to use the following `"parent" in segment && segment.parent !== undefined`