### PR TITLE
Fix reporting in e2e tests

### DIFF
--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -78,7 +78,15 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 
 	if (process.env.FLUID_TEST_MULTIREPORT === "1") {
 		config["reporter"] = `mocha-multi-reporters`;
-		config["reporter-options"] = [`configFile=${path.join(__dirname, "test-config.json")}`];
+		// See https://www.npmjs.com/package/mocha-multi-reporters#cmroutput-option
+		const outputFilePrefix = testReportPrefix !== undefined ? `${testReportPrefix}-` : "";
+		console.log(outputFilePrefix);
+		config["reporter-options"] = [
+			`configFile=${path.join(
+				__dirname,
+				"test-config.json",
+			)},cmrOutput=xunit+output+${outputFilePrefix}:mocha-json-output-reporter+output+${outputFilePrefix}`,
+		];
 		console.log(`configFile=${path.join(__dirname, "test-config.json")}`);
 	}
 

--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -80,13 +80,15 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		config["reporter"] = `mocha-multi-reporters`;
 		// See https://www.npmjs.com/package/mocha-multi-reporters#cmroutput-option
 		const outputFilePrefix = testReportPrefix !== undefined ? `${testReportPrefix}-` : "";
+		console.log(
+			`Writing test results relative to package to nyc/${outputFilePrefix}junit-report.xml and nyc/${outputFilePrefix}junit-report.json`,
+		);
 		config["reporter-options"] = [
 			`configFile=${path.join(
 				__dirname,
 				"test-config.json",
 			)},cmrOutput=xunit+output+${outputFilePrefix}:mocha-json-output-reporter+output+${outputFilePrefix}`,
 		];
-		console.log(`configFile=${path.join(__dirname, "test-config.json")}`);
 	}
 
 	if (process.env.FLUID_TEST_FORBID_ONLY !== undefined) {

--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -80,7 +80,6 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		config["reporter"] = `mocha-multi-reporters`;
 		// See https://www.npmjs.com/package/mocha-multi-reporters#cmroutput-option
 		const outputFilePrefix = testReportPrefix !== undefined ? `${testReportPrefix}-` : "";
-		console.log(outputFilePrefix);
 		config["reporter-options"] = [
 			`configFile=${path.join(
 				__dirname,

--- a/packages/test/mocha-test-setup/test-config.json
+++ b/packages/test/mocha-test-setup/test-config.json
@@ -1,9 +1,9 @@
 {
 	"reporterEnabled": "xunit,mocha-json-output-reporter",
 	"xunitReporterOptions": {
-		"output": "nyc/junit-report.xml"
+		"output": "nyc/{id}junit-report.xml"
 	},
 	"mochaJsonOutputReporterReporterOptions": {
-		"output": "nyc/junit-report.json"
+		"output": "nyc/{id}junit-report.json"
 	}
 }


### PR DESCRIPTION
## Description

#15983 updated the e2e tests to use FLUID_TEST_MULTIREPORT, but that option previously didn't respect the `testReportPrefix` setting we use to make sure different e2e test configs produces different test result files.
As a result, the tinylicious test results were clobbering those from local server, which makes test failures in local server difficult to diagnose.

This fixes our reporting output files to once again be distinct, which will hopefully make the intermittent failures we're seeing easy to diagnose (it's likely just a flaky test)