### PR TITLE
fix(fluid-build): Don't run script tasks not in task definition

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -216,6 +216,9 @@ export class BuildPackage {
 				return;
 			}
 			const taskConfig = this.taskDefinitions[task.taskName];
+			if (taskConfig === undefined) {
+				return;
+			}
 			if (taskConfig.before.includes("*")) {
 				this.tasks.forEach((depTask) => {
 					if (depTask !== task) {


### PR DESCRIPTION
`fluid-build` can trigger scripts in `package.json` even if it is not part of the task definition.
