### PR TITLE
Move pending blob ops to online flow on reconnection.

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -293,8 +293,14 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		);
 	}
 
-	public get hasPendingOfflineUploads(): boolean {
-		return this.pendingOfflineUploads.length > 0;
+	private get pendingOfflineOps() {
+		return Array.from(this.pendingBlobs.values()).filter(
+			(e) => e.status === PendingBlobStatus.OfflinePendingOp,
+		);
+	}
+
+	public get hasPendingOfflineWork(): boolean {
+		return this.pendingOfflineUploads.length > 0 || this.pendingOfflineOps.length > 0;
 	}
 
 	public get hasPendingBlobs(): boolean {
@@ -310,6 +316,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	public async onConnected() {
 		this.retryThrottler.cancel();
 		const pendingUploads = this.pendingOfflineUploads.map(async (e) => e.uploadP);
+		this.pendingOfflineOps.forEach( pendingblob => pendingblob.status = PendingBlobStatus.OnlinePendingOp);
 		await PerformanceEvent.timedExecAsync(
 			this.mc.logger,
 			{

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1867,7 +1867,7 @@ export class ContainerRuntime
 		// Note that the inner (non-proxy) delta manager is needed here to get the readonly information.
 		const connecting =
 			connected && !this._connected && !this.innerDeltaManager.readOnlyInfo.readonly;
-		if (connecting && this.blobManager.hasPendingOfflineUploads) {
+		if (connecting && this.blobManager.hasPendingOfflineWork) {
 			assert(
 				!this.delayConnectClientId,
 				0x392 /* Connect event delay must be canceled before subsequent connect event */,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -199,7 +199,7 @@ class MockRuntime
 	public async connect(delay?: number) {
 		assert(!this.connected);
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));
-		if (this.blobManager.hasPendingOfflineUploads) {
+		if (this.blobManager.hasPendingOfflineWork) {
 			const uploadP = this.blobManager.onConnected();
 			this.processing = true;
 			await this.processBlobs();


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_workitems/edit/4685

When there is a flush in containerRuntime, sendMessages method reconnects the container. This reconnection triggers isDisconnected event  in blob manager, sending all OnlinePendingOp blobs to offline flow. It reconnects immediately but the statuses were already change and code never reaches online code path when processing blob ops. 

This change will be useful to better track blob round trips and attach status.