### PR TITLE
Handle empty commands in fluid-build

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -8,7 +8,7 @@ import * as semver from "semver";
 
 import { FileHashCache } from "../common/fileHashCache";
 import { defaultLogger } from "../common/logging";
-import { Package, Packages } from "../common/npmPackage";
+import { Package } from "../common/npmPackage";
 import { Timer } from "../common/timer";
 import { options } from "./options";
 import { Task, TaskExec } from "./tasks/task";
@@ -342,11 +342,21 @@ export class BuildGraph {
 		this.buildContext.fileHashCache.clear();
 		const q = Task.createTaskQueue();
 		const p: Promise<BuildResult>[] = [];
+		let hasError = false;
+		q.error((err, task) => {
+			console.error(
+				`${task.task.nameColored}: Internal uncaught exception: ${err}\n${err.stack}`,
+			);
+			hasError = true;
+		});
 		try {
 			this.buildPackages.forEach((node) => {
 				p.push(node.build(q));
 			});
-
+			await q.drain();
+			if (hasError) {
+				return BuildResult.Failed;
+			}
 			return summarizeBuildResult(await Promise.all(p));
 		} finally {
 			this.buildContext.workerPool?.reset();

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -224,6 +224,9 @@ export abstract class LeafTask extends Task {
 	}
 
 	private async execCommand(): Promise<ExecAsyncResult> {
+		if (this.command === "") {
+			return { error: null, stdout: "", stderr: "" };
+		}
 		return execAsync(this.command, {
 			cwd: this.node.pkg.directory,
 			env: {
@@ -479,6 +482,10 @@ export abstract class LeafWithDoneFileTask extends LeafTask {
 
 export class UnknownLeafTask extends LeafTask {
 	protected async checkLeafIsUpToDate() {
+		if (this.command === "") {
+			// Empty command is always up to date.
+			return true;
+		}
 		// Because we don't know, it is always out of date and need to rebuild
 		return false;
 	}


### PR DESCRIPTION
Sometime, we want to empty out script command locally for testing.  Make fluid-build able to handle that.
Also add internal error handling on the task queue.