### PR TITLE
Provide different layers' APIs to describeCompat suites

### DIFF
--- a/examples/data-objects/table-document/src/test/.mocharc.js
+++ b/examples/data-objects/table-document/src/test/.mocharc.js
@@ -7,6 +7,6 @@
 
 const packageDir = `${__dirname}/../..`;
 
-const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.js");
+const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.cjs");
 const config = getFluidTestMochaConfig(packageDir);
 module.exports = config;

--- a/examples/data-objects/webflow/src/test/.mocharc.cjs
+++ b/examples/data-objects/webflow/src/test/.mocharc.cjs
@@ -7,6 +7,6 @@
 
 const packageDir = `${__dirname}/../..`;
 
-const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.js");
+const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.cjs");
 const config = getFluidTestMochaConfig(packageDir);
 module.exports = config;

--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
@@ -6,6 +6,6 @@
 "use strict";
 
 const packageDir = `${__dirname}/../..`;
-const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.js");
+const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.cjs");
 const config = getFluidTestMochaConfig(packageDir, ["source-map-support/register"]);
 module.exports = config;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummary.spec.ts
@@ -4,64 +4,18 @@
  */
 
 import { strict as assert } from "assert";
-
-import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
-	DataObject,
-	DataObjectFactory,
-} from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 import { Marker, ReferenceType, reservedMarkerIdKey } from "@fluidframework/merge-tree";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluid-internal/test-version-utils";
 import { UndoRedoStackManager } from "@fluidframework/undo-redo";
-
-class TestDataObject extends DataObject {
-	public get _root() {
-		return this.root;
-	}
-
-	public get _context() {
-		return this.context;
-	}
-
-	private readonly matrixKey = "matrix";
-	public matrix!: SharedMatrix;
-	public undoRedoStackManager!: UndoRedoStackManager;
-
-	private readonly sharedStringKey = "sharedString";
-	public sharedString!: SharedString;
-
-	protected async initializingFirstTime() {
-		const sharedMatrix = SharedMatrix.create(this.runtime);
-		this.root.set(this.matrixKey, sharedMatrix.handle);
-
-		const sharedString = SharedString.create(this.runtime);
-		this.root.set(this.sharedStringKey, sharedString.handle);
-	}
-
-	protected async hasInitialized() {
-		const matrixHandle = this.root.get<IFluidHandle<SharedMatrix>>(this.matrixKey);
-		assert(matrixHandle !== undefined, "SharedMatrix not found");
-		this.matrix = await matrixHandle.get();
-
-		this.undoRedoStackManager = new UndoRedoStackManager();
-		this.matrix.insertRows(0, 3);
-		this.matrix.insertCols(0, 3);
-		this.matrix.openUndo(this.undoRedoStackManager);
-
-		const sharedStringHandle = this.root.get<IFluidHandle<SharedString>>(this.sharedStringKey);
-		assert(sharedStringHandle !== undefined, "SharedMatrix not found");
-		this.sharedString = await sharedStringHandle.get();
-	}
-}
 
 /**
  * Validates this scenario: When all references to a data store are deleted, the data store is marked as unreferenced
@@ -70,9 +24,53 @@ class TestDataObject extends DataObject {
  * property set to true. If the handle to a data store exists or it's a root data store, its summary tree does not have
  * the "unreferenced" property.
  */
-describeFullCompat("GC reference updates in local summary", (getTestObjectProvider) => {
+describeFullCompat("GC reference updates in local summary", (getTestObjectProvider, apis) => {
+	const { SharedMatrix, SharedString } = apis.dds;
+
+	class TestDataObject extends apis.dataRuntime.DataObject {
+		public get _root() {
+			return this.root;
+		}
+
+		public get _context() {
+			return this.context;
+		}
+
+		private readonly matrixKey = "matrix";
+		public matrix!: SharedMatrix;
+		public undoRedoStackManager!: UndoRedoStackManager;
+
+		private readonly sharedStringKey = "sharedString";
+		public sharedString!: SharedString;
+
+		protected async initializingFirstTime() {
+			const sharedMatrix = SharedMatrix.create(this.runtime);
+			this.root.set(this.matrixKey, sharedMatrix.handle);
+
+			const sharedString = SharedString.create(this.runtime);
+			this.root.set(this.sharedStringKey, sharedString.handle);
+		}
+
+		protected async hasInitialized() {
+			const matrixHandle = this.root.get<IFluidHandle<SharedMatrix>>(this.matrixKey);
+			assert(matrixHandle !== undefined, "SharedMatrix not found");
+			this.matrix = await matrixHandle.get();
+
+			this.undoRedoStackManager = new UndoRedoStackManager();
+			this.matrix.insertRows(0, 3);
+			this.matrix.insertCols(0, 3);
+			this.matrix.openUndo(this.undoRedoStackManager);
+
+			const sharedStringHandle = this.root.get<IFluidHandle<SharedString>>(
+				this.sharedStringKey,
+			);
+			assert(sharedStringHandle !== undefined, "SharedMatrix not found");
+			this.sharedString = await sharedStringHandle.get();
+		}
+	}
+
 	let provider: ITestObjectProvider;
-	const factory = new DataObjectFactory(
+	const factory = new apis.dataRuntime.DataObjectFactory(
 		"TestDataObject",
 		TestDataObject,
 		[SharedMatrix.getFactory(), SharedString.getFactory()],
@@ -87,7 +85,7 @@ describeFullCompat("GC reference updates in local summary", (getTestObjectProvid
 		},
 		gcOptions: { gcAllowed: true },
 	};
-	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+	const runtimeFactory = new apis.containerRuntime.ContainerRuntimeFactoryWithDefaultDataStore(
 		factory,
 		[[factory.type, Promise.resolve(factory)]],
 		undefined,

--- a/packages/test/test-version-utils/.eslintrc.cjs
+++ b/packages/test/test-version-utils/.eslintrc.cjs
@@ -8,6 +8,12 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
 		"import/no-nodejs-modules": "off",
+		// ESLint's resolver doesn't resolve relative imports of ESNext modules correctly, since
+		// it resolves the path relative to the .ts file (and assumes a file with a .js extension
+		// should exist there)
+		// AB#4614 tracks moving to eslint-import-resolver-typescript (which handles such imports
+		// out of the box) and removing this exception.
+		"import/no-unresolved": ["error", { ignore: ["^\\.(.*)\\.js$"] }],
 	},
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],

--- a/packages/test/test-version-utils/mocharc-common.cjs
+++ b/packages/test/test-version-utils/mocharc-common.cjs
@@ -4,8 +4,7 @@
  */
 
 "use strict";
-
-const options = require("./dist/compatOptions");
+const options = import("./dist/compatOptions.js");
 const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common.js");
 
 function getFluidTestVariant() {
@@ -32,11 +31,7 @@ function getFluidTestMochaConfigWithCompat(packageDir, additionalRequiredModules
 		testReportPrefix += `_${options.compatKind.join("_")}`;
 	}
 
-	return getFluidTestMochaConfig(
-		packageDir,
-		["@fluid-internal/test-version-utils", ...additionalRequiredModules],
-		testReportPrefix,
-	);
+	return getFluidTestMochaConfig(packageDir, additionalRequiredModules, testReportPrefix);
 }
 
 module.exports = getFluidTestMochaConfigWithCompat;

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
+	"type": "module",
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 import { Lazy, assert } from "@fluidframework/common-utils";
-import { ensurePackageInstalled } from "./testApi";
-import { pkgVersion } from "./packageVersion";
+import { ensurePackageInstalled } from "./testApi.js";
+import { pkgVersion } from "./packageVersion.js";
 import {
 	CompatKind,
 	compatKind,
@@ -14,7 +14,7 @@ import {
 	tenantIndex,
 	baseVersion,
 	reinstall,
-} from "./compatOptions";
+} from "./compatOptions.js";
 
 /*
  * Generate configuration combinations for a particular compat version
@@ -229,8 +229,40 @@ export const configList = new Lazy<readonly CompatConfig[]>(() => {
 	return _configList;
 });
 
-/*
+/**
  * Mocha start up to ensure legacy versions are installed
+ * @privateRemarks
+ * This isn't currently used in a global setup hook due to https://github.com/mochajs/mocha/issues/4508.
+ * Instead, we ensure that all requested compatibility versions are loaded at `describeCompat` module import time by
+ * leveraging top-level await.
+ *
+ * This makes compatibility layer APIs (e.g. DDSes, data object, etc.) available at mocha suite creation time rather than
+ * hook/test execution time, which is convenient for test authors: this sort of code can be used
+ * ```ts
+ * describeCompat("my suite", (getTestObjectProvider, apis) => {
+ *     class MyDataObject extends apis.dataRuntime.DataObject {
+ *         // ...
+ *     }
+ * });
+ * ```
+ *
+ * instead of code like this:
+ *
+ * ```ts
+ * describeCompat("my suite", (getTestObjectProvider, getApis) => {
+ *
+ *     const makeDataObjectClass = (apis: CompatApis) => class MyDataObject extends apis.dataRuntime.DataObject {
+ *         // ...
+ *     }
+ *
+ *     before(() => {
+ *         // `getApis` can only be invoked from inside a hook or test
+ *         const MyDataObject = makeDataObjectClass(getApis())
+ *     });
+ * });
+ * ```
+ *
+ * If the linked github issue is ever fixed, this can be once again used as a global setup fixture.
  */
 export async function mochaGlobalSetup() {
 	const versions = new Set(configList.value.map((value) => value.compatVersion));

--- a/packages/test/test-version-utils/src/compatOptions.ts
+++ b/packages/test/test-version-utils/src/compatOptions.ts
@@ -5,8 +5,8 @@
 
 import nconf from "nconf";
 import { RouterliciousEndpoint, TestDriverTypes } from "@fluidframework/test-driver-definitions";
-import { resolveVersion } from "./versionUtils";
-import { pkgVersion } from "./packageVersion";
+import { resolveVersion } from "./versionUtils.js";
+import { pkgVersion } from "./packageVersion.js";
 
 /**
  * Different kind of compat version config

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -9,15 +9,25 @@ import {
 	ITestObjectProvider,
 	TestObjectProvider,
 } from "@fluidframework/test-utils";
-import { configList } from "./compatConfig";
-import { CompatKind, baseVersion, driver, r11sEndpointName, tenantIndex } from "./compatOptions";
-import { getVersionedTestObjectProvider } from "./compatUtils";
+import { configList, mochaGlobalSetup } from "./compatConfig.js";
+import { CompatKind, baseVersion, driver, r11sEndpointName, tenantIndex } from "./compatOptions.js";
+import { getVersionedTestObjectProviderFromApis } from "./compatUtils.js";
+import {
+	getContainerRuntimeApi,
+	getDataRuntimeApi,
+	getLoaderApi,
+	CompatApis,
+	getDriverApi,
+} from "./testApi.js";
+
+// See doc comment on mochaGlobalSetup.
+await mochaGlobalSetup();
 
 /*
  * Mocha Utils for test to generate the compat variants.
  */
 function createCompatSuite(
-	tests: (this: Mocha.Suite, provider: () => ITestObjectProvider) => void,
+	tests: (this: Mocha.Suite, provider: () => ITestObjectProvider, apis: CompatApis) => void,
 	compatFilter?: CompatKind[],
 ) {
 	return function (this: Mocha.Suite) {
@@ -30,22 +40,24 @@ function createCompatSuite(
 			describe(config.name, function () {
 				let provider: TestObjectProvider;
 				let resetAfterEach: boolean;
+				const dataRuntimeApi = getDataRuntimeApi(baseVersion, config.dataRuntime);
+				const apis: CompatApis = {
+					containerRuntime: getContainerRuntimeApi(baseVersion, config.containerRuntime),
+					dataRuntime: dataRuntimeApi,
+					dds: dataRuntimeApi.dds,
+					driver: getDriverApi(baseVersion, config.driver),
+					loader: getLoaderApi(baseVersion, config.loader),
+				};
+
 				before(async function () {
 					try {
-						provider = await getVersionedTestObjectProvider(
-							baseVersion,
-							config.loader,
-							{
-								type: driver,
-								version: config.driver,
-								config: {
-									r11s: { r11sEndpointName },
-									odsp: { tenantIndex },
-								},
+						provider = await getVersionedTestObjectProviderFromApis(apis, {
+							type: driver,
+							config: {
+								r11s: { r11sEndpointName },
+								odsp: { tenantIndex },
 							},
-							config.containerRuntime,
-							config.dataRuntime,
-						);
+						});
 					} catch (error) {
 						const logger = ChildLogger.create(getTestLogger?.(), "DescribeCompatSetup");
 						logger.sendErrorEvent(
@@ -60,13 +72,14 @@ function createCompatSuite(
 
 					Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
 				});
+
 				tests.bind(this)((options?: ITestObjectProviderOptions) => {
 					resetAfterEach = options?.resetAfterEach ?? true;
 					if (options?.syncSummarizer === true) {
 						provider.resetLoaderContainerTracker(true /* syncSummarizerClients */);
 					}
 					return provider;
-				});
+				}, apis);
 
 				afterEach(function (done: Mocha.Done) {
 					const logErrors = getUnexpectedLogErrorException(provider.logger);
@@ -99,6 +112,7 @@ export type DescribeCompatSuite = (
 	tests: (
 		this: Mocha.Suite,
 		provider: (options?: ITestObjectProviderOptions) => ITestObjectProvider,
+		apis: CompatApis,
 	) => void,
 ) => Mocha.Suite | void;
 

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -11,10 +11,10 @@ import {
 	ITestObjectProvider,
 	TestObjectProvider,
 } from "@fluidframework/test-utils";
-import { configList } from "./compatConfig";
-import { CompatKind, baseVersion, driver, r11sEndpointName, tenantIndex } from "./compatOptions";
-import { getVersionedTestObjectProvider } from "./compatUtils";
-import { ITestObjectProviderOptions } from "./describeCompat";
+import { configList } from "./compatConfig.js";
+import { CompatKind, baseVersion, driver, r11sEndpointName, tenantIndex } from "./compatOptions.js";
+import { getVersionedTestObjectProvider } from "./compatUtils.js";
+import { ITestObjectProviderOptions } from "./describeCompat.js";
 
 /*
  * Types of documents to be used during the performance runs.

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -8,11 +8,11 @@ import {
 	ITestObjectProvider,
 	TestObjectProvider,
 } from "@fluidframework/test-utils";
-import { driver, r11sEndpointName, tenantIndex } from "./compatOptions";
-import { getVersionedTestObjectProvider } from "./compatUtils";
-import { ITestObjectProviderOptions } from "./describeCompat";
-import { pkgVersion } from "./packageVersion";
-import { ensurePackageInstalled, InstalledPackage } from "./testApi";
+import { driver, r11sEndpointName, tenantIndex } from "./compatOptions.js";
+import { getVersionedTestObjectProvider } from "./compatUtils.js";
+import { ITestObjectProviderOptions } from "./describeCompat.js";
+import { pkgVersion } from "./packageVersion.js";
+import { ensurePackageInstalled, InstalledPackage } from "./testApi.js";
 
 /**
  * Interface to hold the requested versions which should be installed

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -2,14 +2,15 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export { mochaGlobalSetup } from "./compatConfig";
+export { mochaGlobalSetup } from "./compatConfig.js";
 export {
 	getDataStoreFactory,
 	getVersionedTestObjectProvider,
+	getVersionedTestObjectProviderFromApis,
 	ITestDataObject,
 	TestDataObjectType,
-} from "./compatUtils";
-export { describeInstallVersions } from "./describeWithVersions";
+} from "./compatUtils.js";
+export { describeInstallVersions } from "./describeWithVersions.js";
 export {
 	DescribeCompat,
 	DescribeCompatSuite,
@@ -17,7 +18,7 @@ export {
 	describeLoaderCompat,
 	describeNoCompat,
 	ITestObjectProviderOptions,
-} from "./describeCompat";
+} from "./describeCompat.js";
 export {
 	describeE2EDocs,
 	DocumentType,
@@ -36,12 +37,13 @@ export {
 	isDocumentMapInfo,
 	isDocumentMultipleDataStoresInfo,
 	isDocumentMatrixInfo,
-} from "./describeE2eDocs";
-export { ExpectedEvents, ExpectsTest, itExpects } from "./itExpects";
+} from "./describeE2eDocs.js";
+export { ExpectedEvents, ExpectsTest, itExpects } from "./itExpects.js";
 export {
+	CompatApis,
 	ensurePackageInstalled,
 	getContainerRuntimeApi,
 	getDataRuntimeApi,
 	getDriverApi,
 	getLoaderApi,
-} from "./testApi";
+} from "./testApi.js";

--- a/packages/test/test-version-utils/src/test/tsconfig.json
+++ b/packages/test/test-version-utils/src/test/tsconfig.json
@@ -7,6 +7,7 @@
 		"declaration": false,
 		"declarationMap": false,
 		"skipLibCheck": true,
+		"module": "esnext",
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/test/test-version-utils/src/test/versionUtils.spec.ts
+++ b/packages/test/test-version-utils/src/test/versionUtils.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { getRequestedRange, versionHasMovedSparsedMatrix } from "../versionUtils";
+import { getRequestedRange, versionHasMovedSparsedMatrix } from "../versionUtils.js";
 
 describe("versionUtils", () => {
 	it("Get the major version number above or below the baseVersion", () => {

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -32,14 +32,14 @@ import {
 import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 
 import * as semver from "semver";
-import { pkgVersion } from "./packageVersion";
+import { pkgVersion } from "./packageVersion.js";
 import {
 	checkInstalled,
 	ensureInstalled,
 	getRequestedRange,
 	loadPackage,
 	versionHasMovedSparsedMatrix,
-} from "./versionUtils";
+} from "./versionUtils.js";
 
 // List of package that needs to be install for legacy versions
 const packageList = [
@@ -69,8 +69,23 @@ export const ensurePackageInstalled = async (
 	baseVersion: string,
 	version: number | string,
 	force: boolean,
-): Promise<InstalledPackage | undefined> =>
-	ensureInstalled(getRequestedRange(baseVersion, version), packageList, force);
+): Promise<InstalledPackage | undefined> => {
+	const pkg = await ensureInstalled(getRequestedRange(baseVersion, version), packageList, force);
+	await Promise.all([
+		loadContainerRuntime(baseVersion, version),
+		loadDataRuntime(baseVersion, version),
+		loadLoader(baseVersion, version),
+		loadDriver(baseVersion, version),
+	]);
+	return pkg;
+};
+
+// This module supports synchronous functions to import packages once their install has been completed.
+// Since dynamic import is async, we thus cache the modules based on their package version.
+const loaderCache = new Map<string, typeof LoaderApi>();
+const containerRuntimeCache = new Map<string, typeof ContainerRuntimeApi>();
+const dataRuntimeCache = new Map<string, typeof DataRuntimeApi>();
+const driverCache = new Map<string, typeof DriverApi>();
 
 // Current versions of the APIs
 const LoaderApi = {
@@ -103,6 +118,166 @@ const DataRuntimeApi = {
 	},
 };
 
+async function loadLoader(baseVersion: string, requested?: number | string): Promise<void> {
+	const requestedStr = getRequestedRange(baseVersion, requested);
+	if (semver.satisfies(pkgVersion, requestedStr)) {
+		return;
+	}
+
+	const { version, modulePath } = checkInstalled(requestedStr);
+	if (!loaderCache.has(version)) {
+		const loader = {
+			version,
+			Loader: (await loadPackage(modulePath, "@fluidframework/container-loader")).Loader,
+		};
+		loaderCache.set(version, loader);
+	}
+}
+
+async function loadContainerRuntime(
+	baseVersion: string,
+	requested?: number | string,
+): Promise<void> {
+	const requestedStr = getRequestedRange(baseVersion, requested);
+	if (semver.satisfies(pkgVersion, requestedStr)) {
+		return;
+	}
+
+	const { version, modulePath } = checkInstalled(requestedStr);
+	if (!containerRuntimeCache.has(version)) {
+		const containerRuntime = {
+			version,
+			ContainerRuntime: (await loadPackage(modulePath, "@fluidframework/container-runtime"))
+				.ContainerRuntime,
+			ContainerRuntimeFactoryWithDefaultDataStore: (
+				await loadPackage(modulePath, "@fluidframework/aqueduct")
+			).ContainerRuntimeFactoryWithDefaultDataStore,
+		};
+		containerRuntimeCache.set(version, containerRuntime);
+	}
+}
+
+async function loadDataRuntime(baseVersion: string, requested?: number | string): Promise<void> {
+	const requestedStr = getRequestedRange(baseVersion, requested);
+	if (semver.satisfies(pkgVersion, requestedStr)) {
+		return;
+	}
+	const { version, modulePath } = checkInstalled(requestedStr);
+	if (!dataRuntimeCache.has(version)) {
+		/* eslint-disable @typescript-eslint/no-shadow */
+		const [
+			{ DataObject, DataObjectFactory },
+			{ TestFluidObjectFactory },
+			{ SharedMap, SharedDirectory },
+			{ SharedString },
+			{ SharedCell },
+			{ SharedCounter },
+			{ SharedMatrix },
+			{ Ink },
+			{ ConsensusQueue },
+			{ ConsensusRegisterCollection },
+			{ SparseMatrix },
+		] = await Promise.all([
+			loadPackage(modulePath, "@fluidframework/aqueduct"),
+			loadPackage(modulePath, "@fluidframework/test-utils"),
+			loadPackage(modulePath, "@fluidframework/map"),
+			loadPackage(modulePath, "@fluidframework/sequence"),
+			loadPackage(modulePath, "@fluidframework/cell"),
+			loadPackage(modulePath, "@fluidframework/counter"),
+			loadPackage(modulePath, "@fluidframework/matrix"),
+			loadPackage(modulePath, "@fluidframework/ink"),
+			loadPackage(modulePath, "@fluidframework/ordered-collection"),
+			loadPackage(modulePath, "@fluidframework/register-collection"),
+			loadPackage(
+				modulePath,
+				versionHasMovedSparsedMatrix(version)
+					? "@fluid-experimental/sequence-deprecated"
+					: "@fluidframework/sequence",
+			),
+		]);
+		/* eslint-enable @typescript-eslint/no-shadow */
+
+		const dataRuntime = {
+			version,
+			DataObject,
+			DataObjectFactory,
+			TestFluidObjectFactory,
+			dds: {
+				SharedCell,
+				SharedCounter,
+				Ink,
+				SharedDirectory,
+				SharedMap,
+				SharedMatrix,
+				ConsensusQueue,
+				ConsensusRegisterCollection,
+				SharedString,
+				SparseMatrix,
+			},
+		};
+		dataRuntimeCache.set(version, dataRuntime);
+	}
+}
+
+async function loadDriver(baseVersion: string, requested?: number | string): Promise<void> {
+	const requestedStr = getRequestedRange(baseVersion, requested);
+	if (semver.satisfies(pkgVersion, requestedStr)) {
+		return;
+	}
+
+	const { version, modulePath } = checkInstalled(requestedStr);
+	if (!driverCache.has(version)) {
+		const [
+			{ LocalDocumentServiceFactory, LocalResolver, createLocalResolverCreateNewRequest },
+			{ LocalDeltaConnectionServer },
+			{
+				OdspDocumentServiceFactory,
+				OdspDriverUrlResolver,
+				createOdspCreateContainerRequest,
+				createOdspUrl,
+			},
+			{ RouterliciousDocumentServiceFactory },
+		] = await Promise.all([
+			loadPackage(modulePath, "@fluidframework/local-driver"),
+			loadPackage(modulePath, "@fluidframework/server-local-server"),
+			loadPackage(modulePath, "@fluidframework/odsp-driver"),
+			loadPackage(modulePath, "@fluidframework/routerlicious-driver"),
+		]);
+
+		const LocalDriverApi: typeof DriverApi.LocalDriverApi = {
+			version,
+			LocalDocumentServiceFactory,
+			LocalResolver,
+			LocalDeltaConnectionServer,
+			createLocalResolverCreateNewRequest,
+		};
+
+		const OdspDriverApi: typeof DriverApi.OdspDriverApi = {
+			version,
+			OdspDocumentServiceFactory,
+			OdspDriverUrlResolver,
+			createOdspCreateContainerRequest,
+			createOdspUrl,
+		};
+
+		const RouterliciousDriverApi: typeof DriverApi.RouterliciousDriverApi = {
+			version,
+			modulePath,
+			RouterliciousDocumentServiceFactory,
+		};
+
+		driverCache.set(version, {
+			LocalDriverApi,
+			OdspDriverApi,
+			RouterliciousDriverApi,
+		});
+	}
+}
+
+function throwNotFound(layer: string, version: string): never {
+	throw new Error(`${layer}@${version} not found. Missing install step?`);
+}
+
 export function getLoaderApi(baseVersion: string, requested?: number | string): typeof LoaderApi {
 	const requestedStr = getRequestedRange(baseVersion, requested);
 
@@ -111,11 +286,9 @@ export function getLoaderApi(baseVersion: string, requested?: number | string): 
 		return LoaderApi;
 	}
 
-	const { version, modulePath } = checkInstalled(requestedStr);
-	return {
-		version,
-		Loader: loadPackage(modulePath, "@fluidframework/container-loader").Loader,
-	};
+	const { version } = checkInstalled(requestedStr);
+	const loaderApi = loaderCache.get(version);
+	return loaderApi ?? throwNotFound("Loader", version);
 }
 
 export function getContainerRuntimeApi(
@@ -126,16 +299,8 @@ export function getContainerRuntimeApi(
 	if (semver.satisfies(pkgVersion, requestedStr)) {
 		return ContainerRuntimeApi;
 	}
-	const { version, modulePath } = checkInstalled(requestedStr);
-	return {
-		version,
-		ContainerRuntime: loadPackage(modulePath, "@fluidframework/container-runtime")
-			.ContainerRuntime,
-		ContainerRuntimeFactoryWithDefaultDataStore: loadPackage(
-			modulePath,
-			"@fluidframework/aqueduct",
-		).ContainerRuntimeFactoryWithDefaultDataStore,
-	};
+	const { version } = checkInstalled(requestedStr);
+	return containerRuntimeCache.get(version) ?? throwNotFound("ContainerRuntime", version);
 }
 
 export function getDataRuntimeApi(
@@ -146,35 +311,8 @@ export function getDataRuntimeApi(
 	if (semver.satisfies(pkgVersion, requestedStr)) {
 		return DataRuntimeApi;
 	}
-	const { version, modulePath } = checkInstalled(requestedStr);
-	return {
-		version,
-		DataObject: loadPackage(modulePath, "@fluidframework/aqueduct").DataObject,
-		DataObjectFactory: loadPackage(modulePath, "@fluidframework/aqueduct").DataObjectFactory,
-		TestFluidObjectFactory: loadPackage(modulePath, "@fluidframework/test-utils")
-			.TestFluidObjectFactory,
-		dds: {
-			SharedCell: loadPackage(modulePath, "@fluidframework/cell").SharedCell,
-			SharedCounter: loadPackage(modulePath, "@fluidframework/counter").SharedCounter,
-			Ink: loadPackage(modulePath, "@fluidframework/ink").Ink,
-			SharedDirectory: loadPackage(modulePath, "@fluidframework/map").SharedDirectory,
-			SharedMap: loadPackage(modulePath, "@fluidframework/map").SharedMap,
-			SharedMatrix: loadPackage(modulePath, "@fluidframework/matrix").SharedMatrix,
-			ConsensusQueue: loadPackage(modulePath, "@fluidframework/ordered-collection")
-				.ConsensusQueue,
-			ConsensusRegisterCollection: loadPackage(
-				modulePath,
-				"@fluidframework/register-collection",
-			).ConsensusRegisterCollection,
-			SharedString: loadPackage(modulePath, "@fluidframework/sequence").SharedString,
-			SparseMatrix: loadPackage(
-				modulePath,
-				versionHasMovedSparsedMatrix(version)
-					? "@fluid-experimental/sequence-deprecated"
-					: "@fluidframework/sequence",
-			).SparseMatrix,
-		},
-	};
+	const { version } = checkInstalled(requestedStr);
+	return dataRuntimeCache.get(version) ?? throwNotFound("DataRuntime", version);
 }
 
 export function getDriverApi(baseVersion: string, requested?: number | string): typeof DriverApi {
@@ -185,41 +323,14 @@ export function getDriverApi(baseVersion: string, requested?: number | string): 
 		return DriverApi;
 	}
 
-	const { version, modulePath } = checkInstalled(requestedStr);
-	const localDriverApi: typeof DriverApi.LocalDriverApi = {
-		version,
-		LocalDocumentServiceFactory: loadPackage(modulePath, "@fluidframework/local-driver")
-			.LocalDocumentServiceFactory,
-		LocalResolver: loadPackage(modulePath, "@fluidframework/local-driver").LocalResolver,
-		LocalDeltaConnectionServer: loadPackage(modulePath, "@fluidframework/server-local-server")
-			.LocalDeltaConnectionServer,
-		createLocalResolverCreateNewRequest: loadPackage(modulePath, "@fluidframework/local-driver")
-			.createLocalResolverCreateNewRequest,
-	};
+	const { version } = checkInstalled(requestedStr);
+	return driverCache.get(version) ?? throwNotFound("Driver", version);
+}
 
-	const odspDriverApi: typeof DriverApi.OdspDriverApi = {
-		version,
-		OdspDocumentServiceFactory: loadPackage(modulePath, "@fluidframework/odsp-driver")
-			.OdspDocumentServiceFactory,
-		OdspDriverUrlResolver: loadPackage(modulePath, "@fluidframework/odsp-driver")
-			.OdspDriverUrlResolver,
-		createOdspCreateContainerRequest: loadPackage(modulePath, "@fluidframework/odsp-driver")
-			.createOdspCreateContainerRequest,
-		createOdspUrl: loadPackage(modulePath, "@fluidframework/odsp-driver").createOdspUrl,
-	};
-
-	const routerliciousDriverApi: typeof DriverApi.RouterliciousDriverApi = {
-		version,
-		modulePath,
-		RouterliciousDocumentServiceFactory: loadPackage(
-			modulePath,
-			"@fluidframework/routerlicious-driver",
-		).RouterliciousDocumentServiceFactory,
-	};
-
-	return {
-		LocalDriverApi: localDriverApi,
-		OdspDriverApi: odspDriverApi,
-		RouterliciousDriverApi: routerliciousDriverApi,
-	};
+export interface CompatApis {
+	containerRuntime: ReturnType<typeof getContainerRuntimeApi>;
+	dataRuntime: ReturnType<typeof getDataRuntimeApi>;
+	dds: ReturnType<typeof getDataRuntimeApi>["dds"];
+	driver: ReturnType<typeof getDriverApi>;
+	loader: ReturnType<typeof getLoaderApi>;
 }

--- a/packages/test/test-version-utils/tsconfig.json
+++ b/packages/test/test-version-utils/tsconfig.json
@@ -5,6 +5,7 @@
 		"rootDir": "./src",
 		"outDir": "./dist",
 		"composite": true,
+		"module": "esnext",
 	},
 	"include": ["src/**/*"],
 }


### PR DESCRIPTION
## Description

This allows e2e tests which create their own data objects to correctly test the same compatibility matrix that other e2e tests do. See https://github.com/microsoft/FluidFramework/pull/12052 for a historical approach which generally aligns with this one.

Note: this is a reapplication of the changes in #15917. Reverting this PR didn't fix the issue, and we have since discovered there was a test reporting issue (fixed in #16098). The intermittent failures are therefore likely due to a flaky test, and not changes related to the esnext switch.
