### PR TITLE
Move Sequence Handler to MergeTree Revertibles

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -264,9 +264,9 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		}
 		const op = createInsertSegmentOp(pos, segment);
 
-		const opArgs = { op };
-		this._mergeTree.insertAtReferencePosition(refPos, segment, opArgs);
-		return op;
+		if (this.applyInsertOp({ op })) {
+			return op;
+		}
 	}
 
 	public walkSegments<TClientData>(

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -4,14 +4,11 @@
  */
 
 import {
-	IJSONSegment,
+	appendToMergeTreeDeltaRevertibles,
+	discardMergeTreeDeltaRevertible,
 	ISegment,
-	matchProperties,
-	MergeTreeDeltaOperationType,
-	MergeTreeDeltaType,
-	PropertySet,
-	ReferenceType,
-	TrackingGroup,
+	MergeTreeDeltaRevertible,
+	revertMergeTreeDeltaRevertibles,
 } from "@fluidframework/merge-tree";
 import { SequenceDeltaEvent, SharedSegmentSequence } from "@fluidframework/sequence";
 import { IRevertible, UndoRedoStackManager } from "./undoRedoStackManager";
@@ -54,108 +51,25 @@ export class SharedSegmentSequenceUndoRedoHandler {
 	};
 }
 
-interface ITrackedSharedSegmentSequenceRevertible {
-	trackingGroup: TrackingGroup;
-	propertyDelta: PropertySet;
-	operation: MergeTreeDeltaOperationType;
-}
-
 /**
  * Tracks a change on a shared segment sequence and allows reverting it
  */
 export class SharedSegmentSequenceRevertible implements IRevertible {
-	private readonly tracking: ITrackedSharedSegmentSequenceRevertible[];
+	private readonly revertibles: MergeTreeDeltaRevertible[];
 
 	constructor(public readonly sequence: SharedSegmentSequence<ISegment>) {
-		this.tracking = [];
+		this.revertibles = [];
 	}
 
 	public add(event: SequenceDeltaEvent) {
-		if (event.ranges.length > 0) {
-			let current =
-				this.tracking.length > 0 ? this.tracking[this.tracking.length - 1] : undefined;
-			for (const range of event.ranges) {
-				if (
-					current !== undefined &&
-					current.operation === event.deltaOperation &&
-					matchProperties(current.propertyDelta, range.propertyDeltas)
-				) {
-					current.trackingGroup.link(range.segment);
-				} else {
-					const tg = new TrackingGroup();
-					tg.link(range.segment);
-					current = {
-						trackingGroup: tg,
-						propertyDelta: range.propertyDeltas,
-						operation: event.deltaOperation,
-					};
-					this.tracking.push(current);
-				}
-			}
-		}
+		appendToMergeTreeDeltaRevertibles(event.deltaArgs, this.revertibles);
 	}
 
 	public revert() {
-		while (this.tracking.length > 0) {
-			const tracked = this.tracking.pop();
-			if (tracked !== undefined) {
-				while (tracked.trackingGroup.size > 0) {
-					const sg = tracked.trackingGroup.segments[0];
-					sg.trackingCollection.unlink(tracked.trackingGroup);
-					switch (tracked.operation) {
-						case MergeTreeDeltaType.INSERT:
-							if (sg.removedSeq === undefined) {
-								const start = this.sequence.getPosition(sg);
-								this.sequence.removeRange(start, start + sg.cachedLength);
-							}
-							break;
-
-						case MergeTreeDeltaType.REMOVE:
-							const insertSegment = this.sequence.segmentFromSpec(
-								sg.toJSONObject() as IJSONSegment,
-							);
-							this.sequence.insertAtReferencePosition(
-								this.sequence.createLocalReferencePosition(
-									sg,
-									0,
-									ReferenceType.Transient,
-									undefined,
-								),
-								insertSegment,
-							);
-							sg.trackingCollection.trackingGroups.forEach((tg) => {
-								tg.link(insertSegment);
-								tg.unlink(sg);
-							});
-							break;
-
-						case MergeTreeDeltaType.ANNOTATE:
-							if (sg.removedSeq === undefined) {
-								const start = this.sequence.getPosition(sg);
-								this.sequence.annotateRange(
-									start,
-									start + sg.cachedLength,
-									tracked.propertyDelta,
-									undefined,
-								);
-							}
-							break;
-						default:
-							throw new Error("operation type not revertible");
-					}
-				}
-			}
-		}
+		revertMergeTreeDeltaRevertibles(this.sequence, this.revertibles);
 	}
 
 	public discard() {
-		while (this.tracking.length > 0) {
-			const tracked = this.tracking.pop();
-			if (tracked !== undefined) {
-				while (tracked.trackingGroup.size > 0) {
-					tracked.trackingGroup.unlink(tracked.trackingGroup.segments[0]);
-				}
-			}
-		}
+		discardMergeTreeDeltaRevertible(this.revertibles);
 	}
 }


### PR DESCRIPTION
## Description
Now that mergeTreeNewLengthCalculations is on by default we can swap the internals of the sequence handler to the common undo redo constructs exported by MergeTree. This also allows a bit of clean up in the merge tree internals to remove code only used by previous and broken undo stack.