### PR TITLE
Fix bug in --private handling

### DIFF
--- a/build-tools/packages/build-cli/src/filter.ts
+++ b/build-tools/packages/build-cli/src/filter.ts
@@ -150,7 +150,7 @@ export function filterPackages(
 		const { package: pkg } = details;
 
 		const isPrivate: boolean = pkg.packageJson.private ?? false;
-		if (pkg.packageJson.private !== undefined && filters.private !== isPrivate) {
+		if (filters.private !== undefined && filters.private !== isPrivate) {
 			return false;
 		}
 


### PR DESCRIPTION
## Description

Some refactoring done in #16054 seems to have introduced an issue with handling of the absence of `--private`. See logical difference between `BasePackageCommand.filterScopes` and the corresponding moved code in `filter.ts`.
