### PR TITLE
test(devtools-view): Add some simple component-level unit tests

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
@@ -81,6 +81,8 @@ export function AudienceHistoryTable(props: AudienceHistoryTableProps): React.Re
 			<TableBody>
 				{audienceHistoryItems.map((item, itemIndex) => (
 					<TableRow
+						// The list of items here is never reordered, and is strictly appended to,
+						// so using the index as the key here is safe.
 						key={itemIndex}
 						style={{
 							backgroundColor:

--- a/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
@@ -136,5 +136,5 @@ export interface TransformedAudienceStateData {
 export interface TransformedAudienceHistoryData {
 	clientId: string;
 	time: string;
-	changeKind: string;
+	changeKind: "joined" | "left";
 }

--- a/packages/tools/devtools/devtools-view/src/components/Waiting.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/Waiting.tsx
@@ -6,7 +6,10 @@
 import { Spinner } from "@fluentui/react-components";
 import React from "react";
 
-const defaultLabel = "Waiting for data from webpage.";
+/**
+ * Default label displayed by {@link Waiting} when no {@link WaitingProps.label} is specified.
+ */
+export const defaultWaitingLabel = "Waiting for data from webpage.";
 
 /**
  * {@link Waiting} input props.
@@ -14,6 +17,8 @@ const defaultLabel = "Waiting for data from webpage.";
 export interface WaitingProps {
 	/**
 	 * Label text to accompany the spinner.
+	 *
+	 * @defaultValue {@link defaultWaitingLabel}
 	 */
 	label?: string;
 }
@@ -23,5 +28,5 @@ export interface WaitingProps {
  */
 export function Waiting(props: WaitingProps): React.ReactElement {
 	const { label } = props;
-	return <Spinner label={label ?? defaultLabel} />;
+	return <Spinner label={label ?? defaultWaitingLabel} />;
 }

--- a/packages/tools/devtools/devtools-view/src/components/index.ts
+++ b/packages/tools/devtools/devtools-view/src/components/index.ts
@@ -9,6 +9,7 @@
 
 export * from "./data-visualization";
 
+export * from "./AudienceHistoryTable";
 export * from "./AudienceView";
 export * from "./ContainerDevtoolsView";
 export * from "./ContainerHistoryView";

--- a/packages/tools/devtools/devtools-view/src/test/AudienceHistoryTable.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/AudienceHistoryTable.test.tsx
@@ -1,0 +1,54 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+// eslint-disable-next-line import/no-unassigned-import
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { AudienceHistoryTable, TransformedAudienceHistoryData } from "../components";
+
+describe("AudienceHistoryTable component tests", () => {
+	async function getTableBodyRows(): Promise<HTMLCollection> {
+		const tableElement = await screen.findByRole("table");
+		expect(tableElement.children).toHaveLength(2); // Header and body
+
+		const tableBodyElement = tableElement.children[1];
+		return tableBodyElement.children;
+	}
+
+	it("Empty list", async (): Promise<void> => {
+		render(<AudienceHistoryTable audienceHistoryItems={[]} />);
+
+		const tableBodyRows = await getTableBodyRows();
+		expect(tableBodyRows).toHaveLength(0);
+	});
+
+	it("Non-empty list", async (): Promise<void> => {
+		const audienceHistoryItems: TransformedAudienceHistoryData[] = [
+			{
+				clientId: "Foo",
+				time: "yesterday",
+				changeKind: "joined",
+			},
+			{
+				clientId: "Bar",
+				time: "yesterday",
+				changeKind: "joined",
+			},
+			{
+				clientId: "Foo",
+				time: "today",
+				changeKind: "left",
+			},
+		];
+
+		render(<AudienceHistoryTable audienceHistoryItems={audienceHistoryItems} />);
+
+		const tableBodyRows = await getTableBodyRows();
+		expect(tableBodyRows).toHaveLength(3);
+	});
+});

--- a/packages/tools/devtools/devtools-view/src/test/Waiting.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/Waiting.test.tsx
@@ -5,8 +5,6 @@
 
 import React from "react";
 
-// // eslint-disable-next-line import/no-unassigned-import
-// import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
 import { Waiting, defaultWaitingLabel } from "../components";

--- a/packages/tools/devtools/devtools-view/src/test/Waiting.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/Waiting.test.tsx
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+// // eslint-disable-next-line import/no-unassigned-import
+// import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { Waiting, defaultWaitingLabel } from "../components";
+
+describe("Waiting component tests", () => {
+	// eslint-disable-next-line jest/expect-expect
+	it("Displays default label when a label is not specified", async (): Promise<void> => {
+		render(<Waiting />);
+
+		await screen.findByText(defaultWaitingLabel); // Will throw if exact text not found
+	});
+
+	// eslint-disable-next-line jest/expect-expect
+	it("Displays the provided label", async (): Promise<void> => {
+		const label = "Hello world!";
+		render(<Waiting label={label} />);
+
+		await screen.findByText(label); // Will throw if exact text not found
+	});
+});


### PR DESCRIPTION
Adds a bit of test coverage and adds simple examples of how to write `@testing-library/react`-based unit tests for our view components.

\+ Some misc. docs and refactoring