### PR TITLE
Skip flaky e2e blob test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1123,6 +1123,11 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 	});
 
 	it("load offline with blob redirect table", async function () {
+		if (provider.driver.type === "local") {
+			// TODO:AB#4746: Resolve flakiness of this test on localserver CI.
+			this.skip();
+		}
+
 		// upload blob offline so an entry is added to redirect table
 		const container = await loadOffline(provider, { url });
 		const dataStore = await requestFluidObject<ITestFluidObject>(


### PR DESCRIPTION
## Description

Skips a flaky test for local server.

Increasing the timeout might also be sufficient here--the test doesn't fail on t9s where we have a higher default timeout.