### PR TITLE
Handle log offset assertion error

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -81,7 +81,6 @@ export class DocumentContextManager extends EventEmitter {
 	 */
 	public setHead(head: IQueuedMessage) {
 		if (head.offset > this.head.offset) {
-			console.log(`MSG OFFSET: ${head.offset}, HEAD: ${this.head.offset}`);
 			this.head = head;
 			return true;
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -81,10 +81,11 @@ export class DocumentContextManager extends EventEmitter {
 	 */
 	public setHead(head: IQueuedMessage) {
 		if (head.offset > this.head.offset) {
+			console.log(`MSG OFFSET: ${head.offset}, HEAD: ${this.head.offset}`);
 			this.head = head;
 			return true;
 		}
-
+		console.log(`MSG OFFSET: ${head.offset}, HEAD: ${this.head.offset}`);
 		return false;
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -84,6 +84,7 @@ export class DocumentContextManager extends EventEmitter {
 			this.head = head;
 			return true;
 		}
+
 		return false;
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -85,7 +85,6 @@ export class DocumentContextManager extends EventEmitter {
 			this.head = head;
 			return true;
 		}
-		console.log(`MSG OFFSET: ${head.offset}, HEAD: ${this.head.offset}`);
 		return false;
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -20,7 +20,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 	// the document.
 	private headInternal: IQueuedMessage;
 	private tailInternal: IQueuedMessage;
-	private firstTest: boolean;
 
 	private closed = false;
 	private contextError = undefined;
@@ -82,17 +81,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		// Assert offset is between the current tail and head
 		const offset = message.offset;
 
-		// let offset = message.offset;
-		if (this.firstTest) {
-			this.tail.offset = this.head.offset;
-			// offset = offset-1;
-			this.firstTest = false;
-		}
-
 		try {
-			console.log(`*********`);
-			console.log(`Tail: ${this.tail.offset}, Offset: ${offset}, Head: ${this.head.offset}`);
-			console.log(`*********`);
 			assert(
 				offset > this.tail.offset && offset <= this.head.offset,
 				`${offset} > ${this.tail.offset} && ${offset} <= ${this.head.offset} ` +
@@ -101,10 +90,8 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 			// Update the tail and broadcast the checkpoint
 			this.tailInternal = message;
-			console.log(`*******EMIT HERE*********`);
 			this.emit("checkpoint", restartOnCheckpointFailure);
 		} catch (error) {
-			console.log(`*******ERROR*********`);
 			// Mark the document as corrupted
 			const documentId = this.routingKey.documentId;
 			const tenantId = this.routingKey.tenantId;

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -36,7 +36,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 		// Tail will be set to the checkpoint offset of the previous head
 		this.headInternal = head;
 		this.tailInternal = this.getLatestTail();
-		this.firstTest = true;
 	}
 
 	public get head(): IQueuedMessage {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -68,7 +68,7 @@ export class DocumentPartition {
 
 		this.context.on("error", (error: any, errorData: IContextErrorData) => {
 			if (errorData.markAsCorrupt) {
-				this.markAsCorrupt(error, errorData.markAsCorrupt);
+				this.markAsCorrupt(error, errorData.markAsCorrupt, errorData.skipCheckpoint);
 			} else if (errorData.restart) {
 				// ensure no more messages are processed by this partition
 				// while the process is restarting / closing
@@ -140,7 +140,7 @@ export class DocumentPartition {
 	 * Marks this document partition as corrupt
 	 * Future messages will be checkpointed but no real processing will happen
 	 */
-	private markAsCorrupt(error: any, message?: IQueuedMessage) {
+	private markAsCorrupt(error: any, message?: IQueuedMessage, skipCheckpoint: boolean = false) {
 		this.corrupt = true;
 		this.context.log?.error(`Marking document as corrupted due to error: ${inspect(error)}`, {
 			messageMetaData: {
@@ -159,7 +159,8 @@ export class DocumentPartition {
 			tenantId: this.tenantId,
 			documentId: this.documentId,
 		});
-		if (message) {
+		console.log(`SKIP CHECKPOINT: ${skipCheckpoint}`);
+		if (message && !skipCheckpoint) {
 			this.context.checkpoint(message);
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -50,6 +50,11 @@ export interface IContextErrorData {
 	 */
 	markAsCorrupt?: IQueuedMessage;
 
+	/**
+	 * Indicates if the checkpoint should be skipped when marking a document as corrupt.
+	 */
+	skipCheckpoint?: boolean;
+
 	tenantId?: string;
 	documentId?: string;
 }


### PR DESCRIPTION
About
> Currently, the service restarts when the assertion that current message is between the current head and tail fails. We do not need to restart on this, but rather mark the document as corrupted and move the tail forward to continue processing messages. This also adds the option to skip the checkpoint when marking a document as corrupt, as the offset error caused us to enter an error loop when trying to checkpoint.

Testing
> This was tested by manually setting the current head and tail equal to each other, so that the assertion failed. 
> - Verified that the error is caught and the document is marked as corrupted.
> - Verified that new documents are able to be created and sync properly after processing the above error.
> - Verified that the checkpoint is skipped after the document is marked as corrupted.