### PR TITLE
fix(changesets): Handle uncommitted changesets

### DIFF
--- a/build-tools/packages/build-cli/src/lib/changesets.ts
+++ b/build-tools/packages/build-cli/src/lib/changesets.ts
@@ -5,7 +5,7 @@
 
 import { VersionBumpType } from "@fluid-tools/version-tools";
 import { Logger } from "@fluidframework/build-tools";
-import { compareAsc, parseISO } from "date-fns";
+import { compareAsc, formatISO, parseISO } from "date-fns";
 import globby from "globby";
 import matter from "gray-matter";
 import path from "node:path";
@@ -59,7 +59,9 @@ export async function loadChangesets(dir: string, log?: Logger): Promise<Changes
 		// Get the date the changeset file was added to git.
 		// eslint-disable-next-line no-await-in-loop
 		const results = await repo.gitClient.log({ file, maxCount: 1, strictDate: true });
-		const added = parseISO(results.all[0].date);
+		
+		// Newly added files won't have any results from git log, so default to now.
+		const added = parseISO(results.all?.[0]?.date ?? formatISO(Date.now()));
 
 		// Read the changeset file into content and metadata (front-matter)
 		const md = matter.read(file);

--- a/build-tools/packages/build-cli/src/lib/changesets.ts
+++ b/build-tools/packages/build-cli/src/lib/changesets.ts
@@ -59,7 +59,7 @@ export async function loadChangesets(dir: string, log?: Logger): Promise<Changes
 		// Get the date the changeset file was added to git.
 		// eslint-disable-next-line no-await-in-loop
 		const results = await repo.gitClient.log({ file, maxCount: 1, strictDate: true });
-		
+
 		// Newly added files won't have any results from git log, so default to now.
 		const added = parseISO(results.all?.[0]?.date ?? formatISO(Date.now()));
 


### PR DESCRIPTION
An uncommitted changeset will not have a date associated with it in `git log`. This change handles that case and sets the added date to `Date.now()` if needed.