### PR TITLE
Hide IConnectionDetailsInternal and IDeltaHandlerStrategy, and remove two events

### DIFF
--- a/.changeset/early-knives-ask.md
+++ b/.changeset/early-knives-ask.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-definitions": major
+---
+
+allSentOpsAckd and processTime events removed from IDeltaManagerEvents
+
+The "allSentOpsAckd" and "processTime" events on the IDeltaManagerEvents interface were deprecated in 2.0.0-internal.2.2.0 and have now been removed.

--- a/.changeset/eight-berries-grab.md
+++ b/.changeset/eight-berries-grab.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-definitions": major
+---
+
+IConnectionDetailsInternal and IDeltaHandlerStrategy removed
+
+IConnectionDetailsInternal and IDeltaHandlerStrategy from the @fluidframework/container-definitions package were deprecated in 2.0.0-internal.5.2.0 and have now been removed.

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { EventEmitter } from 'events';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IAnyDriverError } from '@fluidframework/driver-definitions';
@@ -24,7 +23,6 @@ import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedProposal } from '@fluidframework/protocol-definitions';
-import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { ISummaryContent } from '@fluidframework/protocol-definitions';
@@ -113,18 +111,6 @@ export interface IConnectionDetails {
     clientId: string;
     // (undocumented)
     serviceConfiguration: IClientConfiguration;
-}
-
-// @public @deprecated
-export interface IConnectionDetailsInternal extends IConnectionDetails {
-    // @deprecated (undocumented)
-    initialClients: ISignalClient[];
-    // @deprecated (undocumented)
-    mode: ConnectionMode;
-    // @deprecated (undocumented)
-    reason: string;
-    // @deprecated (undocumented)
-    version: string;
 }
 
 // @public
@@ -240,14 +226,6 @@ export interface IContainerLoadMode {
 // @public
 export type ICriticalContainerError = IErrorBase;
 
-// @public @deprecated
-export interface IDeltaHandlerStrategy {
-    // @deprecated
-    process: (message: ISequencedDocumentMessage) => void;
-    // @deprecated
-    processSignal: (message: ISignalMessage) => void;
-}
-
 // @public
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender, IDisposable {
     readonly active: boolean;
@@ -277,11 +255,7 @@ export interface IDeltaManagerEvents extends IEvent {
     (event: "submitOp", listener: (message: IDocumentMessage) => void): any;
     (event: "op", listener: (message: ISequencedDocumentMessage, processingTime: number) => void): any;
     // @deprecated (undocumented)
-    (event: "allSentOpsAckd", listener: () => void): any;
-    // @deprecated (undocumented)
     (event: "pong", listener: (latency: number) => void): any;
-    // @deprecated (undocumented)
-    (event: "processTime", listener: (latency: number) => void): any;
     (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void): any;
     (event: "disconnect", listener: (reason: string, error?: IAnyDriverError) => void): any;
     (event: "readonly", listener: (readonly: boolean) => void): any;

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -64,6 +64,14 @@
 		"broken": {
 			"InterfaceDeclaration_IContainerContext": {
 				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_IConnectionDetailsInternal": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedInterfaceDeclaration_IDeltaHandlerStrategy": {
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -5,18 +5,16 @@
 
 import {
 	IDisposable,
+	IErrorEvent,
 	IEventProvider,
 	IEvent,
-	IErrorEvent,
 } from "@fluidframework/common-definitions";
 import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import {
-	ConnectionMode,
 	IClientConfiguration,
 	IClientDetails,
 	IDocumentMessage,
 	ISequencedDocumentMessage,
-	ISignalClient,
 	ISignalMessage,
 	ITokenClaims,
 } from "@fluidframework/protocol-definitions";
@@ -40,47 +38,6 @@ export interface IConnectionDetails {
 	 * that is likely to be more up-to-date.
 	 */
 	checkpointSequenceNumber: number | undefined;
-}
-
-/**
- * Internal version of IConnectionDetails with props are only exposed internally
- * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
- */
-export interface IConnectionDetailsInternal extends IConnectionDetails {
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
-	 */
-	mode: ConnectionMode;
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
-	 */
-	version: string;
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
-	 */
-	initialClients: ISignalClient[];
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
-	 */
-	reason: string;
-}
-
-/**
- * Interface used to define a strategy for handling incoming delta messages
- * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
- */
-export interface IDeltaHandlerStrategy {
-	/**
-	 * Processes the message.
-	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
-	 */
-	process: (message: ISequencedDocumentMessage) => void;
-
-	/**
-	 * Processes the signal.
-	 * @deprecated 2.0.0-internal.5.2.0 - Intended for internal use only and will be removed in an upcoming relase.
-	 */
-	processSignal: (message: ISignalMessage) => void;
 }
 
 /**
@@ -127,17 +84,7 @@ export interface IDeltaManagerEvents extends IEvent {
 	/**
 	 * @deprecated No replacement API recommended.
 	 */
-	(event: "allSentOpsAckd", listener: () => void);
-
-	/**
-	 * @deprecated No replacement API recommended.
-	 */
 	(event: "pong", listener: (latency: number) => void);
-
-	/**
-	 * @deprecated No replacement API recommended.
-	 */
-	(event: "processTime", listener: (latency: number) => void);
 
 	/**
 	 * Emitted when the {@link IDeltaManager} completes connecting to the Fluid service.

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -17,13 +17,11 @@ export {
 } from "./browserPackage";
 export {
 	IConnectionDetails,
-	IConnectionDetailsInternal,
-	IDeltaHandlerStrategy,
 	IDeltaManager,
 	IDeltaManagerEvents,
-	IDeltaSender,
 	IDeltaQueue,
 	IDeltaQueueEvents,
+	IDeltaSender,
 	ReadOnlyInfo,
 } from "./deltas";
 export {

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -352,26 +352,14 @@ use_old_InterfaceDeclaration_IConnectionDetails(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IConnectionDetailsInternal": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IConnectionDetailsInternal": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IConnectionDetailsInternal():
-    TypeOnly<old.IConnectionDetailsInternal>;
-declare function use_current_InterfaceDeclaration_IConnectionDetailsInternal(
-    use: TypeOnly<current.IConnectionDetailsInternal>);
-use_current_InterfaceDeclaration_IConnectionDetailsInternal(
-    get_old_InterfaceDeclaration_IConnectionDetailsInternal());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IConnectionDetailsInternal": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IConnectionDetailsInternal": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IConnectionDetailsInternal():
-    TypeOnly<current.IConnectionDetailsInternal>;
-declare function use_old_InterfaceDeclaration_IConnectionDetailsInternal(
-    use: TypeOnly<old.IConnectionDetailsInternal>);
-use_old_InterfaceDeclaration_IConnectionDetailsInternal(
-    get_current_InterfaceDeclaration_IConnectionDetailsInternal());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -497,26 +485,14 @@ use_old_TypeAliasDeclaration_ICriticalContainerError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IDeltaHandlerStrategy": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IDeltaHandlerStrategy": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IDeltaHandlerStrategy():
-    TypeOnly<old.IDeltaHandlerStrategy>;
-declare function use_current_InterfaceDeclaration_IDeltaHandlerStrategy(
-    use: TypeOnly<current.IDeltaHandlerStrategy>);
-use_current_InterfaceDeclaration_IDeltaHandlerStrategy(
-    get_old_InterfaceDeclaration_IDeltaHandlerStrategy());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IDeltaHandlerStrategy": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IDeltaHandlerStrategy": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IDeltaHandlerStrategy():
-    TypeOnly<current.IDeltaHandlerStrategy>;
-declare function use_old_InterfaceDeclaration_IDeltaHandlerStrategy(
-    use: TypeOnly<old.IDeltaHandlerStrategy>);
-use_old_InterfaceDeclaration_IDeltaHandlerStrategy(
-    get_current_InterfaceDeclaration_IDeltaHandlerStrategy());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -7,10 +7,9 @@ import { default as AbortController } from "abort-controller";
 import { IDisposable, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { assert, performance, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
+	ICriticalContainerError,
 	IDeltaQueue,
 	ReadOnlyInfo,
-	IConnectionDetailsInternal,
-	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 import { GenericError, UsageError } from "@fluidframework/container-utils";
 import {
@@ -48,7 +47,12 @@ import {
 	TelemetryLogger,
 	normalizeError,
 } from "@fluidframework/telemetry-utils";
-import { ReconnectMode, IConnectionManager, IConnectionManagerFactoryArgs } from "./contracts";
+import {
+	IConnectionDetailsInternal,
+	IConnectionManager,
+	IConnectionManagerFactoryArgs,
+	ReconnectMode,
+} from "./contracts";
 import { DeltaQueue } from "./deltaQueue";
 import { SignalType } from "./protocol";
 import { isDeltaStreamConnectionForbiddenError } from "./utils";

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -5,7 +5,7 @@
 
 import { ITelemetryProperties, TelemetryEventCategory } from "@fluidframework/common-definitions";
 import { assert, Timer } from "@fluidframework/common-utils";
-import { IConnectionDetailsInternal, IDeltaManager } from "@fluidframework/container-definitions";
+import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import { ISequencedClient, IClient } from "@fluidframework/protocol-definitions";
 import {
@@ -13,8 +13,9 @@ import {
 	PerformanceEvent,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils";
-import { ConnectionState } from "./connectionState";
 import { CatchUpMonitor, ICatchUpMonitor } from "./catchUpMonitor";
+import { ConnectionState } from "./connectionState";
+import { IConnectionDetailsInternal } from "./contracts";
 import { ILocalSequencedClient, IProtocolHandler } from "./protocol";
 
 // Based on recent data, it looks like majority of cases where we get stuck are due to really slow or

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -11,22 +11,21 @@ import { ITelemetryProperties, TelemetryEventCategory } from "@fluidframework/co
 import { assert, performance, unreachableCase } from "@fluidframework/common-utils";
 import { IRequest, IResponse, IFluidRouter, FluidObject } from "@fluidframework/core-interfaces";
 import {
-	IAudience,
-	IConnectionDetailsInternal,
-	IContainer,
-	IContainerEvents,
-	IDeltaManager,
-	ICriticalContainerError,
-	ContainerWarning,
 	AttachState,
-	IThrottlingWarning,
-	ReadOnlyInfo,
-	IContainerLoadMode,
-	IFluidCodeDetails,
-	isFluidCodeDetails,
+	ContainerWarning,
+	IAudience,
 	IBatchMessage,
 	ICodeDetailsLoader,
+	IContainer,
+	IContainerEvents,
+	IContainerLoadMode,
+	ICriticalContainerError,
+	IDeltaManager,
+	IFluidCodeDetails,
 	IHostLoader,
+	isFluidCodeDetails,
+	IThrottlingWarning,
+	ReadOnlyInfo,
 } from "@fluidframework/container-definitions";
 import { GenericError, UsageError } from "@fluidframework/container-utils";
 import {
@@ -81,7 +80,12 @@ import {
 } from "@fluidframework/telemetry-utils";
 import { Audience } from "./audience";
 import { ContainerContext } from "./containerContext";
-import { ReconnectMode, IConnectionManagerFactoryArgs, getPackageName } from "./contracts";
+import {
+	ReconnectMode,
+	IConnectionManagerFactoryArgs,
+	getPackageName,
+	IConnectionDetailsInternal,
+} from "./contracts";
 import { DeltaManager, IConnectionArgs } from "./deltaManager";
 import { DeltaManagerProxy } from "./deltaManagerProxy";
 import { IDetachedBlobStorage, ILoaderOptions, RelativeLoader } from "./loader";

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -5,19 +5,20 @@
 
 import { ITelemetryProperties } from "@fluidframework/common-definitions";
 import {
-	IDeltaQueue,
-	ReadOnlyInfo,
-	IConnectionDetailsInternal,
+	IConnectionDetails,
 	ICriticalContainerError,
+	IDeltaQueue,
 	IFluidCodeDetails,
 	isFluidPackage,
+	ReadOnlyInfo,
 } from "@fluidframework/container-definitions";
 import {
 	ConnectionMode,
-	IDocumentMessage,
-	ISequencedDocumentMessage,
 	IClientConfiguration,
 	IClientDetails,
+	IDocumentMessage,
+	ISequencedDocumentMessage,
+	ISignalClient,
 	ISignalMessage,
 } from "@fluidframework/protocol-definitions";
 import { IAnyDriverError, IContainerPackageInfo } from "@fluidframework/driver-definitions";
@@ -26,6 +27,16 @@ export enum ReconnectMode {
 	Never = "Never",
 	Disabled = "Disabled",
 	Enabled = "Enabled",
+}
+
+/**
+ * Internal version of IConnectionDetails with props are only exposed internally
+ */
+export interface IConnectionDetailsInternal extends IConnectionDetails {
+	mode: ConnectionMode;
+	version: string;
+	initialClients: ISignalClient[];
+	reason: string;
 }
 
 /**

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -11,13 +11,11 @@ import {
 	ITelemetryErrorEvent,
 } from "@fluidframework/common-definitions";
 import {
-	IDeltaHandlerStrategy,
+	ICriticalContainerError,
 	IDeltaManager,
 	IDeltaManagerEvents,
 	IDeltaQueue,
-	ICriticalContainerError,
 	IThrottlingWarning,
-	IConnectionDetailsInternal,
 } from "@fluidframework/container-definitions";
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
@@ -48,7 +46,11 @@ import {
 	DataProcessingError,
 	UsageError,
 } from "@fluidframework/container-utils";
-import { IConnectionManagerFactoryArgs, IConnectionManager } from "./contracts";
+import {
+	IConnectionDetailsInternal,
+	IConnectionManager,
+	IConnectionManagerFactoryArgs,
+} from "./contracts";
 import { DeltaQueue } from "./deltaQueue";
 import { OnlyValidTermValue } from "./protocol";
 
@@ -68,6 +70,21 @@ export interface IDeltaManagerInternalEvents extends IDeltaManagerEvents {
 	(event: "connect", listener: (details: IConnectionDetailsInternal, opsBehind?: number) => void);
 	(event: "establishingConnection", listener: (reason: string) => void);
 	(event: "cancelEstablishingConnection", listener: (reason: string) => void);
+}
+
+/**
+ * Interface used to define a strategy for handling incoming delta messages
+ */
+export interface IDeltaHandlerStrategy {
+	/**
+	 * Processes the message.
+	 */
+	process: (message: ISequencedDocumentMessage) => void;
+
+	/**
+	 * Processes the signal.
+	 */
+	processSignal: (message: ISignalMessage) => void;
 }
 
 /**

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -12,20 +12,17 @@ import {
 	ITokenClaims,
 	ISequencedClient,
 } from "@fluidframework/protocol-definitions";
-import {
-	IConnectionDetailsInternal,
-	IDeltaManager,
-	IDeltaManagerEvents,
-} from "@fluidframework/container-definitions";
+import { IDeltaManager, IDeltaManagerEvents } from "@fluidframework/container-definitions";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { ITelemetryProperties, TelemetryEventCategory } from "@fluidframework/common-definitions";
+import { Audience } from "../audience";
 import { ConnectionState } from "../connectionState";
 import {
 	IConnectionStateHandlerInputs,
 	IConnectionStateHandler,
 	createConnectionStateHandlerCore,
 } from "../connectionStateHandler";
-import { Audience } from "../audience";
+import { IConnectionDetailsInternal } from "../contracts";
 import { ProtocolHandler } from "../protocol";
 
 class MockDeltaManagerForCatchingUp


### PR DESCRIPTION
Followups from #12683 and #16065

I only removed the events that are no longer fired.  The other deprecated events are actually in use and need some plan to remove safely.

Also did a little bit of alphabetizing while I was in the neighborhood, though didn't try to fix everything.