### PR TITLE
Log container dispose error telemetry if not already closed

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1024,7 +1024,8 @@ export class Container
 				this.mc.logger.sendTelemetryEvent(
 					{
 						eventName: "ContainerDispose",
-						category: "generic",
+						// Only log error if container isn't closed
+						category: !this.closed && error !== undefined ? "error" : "generic",
 					},
 					error,
 				);

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -50,6 +50,7 @@ import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IClient } from "@fluidframework/protocol-definitions";
+import { DataCorruptionError } from "@fluidframework/container-utils";
 
 const id = "fluid-test://localhost/containerTest";
 const testRequest: IRequest = { url: id };
@@ -100,19 +101,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 	}
 
 	async function createConnectedContainer(): Promise<IContainer> {
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
-		const runtimeFactory = (_?: unknown) =>
-			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {}, [
-				innerRequestHandler,
-			]);
-		const localTestObjectProvider = new TestObjectProvider(
-			Loader,
-			provider.driver,
-			runtimeFactory,
-		);
-
-		const container = await localTestObjectProvider.makeTestContainer();
+		const container = await provider.makeTestContainer();
 		await waitForContainerConnection(container, true, {
 			durationMs: timeoutMs,
 			errorMsg: "Container initial connection timeout",
@@ -594,78 +583,89 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 		assert.strictEqual(run, 1, "DeltaManager should send readonly event on container close");
 	});
 
-	it("Disposing container should send dispose events", async () => {
-		const container = await createConnectedContainer();
-		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
+	itExpects(
+		"Disposing container should send dispose events",
+		[{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" }],
+		async () => {
+			const container = await createConnectedContainer();
+			const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 
-		let containerDisposed = 0;
-		let containerClosed = 0;
-		let deltaManagerDisposed = 0;
-		let deltaManagerClosed = 0;
-		let runtimeDispose = 0;
-		container.on("disposed", () => containerDisposed++);
-		container.on("closed", () => containerClosed++);
-		(container.deltaManager as any).on("disposed", () => deltaManagerDisposed++);
-		(container.deltaManager as any).on("closed", () => deltaManagerClosed++);
-		(dataObject._context.containerRuntime as ContainerRuntime).on(
-			"dispose",
-			() => runtimeDispose++,
-		);
+			let containerDisposed = 0;
+			let containerClosed = 0;
+			let deltaManagerDisposed = 0;
+			let deltaManagerClosed = 0;
+			let runtimeDispose = 0;
+			container.on("disposed", () => containerDisposed++);
+			container.on("closed", () => containerClosed++);
+			(container.deltaManager as any).on("disposed", () => deltaManagerDisposed++);
+			(container.deltaManager as any).on("closed", () => deltaManagerClosed++);
+			(dataObject._context.containerRuntime as ContainerRuntime).on(
+				"dispose",
+				() => runtimeDispose++,
+			);
 
-		container.dispose();
-		assert.strictEqual(
-			containerDisposed,
-			1,
-			"Container should send disposed event on container dispose",
-		);
-		assert.strictEqual(
-			containerClosed,
-			0,
-			"Container should not send closed event on container dispose",
-		);
-		assert.strictEqual(
-			deltaManagerDisposed,
-			1,
-			"DeltaManager should send disposed event on container dispose",
-		);
-		assert.strictEqual(
-			deltaManagerClosed,
-			0,
-			"DeltaManager should not send closed event on container dispose",
-		);
-		assert.strictEqual(
-			runtimeDispose,
-			1,
-			"ContainerRuntime should send dispose event on container dispose",
-		);
-	});
+			container.dispose(new DataCorruptionError("expected", {}));
+			assert.strictEqual(
+				containerDisposed,
+				1,
+				"Container should send disposed event on container dispose",
+			);
+			assert.strictEqual(
+				containerClosed,
+				0,
+				"Container should not send closed event on container dispose",
+			);
+			assert.strictEqual(
+				deltaManagerDisposed,
+				1,
+				"DeltaManager should send disposed event on container dispose",
+			);
+			assert.strictEqual(
+				deltaManagerClosed,
+				0,
+				"DeltaManager should not send closed event on container dispose",
+			);
+			assert.strictEqual(
+				runtimeDispose,
+				1,
+				"ContainerRuntime should send dispose event on container dispose",
+			);
+		},
+	);
 
-	it("Closing then disposing container should send close and dispose events", async () => {
-		const container = await createConnectedContainer();
-		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
+	itExpects(
+		"Closing then disposing container should send close and dispose events",
+		[
+			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "error" },
+			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "generic" },
+		],
+		async () => {
+			const container = await createConnectedContainer();
+			const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 
-		let containerDisposed = 0;
-		let containerClosed = 0;
-		let deltaManagerDisposed = 0;
-		let deltaManagerClosed = 0;
-		let runtimeDispose = 0;
-		container.on("disposed", () => containerDisposed++);
-		container.on("closed", () => containerClosed++);
-		(container.deltaManager as any).on("disposed", () => deltaManagerDisposed++);
-		(container.deltaManager as any).on("closed", () => deltaManagerClosed++);
-		(dataObject._context.containerRuntime as ContainerRuntime).on(
-			"dispose",
-			() => runtimeDispose++,
-		);
+			let containerDisposed = 0;
+			let containerClosed = 0;
+			let deltaManagerDisposed = 0;
+			let deltaManagerClosed = 0;
+			let runtimeDispose = 0;
+			container.on("disposed", () => containerDisposed++);
+			container.on("closed", () => containerClosed++);
+			(container.deltaManager as any).on("disposed", () => deltaManagerDisposed++);
+			(container.deltaManager as any).on("closed", () => deltaManagerClosed++);
+			(dataObject._context.containerRuntime as ContainerRuntime).on(
+				"dispose",
+				() => runtimeDispose++,
+			);
 
-		container.close();
-		container.dispose();
-		assert.strictEqual(containerDisposed, 1, "Container should send disposed event");
-		assert.strictEqual(containerClosed, 1, "Container should send closed event");
-		assert.strictEqual(deltaManagerDisposed, 1, "DeltaManager should send disposed event");
-		assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
-		assert.strictEqual(runtimeDispose, 1, "ContainerRuntime should send dispose event");
-	});
+			container.close(new DataCorruptionError("expected", {}));
+			container.dispose(new DataCorruptionError("expected", {}));
+			assert.strictEqual(containerDisposed, 1, "Container should send disposed event");
+			assert.strictEqual(containerClosed, 1, "Container should send closed event");
+			assert.strictEqual(deltaManagerDisposed, 1, "DeltaManager should send disposed event");
+			assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
+			assert.strictEqual(runtimeDispose, 1, "ContainerRuntime should send dispose event");
+		},
+	);
 
 	// Temporary disable since we reverted the fix that caused an increase in loader bundle size.
 	// Tracking alternative fix in AB#4129.


### PR DESCRIPTION
Currently if container is disposed with an error, the error will always be sent as generic telemetry. The telemetry event should be an error if we haven't already closed the container (to prevent double counting the error).

[AB#4611](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4611)