### PR TITLE
Entry point tweaks

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -178,7 +178,6 @@ export interface IContainerContext extends IDisposable {
     // @deprecated (undocumented)
     readonly existing: boolean | undefined;
     getAbsoluteUrl?(relativeUrl: string): Promise<string | undefined>;
-    getEntryPoint?(): Promise<FluidObject | undefined>;
     // (undocumented)
     getLoadedFromVersion(): IVersion | undefined;
     // @deprecated (undocumented)

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -204,13 +204,6 @@ export interface IContainerContext extends IDisposable {
 	 * and scenarios which can change in the future.
 	 */
 	readonly id: string;
-
-	/**
-	 * Proxy for {@link IRuntime.getEntryPoint}, the entryPoint defined in the container's runtime.
-	 *
-	 * @see {@link IContainer.getEntryPoint}
-	 */
-	getEntryPoint?(): Promise<FluidObject | undefined>;
 }
 
 export const IRuntimeFactory: keyof IProvideRuntimeFactory = "IRuntimeFactory";

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -695,14 +695,14 @@ export class Container
 	/**
 	 * {@inheritDoc @fluidframework/container-definitions#IContainer.entryPoint}
 	 */
-	public async getEntryPoint?(): Promise<FluidObject | undefined> {
+	public async getEntryPoint(): Promise<FluidObject | undefined> {
 		// Only the disposing/disposed lifecycle states should prevent access to the entryPoint; closing/closed should still
 		// allow it since they mean a kind of read-only state for the Container.
 		// Note that all 4 are lifecycle states but only 'closed' and 'disposed' are emitted as events.
 		if (this._lifecycleState === "disposing" || this._lifecycleState === "disposed") {
 			throw new UsageError("The container is disposing or disposed");
 		}
-		while (this._context === undefined) {
+		if (this._context === undefined) {
 			await new Promise<void>((resolve, reject) => {
 				const contextChangedHandler = () => {
 					resolve();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -722,9 +722,7 @@ export class Container
 				0x5a2 /* Context still not defined after contextChanged event */,
 			);
 		}
-		// Disable lint rule for the sake of more complete stack traces
-		// eslint-disable-next-line no-return-await
-		return await this._context.getEntryPoint?.();
+		return this._context.getEntryPoint();
 	}
 
 	/**

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -161,7 +161,9 @@ export class ContainerContext implements IContainerContext {
 	}
 
 	/**
-	 * {@inheritDoc @fluidframework/container-definitions#IContainerContext.getEntryPoint}
+	 * Proxy for {@link IRuntime.getEntryPoint}, the entryPoint defined in the container's runtime.
+	 *
+	 * @see {@link IContainer.getEntryPoint}
 	 */
 	public async getEntryPoint(): Promise<FluidObject | undefined> {
 		if (this._disposed) {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -163,12 +163,12 @@ export class ContainerContext implements IContainerContext {
 	/**
 	 * {@inheritDoc @fluidframework/container-definitions#IContainerContext.getEntryPoint}
 	 */
-	public async getEntryPoint?(): Promise<FluidObject | undefined> {
+	public async getEntryPoint(): Promise<FluidObject | undefined> {
 		if (this._disposed) {
 			throw new UsageError("The context is already disposed");
 		}
 		if (this._runtime !== undefined) {
-			return this._runtime?.getEntryPoint?.();
+			return this._runtime.getEntryPoint?.();
 		}
 		return new Promise<FluidObject | undefined>((resolve, reject) => {
 			const runtimeInstantiatedHandler = () => {


### PR DESCRIPTION
Main goal here is to eliminate IContainerContext.getEntryPoint() - the runtime already has access to the entry point (it is the one who provides it) so we don't need to give it a loopback access through the loader layer.  This clarifies ContainerContext.getEntryPoint() as being a purely upward-facing (host-facing) API.

Accessory changes are mostly unnecessary null checks and other small stuff.  AFAICT the await doesn't actually impact stack reporting in error cases so removing it here.  The while loop can't actually loop, so an if is appropriate instead.