### PR TITLE
feat(changesets): Prompt to select target branch

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/changeset.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changeset.ts
@@ -138,7 +138,7 @@ export default class GenerateChangesetCommand extends BaseCommand<typeof Generat
 				const answer = await prompts({
 					type: "select",
 					name: "selectedBranch",
-					message: `More than ${BRANCH_PROMPT_LIMIT} packages were edited compared to ${branch}. Maybe you meant to select a different target branch?`,
+					message: `More than ${BRANCH_PROMPT_LIMIT} packages were edited compared to the ${branch} branch. Maybe you meant to select a different target branch?`,
 					choices: [
 						{ title: "next", value: "next" },
 						{ title: "main", value: "main" },


### PR DESCRIPTION
When creating a changeset, if the detected number of packages is greater than 10, the user will be prompted to select the target branch. The prompt will be suppressed if the `--branch`/`-b` flags are used.