### PR TITLE
Dispose summarizer instead of closing

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1006,6 +1006,11 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
+
+			// There is no user for summarizer, so we need to ensure dispose is called
+			if (this.client.details.type === summarizerClientType) {
+				this.dispose(error);
+			}
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -837,6 +837,11 @@ export class ContainerRuntime
 	}
 
 	public get closeFn(): (error?: ICriticalContainerError) => void {
+		if (this._summarizer !== undefined) {
+			// In cases of summarizer, we want to dispose instead since consumer doesn't interact with this container
+			return this.disposeFn;
+		}
+
 		// Also call disposeFn to retain functionality of runtime being disposed on close
 		return (error?: ICriticalContainerError) => {
 			this.context.closeFn(error);


### PR DESCRIPTION
For summarizer, there is no user to call `Container.dispose(...)`. So, if code ever closes the summarizer, it should dispose instead.

Where we used to have a single container shutdown concept ("close"), now we also have "dispose". The difference being:
- "close" is how an app or internal code should respond to a critical error, assuming the user is still there. This gives the user the chance to review the document read-only before leaving the session entirely
- "dispose" is for completely tearing down the container and all resources, for when the user is gone.
For the Summarizer, there is no user.  If the code ever closes it, it should immediately be disposed.

[AB#4610](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4610)