### PR TITLE
refactor(fetch-tool): Low-hanging-fruit refactor/cleanup of fetch-tool

### DIFF
--- a/packages/tools/fetch-tool/README.md
+++ b/packages/tools/fetch-tool/README.md
@@ -1,7 +1,7 @@
 # @fluid-tools/fetch-tool
 
 Connection using ODSP or routerlicious driver to dump the messages or snapshot information on the server.
-In order to connect to ODSP, the clientID and clientSecret must be set as environment variables login**microsoft**clientId and login**microsoft**secret, respectively. If you have access to the keyvault this can be done by running [this tool](../../../tools/getkeys).
+In order to connect to ODSP, the clientID and clientSecret must be set as environment variables `login__microsoft__clientId` and `login__microsoft__secret`, respectively. If you have access to the keyvault this can be done by running [this tool](../../../tools/getkeys).
 Beware that to use fetch-tool on documents in the Microsoft tenant, you will need to follow the fetch tool usage instructions on the "Debugging Tools" page of the internal Fluid wiki.
 
 ## Usage

--- a/packages/tools/fetch-tool/src/fluidFetchArgs.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchArgs.ts
@@ -56,7 +56,7 @@ const optionsArray = [
 	["--local", "Do not connect to storage, use earlier downloaded data. Requires --saveDir."],
 ];
 
-export function printUsage() {
+function printUsage() {
 	console.log("Usage: fluid-fetch [options] URL");
 	console.log("URL: <ODSP URL>|<Routerlicious URL>");
 	console.log("Options:");

--- a/packages/tools/fetch-tool/src/fluidFetchArgs.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchArgs.ts
@@ -35,8 +35,6 @@ export let connectToWebSocket = false;
 
 export let localDataOnly = false;
 
-export let paramSite: string | undefined;
-
 const optionsArray = [
 	["--dump:rawmessage", "dump all messages"],
 	["--dump:snapshotVersion", "dump a list of snapshot version"],

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -4,7 +4,6 @@
  */
 
 import { URL } from "url";
-import child_process from "child_process";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { FluidAppOdspUrlResolver } from "@fluid-tools/fluidapp-odsp-urlresolver";
@@ -23,16 +22,6 @@ import { resolveWrapper } from "./fluidFetchSharePoint";
 
 export let latestVersionsId: string = "";
 export let connectionInfo: any;
-
-export const fluidFetchWebNavigator = (url: string) => {
-	let message = "Please open browser and navigate to this URL:";
-	if (process.platform === "win32") {
-		child_process.exec(`start "fluid-fetch" /B "${url}"`);
-		message =
-			"Opening browser to get authorization code.  If that doesn't open, please go to this URL manually";
-	}
-	console.log(`${message}\n  ${url}`);
-};
 
 async function initializeODSPCore(
 	odspResolvedUrl: IOdspResolvedUrl,

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -67,7 +67,7 @@ export async function resolveWrapper<T>(
 	}
 }
 
-export async function resolveDriveItemByServerRelativePath(
+async function resolveDriveItemByServerRelativePath(
 	server: string,
 	serverRelativePath: string,
 	clientConfig: IClientConfig,

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import child_process from "child_process";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import {
 	getChildrenByDriveItem,
@@ -20,7 +21,6 @@ import {
 	OdspTokenConfig,
 	IOdspTokenManagerCacheKey,
 } from "@fluidframework/tool-utils";
-import { fluidFetchWebNavigator } from "./fluidFetchInit";
 import { getForceTokenReauth } from "./fluidFetchArgs";
 
 export async function resolveWrapper<T>(
@@ -147,3 +147,13 @@ export async function getSingleSharePointFile(server: string, drive: string, ite
 		clientConfig,
 	);
 }
+
+const fluidFetchWebNavigator = (url: string) => {
+	let message = "Please open browser and navigate to this URL:";
+	if (process.platform === "win32") {
+		child_process.exec(`start "fluid-fetch" /B "${url}"`);
+		message =
+			"Opening browser to get authorization code.  If that doesn't open, please go to this URL manually";
+	}
+	console.log(`${message}\n  ${url}`);
+};


### PR DESCRIPTION
## Description

A few bits of cleanup/refactor:

- Fix env variable names in README.
- Remove unused variable `paramSite` in `fluidFetchArgs.ts`.
- Stop exporting `printUsage()`, not used outside `fluidFetchArgs.ts`.
- Stop exporting `resolveDriveItemByServerRelativePath()`, not used outside `fluidFetchSharePoint.ts`.
- Move `fluidFetchWebNavigator()` to the only file that uses it and stop exporting it.
 
## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).