### PR TITLE
Clear snapshot from prefetch cache after 5s or on load

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -437,6 +437,8 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 			const result = await this.cache.snapshotPrefetchResultCache
 				?.get(prefetchCacheKey)
 				?.then(async (response) => {
+					// Remove it from cache once used.
+					this.cache.snapshotPrefetchResultCache.remove(prefetchCacheKey);
 					// Validate the epoch from the prefetched snapshot result.
 					await this.epochTracker.validateEpoch(response.fluidEpoch, "treesLatest");
 					return response;


### PR DESCRIPTION
## Description

Clear snapshot from prefetch cache after 5s or on load. If we clear it immediately then we will make a network call again to fetch this snapshot which is redundant. So don't clear this cache immediately. We also clear it once it is used.