### PR TITLE
tree2: Recommend plugin to enable mermaid in vscode

### DIFF
--- a/experimental/dds/tree2/.vscode/extensions.json
+++ b/experimental/dds/tree2/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-	"recommendations": ["hbenl.vscode-mocha-test-adapter", "streetsidesoftware.code-spell-checker"],
+	"recommendations": [
+		"hbenl.vscode-mocha-test-adapter",
+		"streetsidesoftware.code-spell-checker",
+		"bierner.markdown-mermaid",
+	],
 }


### PR DESCRIPTION
## Description

Recommends a common vs-code plugin which enables viewing mermaid diagrams in markdown files in vs-code like we can on github.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

