### PR TITLE
fix(devtools): Add missing convenience re-exports in devtools package

### DIFF
--- a/packages/tools/devtools/devtools/api-report/devtools.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ContainerKey } from '@fluid-experimental/devtools-core';
 import { DevtoolsLogger } from '@fluid-experimental/devtools-core';
 import { HasContainerKey } from '@fluid-experimental/devtools-core';
 import { IDisposable } from '@fluidframework/common-definitions';
@@ -16,6 +17,8 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
     dataVisualizers?: Record<string, VisualizeSharedObject>;
 }
 
+export { ContainerKey }
+
 export { DevtoolsLogger }
 
 // @public
@@ -25,6 +28,8 @@ export interface DevtoolsProps {
     logger?: DevtoolsLogger;
 }
 
+export { HasContainerKey }
+
 // @public
 export interface IDevtools extends IDisposable {
     closeContainerDevtools(id: string): void;
@@ -33,5 +38,7 @@ export interface IDevtools extends IDisposable {
 
 // @public (undocumented)
 export function initializeDevtools(props: DevtoolsProps): IDevtools;
+
+export { VisualizeSharedObject }
 
 ```

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -219,5 +219,14 @@ function mapContainerProps(
 	};
 }
 
-// Convenience re-exports
-export { DevtoolsLogger } from "@fluid-experimental/devtools-core";
+// Convenience re-exports. Need to cover the things we export form this package,
+// so consumers don't need to import from this one *and* devtools-core.
+// DevtoolsLogger is necessary for consumers to set up Devtools.
+// DevtoolsProps and ContainerDevtoolsProps both use VisualizeSharedObject.
+// ContainerDevtoolsProps extends HasContainerKey, so it needs ContainerKey.
+export {
+	DevtoolsLogger,
+	VisualizeSharedObject,
+	ContainerKey,
+	HasContainerKey,
+} from "@fluid-experimental/devtools-core";


### PR DESCRIPTION
## Description

Add more convenience re-exports to the devtools package so consumers don't have to import from both devtools _and_ devtools core.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
