### PR TITLE
fix(bundleStats): Correctly handle pnpm list output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
 			"type": "node",
 			"args": ["release", "-g", "client", "-v", "--no-policyCheck"],
 		},
-    {
+		{
 			"name": "flub generate bundleStats",
 			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev",
 			"cwd": "${workspaceFolder}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,15 @@
 			"type": "node",
 			"args": ["release", "-g", "client", "-v", "--no-policyCheck"],
 		},
+    {
+			"name": "flub generate bundleStats",
+			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev",
+			"cwd": "${workspaceFolder}",
+			"request": "launch",
+			"skipFiles": ["<node_internals>/**"],
+			"type": "node",
+			"args": ["generate", "bundleStats", "-v"],
+		},
 		{
 			// Runs the `flub release report --all` command with a debugger attached.
 			"name": "flub release report",

--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 import { Flags } from "@oclif/core";
-import { execSync } from "child_process";
-import { copySync, existsSync, readJSONSync } from "fs-extra";
+import { copySync, existsSync, readJson } from "fs-extra";
 import path from "path";
 
 import { BaseCommand } from "../../base";
+import { PnpmListEntry, pnpmList } from "../../pnpm";
 
 export default class GenerateBundlestats extends BaseCommand<typeof GenerateBundlestats> {
 	static description = `Find all bundle analysis artifacts and copy them into a central location to upload as build artifacts for later consumption`;
@@ -28,11 +28,11 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 
 	public async run(): Promise<void> {
 		const flags = this.flags;
-		const lernaOutput =
-			flags.packageMetadataPath ??
-			JSON.parse(execSync("pnpm -r list --depth -1 --json").toString());
+		const pkgList = await (flags.packageMetadataPath === undefined
+			? pnpmList(process.cwd())
+			: (readJson(flags.packageMetadataPath) as Promise<PnpmListEntry[]>));
 
-		if (!Array.isArray(lernaOutput)) {
+		if (!Array.isArray(pkgList) || pkgList.length === 0) {
 			this.error("failed to get package information");
 		}
 
@@ -41,13 +41,13 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 		let hasSmallAssetError = false;
 		const analysesDestPath = path.join(process.cwd(), "artifacts/bundleAnalysis");
 
-		for (const pkg of lernaOutput) {
-			if (pkg.location === undefined) {
+		for (const pkg of pkgList) {
+			if (pkg.path === undefined) {
 				this.exit(-1);
 				this.error("missing location in lerna package entry");
 			}
 
-			const packageAnalysisPath = path.join(pkg.location, "bundleAnalysis");
+			const packageAnalysisPath = path.join(pkg.path, "bundleAnalysis");
 			if (existsSync(packageAnalysisPath)) {
 				this.log(`found bundleAnalysis for ${pkg.name}`);
 
@@ -57,7 +57,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 					this.error(`${reportPath} is missing; bundle analysis may not be accurate.`);
 				}
 
-				const report = readJSONSync(reportPath);
+				const report = await readJson(reportPath);
 				if (report.assets?.length === undefined || report.assets?.length === 0) {
 					this.error(`${reportPath} doesn't have any assets info`);
 				}

--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -57,6 +57,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 					this.error(`${reportPath} is missing; bundle analysis may not be accurate.`);
 				}
 
+				// eslint-disable-next-line no-await-in-loop
 				const report = await readJson(reportPath);
 				if (report.assets?.length === undefined || report.assets?.length === 0) {
 					this.error(`${reportPath} doesn't have any assets info`);

--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -43,8 +43,7 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 
 		for (const pkg of pkgList) {
 			if (pkg.path === undefined) {
-				this.exit(-1);
-				this.error("missing location in lerna package entry");
+				this.error(`Missing path in pnpm list results for ${pkg.name}`, { exit: -1 });
 			}
 
 			const packageAnalysisPath = path.join(pkg.path, "bundleAnalysis");
@@ -70,7 +69,9 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 					}
 
 					if (asset.size < flags.smallestAssetSize) {
-						this.warn(`${pkg.name}: asset ${asset.name} (${asset.size}) is too small`);
+						this.warning(
+							`${pkg.name}: asset ${asset.name} (${asset.size}) is too small`,
+						);
 						hasSmallAssetError = true;
 					}
 				}

--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -39,7 +39,7 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 		}
 
 		const filterOptions = parsePackageFilterFlags(this.flags);
-    const pnpmListResults = await pnpmList(releaseGroup.repoPath);
+		const pnpmListResults = await pnpmList(releaseGroup.repoPath);
 		const filtered = filterPackages(pnpmListResults, filterOptions)
 			.reverse()
 			.map((item) => {

--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -8,16 +8,7 @@ import execa from "execa";
 import { BaseCommand } from "../base";
 import { filterPackages, parsePackageFilterFlags } from "../filter";
 import { filterFlags, releaseGroupFlag } from "../flags";
-
-/**
- * The output of `pnpm -r list` is an array of objects of this shape.
- */
-interface PnpmListEntry {
-	name: string;
-	version: string;
-	path: string;
-	private: boolean;
-}
+import { PnpmListEntry, pnpmList } from "../pnpm";
 
 /**
  * Lists all the packages in a release group in topological order.
@@ -48,16 +39,8 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 		}
 
 		const filterOptions = parsePackageFilterFlags(this.flags);
-		const raw = await execa(`pnpm`, [`-r`, `list`, `--depth=-1`, `--json`], {
-			cwd: releaseGroup.repoPath,
-		});
-
-		if (raw.stdout === undefined) {
-			this.error(`No output from pnpm list.`, { exit: 1 });
-		}
-
-		const parsed: PnpmListEntry[] = JSON.parse(raw.stdout);
-		const filtered = filterPackages(parsed, filterOptions)
+    const pnpmListResults = await pnpmList(releaseGroup.repoPath);
+		const filtered = filterPackages(pnpmListResults, filterOptions)
 			.reverse()
 			.map((item) => {
 				// pnpm returns absolute paths, but repo relative is more useful

--- a/build-tools/packages/build-cli/src/pnpm.ts
+++ b/build-tools/packages/build-cli/src/pnpm.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import execa from "execa";
+
+/**
+ * The output of `pnpm -r list` is an array of objects of this shape.
+ */
+export interface PnpmListEntry {
+	name: string;
+	version: string;
+	path: string;
+	private: boolean;
+}
+
+/**
+ * Runs `pnpm -r list --depth=-1 --json` in the given directory and returns the parsed output.
+ *
+ * @param directory - The directory to run pnpm in.
+ * @returns an array of PnpmListEntry objects, one for each package in the output.
+ */
+export async function pnpmList(directory: string): Promise<PnpmListEntry[]> {
+	const raw = await execa(`pnpm`, [`-r`, `list`, `--depth=-1`, `--json`], {
+		cwd: directory,
+	});
+
+	if (raw.stdout === undefined) {
+		throw new Error(`No output from pnpm list.`);
+	}
+
+	const parsed: PnpmListEntry[] = JSON.parse(raw.stdout);
+	return parsed;
+}


### PR DESCRIPTION
The bundle size tool was updated to use pnpm list, instead of lerna, but that change was incomplete because the property names in the JSON output differs between the two tools.

I updated the command to use a shared type and unified all the `pnpm list` code into one shared function.