### PR TITLE
Update mongo retry rules

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -77,7 +77,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
 		this.pendingOffset = message;
 
-		if (this.telemetryEnabled) {
+		if (this.telemetryEnabled && this.pending.size > 0) {
 			if (this.pendingMetric === undefined) {
 				// create a new metric for processing the current kafka batch
 				this.pendingMetric = Lumberjack.newLumberMetric(

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -35,7 +35,7 @@ class InternalBulkWriteErrorRule extends BaseMongoExceptionRetryRule {
 		return (
 			error.code === 1 &&
 			error.name &&
-			(error.name as string) === InternalBulkWriteErrorRule.errorName
+			(error.name as string).includes(InternalBulkWriteErrorRule.errorName)
 		);
 	}
 }
@@ -373,7 +373,6 @@ export function createMongoErrorRetryRuleset(
 	const mongoErrorRetryRuleset: IMongoExceptionRetryRule[] = [
 		// The rules are using exactly equal
 		new InternalErrorRule(retryRuleOverride),
-		new InternalBulkWriteErrorRule(retryRuleOverride),
 		new NoPrimaryInReplicasetRule(retryRuleOverride),
 		new RequestTimedNoRateLimitInfo(retryRuleOverride),
 		new RequestTimedOutWithRateLimitTrue(retryRuleOverride),
@@ -393,6 +392,7 @@ export function createMongoErrorRetryRuleset(
 		// The rules are using string contains
 		new ServiceUnavailableRule(retryRuleOverride),
 		new RequestTimedOutBulkWriteErrorRule(retryRuleOverride),
+		new InternalBulkWriteErrorRule(retryRuleOverride),
 
 		// The rules are using regex
 		new ConnectionClosedMongoErrorRule(retryRuleOverride),

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -222,7 +222,7 @@ class RequestTimedOutBulkWriteErrorRule extends BaseMongoExceptionRetryRule {
 		return (
 			error.code === 50 &&
 			error.name &&
-			(error.name as string) === RequestTimedOutBulkWriteErrorRule.errorName
+			(error.name as string).includes(RequestTimedOutBulkWriteErrorRule.errorName)
 		);
 	}
 }
@@ -329,6 +329,24 @@ class ConnectionTimedOutBulkWriteErrorRule extends BaseMongoExceptionRetryRule {
 	}
 }
 
+class NetworkTimedOutErrorRule extends BaseMongoExceptionRetryRule {
+	private static readonly errorName = "MongoNetworkTimeoutError";
+	protected defaultRetryDecision: boolean = true;
+
+	constructor(retryRuleOverride: Map<string, boolean>) {
+		super("NetworkTimedOutErrorRule", retryRuleOverride);
+	}
+
+	public match(error: any): boolean {
+		return (
+			error.name &&
+			(error.name as string) === NetworkTimedOutErrorRule.errorName &&
+			error.message &&
+			/^connection .*timed out$/.test(error.message as string) === true
+		);
+	}
+}
+
 class MongoServerSelectionErrorRule extends BaseMongoExceptionRetryRule {
 	private static readonly errorName = "MongoServerSelectionError";
 	protected defaultRetryDecision: boolean = true;
@@ -360,7 +378,6 @@ export function createMongoErrorRetryRuleset(
 		new RequestTimedNoRateLimitInfo(retryRuleOverride),
 		new RequestTimedOutWithRateLimitTrue(retryRuleOverride),
 		new RequestTimedOutWithRateLimitFalse(retryRuleOverride),
-		new RequestTimedOutBulkWriteErrorRule(retryRuleOverride),
 		new TopologyDestroyed(retryRuleOverride),
 		new UnauthorizedRule(retryRuleOverride),
 		new ConnectionPoolClearedErrorRule(retryRuleOverride),
@@ -375,11 +392,13 @@ export function createMongoErrorRetryRuleset(
 
 		// The rules are using string contains
 		new ServiceUnavailableRule(retryRuleOverride),
+		new RequestTimedOutBulkWriteErrorRule(retryRuleOverride),
 
 		// The rules are using regex
 		new ConnectionClosedMongoErrorRule(retryRuleOverride),
 		new ConnectionTimedOutBulkWriteErrorRule(retryRuleOverride),
 		new MongoServerSelectionErrorRule(retryRuleOverride),
+		new NetworkTimedOutErrorRule(retryRuleOverride),
 	];
 	return mongoErrorRetryRuleset;
 }


### PR DESCRIPTION
## Description

- Updated the mongo retry rules for new mongo sdk 
- Also a minor fix in scriptorium to start the ScriptoriumProcessBatch metric only if there is a pending item to write in db. 