### PR TITLE
Fix the failure of lint and accessing tinylicious log in Test Stability pipeline

### DIFF
--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -15,6 +15,10 @@ parameters:
   type: boolean
   default: true
 
+- name: taskLintName
+  type: string
+  default: lint
+
 - name: taskTest
   type: object
   default:
@@ -38,6 +42,14 @@ parameters:
 
 - name: stageName
   type: string
+
+- name: packageManager
+  type: string
+  default: npm
+
+- name: packageManagerInstallCommand
+  type: string
+  default: 'npm ci --unsafe-perm'
 
 jobs:
   # Job - Build
@@ -81,11 +93,10 @@ jobs:
       inputs:
         version: 16.x
 
-    - template: include-install-pnpm.yml
-      parameters:
-        buildDirectory: ${{ parameters.buildDirectory }}
-        # This pipeline experiences a high failure rate when the cache is enabled, so we disable it
-        enableCache: false
+    - ${{ if eq(parameters.packageManager, 'pnpm') }}:
+          - template: include-install-pnpm.yml
+            parameters:
+              buildDirectory: ${{ parameters.buildDirectory }}
 
     - task: Bash@3
       displayName: Install dependencies
@@ -93,7 +104,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          pnpm i --frozen-lockfile
+          ${{ parameters.packageManagerInstallCommand }}
 
     # Build
     - ${{ if ne(parameters.taskBuild, 'false') }}:
@@ -139,27 +150,25 @@ jobs:
                 workingDir: ${{ parameters.buildDirectory }}
                 customCommand: 'run ${{ taskTestStep }}'
               condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-        # Rename the tinylicious log file, only if tests failed
+        # Verify if the tinylicious log exists
         - task: Bash@3
-          displayName: Rename tinylicious log
+          displayName: Validate Tinylicious Log 
           inputs: 
             targetType: 'inline'
             workingDirectory: ${{ parameters.buildDirectory }}
             script: |
-              oldname=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log
-              stageName=${{ parameters.stageName }}
-              newname=$(echo $oldname | sed 's/\.log$/'"_$stageName.log"/)
-              mv $oldname $newname
+              logFile=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log
+              echo "##vso[task.setvariable variable=LogExists]$(if [ -f "$logFile" ]; then echo "true"; else echo "false"; fi)"
           condition: and(failed(), contains('${{ taskTestStep }}', 'tinylicious'))
-        # Publish tinylicious log for troubleshooting
+        # Publish tinylicious log for troubleshooting (only run when the tinylicious log is verified existing)
         - task: PublishPipelineArtifact@1
           displayName: Publish Artifact - Tinylicious Log
           inputs:
-            targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious_${{ parameters.stageName }}.log'
+            targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
             artifactName: 'tinyliciousLog_${{ parameters.stageName }}'
             publishLocation: 'pipeline'
-          condition: and(failed(), contains('${{ taskTestStep }}', 'tinylicious'))
-          continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
+          condition: and(failed(), eq(variables['logExists'], 'true'), contains('${{ taskTestStep }}', 'tinylicious'))
+          continueOnError: true
 
       # Test - Upload results
       - task: PublishTestResults@2

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -118,12 +118,12 @@ jobs:
 
     # Lint
     - ${{ if ne(parameters.taskLint, false) }}:
-        - task: Npm@1
-          displayName: npm run ${{ parameters.taskLintName }}
-          inputs:
-            command: 'custom'
-            workingDir: ${{ parameters.buildDirectory }}
-            customCommand: 'run ${{ parameters.taskLintName }}'
+      - task: Npm@1
+        displayName: npm run ${{ parameters.taskLintName }}
+        inputs:
+          command: 'custom'
+          workingDir: ${{ parameters.buildDirectory }}
+          customCommand: 'run ${{ parameters.taskLintName }}'
 
     # Test
     - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -83,6 +83,7 @@ jobs:
             BuildDir=${{ parameters.buildDirectory }}
             Build=${{ parameters.taskBuild }}
             Lint=${{ parameters.taskLint }}
+            LintName: ${{ parameters.taskLintName }}
             Test=${{ convertToJson(parameters.taskTest) }}
             TestCoverage=$(testCoverage)
           "
@@ -117,12 +118,12 @@ jobs:
 
     # Lint
     - ${{ if ne(parameters.taskLint, false) }}:
-      - task: Npm@1
-        displayName: npm run lint
-        inputs:
-          command: 'custom'
-          workingDir: ${{ parameters.buildDirectory }}
-          customCommand: 'run lint'
+        - task: Npm@1
+          displayName: npm run ${{ parameters.taskLintName }}
+          inputs:
+            command: 'custom'
+            workingDir: ${{ parameters.buildDirectory }}
+            customCommand: 'run ${{ parameters.taskLintName }}'
 
     # Test
     - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -121,16 +121,6 @@ parameters:
   type: string
   default: ci:build
 
-- name: taskTest
-  type: object
-  default:
-  - ci:test:mocha
-  - ci:test:jest
-  - ci:test:realsvc:local
-  - ci:test:realsvc:tinylicious
-  - ci:test:stress:tinylicious
-  - test:copyresults
-
 - name: checkoutSubmodules
   type: boolean
   default: true
@@ -162,10 +152,23 @@ stages:
       jobs:
       - template: templates/include-test-stability.yml
         parameters:
+          packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
+          packageManager: pnpm
           buildDirectory: .
           poolBuild: ${{ parameters.poolBuild }}
           checkoutSubmodules: ${{ parameters.checkoutSubmodules }}
           timeoutInMinutes: 360
           taskBuild : ${{ parameters.taskBuild }}
-          taskTest: ${{ parameters.taskTest }}
+          taskLint: false
+          taskTest: 
+          - ci:test:mocha
+          - ci:test:jest
+          - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            - ci:test:realsvc:local
+            - ci:test:realsvc:tinylicious
+          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            - ci:test:realsvc:local:full
+            - ci:test:realsvc:tinylicious:full
+          - ci:test:stress:tinylicious
+          - test:copyresults
           stageName: ${{ stageName }}

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -163,12 +163,8 @@ stages:
           taskTest: 
           - ci:test:mocha
           - ci:test:jest
-          - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            - ci:test:realsvc:local
-            - ci:test:realsvc:tinylicious
-          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            - ci:test:realsvc:local:full
-            - ci:test:realsvc:tinylicious:full
+          - ci:test:realsvc:local:full
+          - ci:test:realsvc:tinylicious:full
           - ci:test:stress:tinylicious
           - test:copyresults
           stageName: ${{ stageName }}


### PR DESCRIPTION
[AB#4778](https://dev.azure.com/fluidframework/internal/_workitems/edit/4778)

This PR aims to resolve the recent failures encountered in the Test Stability pipelines. The key changes included are as follows:

1. Sync the `taskLint` section with that in CI build pipeline YAML file

2. Validate the existence of tinylicious log file before proceeding to publish it as an artifact 

The updates were tested on my personal [test branch](https://github.com/microsoft/FluidFramework/tree/test/clarenceli) with reducing the count of test stages. 

The test pipeline run: https://dev.azure.com/fluidframework/internal/_build/results?buildId=171253&view=results

The run after I broke an e2e test intentionally, where 3 different artifacts should exist: https://dev.azure.com/fluidframework/internal/_build/results?buildId=171246&view=results