### PR TITLE
Return the first consecutive sub block of ops for frs driver instead of 0 ops on violation

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -105,7 +105,7 @@ export function promiseRaceWithWinner<T>(promises: Promise<T>[]): Promise<{
 }>;
 
 // @public (undocumented)
-export function validateMessages(reason: string, messages: ISequencedDocumentMessage[], from: number, logger: ITelemetryLoggerExt): void;
+export function validateMessages(reason: string, messages: ISequencedDocumentMessage[], from: number, logger: ITelemetryLoggerExt, strict?: boolean): void;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/drivers/driver-base/.eslintrc.js
+++ b/packages/drivers/driver-base/.eslintrc.js
@@ -5,6 +5,9 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	parserOptions: {
+		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+	},
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 	},

--- a/packages/drivers/driver-base/.mocharc.js
+++ b/packages/drivers/driver-base/.mocharc.js
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+"use strict";
+
+const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
+
+const packageDir = __dirname;
+const config = getFluidTestMochaConfig(packageDir);
+module.exports = config;

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -21,6 +21,7 @@
 		"build:docs": "api-extractor run --local --typescript-compiler-folder ../../../node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
 		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:genver": "gen-version",
+		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"ci:build:docs": "api-extractor run --typescript-compiler-folder ../../../node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/* ../../../_api-extractor-temp/",
 		"clean": "rimraf dist lib *.tsbuildinfo *.build.log",
 		"eslint": "eslint --format stylish src",
@@ -30,9 +31,34 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
+		"test": "npm run test:mocha",
+		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
+		"test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
+		"test:mocha:multireport": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:mocha",
+		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+	},
+	"nyc": {
+		"all": true,
+		"cache-dir": "nyc/.cache",
+		"exclude": [
+			"src/test/**/*.ts",
+			"dist/test/**/*.js"
+		],
+		"exclude-after-remap": false,
+		"include": [
+			"src/**/*.ts",
+			"dist/**/*.js"
+		],
+		"report-dir": "nyc/report",
+		"reporter": [
+			"cobertura",
+			"html",
+			"text"
+		],
+		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -48,11 +74,19 @@
 		"@fluidframework/build-tools": "^0.20.0-169245",
 		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.5.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
+		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
+		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",
+		"cross-env": "^7.0.3",
 		"eslint": "~8.6.0",
+		"mocha": "^10.2.0",
+		"mocha-json-output-reporter": "^2.0.1",
+		"mocha-multi-reporters": "^1.5.1",
+		"moment": "^2.21.0",
+		"nyc": "^15.1.0",
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"socket.io-client": "^4.6.1",

--- a/packages/drivers/driver-base/src/test/driverUtilsTests.spec.ts
+++ b/packages/drivers/driver-base/src/test/driverUtilsTests.spec.ts
@@ -23,23 +23,30 @@ describe("driver utils tests", () => {
 
 		beforeEach(() => {
 			mockLogger.clear();
-		})
+		});
 
 		it("from not equal to start", () => {
 			const ops = generateOps(1, 5);
 			validateMessages("test1", ops, 0, mockLogger, true);
 			assert(ops.length === 0, "no ops should be returned");
-			assert(mockLogger.matchEventStrict([
-				{
-					eventName: "OpsFetchViolation",
-					reason: "test1",
-					from: 0,
-					start: 1,
-					last: 5,
-					length: 5,
-					details: JSON.stringify({ validLength: 0, lastValidOpSeqNumber: undefined, strict: true }),
-				},
-			]), "Ops fetch violation event not correctly recorded");
+			assert(
+				mockLogger.matchEventStrict([
+					{
+						eventName: "OpsFetchViolation",
+						reason: "test1",
+						from: 0,
+						start: 1,
+						last: 5,
+						length: 5,
+						details: JSON.stringify({
+							validLength: 0,
+							lastValidOpSeqNumber: undefined,
+							strict: true,
+						}),
+					},
+				]),
+				"Ops fetch violation event not correctly recorded",
+			);
 		});
 
 		it("contiguous ops", () => {
@@ -55,17 +62,24 @@ describe("driver utils tests", () => {
 			ops[4].sequenceNumber = 7;
 			validateMessages("test", ops, 1, mockLogger, true);
 			assert(ops.length === 0, "no ops should be returned as strict == true");
-			assert(mockLogger.matchEventStrict([
-				{
-					eventName: "OpsFetchViolation",
-					reason: "test",
-					from: 1,
-					start: 1,
-					last: 7,
-					length: 5,
-					details: JSON.stringify({ validLength: 0, lastValidOpSeqNumber: undefined, strict: true }),
-				},
-			]), "Ops fetch violation event not correctly recorded");
+			assert(
+				mockLogger.matchEventStrict([
+					{
+						eventName: "OpsFetchViolation",
+						reason: "test",
+						from: 1,
+						start: 1,
+						last: 7,
+						length: 5,
+						details: JSON.stringify({
+							validLength: 0,
+							lastValidOpSeqNumber: undefined,
+							strict: true,
+						}),
+					},
+				]),
+				"Ops fetch violation event not correctly recorded",
+			);
 		});
 
 		it("non contiguous ops: strict = false", () => {
@@ -74,17 +88,24 @@ describe("driver utils tests", () => {
 			ops[4].sequenceNumber = 7;
 			validateMessages("test", ops, 1, mockLogger, false);
 			assert(ops.length === 4, "some should be returned as strict == false");
-			assert(mockLogger.matchEventStrict([
-				{
-					eventName: "OpsFetchViolation",
-					reason: "test",
-					from: 1,
-					start: 1,
-					last: 7,
-					length: 5,
-					details: JSON.stringify({ validLength: 4, lastValidOpSeqNumber: 4, strict: false }),
-				},
-			]), "Ops fetch violation event not correctly recorded");
+			assert(
+				mockLogger.matchEventStrict([
+					{
+						eventName: "OpsFetchViolation",
+						reason: "test",
+						from: 1,
+						start: 1,
+						last: 7,
+						length: 5,
+						details: JSON.stringify({
+							validLength: 4,
+							lastValidOpSeqNumber: 4,
+							strict: false,
+						}),
+					},
+				]),
+				"Ops fetch violation event not correctly recorded",
+			);
 		});
 	});
 });

--- a/packages/drivers/driver-base/src/test/driverUtilsTests.spec.ts
+++ b/packages/drivers/driver-base/src/test/driverUtilsTests.spec.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/common-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { validateMessages } from "../driverUtils";
+
+describe("driver utils tests", () => {
+	describe("validateMessagesTests", () => {
+		const mockLogger = new MockLogger();
+		const generateOps = (start: number, count: number) => {
+			const ops: ISequencedDocumentMessage[] = [];
+			let i = 0;
+			while (i < count) {
+				ops.push({ sequenceNumber: start + i } as any as ISequencedDocumentMessage);
+				i++;
+			}
+			return ops;
+		};
+
+		beforeEach(() => {
+			mockLogger.clear();
+		})
+
+		it("from not equal to start", () => {
+			const ops = generateOps(1, 5);
+			validateMessages("test1", ops, 0, mockLogger, true);
+			assert(ops.length === 0, "no ops should be returned");
+			assert(mockLogger.matchEventStrict([
+				{
+					eventName: "OpsFetchViolation",
+					reason: "test1",
+					from: 0,
+					start: 1,
+					last: 5,
+					length: 5,
+					details: JSON.stringify({ validLength: 0, lastValidOpSeqNumber: undefined, strict: true }),
+				},
+			]), "Ops fetch violation event not correctly recorded");
+		});
+
+		it("contiguous ops", () => {
+			const ops = generateOps(1, 5);
+			validateMessages("test2", ops, 1, mockLogger, true);
+			assert(ops.length === 5, "ops should be returned");
+			assert(mockLogger.events.length === 0, "no events should be there");
+		});
+
+		it("non contiguous ops: strict = true", () => {
+			const ops = generateOps(1, 5);
+			// Change seq number of last op
+			ops[4].sequenceNumber = 7;
+			validateMessages("test", ops, 1, mockLogger, true);
+			assert(ops.length === 0, "no ops should be returned as strict == true");
+			assert(mockLogger.matchEventStrict([
+				{
+					eventName: "OpsFetchViolation",
+					reason: "test",
+					from: 1,
+					start: 1,
+					last: 7,
+					length: 5,
+					details: JSON.stringify({ validLength: 0, lastValidOpSeqNumber: undefined, strict: true }),
+				},
+			]), "Ops fetch violation event not correctly recorded");
+		});
+
+		it("non contiguous ops: strict = false", () => {
+			const ops = generateOps(1, 5);
+			// Change seq number of last op
+			ops[4].sequenceNumber = 7;
+			validateMessages("test", ops, 1, mockLogger, false);
+			assert(ops.length === 4, "some should be returned as strict == false");
+			assert(mockLogger.matchEventStrict([
+				{
+					eventName: "OpsFetchViolation",
+					reason: "test",
+					from: 1,
+					start: 1,
+					last: 7,
+					length: 5,
+					details: JSON.stringify({ validLength: 4, lastValidOpSeqNumber: 4, strict: false }),
+				},
+			]), "Ops fetch violation event not correctly recorded");
+		});
+	});
+});

--- a/packages/drivers/driver-base/src/test/tsconfig.json
+++ b/packages/drivers/driver-base/src/test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["mocha"],
+		"declaration": false,
+		"declarationMap": false,
+	},
+	"include": ["./**/*"],
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/drivers/driver-base/tsconfig.json
+++ b/packages/drivers/driver-base/tsconfig.json
@@ -1,9 +1,10 @@
 {
 	"extends": "@fluidframework/build-common/ts-common-config.json",
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./dist",
+		"composite": true,
 	},
 	"include": ["src/**/*"],
 }

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -73,7 +73,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 				const messages = this.snapshotOps.filter(
 					(op) => op.sequenceNumber >= from && op.sequenceNumber < to,
 				);
-				validateMessages("snapshotOps", messages, from, this.logger);
+				validateMessages("snapshotOps", messages, from, this.logger, false);
 				if (messages.length > 0 && messages[0].sequenceNumber === from) {
 					this.snapshotOps = this.snapshotOps.filter((op) => op.sequenceNumber >= to);
 					opsFromSnapshot += messages.length;
@@ -83,7 +83,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 			}
 
 			const ops = await this.deltaStorageService.get(this.tenantId, this.id, from, to);
-			validateMessages("storage", ops.messages, from, this.logger);
+			validateMessages("storage", ops.messages, from, this.logger, false);
 			opsFromStorage += ops.messages.length;
 			return ops;
 		};

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -73,7 +73,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 				const messages = this.snapshotOps.filter(
 					(op) => op.sequenceNumber >= from && op.sequenceNumber < to,
 				);
-				validateMessages("snapshotOps", messages, from, this.logger, false);
+				validateMessages("snapshotOps", messages, from, this.logger, false /* strict */);
 				if (messages.length > 0 && messages[0].sequenceNumber === from) {
 					this.snapshotOps = this.snapshotOps.filter((op) => op.sequenceNumber >= to);
 					opsFromSnapshot += messages.length;
@@ -83,7 +83,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 			}
 
 			const ops = await this.deltaStorageService.get(this.tenantId, this.id, from, to);
-			validateMessages("storage", ops.messages, from, this.logger, false);
+			validateMessages("storage", ops.messages, from, this.logger, false /* strict */);
 			opsFromStorage += ops.messages.length;
 			return ops;
 		};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7133,13 +7133,21 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
+      '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
+      '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
+      cross-env: ^7.0.3
       eslint: ~8.6.0
+      mocha: ^10.2.0
+      mocha-json-output-reporter: ^2.0.1
+      mocha-multi-reporters: ^1.5.1
+      moment: ^2.21.0
+      nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
       socket.io-client: ^4.6.1
@@ -7157,11 +7165,19 @@ importers:
       '@fluidframework/build-tools': 0.20.0-169245_@types+node@14.18.47
       '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.5.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
+      '@types/mocha': 9.1.1
       '@types/node': 14.18.47
       concurrently: 7.6.0
       copyfiles: 2.4.1
+      cross-env: 7.0.3
       eslint: 8.6.0
+      mocha: 10.2.0
+      mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
+      mocha-multi-reporters: 1.5.1_mocha@10.2.0
+      moment: 2.29.4
+      nyc: 15.1.0
       prettier: 2.6.2
       rimraf: 4.4.1
       socket.io-client: 4.6.1


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4668
When we fetch ops for frs through delta storage or through snapshot, it could happen that the ops are not contiguous. In that case, return the first set of contiguous ops so that we can make at least some progress.

It's an issue service needs to address, but this change is a temp experiment to see if it mitigates issues for users while we are waiting for proper fix. 
