### PR TITLE
Move runtime instantiation to Container and have Container talk to runtime directly

### DIFF
--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -130,12 +130,9 @@ export interface IBatchMessage {
 }
 
 /**
- * The ContainerContext is a proxy standing between the Container and the Container's IRuntime.
- * This allows the Container to terminate the connection to the IRuntime.
- *
- * Specifically, there is an event on Container, onContextChanged, which mean a new code proposal has been loaded,
- * so the old IRuntime is no longer valid, as its ContainerContext has been revoked,
- * and the Container has created a new ContainerContext.
+ * IContainerContext is fundamentally just the set of things that an IRuntimeFactory (and IRuntime) will consume from the
+ * loader layer.  It gets passed into the IRuntimeFactory.instantiateRuntime call.  Only include members on this interface
+ * if you intend them to be consumed/called from the runtime layer.
  */
 export interface IContainerContext extends IDisposable {
 	/** @deprecated Please pass in existing directly in instantiateRuntime */

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -687,41 +687,6 @@ export class Container
 	 * {@inheritDoc @fluidframework/container-definitions#IContainer.entryPoint}
 	 */
 	public async getEntryPoint(): Promise<FluidObject | undefined> {
-		// Only the disposing/disposed lifecycle states should prevent access to the entryPoint; closing/closed should still
-		// allow it since they mean a kind of read-only state for the Container.
-		// Note that all 4 are lifecycle states but only 'closed' and 'disposed' are emitted as events.
-		if (this._lifecycleState === "disposing" || this._lifecycleState === "disposed") {
-			throw new UsageError("The container is disposing or disposed");
-		}
-		if (this._context === undefined) {
-			await new Promise<void>((resolve, reject) => {
-				const contextChangedHandler = () => {
-					resolve();
-					this.off("disposed", disposedHandler);
-				};
-				const disposedHandler = (error) => {
-					reject(error ?? "The Container is disposed");
-					this.off("contextChanged", contextChangedHandler);
-				};
-				this.once("contextChanged", contextChangedHandler);
-				this.once("disposed", disposedHandler);
-			});
-			// The Promise above should only resolve (vs reject) if the 'contextChanged' event was emitted and that
-			// should have set this._context; making sure.
-			assert(
-				this._context !== undefined,
-				0x5a2 /* Context still not defined after contextChanged event */,
-			);
-		}
-		return this.contextGetEntryPoint();
-	}
-
-	/**
-	 * Proxy for {@link IRuntime.getEntryPoint}, the entryPoint defined in the container's runtime.
-	 *
-	 * @see {@link IContainer.getEntryPoint}
-	 */
-	public async contextGetEntryPoint(): Promise<FluidObject | undefined> {
 		if (this._disposed) {
 			throw new UsageError("The context is already disposed");
 		}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -933,6 +933,7 @@ export class Container
 
 	public dispose(error?: ICriticalContainerError) {
 		this._deltaManager.dispose(error);
+		this.lifecycleEvents.emit("disposed");
 		this.verifyClosed();
 	}
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -7,8 +7,17 @@
 import merge from "lodash/merge";
 
 import { v4 as uuid } from "uuid";
-import { IEvent, ITelemetryProperties, TelemetryEventCategory } from "@fluidframework/common-definitions";
-import { TypedEventEmitter, assert, performance, unreachableCase } from "@fluidframework/common-utils";
+import {
+	IEvent,
+	ITelemetryProperties,
+	TelemetryEventCategory,
+} from "@fluidframework/common-definitions";
+import {
+	TypedEventEmitter,
+	assert,
+	performance,
+	unreachableCase,
+} from "@fluidframework/common-utils";
 import { IRequest, IResponse, IFluidRouter, FluidObject } from "@fluidframework/core-interfaces";
 import {
 	IAudience,
@@ -1051,7 +1060,7 @@ export class Container
 
 				this.connectionStateHandler.dispose();
 
-				const maybeError = error !== undefined ? new Error(error.message) : undefined
+				const maybeError = error !== undefined ? new Error(error.message) : undefined;
 				this._runtime?.dispose(maybeError);
 				this._context?.dispose(maybeError);
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2309,7 +2309,7 @@ export class Container
 			throw new Error(packageNotFactoryError);
 		}
 
-		const context = await ContainerContext.createOrLoad(
+		const context = new ContainerContext(
 			this.options,
 			this.scope,
 			snapshot,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2321,9 +2321,9 @@ export class Container
 			() => this.clientId,
 			() => this.serviceConfiguration,
 			() => this.attachState,
+			() => this.connected,
 			this._deltaManager.clientDetails,
 			existing,
-			this.connected,
 			this.subLogger,
 			pendingLocalState,
 		);

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -212,7 +212,6 @@ export class ContainerContext implements IContainerContext {
 		}
 		this._disposed = true;
 
-		// this.runtime.dispose(error);
 		this._quorum.dispose();
 		this.deltaManager.dispose();
 	}

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -31,66 +31,6 @@ import {
 } from "@fluidframework/protocol-definitions";
 
 export class ContainerContext implements IContainerContext {
-	public static async createOrLoad(
-		options: ILoaderOptions,
-		scope: FluidObject,
-		baseSnapshot: ISnapshotTree | undefined,
-		version: IVersion | undefined,
-		deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-		storage: IDocumentStorageService,
-		quorum: IQuorum,
-		audience: IAudience,
-		loader: ILoader,
-		submitFn: (type: MessageType, contents: any, batch: boolean, appData: any) => number,
-		submitSummaryFn: (summaryOp: ISummaryContent, referenceSequenceNumber?: number) => number,
-		submitBatchFn: (batch: IBatchMessage[], referenceSequenceNumber?: number) => number,
-		submitSignalFn: (contents: any) => void,
-		disposeFn: (error?: ICriticalContainerError) => void,
-		closeFn: (error?: ICriticalContainerError) => void,
-		updateDirtyContainerState: (dirty: boolean) => void,
-		getAbsoluteUrl: (relativeUrl: string) => Promise<string | undefined>,
-		getContainerDiagnosticId: () => string | undefined,
-		getClientId: () => string | undefined,
-		getServiceConfiguration: () => IClientConfiguration | undefined,
-		getAttachState: () => AttachState,
-		getConnected: () => boolean,
-		clientDetails: IClientDetails,
-		existing: boolean,
-		taggedLogger: ITelemetryLoggerExt,
-		pendingLocalState?: unknown,
-	): Promise<ContainerContext> {
-		const context = new ContainerContext(
-			options,
-			scope,
-			baseSnapshot,
-			version,
-			deltaManager,
-			storage,
-			quorum,
-			audience,
-			loader,
-			submitFn,
-			submitSummaryFn,
-			submitBatchFn,
-			submitSignalFn,
-			disposeFn,
-			closeFn,
-			updateDirtyContainerState,
-			getAbsoluteUrl,
-			getContainerDiagnosticId,
-			getClientId,
-			getServiceConfiguration,
-			getAttachState,
-			getConnected,
-			clientDetails,
-			existing,
-			taggedLogger,
-			pendingLocalState,
-		);
-		// await context.instantiateRuntime(existing);
-		return context;
-	}
-
 	public readonly supportedFeatures: ReadonlyMap<string, unknown> = new Map([
 		/**
 		 * This version of the loader accepts `referenceSequenceNumber`, provided by the container runtime,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -192,7 +192,7 @@ export class ContainerContext implements IContainerContext {
 		public readonly existing: boolean,
 		public readonly taggedLogger: ITelemetryLoggerExt,
 		public readonly pendingLocalState?: unknown,
-	) { }
+	) {}
 
 	/**
 	 * @deprecated Temporary migratory API, to be removed when customers no longer need it.

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -70,9 +70,9 @@ export class ContainerContext implements IContainerContext {
 		getClientId: () => string | undefined,
 		getServiceConfiguration: () => IClientConfiguration | undefined,
 		getAttachState: () => AttachState,
+		getConnected: () => boolean,
 		clientDetails: IClientDetails,
 		existing: boolean,
-		connected: boolean,
 		taggedLogger: ITelemetryLoggerExt,
 		pendingLocalState?: unknown,
 	): Promise<ContainerContext> {
@@ -99,9 +99,9 @@ export class ContainerContext implements IContainerContext {
 			getClientId,
 			getServiceConfiguration,
 			getAttachState,
+			getConnected,
 			clientDetails,
 			existing,
-			connected,
 			taggedLogger,
 			pendingLocalState,
 		);
@@ -131,7 +131,7 @@ export class ContainerContext implements IContainerContext {
 	 * When false, ops should be kept as pending or rejected
 	 */
 	public get connected(): boolean {
-		return this._connected;
+		return this._getConnected();
 	}
 
 	public get canSummarize(): boolean {
@@ -248,9 +248,9 @@ export class ContainerContext implements IContainerContext {
 		private readonly _getClientId: () => string | undefined,
 		private readonly _getServiceConfiguration: () => IClientConfiguration | undefined,
 		private readonly _getAttachState: () => AttachState,
+		private readonly _getConnected: () => boolean,
 		private readonly _clientDetails: IClientDetails,
 		public readonly existing: boolean,
-		private _connected: boolean,
 		public readonly taggedLogger: ITelemetryLoggerExt,
 		public readonly pendingLocalState?: unknown,
 	) {
@@ -310,7 +310,6 @@ export class ContainerContext implements IContainerContext {
 	}
 
 	public setConnectionState(connected: boolean, clientId?: string) {
-		this._connected = connected;
 		this.runtime.setConnectionState(connected, clientId);
 	}
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -30,6 +30,9 @@ import {
 	ISummaryContent,
 } from "@fluidframework/protocol-definitions";
 
+/**
+ * {@inheritDoc @fluidframework/container-definitions#IContainerContext}
+ */
 export class ContainerContext implements IContainerContext {
 	public readonly supportedFeatures: ReadonlyMap<string, unknown> = new Map([
 		/**

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -3,22 +3,19 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
+import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import {
 	IAudience,
 	IContainerContext,
 	IDeltaManager,
 	ILoader,
-	IRuntime,
 	ICriticalContainerError,
 	AttachState,
 	ILoaderOptions,
-	IRuntimeFactory,
 	IFluidCodeDetails,
 	IBatchMessage,
 } from "@fluidframework/container-definitions";
-import { IRequest, IResponse, FluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
 	IClientConfiguration,
@@ -27,30 +24,16 @@ import {
 	IQuorum,
 	IQuorumClients,
 	ISequencedDocumentMessage,
-	ISignalMessage,
 	ISnapshotTree,
-	ISummaryTree,
 	IVersion,
 	MessageType,
 	ISummaryContent,
 } from "@fluidframework/protocol-definitions";
-import { UsageError } from "@fluidframework/container-utils";
-
-/**
- * Events that {@link ContainerContext} can emit through its lifecycle.
- *
- * "runtimeInstantiated" - When an {@link @fluidframework/container-definitions#IRuntime} has been instantiated (by
- * calling instantiateRuntime() on the runtime factory), and this._runtime is set.
- *
- * "disposed" - When its dispose() method is called. The {@link ContainerContext} is no longer usable at that point.
- */
-type ContextLifecycleEvents = "runtimeInstantiated" | "disposed";
 
 export class ContainerContext implements IContainerContext {
 	public static async createOrLoad(
 		options: ILoaderOptions,
 		scope: FluidObject,
-		runtimeFactory: IRuntimeFactory,
 		baseSnapshot: ISnapshotTree | undefined,
 		version: IVersion | undefined,
 		deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
@@ -79,7 +62,6 @@ export class ContainerContext implements IContainerContext {
 		const context = new ContainerContext(
 			options,
 			scope,
-			runtimeFactory,
 			baseSnapshot,
 			version,
 			deltaManager,
@@ -105,11 +87,18 @@ export class ContainerContext implements IContainerContext {
 			taggedLogger,
 			pendingLocalState,
 		);
-		await context.instantiateRuntime(existing);
+		// await context.instantiateRuntime(existing);
 		return context;
 	}
 
-	public readonly supportedFeatures: ReadonlyMap<string, unknown>;
+	public readonly supportedFeatures: ReadonlyMap<string, unknown> = new Map([
+		/**
+		 * This version of the loader accepts `referenceSequenceNumber`, provided by the container runtime,
+		 * as a parameter to the `submitBatchFn` and `submitSummaryFn` functions.
+		 * This is then used to set the reference sequence numbers of the submitted ops in the DeltaManager.
+		 */
+		["referenceSequenceNumbers", true],
+	]);
 
 	public get clientId(): string | undefined {
 		return this._getClientId();
@@ -134,10 +123,6 @@ export class ContainerContext implements IContainerContext {
 		return this._getConnected();
 	}
 
-	public get canSummarize(): boolean {
-		return "summarize" in this.runtime;
-	}
-
 	public get serviceConfiguration(): IClientConfiguration | undefined {
 		return this._getServiceConfiguration();
 	}
@@ -158,70 +143,24 @@ export class ContainerContext implements IContainerContext {
 		return this._storage;
 	}
 
-	private _runtime: IRuntime | undefined;
-	private get runtime() {
-		if (this._runtime === undefined) {
-			throw new Error("Attempted to access runtime before it was defined");
-		}
-		return this._runtime;
-	}
-
 	private _disposed = false;
 
 	public get disposed() {
 		return this._disposed;
 	}
 
-	private readonly _quorum: IQuorum;
 	public get quorum(): IQuorumClients {
 		return this._quorum;
 	}
 
-	/**
-	 * Proxy for {@link IRuntime.getEntryPoint}, the entryPoint defined in the container's runtime.
-	 *
-	 * @see {@link IContainer.getEntryPoint}
-	 */
-	public async getEntryPoint(): Promise<FluidObject | undefined> {
-		if (this._disposed) {
-			throw new UsageError("The context is already disposed");
-		}
-		if (this._runtime !== undefined) {
-			return this._runtime.getEntryPoint?.();
-		}
-		return new Promise<FluidObject | undefined>((resolve, reject) => {
-			const runtimeInstantiatedHandler = () => {
-				assert(
-					this._runtime !== undefined,
-					0x5a3 /* runtimeInstantiated fired but runtime is still undefined */,
-				);
-				resolve(this._runtime.getEntryPoint?.());
-				this.lifecycleEvents.off("disposed", disposedHandler);
-			};
-			const disposedHandler = () => {
-				reject(new Error("ContainerContext was disposed"));
-				this.lifecycleEvents.off("runtimeInstantiated", runtimeInstantiatedHandler);
-			};
-			this.lifecycleEvents.once("runtimeInstantiated", runtimeInstantiatedHandler);
-			this.lifecycleEvents.once("disposed", disposedHandler);
-		});
-	}
-
-	/**
-	 * Emits events about the container context's lifecycle.
-	 * Use it to coordinate things inside the ContainerContext class.
-	 */
-	private readonly lifecycleEvents = new TypedEventEmitter<ContextLifecycleEvents>();
-
 	constructor(
 		private readonly _options: ILoaderOptions,
 		public readonly scope: FluidObject,
-		private readonly _runtimeFactory: IRuntimeFactory,
 		private readonly _baseSnapshot: ISnapshotTree | undefined,
 		private readonly _version: IVersion | undefined,
 		public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
 		private readonly _storage: IDocumentStorageService,
-		quorum: IQuorum,
+		private readonly _quorum: IQuorum,
 		private readonly _audience: IAudience,
 		public readonly loader: ILoader,
 		public readonly submitFn: (
@@ -253,18 +192,7 @@ export class ContainerContext implements IContainerContext {
 		public readonly existing: boolean,
 		public readonly taggedLogger: ITelemetryLoggerExt,
 		public readonly pendingLocalState?: unknown,
-	) {
-		this._quorum = quorum;
-
-		this.supportedFeatures = new Map([
-			/**
-			 * This version of the loader accepts `referenceSequenceNumber`, provided by the container runtime,
-			 * as a parameter to the `submitBatchFn` and `submitSummaryFn` functions.
-			 * This is then used to set the reference sequence numbers of the submitted ops in the DeltaManager.
-			 */
-			["referenceSequenceNumbers", true],
-		]);
-	}
+	) { }
 
 	/**
 	 * @deprecated Temporary migratory API, to be removed when customers no longer need it.
@@ -284,8 +212,7 @@ export class ContainerContext implements IContainerContext {
 		}
 		this._disposed = true;
 
-		this.lifecycleEvents.emit("disposed");
-		this.runtime.dispose(error);
+		// this.runtime.dispose(error);
 		this._quorum.dispose();
 		this.deltaManager.dispose();
 	}
@@ -297,56 +224,4 @@ export class ContainerContext implements IContainerContext {
 	public get attachState(): AttachState {
 		return this._getAttachState();
 	}
-
-	/**
-	 * Create a summary. Used when attaching or serializing a detached container.
-	 *
-	 * @param blobRedirectTable - A table passed during the attach process. While detached, blob upload is supported
-	 * using IDs generated locally. After attach, these IDs cannot be used, so this table maps the old local IDs to the
-	 * new storage IDs so requests can be redirected.
-	 */
-	public createSummary(blobRedirectTable?: Map<string, string>): ISummaryTree {
-		return this.runtime.createSummary(blobRedirectTable);
-	}
-
-	public setConnectionState(connected: boolean, clientId?: string) {
-		this.runtime.setConnectionState(connected, clientId);
-	}
-
-	public process(message: ISequencedDocumentMessage, local: boolean) {
-		this.runtime.process(message, local);
-	}
-
-	public processSignal(message: ISignalMessage, local: boolean) {
-		this.runtime.processSignal(message, local);
-	}
-
-	public async request(path: IRequest): Promise<IResponse> {
-		return this.runtime.request(path);
-	}
-
-	public getPendingLocalState(): unknown {
-		return this.runtime.getPendingLocalState();
-	}
-
-	public async notifyOpReplay(message: ISequencedDocumentMessage): Promise<void> {
-		return this.runtime.notifyOpReplay?.(message);
-	}
-
-	public setAttachState(attachState: AttachState.Attaching | AttachState.Attached) {
-		this.runtime.setAttachState(attachState);
-	}
-
-	// #region private
-
-	private async instantiateRuntime(existing: boolean) {
-		this._runtime = await PerformanceEvent.timedExecAsync(
-			this.taggedLogger,
-			{ eventName: "InstantiateRuntime" },
-			async () => this._runtimeFactory.instantiateRuntime(this, existing),
-		);
-		this.lifecycleEvents.emit("runtimeInstantiated");
-	}
-
-	// #endregion
 }

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -111,10 +111,6 @@ export class ContainerContext implements IContainerContext {
 		return this._getContainerDiagnosticId() ?? "";
 	}
 
-	public get clientDetails(): IClientDetails {
-		return this._clientDetails;
-	}
-
 	/**
 	 * When true, ops are free to flow
 	 * When false, ops should be kept as pending or rejected
@@ -125,22 +121,6 @@ export class ContainerContext implements IContainerContext {
 
 	public get serviceConfiguration(): IClientConfiguration | undefined {
 		return this._getServiceConfiguration();
-	}
-
-	public get audience(): IAudience {
-		return this._audience;
-	}
-
-	public get options(): ILoaderOptions {
-		return this._options;
-	}
-
-	public get baseSnapshot() {
-		return this._baseSnapshot;
-	}
-
-	public get storage(): IDocumentStorageService {
-		return this._storage;
 	}
 
 	private _disposed = false;
@@ -154,14 +134,14 @@ export class ContainerContext implements IContainerContext {
 	}
 
 	constructor(
-		private readonly _options: ILoaderOptions,
+		public readonly options: ILoaderOptions,
 		public readonly scope: FluidObject,
-		private readonly _baseSnapshot: ISnapshotTree | undefined,
+		public readonly baseSnapshot: ISnapshotTree | undefined,
 		private readonly _version: IVersion | undefined,
 		public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-		private readonly _storage: IDocumentStorageService,
+		public readonly storage: IDocumentStorageService,
 		private readonly _quorum: IQuorum,
-		private readonly _audience: IAudience,
+		public readonly audience: IAudience,
 		public readonly loader: ILoader,
 		public readonly submitFn: (
 			type: MessageType,
@@ -188,7 +168,7 @@ export class ContainerContext implements IContainerContext {
 		private readonly _getServiceConfiguration: () => IClientConfiguration | undefined,
 		private readonly _getAttachState: () => AttachState,
 		private readonly _getConnected: () => boolean,
-		private readonly _clientDetails: IClientDetails,
+		public readonly clientDetails: IClientDetails,
 		public readonly existing: boolean,
 		public readonly taggedLogger: ITelemetryLoggerExt,
 		public readonly pendingLocalState?: unknown,

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -184,7 +184,7 @@ export const shortCodeMap = {
 	"0x0d3": "Should only be called in detached container",
 	"0x0d6": "Inbound queue should be empty when attaching",
 	"0x0d9": "Attempting to connect() a closed DeltaManager",
-	"0x0dd": "Existing context not disposed",
+	"0x0dd": "Existing runtime not disposed",
 	"0x0df": "Missing active connection",
 	"0x0e0": "lost minBlobSize policy",
 	"0x0e2": "DeltaManager already has attached op handler!",

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -265,7 +265,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 		dataStore._root.set("my blob", blob);
 		await attachOpP;
 
-		const snapshot1 = (container1 as any).context.runtime.blobManager.summarize();
+		const snapshot1 = (container1 as any).runtime.blobManager.summarize();
 
 		// wait for summarize, then summary ack so the next container will load from snapshot
 		await new Promise<void>((resolve, reject) => {
@@ -294,7 +294,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 		});
 
 		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const snapshot2 = (container2 as any).context.runtime.blobManager.summarize();
+		const snapshot2 = (container2 as any).runtime.blobManager.summarize();
 		assert.strictEqual(snapshot2.stats.treeNodeCount, 1);
 		assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
 	});

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -507,7 +507,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 	it("resends batched ops", async function () {
 		const pendingOps = await getPendingOps(provider, false, async (c, d) => {
 			const map = await d.getSharedObject<SharedMap>(mapId);
-			(c as any).context.runtime.orderSequentially(() => {
+			(c as any).runtime.orderSequentially(() => {
 				[...Array(lots).keys()].map((i) => map.set(i.toString(), i));
 			});
 		});
@@ -537,7 +537,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 	it("doesn't resend successful batched ops", async function () {
 		const pendingOps = await getPendingOps(provider, true, async (c, d) => {
 			const map = await d.getSharedObject<SharedMap>(mapId);
-			(c as any).context.runtime.orderSequentially(() => {
+			(c as any).runtime.orderSequentially(() => {
 				[...Array(lots).keys()].map((i) => map.set(i.toString(), i));
 			});
 		});


### PR DESCRIPTION
Followup to #16153

This change splits ContainerContext into two parts - (1) the IContainerContext stuff which is consumed by the IRuntimeFactory and (2) the actual instantiation of the IRuntime and communication with it.  (2) gets moved up into Container, and then Container can talk directly to the IRuntime without passing through the context.

This leaves ContainerContext as just (1) which is close to being a InitProperties-type object, or a proxy-ish thing.  There's probably still more opportunity to clean that up further if we open the door to changes to IContainerContext or IRuntime/IRuntimeFactory (which this PR explicitly avoids).

The dispose flow is still pretty messy - I'm checking with @kian-thompson to clarify whether some of the unusual calling patterns are required for correctness or if we have some room to clean this up.  In particular I think IContainerContext should probably not extend IDisposable, which would really help lock down entrypoints into the dispose graph.