### PR TITLE
Use only single commit for odsp

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,14 +28,12 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.Container.summarizeProtocolTree2": [true, false],
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-						"Fluid.Container.summarizeProtocolTree2": [true, false],
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				},
@@ -100,7 +98,6 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.Container.summarizeProtocolTree2": [true, false],
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				}


### PR DESCRIPTION
During an FF Hot investigation, we found that single commit summaries weren't always running with ODSP. This updatest the test configs to only run single commit for ODSP