### PR TITLE
SharedTree peer branches use SharedTreeBranch

### DIFF
--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -99,7 +99,6 @@ export function rebaseBranch<TChange>(
  *
  * The source and target branch must share an ancestor.
  * @param changeRebaser - the change rebaser responsible for rebasing the changes in the commits of each branch
- * @param intoDelta - a utility for converting changes into deltas
  * @param sourceRepairDataStoreProvider - the {@link IRepairDataStoreProvider} of the source branch. This is must be passed in
  * in order to update the repair data of the rebased commits. A branch may not have an {@link IRepairDataStoreProvider} if it
  * does not need to maintain repair data.

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -399,14 +399,16 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	}
 
 	/**
-	 * Rebase the changes that have been applied to this branch over all the divergent changes in the given branch.
+	 * Rebase the changes that have been applied to this branch over any divergent changes in the given branch.
 	 * After this operation completes, this branch will be based off of `branch`.
 	 * @param branch - the branch to rebase onto
+	 * @param upTo - the furthest commit on `branch` over which to rebase (inclusive). Defaults to the head commit of `branch`.
 	 * @returns the net change to this branch and the commits that were removed and added to this branch by the rebase,
 	 * or undefined if nothing changed
 	 */
 	public rebaseOnto(
 		branch: SharedTreeBranch<TEditor, TChange>,
+		upTo = branch.getHead(),
 	):
 		| [
 				change: TChange | undefined,
@@ -416,7 +418,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		| undefined {
 		this.assertNotDisposed();
 		// Rebase this branch onto the given branch
-		const rebaseResult = this.rebaseBranch(this, branch.getHead());
+		const rebaseResult = this.rebaseBranch(this, branch, upTo);
 		if (rebaseResult === undefined) {
 			return undefined;
 		}
@@ -446,6 +448,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 	/**
 	 * Apply all the divergent changes on the given branch to this branch.
+	 * @param branch - the branch to merge into this branch
 	 * @returns the net change to this branch and the commits that were added to this branch by the merge,
 	 * or undefined if nothing changed
 	 */
@@ -459,7 +462,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		);
 
 		// Rebase the given branch onto this branch
-		const rebaseResult = this.rebaseBranch(branch, this.head);
+		const rebaseResult = this.rebaseBranch(branch, this);
 		if (rebaseResult === undefined) {
 			return undefined;
 		}
@@ -486,9 +489,13 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	}
 
 	/** Rebase `branchHead` onto `onto`, but return undefined if nothing changed */
-	private rebaseBranch(branch: SharedTreeBranch<TEditor, TChange>, onto: GraphCommit<TChange>) {
+	private rebaseBranch(
+		branch: SharedTreeBranch<TEditor, TChange>,
+		onto: SharedTreeBranch<TEditor, TChange>,
+		upTo = onto.getHead(),
+	) {
 		const { head, repairDataStoreProvider } = branch;
-		if (head === onto) {
+		if (head === upTo) {
 			return undefined;
 		}
 
@@ -496,8 +503,8 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			this.changeFamily.rebaser,
 			repairDataStoreProvider,
 			head,
-			onto,
-			onto,
+			upTo,
+			onto.getHead(),
 		);
 		const [rebasedHead] = rebaseResult;
 		if (this.head === rebasedHead) {

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -399,7 +399,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	}
 
 	/**
-	 * Rebase the changes that have been applied to this branch over any divergent changes in the given branch.
+	 * Rebase the changes that have been applied to this branch over divergent changes in the given branch.
 	 * After this operation completes, this branch will be based off of `branch`.
 	 * @param branch - the branch to rebase onto
 	 * @param upTo - the furthest commit on `branch` over which to rebase (inclusive). Defaults to the head commit of `branch`.

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -72,19 +72,12 @@ describe("rebaseBranch", () => {
 		const n3 = newCommit(3);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), new MockRepairDataStoreProvider(), n3, n2),
+			() => rebaseBranch(new TestChangeRebaser(), undefined, n3, n2),
 			(e) => validateAssertionError(e, "branches must be related"),
 		);
 
 		assert.throws(
-			() =>
-				rebaseBranch(
-					new TestChangeRebaser(),
-					new MockRepairDataStoreProvider(),
-					n2,
-					n3,
-					n1,
-				),
+			() => rebaseBranch(new TestChangeRebaser(), undefined, n2, n3, n1),
 			(e) => validateAssertionError(e, "target commit is not in target branch"),
 		);
 	});
@@ -98,12 +91,7 @@ describe("rebaseBranch", () => {
 
 		// (1)
 		//  └─ 2 ─ 3
-		const [n3_1, change, commits] = rebaseBranch(
-			new TestChangeRebaser(),
-			new MockRepairDataStoreProvider(),
-			n3,
-			n1,
-		);
+		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), undefined, n3, n1);
 		assert.equal(n3_1, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
@@ -122,12 +110,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)
 		//         └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(
-			new TestChangeRebaser(),
-			new MockRepairDataStoreProvider(),
-			n5,
-			n3,
-		);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), undefined, n5, n3);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(
 			newPath,
@@ -153,7 +136,7 @@ describe("rebaseBranch", () => {
 		//     └─ 4'─ 5'
 		const [n5_1, change, commits] = rebaseBranch(
 			new TestChangeRebaser(),
-			new MockRepairDataStoreProvider(),
+			undefined,
 			n5,
 			n2,
 			n3,
@@ -185,7 +168,7 @@ describe("rebaseBranch", () => {
 		//         └─ 5'
 		const [n5_1, change, commits] = rebaseBranch(
 			new TestChangeRebaser(),
-			new MockRepairDataStoreProvider(),
+			undefined,
 			n5,
 			n2,
 			n4,
@@ -215,12 +198,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(
-			new TestChangeRebaser(),
-			new MockRepairDataStoreProvider(),
-			n5,
-			n4,
-		);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), undefined, n5, n4);
 		const newPath = getPath(n4, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3, 4],
@@ -247,7 +225,7 @@ describe("rebaseBranch", () => {
 		//         └─
 		const [n3_2, change, commits] = rebaseBranch(
 			new TestChangeRebaser(),
-			new MockRepairDataStoreProvider(),
+			undefined,
 			n3_1,
 			n3,
 			n4,
@@ -273,7 +251,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(
+		const [n5_1] = rebaseBranch(
 			new TestChangeRebaser(),
 			new MockRepairDataStoreProvider(),
 			n5,

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -21,7 +21,7 @@ import {
 	DefaultChangeFamily,
 	singleTextCursor,
 } from "../../feature-libraries";
-import { brand } from "../../util";
+import { brand, fail } from "../../util";
 import { MockRepairDataStoreProvider } from "../utils";
 import { noopValidator } from "../../codec";
 
@@ -93,6 +93,23 @@ describe("Branches", () => {
 		assertBased(parent, child);
 		// Ensure that the changes are now present on the parent
 		assertHistory(parent, tag1, tag2);
+	});
+
+	it("rebase changes up to a certain commit", () => {
+		// Create a parent branch and a child fork
+		const parent = create();
+		const child = parent.fork();
+		// Apply a couple of changes to the parent
+		const tag1 = change(parent);
+		change(parent);
+		// Rebase the child onto the parent up to the first new commit
+		const parentCommit1 =
+			findAncestor(parent.getHead(), (c) => c.revision === tag1) ??
+			fail("Expected to find commit");
+
+		child.rebaseOnto(parent, parentCommit1);
+		// Ensure that the changes are now present on the child
+		assertHistory(child, tag1);
 	});
 
 	it("merge changes from a child into a parent", () => {


### PR DESCRIPTION
## Description

This changes the local peer branches in the EditManager to be tracked by `SharedTreeBranches` rather than just head commits. This allows for some minor simplifications of the code in EditManager. `SharedTreeBranch.rebaseOnto` has been updated with an `upTo` parameter to accommodate the peer branch behavior. 