### PR TITLE
IContainerContext deprecations

### DIFF
--- a/.changeset/deep-places-reply.md
+++ b/.changeset/deep-places-reply.md
@@ -1,0 +1,15 @@
+---
+"@fluidframework/container-definitions": minor
+"@fluidframework/container-loader": minor
+"@fluidframework/container-runtime": minor
+---
+
+IContainerContext members deprecated
+
+IContainerContext members disposed, dispose(), and id have been deprecated and will be removed in an upcoming release.
+
+disposed - The disposed state on the IContainerContext is not meaningful to the runtime.
+
+dispose() - The runtime is not permitted to dispose the IContainerContext, this results in an inconsistent system state.
+
+id - The docId is already logged by the IContainerContext.taggedLogger for telemetry purposes, so this is generally unnecessary for telemetry.  If the id is needed for other purposes it should be passed to the consumer explicitly.

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -157,7 +157,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 }
 
 // @public
-export interface IContainerContext extends IDisposable {
+export interface IContainerContext {
     readonly attachState: AttachState;
     // (undocumented)
     readonly audience: IAudience | undefined;
@@ -173,6 +173,10 @@ export interface IContainerContext extends IDisposable {
     readonly connected: boolean;
     // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    // @deprecated (undocumented)
+    dispose(error?: Error): void;
+    // @deprecated (undocumented)
+    readonly disposed: boolean;
     // (undocumented)
     readonly disposeFn?: (error?: ICriticalContainerError) => void;
     // @deprecated (undocumented)

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -186,6 +186,7 @@ export interface IContainerContext {
     getLoadedFromVersion(): IVersion | undefined;
     // @deprecated (undocumented)
     getSpecifiedCodeDetails?(): IFluidCodeDetails | undefined;
+    // @deprecated
     readonly id: string;
     // (undocumented)
     readonly loader: ILoader;

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -199,6 +199,9 @@ export interface IContainerContext {
 	 * WARNING: this id is meant for telemetry usages ONLY, not recommended for other consumption
 	 * This id is not supposed to be exposed anywhere else. It is dependant on usage or drivers
 	 * and scenarios which can change in the future.
+	 * @deprecated - 2.0.0-internal.5.2.0 - The docId is already logged by the IContainerContext.taggedLogger for
+	 * telemetry purposes, so this is generally unnecessary for telemetry.  If the id is needed for other purposes
+	 * it should be passed to the consumer explicitly.  This member will be removed in an upcoming release.
 	 */
 	readonly id: string;
 

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -134,7 +134,7 @@ export interface IBatchMessage {
  * loader layer.  It gets passed into the IRuntimeFactory.instantiateRuntime call.  Only include members on this interface
  * if you intend them to be consumed/called from the runtime layer.
  */
-export interface IContainerContext extends IDisposable {
+export interface IContainerContext {
 	/** @deprecated Please pass in existing directly in instantiateRuntime */
 	readonly existing: boolean | undefined;
 	readonly options: ILoaderOptions;
@@ -201,6 +201,17 @@ export interface IContainerContext extends IDisposable {
 	 * and scenarios which can change in the future.
 	 */
 	readonly id: string;
+
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - The disposed state on the IContainerContext is not meaningful to the runtime.
+	 * This member will be removed in an upcoming release.
+	 */
+	readonly disposed: boolean;
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - The runtime is not permitted to dispose the IContainerContext, this results
+	 * in an inconsistent system state.  This member will be removed in an upcoming release.
+	 */
+	dispose(error?: Error): void;
 }
 
 export const IRuntimeFactory: keyof IProvideRuntimeFactory = "IRuntimeFactory";

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2344,6 +2344,7 @@ export class Container
 			pendingLocalState,
 		);
 		this._lifecycleEvents.once("disposed", () => {
+			context.dispose();
 			quorumProxy.dispose();
 			deltaManagerProxy.dispose();
 		});

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2309,14 +2309,17 @@ export class Container
 			throw new Error(packageNotFactoryError);
 		}
 
+		const deltaManagerProxy = new DeltaManagerProxy(this._deltaManager);
+		const quorumProxy = new QuorumProxy(this.protocolHandler.quorum);
+
 		const context = new ContainerContext(
 			this.options,
 			this.scope,
 			snapshot,
 			this._loadedFromVersion,
-			new DeltaManagerProxy(this._deltaManager),
+			deltaManagerProxy,
 			this.storageAdapter,
-			new QuorumProxy(this.protocolHandler.quorum),
+			quorumProxy,
 			this.protocolHandler.audience,
 			loader,
 			(type, contents, batch, metadata) =>
@@ -2340,7 +2343,10 @@ export class Container
 			this.subLogger,
 			pendingLocalState,
 		);
-		this._lifecycleEvents.once("disposed", () => context.dispose());
+		this._lifecycleEvents.once("disposed", () => {
+			quorumProxy.dispose();
+			deltaManagerProxy.dispose();
+		});
 
 		this._runtime = await PerformanceEvent.timedExecAsync(
 			this.subLogger,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -130,13 +130,7 @@ export class ContainerContext implements IContainerContext {
 	}
 
 	public dispose(error?: Error): void {
-		if (this._disposed) {
-			return;
-		}
 		this._disposed = true;
-
-		this._quorum.dispose();
-		this.deltaManager.dispose();
 	}
 
 	public getLoadedFromVersion(): IVersion | undefined {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1218,7 +1218,6 @@ export class ContainerRuntime
 			getNodePackagePath: async (nodePath: string) => this.getGCNodePackagePath(nodePath),
 			getLastSummaryTimestampMs: () => this.messageAtLastSummary?.timestamp,
 			readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
-			getContainerDiagnosticId: () => this.context.id,
 			// GC runs in summarizer client and needs access to the real (non-proxy) active information. The proxy
 			// delta manager would always return false for summarizer client.
 			activeConnection: () => this.innerDeltaManager.active,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -263,7 +263,6 @@ export interface IGarbageCollectorCreateParams {
 	readonly getLastSummaryTimestampMs: () => number | undefined;
 	readonly readAndParseBlob: ReadAndParseBlob;
 	readonly activeConnection: () => boolean;
-	readonly getContainerDiagnosticId: () => string;
 }
 
 export interface IGCRuntimeOptions {

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -159,7 +159,6 @@ describe("Garbage Collection Tests", () => {
 			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
 			activeConnection: () => true,
-			getContainerDiagnosticId: () => "someDocId",
 		});
 	}
 	let gc: GcWithPrivates | undefined;

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -134,7 +134,6 @@ describe("Garbage Collection configurations", () => {
 			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
 			activeConnection: () => true,
-			getContainerDiagnosticId: () => "someDocId",
 		});
 	}
 


### PR DESCRIPTION
Deprecates disposed, dispose(), and id on IContainerContext.

Container creates the proxies, so it's appropriate for it to own the disposal as well (this consolidates the lifecycle ownership and authority to revoke access).

id was already noted as being for telemetry only, but we already log the docId (Container includes it in the logger it passes through) so this is redundant.  The one place referencing it in the runtime doesn't actually access it.

We should be able to remove all of the above immediately in `next` after the change ports.