### PR TITLE
Deprecate IContainerContext serviceConfiguration

### DIFF
--- a/.changeset/deep-places-reply.md
+++ b/.changeset/deep-places-reply.md
@@ -6,10 +6,12 @@
 
 IContainerContext members deprecated
 
-IContainerContext members disposed, dispose(), and id have been deprecated and will be removed in an upcoming release.
+IContainerContext members disposed, dispose(), serviceConfiguration and id have been deprecated and will be removed in an upcoming release.
 
 disposed - The disposed state on the IContainerContext is not meaningful to the runtime.
 
 dispose() - The runtime is not permitted to dispose the IContainerContext, this results in an inconsistent system state.
 
-id - The docId is already logged by the IContainerContext.taggedLogger for telemetry purposes, so this is generally unnecessary for telemetry.  If the id is needed for other purposes it should be passed to the consumer explicitly.
+serviceConfiguration - This property is redundant, and is unused by the runtime. The same information can be found via `deltaManager.serviceConfiguration` on this object if it is necessary.
+
+id - The docId is already logged by the IContainerContext.taggedLogger for telemetry purposes, so this is generally unnecessary for telemetry. If the id is needed for other purposes it should be passed to the consumer explicitly.

--- a/.changeset/deep-places-reply.md
+++ b/.changeset/deep-places-reply.md
@@ -6,7 +6,7 @@
 
 IContainerContext members deprecated
 
-IContainerContext members disposed, dispose(), serviceConfiguration and id have been deprecated and will be removed in an upcoming release.
+IContainerContext members disposed, dispose(), serviceConfiguration, and id have been deprecated and will be removed in an upcoming release.
 
 disposed - The disposed state on the IContainerContext is not meaningful to the runtime.
 

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -197,7 +197,7 @@ export interface IContainerContext {
     // (undocumented)
     readonly quorum: IQuorumClients;
     readonly scope: FluidObject;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly serviceConfiguration: IClientConfiguration | undefined;
     // (undocumented)
     readonly storage: IDocumentStorageService;

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -168,6 +168,10 @@ export interface IContainerContext {
 	readonly loader: ILoader;
 	// The logger implementation, which would support tagged events, should be provided by the loader.
 	readonly taggedLogger: ITelemetryBaseLogger;
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - This property is redundant, and is unused by the runtime. The same information can be found via
+	 * deltaManager.serviceConfiguration on this object if it is necessary.
+	 */
 	readonly serviceConfiguration: IClientConfiguration | undefined;
 	pendingLocalState?: unknown;
 


### PR DESCRIPTION
## Description
Deprecate serviceConfiguration - This property is redundant, and is unused by the runtime. The same information can be found via `deltaManager.serviceConfiguration` on this object if it is necessary.