### PR TITLE
Add missing export SummaryStage introduced by #15988

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -655,8 +655,6 @@ export enum RuntimeMessage {
 
 // @public
 export interface SubmitSummaryFailureData {
-    // Warning: (ae-forgotten-export) The symbol "SummaryStage" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     stage: SummaryStage;
 }
@@ -751,6 +749,9 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
     waitFlushed(): Promise<IAckedSummary | undefined>;
     waitSummaryAck(referenceSequenceNumber: number): Promise<IAckedSummary>;
 }
+
+// @public
+export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 
 // @public
 export const TombstoneResponseHeaderKey = "isTombstoned";

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -68,6 +68,7 @@ export {
 	OpActionEventName,
 	ICancellableSummarizerController,
 	SubmitSummaryFailureData,
+	SummaryStage,
 } from "./summary";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle";
 export { generateStableId, isStableId, assertIsStableId } from "./id-compressor";

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -63,6 +63,7 @@ export {
 	IUploadSummaryResult,
 	SummarizeResultPart,
 	SubmitSummaryFailureData,
+	SummaryStage,
 } from "./summarizerTypes";
 export {
 	IAckedSummary,


### PR DESCRIPTION
#15988 added a type `SummaryStage`  but it was not exported as expected. This PR exports the missing symbol removing the warning in the container-runtime.api.md file.