### PR TITLE
Stress Test Config: Adjust summarizer-based flights for stress tests

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -29,20 +29,20 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				}
 			},
@@ -73,7 +73,7 @@
 				"routerlicious": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				}
 			}
@@ -103,7 +103,7 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				}
 			}

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,18 +28,21 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
 					}
 				},
 				"tinylicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
 					}
 				}
 			},
@@ -69,7 +72,8 @@
 			"optionOverrides": {
 				"routerlicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
 					}
 				}
 			}
@@ -98,7 +102,8 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2": ["restart", "default"],
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": "true"
 					}
 				}
 			}


### PR DESCRIPTION
## Description

We renamed the flight name to differentiate new v. old code in the flight system (#16187).  But I forgot to update the stress tests to use the new flight value.  Furthermore, we want to enable another setting in tandem, so add that too.

## Reviewer Guidance

These configurations feed into the Pairwise Generator, so I think we'll end up with clients with all combos of these 2.  For Loop users, we'll only enable them together.  So we'll have coverage here that we won't expose real users too - probably ok, all combos should be supported.