### PR TITLE
Add tool version changes as incremental rebuild trigger

### DIFF
--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -8,7 +8,6 @@ import * as chalk from "chalk";
 import detectIndent from "detect-indent";
 import * as fs from "fs";
 import { readFileSync, readJsonSync, writeJsonSync } from "fs-extra";
-import { sync as globSync, hasMagic } from "glob";
 import * as path from "path";
 import sortPackageJson from "sort-package-json";
 

--- a/build-tools/packages/build-tools/src/common/taskUtils.ts
+++ b/build-tools/packages/build-tools/src/common/taskUtils.ts
@@ -19,15 +19,15 @@ export function getEsLintConfigFilePath(dir: string) {
 }
 
 export async function getInstalledPackageVersion(packageName: string, cwd: string) {
-	const tsPath = require.resolve(packageName, { paths: [cwd] });
-	const tsPackageJsonPath = await lookUpDirSync(tsPath, (currentDir) => {
+	const resolvedPath = require.resolve(packageName, { paths: [cwd] });
+	const packageJsonPath = await lookUpDirSync(resolvedPath, (currentDir) => {
 		return existsSync(path.join(currentDir, "package.json"));
 	});
-	if (tsPackageJsonPath === undefined) {
+	if (packageJsonPath === undefined) {
 		throw new Error(`Unable to find package ${packageName} from ${cwd}`);
 	}
 	const packageJson = JSON.parse(
-		await readFileAsync(path.join(tsPackageJsonPath, "package.json"), "utf8"),
+		await readFileAsync(path.join(packageJsonPath, "package.json"), "utf8"),
 	);
 	return packageJson.version;
 }

--- a/build-tools/packages/build-tools/src/common/taskUtils.ts
+++ b/build-tools/packages/build-tools/src/common/taskUtils.ts
@@ -4,6 +4,7 @@
  */
 import * as path from "path";
 import { existsSync } from "fs";
+import { lookUpDirSync, readFileAsync } from "./utils";
 
 export function getEsLintConfigFilePath(dir: string) {
 	// TODO: we currently don't support .yaml and .yml, or config in package.json
@@ -15,4 +16,18 @@ export function getEsLintConfigFilePath(dir: string) {
 		}
 	}
 	return undefined;
+}
+
+export async function getInstalledPackageVersion(packageName: string, cwd: string) {
+	const tsPath = require.resolve(packageName, { paths: [cwd] });
+	const tsPackageJsonPath = await lookUpDirSync(tsPath, (currentDir) => {
+		return existsSync(path.join(currentDir, "package.json"));
+	});
+	if (tsPackageJsonPath === undefined) {
+		throw new Error(`Unable to find package ${packageName} from ${cwd}`);
+	}
+	const packageJson = JSON.parse(
+		await readFileAsync(path.join(tsPackageJsonPath, "package.json"), "utf8"),
+	);
+	return packageJson.version;
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/apiExtractorTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/apiExtractorTask.ts
@@ -2,10 +2,15 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { getInstalledPackageVersion } from "../../../common/taskUtils";
 import { TscDependentTask } from "./tscTask";
 
 export class ApiExtractorTask extends TscDependentTask {
 	protected get configFileFullPath() {
 		return this.getPackageFileFullPath("api-extractor.json");
+	}
+
+	protected async getToolVersion() {
+		return getInstalledPackageVersion("@microsoft/api-extractor", this.node.pkg.directory);
 	}
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -2,12 +2,16 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { getEsLintConfigFilePath } from "../../../common/taskUtils";
+import { getEsLintConfigFilePath, getInstalledPackageVersion } from "../../../common/taskUtils";
 import { TscDependentTask } from "./tscTask";
 
 export class TsLintTask extends TscDependentTask {
 	protected get configFileFullPath() {
 		return this.getPackageFileFullPath("tslint.json");
+	}
+
+	protected async getToolVersion() {
+		return getInstalledPackageVersion("tslint", this.node.pkg.directory);
 	}
 }
 
@@ -29,5 +33,9 @@ export class EsLintTask extends TscDependentTask {
 			return this.node.buildContext.workerPool?.useWorkerThreads === false;
 		}
 		return false;
+	}
+
+	protected async getToolVersion() {
+		return getInstalledPackageVersion("eslint", this.node.pkg.directory);
 	}
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
@@ -8,7 +8,8 @@ import * as path from "path";
 
 import { existsSync, globFn, readFileAsync, statAsync } from "../../../common/utils";
 import { BuildPackage } from "../../buildGraph";
-import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
+import { LeafWithDoneFileTask } from "./leafTask";
+import { getInstalledPackageVersion } from "../../../common/taskUtils";
 
 export class PrettierTask extends LeafWithDoneFileTask {
 	private parsed: boolean = false;
@@ -104,7 +105,10 @@ export class PrettierTask extends LeafWithDoneFileTask {
 				return { name, hash };
 			});
 			const hashes = await Promise.all(hashesP);
-			return JSON.stringify(hashes);
+			return JSON.stringify({
+				version: await getInstalledPackageVersion("prettier", this.node.pkg.directory),
+				hashes,
+			});
 		} catch (e) {
 			this.traceExec(`error generating done file content. ${e}`);
 			return undefined;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -119,6 +119,7 @@ export class TscTask extends LeafTask {
 			this.traceTrigger(
 				`Unable to get installed package version for typescript from ${this.node.pkg.directory}`,
 			);
+			return false;
 		}
 
 		// Check tsconfig.json
@@ -333,9 +334,6 @@ export class TscTask extends LeafTask {
 					);
 					if (tsBuildInfo.program && tsBuildInfo.program.fileNames) {
 						this._tsBuildInfo = tsBuildInfo;
-						this.traceTrigger(
-							`Unable to get installed package version for typescript from ${this.node.pkg.directory}`,
-						);
 					} else {
 						verbose(
 							`${this.node.pkg.nameColored}: Missing program or fileNames property ${tsBuildInfoFileFullPath}`,

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -11,7 +11,6 @@ import type { WorkerExecResult, WorkerMessage } from "./worker";
 export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 	const { command, cwd } = msg;
 	// Load the typescript version that is in the cwd scope
-	// Load the eslint version that is in the cwd scope
 	const tsPath = require.resolve("typescript", { paths: [cwd] });
 	const ts: typeof tsLib = require(tsPath);
 


### PR DESCRIPTION
For tsc, add a version check with the tsBuildInfo file to trigger incremental rebuild trigger.
For the following tools, add the tool version in the done log files to serve as an incremental rebuild trigger when it changes.
- api-extractor
- tslint
- eslint
- prettier

Fixes [AB#4809](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4809)