### PR TITLE
Deprecate disposal and event forwarding members of PureDataObject

### DIFF
--- a/.changeset/whole-tigers-refuse.md
+++ b/.changeset/whole-tigers-refuse.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/aqueduct": minor
+---
+
+EventForwarder and IDisposable members deprecated from PureDataObject
+
+The EventForwarder and IDisposable members have been deprecated from PureDataObject and will be removed in an upcoming release. The EventForwarder pattern was mostly unused by the current implementation, and is also recommended against generallly (instead, register and forward events explicitly). The disposal implementation was incomplete and likely to cause poor behavior as the disposal was not observable by default. Inheritors of the PureDataObject can of course still implement their own disposal logic.

--- a/.changeset/whole-tigers-refuse.md
+++ b/.changeset/whole-tigers-refuse.md
@@ -4,4 +4,4 @@
 
 EventForwarder and IDisposable members deprecated from PureDataObject
 
-The EventForwarder and IDisposable members have been deprecated from PureDataObject and will be removed in an upcoming release. The EventForwarder pattern was mostly unused by the current implementation, and is also recommended against generallly (instead, register and forward events explicitly). The disposal implementation was incomplete and likely to cause poor behavior as the disposal was not observable by default. Inheritors of the PureDataObject can of course still implement their own disposal logic.
+The EventForwarder and IDisposable members have been deprecated from PureDataObject and will be removed in an upcoming release. The EventForwarder pattern was mostly unused by the current implementation, and is also recommended against generally (instead, register and forward events explicitly). The disposal implementation was incomplete and likely to cause poor behavior as the disposal was not observable by default. Inheritors of the PureDataObject can of course still implement their own disposal logic.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -34,6 +34,6 @@ serviceConfiguration - This property is redundant, and is unused by the runtime.
 
 id - The docId is already logged by the IContainerContext.taggedLogger for telemetry purposes, so this is generally unnecessary for telemetry. If the id is needed for other purposes it should be passed to the consumer explicitly.
 
-## EventForwarder and IDisposable members deprecated from PureDataObject (2023-06-29)
+## EventForwarder and IDisposable members deprecated from PureDataObject (2023-06-30)
 
-The EventForwarder and IDisposable members have been deprecated from PureDataObject and will be removed in an upcoming release. The EventForwarder pattern was mostly unused by the current implementation, and is also recommended against generallly (instead, register and forward events explicitly). The disposal implementation was incomplete and likely to cause poor behavior as the disposal was not observable by default. Inheritors of the PureDataObject can of course still implement their own disposal logic.
+The EventForwarder and IDisposable members have been deprecated from PureDataObject and will be removed in an upcoming release. The EventForwarder pattern was mostly unused by the current implementation, and is also recommended against generally (instead, register and forward events explicitly). The disposal implementation was incomplete and likely to cause poor behavior as the disposal was not observable by default. Inheritors of the PureDataObject can of course still implement their own disposal logic.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -33,3 +33,7 @@ dispose() - The runtime is not permitted to dispose the IContainerContext, this 
 serviceConfiguration - This property is redundant, and is unused by the runtime. The same information can be found via `deltaManager.serviceConfiguration` on this object if it is necessary.
 
 id - The docId is already logged by the IContainerContext.taggedLogger for telemetry purposes, so this is generally unnecessary for telemetry. If the id is needed for other purposes it should be passed to the consumer explicitly.
+
+## EventForwarder and IDisposable members deprecated from PureDataObject (2023-06-29)
+
+The EventForwarder and IDisposable members have been deprecated from PureDataObject and will be removed in an upcoming release. The EventForwarder pattern was mostly unused by the current implementation, and is also recommended against generallly (instead, register and forward events explicitly). The disposal implementation was incomplete and likely to cause poor behavior as the disposal was not observable by default. Inheritors of the PureDataObject can of course still implement their own disposal logic.

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -6,6 +6,7 @@
 
 import { AsyncFluidObjectProvider } from '@fluidframework/synthesize';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
+import type { EventEmitter } from 'events';
 import { EventForwarder } from '@fluidframework/common-utils';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
 import { FluidObject } from '@fluidframework/core-interfaces';
@@ -17,6 +18,7 @@ import { IContainerRuntime } from '@fluidframework/container-runtime-definitions
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
 import { IContainerRuntimeOptions } from '@fluidframework/container-runtime';
 import { IEvent } from '@fluidframework/common-definitions';
+import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidDataStoreContext } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreContextDetached } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
@@ -122,10 +124,13 @@ export const mountableViewRequestHandler: (MountableViewClass: IFluidMountableVi
 export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends EventForwarder<I["Events"] & IEvent> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle {
     constructor(props: IDataObjectProps<I>);
     protected readonly context: IFluidDataStoreContext;
+    // @deprecated
     dispose(): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     get disposed(): boolean;
     finishInitialization(existing: boolean): Promise<void>;
+    // @deprecated (undocumented)
+    protected forwardEvent(source: EventEmitter | IEventProvider<I["Events"] & IEvent>, ...events: string[]): void;
     // (undocumented)
     static getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject<DataObjectTypes>>;
     get handle(): IFluidHandle<this>;
@@ -145,10 +150,14 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     protected initializingFromExisting(): Promise<void>;
     // (undocumented)
     protected initProps?: I["InitialState"];
+    // @deprecated (undocumented)
+    protected static isEmitterEvent(event: string): boolean;
     protected preInitialize(): Promise<void>;
     protected readonly providers: AsyncFluidObjectProvider<I["OptionalProviders"]>;
     request(req: IRequest): Promise<IResponse>;
     protected readonly runtime: IFluidDataStoreRuntime;
+    // @deprecated (undocumented)
+    protected unforwardEvent(source: EventEmitter | IEventProvider<I["Events"] & IEvent>, ...events: string[]): void;
 }
 
 // @public

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -191,9 +191,12 @@ export class TableDocument extends DataObject<{ Events: ITableDocumentEvents }> 
 		this.rows = await this.root.get<IFluidHandle<SharedNumberSequence>>("rows").get();
 		this.cols = await this.root.get<IFluidHandle<SharedNumberSequence>>("cols").get();
 
-		this.forwardEvent(this.cols, "op", "sequenceDelta");
-		this.forwardEvent(this.rows, "op", "sequenceDelta");
-		this.forwardEvent(this.matrix, "op", "sequenceDelta");
+		this.cols.on("op", (...args: any[]) => this.emit("op", ...args));
+		this.cols.on("sequenceDelta", (...args: any[]) => this.emit("sequenceDelta", ...args));
+		this.rows.on("op", (...args: any[]) => this.emit("op", ...args));
+		this.rows.on("sequenceDelta", (...args: any[]) => this.emit("sequenceDelta", ...args));
+		this.matrix.on("op", (...args: any[]) => this.emit("op", ...args));
+		this.matrix.on("sequenceDelta", (...args: any[]) => this.emit("sequenceDelta", ...args));
 	}
 
 	private readonly localRefToRowCol = (localRef: ReferencePosition) => {

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -89,6 +89,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
+		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent } from "@fluidframework/common-definitions";
+import type { EventEmitter } from "events";
+import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
 import { assert, EventForwarder } from "@fluidframework/common-utils";
 import {
 	IFluidHandle,
@@ -55,6 +56,10 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 
 	protected initializeP: Promise<void> | undefined;
 
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - PureDataObject does not provide a functioning built-in disposed flow.
+	 * This member will be removed in an upcoming release.
+	 */
 	public get disposed() {
 		return this._disposed;
 	}
@@ -190,8 +195,39 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 
 	/**
 	 * Called when the host container closes and disposes itself
+	 * @deprecated - 2.0.0-internal.5.2.0 - Dispose does nothing and will be removed in an upcoming release.
 	 */
 	public dispose(): void {
 		super.dispose();
+	}
+
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - PureDataObject does not actually set up to forward events, and will not be an EventForwarder
+	 * in a future release.
+	 */
+	protected static isEmitterEvent(event: string): boolean {
+		return super.isEmitterEvent(event);
+	}
+
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - PureDataObject does not actually set up to forward events, and will not be an EventForwarder
+	 * in a future release.
+	 */
+	protected forwardEvent(
+		source: EventEmitter | IEventProvider<I["Events"] & IEvent>,
+		...events: string[]
+	): void {
+		super.forwardEvent(source, ...events);
+	}
+
+	/**
+	 * @deprecated - 2.0.0-internal.5.2.0 - PureDataObject does not actually set up to forward events, and will not be an EventForwarder
+	 * in a future release.
+	 */
+	protected unforwardEvent(
+		source: EventEmitter | IEventProvider<I["Events"] & IEvent>,
+		...events: string[]
+	): void {
+		super.unforwardEvent(source, ...events);
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7908,6 +7908,7 @@ importers:
       '@fluidframework/synthesize': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.34.4
+      '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
@@ -7947,6 +7948,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
+      '@types/events': 3.0.0
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
       concurrently: 7.6.0


### PR DESCRIPTION
[AB#4861](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4861) and [AB#4760](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4760)

PureDataObject is an EventForwarder, but doesn't actually pass a source in its constructor super() call so doesn't automatically participate in any event forwarding.

It's possible to explicitly call forwardEvent like table-document does, but this is trivially replaced by just registering the event yourself and not requiring the concrete inheritance.  This is also a terrible pattern and no one should do it.  I'll change PureDataObject to instead inherit from TypedEventEmitter in `next`.

The disposal members do very little as a result.  The flag does get set when the runtime disposes, but with no emitted event there's no way for a consumer of the PureDataObject to realize that the disposal has happened.  Since we don't have any intended built-in disposal behavior, this change deprecates the members from the base class (inheritors could still feel free to include their own disposal logic).  When PureDataObject is no longer an EventForwarder, it will also stop being IDisposable as a result.

A benefit to this is putting control of disposal fully in our customers' hands, which should e.g. give control to solve [AB#4760](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4760)