### PR TITLE
fix(upcoming): Don't output the changeset dates

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
@@ -76,9 +76,7 @@ export default class GenerateUpcomingCommand extends BaseCommand<typeof Generate
 		let body: string = "";
 		for (const change of changes) {
 			if (change.changeTypes.includes(flags.releaseType)) {
-				body += `## ${change.summary}\n\n${
-					change.content
-				}\n\n`;
+				body += `## ${change.summary}\n\n${change.content}\n\n`;
 			} else {
 				this.info(
 					`Excluding changeset: ${path.basename(change.sourceFile)} because it has no ${

--- a/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
@@ -76,7 +76,7 @@ export default class GenerateUpcomingCommand extends BaseCommand<typeof Generate
 		let body: string = "";
 		for (const change of changes) {
 			if (change.changeTypes.includes(flags.releaseType)) {
-				body += `## ${change.summary} (${getDisplayDate(change.added)})\n\n${
+				body += `## ${change.summary}\n\n${
 					change.content
 				}\n\n`;
 			} else {


### PR DESCRIPTION
The dates apparently can sometimes differ when running in CI. While we figure out exactly what's happening, remove the date from the UPCOMING output.