### PR TITLE
Remove not required min

### DIFF
--- a/packages/drivers/driver-base/src/driverUtils.ts
+++ b/packages/drivers/driver-base/src/driverUtils.ts
@@ -131,7 +131,7 @@ export function validateMessages(
 				) {
 					validOpsCount++;
 				}
-				messages.length = Math.min(messages.length, validOpsCount);
+				messages.length = validOpsCount;
 			}
 			logger.sendErrorEvent({
 				eventName: "OpsFetchViolation",

--- a/packages/drivers/driver-base/src/test/driverUtilsTests.spec.ts
+++ b/packages/drivers/driver-base/src/test/driverUtilsTests.spec.ts
@@ -107,5 +107,12 @@ describe("driver utils tests", () => {
 				"Ops fetch violation event not correctly recorded",
 			);
 		});
+
+		it("only 1 op: strict = false", () => {
+			const ops = generateOps(1, 1);
+			validateMessages("test", ops, 1, mockLogger, false);
+			assert(ops.length === 1, "some should be returned as strict == false");
+			assert(mockLogger.events.length === 0, "no events should be there");
+		});
 	});
 });


### PR DESCRIPTION
## Description

Remove min function to set the length as there will be at least 1 valid op according to the logic in this case.
Follow up in this PR: https://github.com/microsoft/FluidFramework/pull/16172