### PR TITLE
Component governance - update semver to 7.5.2 or greater

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -120,7 +120,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
 		"@types/prompts": "^2.4.4",
-		"@types/semver": "^7.5.0",
+		"@types/semver": "7.5.0",
 		"@types/semver-utils": "^1.1.1",
 		"@types/sort-json": "^2.0.1",
 		"chai": "^4.3.7",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -120,7 +120,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
 		"@types/prompts": "^2.4.4",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"@types/semver-utils": "^1.1.1",
 		"@types/sort-json": "^2.0.1",
 		"chai": "^4.3.7",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -98,7 +98,7 @@
 		"prettier": "~2.6.2",
 		"prompts": "^2.4.2",
 		"read-pkg-up": "^7.0.1",
-		"semver": "^7.5.1",
+		"semver": "^7.5.3",
 		"semver-utils": "^1.1.4",
 		"simple-git": "^3.19.0",
 		"sort-json": "^2.0.1",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -95,7 +95,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
 		"@types/rimraf": "^2.0.5",
-		"@types/semver": "^7.5.0",
+		"@types/semver": "7.5.0",
 		"@types/shelljs": "^0.8.12",
 		"concurrently": "^7.6.0",
 		"eslint": "~8.6.0",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -75,7 +75,7 @@
 		"minimatch": "^7.4.6",
 		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.1",
-		"semver": "^7.5.1",
+		"semver": "^7.5.3",
 		"shelljs": "^0.8.5",
 		"sort-package-json": "1.57.0",
 		"ts-morph": "^17.0.1",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -95,7 +95,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
 		"@types/rimraf": "^2.0.5",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"@types/shelljs": "^0.8.12",
 		"concurrently": "^7.6.0",
 		"eslint": "~8.6.0",

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -54,7 +54,7 @@
 		"@types/chai-arrays": "^2.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"chai": "^4.3.7",
 		"chai-arrays": "^2.2.0",
 		"concurrently": "^7.6.0",

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -54,7 +54,7 @@
 		"@types/chai-arrays": "^2.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
-		"@types/semver": "^7.5.0",
+		"@types/semver": "7.5.0",
 		"chai": "^4.3.7",
 		"chai-arrays": "^2.2.0",
 		"concurrently": "^7.6.0",

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -45,7 +45,7 @@
 		"@oclif/plugin-plugins": "^3.1.2",
 		"@oclif/test": "^2.3.22",
 		"oclif": "^3.9.1",
-		"semver": "^7.5.1"
+		"semver": "^7.5.3"
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^2.0.0",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -86,7 +86,7 @@
 		"@types/chai": "^4.3.5",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"chai": "^4.3.7",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -86,7 +86,7 @@
 		"@types/chai": "^4.3.5",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.51",
-		"@types/semver": "^7.5.0",
+		"@types/semver": "7.5.0",
 		"chai": "^4.3.7",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -74,7 +74,7 @@
 		"@oclif/plugin-not-found": "^2.3.25",
 		"@oclif/plugin-plugins": "^3.1.2",
 		"chalk": "^2.4.2",
-		"semver": "^7.5.1",
+		"semver": "^7.5.3",
 		"table": "^6.8.1"
 	},
 	"devDependencies": {

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
       '@types/prompts': ^2.4.4
-      '@types/semver': ^7.5.0
+      '@types/semver': 7.5.0
       '@types/semver-utils': ^1.1.1
       '@types/sort-json': ^2.0.1
       async: ^3.2.4
@@ -117,7 +117,7 @@ importers:
       prompts: ^2.4.2
       read-pkg-up: ^7.0.1
       rimraf: ^4.4.1
-      semver: ^7.5.1
+      semver: ^7.5.3
       semver-utils: ^1.1.4
       simple-git: ^3.19.0
       sort-json: ^2.0.1
@@ -159,7 +159,7 @@ importers:
       prettier: 2.6.2
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       semver-utils: 1.1.4
       simple-git: 3.19.0
       sort-json: 2.0.1
@@ -221,7 +221,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
       '@types/rimraf': ^2.0.5
-      '@types/semver': ^7.5.0
+      '@types/semver': 7.5.0
       '@types/shelljs': ^0.8.12
       async: ^3.2.4
       chalk: ^2.4.2
@@ -247,7 +247,7 @@ importers:
       prettier: ~2.6.2
       replace-in-file: ^6.3.5
       rimraf: ^4.4.1
-      semver: ^7.5.1
+      semver: ^7.5.3
       shelljs: ^0.8.5
       sort-package-json: 1.57.0
       ts-morph: ^17.0.1
@@ -280,7 +280,7 @@ importers:
       minimatch: 7.4.6
       replace-in-file: 6.3.5
       rimraf: 4.4.1
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       sort-package-json: 1.57.0
       ts-morph: 17.0.1
@@ -364,7 +364,7 @@ importers:
       '@types/chai-arrays': ^2.0.0
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
-      '@types/semver': ^7.5.0
+      '@types/semver': 7.5.0
       chai: ^4.3.7
       chai-arrays: ^2.2.0
       concurrently: ^7.6.0
@@ -382,7 +382,7 @@ importers:
       oclif: ^3.9.1
       prettier: ~2.6.2
       rimraf: ^4.4.1
-      semver: ^7.5.1
+      semver: ^7.5.3
       ts-node: ^10.9.1
       tslib: ^2.5.3
       typescript: ~4.5.5
@@ -392,7 +392,7 @@ importers:
       '@oclif/plugin-plugins': 3.1.2_pu3bu3agnrmjetwliwzp7hv3y4
       '@oclif/test': 2.3.22_pu3bu3agnrmjetwliwzp7hv3y4
       oclif: 3.9.1_pu3bu3agnrmjetwliwzp7hv3y4
-      semver: 7.5.1
+      semver: 7.5.3
     devDependencies:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -437,7 +437,7 @@ importers:
       '@types/chai': ^4.3.5
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
-      '@types/semver': ^7.5.0
+      '@types/semver': 7.5.0
       chai: ^4.3.7
       chalk: ^2.4.2
       concurrently: ^7.6.0
@@ -455,7 +455,7 @@ importers:
       oclif: ^3.9.1
       prettier: ~2.6.2
       rimraf: ^4.4.1
-      semver: ^7.5.1
+      semver: ^7.5.3
       table: ^6.8.1
       ts-node: ^10.9.1
       tslib: ^2.5.3
@@ -468,7 +468,7 @@ importers:
       '@oclif/plugin-not-found': 2.3.25_pu3bu3agnrmjetwliwzp7hv3y4
       '@oclif/plugin-plugins': 3.1.2_pu3bu3agnrmjetwliwzp7hv3y4
       chalk: 2.4.2
-      semver: 7.5.1
+      semver: 7.5.3
       table: 6.8.1
     devDependencies:
       '@fluid-internal/readme-command': link:../readme-command
@@ -1141,7 +1141,7 @@ packages:
       npm-package-arg: 8.1.1
       p-map: 4.0.0
       pacote: 13.6.2
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -1172,7 +1172,7 @@ packages:
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-waterfall: 2.1.1
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -1279,7 +1279,7 @@ packages:
       npm-package-arg: 8.1.1
       npmlog: 6.0.2
       pify: 5.0.0
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@lerna/create-symlink/5.6.2:
@@ -1306,7 +1306,7 @@ packages:
       p-reduce: 2.1.0
       pacote: 13.6.2
       pify: 5.0.0
-      semver: 7.5.1
+      semver: 7.5.3
       slash: 3.0.0
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 4.0.0
@@ -1415,7 +1415,7 @@ packages:
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
       '@lerna/child-process': 5.6.2
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@lerna/import/5.6.2:
@@ -1592,7 +1592,7 @@ packages:
       '@lerna/validation-error': 5.6.2
       npm-package-arg: 8.1.1
       npmlog: 6.0.2
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@lerna/package/5.6.2:
@@ -1608,7 +1608,7 @@ packages:
     resolution: {integrity: sha512-7gIm9fecWFVNy2kpj/KbH11bRcpyANAwpsft3X5m6J7y7A6FTUscCbEvl3ZNdpQKHNuvnHgCtkm3A5PMSCEgkA==}
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@lerna/profiler/5.6.2:
@@ -1678,7 +1678,7 @@ packages:
       p-map: 4.0.0
       p-pipe: 3.1.0
       pacote: 13.6.2
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - encoding
@@ -1828,7 +1828,7 @@ packages:
       p-pipe: 3.1.0
       p-reduce: 2.1.0
       p-waterfall: 2.1.1
-      semver: 7.5.1
+      semver: 7.5.3
       slash: 3.0.0
       write-json-file: 4.3.0
     transitivePeerDependencies:
@@ -2019,7 +2019,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       ssri: 8.0.1
       treeverse: 1.0.4
       walk-up-path: 1.0.0
@@ -2062,7 +2062,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       ssri: 9.0.1
       treeverse: 2.0.0
       walk-up-path: 1.0.0
@@ -2075,20 +2075,20 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.1
+      semver: 7.5.3
 
   /@npmcli/fs/2.1.2:
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.1
+      semver: 7.5.3
 
   /@npmcli/fs/3.1.0:
     resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
 
   /@npmcli/git/2.1.0:
     resolution: {integrity: sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==}
@@ -2099,7 +2099,7 @@ packages:
       npm-pick-manifest: 6.1.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -2115,7 +2115,7 @@ packages:
       proc-log: 2.0.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -2131,7 +2131,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -2168,7 +2168,7 @@ packages:
       cacache: 15.3.0
       json-parse-even-better-errors: 2.3.1
       pacote: 12.0.3
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -2180,7 +2180,7 @@ packages:
       cacache: 16.1.3
       json-parse-even-better-errors: 2.3.1
       pacote: 13.6.2
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -2444,7 +2444,7 @@ packages:
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.2
-      semver: 7.5.1
+      semver: 7.5.3
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -2526,7 +2526,7 @@ packages:
       load-json-file: 5.3.0
       npm: 9.7.1
       npm-run-path: 4.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.3
       validate-npm-package-name: 5.0.0
@@ -2549,7 +2549,7 @@ packages:
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -3261,7 +3261,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -3288,7 +3288,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -3461,7 +3461,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -3482,7 +3482,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -3503,7 +3503,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -4050,7 +4050,7 @@ packages:
     dependencies:
       arg-parser: 1.2.0
       commander: 9.5.0
-      semver: 7.5.1
+      semver: 7.5.3
     dev: false
 
   /bin-links/3.0.3:
@@ -4166,7 +4166,7 @@ packages:
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
 
   /byte-size/7.0.1:
     resolution: {integrity: sha512-crQdqyCwhokxwV1UyDzLZanhkugAgft7vt0qbbdt60C6Zf3CAiGmtUCylbtYwrU6loOUw3euGrNtW1J651ot1A==}
@@ -5884,7 +5884,7 @@ packages:
       escape-string-regexp: 4.0.0
       eslint: 8.6.0
       esquery: 1.4.2
-      semver: 7.5.1
+      semver: 7.5.3
       spdx-expression-parse: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -5973,7 +5973,7 @@ packages:
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.24
       safe-regex: 2.1.1
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5997,7 +5997,7 @@ packages:
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.24
       safe-regex: 2.1.1
-      semver: 7.5.1
+      semver: 7.5.3
       strip-indent: 3.0.0
     dev: true
 
@@ -6190,7 +6190,7 @@ packages:
       optionator: 0.9.1
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       text-table: 0.2.0
@@ -7418,7 +7418,7 @@ packages:
       promzard: 0.3.0
       read: 1.0.7
       read-package-json: 5.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 4.0.0
     dev: true
@@ -8201,7 +8201,7 @@ packages:
       normalize-package-data: 4.0.1
       npm-package-arg: 9.1.2
       npm-registry-fetch: 13.3.1
-      semver: 7.5.1
+      semver: 7.5.3
       ssri: 9.0.1
     transitivePeerDependencies:
       - bluebird
@@ -9024,7 +9024,7 @@ packages:
     resolution: {integrity: sha512-p+0xx5ruIQ+8X57CRIMxbTZRT7tU0Tjn2C/aAK68AEMrbGsCo6IjnDdPNhEyyjWCT4bRtzomXchYd3sSgk3BJQ==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: false
 
   /node-addon-api/3.2.1:
@@ -9067,7 +9067,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       tar: 6.1.13
       which: 2.0.2
     transitivePeerDependencies:
@@ -9086,7 +9086,7 @@ packages:
       nopt: 6.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       tar: 6.1.13
       which: 2.0.2
     transitivePeerDependencies:
@@ -9138,7 +9138,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.11.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
 
   /normalize-package-data/4.0.1:
@@ -9147,7 +9147,7 @@ packages:
     dependencies:
       hosted-git-info: 5.2.1
       is-core-module: 2.11.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -9157,7 +9157,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.11.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
 
   /normalize-path/3.0.0:
@@ -9219,7 +9219,7 @@ packages:
       rc-config-loader: 4.1.3
       remote-git-tags: 3.0.0
       rimraf: 5.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       semver-utils: 1.1.4
       source-map-support: 0.5.21
       spawn-please: 2.0.1
@@ -9235,20 +9235,20 @@ packages:
     resolution: {integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
 
   /npm-install-checks/5.0.0:
     resolution: {integrity: sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /npm-install-checks/6.1.1:
     resolution: {integrity: sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
 
   /npm-normalize-package-bin/1.0.1:
     resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==}
@@ -9267,7 +9267,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-name: 5.0.0
 
   /npm-package-arg/8.1.1:
@@ -9275,7 +9275,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 3.0.8
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -9284,7 +9284,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-name: 3.0.0
 
   /npm-package-arg/9.1.2:
@@ -9293,7 +9293,7 @@ packages:
     dependencies:
       hosted-git-info: 5.2.1
       proc-log: 2.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-name: 4.0.0
     dev: true
 
@@ -9330,7 +9330,7 @@ packages:
       npm-install-checks: 4.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 8.1.5
-      semver: 7.5.1
+      semver: 7.5.3
 
   /npm-pick-manifest/7.0.2:
     resolution: {integrity: sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==}
@@ -9339,7 +9339,7 @@ packages:
       npm-install-checks: 5.0.0
       npm-normalize-package-bin: 2.0.0
       npm-package-arg: 9.1.2
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /npm-pick-manifest/8.0.1:
@@ -9349,7 +9349,7 @@ packages:
       npm-install-checks: 6.1.1
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.5.1
+      semver: 7.5.3
 
   /npm-registry-fetch/12.0.2:
     resolution: {integrity: sha512-Df5QT3RaJnXYuOwtXBXS9BWs+tHH2olvkCLh6jcR/b/u3DvPMlp3J0TvvYwplPKxHMOwfg287PYih9QqaVFoKA==}
@@ -9677,7 +9677,7 @@ packages:
       got: 11.8.6
       lodash: 4.17.21
       normalize-package-data: 3.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.3
       yeoman-environment: 3.19.3
@@ -9904,7 +9904,7 @@ packages:
       got: 12.5.3
       registry-auth-token: 5.0.1
       registry-url: 6.0.1
-      semver: 7.5.1
+      semver: 7.5.3
     dev: false
 
   /pacote/12.0.3:
@@ -10884,7 +10884,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: false
 
   /semver-utils/1.1.4:
@@ -10923,8 +10923,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver/7.5.1:
-    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+  /semver/7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -10965,7 +10965,7 @@ packages:
       detect-libc: 2.0.1
       node-addon-api: 5.0.0
       prebuild-install: 7.1.1
-      semver: 7.5.1
+      semver: 7.5.3
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
@@ -12061,7 +12061,7 @@ packages:
       is-yarn-global: 0.4.0
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.5.1
+      semver: 7.5.3
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: false
@@ -12598,7 +12598,7 @@ packages:
       preferred-pm: 3.0.3
       pretty-bytes: 5.6.0
       readable-stream: 4.4.0
-      semver: 7.5.1
+      semver: 7.5.3
       slash: 3.0.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
@@ -12628,7 +12628,7 @@ packages:
       pacote: 15.2.0
       read-pkg-up: 7.0.1
       run-async: 2.4.1
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       sort-keys: 4.2.0
       text-table: 0.2.0

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
       '@types/prompts': ^2.4.4
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       '@types/semver-utils': ^1.1.1
       '@types/sort-json': ^2.0.1
       async: ^3.2.4
@@ -221,7 +221,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
       '@types/rimraf': ^2.0.5
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       '@types/shelljs': ^0.8.12
       async: ^3.2.4
       chalk: ^2.4.2
@@ -364,7 +364,7 @@ importers:
       '@types/chai-arrays': ^2.0.0
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       chai: ^4.3.7
       chai-arrays: ^2.2.0
       concurrently: ^7.6.0
@@ -437,7 +437,7 @@ importers:
       '@types/chai': ^4.3.5
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.51
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       chai: ^4.3.7
       chalk: ^2.4.2
       concurrently: ^7.6.0

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -67,7 +67,7 @@
 		"async": "^3.2.2",
 		"fastest-json-copy": "^1.0.1",
 		"lodash": "^4.17.21",
-		"semver": "^7.3.4",
+		"semver": "^7.5.3",
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -75,7 +75,7 @@
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"chai": "^4.2.0",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -75,7 +75,7 @@
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
-		"@types/semver": "^7.3.6",
+		"@types/semver": "7.5.0",
 		"chai": "^4.2.0",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -62,7 +62,7 @@
 		"fastest-json-copy": "^1.0.1",
 		"lodash": "^4.17.21",
 		"murmurhash3js": "3.0.1",
-		"semver": "^7.3.4",
+		"semver": "^7.5.3",
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -67,7 +67,7 @@
 		"async": "^3.2.2",
 		"fastest-json-copy": "^1.0.1",
 		"lodash": "^4.17.21",
-		"semver": "^7.3.4",
+		"semver": "^7.5.3",
 		"traverse": "0.6.6",
 		"underscore": "^1.13.6"
 	},

--- a/experimental/PropertyDDS/packages/property-query/package.json
+++ b/experimental/PropertyDDS/packages/property-query/package.json
@@ -37,7 +37,7 @@
 		"lodash": "^4.17.21",
 		"long": "^4.0.0",
 		"lru-cache": "^6.0.0",
-		"semver": "^7.3.4",
+		"semver": "^7.5.3",
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"@fluidframework/tool-utils": "workspace:~",
 		"axios": "^0.26.0",
-		"semver": "^7.3.4",
+		"semver": "^7.5.3",
 		"uuid": "^8.3.1"
 	},
 	"devDependencies": {

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -117,7 +117,7 @@
 		"@fluidframework/undo-redo": "workspace:~",
 		"cross-env": "^7.0.3",
 		"mocha": "^10.2.0",
-		"semver": "^7.3.4",
+		"semver": "^7.5.3",
 		"sinon": "^7.4.2",
 		"source-map-support": "^0.5.16",
 		"start-server-and-test": "^1.11.7",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -94,7 +94,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^14.18.38",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"@types/uuid": "^8.3.0",
 		"concurrently": "^7.6.0",
 		"cross-env": "^7.0.3",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -94,7 +94,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^14.18.38",
-		"@types/semver": "^7.3.6",
+		"@types/semver": "7.5.0",
 		"@types/uuid": "^8.3.0",
 		"concurrently": "^7.6.0",
 		"cross-env": "^7.0.3",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"nconf": "^0.12.0",
 		"proper-lockfile": "^4.1.2",
-		"semver": "^7.3.4"
+		"semver": "^7.5.3"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4571,7 +4571,7 @@ importers:
       '@types/lodash': ^4.14.118
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
-      '@types/semver': ^7.3.6
+      '@types/semver': 7.5.0
       ajv: 7.1.1
       async: ^3.2.2
       base64-js: 1.3.0
@@ -10495,7 +10495,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
       '@types/node': ^14.18.38
-      '@types/semver': ^7.3.6
+      '@types/semver': 7.5.0
       '@types/uuid': ^8.3.0
       concurrently: ^7.6.0
       cross-env: ^7.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4525,7 +4525,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      semver: ^7.3.4
+      semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
       typescript: ~4.5.5
@@ -4536,7 +4536,7 @@ importers:
       async: 3.2.4
       fastest-json-copy: 1.0.1
       lodash: 4.17.21
-      semver: 7.5.1
+      semver: 7.5.3
       traverse: 0.6.6
     devDependencies:
       '@fluidframework/build-common': 1.2.0
@@ -4592,7 +4592,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      semver: ^7.3.4
+      semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
       typescript: ~4.5.5
@@ -4604,7 +4604,7 @@ importers:
       fastest-json-copy: 1.0.1
       lodash: 4.17.21
       murmurhash3js: 3.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       traverse: 0.6.6
     devDependencies:
       '@fluidframework/build-common': 1.2.0
@@ -4904,7 +4904,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      semver: ^7.3.4
+      semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
       typescript: ~4.5.5
@@ -4916,7 +4916,7 @@ importers:
       async: 3.2.4
       fastest-json-copy: 1.0.1
       lodash: 4.17.21
-      semver: 7.5.1
+      semver: 7.5.3
       traverse: 0.6.6
       underscore: 1.13.6
     devDependencies:
@@ -5013,7 +5013,7 @@ importers:
       nock: ^10.0.1
       nyc: ^15.1.0
       prettier: ~2.6.2
-      semver: ^7.3.4
+      semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
     dependencies:
@@ -5027,7 +5027,7 @@ importers:
       lodash: 4.17.21
       long: 4.0.0
       lru-cache: 6.0.0
-      semver: 7.5.1
+      semver: 7.5.3
       traverse: 0.6.6
     devDependencies:
       '@fluid-experimental/property-properties': link:../property-properties
@@ -10040,7 +10040,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      semver: ^7.3.4
+      semver: ^7.5.3
       typescript: ~4.5.5
       uuid: ^8.3.1
     dependencies:
@@ -10062,7 +10062,7 @@ importers:
       '@fluidframework/tinylicious-driver': link:../../drivers/tinylicious-driver
       '@fluidframework/tool-utils': link:../../utils/tool-utils
       axios: 0.26.1
-      semver: 7.5.1
+      semver: 7.5.3
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
@@ -10143,7 +10143,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      semver: ^7.3.4
+      semver: ^7.5.3
       sinon: ^7.4.2
       source-map-support: ^0.5.16
       start-server-and-test: ^1.11.7
@@ -10196,7 +10196,7 @@ importers:
       '@fluidframework/undo-redo': link:../../framework/undo-redo
       cross-env: 7.0.3
       mocha: 10.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       sinon: 7.5.0
       source-map-support: 0.5.21
       start-server-and-test: 1.15.5
@@ -10510,7 +10510,7 @@ importers:
       prettier: ~2.6.2
       proper-lockfile: ^4.1.2
       rimraf: ^4.4.0
-      semver: ^7.3.4
+      semver: ^7.5.3
       ts-loader: ^9.3.0
       typescript: ~4.5.5
       uuid: ^8.3.1
@@ -10545,7 +10545,7 @@ importers:
       '@fluidframework/test-utils': link:../test-utils
       nconf: 0.12.0
       proper-lockfile: 4.1.2
-      semver: 7.5.1
+      semver: 7.5.3
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_aaj3xo5wh3dcbnhbyxbrutbslq
       '@fluidframework/build-common': 1.2.0
@@ -15280,7 +15280,7 @@ packages:
       '@oclif/plugin-not-found': 2.3.26
       '@oclif/plugin-plugins': 3.1.3
       chalk: 2.4.2
-      semver: 7.5.1
+      semver: 7.5.3
       table: 6.8.1
     transitivePeerDependencies:
       - supports-color
@@ -19379,7 +19379,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       ssri: 8.0.1
       treeverse: 1.0.4
       walk-up-path: 1.0.0
@@ -19392,7 +19392,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@npmcli/fs/2.1.2:
@@ -19400,14 +19400,14 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@npmcli/fs/3.1.0:
     resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /@npmcli/git/2.1.0:
@@ -19419,7 +19419,7 @@ packages:
       npm-pick-manifest: 6.1.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -19435,7 +19435,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -19476,7 +19476,7 @@ packages:
       cacache: 15.3.0
       json-parse-even-better-errors: 2.3.1
       pacote: 12.0.3
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -19592,7 +19592,7 @@ packages:
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.2
-      semver: 7.5.1
+      semver: 7.5.3
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -19652,7 +19652,7 @@ packages:
       load-json-file: 5.3.0
       npm: 9.7.1
       npm-run-path: 4.0.1
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.0
       validate-npm-package-name: 5.0.0
@@ -19671,7 +19671,7 @@ packages:
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19997,7 +19997,7 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.4.1
       require-in-the-middle: 5.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -22588,7 +22588,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -22615,7 +22615,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -22815,7 +22815,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -22836,7 +22836,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -22857,7 +22857,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -22878,7 +22878,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -22917,7 +22917,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.6_typescript@4.5.5
       eslint: 8.6.0
       eslint-scope: 5.1.1
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24158,7 +24158,7 @@ packages:
       handlebars: 4.7.7
       node-fetch: 2.6.11
       parse-github-url: 1.0.2
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -24775,7 +24775,7 @@ packages:
     dependencies:
       arg-parser: 1.2.0
       commander: 9.5.0
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /bfj/7.0.2:
@@ -25173,7 +25173,7 @@ packages:
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /bytes/3.0.0:
@@ -26662,7 +26662,7 @@ packages:
     resolution: {integrity: sha512-cllzD6IU/mzXBs5OdQVWL3+ne5Elpu3Wdm7h5OldMbGXk76yr9XzHlQXWJ4zfs0ZAibe26rkbs4KvMAJm7fIZA==}
     engines: {node: '>=14.x'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /create-hash/1.2.0:
@@ -26845,7 +26845,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.23
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
-      semver: 7.5.1
+      semver: 7.5.3
       webpack: 5.87.0_webpack-cli@4.10.0
     dev: true
 
@@ -29771,7 +29771,7 @@ packages:
       memfs: 3.5.1
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.1
+      semver: 7.5.3
       tapable: 1.1.3
       typescript: 4.5.5
       webpack: 5.87.0_webpack-cli@4.10.0
@@ -29803,7 +29803,7 @@ packages:
       memfs: 3.5.1
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.1
+      semver: 7.5.3
       tapable: 1.1.3
       typescript: 4.5.5
       webpack: 4.46.0_webpack-cli@4.10.0
@@ -32991,7 +32991,7 @@ packages:
       jest-resolve: 26.6.2
       natural-compare: 1.4.0
       pretty-format: 26.6.2
-      semver: 7.5.1
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -33448,7 +33448,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.5.1
+      semver: 7.5.3
 
   /jsprim/1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
@@ -35616,7 +35616,7 @@ packages:
     resolution: {integrity: sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /node-addon-api/5.1.0:
@@ -35671,7 +35671,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       tar: 6.1.15
       which: 2.0.2
     transitivePeerDependencies:
@@ -35691,7 +35691,7 @@ packages:
       nopt: 6.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       tar: 6.1.15
       which: 2.0.2
     transitivePeerDependencies:
@@ -35736,7 +35736,7 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.5.1
+      semver: 7.5.3
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -35798,7 +35798,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.12.1
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -35808,7 +35808,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.12.1
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -35889,7 +35889,7 @@ packages:
       rc-config-loader: 4.1.2
       remote-git-tags: 3.0.0
       rimraf: 5.0.0
-      semver: 7.5.1
+      semver: 7.5.3
       semver-utils: 1.1.4
       source-map-support: 0.5.21
       spawn-please: 2.0.1
@@ -35905,14 +35905,14 @@ packages:
     resolution: {integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /npm-install-checks/6.1.1:
     resolution: {integrity: sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /npm-normalize-package-bin/1.0.1:
@@ -35935,7 +35935,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -35944,7 +35944,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.1
+      semver: 7.5.3
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -35972,7 +35972,7 @@ packages:
       npm-install-checks: 4.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 8.1.5
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /npm-pick-manifest/8.0.1:
@@ -35982,7 +35982,7 @@ packages:
       npm-install-checks: 6.1.1
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /npm-registry-fetch/12.0.2:
@@ -36334,7 +36334,7 @@ packages:
       got: 11.8.6
       lodash: 4.17.21
       normalize-package-data: 3.0.3
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.0
       yeoman-environment: 3.17.0
@@ -36759,7 +36759,7 @@ packages:
       got: 12.6.0
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /pacote/12.0.3:
@@ -37261,7 +37261,7 @@ packages:
       loader-utils: 2.0.4
       postcss: 7.0.39
       schema-utils: 3.3.0
-      semver: 7.5.1
+      semver: 7.5.3
       webpack: 4.46.0_webpack-cli@4.10.0
     dev: true
 
@@ -39543,7 +39543,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.3
     dev: true
 
   /semver-utils/1.1.4:
@@ -39576,6 +39576,14 @@ packages:
 
   /semver/7.5.1:
     resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver/7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -39726,7 +39734,7 @@ packages:
       detect-libc: 2.0.1
       node-addon-api: 5.1.0
       prebuild-install: 7.1.1
-      semver: 7.5.1
+      semver: 7.5.3
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
@@ -42253,7 +42261,7 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.5.1
+      semver: 7.5.3
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
@@ -44057,7 +44065,7 @@ packages:
       pacote: 12.0.3
       preferred-pm: 3.0.3
       pretty-bytes: 5.6.0
-      semver: 7.5.1
+      semver: 7.5.3
       slash: 3.0.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
@@ -44087,7 +44095,7 @@ packages:
       minimist: 1.2.8
       read-pkg-up: 7.0.1
       run-async: 2.4.1
-      semver: 7.5.1
+      semver: 7.5.3
       shelljs: 0.8.5
       sort-keys: 4.2.0
       text-table: 0.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4571,7 +4571,7 @@ importers:
       '@types/lodash': ^4.14.118
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       ajv: 7.1.1
       async: ^3.2.2
       base64-js: 1.3.0
@@ -10495,7 +10495,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
       '@types/node': ^14.18.38
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       '@types/uuid': ^8.3.0
       concurrently: ^7.6.0
       cross-env: ^7.0.3

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/server-services-client": "workspace:*",
 		"@fluidframework/server-services-core": "workspace:*",
 		"@fluidframework/server-services-telemetry": "workspace:*",
-		"@types/semver": "7.5.0",
+		"@types/semver": "^7.5.0",
 		"assert": "^2.0.0",
 		"async": "^3.2.2",
 		"axios": "^0.26.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/server-services-client": "workspace:*",
 		"@fluidframework/server-services-core": "workspace:*",
 		"@fluidframework/server-services-telemetry": "workspace:*",
-		"@types/semver": "^6.0.1",
+		"@types/semver": "7.5.0",
 		"assert": "^2.0.0",
 		"async": "^3.2.2",
 		"axios": "^0.26.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -71,7 +71,7 @@
 		"json-stringify-safe": "^5.0.1",
 		"lodash": "^4.17.21",
 		"nconf": "^0.12.0",
-		"semver": "^6.3.0",
+		"semver": "^7.5.3",
 		"sha.js": "^2.4.11",
 		"uuid": "^8.3.1"
 	},

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
       '@types/mocha': ^10.0.1
       '@types/nconf': ^0.10.2
       '@types/node': ^16.18.16
-      '@types/semver': 7.5.0
+      '@types/semver': ^7.5.0
       '@types/sinon': ^9.0.9
       '@types/uuid': ^8.3.0
       assert: ^2.0.0

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
       '@types/mocha': ^10.0.1
       '@types/nconf': ^0.10.2
       '@types/node': ^16.18.16
-      '@types/semver': ^6.0.1
+      '@types/semver': 7.5.0
       '@types/sinon': ^9.0.9
       '@types/uuid': ^8.3.0
       assert: ^2.0.0
@@ -135,7 +135,7 @@ importers:
       nyc: ^15.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      semver: ^6.3.0
+      semver: ^7.5.3
       sha.js: ^2.4.11
       sinon: ^9.2.3
       source-map-loader: ^0.2.4
@@ -153,7 +153,7 @@ importers:
       '@fluidframework/server-services-client': link:../services-client
       '@fluidframework/server-services-core': link:../services-core
       '@fluidframework/server-services-telemetry': link:../services-telemetry
-      '@types/semver': 6.2.3
+      '@types/semver': 7.5.0
       assert: 2.0.0
       async: 3.2.4
       axios: 0.26.1
@@ -163,7 +163,7 @@ importers:
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       nconf: 0.12.0
-      semver: 6.3.0
+      semver: 7.5.3
       sha.js: 2.4.11
       uuid: 8.3.2
     devDependencies:
@@ -2615,7 +2615,7 @@ packages:
       '@oclif/plugin-not-found': 2.3.26_fu6vecow5ai5c26swy67nv6dse
       '@oclif/plugin-plugins': 3.1.3_fu6vecow5ai5c26swy67nv6dse
       chalk: 2.4.2
-      semver: 7.5.2
+      semver: 7.5.3
       table: 6.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -2637,7 +2637,7 @@ packages:
       '@oclif/plugin-not-found': 2.3.26_typescript@4.5.5
       '@oclif/plugin-plugins': 3.1.3_typescript@4.5.5
       chalk: 2.4.2
-      semver: 7.5.2
+      semver: 7.5.3
       table: 6.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -3426,7 +3426,7 @@ packages:
       npm-package-arg: 8.1.1
       p-map: 4.0.0
       pacote: 13.6.2
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -3457,7 +3457,7 @@ packages:
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-waterfall: 2.1.1
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -3564,7 +3564,7 @@ packages:
       npm-package-arg: 8.1.1
       npmlog: 6.0.2
       pify: 5.0.0
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@lerna/create-symlink/5.6.2:
@@ -3591,7 +3591,7 @@ packages:
       p-reduce: 2.1.0
       pacote: 13.6.2
       pify: 5.0.0
-      semver: 7.5.2
+      semver: 7.5.3
       slash: 3.0.0
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 4.0.0
@@ -3700,7 +3700,7 @@ packages:
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
       '@lerna/child-process': 5.6.2
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@lerna/import/5.6.2:
@@ -3876,7 +3876,7 @@ packages:
       '@lerna/validation-error': 5.6.2
       npm-package-arg: 8.1.1
       npmlog: 6.0.2
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@lerna/package/5.6.2:
@@ -3892,7 +3892,7 @@ packages:
     resolution: {integrity: sha512-7gIm9fecWFVNy2kpj/KbH11bRcpyANAwpsft3X5m6J7y7A6FTUscCbEvl3ZNdpQKHNuvnHgCtkm3A5PMSCEgkA==}
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@lerna/profiler/5.6.2:
@@ -3962,7 +3962,7 @@ packages:
       p-map: 4.0.0
       p-pipe: 3.1.0
       pacote: 13.6.2
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - encoding
@@ -4111,7 +4111,7 @@ packages:
       p-pipe: 3.1.0
       p-reduce: 2.1.0
       p-waterfall: 2.1.1
-      semver: 7.5.2
+      semver: 7.5.3
       slash: 3.0.0
       write-json-file: 4.3.0
     transitivePeerDependencies:
@@ -4298,7 +4298,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.5.2
+      semver: 7.5.3
       ssri: 8.0.1
       treeverse: 1.0.4
       walk-up-path: 1.0.0
@@ -4342,7 +4342,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.5.2
+      semver: 7.5.3
       ssri: 9.0.1
       treeverse: 2.0.0
       walk-up-path: 1.0.0
@@ -4355,7 +4355,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@npmcli/fs/2.1.2:
@@ -4363,14 +4363,14 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@npmcli/fs/3.1.0:
     resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /@npmcli/git/2.1.0:
@@ -4382,7 +4382,7 @@ packages:
       npm-pick-manifest: 6.1.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -4399,7 +4399,7 @@ packages:
       proc-log: 2.0.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -4415,7 +4415,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -4456,7 +4456,7 @@ packages:
       cacache: 15.3.0
       json-parse-even-better-errors: 2.3.1
       pacote: 12.0.3
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -4469,7 +4469,7 @@ packages:
       cacache: 16.1.3
       json-parse-even-better-errors: 2.3.1
       pacote: 13.6.2
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -4731,7 +4731,7 @@ packages:
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.2
-      semver: 7.5.2
+      semver: 7.5.3
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -4771,7 +4771,7 @@ packages:
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.2
-      semver: 7.5.2
+      semver: 7.5.3
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -4911,7 +4911,7 @@ packages:
       load-json-file: 5.3.0
       npm: 9.7.1
       npm-run-path: 4.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.3
       validate-npm-package-name: 5.0.0
@@ -4937,7 +4937,7 @@ packages:
       load-json-file: 5.3.0
       npm: 9.7.1
       npm-run-path: 4.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.3
       validate-npm-package-name: 5.0.0
@@ -4960,7 +4960,7 @@ packages:
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4979,7 +4979,7 @@ packages:
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -5853,6 +5853,11 @@ packages:
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
+    dev: true
+
+  /@types/semver/7.5.0:
+    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+    dev: false
 
   /@types/send/0.17.1:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
@@ -5951,7 +5956,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
-      semver: 7.5.2
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -6073,7 +6078,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -6094,7 +6099,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -6796,7 +6801,7 @@ packages:
     dependencies:
       arg-parser: 1.2.0
       commander: 9.5.0
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /big.js/5.2.2:
@@ -7034,7 +7039,7 @@ packages:
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /byte-size/7.0.1:
@@ -8728,7 +8733,7 @@ packages:
       escape-string-regexp: 4.0.0
       eslint: 8.27.0
       esquery: 1.5.0
-      semver: 7.5.2
+      semver: 7.5.3
       spdx-expression-parse: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8792,7 +8797,7 @@ packages:
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.27
       safe-regex: 2.1.1
-      semver: 7.5.2
+      semver: 7.5.3
       strip-indent: 3.0.0
     dev: true
 
@@ -10355,7 +10360,7 @@ packages:
       promzard: 0.3.0
       read: 1.0.7
       read-package-json: 5.0.2
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 4.0.0
     dev: true
@@ -10416,7 +10421,7 @@ packages:
       fengari: 0.1.4
       fengari-interop: 0.1.3_fengari@0.1.4
       ioredis: 5.3.2
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /ioredis/4.28.5:
@@ -11073,7 +11078,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.5.2
+      semver: 7.5.3
 
   /jsprim/1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
@@ -11313,7 +11318,7 @@ packages:
       normalize-package-data: 4.0.1
       npm-package-arg: 9.1.2
       npm-registry-fetch: 13.3.1
-      semver: 7.5.2
+      semver: 7.5.3
       ssri: 9.0.1
     transitivePeerDependencies:
       - bluebird
@@ -12265,7 +12270,7 @@ packages:
     resolution: {integrity: sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /node-addon-api/3.2.1:
@@ -12308,7 +12313,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.2
+      semver: 7.5.3
       tar: 6.1.15
       which: 2.0.2
     transitivePeerDependencies:
@@ -12329,7 +12334,7 @@ packages:
       nopt: 6.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.2
+      semver: 7.5.3
       tar: 6.1.15
       which: 2.0.2
     transitivePeerDependencies:
@@ -12397,7 +12402,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.12.1
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -12407,7 +12412,7 @@ packages:
     dependencies:
       hosted-git-info: 5.2.1
       is-core-module: 2.12.1
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -12417,7 +12422,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.12.1
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -12493,7 +12498,7 @@ packages:
       rc-config-loader: 4.1.3
       remote-git-tags: 3.0.0
       rimraf: 5.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       semver-utils: 1.1.4
       source-map-support: 0.5.21
       spawn-please: 2.0.1
@@ -12509,21 +12514,21 @@ packages:
     resolution: {integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /npm-install-checks/5.0.0:
     resolution: {integrity: sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /npm-install-checks/6.1.1:
     resolution: {integrity: sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /npm-normalize-package-bin/1.0.1:
@@ -12546,7 +12551,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -12555,7 +12560,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 3.0.8
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -12564,7 +12569,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -12574,7 +12579,7 @@ packages:
     dependencies:
       hosted-git-info: 5.2.1
       proc-log: 2.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       validate-npm-package-name: 4.0.0
     dev: true
 
@@ -12613,7 +12618,7 @@ packages:
       npm-install-checks: 4.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 8.1.5
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /npm-pick-manifest/7.0.2:
@@ -12623,7 +12628,7 @@ packages:
       npm-install-checks: 5.0.0
       npm-normalize-package-bin: 2.0.0
       npm-package-arg: 9.1.2
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /npm-pick-manifest/8.0.1:
@@ -12633,7 +12638,7 @@ packages:
       npm-install-checks: 6.1.1
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /npm-registry-fetch/12.0.2:
@@ -12987,7 +12992,7 @@ packages:
       got: 11.8.6
       lodash: 4.17.21
       normalize-package-data: 3.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.3
       yeoman-environment: 3.19.3
@@ -13022,7 +13027,7 @@ packages:
       got: 11.8.6
       lodash: 4.17.21
       normalize-package-data: 3.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       shelljs: 0.8.5
       tslib: 2.5.3
       yeoman-environment: 3.19.3
@@ -13287,7 +13292,7 @@ packages:
       got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /pacote/12.0.3:
@@ -14492,7 +14497,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /semver-utils/1.1.4:
@@ -14506,6 +14511,7 @@ packages:
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
+    dev: true
 
   /semver/7.3.4:
     resolution: {integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==}
@@ -14525,6 +14531,14 @@ packages:
 
   /semver/7.5.2:
     resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver/7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -14612,7 +14626,7 @@ packages:
       detect-libc: 2.0.1
       node-addon-api: 5.1.0
       prebuild-install: 7.1.1
-      semver: 7.5.2
+      semver: 7.5.3
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
@@ -15579,7 +15593,7 @@ packages:
       chalk: 4.1.2
       enhanced-resolve: 5.15.0
       micromatch: 4.0.5
-      semver: 7.5.2
+      semver: 7.5.3
       typescript: 4.5.5
       webpack: 5.87.0
     dev: true
@@ -15973,7 +15987,7 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.5.2
+      semver: 7.5.3
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
@@ -16707,7 +16721,7 @@ packages:
       preferred-pm: 3.0.3
       pretty-bytes: 5.6.0
       readable-stream: 4.4.0
-      semver: 7.5.2
+      semver: 7.5.3
       slash: 3.0.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
@@ -16738,7 +16752,7 @@ packages:
       pacote: 15.2.0
       read-pkg-up: 7.0.1
       run-async: 2.4.1
-      semver: 7.5.2
+      semver: 7.5.3
       shelljs: 0.8.5
       sort-keys: 4.2.0
       text-table: 0.2.0


### PR DESCRIPTION
#16139

Component governance, there is a security vulnerability with semver. Upgrade semver to remove the security vulnerability.