### PR TITLE
fix(devtools-view): Theme selection dropdown in settings does not keep currently selected value

### DIFF
--- a/packages/tools/devtools/devtools-view/src/ThemeHelper.ts
+++ b/packages/tools/devtools/devtools-view/src/ThemeHelper.ts
@@ -9,6 +9,7 @@ import {
 	teamsHighContrastTheme,
 	Theme,
 } from "@fluentui/react-components";
+import { ThemeOption } from "./components";
 
 teamsHighContrastTheme.colorSubtleBackgroundHover = "#1aebff";
 teamsHighContrastTheme.colorBrandBackground2 = "#1aebff";
@@ -20,14 +21,14 @@ teamsHighContrastTheme.colorCompoundBrandForeground1 = "#000";
  */
 export function getFluentUIThemeToUse(): { name: string; theme: Theme } {
 	let defaultTheme = {
-		name: "light",
+		name: ThemeOption.Light,
 		theme: webLightTheme,
 	};
 
 	// API reference: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
 	if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
 		defaultTheme = {
-			name: "dark",
+			name: ThemeOption.Dark,
 			theme: webDarkTheme,
 		};
 	}
@@ -36,7 +37,7 @@ export function getFluentUIThemeToUse(): { name: string; theme: Theme } {
 	// API reference: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
 	if (window.matchMedia?.("(forced-colors: active)").matches) {
 		defaultTheme = {
-			name: "highcontrast",
+			name: ThemeOption.HighContrast,
 			theme: teamsHighContrastTheme,
 		};
 	}

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -117,7 +117,7 @@ export function SettingsView(): React.ReactElement {
 			<div className={styles.option}>
 				<label className={styles.label}>Select theme</label>
 				<Dropdown
-					placeholder={themeReadableOption[themeInfo.name as ThemeName]}
+					value={themeReadableOption[themeInfo.name as ThemeName]}
 					className={styles.dropdown}
 					onOptionSelect={handleThemeChange}
 				>

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -25,6 +25,17 @@ export enum ThemeOption {
 	HighContrast = "High Contrast",
 }
 
+/**
+ * A map to convert selected theme property to more user friendly displayed value.
+ */
+type ThemeName = "light" | "dark" | "highContrast";
+
+const themeNameDisplayMap: Record<ThemeName, ThemeOption> = {
+	light: ThemeOption.Light,
+	dark: ThemeOption.Dark,
+	highContrast: ThemeOption.HighContrast,
+};
+
 const useStyles = makeStyles({
 	root: {
 		...shorthands.gap("10px"),
@@ -57,12 +68,11 @@ const useStyles = makeStyles({
 		fontWeight: "bold",
 	},
 });
-
 /**
  * Settings page for the devtools.
  */
 export function SettingsView(): React.ReactElement {
-	const { setTheme } = React.useContext(ThemeContext) ?? {};
+	const { themeInfo, setTheme } = React.useContext(ThemeContext) ?? {};
 
 	const styles = useStyles();
 
@@ -107,7 +117,7 @@ export function SettingsView(): React.ReactElement {
 			<div className={styles.option}>
 				<label className={styles.label}>Select theme</label>
 				<Dropdown
-					placeholder="Theme"
+					placeholder={themeNameDisplayMap[themeInfo.name as ThemeName]}
 					className={styles.dropdown}
 					onOptionSelect={handleThemeChange}
 				>

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -30,7 +30,7 @@ export enum ThemeOption {
  */
 type ThemeName = "light" | "dark" | "highContrast";
 
-const themeNameDisplayMap: Record<ThemeName, ThemeOption> = {
+const themeReadableOption: Record<ThemeName, ThemeOption> = {
 	light: ThemeOption.Light,
 	dark: ThemeOption.Dark,
 	highContrast: ThemeOption.HighContrast,
@@ -117,7 +117,7 @@ export function SettingsView(): React.ReactElement {
 			<div className={styles.option}>
 				<label className={styles.label}>Select theme</label>
 				<Dropdown
-					placeholder={themeNameDisplayMap[themeInfo.name as ThemeName]}
+					placeholder={themeReadableOption[themeInfo.name as ThemeName]}
 					className={styles.dropdown}
 					onOptionSelect={handleThemeChange}
 				>

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -19,7 +19,7 @@ import { ThemeContext } from "../ThemeHelper";
 /**
  * An enum with options for the DevTools themes.
  */
-export enum ThemeOption {
+export const enum ThemeOption {
 	Light = "Light",
 	Dark = "Dark",
 	HighContrast = "High Contrast",
@@ -106,7 +106,7 @@ export function SettingsView(): React.ReactElement {
 			<div className={styles.option}>
 				<label className={styles.label}>Select theme</label>
 				<Dropdown
-					value={themeInfo.name === "dark" ? "Dark" : themeInfo.name}
+					value={themeInfo.name}
 					className={styles.dropdown}
 					onOptionSelect={handleThemeChange}
 				>

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -25,17 +25,6 @@ export enum ThemeOption {
 	HighContrast = "High Contrast",
 }
 
-/**
- * A map to convert selected theme property to more user friendly displayed value.
- */
-type ThemeName = "light" | "dark" | "highContrast";
-
-const themeReadableOption: Record<ThemeName, ThemeOption> = {
-	light: ThemeOption.Light,
-	dark: ThemeOption.Dark,
-	highContrast: ThemeOption.HighContrast,
-};
-
 const useStyles = makeStyles({
 	root: {
 		...shorthands.gap("10px"),
@@ -77,7 +66,7 @@ export function SettingsView(): React.ReactElement {
 	const styles = useStyles();
 
 	function handleThemeChange(
-		event,
+		_event,
 		option: {
 			optionValue: string | undefined;
 			optionText: string | undefined;
@@ -87,25 +76,25 @@ export function SettingsView(): React.ReactElement {
 		switch (option.optionValue) {
 			case ThemeOption.Light:
 				setTheme({
-					name: "light",
+					name: ThemeOption.Light,
 					theme: webLightTheme,
 				});
 				break;
 			case ThemeOption.Dark:
 				setTheme({
-					name: "dark",
+					name: ThemeOption.Dark,
 					theme: webDarkTheme,
 				});
 				break;
 			case ThemeOption.HighContrast:
 				setTheme({
-					name: "highContrast",
+					name: ThemeOption.HighContrast,
 					theme: teamsHighContrastTheme,
 				});
 				break;
 			default:
 				setTheme({
-					name: "dark",
+					name: ThemeOption.Dark,
 					theme: webDarkTheme,
 				});
 				break;
@@ -117,7 +106,7 @@ export function SettingsView(): React.ReactElement {
 			<div className={styles.option}>
 				<label className={styles.label}>Select theme</label>
 				<Dropdown
-					value={themeReadableOption[themeInfo.name as ThemeName]}
+					value={themeInfo.name === "dark" ? "Dark" : themeInfo.name}
 					className={styles.dropdown}
 					onOptionSelect={handleThemeChange}
 				>


### PR DESCRIPTION
#### Description

https://dev.azure.com/fluidframework/internal/_workitems/edit/4671/

Devtools supports `Light`, `Dark`, and `High Contrast` themes for the users. Currently, the dropdown menu does not retain the selected value if navigated to a different view. This PR fixes this issue and makes users to see their currently selected theme even after going through different panels. 