### PR TITLE
Remove "Getting to 1.0" section as obsolete

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -58,17 +58,6 @@ The following is a typical flow.
 4. Fluid runtime incorporates that operation into local data and raises a "valueChanged" event.
 5. Client code handles that event (updates view, runs business logic).
 
-## Getting to version 1.0
-
-The core technology powering Fluid Framework is mature and stable. However, the layers built on top of that
-foundation are still a work in progress. Over the coming months we will be evolving APIs, adding new features,
-and working to further simplify using the framework. These changes are driven by Microsoft's use of
-Fluid internally as well as by requirements we are gathering from developers currently building on Fluid.
-
-Fluid Framework is not ready to power production-quality solutions yet. But we are excited to open source it now
-to give developers an opportunity to explore, learn, and contribute both through feedback and through direct
-participation.
-
 ## Next steps
 
 If you want to learn a lot more about how Fluid works, start with our


### PR DESCRIPTION
Removing the section titled "Getting to 1.0" as that's now long obsolete.

Also using this to validate that I can make doc changes, submit the PR, etc...