### PR TITLE
fix(devtools): Fix DOM layout issues

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -17,6 +17,7 @@ import {
 	TableColumnSizingOptions,
 	useTableFeatures,
 	useTableColumnSizing_unstable,
+	TableBody,
 } from "@fluentui/react-components";
 import { InfoLabel } from "@fluentui/react-components/unstable";
 import {
@@ -105,6 +106,8 @@ interface DataRowProps {
 
 /**
  * Displays a row with basic stats about the Container.
+ *
+ * @remarks {@link DataRowProps.value} will be wrapped in a <TableCell /> so it shouldn't have one itself.
  */
 function DataRow(props: DataRowProps): React.ReactElement {
 	const { label, infoTooltipContent, value, columnProps } = props;
@@ -132,42 +135,40 @@ function DataRow(props: DataRowProps): React.ReactElement {
 
 function containerStatusValueCell(statusComponents: string[]): React.ReactElement {
 	return (
-		<TableCell>
-			<TableCellLayout
-				media={((): JSX.Element => {
-					switch (statusComponents[0]) {
-						case AttachState.Attaching:
-							return (
-								<Badge shape="rounded" color="warning">
-									{statusComponents[0]}
-								</Badge>
-							);
-						case AttachState.Detached:
-							return (
-								<Badge shape="rounded" color="danger">
-									{statusComponents[0]}
-								</Badge>
-							);
-						default:
-							return (
-								<Badge shape="rounded" color="success">
-									{statusComponents[0]}
-								</Badge>
-							);
-					}
-				})()}
-			>
-				{statusComponents[1] === "Connected" ? (
-					<Badge shape="rounded" color="success">
-						{statusComponents[1]}
-					</Badge>
-				) : (
-					<Badge shape="rounded" color="danger">
-						{statusComponents[1]}
-					</Badge>
-				)}
-			</TableCellLayout>
-		</TableCell>
+		<TableCellLayout
+			media={((): JSX.Element => {
+				switch (statusComponents[0]) {
+					case AttachState.Attaching:
+						return (
+							<Badge shape="rounded" color="warning">
+								{statusComponents[0]}
+							</Badge>
+						);
+					case AttachState.Detached:
+						return (
+							<Badge shape="rounded" color="danger">
+								{statusComponents[0]}
+							</Badge>
+						);
+					default:
+						return (
+							<Badge shape="rounded" color="success">
+								{statusComponents[0]}
+							</Badge>
+						);
+				}
+			})()}
+		>
+			{statusComponents[1] === "Connected" ? (
+				<Badge shape="rounded" color="success">
+					{statusComponents[1]}
+				</Badge>
+			) : (
+				<Badge shape="rounded" color="danger">
+					{statusComponents[1]}
+				</Badge>
+			)}
+		</TableCellLayout>
 	);
 }
 
@@ -304,24 +305,26 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 			</div>
 			<div>
 				<Table size="extra-small" ref={tableRef}>
-					<DataRow
-						label="Status"
-						infoTooltipContent={containerStatusTooltipText}
-						value={containerStatusValueCell(statusComponents)}
-						columnProps={columnSizing_unstable}
-					/>
-					<DataRow
-						label="Client ID"
-						infoTooltipContent={clientIdTooltipText}
-						value={containerState.clientId}
-						columnProps={columnSizing_unstable}
-					/>
-					<DataRow
-						label="User ID"
-						infoTooltipContent={userIdTooltipText}
-						value={containerState.userId}
-						columnProps={columnSizing_unstable}
-					/>
+					<TableBody>
+						<DataRow
+							label="Status"
+							infoTooltipContent={containerStatusTooltipText}
+							value={containerStatusValueCell(statusComponents)}
+							columnProps={columnSizing_unstable}
+						/>
+						<DataRow
+							label="Client ID"
+							infoTooltipContent={clientIdTooltipText}
+							value={containerState.clientId}
+							columnProps={columnSizing_unstable}
+						/>
+						<DataRow
+							label="User ID"
+							infoTooltipContent={userIdTooltipText}
+							value={containerState.userId}
+							columnProps={columnSizing_unstable}
+						/>
+					</TableBody>
 				</Table>
 			</div>
 			<div className={styles.actions}>


### PR DESCRIPTION
## Description

Fixes a few errors reported in the browser console with the DOM layout in the Container Summary View.

- A `<TableCell>` that was nested inside another.
- A `<Table>` with no `<TableBody>` between it and its `<TableRow>`s.

These are the errors that show up currently when one navigates to the view for a Container:

<details>
<summary>Nested &lt;td&gt;</summary>

```plaintext
Warning: validateDOMNesting(...): <td> cannot appear as a child of <td>.
    at td
    at http://localhost:8080/main.bundle.js:91812:59
    at td
    at http://localhost:8080/main.bundle.js:91812:59
    at tr
    at http://localhost:8080/main.bundle.js:93478:57
    at DataRow (http://localhost:8080/main.bundle.js:309995:13)
    at table
    at http://localhost:8080/main.bundle.js:91357:51
    at div
    at div
    at ContainerSummaryView (http://localhost:8080/main.bundle.js:310030:13)
    at div
    at _ContainerDevtoolsView (http://localhost:8080/main.bundle.js:309751:13)
    at ContainerDevtoolsView (http://localhost:8080/main.bundle.js:309711:13)
    at div
    at View (http://localhost:8080/main.bundle.js:308968:13)
    at div
    at _DevtoolsView (http://localhost:8080/main.bundle.js:308917:13)
    at div
    at TextDirectionProvider (http://localhost:8080/main.bundle.js:190419:3)
    at http://localhost:8080/main.bundle.js:82951:69
    at DevtoolsView (http://localhost:8080/main.bundle.js:308846:71)
    at DevtoolsPanel (http://localhost:8080/main.bundle.js:308759:13)
    at div
    at Resizable (http://localhost:8080/main.bundle.js:209048:28)
    at DevtoolsView
```
</details>

<details>
<summary>Missing &lt;TableBody&gt;</summary>

```plaintext
Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.
    at tr
    at http://localhost:8080/main.bundle.js:93478:57
    at DataRow (http://localhost:8080/main.bundle.js:309995:13)
    at table
    at http://localhost:8080/main.bundle.js:91357:51
    at div
    at div
    at ContainerSummaryView (http://localhost:8080/main.bundle.js:310030:13)
    at div
    at _ContainerDevtoolsView (http://localhost:8080/main.bundle.js:309751:13)
    at ContainerDevtoolsView (http://localhost:8080/main.bundle.js:309711:13)
    at div
    at View (http://localhost:8080/main.bundle.js:308968:13)
    at div
    at _DevtoolsView (http://localhost:8080/main.bundle.js:308917:13)
    at div
    at TextDirectionProvider (http://localhost:8080/main.bundle.js:190419:3)
    at http://localhost:8080/main.bundle.js:82951:69
    at DevtoolsView (http://localhost:8080/main.bundle.js:308846:71)
    at DevtoolsPanel (http://localhost:8080/main.bundle.js:308759:13)
    at div
    at Resizable (http://localhost:8080/main.bundle.js:209048:28)
    at DevtoolsView
```
</details>

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
