### PR TITLE
Server changes for handling new ping events

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -77,6 +77,13 @@ class SocketIoServer implements core.IWebSocketServer {
 		this.io.on("connection", (socket: Socket) => {
 			const webSocket = new SocketIoSocket(socket);
 			this.events.emit("connection", webSocket);
+
+			// Server side listening for ping events
+			socket.on("ping", (cb) => {
+				if (typeof cb === "function") {
+					cb();
+				}
+			});
 		});
 		this.io.engine.on("connection_error", (error) => {
 			if (isSocketIoConnectionError(error) && error.req.url !== undefined) {

--- a/server/tinylicious/src/services/webServerFactory.ts
+++ b/server/tinylicious/src/services/webServerFactory.ts
@@ -57,6 +57,13 @@ class SocketIoServer extends EventEmitter implements IWebSocketServer {
 		this.io.on("connection", (socket: Socket) => {
 			const webSocket = new SocketIoSocket(socket);
 			this.emit("connection", webSocket);
+
+			// Server side listening for ping events
+			socket.on("ping", (cb) => {
+				if (typeof cb === "function") {
+					cb();
+				}
+			});
 		});
 	}
 


### PR DESCRIPTION
Server-side changes for https://github.com/microsoft/FluidFramework/pull/15069

We lost ability to collect ping data: [Migrating from 2.x to 3.0 | Socket.IO](https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#no-more-pong-event-for-retrieving-latency). Thus, we need to implement new handling for "ping" events.

Continuation of https://github.com/microsoft/FluidFramework/pull/13942

[AB#2499](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2499)