### PR TITLE
feat(devtools): Opt-in setting for usage telemetry

### DIFF
--- a/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
@@ -9,7 +9,7 @@ import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { DevtoolsView } from "./DevtoolsView";
 import { MessageRelayContext } from "./MessageRelayContext";
-import { ConsoleVerboseLogger, LoggerContext } from "./TelemetryUtils";
+import { ConsoleVerboseLogger, LoggerContext, TelemetryOptInLogger } from "./TelemetryUtils";
 
 /**
  * {@link DevtoolsPanel} input props.
@@ -44,7 +44,8 @@ export interface DevtoolsPanelProps {
 export function DevtoolsPanel(props: DevtoolsPanelProps): React.ReactElement {
 	const { usageTelemetryLogger, messageRelay } = props;
 	const consoleLogger = new ConsoleVerboseLogger(usageTelemetryLogger);
-	const topLevelLogger = ChildLogger.create(consoleLogger);
+	const telemetryOptInLogger = new TelemetryOptInLogger(consoleLogger);
+	const topLevelLogger = ChildLogger.create(telemetryOptInLogger);
 	topLevelLogger?.sendTelemetryEvent({ eventName: "DevtoolsPanelRendered" });
 
 	return (

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -40,7 +40,6 @@ import {
 } from "./components";
 import { useMessageRelay } from "./MessageRelayContext";
 import { getFluentUIThemeToUse, ThemeContext } from "./ThemeHelper";
-import { useLogger } from "./TelemetryUtils";
 
 const loggingContext = "INLINE(DevtoolsView)";
 
@@ -466,25 +465,20 @@ function Menu(props: MenuProps): React.ReactElement {
 	const { currentSelection, setSelection, supportedFeatures, containers } = props;
 
 	const styles = useMenuStyles();
-	const logger = useLogger();
 
 	function onContainerClicked(containerKey: ContainerKey): void {
-		logger?.sendTelemetryEvent({ eventName: "containerClicked", containerKey });
 		setSelection({ type: "containerMenuSelection", containerKey });
 	}
 
 	function onTelemetryClicked(): void {
-		logger?.sendTelemetryEvent({ eventName: "telemetryClicked" });
 		setSelection({ type: "telemetryMenuSelection" });
 	}
 
 	function onSettingsClicked(): void {
-		logger?.sendTelemetryEvent({ eventName: "settingsClicked" });
 		setSelection({ type: "settingsMenuSelection" });
 	}
 
 	function onHomeClicked(): void {
-		logger?.sendTelemetryEvent({ eventName: "homeClicked" });
 		setSelection({ type: "homeMenuSelection" });
 	}
 

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -40,6 +40,7 @@ import {
 } from "./components";
 import { useMessageRelay } from "./MessageRelayContext";
 import { getFluentUIThemeToUse, ThemeContext } from "./ThemeHelper";
+import { useLogger } from "./TelemetryUtils";
 
 const loggingContext = "INLINE(DevtoolsView)";
 
@@ -465,20 +466,25 @@ function Menu(props: MenuProps): React.ReactElement {
 	const { currentSelection, setSelection, supportedFeatures, containers } = props;
 
 	const styles = useMenuStyles();
+	const logger = useLogger();
 
 	function onContainerClicked(containerKey: ContainerKey): void {
+		logger?.sendTelemetryEvent({ eventName: "containerClicked", containerKey });
 		setSelection({ type: "containerMenuSelection", containerKey });
 	}
 
 	function onTelemetryClicked(): void {
+		logger?.sendTelemetryEvent({ eventName: "telemetryClicked" });
 		setSelection({ type: "telemetryMenuSelection" });
 	}
 
 	function onSettingsClicked(): void {
+		logger?.sendTelemetryEvent({ eventName: "settingsClicked" });
 		setSelection({ type: "settingsMenuSelection" });
 	}
 
 	function onHomeClicked(): void {
+		logger?.sendTelemetryEvent({ eventName: "homeClicked" });
 		setSelection({ type: "homeMenuSelection" });
 	}
 

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -60,7 +60,7 @@ const telemetryOptInKey: string = "fluid:devtools:telemetry:optIn";
  */
 export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
 	const [value, setValue] = React.useState(() => {
-		return getStorageValue(telemetryOptInKey, true);
+		return getStorageValue(telemetryOptInKey);
 	});
 
 	React.useEffect(() => {
@@ -89,14 +89,14 @@ export class TelemetryOptInLogger implements ITelemetryBaseLogger {
 	public constructor(private readonly baseLogger?: ITelemetryBaseLogger) {}
 
 	public send(event: ITelemetryBaseEvent): void {
-		const optIn = getStorageValue(telemetryOptInKey, true);
-		if (optIn === null || Boolean(optIn)) {
+		const optIn = getStorageValue(telemetryOptInKey);
+		if (optIn === true) {
 			this.baseLogger?.send(event);
 		}
 	}
 }
 
-function getStorageValue(key: string, defaultValue: boolean): boolean {
+function getStorageValue(key: string, defaultValue: boolean = false): boolean {
 	const saved = localStorage.getItem(key);
 	if (saved === null) {
 		return defaultValue;

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -67,6 +67,19 @@ export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateActi
 		localStorage.setItem(telemetryOptInKey, value.toString());
 	}, [value]);
 
+	const localStorageChangeHandler = (event: StorageEvent): void => {
+		if (event.storageArea === localStorage) {
+			setValue(event.newValue === "true");
+		}
+	}
+	React.useEffect(() => {
+		localStorage.setItem(telemetryOptInKey, value.toString());
+		window.addEventListener('storage', localStorageChangeHandler);
+		return (): void => {
+			window.removeEventListener('storage', localStorageChangeHandler);
+		};
+	});
+
 	return [value, setValue];
 };
 

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -68,12 +68,11 @@ export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateActi
 	}, [value]);
 
 	const localStorageChangeHandler = (event: StorageEvent): void => {
-		if (event.storageArea === localStorage) {
+		if (event.storageArea === localStorage && event.key === telemetryOptInKey) {
 			setValue(event.newValue === "true");
 		}
 	}
 	React.useEffect(() => {
-		localStorage.setItem(telemetryOptInKey, value.toString());
 		window.addEventListener('storage', localStorageChangeHandler);
 		return (): void => {
 			window.removeEventListener('storage', localStorageChangeHandler);

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -48,3 +48,46 @@ export class ConsoleVerboseLogger implements ITelemetryBaseLogger {
 		this.baseLogger?.send(event);
 	}
 }
+
+/**
+ * Key for the local storage entry that stores the usage telemetry opt-in setting.
+ */
+const telemetryOptInKey: string = "fluid:devtools:telemetry:optIn";
+
+/**
+ * Hook for getting and setting the usage telemetry opt-in setting, backed by brower's local storage.
+ * @returns A tuple (React state) with the current value and a setter for the value.
+ */
+export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
+	const [value, setValue] = React.useState(() => {
+		return getStorageValue(telemetryOptInKey, true);
+	});
+
+	React.useEffect(() => {
+		localStorage.setItem(telemetryOptInKey, value.toString());
+	}, [value]);
+
+	return [value, setValue];
+};
+
+/**
+ * Logger that forwards events to another logger only when the setting to opt-in to usage telemetry is enabled.
+ */
+export class TelemetryOptInLogger implements ITelemetryBaseLogger {
+	public constructor(private readonly baseLogger?: ITelemetryBaseLogger) {}
+
+	public send(event: ITelemetryBaseEvent): void {
+		const optIn = getStorageValue(telemetryOptInKey, true);
+		if (optIn === null || Boolean(optIn)) {
+			this.baseLogger?.send(event);
+		}
+	}
+}
+
+function getStorageValue(key: string, defaultValue: boolean): boolean {
+	const saved = localStorage.getItem(key);
+	if (saved === null) {
+		return defaultValue;
+	}
+	return saved === "true";
+}

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -71,11 +71,11 @@ export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateActi
 		if (event.storageArea === localStorage && event.key === telemetryOptInKey) {
 			setValue(event.newValue === "true");
 		}
-	}
+	};
 	React.useEffect(() => {
-		window.addEventListener('storage', localStorageChangeHandler);
+		window.addEventListener("storage", localStorageChangeHandler);
 		return (): void => {
-			window.removeEventListener('storage', localStorageChangeHandler);
+			window.removeEventListener("storage", localStorageChangeHandler);
 		};
 	});
 

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import {
 	Dropdown,
 	Option,
+	Switch,
 	makeStyles,
 	teamsHighContrastTheme,
 	webDarkTheme,
@@ -14,6 +15,7 @@ import {
 } from "@fluentui/react-components";
 
 import { ThemeContext } from "../ThemeHelper";
+import { useTelemetryOptIn } from "../TelemetryUtils";
 
 /**
  * An enum with options for the DevTools themes.
@@ -68,6 +70,7 @@ export function SettingsView(): React.ReactElement {
 	const { themeInfo, setTheme } = React.useContext(ThemeContext) ?? {};
 
 	const styles = useStyles();
+	const [optedIn, setOptedIn] = useTelemetryOptIn();
 
 	function handleThemeChange(
 		_event,
@@ -118,6 +121,14 @@ export function SettingsView(): React.ReactElement {
 					<Option value={ThemeOption.Dark}>Dark</Option>
 					<Option value={ThemeOption.HighContrast}>High Contrast</Option>
 				</Dropdown>
+			</div>
+			<div className={styles.section}>
+				<h4 className={styles.sectionHeader}>Usage telemetry</h4>
+				<Switch
+					label="Send usage telemetry to Microsoft"
+					checked={optedIn}
+					onChange={(ev, data): void => setOptedIn(data.checked)}
+				/>
 			</div>
 		</div>
 	);

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import {
 	Dropdown,
+	Link,
 	Option,
 	Switch,
 	makeStyles,
@@ -124,6 +125,14 @@ export function SettingsView(): React.ReactElement {
 			</div>
 			<div className={styles.section}>
 				<h4 className={styles.sectionHeader}>Usage telemetry</h4>
+				<Link
+					href="https://go.microsoft.com/fwlink/?LinkId=521839"
+					target="_blank"
+					rel="noreferrer"
+					inline
+				>
+					Microsoft Privacy Statement
+				</Link>
 				<Switch
 					label="Send usage telemetry to Microsoft"
 					checked={optedIn}


### PR DESCRIPTION
## Description

Adds an option in the Settings view to opt in/out of sending usage telemetry. The setting just controls if the usage telemetry events generated by Devtools get forwarded to the logger provided to `<DevtoolsPanel>` through its props. The events will be written to the browser's console regardless of the value of the setting.

Still in the process of figuring out if we need any additional bits for this feature, like links to privacy policies and such.

<img width="401" alt="image" src="https://github.com/microsoft/FluidFramework/assets/716334/57f156e5-d032-4da3-9671-bb275524f2a4">

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#4717](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4717)