### PR TITLE
refactor(core-utils): Use TS project references for code reuse

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -44,7 +44,6 @@
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
-		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@fluidframework/runtime-definitions": "workspace:~",

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -7,7 +7,8 @@ import BTree from 'sorted-btree';
 import { TypedEventEmitter, assert } from '@fluidframework/common-utils';
 import type { IEvent } from '@fluidframework/common-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
-import { compareArrays } from '@fluidframework/core-utils';
+// eslint-disable-next-line import/no-internal-modules
+import { compareArrays } from '../../../../packages/common/core-utils';
 import { fail } from './Common';
 import type { EditId } from './Identifiers';
 import type { StringInterner } from './StringInterner';

--- a/experimental/dds/tree/src/EditUtilities.ts
+++ b/experimental/dds/tree/src/EditUtilities.ts
@@ -4,7 +4,8 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { compareArrays } from '@fluidframework/core-utils';
+// eslint-disable-next-line import/no-internal-modules
+import { compareArrays } from '../../../../packages/common/core-utils';
 import { copyPropertyIfDefined, fail, Mutable } from './Common';
 import { Definition, DetachedSequenceId, EditId, NodeId, StableNodeId, TraitLabel } from './Identifiers';
 import { NodeIdContext, NodeIdConverter } from './NodeIdUtilities';

--- a/experimental/dds/tree/src/PayloadUtilities.ts
+++ b/experimental/dds/tree/src/PayloadUtilities.ts
@@ -4,7 +4,8 @@
  */
 
 import { IFluidHandle } from '@fluidframework/core-interfaces';
-import { compareArrays } from '@fluidframework/core-utils';
+// eslint-disable-next-line import/no-internal-modules
+import { compareArrays } from '../../../../packages/common/core-utils';
 import { Payload } from './persisted-types';
 
 /**

--- a/experimental/dds/tree/tsconfig.json
+++ b/experimental/dds/tree/tsconfig.json
@@ -9,5 +9,6 @@
 		"rootDir": "./src",
 		"types": ["mocha"]
 	},
-	"include": ["src/**/*"]
+	"include": ["src/**/*"],
+	"references": [{ "path": "../../../packages/common/core-utils" }]
 }

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -70,7 +70,6 @@
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
-		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@fluidframework/runtime-definitions": "workspace:~",

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -4,7 +4,8 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { compareArrays } from "@fluidframework/core-utils";
+// eslint-disable-next-line import/no-internal-modules
+import { compareArrays } from "../../../../../../packages/common/core-utils";
 import {
 	FieldKey,
 	TreeSchemaIdentifier,

--- a/experimental/dds/tree2/tsconfig.json
+++ b/experimental/dds/tree2/tsconfig.json
@@ -14,4 +14,5 @@
 		"noImplicitOverride": true,
 	},
 	"include": ["src/**/*"],
+	"references": [{ "path": "../../../packages/common/core-utils" }],
 }

--- a/layerInfo.json
+++ b/layerInfo.json
@@ -33,10 +33,6 @@
 				"packages": ["@fluidframework/common-utils"],
 				"deps": ["Base-Definitions"]
 			},
-			"Core-Utils": {
-				"packages": ["@fluidframework/core-utils"],
-				"deps": []
-			},
 			"Protocol-Utils": {
 				"packages": ["@fluidframework/protocol-base"],
 				"deps": ["Base-Utils", "Protocol-Definitions"]
@@ -82,7 +78,7 @@
 			},
 			"Runtime": {
 				"dirs": ["experimental/dds/", "packages/dds/", "packages/runtime/"],
-				"deps": ["Container-Definitions", "Container-Utils", "Core-Utils", "Driver-Utils"]
+				"deps": ["Container-Definitions", "Container-Utils", "Driver-Utils"]
 			},
 			"Framework": {
 				"packages": ["@fluid-experimental/data-objects", "@fluidframework/fluid-static"],

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@fluidframework/core-utils",
 	"version": "2.0.0-internal.5.2.0",
+	"private": true,
 	"description": "Not intended for use outside the Fluid client repo.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5450,7 +5450,6 @@ importers:
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -5494,7 +5493,6 @@ importers:
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/core-interfaces': link:../../../packages/common/core-interfaces
-      '@fluidframework/core-utils': link:../../../packages/common/core-utils
       '@fluidframework/datastore-definitions': link:../../../packages/runtime/datastore-definitions
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
@@ -5617,7 +5615,6 @@ importers:
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -5661,7 +5658,6 @@ importers:
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/container-runtime': link:../../../packages/runtime/container-runtime
       '@fluidframework/core-interfaces': link:../../../packages/common/core-interfaces
-      '@fluidframework/core-utils': link:../../../packages/common/core-utils
       '@fluidframework/datastore-definitions': link:../../../packages/runtime/datastore-definitions
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions


### PR DESCRIPTION
## Description

Sample/experiment using TypeScript project references for code reuse that doesn't force us to expose additional public API surface, since it avoids publishing an npm package with the shared code.

It would force us to figure out how to best work around the lint rule for reaching into internal modules, and having to use relative paths doesn't feel ideal; but to me the gains of cleaning up our published packages / public API surface, outweigh that. The project references (and thus the build) would immediately break if the folder structure changes such that the relative path they point to doesn't work.
 
## Breaking Changes

No? We could deprecate the now-unnecessary packages an just stop publishing more updates for them.

## Reviewer Guidance

Any and all feedback welcome. 

<details>
<summary>Output of building tree</summary>

```plaintext
[19][14:53:29] npx tsc --build --verbose
[2:53:29 PM] Projects in this build: 
    * ../../../packages/common/core-utils/tsconfig.json
    * tsconfig.json

[2:53:29 PM] Project '../../../packages/common/core-utils/tsconfig.json' is up to date because newest input '../../../packages/common/core-utils/src/compare.ts' is older than oldest output '../../../packages/common/core-utils/dist/compare.js'

[2:53:29 PM] Project 'tsconfig.json' is out of date because oldest output 'dist/ChangeCompression.js' is older than newest input 'src/EditUtilities.ts'

[2:53:29 PM] Building project '/workspaces/FluidFramework/experimental/dds/tree/tsconfig.json'...

[2:53:35 PM] Updating unchanged output timestamps of project '/workspaces/FluidFramework/experimental/dds/tree/tsconfig.json'...

  6.864s
```

</details>

<details>
<summary>Output of building tree2</summary>

```plaintext
[2][14:53:51] npx tsc --build --verbose
[2:53:52 PM] Projects in this build: 
    * ../../../packages/common/core-utils/tsconfig.json
    * tsconfig.json

[2:53:52 PM] Project '../../../packages/common/core-utils/tsconfig.json' is up to date because newest input '../../../packages/common/core-utils/src/compare.ts' is older than oldest output '../../../packages/common/core-utils/dist/compare.js'

[2:53:52 PM] Project 'tsconfig.json' is out of date because oldest output 'dist/index.js' is older than newest input 'src/feature-libraries/chunked-forest/uniformChunk.ts'

[2:53:52 PM] Building project '/workspaces/FluidFramework/experimental/dds/tree2/tsconfig.json'...

[2:53:57 PM] Updating unchanged output timestamps of project '/workspaces/FluidFramework/experimental/dds/tree2/tsconfig.json'...

  5.441s
```

</details>

Not sure why policy check complains of a missing `tsc` script in core-utils, since it's there:

```plaintext
WARNING: 
file failed policy check: experimental/dds/tree/package.json
Unable to find tsc script for referenced project ./../../../packages/common/core-utils/tsconfig.json
WARNING: 
file failed policy check: experimental/dds/tree2/package.json
Unable to find tsc script for referenced project ./../../../packages/common/core-utils/tsconfig.json
```