### PR TITLE
Server: Fix prettier warnings when building GitRest/Historian in container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ docs/resources/_gen/
 # documentation tool artifact
 tsdoc-metadata.json
 
-# PNPM store (when opening local file system in dev container)
+# PNPM store (when mounting host file system in docker container)
 .pnpm-store/

--- a/server/gitrest/.prettierignore
+++ b/server/gitrest/.prettierignore
@@ -99,3 +99,6 @@ tools/markdown-magic/test/include.md
 
 # These files are auto-generated according to the comments in the files
 **/charts/**/Chart.yaml
+
+# PNPM store (when mounting host file system in docker container)
+.pnpm-store/

--- a/server/historian/.prettierignore
+++ b/server/historian/.prettierignore
@@ -99,3 +99,6 @@ tools/markdown-magic/test/include.md
 
 # These files are auto-generated according to the comments in the files
 **/charts/**/Chart.yaml
+
+# PNPM store (when mounting host file system in docker container)
+.pnpm-store/


### PR DESCRIPTION
This prevents 'prettier' from emitting warnings for files in '.pnpm-store/' when building the GitRest and Historian services per the dev instructions in the README.md.

Because the dependencies required to build these services are tricky to install locally (esp. on non-Linux systems), the README for these services recommends:

* Building the service in a Docker container
* Mounting the 'gitrest/' or 'historian/' directories from the local filesystem into the container.
* Running 'bash' inside the container to run 'pnpm i' and 'pnpm run build'

A side effect or running 'pnpm i' with the local file system mount as described above is that it places the '.pnpm-store' cache in the build directory, causing 'prettier' to include this directory while scanning.