### PR TITLE
Handle deleted/revived subtrees and deactivate/reactivate paired marks

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -612,7 +612,7 @@ export interface FieldChangeRebaser<TChangeset> {
     compose(changes: TaggedChange<TChangeset>[], composeChild: NodeChangeComposer, genId: IdAllocator, crossFieldManager: CrossFieldManager, revisionMetadata: RevisionMetadataSource): TChangeset;
     // (undocumented)
     invert(change: TaggedChange<TChangeset>, invertChild: NodeChangeInverter, reviver: NodeReviver, genId: IdAllocator, crossFieldManager: CrossFieldManager): TChangeset;
-    rebase(change: TChangeset, over: TaggedChange<TChangeset>, rebaseChild: NodeChangeRebaser, genId: IdAllocator, crossFieldManager: CrossFieldManager, revisionMetadata: RevisionMetadataSource): TChangeset;
+    rebase(change: TChangeset, over: TaggedChange<TChangeset>, rebaseChild: NodeChangeRebaser, genId: IdAllocator, crossFieldManager: CrossFieldManager, revisionMetadata: RevisionMetadataSource, existenceState?: NodeExistenceState): TChangeset;
 }
 
 // @alpha (undocumented)

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -96,6 +96,7 @@ export interface FieldChangeRebaser<TChangeset> {
 		genId: IdAllocator,
 		crossFieldManager: CrossFieldManager,
 		revisionMetadata: RevisionMetadataSource,
+		existenceState?: NodeExistenceState,
 	): TChangeset;
 
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -663,6 +663,7 @@ export class ModularChangeFamily
 					genId,
 					manager,
 					revisionMetadata,
+					existenceState,
 				);
 				const rebasedFieldChange: FieldChange = {
 					fieldKind: fieldKind.identifier,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -112,7 +112,7 @@ function rebaseMarkList<TNodeChange>(
 	rebaseChild: NodeChangeRebaser<TNodeChange>,
 	genId: IdAllocator,
 	moveEffects: CrossFieldManager<MoveEffect<TNodeChange>>,
-	nodeExistenceState: NodeExistenceState = NodeExistenceState.Alive,
+	nodeExistenceState: NodeExistenceState,
 ): MarkList<TNodeChange> {
 	const factory = new MarkListFactory<TNodeChange>();
 	const queue = new RebaseQueue(
@@ -342,7 +342,7 @@ function rebaseMark<TNodeChange>(
 	baseInputOffset: number,
 	rebaseChild: NodeChangeRebaser<TNodeChange>,
 	moveEffects: MoveEffectTable<TNodeChange>,
-	nodeExistenceState: NodeExistenceState = NodeExistenceState.Alive,
+	nodeExistenceState: NodeExistenceState,
 ): Mark<TNodeChange> {
 	let rebasedMark = rebaseNodeChange(cloneMark(currMark), baseMark, rebaseChild);
 	const baseMarkIntention = getMarkIntention(baseMark, baseIntention);
@@ -619,7 +619,10 @@ function amendRebaseI<TNodeChange>(
 		const { baseMark, newMark } = queue.pop();
 
 		if (baseMark === undefined) {
-			assert(newMark !== undefined, "Both marks shouldn't be undefined at the same time");
+			assert(
+				newMark !== undefined,
+				"Non-empty RebaseQueue should not provide two empty marks",
+			);
 			factory.push(withNodeChange(newMark, rebaseChild(getNodeChange(newMark), undefined)));
 		}
 

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -489,7 +489,8 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], ["B", "A", "D", "C"]);
 		});
 
-		it("destination of move's ancestor deleted", () => {
+		// Moving a node into a concurrently deleted subtree should result in the moved node being deleted
+		it("ancestor of move destination deleted", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const tree2 = tree.fork();
 
@@ -527,7 +528,8 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 		});
 
-		it("source of move's ancestor deleted", () => {
+		// Tests that a move is aborted if the moved node has been concurrently deleted
+		it("ancestor of move source deleted", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const tree2 = tree.fork();
 
@@ -565,7 +567,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 		});
 
-		it("source of move's ancestor deleted then revived", () => {
+		it("ancestor of move source deleted then revived", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const tree2 = tree.fork();
 
@@ -689,7 +691,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 		});
 
-		it("delete source ancestor of return mark", () => {
+		it("delete ancestor of return source", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const first: UpPath = {
 				parent: undefined,
@@ -730,7 +732,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 		});
 
-		it("delete destination ancestor of return mark", () => {
+		it("delete ancestor of return destination", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const first: UpPath = {
 				parent: undefined,

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -689,7 +689,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 		});
 
-		it.skip("delete source ancestor of return mark", () => {
+		it("delete source ancestor of return mark", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const first: UpPath = {
 				parent: undefined,

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -689,7 +689,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 		});
 
-		it("delete source ancestor of return mark", () => {
+		it.skip("delete source ancestor of return mark", () => {
 			const tree = makeTreeFromJson([{ foo: ["a"] }, {}]);
 			const first: UpPath = {
 				parent: undefined,


### PR DESCRIPTION
## Description
Before this change, we would crash when the ancestor of a node being moved was concurrently deleted. This fixes that crash and gives the desired merge semantics (the move doesn't occur unless the ancestor is revived). 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
