### PR TITLE
[fluid-runner] Dispose container instead of closing

### DIFF
--- a/packages/tools/fluid-runner/src/exportFile.ts
+++ b/packages/tools/fluid-runner/src/exportFile.ts
@@ -122,9 +122,11 @@ export async function createContainerAndExecute(
 		});
 
 		return PerformanceEvent.timedExecAsync(logger, { eventName: "ExportFile" }, async () => {
-			const result = await fluidFileConverter.execute(container, options);
-			container.close();
-			return result;
+			try {
+				return await fluidFileConverter.execute(container, options);
+			} finally {
+				container.dispose();
+			}
 		});
 	};
 


### PR DESCRIPTION
There was a change to the `IContainer.close(...)` method where it no longer disposes resources. For the implementation of the fluid-runner, we should be using the `IContainer.dispose(...)` method instead.

See https://github.com/microsoft/FluidFramework/pull/13730