### PR TITLE
fix(devtools-view): Change TreeHeader to use Enum Type 

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import { tokens } from "@fluentui/react-components";
 import { ThemeContext } from "../../ThemeHelper";
+import { ThemeOption } from "../SettingsView";
 import { HasLabel } from "./CommonInterfaces";
 
 /**
@@ -39,7 +40,9 @@ export function TreeHeader(props: TreeHeaderProps): React.ReactElement {
 			<span
 				style={{
 					color:
-						themeInfo.name === "highContrast" ? "" : tokens.colorPaletteRedBorderActive,
+						themeInfo.name === ThemeOption.HighContrast
+							? ""
+							: tokens.colorPaletteRedBorderActive,
 					fontSize: "10px",
 				}}
 			>
@@ -48,7 +51,7 @@ export function TreeHeader(props: TreeHeaderProps): React.ReactElement {
 			<span
 				style={{
 					color:
-						themeInfo.name === "highContrast"
+						themeInfo.name === ThemeOption.HighContrast
 							? ""
 							: tokens.colorPalettePlatinumBorderActive,
 					fontStyle: "oblique",


### PR DESCRIPTION
#### Description

With the merge of [16214](https://github.com/microsoft/FluidFramework/pull/16214), `typemetadata` of container state gets indistinguishable when hovered (which was initially fixed by [16185](https://github.com/microsoft/FluidFramework/pull/16185)). 

This PR changes the harcdoded string value to use enum which follows the pattern used in `devtools` package and fixes the bug. 