### PR TITLE
fix(devtools): Fix timeout screen to show limited menu and home page

### DIFF
--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -213,50 +213,42 @@ export function DevtoolsView(): React.ReactElement {
 		<ThemeContext.Provider value={{ themeInfo: selectedTheme, setTheme: setSelectedTheme }}>
 			<FluentProvider theme={selectedTheme.theme} style={{ height: "100%" }}>
 				{supportedFeatures === undefined ? (
-					queryTimedOut ? (
-						<>
-							{!isMessageDismissed && (
-								<MessageBar
-									messageBarType={MessageBarType.error}
-									isMultiline={true}
-									onDismiss={(): void => setIsMessageDismissed(true)}
-									dismissButtonAriaLabel="Close"
-									className={styles.icon}
+					<>
+						{!queryTimedOut && <Waiting />}
+						{queryTimedOut && !isMessageDismissed && (
+							<MessageBar
+								messageBarType={MessageBarType.error}
+								isMultiline={true}
+								onDismiss={(): void => setIsMessageDismissed(true)}
+								dismissButtonAriaLabel="Close"
+								className={styles.icon}
+							>
+								It seems that Fluid Devtools has not been initialized in the current
+								tab, or it did not respond in a timely manner.
+								<Tooltip
+									content="Retry communicating with Fluid Devtools in the current tab."
+									relationship="description"
 								>
-									It seems that Fluid Devtools has not been initialized in the
-									current tab, or it did not respond in a timely manner.
-									<Tooltip
-										content="Retry communicating with Fluid Devtools in the current tab."
-										relationship="description"
+									<Button
+										className={styles.retryButton}
+										size="small"
+										onClick={retryQuery}
 									>
-										<Button
-											className={styles.retryButton}
-											size="small"
-											onClick={retryQuery}
-										>
-											Try again
-										</Button>
-									</Tooltip>
-									<br />
-									<h4 className={styles.debugNote}>
-										Need help? Please refer to our
-										<Link
-											href="https://aka.ms/fluid/devtool/docs"
-											target="_blank"
-										>
-											documentation page
-										</Link>{" "}
-										for guidance on getting the extension working.{" "}
-									</h4>
-								</MessageBar>
-							)}
-						</>
-					) : (
-						<>
-							<Waiting />
-							<_DevtoolsView supportedFeatures={{}} />
-						</>
-					)
+										Try again
+									</Button>
+								</Tooltip>
+								<br />
+								<h4 className={styles.debugNote}>
+									Need help? Please refer to our
+									<Link href="https://aka.ms/fluid/devtool/docs" target="_blank">
+										documentation page
+									</Link>{" "}
+									for guidance on getting the extension working.{" "}
+								</h4>
+							</MessageBar>
+						)}
+						<_DevtoolsView supportedFeatures={{}} />
+					</>
 				) : (
 					<_DevtoolsView supportedFeatures={supportedFeatures} />
 				)}


### PR DESCRIPTION
## Description

This PR updates the components that render when the devtools extension times out.

Preview
![image](https://github.com/microsoft/FluidFramework/assets/23732584/07ea4afa-02cc-4417-9316-d7f5389f2276)
