### PR TITLE
Updating logging on Scribe to include lastSummaryHead

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -130,7 +130,7 @@ export class SummaryWriter implements ISummaryWriter {
 									existingRef ? existingRef.object.sha : "n/a"
 								}" nor other valid parent summaries "[${
 									checkpoint.validParentSummaries?.join(",") ?? ""
-								}]".`,
+								}] nor the last known client summary "${lastSummaryHead}".`,
 								summaryProposal: {
 									summarySequenceNumber: op.sequenceNumber,
 								},


### PR DESCRIPTION
## Description

We have recently seen an increased number of Client Summary failures in Scribe due to the proposed parent summary not matching actual parent summary.

Based on the current logging, we have narrowed the failure down to this condition:
`lastSummaryHead !== content.head`

https://github.com/microsoft/FluidFramework/blob/08a28bef08486a0f5af090736d1435562c80b263/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts#L112

However, we can't proceed with the investigation since `lastSummaryHead` is currently not logged. Therefore, this PR attempts to address that.
