### PR TITLE
Cleanup TypeTests

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -37,7 +37,7 @@
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7070 test:realsvc:local:run",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -33,7 +33,7 @@
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/protocol-definitions": "^1.0.0",

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -37,7 +37,7 @@
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -52,7 +52,7 @@
 		"test:report": "nyc npm run test:mocha:report && npm run test:jest:report",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -34,7 +34,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1"

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -43,7 +43,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -37,7 +37,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -36,7 +36,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -36,7 +36,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -40,7 +40,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -34,7 +34,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -41,7 +41,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -84,7 +84,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.5.0.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.5.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -44,7 +44,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.5.0.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.5.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -43,7 +43,7 @@
 		"test:stress": "cross-env FUZZ_STRESS_RUN=1 FUZZ_TEST_COUNT=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.5.0.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.5.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.5.0.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.5.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.5.0.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.5.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -47,7 +47,7 @@
 		"testfarm": "node dist/test/testFarm.js",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -93,7 +93,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources": "^0.1039.1000",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.5.0.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.5.2.0",
 		"@fluidframework/server-services-client": "^0.1039.1000",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -40,6 +40,30 @@ use_old_TypeAliasDeclaration_DeserializeCallback(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IEndpointInRangeIndex": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IEndpointInRangeIndex():
+    TypeOnly<old.IEndpointInRangeIndex<any>>;
+declare function use_current_InterfaceDeclaration_IEndpointInRangeIndex(
+    use: TypeOnly<current.IEndpointInRangeIndex<any>>);
+use_current_InterfaceDeclaration_IEndpointInRangeIndex(
+    get_old_InterfaceDeclaration_IEndpointInRangeIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IEndpointInRangeIndex": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IEndpointInRangeIndex():
+    TypeOnly<current.IEndpointInRangeIndex<any>>;
+declare function use_old_InterfaceDeclaration_IEndpointInRangeIndex(
+    use: TypeOnly<old.IEndpointInRangeIndex<any>>);
+use_old_InterfaceDeclaration_IEndpointInRangeIndex(
+    get_current_InterfaceDeclaration_IEndpointInRangeIndex());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IInterval": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IInterval():
@@ -184,6 +208,30 @@ use_old_InterfaceDeclaration_IMapMessageLocalMetadata(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOverlappingIntervalsIndex": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IOverlappingIntervalsIndex():
+    TypeOnly<old.IOverlappingIntervalsIndex<any>>;
+declare function use_current_InterfaceDeclaration_IOverlappingIntervalsIndex(
+    use: TypeOnly<current.IOverlappingIntervalsIndex<any>>);
+use_current_InterfaceDeclaration_IOverlappingIntervalsIndex(
+    get_old_InterfaceDeclaration_IOverlappingIntervalsIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOverlappingIntervalsIndex": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IOverlappingIntervalsIndex():
+    TypeOnly<current.IOverlappingIntervalsIndex<any>>;
+declare function use_old_InterfaceDeclaration_IOverlappingIntervalsIndex(
+    use: TypeOnly<old.IOverlappingIntervalsIndex<any>>);
+use_old_InterfaceDeclaration_IOverlappingIntervalsIndex(
+    get_current_InterfaceDeclaration_IOverlappingIntervalsIndex());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISequenceDeltaRange": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISequenceDeltaRange():
@@ -324,6 +372,30 @@ declare function use_old_InterfaceDeclaration_ISharedString(
     use: TypeOnly<old.ISharedString>);
 use_old_InterfaceDeclaration_ISharedString(
     get_current_InterfaceDeclaration_ISharedString());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IStartpointInRangeIndex": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IStartpointInRangeIndex():
+    TypeOnly<old.IStartpointInRangeIndex<any>>;
+declare function use_current_InterfaceDeclaration_IStartpointInRangeIndex(
+    use: TypeOnly<current.IStartpointInRangeIndex<any>>);
+use_current_InterfaceDeclaration_IStartpointInRangeIndex(
+    get_old_InterfaceDeclaration_IStartpointInRangeIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IStartpointInRangeIndex": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IStartpointInRangeIndex():
+    TypeOnly<current.IStartpointInRangeIndex<any>>;
+declare function use_old_InterfaceDeclaration_IStartpointInRangeIndex(
+    use: TypeOnly<old.IStartpointInRangeIndex<any>>);
+use_old_InterfaceDeclaration_IStartpointInRangeIndex(
+    get_current_InterfaceDeclaration_IStartpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -636,6 +708,30 @@ declare function use_old_ClassDeclaration_SequenceInterval(
     use: TypeOnly<old.SequenceInterval>);
 use_old_ClassDeclaration_SequenceInterval(
     get_current_ClassDeclaration_SequenceInterval());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_SequenceIntervalIndexes.Overlapping": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping():
+    TypeOnly<old.SequenceIntervalIndexes.Overlapping>;
+declare function use_current_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping(
+    use: TypeOnly<current.SequenceIntervalIndexes.Overlapping>);
+use_current_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping(
+    get_old_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_SequenceIntervalIndexes.Overlapping": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping():
+    TypeOnly<current.SequenceIntervalIndexes.Overlapping>;
+declare function use_old_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping(
+    use: TypeOnly<old.SequenceIntervalIndexes.Overlapping>);
+use_old_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping(
+    get_current_InterfaceDeclaration_SequenceIntervalIndexes_Overlapping());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1048,6 +1144,102 @@ use_old_FunctionDeclaration_appendSharedStringDeltaToRevertibles(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createEndpointInRangeIndex": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_createEndpointInRangeIndex():
+    TypeOnly<typeof old.createEndpointInRangeIndex>;
+declare function use_current_FunctionDeclaration_createEndpointInRangeIndex(
+    use: TypeOnly<typeof current.createEndpointInRangeIndex>);
+use_current_FunctionDeclaration_createEndpointInRangeIndex(
+    get_old_FunctionDeclaration_createEndpointInRangeIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createEndpointInRangeIndex": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_createEndpointInRangeIndex():
+    TypeOnly<typeof current.createEndpointInRangeIndex>;
+declare function use_old_FunctionDeclaration_createEndpointInRangeIndex(
+    use: TypeOnly<typeof old.createEndpointInRangeIndex>);
+use_old_FunctionDeclaration_createEndpointInRangeIndex(
+    get_current_FunctionDeclaration_createEndpointInRangeIndex());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createOverlappingIntervalsIndex": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_createOverlappingIntervalsIndex():
+    TypeOnly<typeof old.createOverlappingIntervalsIndex>;
+declare function use_current_FunctionDeclaration_createOverlappingIntervalsIndex(
+    use: TypeOnly<typeof current.createOverlappingIntervalsIndex>);
+use_current_FunctionDeclaration_createOverlappingIntervalsIndex(
+    get_old_FunctionDeclaration_createOverlappingIntervalsIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createOverlappingIntervalsIndex": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_createOverlappingIntervalsIndex():
+    TypeOnly<typeof current.createOverlappingIntervalsIndex>;
+declare function use_old_FunctionDeclaration_createOverlappingIntervalsIndex(
+    use: TypeOnly<typeof old.createOverlappingIntervalsIndex>);
+use_old_FunctionDeclaration_createOverlappingIntervalsIndex(
+    get_current_FunctionDeclaration_createOverlappingIntervalsIndex());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createOverlappingSequenceIntervalsIndex": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_createOverlappingSequenceIntervalsIndex():
+    TypeOnly<typeof old.createOverlappingSequenceIntervalsIndex>;
+declare function use_current_FunctionDeclaration_createOverlappingSequenceIntervalsIndex(
+    use: TypeOnly<typeof current.createOverlappingSequenceIntervalsIndex>);
+use_current_FunctionDeclaration_createOverlappingSequenceIntervalsIndex(
+    get_old_FunctionDeclaration_createOverlappingSequenceIntervalsIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createOverlappingSequenceIntervalsIndex": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_createOverlappingSequenceIntervalsIndex():
+    TypeOnly<typeof current.createOverlappingSequenceIntervalsIndex>;
+declare function use_old_FunctionDeclaration_createOverlappingSequenceIntervalsIndex(
+    use: TypeOnly<typeof old.createOverlappingSequenceIntervalsIndex>);
+use_old_FunctionDeclaration_createOverlappingSequenceIntervalsIndex(
+    get_current_FunctionDeclaration_createOverlappingSequenceIntervalsIndex());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createStartpointInRangeIndex": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_createStartpointInRangeIndex():
+    TypeOnly<typeof old.createStartpointInRangeIndex>;
+declare function use_current_FunctionDeclaration_createStartpointInRangeIndex(
+    use: TypeOnly<typeof current.createStartpointInRangeIndex>);
+use_current_FunctionDeclaration_createStartpointInRangeIndex(
+    get_old_FunctionDeclaration_createStartpointInRangeIndex());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_createStartpointInRangeIndex": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_createStartpointInRangeIndex():
+    TypeOnly<typeof current.createStartpointInRangeIndex>;
+declare function use_old_FunctionDeclaration_createStartpointInRangeIndex(
+    use: TypeOnly<typeof old.createStartpointInRangeIndex>);
+use_old_FunctionDeclaration_createStartpointInRangeIndex(
+    get_current_FunctionDeclaration_createStartpointInRangeIndex());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_discardSharedStringRevertibles": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_discardSharedStringRevertibles():
@@ -1140,3 +1332,27 @@ declare function use_old_FunctionDeclaration_revertSharedStringRevertibles(
     use: TypeOnly<typeof old.revertSharedStringRevertibles>);
 use_old_FunctionDeclaration_revertSharedStringRevertibles(
     get_current_FunctionDeclaration_revertSharedStringRevertibles());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_sequenceIntervalHelpers": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_sequenceIntervalHelpers():
+    TypeOnly<typeof old.sequenceIntervalHelpers>;
+declare function use_current_VariableDeclaration_sequenceIntervalHelpers(
+    use: TypeOnly<typeof current.sequenceIntervalHelpers>);
+use_current_VariableDeclaration_sequenceIntervalHelpers(
+    get_old_VariableDeclaration_sequenceIntervalHelpers());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_sequenceIntervalHelpers": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_sequenceIntervalHelpers():
+    TypeOnly<typeof current.sequenceIntervalHelpers>;
+declare function use_old_VariableDeclaration_sequenceIntervalHelpers(
+    use: TypeOnly<typeof old.sequenceIntervalHelpers>);
+use_old_VariableDeclaration_sequenceIntervalHelpers(
+    get_current_VariableDeclaration_sequenceIntervalHelpers());

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -39,7 +39,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -82,7 +82,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.5.0.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.5.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -39,7 +39,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.5.0.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.5.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -74,7 +74,6 @@
 		"events": "^3.1.0"
 	},
 	"devDependencies": {
-		"@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@2.0.0-internal.2.1.1",
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.20.0",
@@ -82,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.5.0.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.5.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -30,7 +30,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-utils": "^1.1.1",
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.5.0.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.5.0.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
+++ b/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
@@ -84,3 +84,27 @@ declare function use_old_FunctionDeclaration_promiseRaceWithWinner(
     use: TypeOnly<typeof old.promiseRaceWithWinner>);
 use_old_FunctionDeclaration_promiseRaceWithWinner(
     get_current_FunctionDeclaration_promiseRaceWithWinner());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_validateMessages": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_validateMessages():
+    TypeOnly<typeof old.validateMessages>;
+declare function use_current_FunctionDeclaration_validateMessages(
+    use: TypeOnly<typeof current.validateMessages>);
+use_current_FunctionDeclaration_validateMessages(
+    get_old_FunctionDeclaration_validateMessages());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_validateMessages": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_validateMessages():
+    TypeOnly<typeof current.validateMessages>;
+declare function use_old_FunctionDeclaration_validateMessages(
+    use: TypeOnly<typeof old.validateMessages>);
+use_old_FunctionDeclaration_validateMessages(
+    get_current_FunctionDeclaration_validateMessages());

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -34,7 +34,7 @@
 		"test": "jest",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.5.0.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jest": "22.2.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -29,7 +29,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.5.0.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -34,7 +34,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-utils": "^1.1.1",
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.5.0.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.5.2.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -39,7 +39,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.5.0.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.5.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -32,7 +32,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/driver-definitions": "workspace:~"
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.5.0.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.5.2.0",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -84,7 +84,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.5.0.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
@@ -106,16 +106,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_OdspDocumentServiceFactory": {
-				"forwardCompat": false
-			},
-			"ClassDeclaration_OdspDocumentServiceFactoryCore": {
-				"forwardCompat": false
-			},
-			"ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
@@ -112,6 +112,30 @@ use_old_InterfaceDeclaration_ISnapshotContents(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISocketStorageDiscovery": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISocketStorageDiscovery():
+    TypeOnly<old.ISocketStorageDiscovery>;
+declare function use_current_InterfaceDeclaration_ISocketStorageDiscovery(
+    use: TypeOnly<current.ISocketStorageDiscovery>);
+use_current_InterfaceDeclaration_ISocketStorageDiscovery(
+    get_old_InterfaceDeclaration_ISocketStorageDiscovery());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISocketStorageDiscovery": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISocketStorageDiscovery():
+    TypeOnly<current.ISocketStorageDiscovery>;
+declare function use_old_InterfaceDeclaration_ISocketStorageDiscovery(
+    use: TypeOnly<old.ISocketStorageDiscovery>);
+use_old_InterfaceDeclaration_ISocketStorageDiscovery(
+    get_current_InterfaceDeclaration_ISocketStorageDiscovery());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_OdcApiSiteOrigin": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_OdcApiSiteOrigin():
@@ -167,7 +191,6 @@ declare function get_old_ClassDeclaration_OdspDocumentServiceFactory():
 declare function use_current_ClassDeclaration_OdspDocumentServiceFactory(
     use: TypeOnly<current.OdspDocumentServiceFactory>);
 use_current_ClassDeclaration_OdspDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDocumentServiceFactory());
 
 /*
@@ -192,7 +215,6 @@ declare function get_old_ClassDeclaration_OdspDocumentServiceFactoryCore():
 declare function use_current_ClassDeclaration_OdspDocumentServiceFactoryCore(
     use: TypeOnly<current.OdspDocumentServiceFactoryCore>);
 use_current_ClassDeclaration_OdspDocumentServiceFactoryCore(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDocumentServiceFactoryCore());
 
 /*
@@ -217,7 +239,6 @@ declare function get_old_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSpli
 declare function use_current_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit(
     use: TypeOnly<current.OdspDocumentServiceFactoryWithCodeSplit>);
 use_current_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit());
 
 /*

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -34,7 +34,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
@@ -48,7 +48,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.5.0.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.5.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -30,7 +30,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.5.0.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -84,7 +84,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.5.0.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -109,10 +109,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_IRouterliciousDriverPolicies": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
+++ b/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
@@ -71,7 +71,6 @@ declare function get_old_InterfaceDeclaration_IRouterliciousDriverPolicies():
 declare function use_current_InterfaceDeclaration_IRouterliciousDriverPolicies(
     use: TypeOnly<current.IRouterliciousDriverPolicies>);
 use_current_InterfaceDeclaration_IRouterliciousDriverPolicies(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRouterliciousDriverPolicies());
 
 /*

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -34,7 +34,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-utils": "^1.1.1",
@@ -50,7 +50,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.5.0.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.5.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",
 		"@types/node": "^14.18.38",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -32,7 +32,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
@@ -51,7 +51,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-tools": "^0.2.158186",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.5.0.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.5.2.0",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -30,7 +30,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.5.0.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.5.2.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -42,7 +42,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -83,7 +83,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.5.0.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.5.2.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -37,7 +37,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -37,7 +37,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -77,7 +77,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.5.0.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -71,7 +71,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.5.0.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -31,7 +31,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/container-definitions": "workspace:~",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -37,7 +37,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.5.0.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.5.2.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -31,7 +31,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -37,7 +37,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -72,7 +72,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.5.0.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.5.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -41,7 +41,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -74,7 +74,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.5.0.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -33,7 +33,7 @@
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/protocol-definitions": "^1.1.0",
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/uuid": "^8.3.0",
 		"concurrently": "^7.6.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -36,7 +36,7 @@
 		"test:realsvc:tinylicious:run": "mocha --unhandled-rejections=strict --recursive dist/test/**/*.spec.js --exit",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -63,7 +63,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.5.0.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -37,7 +37,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -73,7 +73,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.5.0.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -32,7 +32,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.5.0.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -32,7 +32,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~"
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.5.0.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -39,7 +39,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.5.0.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -38,7 +38,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -71,7 +71,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -38,7 +38,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
@@ -100,10 +100,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_DeltaStreamConnectionForbiddenError": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -119,7 +119,6 @@ declare function get_old_ClassDeclaration_DeltaStreamConnectionForbiddenError():
 declare function use_current_ClassDeclaration_DeltaStreamConnectionForbiddenError(
     use: TypeOnly<current.DeltaStreamConnectionForbiddenError>);
 use_current_ClassDeclaration_DeltaStreamConnectionForbiddenError(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_DeltaStreamConnectionForbiddenError());
 
 /*
@@ -229,6 +228,30 @@ declare function use_old_ClassDeclaration_GenericNetworkError(
     use: TypeOnly<old.GenericNetworkError>);
 use_old_ClassDeclaration_GenericNetworkError(
     get_current_ClassDeclaration_GenericNetworkError());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICompressionStorageConfig": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ICompressionStorageConfig():
+    TypeOnly<old.ICompressionStorageConfig>;
+declare function use_current_InterfaceDeclaration_ICompressionStorageConfig(
+    use: TypeOnly<current.ICompressionStorageConfig>);
+use_current_InterfaceDeclaration_ICompressionStorageConfig(
+    get_old_InterfaceDeclaration_ICompressionStorageConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICompressionStorageConfig": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ICompressionStorageConfig():
+    TypeOnly<current.ICompressionStorageConfig>;
+declare function use_old_InterfaceDeclaration_ICompressionStorageConfig(
+    use: TypeOnly<old.ICompressionStorageConfig>);
+use_old_InterfaceDeclaration_ICompressionStorageConfig(
+    get_current_InterfaceDeclaration_ICompressionStorageConfig());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -589,6 +612,54 @@ declare function use_old_ClassDeclaration_UsageError(
     use: TypeOnly<old.UsageError>);
 use_old_ClassDeclaration_UsageError(
     get_current_ClassDeclaration_UsageError());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_applyStorageCompression": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_applyStorageCompression():
+    TypeOnly<typeof old.applyStorageCompression>;
+declare function use_current_FunctionDeclaration_applyStorageCompression(
+    use: TypeOnly<typeof current.applyStorageCompression>);
+use_current_FunctionDeclaration_applyStorageCompression(
+    get_old_FunctionDeclaration_applyStorageCompression());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_applyStorageCompression": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_applyStorageCompression():
+    TypeOnly<typeof current.applyStorageCompression>;
+declare function use_old_FunctionDeclaration_applyStorageCompression(
+    use: TypeOnly<typeof old.applyStorageCompression>);
+use_old_FunctionDeclaration_applyStorageCompression(
+    get_current_FunctionDeclaration_applyStorageCompression());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_blobHeadersBlobName": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_blobHeadersBlobName():
+    TypeOnly<typeof old.blobHeadersBlobName>;
+declare function use_current_VariableDeclaration_blobHeadersBlobName(
+    use: TypeOnly<typeof current.blobHeadersBlobName>);
+use_current_VariableDeclaration_blobHeadersBlobName(
+    get_old_VariableDeclaration_blobHeadersBlobName());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_blobHeadersBlobName": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_blobHeadersBlobName():
+    TypeOnly<typeof current.blobHeadersBlobName>;
+declare function use_old_VariableDeclaration_blobHeadersBlobName(
+    use: TypeOnly<typeof old.blobHeadersBlobName>);
+use_old_VariableDeclaration_blobHeadersBlobName(
+    get_current_VariableDeclaration_blobHeadersBlobName());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -38,7 +38,7 @@
 		"test:report": "npm test -- -- --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -71,7 +71,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.5.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -29,7 +29,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -43,7 +43,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.5.0.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -39,7 +39,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -87,7 +87,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.5.0.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -1312,6 +1312,30 @@ use_old_EnumDeclaration_RuntimeMessage(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_SubmitSummaryFailureData": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_SubmitSummaryFailureData():
+    TypeOnly<old.SubmitSummaryFailureData>;
+declare function use_current_InterfaceDeclaration_SubmitSummaryFailureData(
+    use: TypeOnly<current.SubmitSummaryFailureData>);
+use_current_InterfaceDeclaration_SubmitSummaryFailureData(
+    get_old_InterfaceDeclaration_SubmitSummaryFailureData());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_SubmitSummaryFailureData": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_SubmitSummaryFailureData():
+    TypeOnly<current.SubmitSummaryFailureData>;
+declare function use_old_InterfaceDeclaration_SubmitSummaryFailureData(
+    use: TypeOnly<old.SubmitSummaryFailureData>);
+use_old_InterfaceDeclaration_SubmitSummaryFailureData(
+    get_current_InterfaceDeclaration_SubmitSummaryFailureData());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_SubmitSummaryResult": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_SubmitSummaryResult():
@@ -1428,6 +1452,30 @@ declare function use_old_ClassDeclaration_SummaryCollection(
     use: TypeOnly<old.SummaryCollection>);
 use_old_ClassDeclaration_SummaryCollection(
     get_current_ClassDeclaration_SummaryCollection());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_SummaryStage": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_SummaryStage():
+    TypeOnly<old.SummaryStage>;
+declare function use_current_TypeAliasDeclaration_SummaryStage(
+    use: TypeOnly<current.SummaryStage>);
+use_current_TypeAliasDeclaration_SummaryStage(
+    get_old_TypeAliasDeclaration_SummaryStage());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_SummaryStage": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_SummaryStage():
+    TypeOnly<current.SummaryStage>;
+declare function use_old_TypeAliasDeclaration_SummaryStage(
+    use: TypeOnly<old.SummaryStage>);
+use_old_TypeAliasDeclaration_SummaryStage(
+    get_current_TypeAliasDeclaration_SummaryStage());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -29,7 +29,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -43,7 +43,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.5.0.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -38,7 +38,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -81,7 +81,7 @@
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.5.0.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.5.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -29,7 +29,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
@@ -44,7 +44,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.5.0.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -37,7 +37,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -35,7 +35,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -81,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -33,7 +33,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.5.0.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -33,7 +33,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -67,7 +67,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.5.0.0",
+		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"concurrently": "^7.6.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -29,7 +29,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin",
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
 		"usePrereleaseDeps": "node ./scripts/usePrereleaseDeps.js"
 	},
 	"nyc": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -51,7 +51,7 @@
 		"test:stress:tinylicious:run": "npm run test:stress:run",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin",
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
 		"usePrereleaseDeps": "node ./scripts/usePrereleaseDeps.js"
 	},
 	"nyc": {

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -36,7 +36,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -91,7 +91,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -36,7 +36,7 @@
 		"test:mocha:multireport": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -76,7 +76,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.5.0.0",
+		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.5.2.0",
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -1000,6 +1000,78 @@ use_old_FunctionDeclaration_DataVisualization_createMessage(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_DevtoolsDisposed.Message": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_DevtoolsDisposed_Message():
+    TypeOnly<old.DevtoolsDisposed.Message>;
+declare function use_current_InterfaceDeclaration_DevtoolsDisposed_Message(
+    use: TypeOnly<current.DevtoolsDisposed.Message>);
+use_current_InterfaceDeclaration_DevtoolsDisposed_Message(
+    get_old_InterfaceDeclaration_DevtoolsDisposed_Message());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_DevtoolsDisposed.Message": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_DevtoolsDisposed_Message():
+    TypeOnly<current.DevtoolsDisposed.Message>;
+declare function use_old_InterfaceDeclaration_DevtoolsDisposed_Message(
+    use: TypeOnly<old.DevtoolsDisposed.Message>);
+use_old_InterfaceDeclaration_DevtoolsDisposed_Message(
+    get_current_InterfaceDeclaration_DevtoolsDisposed_Message());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_DevtoolsDisposed.MessageType": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_DevtoolsDisposed_MessageType():
+    TypeOnly<typeof old.DevtoolsDisposed.MessageType>;
+declare function use_current_VariableDeclaration_DevtoolsDisposed_MessageType(
+    use: TypeOnly<typeof current.DevtoolsDisposed.MessageType>);
+use_current_VariableDeclaration_DevtoolsDisposed_MessageType(
+    get_old_VariableDeclaration_DevtoolsDisposed_MessageType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_DevtoolsDisposed.MessageType": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_DevtoolsDisposed_MessageType():
+    TypeOnly<typeof current.DevtoolsDisposed.MessageType>;
+declare function use_old_VariableDeclaration_DevtoolsDisposed_MessageType(
+    use: TypeOnly<typeof old.DevtoolsDisposed.MessageType>);
+use_old_VariableDeclaration_DevtoolsDisposed_MessageType(
+    get_current_VariableDeclaration_DevtoolsDisposed_MessageType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_DevtoolsDisposed.createMessage": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_DevtoolsDisposed_createMessage():
+    TypeOnly<typeof old.DevtoolsDisposed.createMessage>;
+declare function use_current_FunctionDeclaration_DevtoolsDisposed_createMessage(
+    use: TypeOnly<typeof current.DevtoolsDisposed.createMessage>);
+use_current_FunctionDeclaration_DevtoolsDisposed_createMessage(
+    get_old_FunctionDeclaration_DevtoolsDisposed_createMessage());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_DevtoolsDisposed.createMessage": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_DevtoolsDisposed_createMessage():
+    TypeOnly<typeof current.DevtoolsDisposed.createMessage>;
+declare function use_old_FunctionDeclaration_DevtoolsDisposed_createMessage(
+    use: TypeOnly<typeof old.DevtoolsDisposed.createMessage>);
+use_old_FunctionDeclaration_DevtoolsDisposed_createMessage(
+    get_current_FunctionDeclaration_DevtoolsDisposed_createMessage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_DevtoolsFeature": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_DevtoolsFeature():

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -32,7 +32,7 @@
 		"test": "echo TODO: add tests",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -63,7 +63,7 @@
 		"@fluidframework/fluid-static": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.5.0.0",
+		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.5.2.0",
 		"@fluid-tools/build-cli": "^0.20.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -40,6 +40,30 @@ use_old_InterfaceDeclaration_ContainerDevtoolsProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<old.ContainerKey>;
+declare function use_current_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<current.ContainerKey>);
+use_current_TypeAliasDeclaration_ContainerKey(
+    get_old_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<current.ContainerKey>;
+declare function use_old_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<old.ContainerKey>);
+use_old_TypeAliasDeclaration_ContainerKey(
+    get_current_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_DevtoolsLogger": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_DevtoolsLogger():
@@ -88,6 +112,30 @@ use_old_InterfaceDeclaration_DevtoolsProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<old.HasContainerKey>;
+declare function use_current_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<current.HasContainerKey>);
+use_current_InterfaceDeclaration_HasContainerKey(
+    get_old_InterfaceDeclaration_HasContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<current.HasContainerKey>;
+declare function use_old_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<old.HasContainerKey>);
+use_old_InterfaceDeclaration_HasContainerKey(
+    get_current_InterfaceDeclaration_HasContainerKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IDevtools": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IDevtools():
@@ -108,6 +156,30 @@ declare function use_old_InterfaceDeclaration_IDevtools(
     use: TypeOnly<old.IDevtools>);
 use_old_InterfaceDeclaration_IDevtools(
     get_current_InterfaceDeclaration_IDevtools());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_VisualizeSharedObject": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_VisualizeSharedObject():
+    TypeOnly<old.VisualizeSharedObject>;
+declare function use_current_TypeAliasDeclaration_VisualizeSharedObject(
+    use: TypeOnly<current.VisualizeSharedObject>);
+use_current_TypeAliasDeclaration_VisualizeSharedObject(
+    get_old_TypeAliasDeclaration_VisualizeSharedObject());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_VisualizeSharedObject": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_VisualizeSharedObject():
+    TypeOnly<current.VisualizeSharedObject>;
+declare function use_old_TypeAliasDeclaration_VisualizeSharedObject(
+    use: TypeOnly<old.VisualizeSharedObject>);
+use_old_TypeAliasDeclaration_VisualizeSharedObject(
+    get_current_TypeAliasDeclaration_VisualizeSharedObject());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.5.0.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.5.2.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/node": "^14.18.38",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -36,7 +36,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.5.0.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.5.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -39,7 +39,7 @@
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin",
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
 		"webpack": "webpack --color --config webpack.config.js"
 	},
 	"nyc": {
@@ -93,7 +93,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.20.0",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.5.0.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.5.2.0",
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -37,7 +37,7 @@
 		"test:report": "npm test -- -- --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -74,7 +74,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.5.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"@types/node-fetch": "^2.5.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -43,7 +43,7 @@
 		"test:report": "npm test -- -- --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -79,7 +79,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -101,28 +101,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ITelemetryErrorEventExt": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ITelemetryEventExt": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ITelemetryGenericEventExt": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ITelemetryPerformanceEventExt": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ITelemetryPropertiesExt": {
-				"backCompat": false
-			},
-			"TypeAliasDeclaration_TelemetryEventPropertyTypeExt": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -275,7 +275,6 @@ declare function get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeEx
 declare function use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
     use: TypeOnly<old.ITaggedTelemetryPropertyTypeExt>);
 use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt());
 
 /*
@@ -300,7 +299,6 @@ declare function get_current_InterfaceDeclaration_ITelemetryErrorEventExt():
 declare function use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
     use: TypeOnly<old.ITelemetryErrorEventExt>);
 use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryErrorEventExt());
 
 /*
@@ -325,7 +323,6 @@ declare function get_current_InterfaceDeclaration_ITelemetryEventExt():
 declare function use_old_InterfaceDeclaration_ITelemetryEventExt(
     use: TypeOnly<old.ITelemetryEventExt>);
 use_old_InterfaceDeclaration_ITelemetryEventExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryEventExt());
 
 /*
@@ -350,7 +347,6 @@ declare function get_current_InterfaceDeclaration_ITelemetryGenericEventExt():
 declare function use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
     use: TypeOnly<old.ITelemetryGenericEventExt>);
 use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryGenericEventExt());
 
 /*
@@ -447,7 +443,6 @@ declare function get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt(
 declare function use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
     use: TypeOnly<old.ITelemetryPerformanceEventExt>);
 use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt());
 
 /*
@@ -472,7 +467,6 @@ declare function get_current_InterfaceDeclaration_ITelemetryPropertiesExt():
 declare function use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
     use: TypeOnly<old.ITelemetryPropertiesExt>);
 use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryPropertiesExt());
 
 /*
@@ -713,7 +707,6 @@ declare function get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
 declare function use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
     use: TypeOnly<old.TelemetryEventPropertyTypeExt>);
 use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt());
 
 /*

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -39,7 +39,7 @@
 		"test:report": "npm test -- -- --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.20.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.5.0.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.5.2.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/jwt-decode": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6273,7 +6273,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.5.0.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6317,7 +6317,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.5.0.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -6350,7 +6350,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.5.0.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.5.2.0
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6405,7 +6405,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.5.0.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -6445,7 +6445,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.5.0.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6491,7 +6491,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.5.0.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -6524,7 +6524,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.5.0.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
@@ -6562,7 +6562,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.5.0.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
@@ -6660,7 +6660,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.5.0.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.5.2.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -6694,7 +6694,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.5.0.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
@@ -6732,7 +6732,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.5.0.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.5.2.0
       '@fluidframework/server-services-client': ^0.1039.1000
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -6780,7 +6780,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 0.1039.1000
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.5.0.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.5.2.0
       '@fluidframework/server-services-client': 0.1039.1000
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -6821,7 +6821,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.5.0.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.5.2.0
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -6863,7 +6863,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.5.0.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/benchmark': 2.1.2
@@ -6898,7 +6898,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.5.0.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/benchmark': ^2.1.0
@@ -6931,7 +6931,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.5.0.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/benchmark': 2.1.2
@@ -6953,7 +6953,6 @@ importers:
 
   packages/dds/task-manager:
     specifiers:
-      '@fluid-experimental/task-manager-previous': npm:@fluid-experimental/task-manager@2.0.0-internal.2.1.1
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.20.0
@@ -6971,7 +6970,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.5.0.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7003,7 +7002,6 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
       events: 3.3.0
     devDependencies:
-      '@fluid-experimental/task-manager-previous': /@fluid-experimental/task-manager/2.0.0-internal.2.1.1
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
@@ -7011,7 +7009,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.5.0.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
@@ -7089,7 +7087,7 @@ importers:
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.5.0.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.5.2.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7117,7 +7115,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.5.0.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
@@ -7138,7 +7136,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.5.0.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.5.2.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7173,7 +7171,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.5.0.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -7201,7 +7199,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.5.0.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -7228,7 +7226,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.5.0.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/jest': 22.2.3
@@ -7253,7 +7251,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.5.0.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -7277,7 +7275,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.5.0.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/node': 14.18.47
       concurrently: 7.6.0
@@ -7290,7 +7288,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.20.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.5.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.5.2.0
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-utils': ^1.1.1
@@ -7320,7 +7318,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.5.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.5.2.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -7350,7 +7348,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.5.0.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^0.1039.1000
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7405,7 +7403,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.5.0.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/jsrsasign': 8.0.13
@@ -7441,7 +7439,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.5.0.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.5.2.0
       '@fluidframework/protocol-base': ^0.1039.1000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': workspace:~
@@ -7491,7 +7489,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.5.0.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -7519,7 +7517,7 @@ importers:
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.5.0.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
@@ -7536,7 +7534,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.5.0.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -7558,7 +7556,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.5.0.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.5.2.0
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
@@ -7582,7 +7580,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.5.0.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.5.2.0
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
       concurrently: 7.6.0
@@ -7608,7 +7606,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.5.0.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.5.2.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7635,7 +7633,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.5.0.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7665,7 +7663,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^0.1039.1000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.5.2.0
       '@fluidframework/server-services-client': ^0.1039.1000
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -7718,7 +7716,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7753,7 +7751,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.5.2.0
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
       '@types/node': ^14.18.38
@@ -7783,7 +7781,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.5.2.0
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
       '@types/node': 14.18.47
@@ -7813,7 +7811,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/server-services-client': ^0.1039.1000
       '@fluidframework/test-tools': ^0.2.158186
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.5.0.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.5.2.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -7843,7 +7841,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 0.2.158186
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.5.0.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.5.2.0
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -7859,7 +7857,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': ^0.20.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.5.0.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.5.2.0
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -7901,7 +7899,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.5.0.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.5.2.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -7918,7 +7916,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': ^0.20.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.5.0.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.5.2.0
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -7972,7 +7970,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.5.0.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.5.2.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -8133,7 +8131,7 @@ importers:
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.5.0.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.5.2.0
       '@fluidframework/datastore': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -8169,7 +8167,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.5.0.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
@@ -8189,7 +8187,7 @@ importers:
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.5.0.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
       '@fluidframework/merge-tree': workspace:~
@@ -8226,7 +8224,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.5.0.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8309,7 +8307,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.5.0.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.5.2.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -8350,7 +8348,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.5.0.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.5.2.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -8431,7 +8429,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.5.0.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.5.2.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -8466,7 +8464,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.5.0.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/diff': 3.5.5
@@ -8498,7 +8496,7 @@ importers:
       '@fluidframework/datastore': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.5.0.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -8524,7 +8522,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.5.0.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -8548,7 +8546,7 @@ importers:
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.5.0.0
+      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.5.2.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/uuid': ^8.3.0
@@ -8570,7 +8568,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.5.0.0
+      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9
       '@types/uuid': 8.3.4
       concurrently: 7.6.0
@@ -8602,7 +8600,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.5.0.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.5.2.0
       '@fluidframework/tinylicious-driver': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8641,7 +8639,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.5.0.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -8667,7 +8665,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.5.0.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -8702,7 +8700,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.5.0.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/diff': 3.5.5
       '@types/events': 3.0.0
@@ -8731,7 +8729,7 @@ importers:
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.5.0.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.5.2.0
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': 17.0.52
@@ -8754,7 +8752,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.5.0.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8772,7 +8770,7 @@ importers:
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.5.0.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8789,7 +8787,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.5.0.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8809,7 +8807,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.5.0.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.5.2.0
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -8867,7 +8865,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.5.0.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -8899,7 +8897,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.5.0.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -8930,7 +8928,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.5.0.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8959,7 +8957,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.5.0.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^0.1039.1000
       '@fluidframework/mocha-test-setup': workspace:~
@@ -9004,7 +9002,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.5.0.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -9034,7 +9032,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.5.0.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -9063,7 +9061,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.5.0.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
@@ -9128,7 +9126,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.5.0.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.5.2.0
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore': workspace:~
@@ -9190,7 +9188,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.5.0.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9221,7 +9219,7 @@ importers:
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.5.0.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.5.2.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -9245,7 +9243,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.5.0.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -9266,7 +9264,7 @@ importers:
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.5.0.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.5.2.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -9315,7 +9313,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.5.0.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9345,7 +9343,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.5.0.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -9367,7 +9365,7 @@ importers:
       '@fluid-tools/build-cli': 0.20.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.5.0.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.5.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -9389,7 +9387,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.5.0.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
@@ -9409,7 +9407,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.5.0.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
       copyfiles: 2.4.1
@@ -9434,7 +9432,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.5.0.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.5.2.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -9470,7 +9468,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.5.0.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -9508,7 +9506,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.5.0.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -9553,7 +9551,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.5.0.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -9767,7 +9765,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.5.0.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.5.2.0
       '@fluidframework/test-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -9790,7 +9788,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.5.0.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -9987,7 +9985,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.5.0.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       concurrently: ^7.6.0
@@ -10010,7 +10008,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.5.0.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9
       '@types/mocha': 9.1.1
       concurrently: 7.6.0
@@ -10395,7 +10393,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-driver-definitions': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.5.0.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -10452,7 +10450,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.5.0.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/debug': 4.1.7
       '@types/diff': 3.5.5
@@ -10593,7 +10591,7 @@ importers:
   packages/tools/devtools/devtools:
     specifiers:
       '@fluid-experimental/devtools-core': workspace:~
-      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.5.0.0
+      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.5.2.0
       '@fluid-tools/build-cli': ^0.20.0
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
@@ -10631,7 +10629,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
-      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.5.0.0
+      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.5.2.0
       '@fluid-tools/build-cli': 0.20.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
@@ -10774,7 +10772,7 @@ importers:
 
   packages/tools/devtools/devtools-core:
     specifiers:
-      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.5.0.0
+      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.5.2.0
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/build-cli': ^0.20.0
       '@fluidframework/build-common': ^1.2.0
@@ -10834,7 +10832,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
     devDependencies:
-      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.5.0.0
+      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.5.2.0
       '@fluid-tools/build-cli': 0.20.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0
@@ -11082,7 +11080,7 @@ importers:
   packages/tools/fetch-tool:
     specifiers:
       '@fluid-tools/build-cli': ^0.20.0
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.5.0.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.5.2.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/common-utils': ^1.1.1
@@ -11124,7 +11122,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_@types+node@14.18.47
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.5.0.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.5.2.0
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@types/node': 14.18.47
@@ -11146,7 +11144,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.5.0.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
@@ -11184,7 +11182,7 @@ importers:
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.5.0.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.5.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
@@ -11291,7 +11289,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.20.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.5.0.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.5.2.0
       '@fluidframework/build-common': ^1.2.0
       '@fluidframework/build-tools': ^0.20.0
       '@fluidframework/common-utils': ^1.1.1
@@ -11373,7 +11371,7 @@ importers:
       webpack-dev-server: 4.6.0_nwcuyijzf6l5chuh7xhtrzgjly
     devDependencies:
       '@fluid-tools/build-cli': 0.20.0_aaj3xo5wh3dcbnhbyxbrutbslq
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.5.0.0_nwcuyijzf6l5chuh7xhtrzgjly
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.5.2.0_nwcuyijzf6l5chuh7xhtrzgjly
       '@fluidframework/build-common': 1.2.0
       '@fluidframework/build-tools': 0.20.0_aaj3xo5wh3dcbnhbyxbrutbslq
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -11410,7 +11408,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.5.0.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.5.2.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@types/mocha': ^9.1.1
@@ -11442,7 +11440,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.5.0.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.5.2.0
       '@types/mocha': 9.1.1
       '@types/node': 14.18.47
       '@types/node-fetch': 2.6.4
@@ -11468,7 +11466,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.5.0.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -11504,7 +11502,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.5.0.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/debug': 4.1.7
       '@types/events': 3.0.0
@@ -11536,7 +11534,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.5.0.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.5.2.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
@@ -11573,7 +11571,7 @@ importers:
       '@fluidframework/build-tools': 0.20.0_@types+node@14.18.47
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.5.0.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.5.2.0
       '@microsoft/api-extractor': 7.34.9_@types+node@14.18.47
       '@types/debug': 4.1.7
       '@types/jwt-decode': 2.2.1
@@ -14982,76 +14980,60 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-ZL6nOpmf//Rhfd7xbGm0qNsf3urmGIfDS3xMcbrPFmx0Y5LqHCDfOPLX7QVRjV3G8sxKiqSLJY2nX08mUirY3w==}
+  /@fluid-experimental/devtools-core/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-+2qCs3aOkeIMHrIM9vaBhrKfOEjZmmOeQP1ji9sH+ZZnjnSdC6ffSaTS0+AGa4Ml89kFppiki+tnmy832b/MOQ==}
     dependencies:
-      '@fluidframework/cell': 2.0.0-internal.5.0.1
+      '@fluid-experimental/tree2': 2.0.0-internal.5.2.0
+      '@fluidframework/cell': 2.0.0-internal.5.2.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/counter': 2.0.0-internal.5.0.1
-      '@fluidframework/map': 2.0.0-internal.5.0.1
-      '@fluidframework/matrix': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.5.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/counter': 2.0.0-internal.5.2.0
+      '@fluidframework/map': 2.0.0-internal.5.2.0
+      '@fluidframework/matrix': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/sequence': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/sequence': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-yQV5mybE2HmCPZAjiGaoZaJnFtEcyriLClnUyz/E8EHly+unWq0CohtuT8h04aSjhq0rq+1iXqJaMA27gkdVUA==}
+  /@fluid-experimental/devtools/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-BMhktyevNQFJIXq1SxemiXkvZbY373wLGHxCR1F3z0mrQ9To2etZkJOEaj7qRMinbc0/xCPM6TE+7p6tTUrFsg==}
     dependencies:
-      '@fluidframework/cell': 2.0.0-internal.5.0.1
+      '@fluid-experimental/devtools-core': 2.0.0-internal.5.2.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/counter': 2.0.0-internal.5.0.1
-      '@fluidframework/map': 2.0.0-internal.5.0.1
-      '@fluidframework/matrix': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/sequence': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/fluid-static': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-9u/VIYMa68pau5xLJzYpOtQQSX8OxOn+FuBS7clCvInFg+XyJzFBqfA9KZFfR1MTgT/hXINbYnCOAQQu2zbXFA==}
-    dependencies:
-      '@fluid-experimental/devtools-core': 2.0.0-internal.5.0.1
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/fluid-static': 2.0.0-internal.5.0.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluid-experimental/task-manager/2.0.0-internal.2.1.1:
-    resolution: {integrity: sha512-7oRVdnok0F5ijo2DftLzae68KsFT3KlyhSKgfjwBlV5T14TqdkJTUXSDbmMtGPOy7MiHqlPmlHaNLQip0jtVSw==}
+  /@fluid-experimental/tree2/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-hPZ1kPph1CR/DiABe30vmsSeULV6/v31tCBC8gfqvdPx3L0vvIUDBFv19EklPM5kthFMj5qVl9OjCRhK8xp2/Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-utils': 2.0.0-internal.2.4.3
+      '@fluidframework/container-runtime': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.4.3
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
+      '@sinclair/typebox': 0.28.11
+      '@ungap/structured-clone': 0.3.4
+      sorted-btree: 1.8.1
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -15235,26 +15217,25 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-/2hoGzxPPVM057eT1LOMFw+I8nKeX/7RFt5G8a6Xv8RagsnnA/1RR3xhxo1fjMm7cdy98d30WmFV2QLhVvxobA==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-vUD3GBS1s/enZ8hMqkywrgGrCvwvFvF/2OGckTFcshAITTyTo9mCDY6fs6CxZkQCL809UhBTUbhxn152amuyLQ==}
     hasBin: true
     dependencies:
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.5.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.5.2.0
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.5.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/test-client-utils': 2.0.0-internal.5.0.0
-      '@fluidframework/tool-utils': 2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15263,14 +15244,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-eLZ0/9vUSJfdPMnOMlEaGIxeL+Xf+SMEsacaWFXkxdCyY2h7sY0vth4TaJ2dSzVBcALRz9iLkSh9GqK4eiQ6+Q==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-sDwNEPDUBdhv3wdfLNc8kcaDly4dcvJJYKZZH0S1OZdbNXX0nq86UfKKCmVjfOgksJooWPpBuovK/eWoFtkLtg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15297,28 +15278,28 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.5.0.0_nwcuyijzf6l5chuh7xhtrzgjly:
-    resolution: {integrity: sha512-KDRpA++y7prE/pEwf1hNQDm7HpeNSmE6uszEZ4V3PYD30FeFsStQ+O0qdCkc06j/QnqaFSPrhoqHXuh1nbUCZg==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.5.2.0_nwcuyijzf6l5chuh7xhtrzgjly:
+    resolution: {integrity: sha512-DqLtUKnot5nZo4KJjAsMNnSsRocMgKLQchFO8C4bQrL7nfNF0AO/ySH8qd2x676HYY/nx2VXPYTY22gRG7TAWg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/local-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/local-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
       '@fluidframework/server-local-server': 0.1039.1000
       '@fluidframework/server-services-client': 0.1039.1000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.5.0.0
-      '@fluidframework/tool-utils': 2.0.0-internal.5.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.5.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.5.2.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -15338,69 +15319,21 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-NWFhTGM218FF+bEFRQ5mwdvAjbhQ6xzLkEvZfdx4I9+Rzf/pbI/UAtusWHrMGeaOlxQdUPfP4Dl3QPmWJbDLDQ==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-3vkZk+MF6g2bmRiJCmDBuv2421HWV3piWc4i6sryyaGfvqikqCvrc5Sc8MNhAOG6Q1pxcDi0Wa3oA9tVviLt1Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/map': 2.0.0-internal.5.0.1
-      '@fluidframework/register-collection': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/aqueduct/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-KpkiHshHUWGJWqvtZzyNkkXKJ6xin0/g9tbz5vOIfhiraEoCqB+1thUi7d3OZN+K1XHRE761MBD66o2c0AuUWg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/map': 2.0.0-internal.5.0.1
-      '@fluidframework/request-handler': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/synthesize': 2.0.0-internal.5.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.5.0.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/aqueduct/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-KpkiHshHUWGJWqvtZzyNkkXKJ6xin0/g9tbz5vOIfhiraEoCqB+1thUi7d3OZN+K1XHRE761MBD66o2c0AuUWg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/map': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/synthesize': 2.0.0-internal.5.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.5.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/map': 2.0.0-internal.5.2.0
+      '@fluidframework/register-collection': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -15422,6 +15355,29 @@ packages:
       '@fluidframework/request-handler': 2.0.0-internal.5.2.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/synthesize': 2.0.0-internal.5.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.5.2.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/aqueduct/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-3qPhBHvBliu/ydbxXB0IrNQxQ2Yh5uS2jIzYW6DbAy3BhBggeYMmsCRoZw9qS3TV2E5jNTalvxlzmbDC/LWNeA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/map': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/synthesize': 2.0.0-internal.5.2.0
       '@fluidframework/view-interfaces': 2.0.0-internal.5.2.0
       uuid: 8.3.2
@@ -15685,21 +15641,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-zOYXL3uSs5RR8PfkiC9HSfYZghnM7wb9K4Z0stkSex8rByvUZeZnO+azLI783zP0TmsY9Z5On+y1tI1AyPtkbA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
   /@fluidframework/cell/2.0.0-internal.5.2.0:
     resolution: {integrity: sha512-QHXRS3m3gQ287z3xCKM0JPihxV2gqB+tGd772KusjFniovNLw8bzPYVnKmphLcWrk8kjLmjLax5kT+IRCOlXJg==}
     dependencies:
@@ -15729,26 +15670,6 @@ packages:
       lodash: 4.17.21
       sha.js: 2.4.11
 
-  /@fluidframework/container-definitions/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-LajwUIrZZ/L46HmExSMk753Y/km4NFa9PCVCyVAp9Sh6vhQww+TBEVPvzJFry/Ji6cdYXgVVSlqcGG3YRkQDYQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-definitions': 1.2.0
-      events: 3.3.0
-    dev: true
-
-  /@fluidframework/container-definitions/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-MPS0Zsayjvz3T1Y6Bs8RDHwNdVhL8o0FqIGJq07lEjA2zgVLNIT1sJJasEmaa8/J98Cqd0QmHvdl9t+bgpeqDQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      events: 3.3.0
-    dev: true
-
   /@fluidframework/container-definitions/2.0.0-internal.5.2.0:
     resolution: {integrity: sha512-Eq6sCrRsrzQ62NK2ekiiTHnhSG/qLS15TBnwuTZbv3vYf4St0En6CGZnwvqY+L5gNYJq008KNnB+e8ePSof8ww==}
     dependencies:
@@ -15757,78 +15678,6 @@ packages:
       '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
       events: 3.3.0
-    dev: true
-
-  /@fluidframework/container-loader/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-kOQ0/erP9YGKqLyzfGIA6AqAFdCeH52glR91a8hypvC7z0gqI9RHBGNwDe8KrMD6OqcaaM9e2ZgbKl9XkeHIhw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      abort-controller: 3.0.0
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-loader/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-EBQBIWHRUaHbdS82eIFiG2qWDJpHelWpEeSr8vaDRbSS0tx0lrW01gd7xYBnLGyyKWHKFEnosQ2Cq3CHvqQsig==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      abort-controller: 3.0.0
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-loader/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-EBQBIWHRUaHbdS82eIFiG2qWDJpHelWpEeSr8vaDRbSS0tx0lrW01gd7xYBnLGyyKWHKFEnosQ2Cq3CHvqQsig==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      abort-controller: 3.0.0
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: true
 
   /@fluidframework/container-loader/2.0.0-internal.5.2.0:
@@ -15855,37 +15704,28 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-Q+kLdiA9RNQHXWLkPXERmlgQIigL9/00R7YtAWcS96oKTJZ+ceqqZDZYqtgT6C3Rb8tPUiu2zJjXQMsK8TDFZQ==}
+  /@fluidframework/container-loader/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-D9IGhlc4FCgY2ts8jQFcYbcsFwa9rQd3M320tIjira1PmfL4HhwuHeN2OQroIMKeje5ARBiZg+BDqpu2Knr5jQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.4.3
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/protocol-base': 0.1039.1000
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-    dev: true
-
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-Wlu6jYvlIj7kjI3tCPGVyqz/PJUlWmBfLxp7HUBeWlATDeFhvWfavOo6TaPfea4v4qx1VXeMcNpdkdPSIok2DQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-    dev: true
-
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-/+8w84Tg6PQBhWJJW61irwMOUPBDTAEUlxJaMzTY9PHC07U2QbDuvBWvG5HyoA7RshHEO6Ey6f8c+MkdG7psoQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      abort-controller: 3.0.0
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lodash: 4.17.21
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
   /@fluidframework/container-runtime-definitions/2.0.0-internal.5.2.0:
@@ -15897,111 +15737,6 @@ packages:
       '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-uuLdPWbseh6HCv2CEsLwMaAxAn6mnLdhU5iTPSEhqQ8GDyhZsx2Kc42vZOBHOpwhkM5WUaITMWvd9RVutDHegA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/container-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/datastore': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/garbage-collector': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-base': 0.1038.4001
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.4.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-nzGDgZloKbebxceg6/pfLyO0glU/SvQn+voJTgCwfVkAaV20iZ848D3szAFA7IO5ynAk+N7RGK/MBf145A3QWQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      sorted-btree: 1.8.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-UVLI/sH7qgpGnokUxNUPQxmJBSECGhAh0XHvLpWo+Q6V+cn616VuHFk1xuK3qiWdmHHdIGBE0TEDKmpkhDForg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      sorted-btree: 1.8.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-UVLI/sH7qgpGnokUxNUPQxmJBSECGhAh0XHvLpWo+Q6V+cn616VuHFk1xuK3qiWdmHHdIGBE0TEDKmpkhDForg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      sorted-btree: 1.8.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: true
 
   /@fluidframework/container-runtime/2.0.0-internal.5.2.0:
@@ -16030,39 +15765,29 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-H7l5IznD9yJ1nL8cwgti9xoTpMdLBreMkx9wR+GF1rogwUD2YtXvf7kH3UPHK3iVWxaxyGZb4e8cwXoFPdMtog==}
+  /@fluidframework/container-runtime/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-d1Qt+v496XbD0JSV8TJOJeNg8L6uP2NGebLqjvhDKtMNKgaDT6ByQzV/soHDRcu563fe3uJ7b4Egfho9kdxBtQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.4.3
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      sorted-btree: 1.8.1
+      uuid: 8.3.2
     transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-yg2LP3LHJV4wqzQfOuLuuMiyTE6ZmyzmcKlMdn3lPJKSR5JU06rOLWi/aetReebLMvKqEgpQKyiU648dc/D1EA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-utils/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-JzNKPDBMCI+nWa2b8EQYS9nGQ0QT3xg72PxdZKIDM6zeB1xauulqpUg1jY7uI2GYmEy1AVL5B1EGGgx+WvTZTA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
+      - debug
       - supports-color
     dev: true
 
@@ -16078,31 +15803,12 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-wNH5TrE69s8nmP9XCacHAdUDuBlLbWk1FJhtrM+n4fXRBMa+UzJ3JS97ZsMJQcqBrEVtsA1ioov4iaoOFyGQuA==}
-    dev: true
-
-  /@fluidframework/core-interfaces/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-3Lo9OOon99DAYo42zwe2urmkpHmARhgkuHoU/EcdPfo4bHYN0d9ixC5i9V8jKagEHYB4JbqhfCCM8xqcEbLi2g==}
-    dev: true
-
   /@fluidframework/core-interfaces/2.0.0-internal.5.2.0:
     resolution: {integrity: sha512-2ljcMWKc0lPVcmR0oVFhTYq4vBknbDHYwUGcS3Ip1sNiOiLol6mIkkVw55uDpJXmOpliGmM3x5UZ6rO7GUg2WQ==}
     dev: true
 
-  /@fluidframework/counter/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-CQCsMHSFaFDiS9nkwFuZFU2ML9mv87tF8SxImYd6qjC7YvbrbOYReakYEnY2z4ub0mqkzcEhMKROu1sanIGK4A==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
+  /@fluidframework/core-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-l/u1rSDbsiYxA1GBgswzNTEf5kwVMx1T02PZttGcM7OXdH0dyeI6syhv7oz95ErGUEhUyBT4EObIRJ6pcJB0Zg==}
     dev: true
 
   /@fluidframework/counter/2.0.0-internal.5.2.0:
@@ -16120,57 +15826,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-dehR/v+W2Qyb5Ls9Iuws78UnMelrWbNvtITpQOLS64fYiDGGJvNW3WrNafsGY6qHbRPnbSpvFJc5Se+L+8Y1QA==}
+  /@fluidframework/data-object-base/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-sQOH83jFi/lhIjZd5vCda6Jc9q59tsxLV7Lfadpdl5tkMIg5HVoZxOBOmZNBU2S2jzSVOekcPdSpf6UaWWvkcg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/request-handler': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/request-handler': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
-    dev: true
-
-  /@fluidframework/datastore-definitions/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-5nn0/q5ksbjRKQEjVlB2+dFYjzuGiZOtPnTNPd0fSo/o1S4Bx+Q5GbINzRBr5qZwdrbsvwelOnUk2iSSRtdkFw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-    dev: true
-
-  /@fluidframework/datastore-definitions/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-igeEB8ds+UFPZqQmXK8tZ+iXljmxlFan/eiI2uXX077CDzlRJS0famgi2VpRqJP7+9UxdfH+WV0iGfOvvYDv4A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-    dev: true
-
-  /@fluidframework/datastore-definitions/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-lu/n99Zbh9FH3pp11/QXQX+oy4ZQLF0+uhfSepXxKCsFq+MSBChrWi09A0QHi9X0GXOnjSwtuF7z80ULnuhwxg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
     dev: true
 
   /@fluidframework/datastore-definitions/2.0.0-internal.5.2.0:
@@ -16182,99 +15855,6 @@ packages:
       '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
-    dev: true
-
-  /@fluidframework/datastore/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-exiCdGyjfYPwcPQg5grdxKaDF0wxa7v0r3AP5ZFtlHR7hdZiVF3HQvinvM+ZTuSFtWKUoGNRgYYBy/GFf73DRg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/container-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/garbage-collector': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-base': 0.1038.4001
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.4.3
-      lodash: 4.17.21
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/datastore/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-97tpeorBXB/swaBwzKS/nzGW/3e2Nh/TcFjykV7n4VIrEN7atQYhxJB0MzvPktgJvCL6PbKTGki00iUV8+Ez7g==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      lodash: 4.17.21
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/datastore/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-IUQXCyegEmTsMW18ZXfCwo7YAnuaBpartBa9OUoihBkj49xPodt0W3yat82cvMqYUtjl+KEUS6rRTtO40e+RWA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      lodash: 4.17.21
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/datastore/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-IUQXCyegEmTsMW18ZXfCwo7YAnuaBpartBa9OUoihBkj49xPodt0W3yat82cvMqYUtjl+KEUS6rRTtO40e+RWA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      lodash: 4.17.21
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: true
 
   /@fluidframework/datastore/2.0.0-internal.5.2.0:
@@ -16300,56 +15880,51 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-TNWbsuct6P3CSml0Gxyk1r3xkhgrEdonADlv5GXUua4VHohFGcAV73uOzmpUu1x004PoHJtcVMvNNp/GF6Dp/w==}
+  /@fluidframework/datastore/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-QHO9HKnW4wGVkBDgZRcr8lAPuqkFX72a+k7JmDD9wXlAKTtn4nvc9BD7Ft9r4utAvwwbemCgTL21+sJnzmVljA==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/map': 2.0.0-internal.5.0.1
-      '@fluidframework/merge-tree': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/sequence': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/protocol-base': 0.1039.1000
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      lodash: 4.17.21
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-URa59EM6MV0xBxPZriQ+xBoKLXmOnI+etOJEs2YMbpIEq8uaro4efoVB6yg8/6YPSuJrpNSVo70g+cF+vRzx9A==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-K2fh4OYkJjXbJvFXV4UkxNFNTvXba62M72CGDylWuoNGokS1eZmVDCH3lP0gn540PSTSly35Ulq5Bv4aEU/goA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/map': 2.0.0-internal.5.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/sequence': 2.0.0-internal.5.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/debugger/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-PvTKMk8zE3brPKRF4SNcWF3x1hA6f7iNQ7AvnpKAHKALxOpn1YoMZ46PtuMe2PKIItacQx7zuJ0dzDtKFL/vTw==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/replay-driver': 2.0.0-internal.5.0.0
+      '@fluidframework/replay-driver': 2.0.0-internal.5.2.0
       jsonschema: 1.4.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-base/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-tlyUOrnA1qsxTVZRUkXOa7PT9GyO1C+kK7w5dNzFIFAJTaAKQrpJMm4x0dGEjPWp1T7CIMqLRm42kK4PEZ5uAQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-base/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-tlyUOrnA1qsxTVZRUkXOa7PT9GyO1C+kK7w5dNzFIFAJTaAKQrpJMm4x0dGEjPWp1T7CIMqLRm42kK4PEZ5uAQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16370,20 +15945,19 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-6t2DvzDS0x6rtUl+A5BFQVC/5ptlAu0w99yN0X59fN8jGv9KZpFvBdC6A02kATfqkpCVvIxCw9BS8FGRRRuYcQ==}
+  /@fluidframework/driver-base/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-fyh+Zur3tJCuMXD2PfPNW0BdXeeVRYfyH2REOyGAae+isxM/G8wY7+aKdrB4vbK3snOKlPiFMq73P8aJAYq2aA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-    dev: true
-
-  /@fluidframework/driver-definitions/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-Xc1k0Yu2FGwtD1I7adLW15RrepHxLOZ9cHwGGALO7FYN28xhv0ETdJJGSj3iPRMlqRjRTKnSwZRoxQiK2x/5Sw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
   /@fluidframework/driver-definitions/2.0.0-internal.5.2.0:
@@ -16392,82 +15966,6 @@ packages:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-GP/1jkwpAA7uaP8P72QCczyLgmNhiVVDm+B05THl2fNpOVUEmkrxgvAo7O8wDqpb2OJxRqujYI0ngMc1OuXCHw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/gitresources': 0.1038.4001
-      '@fluidframework/protocol-base': 0.1038.4001
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.4.3
-      axios: 0.26.1
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-h3+5mIBFMPWFFBcOEmVJ7Id0LHIu9UxqS/Qmb1iVa8k8KPop7LBDOprWffrHbXp1eNXAY9VPftup6Htqi64jQA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/gitresources': 0.1039.1000
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      axios: 0.26.1
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-rDC+xcSKPEphEpkhu2yxoSUoMerCplxMBbx3vZeGvAqNzQRnPK7TvwOYzEEvgKxNId7LJ/XRcudk/UH9DAa/ng==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/gitresources': 0.1039.1000
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      axios: 0.26.1
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-rDC+xcSKPEphEpkhu2yxoSUoMerCplxMBbx3vZeGvAqNzQRnPK7TvwOYzEEvgKxNId7LJ/XRcudk/UH9DAa/ng==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/gitresources': 0.1039.1000
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      axios: 0.26.1_debug@4.3.4
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: true
 
   /@fluidframework/driver-utils/2.0.0-internal.5.2.0:
@@ -16490,13 +15988,33 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-pBCOyxjMnjhIwbA2Rgf0qrv8Ybsd4/92AkXTEGoawyLlcYFYpBwJWkJdt0l64jeNeJh4ahDRN7uRvJXPCH2i6w==}
+  /@fluidframework/driver-utils/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-SP1WBvCfjzf80SVTW150YjZo55MyVeuqMVmlQDlTT6680WqHaHBJ97+9fXbBG4Tvdmu7ud4CIkvQVJQdDUGB1g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/gitresources': 0.1039.1000
+      '@fluidframework/protocol-base': 0.1039.1000
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      axios: 0.26.1_debug@4.3.4
+      lz4js: 0.2.0
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-web-cache/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-5UL5QHSKFGeRGDZNJD1dGcocu+KnSN/aZAV0vQrt0izAfXfh0AQG+9lsA3distzzu/76585pXwmCdAr4B4MWwA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -16528,33 +16046,34 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-zlRvtvqhge8A+Wt3m+RB7cWQF2Tu/E61ShDtep9kF7i6PQJxnEW9qR6QHkHUrV/ulH43maFGdjCjApJ/yxM9oQ==}
+  /@fluidframework/file-driver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-3aXn3BAwBYKnjOSEqPegFI2HKMutwBSoU9sZFx93ATvREIPv8U5Tq0F7I+bp+hQ20FV51W9RCBruXF1yJp5R3g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/replay-driver': 2.0.0-internal.5.0.0
+      '@fluidframework/replay-driver': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-rEWNBm5t534bZzldE8efItct0LaRyrhVUVJ2+m9XRslJfer22Ku3zc3YQ6CEvD/ixqclONfD6exCFfe5InOPaQ==}
+  /@fluidframework/fluid-runner/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-W720UwDmNeXn8g3GTaBVEKPN5Hz1I8RYlNQRJ5iQbTAZiEa+gQExUSznR0VdnCaP0K3gIaEUWVSu0VvIVjBHGw==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.5.0.0
+      '@fluidframework/aqueduct': 2.0.0-internal.5.2.0
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -16563,26 +16082,6 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
-    dev: true
-
-  /@fluidframework/fluid-static/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-zRM7/B24C2eHkCbRaxOMNWe1L6Ur/a1omW1GSt9UN0E0hktwnPrDQBjbMtlOhwHK9m1YekKe4IFANDLeh4H4Dg==}
-    dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.5.0.0
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: true
 
   /@fluidframework/fluid-static/2.0.0-internal.5.2.0:
@@ -16603,15 +16102,6 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
-    dev: true
-
-  /@fluidframework/garbage-collector/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-oOW7dpui9p+yvAgQDe/vdYIF48XsRknyprXZBW/FEVq1GKgKdJ3KTPpknVjZvNpmdxxA1uadVs+88JzKV4G5fg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
   /@fluidframework/gitresources/0.1038.4001:
@@ -16636,23 +16126,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-HPzicGEZePZnIuZIMzQ3XHKlXH90EFrtraAX48lOmAdhLRfXrcLuEaf2c8rwBZI0MSNtEoIuHfQ5Um3OZznXdA==}
+  /@fluidframework/local-driver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-VRgeUSIyTuE4zfK4ZUvoGlv9QajGXmP/SegG5VaqS+jBIkAsDa3BfwJAcFa2lnWGf4qadfQzPmjTRwFVJ7gcrw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-base': 2.0.0-internal.5.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-base': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-base': 0.1039.1000
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0
       '@fluidframework/server-local-server': 0.1039.1000
       '@fluidframework/server-services-client': 0.1039.1000
       '@fluidframework/server-services-core': 0.1039.1000
       '@fluidframework/server-test-utils': 0.1039.1000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.0
@@ -16665,23 +16155,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-HPzicGEZePZnIuZIMzQ3XHKlXH90EFrtraAX48lOmAdhLRfXrcLuEaf2c8rwBZI0MSNtEoIuHfQ5Um3OZznXdA==}
+  /@fluidframework/local-driver/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-VRgeUSIyTuE4zfK4ZUvoGlv9QajGXmP/SegG5VaqS+jBIkAsDa3BfwJAcFa2lnWGf4qadfQzPmjTRwFVJ7gcrw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-base': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-base': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1039.1000
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/server-local-server': 0.1039.1000
       '@fluidframework/server-services-client': 0.1039.1000
       '@fluidframework/server-services-core': 0.1039.1000
       '@fluidframework/server-test-utils': 0.1039.1000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.0
@@ -16694,71 +16184,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/location-redirection-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-D0GlS4Sxbtoa4GKUOcOp/UPXfhtkgnwD+6XY5x8u8IwYT9QFPc61D3qf0MA9LFy2KV2UF/ZC5/LT8RyxSrNPxg==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-/7a9qwVV/+3F3Z7NFx+HF5xefw+9qG/JlfQb0LGvyziZ5FtLM4YEunivFKNuSmBKSsF6foN0lJ/LorFviHLf8g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-5BsqTFmCJ1/9oZmWS3Z/jBIl/3+z7dcPOwoM7dkPSafeexRO0UbtZ4BoTCZ8l1pIfoasaFXmbPa8UJ6XAPW8GQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-kS4PfQxVZ4viFSu+T2oT3ZPeOQB0yOS8n93/l9MveoVt+m9FPIVA0AnOl20//itl66GXJl0cxjwQhJYjTAUuBg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-kS4PfQxVZ4viFSu+T2oT3ZPeOQB0yOS8n93/l9MveoVt+m9FPIVA0AnOl20//itl66GXJl0cxjwQhJYjTAUuBg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1_debug@4.3.4
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
       - supports-color
     dev: true
 
@@ -16781,20 +16214,39 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-NNzyhfihq5X66uo23ZxzaArLJOniHUfwG2lmFlJpWV1dVrCeg29s0ftMUupPp/OT34YcDxgXKpzEziWavUi74Q==}
+  /@fluidframework/map/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-S6cj2Qyf624YhUqaA9MCSapfXPsCyfpsmq1Y9eXcXOZ99+YZ48zpnP/0xDAEOMVCTRxVAk2TrR5bayfpcxo5jQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/merge-tree': 2.0.0-internal.5.0.1
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0_debug@4.3.4
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/matrix/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-s/tM1pUUxZMBhqB9GSt8Ad7ThRYfXpt8ZxuteJxoNDXYRtQ9Ax/i7BPGuwsd2vg5Z6bo6fRqDuxFQRP4bIWIRA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.5.2.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -16803,83 +16255,42 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-drrp5WY1U4ZGHgI0sN4l1RRuh7cG3653mKj9rw+eVgFV/Gcad1l6QUzITJVhAarJ6ryhsUel3PMfqYBFNvkHTw==}
+  /@fluidframework/merge-tree/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-rQ/q8obSansBpyO0AOFy/gUBKoSul2Z1k1oDi5rvSCRgEuDKMWpQPmoPAfWPgfDp7LRo8vigDEyZccS9kyzn5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/merge-tree': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      '@tiny-calc/nano': 0.0.0-alpha.5
-      events: 3.3.0
-      tslib: 1.14.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-dlFmZidcqYjs1JlPGCYV//tJbE0pY5UwHI8PDp1fjAfsGiLzYpO+4yJzxyXfafhms2blTCqjyE/vQ/6yby+vBg==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-yZqhL45BL1I/7iMopUgYucRuTX9xDGwxQemIiNEyAh2tgoCzoKn20VKUh1XCbm1hKzUdHUHtXBH+zLP1NxaOsg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/merge-tree/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-SYmqMhtA4Cr6DlDSQjvXUEdDR2usSLXE/qUoTIkaKIMnceJKEHpCnykOabJSbqPSl/sNK0brJn1ywnZ/rbF08Q==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/mocha-test-setup/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-fJ/SoO4mwnaXyVlqGOD0/Q9GE3QW+fBp3XiGWEphyhG3D1WBDIQiE6ESSjB6sLTCAipBOsWRSVd7RpInGWB8vA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.5.0.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.5.2.0
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-ao/F+O0iwuGzQ4GHAlCZZhwZ9dFGJXG/7eDIzmxKs6bbhYmuDVgR71YDKFFj2YINIieWax/+DKopdTkFQ3Wthg==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-YYDtSNphum4HyOsxMSlKRFjPOiny/QsgaeYF0Rp5Eo3+PSvhFOjp+SDDrpSaE3M3c+9q2/6DCUPKy4ZTX5L2HQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       node-fetch: 2.6.11
     transitivePeerDependencies:
       - debug
@@ -16887,15 +16298,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-ao/F+O0iwuGzQ4GHAlCZZhwZ9dFGJXG/7eDIzmxKs6bbhYmuDVgR71YDKFFj2YINIieWax/+DKopdTkFQ3Wthg==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-YYDtSNphum4HyOsxMSlKRFjPOiny/QsgaeYF0Rp5Eo3+PSvhFOjp+SDDrpSaE3M3c+9q2/6DCUPKy4ZTX5L2HQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       node-fetch: 2.6.11
     transitivePeerDependencies:
       - debug
@@ -16903,27 +16314,27 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-4yav3/hJiqKn+S7VKwBqVXXPyOH88/SL54x/8B/dkOEOUiA2W1Mw4WbgouIMlJ/c3eeAK0ou5PPmxDfd0Lx61Q==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-1v0FPx6K38bHxMXRh6VL+nj5c7JdH8AT5W6g2C8MiDJvWNK7/W7vxRRjvG6zC/hqX0fsAZA+/oMPOz6eUNZiuw==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-nR5enF6J9Oy4WPiv0osCcE5QqPFhMCJL8bpGns9KGeLPb3M83af7M7zFI5ND2FTLmIMuge+NdD6XjDyerZsLsA==}
+  /@fluidframework/odsp-driver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-NmP5aANDtTf4Nqh/mFOHo83q+n0whE2TFywWI8M7ocaMzAg5pxwaNlsZtHMg/4nGLI9yXElVHqvBAbZ9V61QpQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-base': 2.0.0-internal.5.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-base': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/gitresources': 0.1039.1000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-base': 0.1039.1000
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       abort-controller: 3.0.0
       node-fetch: 2.6.11
       socket.io-client: 4.6.1
@@ -16936,13 +16347,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-1EXJDIE4rcgV/nd6hecTYmNszUN9N1zLEBSDCLIgZx/zaqRpqOhv2Cj64sLxjWhlBj8hkGUJGLD+JIdhFr+FhA==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-zd7Lne9UJg4WsXPxxnXMeOISBwJJgkumysF+rcObtMQghzBovMogp4Q7VbVfC1UMjmoFoqho8lZHSptjXEvBSA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16951,16 +16362,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-q7NRXF3T9pQiP9Oq1oivUMX+EP7gDwfTXqW8hS5csjAmTvN0NbOr2ew6wLq4EZuhw9+xtbOj4ka0QdId2fTCNw==}
+  /@fluidframework/ordered-collection/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-IdUPo4gmJZTZsL67QG6toP5cZgNr9bj5WuEScMmfVV5JcFr2Wl+60Inb/FC7PwatFDWXUeUr3ubgu8KJlr50gg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -16990,56 +16401,31 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-ounTwjObDaGthGQOuxNxxTbilB7KsHDvKJEq6YTxFzegYKUYWm+3U8h/nXz6LLQyZn60JqF/qKvh7yj3Y5CW0Q==}
+  /@fluidframework/register-collection/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-OJ0DHZtnnaVKRPNzFRDfzWWPufCCRbKzsi3SWWd1cyE/eRriLHrQtCLpxV63hXlpFwcRhRORCJJjYCDmo7GPAQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-5mmSYaYl1/YvyEaWtfeWPoui36hZHF4qqWj8jPHn6mTBaPLQwebmoxLOfVrCpJxrFBrwFnms0w7/R6UKfvnRcA==}
+  /@fluidframework/replay-driver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-eGgWtYlbU5t2B0Wh3xDW7xonOd260NAawJkao8H/REZf5GNOsLjkG8tc8kCkmF3p1Gy1i2s1SLDjUSZPb4QHOw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/request-handler/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-WuIqP5eqIqNZPkeF1tqWm20NR/s4DxP/zINGW82daL0v8t9Uci94ToiCwFlJb+MdywAsgq8tGQoy0oxqEVJnWA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/request-handler/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-WuIqP5eqIqNZPkeF1tqWm20NR/s4DxP/zINGW82daL0v8t9Uci94ToiCwFlJb+MdywAsgq8tGQoy0oxqEVJnWA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17058,56 +16444,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-tshznZf8Q15Q9CXGx7ALF3xyQwDKoAKXMBkhkCNeZ/Isvn0nvjeSM+GmdXeABrZLHbEvu5wZAYLD9N0UGaIUmg==}
+  /@fluidframework/request-handler/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-alcPJoF/MQBe94GzCfbUEX7Guh55Re1ieKzvIISn4aByDAuolP2FAnBxjMyDhwQ1ydjG4a0ZkwtvH5f4o3TPoQ==}
     dependencies:
-      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.5.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/gitresources': 0.1039.1000
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-services-client': 0.1039.1000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      cross-fetch: 3.1.6
-      json-stringify-safe: 5.0.1
-      socket.io-client: 4.6.1
-      url-parse: 1.5.10
-      uuid: 8.3.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
     transitivePeerDependencies:
-      - bufferutil
       - debug
-      - encoding
       - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/routerlicious-driver/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-tshznZf8Q15Q9CXGx7ALF3xyQwDKoAKXMBkhkCNeZ/Isvn0nvjeSM+GmdXeABrZLHbEvu5wZAYLD9N0UGaIUmg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/gitresources': 0.1039.1000
-      '@fluidframework/protocol-base': 0.1039.1000
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-services-client': 0.1039.1000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      cross-fetch: 3.1.6
-      json-stringify-safe: 5.0.1
-      socket.io-client: 4.6.1
-      url-parse: 1.5.10
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /@fluidframework/routerlicious-driver/2.0.0-internal.5.2.0:
@@ -17136,48 +16483,41 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-uZ2FBVwIVjnj0SVYAtPjnRdm4M42zu3yTge9arvj0VM8UfpcoBXq6b+feBfED0G/pelIL4u01CeXo2BLGC+Tow==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-lnDbRVYP18l8cyEsj6oxrx5xrdYkvJARyXVrWmkfG9iCACi8/CUEO0AmVeCw1MOX0rlzHnSj2s5kYw9oBpdeug==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/driver-base': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/gitresources': 0.1039.1000
+      '@fluidframework/protocol-base': 0.1039.1000
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/server-services-client': 0.1039.1000
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      cross-fetch: 3.1.6
+      json-stringify-safe: 5.0.1
+      socket.io-client: 4.6.1
+      url-parse: 1.5.10
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-1MgpHlOPSjjLK7vEq//rXMdEARiQUUEGWlTD2UaxzLngO0wsadxFAtnS4r0Yl113oBNZm9ee2KrUj6D/B8QZNw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
       nconf: 0.12.0
       url: 0.11.0
-    dev: true
-
-  /@fluidframework/runtime-definitions/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-vSUlhGiGawKmu73wGucrACSle3mvXX6uq+EjItsV5lkZjC7xV2a99bAQeQcCE5CmyBPfal1qSuPZZytYH1yoMA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-definitions': 1.2.0
-    dev: true
-
-  /@fluidframework/runtime-definitions/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-6qN7ZGTn0N9sI7z1tAn2Upswmrze/KPzl4nbpGTP7mhCb+vu95xCbPxmkJ7KkGjKme7pmYWfUWqbqV+zyqPTjA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-    dev: true
-
-  /@fluidframework/runtime-definitions/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-23xEJx9POwbhfipuktL+0uxZLTNE4UsoMQgPhFPaau4pRI7mWW4NhBd7mpQGESsQtfC4srdKamp3TLixQBINBg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
   /@fluidframework/runtime-definitions/2.0.0-internal.5.2.0:
@@ -17189,78 +16529,6 @@ packages:
       '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
       '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-    dev: true
-
-  /@fluidframework/runtime-utils/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-7wn8nARf+n8iMJuLWBzoIkZi53dtmMXsVRRl9HWQrkyMlA5ee8oTaCGIQtGM31/NgTNj5xaXIID6nX94lGcdlg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/garbage-collector': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-base': 0.1038.4001
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/runtime-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-i0X8aMww2X1CAtExPXptZn5cwhwuEYNVVugSa7sc9PO7q6kWCJ7sVqJph38u1c0pRIuE6pxXyVMyIQeFNOcZIA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/runtime-utils/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-kBC/7J3fjbAHR6Ri9iXNMzFSgANn8yL4ph23hLi5lT9rp7wAncfzNbx7hebuCIXQDTRxmCbhMHnLjK+DWN/aiA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/runtime-utils/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-kBC/7J3fjbAHR6Ri9iXNMzFSgANn8yL4ph23hLi5lT9rp7wAncfzNbx7hebuCIXQDTRxmCbhMHnLjK+DWN/aiA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
     dev: true
 
   /@fluidframework/runtime-utils/2.0.0-internal.5.2.0:
@@ -17281,40 +16549,38 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-TB3GHk7Ls/C2d1LoUgW6aCxjtOLzOzPlvyzC4/X5gvDjmsvW6DxD2DPoihHebssBVoIp8ZUdL0z/vYpPOoCjrg==}
+  /@fluidframework/runtime-utils/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-0w+MW4n2FA44YjGogkV+YeSdSP78ogcSXZ3CKANyYY9yHSwUgdwyyunawrUT3TlVo+8YvwsHyITCR/P4Fd0MOw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/merge-tree': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      uuid: 8.3.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-tm6AMVTyQe6VvoukbTh5IHiRPtZClQyuwdnzikt8qhbrEkyzm36N8jrG766UcuWqSsCgipdBouNe1o1uqkwIPA==}
+  /@fluidframework/sequence/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-j4sGJOnwsXH+UkZ+5lHmeysZa/e99lQc0q9v6ASRm+yZ2APyCgjaYFUyYtkgMj2C3tOr+bYBAELqkfGIVURZKA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/merge-tree': 2.0.0-internal.5.0.1
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -17710,90 +16976,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/shared-object-base/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-dFCLHQ4j60UgAiX0aYN1KIZOK5Hmu2cgBQk/3r0jHwKiYl5p86NNS16CvzHjDKyfYopLDSGnwPiCZg5opm0Ynw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/container-runtime': 2.0.0-internal.2.4.3
-      '@fluidframework/container-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.4.3
-      '@fluidframework/datastore': 2.0.0-internal.2.4.3
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.4.3
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.4.3
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/shared-object-base/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-DeOCrHAv8ewMsFUj0rPXEaI9MPHaLCnWhcaYa6ymUu5pv0pRPliNjHZHsvZiuXocgqwHlN3NPG10zZpmk3eaCw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/shared-object-base/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-eLPczLaBcT2gbrMvbDtyguFsj7/jKArkRSJHgARGsHgxtDFI2eKek5LCR+GZB/qVwCRCBqowS9tJInye+SVtPA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/shared-object-base/2.0.0-internal.5.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-eLPczLaBcT2gbrMvbDtyguFsj7/jKArkRSJHgARGsHgxtDFI2eKek5LCR+GZB/qVwCRCBqowS9tJInye+SVtPA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
   /@fluidframework/shared-object-base/2.0.0-internal.5.2.0:
     resolution: {integrity: sha512-gLVVwsEmNpyP/0xv9HgoWDXMN6DOlLKOzHTc8DNHV3VmbsbRqA1vdLw5ar10/ub7br3M9JGgcrrlZtTVPAQQAw==}
     dependencies:
@@ -17815,25 +16997,40 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-LZArK8uh7pB/FW+cGGPPH2KFpyCSM0SIXxGmNGjndeWGhRU7lpjY2SLluiW/g93+0Im4hfp3GVY4ctDVKz8l2g==}
+  /@fluidframework/shared-object-base/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-gLVVwsEmNpyP/0xv9HgoWDXMN6DOlLKOzHTc8DNHV3VmbsbRqA1vdLw5ar10/ub7br3M9JGgcrrlZtTVPAQQAw==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-DBp1eYcatJ6WeykLYMlJ+ZmR9nGGp/47O3D3B6tnf4XcubvsV3mghg6s6cyNenSbvfMXAd5kQa2iHgAMTHaHRg==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-4duyPA7h2h5oLm5Ah31ZvC76BhfUvTNGLGsyxC8zDpHykDLV53Uy3+pPwlpkEC1Ome0BZ/lBR/L9a4HkzS8Arw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
   /@fluidframework/synthesize/2.0.0-internal.5.2.0:
@@ -17842,58 +17039,22 @@ packages:
       '@fluidframework/common-utils': 1.1.1
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-QLSfEjJlyHZGkgIwlYxbuWBKGXbT+JyYQ19oxvjygfoWwkIm19JVO4ISZTnBBDIGgLeohg5N8Z4h9gHM+A0xEw==}
+  /@fluidframework/task-manager/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-VB3koUwfLc0zMYaD/RyFdqhvV3GlX+URmFuWBykm7PaNRKPVR8QCpHEVAdcg5hQ/HWMfN4ynOwvQbUGgE0kyHQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.5.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.5.2.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/telemetry-utils/2.0.0-internal.2.4.3:
-    resolution: {integrity: sha512-s2Ke9bg+xtEeXKjizyjqOp7gf2ZHCb2W8WdHZJHUBh8ns3W0FyE9uN+O88AEQaufj5VDJzaGRRtupPbcbgdOFQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      debug: 4.3.4
-      events: 3.3.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/telemetry-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-bH2NinVNeLyYw07peki8Tkn3LfWk2t/84LcAp3eusjaea3G3cuwSUenH7AmKFmUe4KWrhkdDas7uAbQkseVpsA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      debug: 4.3.4
-      events: 3.3.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/telemetry-utils/2.0.0-internal.5.0.1:
-    resolution: {integrity: sha512-GlRbJ1uP2M7rOFuboKm4c1wDPisA0ZVkJj0K18A8bO8mfBWYqyZHVv4zWpS2m+xhQDpNuy2MKNV6IODfEIRSag==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      debug: 4.3.4
-      events: 3.3.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
       - supports-color
     dev: true
 
@@ -17910,11 +17071,11 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-client-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-i5DxnXonhTnwRwrWPIRvevLlEKgJgqw8AOENdHiI6oiDzus3W+/2/y4FlaqjsI1aeaAITVVIYNOjfp1CUbJ5Mg==}
+  /@fluidframework/test-client-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-qxJciZTsTB8U4mIgNED5lWuNzgqXhq/C+1WKIFWCtexWKg4/vOJxDxRDtzE8649Jk6ajdzOfz3nr7Jz7chCv6w==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.5.0.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.5.2.0
       sillyname: 0.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17925,31 +17086,31 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-co8tSJ2lB+A6rKhRY0a6k0tpMIkou0M/th/gaTGPvIm8GE/lHYDh66YdAcSJIOUOiiHhmzfcaicJoWdt+KP8pw==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-5A1rCkgBUErdq+PudwbdU9SeifnRPglyo933XvRPuFsnvPFIAxqDD50AnKt1OF77zJWlIu0DArVYMk+xEK6GTA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-NssIxp5cQ3/zaGlPsmEbDNi1bbWaEObGyz2fZ1BkL5juzaFpUJsOMoDRSFG7ISPNv1YH4YlHIyHi8of7lMiI8A==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-KYiDlAvL8gHlg1xaWj4k/wC1kNMFJIS1RMn1jn5Xy6qL5pJ26Kw5lQwbsKFq3qaYjftKYqnh+smv+CSAGZBKVw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17962,21 +17123,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.5.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-NssIxp5cQ3/zaGlPsmEbDNi1bbWaEObGyz2fZ1BkL5juzaFpUJsOMoDRSFG7ISPNv1YH4YlHIyHi8of7lMiI8A==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.5.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-KYiDlAvL8gHlg1xaWj4k/wC1kNMFJIS1RMn1jn5Xy6qL5pJ26Kw5lQwbsKFq3qaYjftKYqnh+smv+CSAGZBKVw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17994,31 +17155,31 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-IiYrX0mrqU7W4Y7FTylA3r1SbS7i1gmRAn5VRS2lp+6TzLLV47O9482XR2w5t3tkO0sMIyggihfoRsNjU8L8YQ==}
+  /@fluidframework/test-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-teFScbMx1j15kELYo7Sa0uAuwS4CyGBi2JnKtgSl2hCUlbEuVEq7W3dB9TPzpZ2X3h1LIUY3+Cvykug2r+EaVA==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.5.0.0_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/datastore': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.5.0.1_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/datastore': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.5.0.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.5.0.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
@@ -18029,21 +17190,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-cJabOlW9w54H+x9CzgE/WTKMKqOs/O95WD8k/QKoBLXOfNYrRkpMzLbuBbf89/rlbXKGknFV0XIylA+MaeJuig==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-OQyi/rdWAgsqOD+0ZnvGgsiRMwwGwkFFZ4tZp2QTmrhYROBWCT1+1tYctuelg0GPjADrNRpZWj3MRpNSP2mCXg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/container-loader': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/fluid-static': 2.0.0-internal.5.0.0
-      '@fluidframework/map': 2.0.0-internal.5.0.1
+      '@fluidframework/container-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/fluid-static': 2.0.0-internal.5.2.0
+      '@fluidframework/map': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.5.0.1
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.5.2.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.5.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -18053,14 +17214,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-xgvqBMPXQ+bPEsEZ3tOIJ3MCoIN3ZOIKFGMM8bqQJ2K/Yvag9HESkHB4lIHLSPfwzTpNRwHH4/D/xtt3cAbE3w==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-dKIdXBGl8NV3t6kXhcm1Z439/7iJufg0IHvc82Z/H2xh0X0VwuwMla81xu4vh6pF9b+XVqrxuhWcT3GL7iFHaA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.5.0.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.5.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.5.2.0
       '@fluidframework/server-services-client': 0.1039.1000
       jsrsasign: 10.8.6
       uuid: 8.3.2
@@ -18072,12 +17233,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-6L6/HMe6s8LB5FxyBXvfwBp8Jlg7w2AdZ1QHbBN2wrsSoLKvDDiqftRptUNN0d6uYaaXaN+3xzHQdSJ/Y0vpHw==}
+  /@fluidframework/tool-utils/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-/JQkuJbnVxM0huhTOmv2Z3OTMuxdtERT3bYqdzdJPbsXkXXC9GefEByqXhT5OC1KqM3OYPPafklQV+ingpM5CA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-utils': 2.0.0-internal.5.0.1_debug@4.3.4
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.0.0_debug@4.3.4
+      '@fluidframework/driver-utils': 2.0.0-internal.5.2.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.5.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
       async-mutex: 0.3.2
       debug: 4.3.4
@@ -18088,32 +17249,26 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-UL5z4VcQPEk7z/coFsam1CMOjdxkTLYvQR2DJcjsZ67wsXbtc7CyrZiSg6aQXaj5phgGh9K0ZxsIvQh0CrIQqQ==}
+  /@fluidframework/undo-redo/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-Yauvjoe3TjcvJFqrvoIB1Ja/F8jW+gMrMfMzMavGFeMpX2xZLi8k3m1lW/KQDbbvn49ivoLSDkNn/yhqu/dP8w==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.5.0.1
-      '@fluidframework/matrix': 2.0.0-internal.5.0.1
-      '@fluidframework/merge-tree': 2.0.0-internal.5.0.1
-      '@fluidframework/sequence': 2.0.0-internal.5.0.1
+      '@fluidframework/map': 2.0.0-internal.5.2.0
+      '@fluidframework/matrix': 2.0.0-internal.5.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.5.2.0
+      '@fluidframework/sequence': 2.0.0-internal.5.2.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-wq4B5iydmcbQ7tuvE5KHWcln2RcJq9zaIsTAdI0+Et/G5S+kQ1Z5aCPQ7GkZREC9SMWG83bEAhR1ZABE3IlIpA==}
+  /@fluidframework/view-adapters/2.0.0-internal.5.2.0:
+    resolution: {integrity: sha512-SiGoOb1Tn08SMFTuoy1Cvzn+SRACKEpxCfQwfPgzor7TOfV9MssUinDgGeLp/zkNu0YQz7Hsca8VckEFbzQ5BA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.5.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.5.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.5.2.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: true
-
-  /@fluidframework/view-interfaces/2.0.0-internal.5.0.0:
-    resolution: {integrity: sha512-gzRzwYq6YV8hOnJnyp9ESrtY9clmmD/TevWSn2P3njaEL+CHxLQ6QaK3Sp0NHv8bu3Q8lTZsUGt9UhlapYQ5Zw==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.5.0.1
     dev: true
 
   /@fluidframework/view-interfaces/2.0.0-internal.5.2.0:
@@ -20654,7 +19809,6 @@ packages:
 
   /@sinclair/typebox/0.28.11:
     resolution: {integrity: sha512-8QPhkOowccAdXa/ra54pq+UVYvzbKjYMuojxCOTFq+yyEfcWZJSdlIVdivTRrIq7Mgjx1n4E37t8Js/RXwyvUg==}
-    dev: false
 
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
@@ -23385,7 +22539,6 @@ packages:
 
   /@ungap/structured-clone/0.3.4:
     resolution: {integrity: sha512-TSVh8CpnwNAsPC5wXcIyh92Bv1gq6E9cNDeeLu7Z4h8V4/qWtXJp7y42qljRkqcpmsve1iozwv1wr+3BNdILCg==}
-    dev: false
 
   /@webassemblyjs/ast/1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -25,7 +25,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.19.0-165129",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -25,7 +25,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/protocol-definitions": "^1.1.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -29,7 +29,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -29,7 +29,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -32,7 +32,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -33,7 +33,7 @@
 		"test:webpack": "webpack --config webpack.config.js",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -35,7 +35,7 @@
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -27,7 +27,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -37,7 +37,7 @@
 		"scriptorium:debug": "node --inspect=0.0.0.0:5858 dist/scriptorium/index.js",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-utils": "^1.1.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -35,7 +35,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -26,7 +26,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-utils": "^1.1.1",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -26,7 +26,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/server-services-client": "workspace:*",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -25,7 +25,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/common-utils": "^1.1.1",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -25,7 +25,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
 		"@fluidframework/server-services-core": "workspace:*",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -29,7 +29,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -29,7 +29,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -29,7 +29,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -28,7 +28,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -28,7 +28,7 @@
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
-		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"nyc": {
 		"all": true,


### PR DESCRIPTION
## Description

Fixes a few issues with the type tests:
- Command to generate them in each package is wrong. Note that the updated command doesn't work either due to an bug with flub package filtering, but it should get fixed soon.
- task manager has an old dep on a version from before the package was renamed which this change removes: `"@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@2.0.0-internal.2.1.1",`
- Manage packages in client type tested against `2.0.0-internal.5.0.0` instead of `2.0.0-internal.5.2.0` (likely due to a bug in flub package enumerate). This was fixed manually, but should have been fixable using `typetests:gen` ince package enumeration is fixed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
