### PR TITLE
Compare checkpoint seq nos instead of offsets 

### DIFF
--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -158,7 +158,7 @@ export class CheckpointService implements ICheckpointService {
 					const globalCheckpoint: IDeliState | IScribe = JSON.parse(document[service]);
 
 					// Compare local and global checkpoints to use latest version
-					if (localCheckpoint.logOffset < globalCheckpoint.logOffset) {
+					if (localCheckpoint.sequenceNumber < globalCheckpoint.sequenceNumber) {
 						// if local checkpoint is behind global, use global
 						lastCheckpoint = globalCheckpoint;
 						checkpointSource = "latestFoundInGlobalCollection";


### PR DESCRIPTION
When there is a cluster change in azure fluid relay, the kafka offsets become irrelevant. To get the newer checkpoint, we need to use the seq no to compare.

This was causing some documents to have duplicate ops.

For example:

Execute in [[Web](https://dataexplorer.azure.com/clusters/frspme.westus2/databases/FRS?query=H4sIAAAAAAAAA3MLCg5OLSxNzUtOTfEvSC1KLMnMz+OqUSjPSC1KVUjJTy7NTc0r8UxRsLVVUDJPTTROTk210E00NTLRNbE0MtC1MDC00E2yTE41MTdJTDFMMlECAGQ181hSAAAA)] [[Desktop](https://frspme.westus2.kusto.windows.net/FRS?query=H4sIAAAAAAAAA3MLCg5OLSxNzUtOTfEvSC1KLMnMz+OqUSjPSC1KVUjJTy7NTc0r8UxRsLVVUDJPTTROTk210E00NTLRNbE0MtC1MDC00E2yTE41MTdJTDFMMlECAGQ181hSAAAA&web=0)] [[cluster('frspme.westus2.kusto.windows.net').database('FRS')](https://dataexplorer.azure.com/clusters/frspme.westus2/databases/FRS)]

![image](https://github.com/microsoft/FluidFramework/assets/448106/200f9d13-735c-45dd-ade1-b02678ba4d65)

The document above had ops stamped until 19 and then the stamping restarted at 9 when there was a cluster change.

![image](https://github.com/microsoft/FluidFramework/assets/448106/82e0fe09-4ace-48e3-a003-20004240f845)

This was due to the above mentioned bug in choosing between the local and the global checkpoint. This was also causing some downstream protocol errors in scribe.