### PR TITLE
fix(merge-tree sequence): resolve failing stickiness fuzz tests

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -2608,6 +2608,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 					newStart,
 					interval.start.refType,
 					op,
+					undefined,
+					undefined,
 					startReferenceSlidingPreference(interval.stickiness),
 				);
 				if (props) {
@@ -2626,6 +2628,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 					newEnd,
 					interval.end.refType,
 					op,
+					undefined,
+					undefined,
 					endReferenceSlidingPreference(interval.stickiness),
 				);
 				if (props) {

--- a/packages/dds/sequence/src/test/intervalCollection.fuzzUtils.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzzUtils.ts
@@ -188,9 +188,9 @@ export function makeReducer(
 		removeRange: async ({ channel }, { start, end }) => {
 			channel.removeRange(start, end);
 		},
-		addInterval: async ({ channel }, { start, end, collectionName, id }) => {
+		addInterval: async ({ channel }, { start, end, collectionName, id, stickiness }) => {
 			const collection = channel.getIntervalCollection(collectionName);
-			collection.add(start, end, IntervalType.SlideOnRemove, { intervalId: id });
+			collection.add(start, end, IntervalType.SlideOnRemove, { intervalId: id }, stickiness);
 		},
 		deleteInterval: async ({ channel }, { id, collectionName }) => {
 			const collection = channel.getIntervalCollection(collectionName);

--- a/packages/dds/sequence/src/test/intervalUtils.ts
+++ b/packages/dds/sequence/src/test/intervalUtils.ts
@@ -56,6 +56,17 @@ export function assertEquivalentSharedStrings(a: SharedString, b: SharedString) 
 			assert(intervalId);
 			const otherInterval = collection2.getIntervalById(intervalId);
 			assert(otherInterval);
+			assert.equal(interval.stickiness, otherInterval.stickiness);
+			assert.equal(
+				interval.start.slidingPreference,
+				otherInterval.start.slidingPreference,
+				"start sliding preference not equal",
+			);
+			assert.equal(
+				interval.end.slidingPreference,
+				otherInterval.end.slidingPreference,
+				"end sliding preference not equal",
+			);
 			const firstStart = a.localReferencePositionToPosition(interval.start);
 			const otherStart = b.localReferencePositionToPosition(otherInterval.start);
 			assert.equal(


### PR DESCRIPTION
Fixes eventual consistency bugs related to segments containing 2 or more references with heterogenous sliding preferences. These issues were found through the SharedString fuzz tests, and were missed by the local reference fuzz tests (localReferenceFarm).