### PR TITLE
feat(shared-string): add more fuzzing option combinations

### DIFF
--- a/packages/dds/sequence/src/test/intervalCollection.fuzzUtils.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzzUtils.ts
@@ -114,7 +114,7 @@ export interface OperationGenerationConfig {
 	weights?: RevertibleWeights;
 }
 
-export const defaultOptions: Required<OperationGenerationConfig> = {
+export const defaultOperationGenerationConfig: Required<OperationGenerationConfig> = {
 	maxStringLength: 1000,
 	maxIntervals: 100,
 	maxInsertLength: 10,


### PR DESCRIPTION
Adds additional fuzz tests for shared string that are specifically targeted at scenarios in which there are no intervals and when there are no reconnects. 

The motivation for this addition is that we are able to get more code coverage by changing around the distribution of ops. In particular the offline fuzz tests have to be disabled in this PR as they are able to find a crash that the fuzz tests with reconnect are unable to (this crash is already tracked in a ticket).