### PR TITLE
Fix exceptions (deleteOne/deleteMany) on InMemoryCollection thrown when running tinylicious locally

### DIFF
--- a/server/tinylicious/src/services/inMemorycollection.ts
+++ b/server/tinylicious/src/services/inMemorycollection.ts
@@ -83,12 +83,26 @@ export class Collection<T> implements ICollection<T> {
 		});
 	}
 
+	private removeOneInternal(value: any): void {
+		const index = this.collection.indexOf(value);
+		if (index >= 0) {
+			this.collection.splice(index, 1);
+		}
+	}
+
 	public async deleteOne(filter: any): Promise<any> {
-		throw new Error("Method not implemented.");
+		const value = this.findOneInternal(filter);
+		this.removeOneInternal(value);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return value;
 	}
 
 	public async deleteMany(filter: any): Promise<any> {
-		throw new Error("Method not implemented.");
+		const values = this.findInternal(filter);
+		values.forEach((value) => {
+			this.removeOneInternal(value);
+		});
+		return values;
 	}
 
 	public async createIndex(index: any, unique: boolean): Promise<void> {


### PR DESCRIPTION
## Description

There are some new exceptions when running tinylicious locally, due to some non-implemented methods from the inMemoryCollection. This change addresses the 2 different exceptions we were running into.  I believe [this change](https://github.com/microsoft/FluidFramework/commit/d022a26977abc20a83273dfd656455a89e9a747f) caused this regression. 
I've validated locally that they do not happen anymore.
