### PR TITLE
fix(r11s-chart): Fixes to r11s chart

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -54,7 +54,12 @@ data:
                 "rdkafkaConsumeTimeout": 5,
                 "rdkafkaMaxConsumerCommitRetries": 10
             },
-            "customRestartOnKafkaErrorCodes": {{ .Values.kafka.customRestartOnKafkaErrorCodes }}
+            "customRestartOnKafkaErrorCodes": [
+                {{- $lastIndex := sub (len .Values.kafka.customRestartOnKafkaErrorCodes) 1}}
+                {{- range $i, $tenant := .Values.kafka.customRestartOnKafkaErrorCodes }}
+                {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
+                {{- end }}
+            ]
         },
         "zookeeper": {
             "endpoint": "{{ .Values.zookeeper.url }}"
@@ -65,8 +70,8 @@ data:
         },
         "checkpoints": {
             "localCheckpointEnabled": {{ .Values.checkpoints.localCheckpointEnabled }},
-            "kafkaCheckpointOnReprocessingOp": {{ .Values.checkpoints.kafkaCheckpointOnReprocessingOp }},
-            },
+            "kafkaCheckpointOnReprocessingOp": {{ .Values.checkpoints.kafkaCheckpointOnReprocessingOp }}
+        },
         "alfred": {
             "kafkaClientId": "{{ template "alfred.fullname" . }}",
             "maxMessageSize": "16KB",
@@ -79,17 +84,17 @@ data:
                     "generalRestCall": {{ toJson .Values.alfred.throttling.restCallsPerTenant.generalRestCall }},
                     "createDoc": {{ toJson .Values.alfred.throttling.restCallsPerTenant.createDoc }},
                     "getDeltas": {{ toJson .Values.alfred.throttling.restCallsPerTenant.getDeltas }},
-                    "getSession": {{ toJson .Values.alfred.throttling.restCallsPerTenant.getSession }}}
+                    "getSession": {{ toJson .Values.alfred.throttling.restCallsPerTenant.getSession }}
                 },
                 "restCallsPerCluster": {
                     "createDoc": {{ toJson .Values.alfred.throttling.restCallsPerCluster.createDoc }},
                     "getDeltas": {{ toJson .Values.alfred.throttling.restCallsPerCluster.getDeltas }},
-                    "getSession": {{ toJson .Values.alfred.throttling.restCallsPerCluster.getSession }}}
+                    "getSession": {{ toJson .Values.alfred.throttling.restCallsPerCluster.getSession }}
                 },
                 "socketConnectionsPerTenant": {{ toJson .Values.alfred.throttling.socketConnectionsPerTenant }},
                 "socketConnectionsPerCluster": {{ toJson .Values.alfred.throttling.socketConnectionsPerCluster }},
                 "submitOps": {{ toJson .Values.alfred.throttling.submitOps }},
-                "submitSignal": {{ toJson .Values.alfred.throttling.submitSignal }}}
+                "submitSignal": {{ toJson .Values.alfred.throttling.submitSignal }}
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -80,6 +80,7 @@ scribe:
   replicas: 8
   getDeltasViaAlfred: true
   verifyLastOpPersistence: false
+  disableTransientTenantFiltering: true
   checkpointHeuristics:
     enable: false
     idleTime: 10000


### PR DESCRIPTION
## Description

Fixes a couple of syntax issues in a JSON template for the r11s chart
- Extra comma
- Extra closing brackets
- Incorrect way of processing an array value in go-template lang (the final JSON in the yml manifest file looked like `"<key>": [1 2 3 4]` without commas between the numbers, and caused a parsing error) 

Also re-adds the default value for the `disableTransientTenantFiltering` property that was mistakenly removed in [this PR](https://github.com/microsoft/FluidFramework/pull/15759/files#diff-954aad429b37e0607aadb54f678e113bf43ed28b4cb6189e57c4e6738733f935).
