### PR TITLE
Allow skipping seeds in DDS fuzz harness

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -301,9 +301,21 @@ export interface DDSFuzzSuiteOptions {
 	 * createDDSFuzzSuite(model, { only: [42] });
 	 * ```
 	 * @remarks
-	 * If you prefer, a variant of the standard `.only` syntax works. See {@link createDDSFuzzSuite.only}
+	 * If you prefer, a variant of the standard `.only` syntax works. See {@link createDDSFuzzSuite.only}.
 	 */
 	only: Iterable<number>;
+
+	/**
+	 * Skips the provided seeds.
+	 * @example
+	 * ```typescript
+	 * // Skips seed 42 for the given model.
+	 * createDDSFuzzSuite(model, { skip: [42] });
+	 * ```
+	 * @remarks
+	 * If you prefer, a variant of the standard `.skip` syntax works. See {@link createDDSFuzzSuite.skip}.
+	 */
+	skip: Iterable<number>;
 
 	/**
 	 * Whether failure files should be saved to disk, and if so, the directory in which they should be saved.
@@ -319,6 +331,7 @@ export const defaultDDSFuzzSuiteOptions: DDSFuzzSuiteOptions = {
 	emitter: new TypedEventEmitter(),
 	numberOfClients: 3,
 	only: [],
+	skip: [],
 	parseOperations: (serialized: string) => JSON.parse(serialized) as BaseOperation[],
 	reconnectProbability: 0,
 	saveFailures: false,
@@ -650,7 +663,7 @@ export async function runTestForSeed<
 	TOperation extends BaseOperation,
 >(
 	model: DDSFuzzModel<TChannelFactory, TOperation>,
-	options: Omit<DDSFuzzSuiteOptions, "only">,
+	options: Omit<DDSFuzzSuiteOptions, "only" | "skip">,
 	seed: number,
 	saveInfo?: SaveInfo,
 ): Promise<DDSFuzzTestState<TChannelFactory>> {
@@ -702,16 +715,19 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 	seed: number,
 	saveInfo: SaveInfo | undefined,
 ): void {
-	const itFn = options.only.has(seed) ? it.only : it;
+	const itFn = options.only.has(seed) ? it.only : options.skip.has(seed) ? it.skip : it;
 	itFn(`seed ${seed}`, async () => {
 		await runTestForSeed(model, options, seed, saveInfo);
 	});
 }
 
-type InternalOptions = Omit<DDSFuzzSuiteOptions, "only"> & { only: Set<number> };
+type InternalOptions = Omit<DDSFuzzSuiteOptions, "only" | "skip"> & {
+	only: Set<number>;
+	skip: Set<number>;
+};
 
 function isInternalOptions(options: DDSFuzzSuiteOptions): options is InternalOptions {
-	return options.only instanceof Set;
+	return options.only instanceof Set && options.skip instanceof Set;
 }
 
 export async function replayTest<
@@ -728,6 +744,7 @@ export async function replayTest<
 		...defaultDDSFuzzSuiteOptions,
 		...providedOptions,
 		only: new Set(providedOptions?.only ?? []),
+		skip: new Set(providedOptions?.skip ?? []),
 	};
 
 	const _model = mixinSynchronization(
@@ -760,7 +777,8 @@ export function createDDSFuzzSuite<
 	};
 
 	const only = new Set(options.only);
-	options.only = only;
+	const skip = new Set(options.skip);
+	Object.assign(options, { only, skip });
 	assert(isInternalOptions(options));
 
 	const model = mixinSynchronization(
@@ -823,4 +841,23 @@ createDDSFuzzSuite.only =
 		createDDSFuzzSuite(ddsModel, {
 			...providedOptions,
 			only: [...seeds, ...(providedOptions?.only ?? [])],
+		});
+
+/**
+ * Skips the provided seeds.
+ * @example
+ * ```typescript
+ * // Skips seed 42 for the given model.
+ * createDDSFuzzSuite(model, { skip: [42] });
+ * ```
+ */
+createDDSFuzzSuite.skip =
+	(...seeds: number[]) =>
+	<TChannelFactory extends IChannelFactory, TOperation extends BaseOperation>(
+		ddsModel: DDSFuzzModel<TChannelFactory, TOperation>,
+		providedOptions?: Partial<DDSFuzzSuiteOptions>,
+	): void =>
+		createDDSFuzzSuite(ddsModel, {
+			...providedOptions,
+			skip: [...seeds, ...(providedOptions?.skip ?? [])],
 		});

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -625,6 +625,52 @@ describe("DDS Fuzz Harness", () => {
 			});
 		});
 
+		describe("supports modified .skip syntax", () => {
+			let runResults: MochaReport;
+			before(async function () {
+				// 2s timeout is a bit aggressive to run mocha, even though the suite of tests is very fast.
+				this.timeout(5000);
+				runResults = await runTestFile("dotSkip");
+			});
+
+			it("via .skip(2, 3)", () => {
+				const tests = runResults.passes
+					.filter((p) => p.fullTitle.includes("1: .skip via function"))
+					.sort();
+				assert.deepEqual(
+					tests.map((t) => t.title),
+					[0, 1, 4, 5, 6, 7, 8, 9].map((i) => `seed ${i}`),
+				);
+			});
+
+			it("via `skip: [4, 7]`", () => {
+				const tests = runResults.passes
+					.filter((p) => p.fullTitle.includes("2: .skip via options"))
+					.sort();
+				assert.deepEqual(
+					tests.map((t) => t.title),
+					[0, 1, 2, 3, 5, 6, 8, 9].map((i) => `seed ${i}`),
+				);
+			});
+
+			it("via a combination of .skip() and `skip: []`", () => {
+				const tests = runResults.passes
+					.filter((p) => p.fullTitle.includes("3: .skip via function and options"))
+					.sort();
+				assert.deepEqual(
+					tests.map((t) => t.title),
+					[0, 1, 3, 5, 6, 8, 9].map((i) => `seed ${i}`),
+				);
+			});
+
+			it("runs multiple suites with .skip simultaneously set", () => {
+				assert.equal(runResults.stats.tests, 30);
+				assert.equal(runResults.stats.pending, 7);
+				assert.equal(runResults.stats.passes, 23);
+				assert.equal(runResults.stats.failures, 0);
+			});
+		});
+
 		describe("failure", () => {
 			let runResults: MochaReport;
 			const jsonDir = path.join(__dirname, "./ddsSuiteCases/failing-configuration");

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dotSkip.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dotSkip.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { takeAsync } from "@fluid-internal/stochastic-test-utils";
+import { Operation, SharedNothingFactory, baseModel } from "../sharedNothing";
+import { ChangeConnectionState, DDSFuzzModel, createDDSFuzzSuite } from "../../ddsFuzzHarness";
+
+const shortModel: DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionState> = {
+	...baseModel,
+	generatorFactory: () => takeAsync(1, baseModel.generatorFactory()),
+};
+
+createDDSFuzzSuite.skip(2, 3)(
+	{
+		...shortModel,
+		workloadName: "1: .skip via function",
+	},
+	{
+		defaultTestCount: 10,
+	},
+);
+
+createDDSFuzzSuite(
+	{
+		...shortModel,
+		workloadName: "2: .skip via options",
+	},
+	{
+		defaultTestCount: 10,
+		skip: [4, 7],
+	},
+);
+
+createDDSFuzzSuite.skip(2, 4)(
+	{
+		...shortModel,
+		workloadName: "3: .skip via function and options",
+	},
+	{
+		defaultTestCount: 10,
+		skip: [4, 7],
+	},
+);


### PR DESCRIPTION
## Description

Supports skipping individual seeds in fuzz harness tests. This can be nice while stabilizing features.