### PR TITLE
Swallow errors from unavailable port mapping

### DIFF
--- a/tools/test-tools/src/getTestPort.ts
+++ b/tools/test-tools/src/getTestPort.ts
@@ -7,20 +7,26 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
-// Get the port for the pkg from the mapping.  Use a default if the file or the
-// entry doesn't exist (e.g. an individual test is being run and the file was
-// never generated), which should presumably not lead to collisions
+/**
+ * Get the port for the pkg from the mapping.  Use a default if the file or the entry doesn't exist
+ * (e.g. an individual test is being run and the file was never generated), which should presumably
+ * not lead to collisions.
+ */
 export function getTestPort(pkgName: string): string {
-	let mappedPort: string | undefined;
+	let mappedPort: string;
 
-	const portMapPath: string = fs
-		.readFileSync(path.join(os.tmpdir(), "testportmap.json"))
-		.toString();
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const testPortsJson = JSON.parse(portMapPath);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-	mappedPort = testPortsJson[pkgName];
-	if (mappedPort === undefined) {
+	try {
+		const portMapPath: string = fs
+			.readFileSync(path.join(os.tmpdir(), "testportmap.json"))
+			.toString();
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const testPortsJson = JSON.parse(portMapPath);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+		mappedPort = testPortsJson[pkgName];
+	} catch {
+		console.warn(
+			"Port mapping not available, using default port of 8081. If you encounter port collisions, be sure to run assign-test-ports.",
+		);
 		mappedPort = "8081";
 	}
 	return mappedPort;


### PR DESCRIPTION
Looks like the try/catch got accidentally removed a while back - the function comment makes it clear that we intended to swallow the error (and indeed we don't need a port mapping when running tests for a single example).  This reinstates it plus adds a warning just in case someone does start hitting port collisions for some reason.

[AB#4753](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4753)