### PR TITLE
Add socket tracker to alfred customization

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
@@ -8,6 +8,7 @@ import {
 	IStorageNameAllocator,
 	ITokenRevocationManager,
 	IRevokedTokenChecker,
+	IWebSocketTracker,
 } from "@fluidframework/server-services-core";
 import { IDocumentDeleteService } from "./services";
 
@@ -17,4 +18,5 @@ export interface IAlfredResourcesCustomizations {
 	documentDeleteService?: IDocumentDeleteService;
 	tokenRevocationManager?: ITokenRevocationManager;
 	revokedTokenChecker?: IRevokedTokenChecker;
+	webSocketTracker?: IWebSocketTracker;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -553,7 +553,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		let socketTracker: core.IWebSocketTracker | undefined;
 		let tokenRevocationManager: core.ITokenRevocationManager | undefined;
 		if (tokenRevocationEnabled) {
-			socketTracker = new utils.WebSocketTracker();
+			socketTracker = customizations?.webSocketTracker ?? new utils.WebSocketTracker();
 			tokenRevocationManager =
 				customizations?.tokenRevocationManager ?? new utils.DummyTokenRevocationManager();
 			await tokenRevocationManager.initialize().catch((error) => {


### PR DESCRIPTION
Add socket tracker to Alfred resource customization. User can provide their own implementation through customization.