### PR TITLE
Fix incremental build on case insensitive file system by canonicalize path

### DIFF
--- a/build-tools/packages/build-tools/src/common/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/common/tscUtils.ts
@@ -121,6 +121,16 @@ export function convertToOptionsWithAbsolutePath(options: ts.CompilerOptions, cw
 	return result;
 }
 
+// This is a duplicate of how tsc deal with case insenitive file system as keys (in tsBuildInfo)
+function toLowerCase(x: string) {
+	return x.toLowerCase();
+}
+const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
+export const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
+	? (x: string) => x
+	: (x: string) =>
+			fileNameLowerCaseRegExp.test(x) ? x.replace(fileNameLowerCaseRegExp, toLowerCase) : x;
+
 export function getTscUtil(tsLib: typeof ts) {
 	return {
 		parseCommandLine: (command: string) => {

--- a/build-tools/packages/build-tools/src/common/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/common/tscUtils.ts
@@ -125,6 +125,7 @@ export function convertToOptionsWithAbsolutePath(options: ts.CompilerOptions, cw
 function toLowerCase(x: string) {
 	return x.toLowerCase();
 }
+// eslint-disable-next-line no-useless-escape
 const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
 export const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
 	? (x: string) => x

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -65,7 +65,9 @@ export class TscTask extends LeafTask {
 		// Keep a list of files that need to be compiled based on the command line flags and config, and
 		// remove the files that we sees from the tsBuildInfo.  The remaining files are
 		// new files that need to be rebuilt.
-		const configFileNames = new Set(config.fileNames);
+		const configFileNames = new Set(
+			config.fileNames.map((p) => TscUtils.getCanonicalFileName(path.normalize(p))),
+		);
 
 		// Check dependencies file hashes
 		const fileNames = tsBuildInfo.program.fileNames;
@@ -93,7 +95,7 @@ export class TscTask extends LeafTask {
 				}
 
 				// Remove files that we have built before
-				configFileNames.delete(fullPath);
+				configFileNames.delete(TscUtils.getCanonicalFileName(path.normalize(fullPath)));
 			} catch (e: any) {
 				this.traceTrigger(`exception generating hash for ${fileName}\n\t${e.stack}`);
 				return false;


### PR DESCRIPTION
tsc's tsBuildInfo use canonicalized paths as keys for case insensitive file systems, so we need to do the same in the new file detection logic as well.