### PR TITLE
feat: Add search.exclude patterns in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,4 +59,24 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 	},
+
+	// Customizations for VSCode search results.
+	// These entries should probably be kept more or less in sync with the .gitignore file.
+	// They are added here because when doing a search in VSCode and using the "files to include" feature, the underlying
+	// ripgrep command will give higher precedence to including any files that match the patterns from "files to include"
+	// than to excluding files that match the patterns in the .gitignore file, which sometimes results in search results
+	// with a lot of unnecessary matches.
+	// By adding some patterns here too, VSCode passes them explicitly to ripgrep as additional patterns to exclude, with
+	// a higher priority than the "files to include" patterns.
+	// Note that they should be prefixed with "**/" compared to their respective entries in .gitignore.
+	"search.exclude": {
+		"**/*.js.map": true,
+		"**/*build.log": true,
+		"**/*.tsbuildinfo": true,
+		"**/_api-extractor-temp": true,
+		"**/dist/*": true,
+		"**/lib/*": true,
+		"**/*.log": true,
+		"**/DS_Store": true,
+	},
 }


### PR DESCRIPTION
## Description

When doing text searches in the repo with VSCode, by default `.gitignore` files are leveraged and any files that match a pattern there are excluded from the search results.

This behavior is not maintained when doing a search using the "files to include" feature. In that case, the underlying ripgrep command that gets executed for the search gives higher priority to including files that match the patterns in "files to include" than to excluding files that match the patterns in `.gitignore`, which sometimes means we get (arguably) unwanted search results along with the expected ones (see video below).

This PR changes that behavior for _some_ patterns (not all the ones from `.gitignore`), so they are still excluded from search results even when using the "files to include" feature of VSCode search.

Demo:

https://github.com/microsoft/FluidFramework/assets/716334/a4ff0f5d-898d-47d8-a8f0-17be82499113

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I'm interested if anyone has thoughts on whether they _don't_ want this behavior, i.e. you want to see the git-ignored files in the search results when using "files to include", for whatever reason.

Each user can force the behavior locally by adding the patterns to their user-level VSCode settings (which I was partially doing, for some of the patterns added in the PR), but I thought if we all prefer the new behavior it'd be better to have it be part of the repo, so opening this PR to discuss.
