### PR TITLE
Server: Add infrastructure to support any type of Blob

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -52,7 +52,7 @@ export const canWrite: (scopes: string[]) => boolean;
 export const choose: () => string;
 
 // @public
-export function convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree: IWholeSummaryTree): ISummaryTree;
+export function convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree: IWholeSummaryTree, unreferenced?: true | undefined): ISummaryTree;
 
 // @public
 export function convertSortedNumberArrayToRanges(numberArray: number[]): number[][];

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -52,6 +52,9 @@ export const canWrite: (scopes: string[]) => boolean;
 export const choose: () => string;
 
 // @public
+export function convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree: IWholeSummaryTree): ISummaryTree;
+
+// @public
 export function convertSortedNumberArrayToRanges(numberArray: number[]): number[][];
 
 // @public

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -76,6 +76,7 @@ export {
 	buildTreePath,
 	convertSummaryTreeToWholeSummaryTree,
 	convertWholeFlatSummaryToSnapshotTreeAndBlobs,
+	convertFirstSummaryWholeSummaryTreeToSummaryTree,
 } from "./storageUtils";
 export { SummaryTreeUploadManager } from "./summaryTreeUploadManager";
 export { getOrCreateRepository, getRandomInt } from "./utils";

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -245,9 +245,7 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 				const treePayload = (entry as IWholeSummaryTreeValueEntry)
 					.value as IWholeSummaryTree;
 				const nodeReferenced = (entry as IWholeSummaryTreeValueEntry).unreferenced;
-				if (nodeReferenced) {
-					console.log("this is it");
-				}
+				
 				tree[entry.path] = convertFirstSummaryWholeSummaryTreeToSummaryTree(
 					treePayload,
 					nodeReferenced,

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -224,6 +224,7 @@ export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
  */
 export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 	wholeSummaryTree: IWholeSummaryTree,
+	unreferenced?: true | undefined,
 ): ISummaryTree {
 	const tree: { [path: string]: SummaryObject } = {};
 	for (const entry of wholeSummaryTree.entries) {
@@ -243,7 +244,14 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 			case "tree": {
 				const treePayload = (entry as IWholeSummaryTreeValueEntry)
 					.value as IWholeSummaryTree;
-				tree[entry.path] = convertFirstSummaryWholeSummaryTreeToSummaryTree(treePayload);
+				const nodeReferenced = (entry as IWholeSummaryTreeValueEntry).unreferenced;
+				if (nodeReferenced) {
+					console.log("this is it");
+				}
+				tree[entry.path] = convertFirstSummaryWholeSummaryTreeToSummaryTree(
+					treePayload,
+					nodeReferenced,
+				);
 				break;
 			}
 			default: {
@@ -251,8 +259,14 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 			}
 		}
 	}
-	return {
-		type: SummaryType.Tree,
-		tree,
-	};
+	return unreferenced
+		? {
+				type: SummaryType.Tree,
+				tree,
+				unreferenced,
+		  }
+		: {
+				type: SummaryType.Tree,
+				tree,
+		  };
 }

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -245,7 +245,6 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 				const treePayload = (entry as IWholeSummaryTreeValueEntry)
 					.value as IWholeSummaryTree;
 				const nodeReferenced = (entry as IWholeSummaryTreeValueEntry).unreferenced;
-				
 				tree[entry.path] = convertFirstSummaryWholeSummaryTreeToSummaryTree(
 					treePayload,
 					nodeReferenced,

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -226,31 +226,28 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 	wholeSummaryTree: IWholeSummaryTree,
 ): ISummaryTree {
 	const tree: { [path: string]: SummaryObject } = {};
-	if (wholeSummaryTree.entries) {
-		for (const entry of wholeSummaryTree.entries) {
-			switch (entry.type) {
-				case "blob": {
-					const blobPayload = (entry as IWholeSummaryTreeValueEntry)
-						.value as IWholeSummaryBlob;
-					tree[entry.path] = {
-						type: SummaryType.Blob,
-						content:
-							blobPayload.encoding === "base64"
-								? new Uint8Array(stringToBuffer(blobPayload.content, "base64"))
-								: blobPayload.content,
-					};
-					break;
-				}
-				case "tree": {
-					const treePayload = (entry as IWholeSummaryTreeValueEntry)
-						.value as IWholeSummaryTree;
-					tree[entry.path] =
-						convertFirstSummaryWholeSummaryTreeToSummaryTree(treePayload);
-					break;
-				}
-				default: {
-					throw new Error(`Unsupported tree type for first summary`);
-				}
+	for (const entry of wholeSummaryTree.entries) {
+		switch (entry.type) {
+			case "blob": {
+				const blobPayload = (entry as IWholeSummaryTreeValueEntry)
+					.value as IWholeSummaryBlob;
+				tree[entry.path] = {
+					type: SummaryType.Blob,
+					content:
+						blobPayload.encoding === "base64"
+							? new Uint8Array(stringToBuffer(blobPayload.content, "base64"))
+							: blobPayload.content,
+				};
+				break;
+			}
+			case "tree": {
+				const treePayload = (entry as IWholeSummaryTreeValueEntry)
+					.value as IWholeSummaryTree;
+				tree[entry.path] = convertFirstSummaryWholeSummaryTreeToSummaryTree(treePayload);
+				break;
+			}
+			default: {
+				throw new Error(`Unsupported tree type for first summary`);
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -218,6 +218,33 @@ export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
 }
 
 /**
+ * Validates whether the entry is an IWholeSummaryTreeEntry with a value field
+ * @param obj - object to be evaluated
+ * @returns Whether the value is of IWholeSummaryTreeEntry type
+ */
+function isWholeSummaryTreeValueEntry(obj: any): obj is IWholeSummaryTreeValueEntry {
+	return obj && typeof obj === "object" && "value" in obj;
+}
+
+/**
+ * Validates whether a specific value is of IWholeSummaryBlob type.
+ * @param obj - object to be evaluated
+ * @returns Whether the value is of IWholeSummaryBlob type
+ */
+function isWholeSummaryBlob(obj: unknown): obj is IWholeSummaryBlob {
+	return obj && typeof obj === "object" && "content" in obj;
+}
+
+/**
+ * Validates whether a specific value is of IWholeSummaryBlob type.
+ * @param obj - object to be evaluated
+ * @returns Whether the value is of IWholeSummaryBlob type
+ */
+function isWholeSummaryTree(obj: any): obj is IWholeSummaryTree {
+	return obj && typeof obj === "object" && "type" in obj;
+}
+
+/**
  * Converts existing IWholeSummaryTree to ISummaryTree for the first summary (without Handle entries)
  * @param wholeSummaryTree - wholeSummaryTree used on the payload for creating and uploading a document.
  * @returns Summary tree to be used when creating a new document.
@@ -230,8 +257,9 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 	for (const entry of wholeSummaryTree.entries) {
 		switch (entry.type) {
 			case "blob": {
-				const blobPayload = (entry as IWholeSummaryTreeValueEntry)
-					.value as IWholeSummaryBlob;
+				assert(isWholeSummaryTreeValueEntry(entry), "Invalid entry type");
+				assert(isWholeSummaryBlob(entry.value), "entry value is not an IWholeSummaryBlob");
+				const blobPayload = entry.value;
 				tree[entry.path] = {
 					type: SummaryType.Blob,
 					content:
@@ -242,9 +270,10 @@ export function convertFirstSummaryWholeSummaryTreeToSummaryTree(
 				break;
 			}
 			case "tree": {
-				const treePayload = (entry as IWholeSummaryTreeValueEntry)
-					.value as IWholeSummaryTree;
-				const nodeReferenced = (entry as IWholeSummaryTreeValueEntry).unreferenced;
+				assert(isWholeSummaryTreeValueEntry(entry), "Invalid entry type");
+				assert(isWholeSummaryTree(entry.value), "entry value is not an IWholeSummaryTree");
+				const treePayload = entry.value;
+				const nodeReferenced = entry.unreferenced;
 				tree[entry.path] = convertFirstSummaryWholeSummaryTreeToSummaryTree(
 					treePayload,
 					nodeReferenced,

--- a/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
@@ -4,8 +4,13 @@
  */
 
 import assert from "assert";
-import { stringToBuffer } from "@fluidframework/common-utils";
-import { buildTreePath, convertWholeFlatSummaryToSnapshotTreeAndBlobs } from "../storageUtils";
+import { fromUtf8ToBase64, stringToBuffer } from "@fluidframework/common-utils";
+import {
+	buildTreePath,
+	convertSummaryTreeToWholeSummaryTree,
+	convertWholeFlatSummaryToSnapshotTreeAndBlobs,
+	convertFirstSummaryWholeSummaryTreeToSummaryTree,
+} from "../storageUtils";
 
 import {
 	IWholeFlatSummaryBlob,
@@ -13,6 +18,11 @@ import {
 	IWholeFlatSummaryTree,
 	IWholeFlatSummaryTreeEntry,
 } from "../storageContracts";
+import {
+	IDocumentAttributes,
+	ISummaryTree,
+	SummaryType,
+} from "@fluidframework/protocol-definitions";
 
 const summaryBlobs: IWholeFlatSummaryBlob[] = [
 	{
@@ -201,6 +211,48 @@ describe("Storage Utils", () => {
 				snapshotTree: snapshotTreeWithoutPrefixStrip,
 				sequenceNumber,
 			});
+		});
+	});
+
+	describe("convertFirstSummaryWholeSummaryTreeToSummaryTree()", () => {
+		const documentAttributes: IDocumentAttributes = {
+			minimumSequenceNumber: 0,
+			sequenceNumber: 1,
+			term: 1,
+		};
+
+		const summaryTree: ISummaryTree = {
+			tree: {
+				attributes: {
+					content: JSON.stringify(documentAttributes),
+					type: SummaryType.Blob,
+				},
+				quorumMembers: {
+					content: fromUtf8ToBase64(JSON.stringify([])),
+					type: SummaryType.Blob,
+				},
+				quorumProposals: {
+					content: fromUtf8ToBase64("This is a test"),
+					type: SummaryType.Blob,
+				},
+				quorumValues: {
+					content: JSON.stringify([]),
+					type: SummaryType.Blob,
+				},
+			},
+			type: SummaryType.Tree,
+		};
+
+		it("Validate summary tree conversion", () => {
+			const wholeSummaryTree = convertSummaryTreeToWholeSummaryTree(
+				undefined,
+				summaryTree,
+				"",
+				"",
+			);
+			const newSummaryTree =
+				convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree);
+			assert.deepStrictEqual(newSummaryTree, summaryTree);
 		});
 	});
 });

--- a/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
@@ -243,7 +243,7 @@ describe("Storage Utils", () => {
 			type: SummaryType.Tree,
 		};
 
-		const appSummary: ISummaryTree = {
+		const summaryWithUnreferencedNode: ISummaryTree = {
 			type: SummaryType.Tree,
 			tree: {
 				default: {
@@ -284,16 +284,16 @@ describe("Storage Utils", () => {
 			assert.deepStrictEqual(newSummaryTree, summaryTree);
 		});
 
-		it("Validate app summary tree conversion", () => {
+		it("Validate summary with unreferenced node tree conversion", () => {
 			const wholeSummaryTree = convertSummaryTreeToWholeSummaryTree(
 				undefined,
-				appSummary,
+				summaryWithUnreferencedNode,
 				"",
 				"",
 			);
 			const newSummaryTree =
 				convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree);
-			assert.deepStrictEqual(newSummaryTree, appSummary);
+			assert.deepStrictEqual(newSummaryTree, summaryWithUnreferencedNode);
 		});
 
 		it("Validate empty summary tree conversion", () => {

--- a/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
@@ -243,6 +243,35 @@ describe("Storage Utils", () => {
 			type: SummaryType.Tree,
 		};
 
+		const appSummary: ISummaryTree = {
+			type: SummaryType.Tree,
+			tree: {
+				default: {
+					type: SummaryType.Tree,
+					tree: {
+						".component": {
+							type: SummaryType.Blob,
+							content: JSON.stringify("defaultDataStore"),
+						},
+						"root": {
+							type: SummaryType.Tree,
+							tree: {
+								attributes: {
+									type: SummaryType.Blob,
+									content: JSON.stringify("rootattributes"),
+								},
+							},
+						},
+						"unref": {
+							type: SummaryType.Tree,
+							tree: {},
+							unreferenced: true,
+						},
+					},
+				},
+			},
+		};
+
 		it("Validate summary tree conversion", () => {
 			const wholeSummaryTree = convertSummaryTreeToWholeSummaryTree(
 				undefined,
@@ -253,6 +282,31 @@ describe("Storage Utils", () => {
 			const newSummaryTree =
 				convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree);
 			assert.deepStrictEqual(newSummaryTree, summaryTree);
+		});
+
+		it("Validate app summary tree conversion", () => {
+			const wholeSummaryTree = convertSummaryTreeToWholeSummaryTree(
+				undefined,
+				appSummary,
+				"",
+				"",
+			);
+			const newSummaryTree =
+				convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree);
+			assert.deepStrictEqual(newSummaryTree, appSummary);
+		});
+
+		it("Validate empty summary tree conversion", () => {
+			const emptySummaryTree: ISummaryTree = { type: SummaryType.Tree, tree: {} };
+			const wholeSummaryTree = convertSummaryTreeToWholeSummaryTree(
+				undefined,
+				emptySummaryTree,
+				"",
+				"",
+			);
+			const newSummaryTree =
+				convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree);
+			assert.deepStrictEqual(newSummaryTree, emptySummaryTree);
 		});
 	});
 });


### PR DESCRIPTION
## Description
The https://github.com/microsoft/FluidFramework/issues/15969 details the current problem when uploading binary content blobs during the first summary upload.


In order to prepare the server to support distinct formats for decoded and encoded summaries, we are creating a new method that will convert from the IWholeSummaryTree to a ISummaryTree. 


