### PR TITLE
Worker error message improvement

### DIFF
--- a/build-tools/packages/build-tools/src/common/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/common/tscUtils.ts
@@ -127,10 +127,15 @@ function toLowerCase(x: string) {
 }
 // eslint-disable-next-line no-useless-escape
 const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
-export const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
-	? (x: string) => x
-	: (x: string) =>
-			fileNameLowerCaseRegExp.test(x) ? x.replace(fileNameLowerCaseRegExp, toLowerCase) : x;
+function createGetCanonicalFileName(tsLib: typeof ts) {
+	return tsLib.sys.useCaseSensitiveFileNames
+		? (x: string) => x
+		: (x: string) =>
+				fileNameLowerCaseRegExp.test(x)
+					? x.replace(fileNameLowerCaseRegExp, toLowerCase)
+					: x;
+}
+export const getCanonicalFileName = createGetCanonicalFileName(ts);
 
 export function getTscUtil(tsLib: typeof ts) {
 	return {
@@ -173,5 +178,6 @@ export function getTscUtil(tsLib: typeof ts) {
 			return configFile.config;
 		},
 		convertToOptionsWithAbsolutePath,
+		getCanonicalFileName: createGetCanonicalFileName(tsLib),
 	};
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import type { Diagnostic, SortedReadonlyArray } from "typescript";
 import * as tsLib from "typescript";
 
 import { getTscUtil } from "../../../common/tscUtils";
@@ -15,37 +14,19 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 	const ts: typeof tsLib = require(tsPath);
 
 	const TscUtils = getTscUtil(ts);
-	function convertDiagnostics(diagnostics: SortedReadonlyArray<Diagnostic>) {
-		const messages: string[] = [];
-		diagnostics.forEach((diagnostic) => {
-			if (diagnostic.file) {
-				const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
-					diagnostic.start!,
-				);
-				const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
-				messages.push(
-					`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`,
-				);
-			} else {
-				messages.push(ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
-			}
-		});
-		return messages.join("\n");
-	}
 
 	let commandLine = TscUtils.parseCommandLine(command);
-	const diagnostics: Diagnostic[] = [];
-
+	const diagnostics: tsLib.Diagnostic[] = [];
 	if (commandLine) {
 		const configFileName = TscUtils.findConfigFile(cwd, commandLine);
 		if (configFileName) {
 			commandLine = ts.getParsedCommandLineOfConfigFile(configFileName, commandLine.options, {
 				...ts.sys,
 				getCurrentDirectory: () => cwd,
-				onUnRecoverableConfigFileDiagnostic: (diagnostic: Diagnostic) => {
+				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsLib.Diagnostic) => {
 					diagnostics.push(diagnostic);
 				},
-			})!;
+			});
 		} else {
 			throw new Error("Unknown config file in command line");
 		}
@@ -80,7 +61,28 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 		}
 	}
 
-	const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
-	console.log(convertDiagnostics(sortedDiagnostics));
+	if (diagnostics.length > 0) {
+		const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
+
+		const formatDiagnosticsHost: tsLib.FormatDiagnosticsHost = {
+			getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
+			getCanonicalFileName: TscUtils.getCanonicalFileName,
+			getNewLine: () => ts.sys.newLine,
+		};
+
+		// TODO: tsc has more complicated summary than this
+		if (commandLine?.options?.pretty !== false) {
+			console.log(
+				ts.formatDiagnosticsWithColorAndContext(sortedDiagnostics, formatDiagnosticsHost),
+			);
+			console.log(
+				`${ts.sys.newLine}Found ${sortedDiagnostics.length} error${
+					sortedDiagnostics.length > 1 ? "s" : ""
+				}.`,
+			);
+		} else {
+			console.log(ts.formatDiagnostics(sortedDiagnostics, formatDiagnosticsHost));
+		}
+	}
 	return { code };
 }


### PR DESCRIPTION
Current version of type script exported the diagnostic format functions.  Use that instead of the hand rolled version for workers to match output from direct command invocation, and get pretty diagnostics.