### PR TITLE
Set suiteName on FLUID_TEST_MULTIREPORT

### DIFF
--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -77,17 +77,23 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 	}
 
 	if (process.env.FLUID_TEST_MULTIREPORT === "1") {
+		const packageJson = require(`${packageDir}/package.json`);
 		config["reporter"] = `mocha-multi-reporters`;
 		// See https://www.npmjs.com/package/mocha-multi-reporters#cmroutput-option
 		const outputFilePrefix = testReportPrefix !== undefined ? `${testReportPrefix}-` : "";
 		console.log(
 			`Writing test results relative to package to nyc/${outputFilePrefix}junit-report.xml and nyc/${outputFilePrefix}junit-report.json`,
 		);
+		const suiteName =
+			testReportPrefix !== undefined
+				? `${packageJson.name} - ${testReportPrefix}`
+				: packageJson.name;
+		console.log("suite name", suiteName);
 		config["reporter-options"] = [
 			`configFile=${path.join(
 				__dirname,
 				"test-config.json",
-			)},cmrOutput=xunit+output+${outputFilePrefix}:mocha-json-output-reporter+output+${outputFilePrefix}`,
+			)},cmrOutput=xunit+output+${outputFilePrefix}:mocha-json-output-reporter+output+${outputFilePrefix}:xunit+suiteName+${suiteName}`,
 		];
 	}
 

--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -88,7 +88,6 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 			testReportPrefix !== undefined
 				? `${packageJson.name} - ${testReportPrefix}`
 				: packageJson.name;
-		console.log("suite name", suiteName);
 		config["reporter-options"] = [
 			`configFile=${path.join(
 				__dirname,

--- a/packages/test/mocha-test-setup/test-config.json
+++ b/packages/test/mocha-test-setup/test-config.json
@@ -1,7 +1,8 @@
 {
 	"reporterEnabled": "xunit,mocha-json-output-reporter",
 	"xunitReporterOptions": {
-		"output": "nyc/{id}junit-report.xml"
+		"output": "nyc/{id}junit-report.xml",
+		"suiteName": "{id}"
 	},
 	"mochaJsonOutputReporterReporterOptions": {
 		"output": "nyc/{id}junit-report.json"


### PR DESCRIPTION
## Description

Sets suiteName on `FLUID_TEST_MULTIREPORT` similarly to what we did on `FLUID_TEST_REPORT`. This restores some of the niceties in e2e test names we had before switching flags in #15983 
