### PR TITLE
Prototype emitting the summary from the summarizer runtime

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2913,6 +2913,7 @@ export class ContainerRuntime
 					summarizeResult.summary,
 					summaryContext,
 				);
+				this.emit("experimentalSummary", summarizeResult);
 			} catch (error) {
 				return { stage: "generate", ...generateSummaryData, error };
 			}

--- a/packages/test/test-end-to-end-tests/src/test/summarizationSystem.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizationSystem.spec.ts
@@ -42,7 +42,7 @@ describeNoCompat("Do not need summarize on demand", (getTestObjectProvider) => {
 		});
 		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 		const containerRuntime = dataObject._context.containerRuntime;
-		const waitForSummary = new Deferred();
+		const waitForSummary = new Deferred<any>();
 		(containerRuntime as any).summarizerClientElection.on("electedSummarizerChanged", () => {
 			const runtime = (containerRuntime as any).summaryManager.summarizer
 				?.runtime as ContainerRuntime;
@@ -65,5 +65,7 @@ describeNoCompat("Do not need summarize on demand", (getTestObjectProvider) => {
 		dataObject._root.set("an", "op Or 10");
 		const result = await waitForSummary.promise;
 		assert(result !== undefined, "Should be able to get a summary!");
+		assert(result.stats !== undefined, "Should be able to get a summary!");
+		assert(result.summary !== undefined, "Should be able to get a summary!");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/summarizationSystem.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizationSystem.spec.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ITestDataObject, describeNoCompat } from "@fluid-internal/test-version-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ContainerRuntime, DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
+import { Deferred } from "@fluidframework/common-utils";
+
+describeNoCompat("Do not need summarize on demand", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	const testContainerConfig: ITestContainerConfig = {
+		runtimeOptions: { summaryOptions: { summaryConfigOverrides: DefaultSummaryConfiguration } },
+	};
+
+	const createContainer = async (): Promise<IContainer> => {
+		return provider.makeTestContainer(testContainerConfig);
+	};
+
+	beforeEach(async () => {
+		provider = getTestObjectProvider({ syncSummarizer: true });
+	});
+
+	it("Can get summaries", async () => {
+		const container = await createContainer();
+		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
+		const containerRuntime = dataObject._context.containerRuntime;
+		const waitForSummary = new Deferred<void>();
+		(containerRuntime as any).summarizerClientElection.on("electedSummarizerChanged", () => {
+			const runtime = (containerRuntime as any).summaryManager.summarizer
+				?.runtime as ContainerRuntime;
+			if (runtime !== undefined) {
+				runtime.on("experimentalSummary", (summaryResults) => {
+					waitForSummary.resolve(summaryResults);
+				});
+			}
+		});
+		dataObject._root.set("an", "op Or 1");
+		dataObject._root.set("an", "op Or 2");
+		dataObject._root.set("an", "op Or 3");
+		dataObject._root.set("an", "op Or 4");
+		dataObject._root.set("an", "op Or 5");
+		dataObject._root.set("an", "op Or 6");
+		dataObject._root.set("an", "op Or 7");
+		dataObject._root.set("an", "op Or 8");
+		dataObject._root.set("an", "op Or 9");
+		dataObject._root.set("an", "op Or 10");
+		const result = await waitForSummary.promise;
+		assert(result !== undefined, "Should be able to get a summary!");
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/summarizationSystem.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizationSystem.spec.ts
@@ -10,11 +10,18 @@ import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ContainerRuntime, DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
 import { Deferred } from "@fluidframework/common-utils";
+import { MessageType } from "@fluidframework/protocol-definitions";
 
 describeNoCompat("Do not need summarize on demand", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
+	const summaryConfigOverrides = {
+		...DefaultSummaryConfiguration,
+		maxOps: 5,
+		maxIdleTime: 100,
+		initialSummarizerDelayMs: 0,
+	};
 	const testContainerConfig: ITestContainerConfig = {
-		runtimeOptions: { summaryOptions: { summaryConfigOverrides: DefaultSummaryConfiguration } },
+		runtimeOptions: { summaryOptions: { summaryConfigOverrides } },
 	};
 
 	const createContainer = async (): Promise<IContainer> => {
@@ -27,9 +34,15 @@ describeNoCompat("Do not need summarize on demand", (getTestObjectProvider) => {
 
 	it("Can get summaries", async () => {
 		const container = await createContainer();
+		const waitForFirstSummary = new Deferred<void>();
+		container.on("op", (message) => {
+			if (message.type === MessageType.Summarize) {
+				waitForFirstSummary.resolve();
+			}
+		});
 		const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 		const containerRuntime = dataObject._context.containerRuntime;
-		const waitForSummary = new Deferred<void>();
+		const waitForSummary = new Deferred();
 		(containerRuntime as any).summarizerClientElection.on("electedSummarizerChanged", () => {
 			const runtime = (containerRuntime as any).summaryManager.summarizer
 				?.runtime as ContainerRuntime;
@@ -44,6 +57,7 @@ describeNoCompat("Do not need summarize on demand", (getTestObjectProvider) => {
 		dataObject._root.set("an", "op Or 3");
 		dataObject._root.set("an", "op Or 4");
 		dataObject._root.set("an", "op Or 5");
+		await waitForFirstSummary.promise;
 		dataObject._root.set("an", "op Or 6");
 		dataObject._root.set("an", "op Or 7");
 		dataObject._root.set("an", "op Or 8");


### PR DESCRIPTION
Emit the summary results from the runtime. With this, we could do all sorts of testing. This is a proof of concept. We would probably want to modify several other classes. This potentially enables us to validate a series of summaries. Especially if something goes wrong, we could store this data in a file and manually investigate. 