### PR TITLE
Correctly record opsbehind prop in events

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -560,7 +560,6 @@ export class Container
 	private messageCountAfterDisconnection: number = 0;
 	private _loadedFromVersion: IVersion | undefined;
 	private attachStarted = false;
-	private _snapshotSeqNumber: number | undefined;
 	private _dirtyContainer = false;
 	private readonly savedOps: ISequencedDocumentMessage[] = [];
 	private baseSnapshot?: ISnapshotTree;
@@ -1958,7 +1957,6 @@ export class Container
 		attributes: IDocumentAttributes,
 		prefetchType?: "cached" | "all" | "none",
 	) {
-		this._snapshotSeqNumber = attributes.sequenceNumber;
 		return this._deltaManager.attachOpHandler(
 			attributes.minimumSequenceNumber,
 			attributes.sequenceNumber,
@@ -1995,18 +1993,13 @@ export class Container
 				durationFromDisconnected =
 					time - this.connectionTransitionTimes[ConnectionState.Disconnected];
 				durationFromDisconnected = TelemetryLogger.formatTick(durationFromDisconnected);
-				// On first connection, also note how much gap was there between last processed seq number which would
-				// mostly be JoinOp and the snapshot seq number.
-				if (this._snapshotSeqNumber !== undefined && this.firstConnection) {
-					opsBehind = this.deltaManager.lastSequenceNumber - this._snapshotSeqNumber;
-				}
 			} else if (value === ConnectionState.CatchingUp) {
 				// This info is of most interesting while Catching Up.
 				checkpointSequenceNumber = this.deltaManager.lastKnownSeqNumber;
-				// Need to check that we have already fetched the snapshot.
+				// Need to check that we have already loaded and fetched the snapshot.
 				if (
 					this.deltaManager.hasCheckpointSequenceNumber &&
-					this._snapshotSeqNumber !== undefined
+					this._lifecycleState === "loaded"
 				) {
 					opsBehind = checkpointSequenceNumber - this.deltaManager.lastSequenceNumber;
 				}


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4662

We found that Data_opsbehind is not correct when the connection is established in parallel to snapshot fetch as then the lastProcessedSeq number would just be 0 and opsbehind would just be lastKnownSeqNumber - 0 instead of lastKnownSeqNumber - snapshotseqnumber.

Also add opsbehind prop in connected event in case of first connection to see what was the diff between lastProcesssedseqnumber and snapshotseqnumber.