### PR TITLE
feat(tree): Expose revertible event

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1275,6 +1275,13 @@ type LazyItem<Item = unknown> = Item | (() => Item);
 export type LazyTreeSchema = TreeSchema | (() => TreeSchema);
 
 // @alpha
+export enum LocalCommitSource {
+    Default = 0,
+    Redo = 2,
+    Undo = 1
+}
+
+// @alpha
 export type LocalFieldKey = Brand<string, "tree.LocalFieldKey">;
 
 // @alpha (undocumented)
@@ -2221,6 +2228,7 @@ export const valueSymbol: unique symbol;
 // @alpha
 export interface ViewEvents {
     afterBatch(): void;
+    revertible(source: LocalCommitSource, target: ISharedTreeView): void;
 }
 
 // @alpha

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -2228,7 +2228,7 @@ export const valueSymbol: unique symbol;
 // @alpha
 export interface ViewEvents {
     afterBatch(): void;
-    revertible(source: LocalCommitSource, target: ISharedTreeView): void;
+    revertible(source: LocalCommitSource): void;
 }
 
 // @alpha

--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -180,4 +180,4 @@ export {
 
 export { RepairDataStore, ReadonlyRepairDataStore, IRepairDataStoreProvider } from "./repair";
 
-export { UndoRedoManager, UndoRedoManagerCommitType } from "./undo";
+export { UndoRedoManager, LocalCommitSource } from "./undo";

--- a/experimental/dds/tree2/src/core/undo/index.ts
+++ b/experimental/dds/tree2/src/core/undo/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { UndoRedoManager, UndoRedoManagerCommitType } from "./undoRedoManager";
+export { UndoRedoManager, LocalCommitSource } from "./undoRedoManager";

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -90,6 +90,7 @@ export {
 	FieldAdapter,
 	TreeAdapter,
 	MapTree,
+	LocalCommitSource,
 } from "./core";
 
 export {

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -17,7 +17,7 @@ import {
 	UndoRedoManager,
 	tagChange,
 	TaggedChange,
-	UndoRedoManagerCommitType,
+	LocalCommitSource,
 	rebaseBranch,
 	RevisionTag,
 } from "../core";
@@ -94,6 +94,11 @@ export interface SharedTreeBranchEvents<TEditor extends ChangeFamilyEditor, TCha
 	change(change: SharedTreeBranchChange<TChange>): void;
 
 	/**
+	 * Fired when a revertible change is made to this branch.
+	 */
+	revertible(type: LocalCommitSource): void;
+
+	/**
 	 * Fired when this branch forks
 	 * @param fork - the new branch that forked off of this branch
 	 */
@@ -158,13 +163,13 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		change: TChange,
 		revision: RevisionTag,
 	): [change: TChange, newCommit: GraphCommit<TChange>] {
-		return this.applyChange(change, revision, UndoRedoManagerCommitType.Undoable);
+		return this.applyChange(change, revision, LocalCommitSource.Default);
 	}
 
 	private applyChange(
 		change: TChange,
 		revision: RevisionTag,
-		undoRedoType: UndoRedoManagerCommitType | undefined,
+		undoRedoType: LocalCommitSource | undefined,
 	): [change: TChange, newCommit: GraphCommit<TChange>] {
 		this.assertNotDisposed();
 
@@ -186,6 +191,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		// If this is not part of a transaction, add it to the undo commit tree
 		if (undoRedoType !== undefined && !this.isTransacting()) {
 			this.undoRedoManager?.trackCommit(this.head, undoRedoType);
+			this.emit("revertible", undoRedoType);
 		}
 
 		this.emitAndRebaseAnchors({ type: "append", change, newCommits: [this.head] });
@@ -256,7 +262,8 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		// If this transaction is not nested, add it to the undo commit tree and capture its repair data
 		if (!this.isTransacting()) {
 			if (this.undoRedoManager !== undefined) {
-				this.undoRedoManager.trackCommit(this.head, UndoRedoManagerCommitType.Undoable);
+				this.undoRedoManager.trackCommit(this.head, LocalCommitSource.Default);
+				this.emit("revertible", LocalCommitSource.Default);
 			}
 		}
 
@@ -346,7 +353,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		const undoChange = this.undoRedoManager?.undo(this.getHead());
 		if (undoChange !== undefined) {
-			return this.applyChange(undoChange, mintRevisionTag(), UndoRedoManagerCommitType.Undo);
+			return this.applyChange(undoChange, mintRevisionTag(), LocalCommitSource.Undo);
 		}
 
 		return undefined;
@@ -369,7 +376,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		const redoChange = this.undoRedoManager?.redo(this.getHead());
 		if (redoChange !== undefined) {
-			return this.applyChange(redoChange, mintRevisionTag(), UndoRedoManagerCommitType.Redo);
+			return this.applyChange(redoChange, mintRevisionTag(), LocalCommitSource.Redo);
 		}
 
 		return undefined;
@@ -477,6 +484,16 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 				0x689 /* Cannot merge a non-revertible branch into a revertible branch */,
 			);
 			this.undoRedoManager.updateAfterMerge(sourceCommits, branch.undoRedoManager);
+
+			// KLUDGE: Merging does not cause commits to change their ordering. This allows the
+			// revertible events to be accurate for the local branch but it's not guaranteed to be
+			// accurate for any other branch.
+			for (const commit of sourceCommits) {
+				const type = this.undoRedoManager.getCommitType(commit.revision);
+				if (type !== undefined) {
+					this.emit("revertible", type);
+				}
+			}
 		}
 		this.head = newHead;
 		const change = this.changeFamily.rebaser.compose(sourceCommits);

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -408,6 +408,11 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	/**
 	 * Rebase the changes that have been applied to this branch over divergent changes in the given branch.
 	 * After this operation completes, this branch will be based off of `branch`.
+	 *
+	 * @remarks
+	 * This operation can change the relative ordering between revertible commits therefore, the revertible event
+	 * is not emitted during this operation.
+	 *
 	 * @param branch - the branch to rebase onto
 	 * @param upTo - the furthest commit on `branch` over which to rebase (inclusive). Defaults to the head commit of `branch`.
 	 * @returns the net change to this branch and the commits that were removed and added to this branch by the rebase,
@@ -455,6 +460,10 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 	/**
 	 * Apply all the divergent changes on the given branch to this branch.
+	 *
+	 * @remarks
+	 * Revertible events are emitted for new local commits merged into this branch.
+	 *
 	 * @param branch - the branch to merge into this branch
 	 * @returns the net change to this branch and the commits that were added to this branch by the merge,
 	 * or undefined if nothing changed
@@ -485,9 +494,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			);
 			this.undoRedoManager.updateAfterMerge(sourceCommits, branch.undoRedoManager);
 
-			// KLUDGE: Merging does not cause commits to change their ordering. This allows the
-			// revertible events to be accurate for the local branch but it's not guaranteed to be
-			// accurate for any other branch.
 			for (const commit of sourceCommits) {
 				const type = this.undoRedoManager.getCommitType(commit.revision);
 				if (type !== undefined) {

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -68,7 +68,7 @@ export interface ViewEvents {
 	 * the {@link ISharedTreeView}. However, the {@link ISharedTreeView} completely manages its own undo/redo
 	 * stack which cannot be modified and no additional information about the change is provided.
 	 * 
-	 * Revertible events are emitted when merging a view into another view but not when rebasing onto another view. This is because
+	 * Revertible events are emitted when merging a view into this view but not when rebasing this view onto another view. This is because
 	 * rebasing onto another view can cause the relative ordering of revertible commits to change so there is no guarantee they
 	 * are accurate.
 	 * 

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -67,14 +67,13 @@ export interface ViewEvents {
 	 * The event along with the {@link LocalCommitSource} communicates a change has been made that can be undone or redone on
 	 * the {@link ISharedTreeView}. However, the {@link ISharedTreeView} completely manages its own undo/redo
 	 * stack which cannot be modified and no additional information about the change is provided.
-	 *
-	 * This event should only be subscribed to when coming from the local branch. The order of revertible events coming
-	 * from any other branch is not guaranteed to be correct.
 	 * 
-	 * This is because merging and rebasing branches can cause the order of revertibles in the undo/redo stack to change.
-	 * Therefore, the order of revertible events are not guaranteed to be reflective of the order of the undo/redo
-	 * stack in these cases. The only exception is merging a branch into the local branch because the order of commits is
-	 * not changed in this case.
+	 * Revertible events are emitted when merging a view into another view but not when rebasing onto another view. This is because
+	 * rebasing onto another view can cause the relative ordering of revertible commits to change so there is no guarantee they
+	 * are accurate.
+	 * 
+	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the 
+	 * local branch which cannot be rebased onto another branch.
 	 */
 	revertible(source: LocalCommitSource, target: ISharedTreeView): void;
 }
@@ -141,8 +140,8 @@ export interface ISharedTreeView extends AnchorLocator {
 	readonly editor: IDefaultEditBuilder;
 
 	/**
-	 * Undoes the last completed transaction made by the client. 
-	 * 
+	 * Undoes the last completed transaction made by the client.
+	 *
 	 * @remarks
 	 * Calling this does nothing if there are no transactions in the
 	 * undo stack.
@@ -152,8 +151,8 @@ export interface ISharedTreeView extends AnchorLocator {
 	undo(): void;
 
 	/**
-	 * Redoes the last completed undo made by the client. 
-	 * 
+	 * Redoes the last completed undo made by the client.
+	 *
 	 * @remarks
 	 * Calling this does nothing if there are no transactions in the
 	 * redo stack. New local transactions will not clear the redo stack.

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -75,7 +75,7 @@ export interface ViewEvents {
 	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the 
 	 * local branch which cannot be rebased onto another branch.
 	 */
-	revertible(source: LocalCommitSource, target: ISharedTreeView): void;
+	revertible(source: LocalCommitSource): void;
 }
 
 /**

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -365,7 +365,7 @@ export class SharedTreeView implements ISharedTreeView {
 			}
 		});
 		branch.on("revertible", (type) => {
-			this._events.emit("revertible", type, this);
+			this._events.emit("revertible", type);
 		});
 	}
 

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -138,7 +138,10 @@ export interface ISharedTreeView extends AnchorLocator {
 	readonly editor: IDefaultEditBuilder;
 
 	/**
-	 * Undoes the last completed transaction made by the client. Calling this does nothing if there are no transactions in the
+	 * Undoes the last completed transaction made by the client. 
+	 * 
+	 * @remarks
+	 * Calling this does nothing if there are no transactions in the
 	 * undo stack.
 	 *
 	 * It is invalid to call it while a transaction is open (this will be supported in the future).
@@ -146,7 +149,10 @@ export interface ISharedTreeView extends AnchorLocator {
 	undo(): void;
 
 	/**
-	 * Redoes the last completed undo made by the client. Calling this does nothing if there are no transactions in the
+	 * Redoes the last completed undo made by the client. 
+	 * 
+	 * @remarks
+	 * Calling this does nothing if there are no transactions in the
 	 * redo stack. New local transactions will not clear the redo stack.
 	 *
 	 * It is invalid to call it while a transaction is open (this will be supported in the future).

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -70,7 +70,6 @@ export interface ViewEvents {
 	 * 
 	 * Revertible events are emitted when merging a view into this view but not when rebasing this view onto another view. This is because
 	 * rebasing onto another view can cause the relative ordering of existing revertible commits to change.
-	 * are accurate.
 	 * 
 	 * @privateRemarks
 	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the 

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -68,7 +68,10 @@ export interface ViewEvents {
 	 * the {@link ISharedTreeView}. However, the {@link ISharedTreeView} completely manages its own undo/redo
 	 * stack which cannot be modified and no additional information about the change is provided.
 	 *
-	 * Merging and rebasing branches can cause the order of revertibles in the undo/redo stack to change.
+	 * This event should only be subscribed to when coming from the local branch. The order of revertible events coming
+	 * from any other branch is not guaranteed to be correct.
+	 * 
+	 * This is because merging and rebasing branches can cause the order of revertibles in the undo/redo stack to change.
 	 * Therefore, the order of revertible events are not guaranteed to be reflective of the order of the undo/redo
 	 * stack in these cases. The only exception is merging a branch into the local branch because the order of commits is
 	 * not changed in this case.

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -67,12 +67,12 @@ export interface ViewEvents {
 	 * The event along with the {@link LocalCommitSource} communicates a change has been made that can be undone or redone on
 	 * the {@link ISharedTreeView}. However, the {@link ISharedTreeView} completely manages its own undo/redo
 	 * stack which cannot be modified and no additional information about the change is provided.
-	 * 
+	 *
 	 * Revertible events are emitted when merging a view into this view but not when rebasing this view onto another view. This is because
 	 * rebasing onto another view can cause the relative ordering of existing revertible commits to change.
-	 * 
+	 *
 	 * @privateRemarks
-	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the 
+	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the
 	 * local branch which cannot be rebased onto another branch.
 	 */
 	revertible(source: LocalCommitSource): void;

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -72,6 +72,7 @@ export interface ViewEvents {
 	 * rebasing onto another view can cause the relative ordering of existing revertible commits to change.
 	 * are accurate.
 	 * 
+	 * @privateRemarks
 	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the 
 	 * local branch which cannot be rebased onto another branch.
 	 */

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -69,7 +69,7 @@ export interface ViewEvents {
 	 * stack which cannot be modified and no additional information about the change is provided.
 	 * 
 	 * Revertible events are emitted when merging a view into this view but not when rebasing this view onto another view. This is because
-	 * rebasing onto another view can cause the relative ordering of revertible commits to change so there is no guarantee they
+	 * rebasing onto another view can cause the relative ordering of existing revertible commits to change.
 	 * are accurate.
 	 * 
 	 * It is possible to make this event work for rebasing onto another view but this event is currently only necessary for the 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -1150,8 +1150,8 @@ describe("SharedTree", () => {
 			// Syncing will cause both trees to rebase their local changes
 			provider.processMessages();
 
-			assert.deepEqual(revertibles1, [LocalCommitSource.Default, LocalCommitSource.Default]);
-			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
+			assert.deepEqual(revertibles1, [LocalCommitSource.Default]);
+			assert.deepEqual(revertibles2, [LocalCommitSource.Default, LocalCommitSource.Default]);
 		});
 	});
 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -50,6 +50,7 @@ import {
 	SchemaData,
 	ValueSchema,
 	AllowedUpdateType,
+	LocalCommitSource,
 } from "../../core";
 import { typeboxValidator } from "../../external-utilities";
 import { EditManager } from "../../shared-tree-core";
@@ -1046,6 +1047,79 @@ describe("SharedTree", () => {
 				"unsubscribe",
 				"editStart",
 			]);
+		});
+
+		it("triggers revertible events for local changes", () => {
+			const value = "42";
+			const provider = new TestTreeProviderLite(2);
+			const [tree1, tree2] = provider.trees;
+
+			const revertibles1: LocalCommitSource[] = [];
+			tree1.events.on("revertible", (commitSource) => {
+				revertibles1.push(commitSource);
+			});
+
+			const revertibles2: LocalCommitSource[] = [];
+			tree2.events.on("revertible", (commitSource) => {
+				revertibles2.push(commitSource);
+			});
+
+			// Insert node
+			setTestValue(tree1, "42");
+			provider.processMessages();
+
+			// Validate insertion
+			assert.equal(getTestValue(tree2), value);
+			assert.deepEqual(revertibles1, [LocalCommitSource.Default]);
+			assert.deepEqual(revertibles2, []);
+
+			tree1.undo();
+			provider.processMessages();
+
+			// Insert node
+			setTestValue(tree2, "43");
+			provider.processMessages();
+
+			assert.deepEqual(revertibles1, [LocalCommitSource.Default, LocalCommitSource.Undo]);
+			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
+
+			tree1.redo();
+			provider.processMessages();
+
+			assert.deepEqual(revertibles1, [
+				LocalCommitSource.Default,
+				LocalCommitSource.Undo,
+				LocalCommitSource.Redo,
+			]);
+			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
+		});
+
+		it("triggers a revertible event for a changes merged into the local branch", () => {
+			const value = "42";
+			const provider = new TestTreeProviderLite(2);
+			const [tree1] = provider.trees;
+			const branch = tree1.fork();
+
+			const revertibles1: LocalCommitSource[] = [];
+			tree1.events.on("revertible", (commitSource) => {
+				revertibles1.push(commitSource);
+			});
+
+			const revertibles2: LocalCommitSource[] = [];
+			branch.events.on("revertible", (commitSource) => {
+				revertibles2.push(commitSource);
+			});
+
+			// Insert node
+			setTestValue(branch, "42");
+			provider.processMessages();
+
+			assert.deepEqual(revertibles1, []);
+			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
+
+			tree1.merge(branch);
+			assert.deepEqual(revertibles1, [LocalCommitSource.Default]);
+			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
 		});
 	});
 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -787,15 +787,6 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(tree2), value);
 		});
 
-		function stringToJsonableTree(values: string[]): JsonableTree[] {
-			return values.map((value) => {
-				return {
-					type: brand("TestValue"),
-					value,
-				};
-			});
-		}
-
 		it("rebased edits", () => {
 			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
@@ -1119,6 +1110,47 @@ describe("SharedTree", () => {
 
 			tree1.merge(branch);
 			assert.deepEqual(revertibles1, [LocalCommitSource.Default]);
+			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
+		});
+
+		it("doesn't trigger a revertible event for rebases", () => {
+			const value = "42";
+			const provider = new TestTreeProviderLite(2);
+			const [tree1, tree2] = provider.trees;
+
+			// Initialize the tree
+			const expectedState: JsonableTree[] = stringToJsonableTree(["A", "B", "C", "D"]);
+			initializeTestTree(tree1, expectedState);
+			provider.processMessages();
+
+			// Validate initialization
+			validateTree(tree2, expectedState);
+
+			const revertibles1: LocalCommitSource[] = [];
+			tree1.events.on("revertible", (commitSource) => {
+				revertibles1.push(commitSource);
+			});
+
+			const revertibles2: LocalCommitSource[] = [];
+			tree2.events.on("revertible", (commitSource) => {
+				revertibles2.push(commitSource);
+			});
+
+			// Insert a node on tree 2
+			insert(tree2, 4, "z");
+			validateTree(tree2, stringToJsonableTree(["A", "B", "C", "D", "z"]));
+
+			// Insert nodes on both trees
+			insert(tree1, 1, "x");
+			validateTree(tree1, stringToJsonableTree(["A", "x", "B", "C", "D"]));
+
+			insert(tree2, 3, "y");
+			validateTree(tree2, stringToJsonableTree(["A", "B", "C", "y", "D", "z"]));
+
+			// Syncing will cause both trees to rebase their local changes
+			provider.processMessages();
+
+			assert.deepEqual(revertibles1, [LocalCommitSource.Default, LocalCommitSource.Default]);
 			assert.deepEqual(revertibles2, [LocalCommitSource.Default]);
 		});
 	});
@@ -1976,6 +2008,15 @@ const testSchema: SchemaData = {
 		[globalFieldKey, globalFieldSchema],
 	]),
 };
+
+function stringToJsonableTree(values: string[]): JsonableTree[] {
+	return values.map((value) => {
+		return {
+			type: brand("TestValue"),
+			value,
+		};
+	});
+}
 
 /**
  * Updates the given `tree` to the given `schema` and inserts `state` as its root.

--- a/experimental/dds/tree2/src/test/undo/undoRedoManager.spec.ts
+++ b/experimental/dds/tree2/src/test/undo/undoRedoManager.spec.ts
@@ -12,7 +12,7 @@ import {
 	mintRevisionTag,
 } from "../../core";
 // eslint-disable-next-line import/no-internal-modules
-import { UndoRedoManagerCommitType, ReversibleCommit } from "../../core/undo/undoRedoManager";
+import { LocalCommitSource, ReversibleCommit } from "../../core/undo/undoRedoManager";
 import { TestChange, testChangeFamilyFactory } from "../testChange";
 import { MockRepairDataStore } from "../utils";
 
@@ -25,7 +25,7 @@ describe("UndoRedoManager", () => {
 			};
 			const childCommit = createTestGraphCommit([0], 1);
 			const manager = undoRedoManagerFactory(parent);
-			manager.trackCommit(childCommit, UndoRedoManagerCommitType.Undoable);
+			manager.trackCommit(childCommit, LocalCommitSource.Default);
 
 			const headUndoableCommit = manager.headUndoable;
 			assert.equal(headUndoableCommit?.commit, childCommit);
@@ -39,7 +39,7 @@ describe("UndoRedoManager", () => {
 			};
 			const childCommit = createTestGraphCommit([0], 1);
 			const manager = undoRedoManagerFactory(undefined, parent);
-			manager.trackCommit(childCommit, UndoRedoManagerCommitType.Redoable);
+			manager.trackCommit(childCommit, LocalCommitSource.Undo);
 
 			const headRedoableCommit = manager.headRedoable;
 			assert.equal(headRedoableCommit?.commit, childCommit);
@@ -53,7 +53,7 @@ describe("UndoRedoManager", () => {
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
 			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
-			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Undo);
+			manager.trackCommit(fakeInvertedCommit, LocalCommitSource.Undo);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headUndoable, undefined);
 			// The fake undo commit will now be redoable
@@ -67,7 +67,7 @@ describe("UndoRedoManager", () => {
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
 			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
-			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Redo);
+			manager.trackCommit(fakeInvertedCommit, LocalCommitSource.Redo);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headRedoable, undefined);
 			// The fake undo commit will now be redoable
@@ -81,25 +81,11 @@ describe("UndoRedoManager", () => {
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
 			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
-			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Undoable);
+			manager.trackCommit(fakeInvertedCommit, LocalCommitSource.Default);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headUndoable?.commit, fakeInvertedCommit);
 			// The fake undo commit will now be redoable
 			assert.equal(manager.headRedoable, undefined);
-		});
-
-		it("should add redoable commits to the redoable commit tree without changing the undoable commit tree", () => {
-			const initialCommit = {
-				commit: createTestGraphCommit([], 0),
-				repairData: new MockRepairDataStore(),
-			};
-			const manager = undoRedoManagerFactory(initialCommit);
-			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
-			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Redoable);
-			// The head undo commit will not be the new inverted commit
-			assert.equal(manager.headUndoable, initialCommit);
-			// The fake undo commit will now be redoable
-			assert.equal(manager.headRedoable?.commit, fakeInvertedCommit);
 		});
 	});
 


### PR DESCRIPTION
## Description

This emits a "revertible" event when a change is made that can be undone or redone on a SharedTreeView. This allows consumers to listen to the event in order to manage the sequencing of calls to undo/redo on a SharedTree vs other DDSes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).