### PR TITLE
Make node keys use a local field

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -483,6 +483,7 @@ UntypedSequenceField & MarkedArrayLike<TypedChild>
 export interface EditableTree extends Iterable<EditableField>, ContextuallyTypedNodeDataObject {
     readonly [contextSymbol]: EditableTreeContext;
     [getField](fieldKey: FieldKey): EditableField;
+    readonly [localNodeKeySymbol]?: LocalNodeKey;
     // (undocumented)
     [on]<K extends keyof EditableTreeEvents>(eventName: K, listener: EditableTreeEvents[K]): () => void;
     readonly [parentField]: {
@@ -1295,7 +1296,7 @@ interface LocalFields {
 export type LocalNodeKey = Opaque<Brand<SessionSpaceCompressedId, "Local Node Key">>;
 
 // @alpha
-export const localNodeKeySymbol: GlobalFieldKeySymbol;
+export const localNodeKeySymbol: unique symbol;
 
 // @alpha
 export function lookupGlobalFieldSchema(data: SchemaDataAndPolicy, identifier: GlobalFieldKey): FieldStoredSchema;
@@ -1455,18 +1456,21 @@ export interface NodeExistsConstraint {
 }
 
 // @alpha
-export const nodeKeyFieldKey: GlobalFieldKey;
+export const nodeKeyField: {
+    __n_id__: FieldSchema<NodeKeyFieldKind, [TreeSchema<TreeSchemaIdentifier, {
+    value: ValueSchema.String;
+    }>]>;
+};
+
+// @alpha
+export const nodeKeyFieldKey = "__n_id__";
 
 // @alpha (undocumented)
 export interface NodeKeyFieldKind extends BrandedFieldKind<"NodeKey", Multiplicity.Value, FieldEditor<any>> {
 }
 
 // @alpha
-export function nodeKeySchema(): {
-    schema: SchemaLibrary;
-    field: GlobalFieldSchema<NodeKeyFieldKind>;
-    type: TreeSchemaIdentifier;
-};
+export const nodeKeySchema: SchemaLibrary;
 
 // @alpha (undocumented)
 export type NodeReviver = (revision: RevisionTag, index: number, count: number) => Delta.ProtoNode[];

--- a/experimental/dds/tree2/src/domains/index.ts
+++ b/experimental/dds/tree2/src/domains/index.ts
@@ -16,4 +16,4 @@ export {
 	singleJsonCursor,
 } from "./json";
 
-export { nodeKeyFieldKey, nodeKeySchema } from "./nodeKey";
+export { nodeKeyField, nodeKeySchema, nodeKeyTreeSchema } from "./nodeKey";

--- a/experimental/dds/tree2/src/domains/nodeKey/index.ts
+++ b/experimental/dds/tree2/src/domains/nodeKey/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { nodeKeyFieldKey, nodeKeySchema } from "./nodeKeySchema";
+export { nodeKeyField, nodeKeySchema, nodeKeyTreeSchema } from "./nodeKeySchema";

--- a/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
+++ b/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
@@ -22,7 +22,7 @@ export const nodeKeyTreeSchema = builder.leaf(nodeKeyTreeIdentifier, ValueSchema
 /**
  * Key and Field schema for working with {@link LocalNodeKey}s in a shared tree.
  * Node keys are added to struct nodes via a field.
- * This object can be expanded into the a schema to add the field.
+ * This object can be expanded into a schema to add the field.
  *
  * Requires including {@link nodeKeySchema}.
  * @alpha
@@ -32,7 +32,7 @@ export const nodeKeyField = {
 };
 
 /**
- * Create a schema library for working with {@link StableNodeKey}s in a tree.
+ * The schema library for working with {@link StableNodeKey}s in a tree.
  * Required to use {@link nodeKeyField}.
  * @alpha
  */

--- a/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
+++ b/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
@@ -3,38 +3,37 @@
  * Licensed under the MIT License.
  */
 
-import { GlobalFieldKey, TreeSchemaIdentifier } from "../../core";
+import { ValueSchema } from "../../core";
 import {
-	SchemaLibrary,
-	GlobalFieldSchema,
-	NodeKeyFieldKind,
-	buildNodeKeySchema,
+	SchemaBuilder,
+	nodeKeyFieldKey,
+	FieldKinds,
+	nodeKeyTreeIdentifier,
 } from "../../feature-libraries";
-import { brand } from "../../util";
+
+const builder = new SchemaBuilder("Node Key Schema");
 
 /**
- * The key for the special field for node keys,
- * which allows nodes to be given keys that can be used to find the nodes via the node key index.
+ * Schema for a node which holds a {@link StableNodeKey}.
  * @alpha
- * @privateRemarks TODO: Come up with a unified and collision-resistant naming schema for global fields defined by the system.
- * For now, we'll use `__` to reduce the change of collision, since this is what other internal properties use in Fluid.
  */
-export const nodeKeyFieldKey: GlobalFieldKey = brand("__n_id__");
-
-const schema = buildNodeKeySchema(nodeKeyFieldKey);
+export const nodeKeyTreeSchema = builder.leaf(nodeKeyTreeIdentifier, ValueSchema.String);
 
 /**
- * Get the schema for working with {@link LocalNodeKey}s in a shared tree.
- * Node keys are added to nodes via a global field.
- * @returns the type of node key nodes in the schema,
- * the schema for the global field under which node keys reside,
- * and a schema library containing the above.
+ * Key and Field schema for working with {@link LocalNodeKey}s in a shared tree.
+ * Node keys are added to struct nodes via a field.
+ * This object can be expanded into the a schema to add the field.
+ *
+ * Requires including {@link nodeKeySchema}.
  * @alpha
  */
-export function nodeKeySchema(): {
-	schema: SchemaLibrary;
-	field: GlobalFieldSchema<NodeKeyFieldKind>;
-	type: TreeSchemaIdentifier;
-} {
-	return schema;
-}
+export const nodeKeyField = {
+	[nodeKeyFieldKey]: SchemaBuilder.field(FieldKinds.nodeKey, nodeKeyTreeSchema),
+};
+
+/**
+ * Create a schema library for working with {@link StableNodeKey}s in a tree.
+ * Required to use {@link nodeKeyField}.
+ * @alpha
+ */
+export const nodeKeySchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -274,16 +274,7 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 		);
 		if (typeof key === "string" || symbolIsFieldKey(key)) {
 			const fieldKey: FieldKey = brand(key);
-			if (fieldKey === localNodeKeySymbol) {
-				// TODO: this is not very type safe. Can we do better?
-				assert(typeof key === "number", 0x6d9 /* Invalid local node key */);
-				const localNodeKey = key as unknown as LocalNodeKey;
-				const stableNodeKey = target.context.nodeKeys.stabilizeNodeKey(localNodeKey);
-				target.getField(fieldKey).content = stableNodeKey;
-			} else {
-				target.getField(fieldKey).content = value;
-			}
-
+			target.getField(fieldKey).content = value;
 			return true;
 		}
 		return false;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -13,9 +13,9 @@ import {
 	Anchor,
 	SchemaDataAndPolicy,
 	ForestEvents,
-	GlobalFieldKey,
 	FieldStoredSchema,
 	FieldKey,
+	LocalFieldKey,
 } from "../../core";
 import { ISubscribable } from "../../events";
 import { DefaultEditBuilder } from "../defaultChangeFamily";
@@ -135,7 +135,7 @@ export class ProxyContext implements EditableTreeContext {
 		public readonly forest: IEditableForest,
 		public readonly editor: DefaultEditBuilder,
 		public readonly nodeKeys: NodeKeyManager,
-		public readonly nodeKeyFieldKey?: GlobalFieldKey,
+		public readonly nodeKeyFieldKey?: LocalFieldKey,
 	) {
 		this.eventUnregister = [
 			this.forest.on("beforeDelta", () => {
@@ -229,7 +229,7 @@ export function getEditableTreeContext(
 	forest: IEditableForest,
 	editor: DefaultEditBuilder,
 	nodeKeyManager: NodeKeyManager,
-	nodeKeyFieldKey?: GlobalFieldKey,
+	nodeKeyFieldKey?: LocalFieldKey,
 ): EditableTreeContext {
 	return new ProxyContext(forest, editor, nodeKeyManager, nodeKeyFieldKey);
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeTypes.ts
@@ -13,9 +13,7 @@ import {
 	PathVisitor,
 	NamedTreeSchema,
 	isCursor,
-	GlobalFieldKeySymbol,
 } from "../../core";
-import { brand } from "../../util";
 import {
 	PrimitiveValue,
 	MarkedArrayLike,
@@ -24,6 +22,7 @@ import {
 	valueSymbol,
 	ContextuallyTypedFieldData,
 } from "../contextuallyTyped";
+import { LocalNodeKey } from "../node-key";
 import { EditableTreeContext } from "./editableTreeContext";
 
 /**
@@ -64,7 +63,7 @@ export const contextSymbol: unique symbol = Symbol("editable-tree:context");
  * A symbol to get the {@link LocalNodeKey} that identifies this {@link EditableTree} node.
  * @alpha
  */
-export const localNodeKeySymbol: GlobalFieldKeySymbol = brand(Symbol("editable-tree:localNodeKey"));
+export const localNodeKeySymbol: unique symbol = Symbol("editable-tree:localNodeKey");
 
 /**
  * A symbol for subscribing to events.
@@ -134,6 +133,11 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
 	 * The name of the node type.
 	 */
 	readonly [typeNameSymbol]: TreeSchemaIdentifier;
+
+	/**
+	 * {@link LocalNodeKey} that identifies this node.
+	 */
+	readonly [localNodeKeySymbol]?: LocalNodeKey;
 
 	/**
 	 * The type of the node.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/utilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/utilities.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { isStableId } from "@fluidframework/container-runtime";
-import { GlobalFieldKey, TreeStoredSchema, ValueSchema, symbolFromKey } from "../../core";
+import { LocalFieldKey, TreeStoredSchema, ValueSchema } from "../../core";
 import { brand } from "../../util";
 import { valueSymbol } from "../contextuallyTyped";
 import { FieldKinds, forbidden } from "../defaultFieldKinds";
@@ -80,14 +80,13 @@ export function keyIsValidIndex(key: string | number, length: number): boolean {
  * @returns the {@link StableNodeKey} on `node`, or undefined if there is none.
  */
 export function getStableNodeKey(
-	nodeKeyFieldKey: GlobalFieldKey,
+	nodeKeyFieldKey: LocalFieldKey,
 	node: EditableTree,
 ): StableNodeKey | undefined {
-	const nodeKeyFieldKeySymbol = symbolFromKey(nodeKeyFieldKey);
-	if (nodeKeyFieldKeySymbol in node) {
+	if (nodeKeyFieldKey in node) {
 		// Get the ID via a wrapped node rather than an unwrapped node (`node[nodeKeyFieldKeySymbol]`)
 		// so that the field kind can be checked
-		const field = node[getField](nodeKeyFieldKeySymbol);
+		const field = node[getField](nodeKeyFieldKey);
 		assert(
 			field.fieldSchema.kind.identifier === FieldKinds.nodeKey.identifier,
 			0x6df /* Invalid node key field kind */,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -175,7 +175,6 @@ export { mapFromNamed, namedTreeSchema } from "./viewSchemaUtil";
 export { TreeChunk, chunkTree, buildChunkedForest, defaultChunkPolicy } from "./chunked-forest";
 
 export {
-	buildNodeKeySchema,
 	compareLocalNodeKeys,
 	LocalNodeKey,
 	createNodeKeyManager,
@@ -183,6 +182,8 @@ export {
 	StableNodeKey,
 	NodeKeyIndex,
 	NodeKeyManager,
+	nodeKeyFieldKey,
+	nodeKeyTreeIdentifier,
 } from "./node-key";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/node-key/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/node-key/index.ts
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 
-export { buildNodeKeySchema, compareLocalNodeKeys, LocalNodeKey, StableNodeKey } from "./nodeKey";
+export {
+	compareLocalNodeKeys,
+	LocalNodeKey,
+	StableNodeKey,
+	nodeKeyFieldKey,
+	nodeKeyTreeIdentifier,
+} from "./nodeKey";
 
 export { NodeKeyIndex } from "./nodeKeyIndex";
 

--- a/experimental/dds/tree2/src/feature-libraries/node-key/nodeKey.ts
+++ b/experimental/dds/tree2/src/feature-libraries/node-key/nodeKey.ts
@@ -38,7 +38,7 @@ export function compareLocalNodeKeys(a: LocalNodeKey, b: LocalNodeKey): -1 | 0 |
 }
 
 /**
- * The key for the special field for node keys,
+ * The key for the special field for {@link LocalNodeKey}s,
  * which allows nodes to be given keys that can be used to find the nodes via the node key index.
  * @alpha
  * @privateRemarks TODO: Come up with a unified and collision-resistant naming schema for fields defined by the system.

--- a/experimental/dds/tree2/src/feature-libraries/node-key/nodeKey.ts
+++ b/experimental/dds/tree2/src/feature-libraries/node-key/nodeKey.ts
@@ -5,10 +5,7 @@
 
 import { SessionSpaceCompressedId, StableId } from "@fluidframework/runtime-definitions";
 import { Brand, Opaque, brand } from "../../util";
-import { TreeSchemaIdentifier, ValueSchema } from "../../core";
-import { GlobalFieldSchema, SchemaBuilder, SchemaLibrary } from "../modular-schema";
-import { FieldKinds, NodeKeyFieldKind } from "../defaultFieldKinds";
-
+import { TreeSchemaIdentifier } from "../../core";
 /**
  * A key which uniquely identifies a node in the tree within this session.
  * @remarks {@link LocalNodeKey}s must not be serialized and stored as data without first being converted into a {@link StableNodeKey}.
@@ -41,24 +38,18 @@ export function compareLocalNodeKeys(a: LocalNodeKey, b: LocalNodeKey): -1 | 0 |
 }
 
 /**
- * Create a schema library for working with {@link StableNodeKey}s in a tree.
- * Node keys are added to nodes via a global field.
- * @param key - the string used as the global field key as well as the node type for node keys.
- * Defaults to a string that is unlikely to collide with user/application keys.
- * @returns the type of node key nodes in the schema,
- * the schema for the global field under which keys reside,
- * and a schema library containing the above.
+ * The key for the special field for node keys,
+ * which allows nodes to be given keys that can be used to find the nodes via the node key index.
  * @alpha
+ * @privateRemarks TODO: Come up with a unified and collision-resistant naming schema for fields defined by the system.
+ * For now, we'll use `__` to reduce the change of collision, since this is what other internal properties use in Fluid.
  */
-export function buildNodeKeySchema(key: string): {
-	schema: SchemaLibrary;
-	field: GlobalFieldSchema<NodeKeyFieldKind>;
-	type: TreeSchemaIdentifier;
-} {
-	const builder = new SchemaBuilder("Node Key Schema");
-	const field = builder.globalField(
-		key,
-		SchemaBuilder.field(FieldKinds.nodeKey, builder.primitive(key, ValueSchema.String)),
-	);
-	return { schema: builder.intoLibrary(), field, type: brand(key) };
-}
+export const nodeKeyFieldKey = "__n_id__";
+
+/**
+ * The TreeSchemaIdentifier for node keys.
+ * @alpha
+ * @privateRemarks TODO: Come up with a unified and collision-resistant naming schema for types defined by the system.
+ * For now, we'll use `__` to reduce the change of collision, since this is what other internal properties use in Fluid.
+ */
+export const nodeKeyTreeIdentifier: TreeSchemaIdentifier = brand(nodeKeyFieldKey);

--- a/experimental/dds/tree2/src/feature-libraries/node-key/nodeKeyIndex.ts
+++ b/experimental/dds/tree2/src/feature-libraries/node-key/nodeKeyIndex.ts
@@ -4,39 +4,41 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { extractFromOpaque } from "../../util";
-import { GlobalFieldKey, SchemaData } from "../../core";
-import { nodeKey } from "../defaultFieldKinds";
+import { LocalFieldKey, SchemaData, ValueSchema } from "../../core";
+import { FieldKinds } from "../defaultFieldKinds";
 import {
 	EditableTree,
 	EditableTreeContext,
 	localNodeKeySymbol,
 	typeSymbol,
 } from "../editable-tree";
-import { LocalNodeKey } from "./nodeKey";
+import { oneFromSet } from "../../util";
+import { LocalNodeKey, nodeKeyTreeIdentifier } from "./nodeKey";
 
 /**
  * The node key index records nodes with {@link LocalNodeKey}s and allows them to be looked up by key.
  */
-export class NodeKeyIndex<TField extends GlobalFieldKey>
-	implements ReadonlyMap<LocalNodeKey, EditableTree>
-{
+export class NodeKeyIndex implements ReadonlyMap<LocalNodeKey, EditableTree> {
 	// TODO: The data structure that holds the nodes can likely be optimized to better support cloning
 	private readonly nodes: Map<LocalNodeKey, EditableTree>;
 
 	public constructor(
-		public readonly fieldKey: TField,
+		public readonly fieldKey: LocalFieldKey,
 		keys: Iterable<[LocalNodeKey, EditableTree]> = [],
 	) {
 		this.nodes = new Map(keys);
 	}
 
 	/**
-	 * Returns true if the given schema contains the global node key field, otherwise false
+	 * Returns true if the given schema contains the node key type, otherwise false
 	 */
-	public static keysAreInSchema(schema: SchemaData, fieldKey: GlobalFieldKey): boolean {
-		const fieldSchema = schema.globalFieldSchema.get(fieldKey);
-		return fieldSchema !== undefined && fieldSchema.kind.identifier === nodeKey.identifier;
+	public static hasNodeKeyTreeSchema(schema: SchemaData): boolean {
+		// TODO: make SchemaData contain ViewSchema and compare by reference to nodeKeyTreeSchema.
+		const treeSchema = schema.treeSchema.get(nodeKeyTreeIdentifier);
+		if (treeSchema === undefined) {
+			return false;
+		}
+		return treeSchema.value === ValueSchema.String;
 	}
 
 	/**
@@ -46,10 +48,13 @@ export class NodeKeyIndex<TField extends GlobalFieldKey>
 	 */
 	// TODO: This can be optimized by responding to deltas/changes to the tree, rather than rescanning the whole tree every time
 	public scanKeys(context: EditableTreeContext): void {
-		if (NodeKeyIndex.keysAreInSchema(context.schema, this.fieldKey)) {
+		if (NodeKeyIndex.hasNodeKeyTreeSchema(context.schema)) {
 			this.nodes.clear();
 			for (let i = 0; i < context.root.length; i++) {
 				for (const [id, node] of this.findKeys(context.root.getNode(i))) {
+					// TODO:
+					// This invariant (that there is only one node with a given key) is not enforced by tree, so it should not assert.
+					// Multiple nodes (including deleted ones), might occur with the same key.
 					assert(!this.nodes.has(id), 0x6e1 /* Encountered duplicate node key */);
 					this.nodes.set(id, node);
 				}
@@ -60,7 +65,7 @@ export class NodeKeyIndex<TField extends GlobalFieldKey>
 	/**
 	 * Create a copy of this index which can be mutated without affecting this one.
 	 */
-	public clone(context: EditableTreeContext): NodeKeyIndex<TField> {
+	public clone(context: EditableTreeContext): NodeKeyIndex {
 		const indexClone = new NodeKeyIndex(this.fieldKey);
 		indexClone.scanKeys(context);
 		return indexClone;
@@ -101,17 +106,23 @@ export class NodeKeyIndex<TField extends GlobalFieldKey>
 	// #endregion ReadonlyMap interface
 
 	private *findKeys(node: EditableTree): Iterable<[key: LocalNodeKey, node: EditableTree]> {
-		const key = node[localNodeKeySymbol] as LocalNodeKey | undefined;
+		const key = node[localNodeKeySymbol];
 		if (key !== undefined) {
-			yield [extractFromOpaque(key), node];
+			const field = node[typeSymbol].localFields.get(this.fieldKey);
+			assert(field !== undefined, 0x6e2 /* Found node key that is not in schema */);
 			assert(
-				node[typeSymbol].extraGlobalFields ||
-					node[typeSymbol].globalFields.has(this.fieldKey),
-				0x6e2 /* Found node key that is not in schema */,
+				field.kind.identifier === FieldKinds.nodeKey.identifier,
+				"Found node key that is not in schema",
 			);
+			assert(
+				oneFromSet(field.types) === nodeKeyTreeIdentifier,
+				"Found node key that is not in schema",
+			);
+
+			yield [key, node];
 		} else {
 			assert(
-				!node[typeSymbol].globalFields.has(this.fieldKey),
+				!node[typeSymbol].localFields.has(this.fieldKey),
 				0x6e3 /* Node key absent but required by schema */,
 			);
 		}

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -131,7 +131,7 @@ export {
 	jsonObject,
 	jsonString,
 	jsonSchema,
-	nodeKeyFieldKey,
+	nodeKeyField,
 	nodeKeySchema,
 } from "./domains";
 
@@ -282,6 +282,7 @@ export {
 	toDownPath,
 	comparePipeline,
 	compileSyntaxTree,
+	nodeKeyFieldKey,
 } from "./feature-libraries";
 
 export {

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -40,10 +40,10 @@ import {
 	createNodeKeyManager,
 	NewFieldContent,
 	ModularChangeset,
+	nodeKeyFieldKey,
 } from "../feature-libraries";
 import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
-import { JsonCompatibleReadOnly } from "../util";
-import { nodeKeyFieldKey } from "../domains";
+import { JsonCompatibleReadOnly, brand } from "../util";
 import { SchematizeConfiguration, schematizeView } from "./schematizedTree";
 import {
 	ISharedTreeView,
@@ -75,7 +75,7 @@ export class SharedTree
 		HasListeners<ViewEvents>;
 	private readonly view: ISharedTreeView;
 	private readonly schema: SchemaEditor<InMemoryStoredSchemaRepository>;
-	private readonly nodeKeyIndex: NodeKeyIndex<typeof nodeKeyFieldKey>;
+	private readonly nodeKeyIndex: NodeKeyIndex;
 
 	public constructor(
 		id: string,
@@ -107,7 +107,7 @@ export class SharedTree
 			telemetryContextPrefix,
 		);
 		this.schema = new SchemaEditor(schema, (op) => this.submitLocalMessage(op), options);
-		this.nodeKeyIndex = new NodeKeyIndex(nodeKeyFieldKey);
+		this.nodeKeyIndex = new NodeKeyIndex(brand(nodeKeyFieldKey));
 		this._events = createEmitter<ViewEvents>();
 		this.view = createSharedTreeView({
 			branch: this.getLocalBranch(),

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -37,10 +37,10 @@ import {
 	LocalNodeKey,
 	ForestRepairDataStore,
 	ModularChangeset,
+	nodeKeyFieldKey,
 } from "../feature-libraries";
 import { SharedTreeBranch } from "../shared-tree-core";
-import { TransactionResult } from "../util";
-import { nodeKeyFieldKey } from "../domains";
+import { TransactionResult, brand } from "../util";
 import { noopValidator } from "../codec";
 import { SchematizeConfiguration, schematizeView } from "./schematizedTree";
 
@@ -269,7 +269,7 @@ export function createSharedTreeView(args?: {
 	forest?: IEditableForest;
 	repairProvider?: ForestRepairDataStoreProvider<DefaultChangeset>;
 	nodeKeyManager?: NodeKeyManager;
-	nodeKeyIndex?: NodeKeyIndex<typeof nodeKeyFieldKey>;
+	nodeKeyIndex?: NodeKeyIndex;
 	events?: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>;
 }): ISharedTreeView {
 	const schema = args?.schema ?? new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
@@ -295,8 +295,13 @@ export function createSharedTreeView(args?: {
 			forest.anchors,
 		);
 	const nodeKeyManager = args?.nodeKeyManager ?? createNodeKeyManager();
-	const context = getEditableTreeContext(forest, branch.editor, nodeKeyManager, nodeKeyFieldKey);
-	const nodeKeyIndex = args?.nodeKeyIndex ?? new NodeKeyIndex(nodeKeyFieldKey);
+	const context = getEditableTreeContext(
+		forest,
+		branch.editor,
+		nodeKeyManager,
+		brand(nodeKeyFieldKey),
+	);
+	const nodeKeyIndex = args?.nodeKeyIndex ?? new NodeKeyIndex(brand(nodeKeyFieldKey));
 	const events = args?.events ?? createEmitter();
 	return SharedTreeView[create](
 		branch,
@@ -322,7 +327,7 @@ export class SharedTreeView implements ISharedTreeView {
 		private readonly _forest: IEditableForest,
 		public readonly context: EditableTreeContext,
 		private readonly _nodeKeyManager: NodeKeyManager,
-		private readonly _nodeKeyIndex: NodeKeyIndex<typeof nodeKeyFieldKey>,
+		private readonly _nodeKeyIndex: NodeKeyIndex,
 		private readonly _events: ISubscribable<ViewEvents> &
 			IEmitter<ViewEvents> &
 			HasListeners<ViewEvents>,
@@ -345,7 +350,7 @@ export class SharedTreeView implements ISharedTreeView {
 		forest: IEditableForest,
 		context: EditableTreeContext,
 		_nodeKeyManager: NodeKeyManager,
-		nodeKeyIndex: NodeKeyIndex<typeof nodeKeyFieldKey>,
+		nodeKeyIndex: NodeKeyIndex,
 		events: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>,
 	): SharedTreeView {
 		return new SharedTreeView(

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.identifier.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.identifier.spec.ts
@@ -11,40 +11,31 @@ import {
 	createMockNodeKeyManager,
 	StableNodeKey,
 	LocalNodeKey,
+	nodeKeyFieldKey,
 } from "../../../feature-libraries";
-import { nodeKeySchema } from "../../../domains";
+import { nodeKeyField, nodeKeySchema } from "../../../domains";
 import { ISharedTreeView, createSharedTreeView } from "../../../shared-tree";
-import { AllowedUpdateType, GlobalFieldKeySymbol, ValueSchema, symbolFromKey } from "../../../core";
+import { AllowedUpdateType, ValueSchema } from "../../../core";
 import { brand } from "../../../util";
 
-const { field: nodeKeyField, schema: nodeKeyLibrary } = nodeKeySchema();
-const stableNodeKeySymbol = symbolFromKey(nodeKeyField.key);
-
-const builder = new SchemaBuilder("EditableTree Node Keys", nodeKeyLibrary);
+const builder = new SchemaBuilder("EditableTree Node Keys", nodeKeySchema);
 const stringSchema = builder.primitive("string", ValueSchema.String);
-const childNodeSchema = builder.object("ChildNode", {
-	local: {
-		name: SchemaBuilder.fieldValue(stringSchema),
-	},
-	global: [nodeKeyField],
+const childNodeSchema = builder.struct("ChildNode", {
+	...nodeKeyField,
+	name: SchemaBuilder.fieldValue(stringSchema),
 });
 
-const parentNodeSchema = builder.object("ParentNode", {
-	local: {
-		children: SchemaBuilder.fieldSequence(childNodeSchema),
-	},
-	global: [nodeKeyField],
+const parentNodeSchema = builder.struct("ParentNode", {
+	...nodeKeyField,
+	children: SchemaBuilder.fieldSequence(childNodeSchema),
 });
 const rootField = SchemaBuilder.fieldValue(parentNodeSchema);
 const schema = builder.intoDocumentSchema(rootField);
 
 // TODO: this can probably be removed once daesun's stuff goes in
-function addKey(
-	view: ISharedTreeView,
-	key: LocalNodeKey,
-): { [keySymbol: GlobalFieldKeySymbol]: StableNodeKey } {
+function addKey(view: ISharedTreeView, key: LocalNodeKey): { [nodeKeyFieldKey]: StableNodeKey } {
 	return {
-		[symbolFromKey(nodeKeyField.key)]: view.nodeKey.stabilize(key),
+		[nodeKeyFieldKey]: view.nodeKey.stabilize(key),
 	};
 }
 
@@ -100,12 +91,9 @@ describe("editable-tree: node keys", () => {
 		const parentNode = typedRootField.getNode(0);
 		const childA = parentNode[getField](brand("children")).getNode(0);
 		const childB = parentNode[getField](brand("children")).getNode(1);
-		assert.equal(
-			parentNode[symbolFromKey(nodeKeyField.key)],
-			view.nodeKey.stabilize(parentKey),
-		);
-		assert.equal(childA[symbolFromKey(nodeKeyField.key)], view.nodeKey.stabilize(childAKey));
-		assert.equal(childB[symbolFromKey(nodeKeyField.key)], view.nodeKey.stabilize(childBKey));
+		assert.equal(parentNode[nodeKeyFieldKey], view.nodeKey.stabilize(parentKey));
+		assert.equal(childA[nodeKeyFieldKey], view.nodeKey.stabilize(childAKey));
+		assert.equal(childB[nodeKeyFieldKey], view.nodeKey.stabilize(childBKey));
 	});
 
 	it("cannot set node keys", () => {
@@ -113,8 +101,7 @@ describe("editable-tree: node keys", () => {
 		const typedRootField = view.context.root;
 		const parentNode = typedRootField.getNode(0);
 		assert.throws(
-			() =>
-				(parentNode[stableNodeKeySymbol] = view.nodeKey.stabilize(view.nodeKey.generate())),
+			() => (parentNode[nodeKeyFieldKey] = view.nodeKey.stabilize(view.nodeKey.generate())),
 		);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.bench.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.bench.ts
@@ -16,6 +16,7 @@ import {
 	localNodeKeySymbol,
 	SchemaBuilder,
 	FieldKinds,
+	nodeKeyFieldKey,
 } from "../../../feature-libraries";
 import {
 	rootFieldKeySymbol,
@@ -23,13 +24,11 @@ import {
 	moveToDetachedField,
 	JsonableTree,
 	AllowedUpdateType,
-	symbolFromKey,
 } from "../../../core";
-import { nodeKeySchema } from "../../../domains";
+import { nodeKeyField, nodeKeySchema, nodeKeyTreeSchema } from "../../../domains";
+import { brand } from "../../../util";
 
-const { schema: nodeKeyLibrary, field: nodeKeyField, type: nodeKeyType } = nodeKeySchema();
-
-const builder = new SchemaBuilder("node key index benchmarks", nodeKeyLibrary);
+const builder = new SchemaBuilder("node key index benchmarks", nodeKeySchema);
 const nodeSchema = builder.structRecursive("node", {
 	child: SchemaBuilder.fieldRecursive(
 		FieldKinds.optional,
@@ -37,15 +36,13 @@ const nodeSchema = builder.structRecursive("node", {
 		() => nodeWithKeySchema,
 	),
 });
-const nodeWithKeySchema = builder.objectRecursive("nodeWithKey", {
-	local: {
-		child: SchemaBuilder.fieldRecursive(
-			FieldKinds.optional,
-			() => nodeWithKeySchema,
-			() => nodeSchema,
-		),
-	},
-	global: [nodeKeyField],
+const nodeWithKeySchema = builder.structRecursive("nodeWithKey", {
+	...nodeKeyField,
+	child: SchemaBuilder.fieldRecursive(
+		FieldKinds.optional,
+		() => nodeWithKeySchema,
+		() => nodeSchema,
+	),
 });
 const schemaData = builder.intoDocumentSchema(
 	SchemaBuilder.fieldOptional(nodeSchema, nodeWithKeySchema),
@@ -78,10 +75,10 @@ describe("Node Key Index Benchmarks", () => {
 					nodeKey !== undefined
 						? {
 								type: nodeWithKeySchema.name,
-								globalFields: {
-									[nodeKeyField.key]: [
+								fields: {
+									[nodeKeyFieldKey]: [
 										{
-											type: nodeKeyType,
+											type: nodeKeyTreeSchema.name,
 											value: view.nodeKey.stabilize(nodeKey),
 										},
 									],
@@ -126,7 +123,7 @@ describe("Node Key Index Benchmarks", () => {
 							cursor.firstNode();
 							for (let i = 0; i < nodeCount; i++) {
 								if (i % period === 0) {
-									cursor.enterField(symbolFromKey(nodeKeyField.key));
+									cursor.enterField(brand(nodeKeyFieldKey));
 									cursor.enterNode(0);
 									const id = ids[i];
 									const stableId =

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
-import { nodeKeySchema } from "../../../domains";
+import { nodeKeyField, nodeKeySchema, nodeKeyTreeSchema } from "../../../domains";
 import {
 	SchemaBuilder,
 	FieldKinds,
@@ -14,18 +14,17 @@ import {
 	localNodeKeySymbol,
 	createMockNodeKeyManager,
 	StableNodeKey,
+	nodeKeyFieldKey,
 } from "../../../feature-libraries";
 import { ISharedTreeView, createSharedTreeView } from "../../../shared-tree";
 import { compareSets } from "../../../util";
 import { SummarizeType, TestTreeProvider, initializeTestTree } from "../../utils";
-import { AllowedUpdateType, GlobalFieldKeySymbol, symbolFromKey } from "../../../core";
+import { AllowedUpdateType } from "../../../core";
 
-const { schema: nodeKeyLibrary, field: nodeKeyField, type: nodeKeyType } = nodeKeySchema();
-
-const builder = new SchemaBuilder("node key index tests", nodeKeyLibrary);
-const nodeSchema = builder.objectRecursive("node", {
-	local: { child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchema) },
-	global: [nodeKeyField],
+const builder = new SchemaBuilder("node key index tests", nodeKeySchema);
+const nodeSchema = builder.structRecursive("node", {
+	...nodeKeyField,
+	child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchema),
 });
 const nodeSchemaData = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(nodeSchema));
 
@@ -33,9 +32,9 @@ const nodeSchemaData = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(no
 function contextualizeKey(
 	view: ISharedTreeView,
 	key: LocalNodeKey,
-): { [keySymbol: GlobalFieldKeySymbol]: StableNodeKey } {
+): { [nodeKeyFieldKey]: StableNodeKey } {
 	return {
-		[symbolFromKey(nodeKeyField.key)]: view.nodeKey.stabilize(key),
+		[nodeKeyFieldKey]: view.nodeKey.stabilize(key),
 	};
 }
 
@@ -163,31 +162,6 @@ describe("Node Key Index", () => {
 		assertIds(tree2, [tree2.nodeKey.localize(tree.nodeKey.stabilize(key))]);
 	});
 
-	it("errors on nodes which have keys, but are not in schema", () => {
-		// This is missing the global field on the node
-		const builder2 = new SchemaBuilder("node key index test", nodeKeyLibrary);
-		const nodeSchemaNoKey = builder2.structRecursive("node", {
-			child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchemaNoKey),
-		});
-		const nodeSchemaDataNoKey = builder2.intoDocumentSchema(
-			SchemaBuilder.fieldOptional(nodeSchemaNoKey),
-		);
-
-		const view = createView();
-		assert.throws(
-			() =>
-				view.schematize({
-					initialTree: {
-						...contextualizeKey(view, view.nodeKey.generate()),
-						child: undefined,
-					},
-					schema: nodeSchemaDataNoKey,
-					allowedSchemaModifications: AllowedUpdateType.None,
-				}),
-			(e) => validateAssertionError(e, "Found node key that is not in schema"),
-		);
-	});
-
 	it("errors on nodes which have keys of the wrong type", () => {
 		assert.throws(
 			() =>
@@ -195,8 +169,8 @@ describe("Node Key Index", () => {
 					createView(),
 					{
 						type: nodeSchema.name,
-						globalFields: {
-							[nodeKeyField.key]: [{ type: nodeKeyType, value: {} }],
+						fields: {
+							[nodeKeyFieldKey]: [{ type: nodeKeyTreeSchema.name, value: {} }],
 						},
 					},
 					nodeSchemaData,
@@ -210,6 +184,7 @@ describe("Node Key Index", () => {
 		assert.throws(
 			() =>
 				view.schematize({
+					// @ts-expect-error Wrong type
 					initialTree: {
 						child: undefined,
 					},
@@ -220,7 +195,7 @@ describe("Node Key Index", () => {
 		);
 	});
 
-	it("is disabled if key field is not in the global schema", () => {
+	it("is disabled if node type is not in the tree schema", () => {
 		const builder2 = new SchemaBuilder("node key index test");
 		const nodeSchemaNoKey = builder2.objectRecursive("node", {
 			local: {
@@ -231,48 +206,23 @@ describe("Node Key Index", () => {
 		const nodeSchemaDataNoKey = builder2.intoDocumentSchema(
 			SchemaBuilder.fieldOptional(nodeSchemaNoKey),
 		);
-		assert(!nodeSchemaDataNoKey.globalFieldSchema.has(nodeKeyField.key));
+		assert(!nodeSchemaDataNoKey.treeSchema.has(nodeKeyTreeSchema.name));
 
 		const view = createView();
 		initializeTestTree(
 			view,
 			{
 				type: nodeSchema.name,
-				globalFields: {
-					[nodeKeyField.key]: [{ type: nodeKeyType, value: view.nodeKey.generate() }],
+				fields: {
+					[nodeKeyFieldKey]: [
+						{ type: nodeKeyTreeSchema.name, value: view.nodeKey.generate() },
+					],
 				},
 			},
 			nodeSchemaDataNoKey,
 		);
 		assertIds(view, []);
-		const index = view.nodeKey.map as NodeKeyIndex<typeof nodeKeyField.key>;
-		assert(!NodeKeyIndex.keysAreInSchema(view.context.schema, index.fieldKey));
-	});
-
-	it("respects extra global fields", () => {
-		// This is missing the global node key field on the node, but has "extra global fields" enabled
-		const builder2 = new SchemaBuilder("node key index test", nodeKeyLibrary);
-		const nodeSchemaNoKey = builder2.objectRecursive("node", {
-			local: {
-				child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchemaNoKey),
-			},
-			extraGlobalFields: true,
-		});
-		const nodeSchemaDataNoKey = builder2.intoDocumentSchema(
-			SchemaBuilder.fieldOptional(nodeSchemaNoKey),
-		);
-
-		const view = createView();
-		const key = view.nodeKey.generate();
-		const typedView = view.schematize({
-			initialTree: {
-				...contextualizeKey(view, key),
-				child: undefined,
-			},
-			schema: nodeSchemaDataNoKey,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		});
-		assertIds(typedView, [key]);
+		assert(!NodeKeyIndex.hasNodeKeyTreeSchema(view.context.schema));
 	});
 
 	it("is synchronized after each batch update", () => {
@@ -302,7 +252,7 @@ describe("Node Key Index", () => {
 	// TODO: Schema changes are not yet fully hooked up to eventing. A schema change should probably trigger
 	it.skip("reacts to schema changes", () => {
 		// This is missing the global node key field on the node
-		const builder2 = new SchemaBuilder("node key index test", nodeKeyLibrary);
+		const builder2 = new SchemaBuilder("node key index test", nodeKeySchema);
 		const nodeSchemaNoKey = builder2.structRecursive("node", {
 			child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchemaNoKey),
 		});

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -70,6 +70,7 @@ export {
 	generateStableId,
 	useDeterministicStableId,
 	objectToMap,
+	oneFromSet,
 } from "./utils";
 export { ReferenceCountedBase, ReferenceCounted } from "./referenceCounting";
 

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -338,3 +338,18 @@ export function objectToMap<MapKey extends string | number | symbol, MapValue>(
 	}
 	return map;
 }
+
+/**
+ * Returns the value from `set` if it contains exactly one item, otherwise `undefined`.
+ */
+export function oneFromSet<T>(set: ReadonlySet<T> | undefined): T | undefined {
+	if (set === undefined) {
+		return undefined;
+	}
+	if (set.size !== 1) {
+		return undefined;
+	}
+	for (const item of set) {
+		return item;
+	}
+}


### PR DESCRIPTION
## Description

Make node keys use a local field.
Fix API on editable tree to not use a global field key for the compressed key access.

## Breaking Changes

This changes the encoding of node keys: any existing data using them will not work with the new version.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

