### PR TITLE
Compile ESM in app-insights-logger

### DIFF
--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -16,8 +16,10 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",
+		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
+		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"ci:build:docs": "api-extractor run && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
 		"clean": "rimraf _api-extractor-temp coverage dist nyc *.tsbuildinfo *.build.log",
 		"eslint": "eslint src",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -21,7 +21,7 @@
 		"build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
 		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"ci:build:docs": "api-extractor run && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
-		"clean": "rimraf _api-extractor-temp coverage dist nyc *.tsbuildinfo *.build.log",
+		"clean": "rimraf _api-extractor-temp coverage dist lib nyc *.tsbuildinfo *.build.log",
 		"eslint": "eslint src",
 		"eslint:fix": "eslint src --fix",
 		"format": "npm run prettier:fix",

--- a/packages/framework/client-logger/app-insights-logger/tsconfig.esnext.json
+++ b/packages/framework/client-logger/app-insights-logger/tsconfig.esnext.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./lib",
+		"module": "esnext",
+	},
+}

--- a/packages/framework/client-logger/app-insights-logger/tsconfig.json
+++ b/packages/framework/client-logger/app-insights-logger/tsconfig.json
@@ -5,6 +5,7 @@
 		"outDir": "dist",
 		"composite": true,
 		"types": ["mocha"],
+		"target": "ES2020",
 	},
 	"include": ["src/**/*"],
 }

--- a/packages/framework/client-logger/app-insights-logger/tsconfig.json
+++ b/packages/framework/client-logger/app-insights-logger/tsconfig.json
@@ -5,7 +5,6 @@
 		"outDir": "dist",
 		"composite": true,
 		"types": ["mocha"],
-		"target": "ES2020",
 	},
 	"include": ["src/**/*"],
 }


### PR DESCRIPTION
#### Description 

https://dev.azure.com/fluidframework/internal/_workitems/edit/4538/

Fluid Framework adopts ESM (https://nodejs.org/api/esm.html#modules-ecmascript-modules) and also provides CommonJS module format (for internal test purposes). This PR makes the `@fluid-internal/app-insights-logger` to target ESM when compiling. 

Related PRs
https://github.com/microsoft/FluidFramework/pull/16333
https://github.com/microsoft/FluidFramework/pull/16308