### PR TITLE
Revert any to unknown changes

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -108,7 +108,7 @@ export interface IConnect {
     mode: ConnectionMode;
     nonce?: string;
     relayUserAgent?: string;
-    supportedFeatures?: Record<string, unknown>;
+    supportedFeatures?: Record<string, any>;
     tenantId: string;
     token: string | null;
     versions: string[];
@@ -129,7 +129,7 @@ export interface IConnected {
     nonce?: string;
     relayServiceAgent?: string;
     serviceConfiguration: IClientConfiguration;
-    supportedFeatures?: Record<string, unknown>;
+    supportedFeatures?: Record<string, any>;
     supportedVersions: string[];
     timestamp?: number;
     version: string;
@@ -151,10 +151,10 @@ export interface IDocumentAttributes {
 export interface IDocumentMessage {
     clientSequenceNumber: number;
     compression?: string;
-    contents: unknown;
-    metadata?: unknown;
+    contents: any;
+    metadata?: any;
     referenceSequenceNumber: number;
-    serverMetadata?: unknown;
+    serverMetadata?: any;
     traces?: ITrace[];
     type: string;
 }
@@ -264,17 +264,17 @@ export interface ISequencedDocumentMessage {
     clientId: string | null;
     clientSequenceNumber: number;
     compression?: string;
-    contents: unknown;
+    contents: any;
     // (undocumented)
     data?: string;
     // @alpha
     expHash1?: string;
-    metadata?: unknown;
+    metadata?: any;
     minimumSequenceNumber: number;
     origin?: IBranchOrigin;
     referenceSequenceNumber: number;
     sequenceNumber: number;
-    serverMetadata?: unknown;
+    serverMetadata?: any;
     timestamp: number;
     traces?: ITrace[];
     type: string;
@@ -309,7 +309,7 @@ export interface ISignalMessage {
     clientConnectionNumber?: number;
     clientId: string | null;
     // (undocumented)
-    content: unknown;
+    content: any;
     referenceSequenceNumber?: number;
 }
 

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -144,17 +144,20 @@ export interface IDocumentMessage {
 	/**
 	 * The contents of the message.
 	 */
-	contents: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	contents: any;
 
 	/**
 	 * App provided metadata about the operation.
 	 */
-	metadata?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	metadata?: any;
 
 	/**
 	 * Server provided metadata about the operation.
 	 */
-	serverMetadata?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	serverMetadata?: any;
 
 	/**
 	 * Traces related to the packet.
@@ -234,17 +237,20 @@ export interface ISequencedDocumentMessage {
 	/**
 	 * The contents of the message.
 	 */
-	contents: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	contents: any;
 
 	/**
 	 * App provided metadata about the operation.
 	 */
-	metadata?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	metadata?: any;
 
 	/**
 	 * Server provided metadata about the operation.
 	 */
-	serverMetadata?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	serverMetadata?: any;
 
 	/**
 	 * Origin branch information for the message.
@@ -295,7 +301,8 @@ export interface ISignalMessage {
 	// eslint-disable-next-line @rushstack/no-new-null
 	clientId: string | null;
 
-	content: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	content: any;
 
 	/**
 	 * Counts the number of signals sent by the client

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -66,7 +66,8 @@ export interface IConnect {
 	 * Features supported might be service specific.
 	 * If we have standardized features across all services, they need to be exposed in more structured way.
 	 */
-	supportedFeatures?: Record<string, unknown>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	supportedFeatures?: Record<string, any>;
 
 	/**
 	 * Properties that client can send to server to tell info about client environment. These are a bunch of properties
@@ -159,7 +160,8 @@ export interface IConnected {
 	 * Features supported might be service specific.
 	 * If we have standardized features across all services, they need to be exposed in more structured way.
 	 */
-	supportedFeatures?: Record<string, unknown>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	supportedFeatures?: Record<string, any>;
 
 	/**
 	 * The time the client connected


### PR DESCRIPTION
As part of #15353 a number of any's were changed to unknown. While this is a good change, consumption of the change is quite costly, and hard to stage beforehand. 

This PR reverts those changes to avoid the cost of integrating, which was attempted in these outdated PRs:
- #15401
- #15394 
- #15382
- #15380