### PR TITLE
Prepare for "unknown" typing changes in routerlicious

### DIFF
--- a/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
@@ -90,7 +90,9 @@ export class BroadcasterLambda implements IPartitionLambda {
 					topic = `${ticketedSignalMessage.tenantId}/${ticketedSignalMessage.documentId}`;
 
 					if (this.clientManager && ticketedSignalMessage.operation) {
-						const signalContent = JSON.parse(ticketedSignalMessage.operation.content);
+						const signalContent = JSON.parse(
+							ticketedSignalMessage.operation.content as string,
+						);
 						const signalType: MessageType | undefined =
 							typeof signalContent.type === "string" ? signalContent.type : undefined;
 						switch (signalType) {

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointManager.ts
@@ -62,7 +62,6 @@ export function createDeliCheckpointManagerFromCollection(
 			);
 		},
 		deleteCheckpoint: async (checkpointParams: ICheckpointParams, isLocal: boolean) => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return checkpointService.clearCheckpoint(documentId, tenantId, "deli", isLocal);
 		},
 	};

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1384,7 +1384,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				// because scribe will not be involved
 				if (
 					!this.serviceConfiguration.deli.skipSummarizeAugmentationForSingleCommmit ||
-					!(JSON.parse(message.operation.contents) as ISummaryContent).details
+					!(JSON.parse(message.operation.contents as string) as ISummaryContent).details
 						?.includesProtocolTree
 				) {
 					addAdditionalContent = true;

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -76,6 +76,7 @@ import {
 	createRoomLeaveMessage,
 	CheckpointReason,
 	ICheckpoint,
+	IServerMetadata,
 } from "../utils";
 import { CheckpointContext } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
@@ -581,7 +582,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 						(this.serviceConfiguration.deli.enableWriteClientSignals ||
 							(sequencedMessage.serverMetadata &&
 								typeof sequencedMessage.serverMetadata === "object" &&
-								sequencedMessage.serverMetadata.createSignal))
+								(sequencedMessage.serverMetadata as IServerMetadata).createSignal))
 					) {
 						const dataContent = this.extractDataContent(
 							message as IRawOperationMessage,
@@ -955,7 +956,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					this.clientSeqManager.count() === 0
 				) {
 					// add server metadata to indicate the last client left
-					(message.operation.serverMetadata ??= {}).noClient = true;
+					message.operation.serverMetadata ??= {};
+					(message.operation.serverMetadata as IServerMetadata).noClient = true;
 				}
 			} else if (message.operation.type === MessageType.ClientJoin) {
 				const clientJoinMessage = dataContent as IClientJoin;

--- a/server/routerlicious/packages/lambdas/src/moira/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambda.ts
@@ -110,7 +110,7 @@ export class MoiraLambda implements IPartitionLambda {
 
 		for (const message of messages) {
 			if (message?.operation?.type === "op") {
-				const contents = JSON.parse(message.operation.contents);
+				const contents = JSON.parse(message.operation.contents as string);
 				const opData = contents.contents?.contents?.content?.contents;
 				if (opData && opData.op === 0 && opData.changeSet !== undefined) {
 					// At this point is checked to be submitted to Moira

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -44,6 +44,7 @@ import {
 	logCommonSessionEndMetrics,
 	CheckpointReason,
 	ICheckpoint,
+	IServerMetadata,
 } from "../utils";
 import { ICheckpointManager, IPendingMessageReader, ISummaryWriter } from "./interfaces";
 import { initializeProtocol, sendToDeli } from "./utils";
@@ -214,7 +215,7 @@ export class ScribeLambda implements IPartitionLambda {
 				// skip summarize messages that deli already acked
 				if (
 					value.operation.type === MessageType.Summarize &&
-					!value.operation.serverMetadata?.deliAcked
+					!(value.operation.serverMetadata as IServerMetadata | undefined)?.deliAcked
 				) {
 					// ensure the client is requesting a summary for a state that scribe can achieve
 					// the clients summary state (ref seq num) must be at least as high as scribes (protocolHandler.sequenceNumber)

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -91,7 +91,7 @@ export class SummaryWriter implements ISummaryWriter {
 	): Promise<ISummaryWriteResponse> {
 		const clientSummaryMetric = Lumberjack.newLumberMetric(LumberEventName.ClientSummary);
 		this.setSummaryProperties(clientSummaryMetric, op);
-		const content = JSON.parse(op.contents) as ISummaryContent;
+		const content = JSON.parse(op.contents as string) as ISummaryContent;
 		try {
 			// The summary must reference the existing summary to be valid. This guards against accidental sends of
 			// two summaries at the same time. In this case the first one wins.

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -13,3 +13,4 @@ export { createSessionMetric, logCommonSessionEndMetrics } from "./telemetryHelp
 export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";
 export { CheckpointReason, ICheckpoint } from "./checkpointHelper";
 export { ConnectionCountLogger } from "./connectionCountLogger";
+export { IServerMetadata } from "./serverMetadata";

--- a/server/routerlicious/packages/lambdas/src/utils/serverMetadata.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/serverMetadata.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Server makes assumptions about what might be on the metadata. This interface codifies those assumptions, but does not validate them.
+ */
 export interface IServerMetadata {
 	createSignal?: boolean;
 	noClient?: boolean;

--- a/server/routerlicious/packages/lambdas/src/utils/serverMetadata.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/serverMetadata.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface IServerMetadata {
+	createSignal?: boolean;
+	noClient?: boolean;
+	deliAcked?: boolean;
+}


### PR DESCRIPTION
Basically the same as #15394, but purely casting the any/unknown to "what we are assuming it is" (no new/changed outputted code or validation).  This is safe to check in immediately to `main` to reduce the work required when consuming protocol-definitions 2.0.0.

[AB#4932](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4932)