### PR TITLE
Update branching/transaction APIs

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1088,6 +1088,7 @@ export interface ISharedTreeView extends AnchorLocator {
     readonly forest: IForestSubscription;
     fork(): SharedTreeView;
     merge(view: SharedTreeView): void;
+    merge(view: SharedTreeView, disposeView: boolean): void;
     readonly nodeKey: {
         generate(): LocalNodeKey;
         stabilize(key: LocalNodeKey): StableNodeKey;
@@ -1854,11 +1855,13 @@ export class SharedTreeView implements ISharedTreeView {
     // (undocumented)
     locate(anchor: Anchor): AnchorNode | undefined;
     // (undocumented)
-    merge(fork: SharedTreeView): void;
+    merge(view: SharedTreeView): void;
+    // (undocumented)
+    merge(view: SharedTreeView, disposeView: boolean): void;
     // (undocumented)
     readonly nodeKey: ISharedTreeView["nodeKey"];
     // (undocumented)
-    rebase(fork: SharedTreeView): void;
+    rebase(view: SharedTreeView): void;
     rebaseOnto(view: ISharedTreeView): void;
     // (undocumented)
     redo(): void;

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -21,7 +21,7 @@ import {
 	rebaseBranch,
 	RevisionTag,
 } from "../core";
-import { EventEmitter } from "../events";
+import { EventEmitter, ISubscribable } from "../events";
 import { TransactionStack } from "./transactionStack";
 
 /**
@@ -456,6 +456,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		branch: SharedTreeBranch<TEditor, TChange>,
 	): [change: TChange, newCommits: GraphCommit<TChange>[]] | undefined {
 		this.assertNotDisposed();
+		branch.assertNotDisposed();
 		assert(
 			!branch.isTransacting(),
 			0x597 /* Branch may not be merged while transaction is in progress */,
@@ -516,10 +517,20 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 	/**
 	 * Dispose this branch, freezing its state.
-	 * Attempts to further mutate or dispose the branch will error.
+	 *
+	 * @remarks
+	 * Attempts to further mutate the branch will error.
+	 * Any transactions in progress will be aborted.
+	 * Calling dispose more than once has no effect.
 	 */
 	public dispose(): void {
-		this.assertNotDisposed();
+		if (this.disposed) {
+			return;
+		}
+
+		while (this.isTransacting()) {
+			this.abortTransaction();
+		}
 		this.disposed = true;
 		this.emit("dispose");
 	}
@@ -535,4 +546,26 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	private assertNotDisposed(): void {
 		assert(!this.disposed, 0x66e /* Branch is disposed */);
 	}
+}
+
+/**
+ * Registers an event listener that fires when the given forkable object forks.
+ * The listener will also fire when any of those forks fork, and when those forks of forks fork, and so on.
+ * @param forkable - an object that emits an event when it is forked
+ * @param onFork - the fork event listener
+ * @returns a function which when called will deregister all registrations (including transitive) created by this function.
+ * The deregister function has undefined behavior if called more than once.
+ */
+export function onForkTransitive<T extends ISubscribable<{ fork: (t: T) => void }>>(
+	forkable: T,
+	onFork: (fork: T) => void,
+): () => void {
+	const offs: (() => void)[] = [];
+	offs.push(
+		forkable.on("fork", (fork) => {
+			offs.push(onForkTransitive(fork, onFork));
+			onFork(fork);
+		}),
+	);
+	return () => offs.forEach((off) => off());
 }

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -187,7 +187,6 @@ export class EditManager<
 
 		// Record the sequence number of the branch's base commit on the trunk
 		const trunkBase = { sequenceNumber: trackBranch(branch) };
-		// Whenever the branch forks, register the new fork
 		// Whenever the branch is rebased, update our record of its base trunk commit
 		const offRebase = branch.on("change", (args) => {
 			if (args.type === "replace" && getChangeReplaceType(args) === "rebase") {

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -23,7 +23,7 @@ import {
 	UndoRedoManager,
 } from "../core";
 import { createEmitter, ISubscribable } from "../events";
-import { getChangeReplaceType, SharedTreeBranch } from "./branch";
+import { getChangeReplaceType, onForkTransitive, SharedTreeBranch } from "./branch";
 import { Commit, SeqNumber, SequencedCommit, SummarySessionBranch } from "./editManagerFormat";
 
 export const minimumPossibleSequenceNumber: SeqNumber = brand(Number.MIN_SAFE_INTEGER);
@@ -147,8 +147,8 @@ export class EditManager<
 		// never evict the head. That sounds like a good thing, but because the trunk has a privileged
 		// relationship with the local branch (the local branch doesn't undergo normal rebasing), we can
 		// actually safely evict that last commit (assuming there are no other outstanding branches).
-		// TODO: Fiddle with the local case of addSequencedChange some more, and see if you can make it actually do a rebase.
-		this.localBranch.on("fork", (fork) => this.registerBranch(fork));
+		// TODO:#4918: Fiddle with the local case of addSequencedChange some more, and see if you can make it actually do a rebase.
+		onForkTransitive(this.localBranch, (fork) => this.registerBranch(fork));
 	}
 
 	/**
@@ -188,7 +188,6 @@ export class EditManager<
 		// Record the sequence number of the branch's base commit on the trunk
 		const trunkBase = { sequenceNumber: trackBranch(branch) };
 		// Whenever the branch forks, register the new fork
-		const offFork = branch.on("fork", (f) => this.registerBranch(f));
 		// Whenever the branch is rebased, update our record of its base trunk commit
 		const offRebase = branch.on("change", (args) => {
 			if (args.type === "replace" && getChangeReplaceType(args) === "rebase") {
@@ -200,7 +199,6 @@ export class EditManager<
 		const offDispose = branch.on("dispose", () => {
 			untrackBranch(branch, trunkBase.sequenceNumber);
 			this.trimTrunk();
-			offFork();
 			offRebase();
 			offDispose();
 		});
@@ -283,8 +281,12 @@ export class EditManager<
 		} else {
 			// If no trunk commit is found, it means that all trunk commits are below the search key, so evict them all
 			assert(
-				this.trunkBranches.isEmpty,
-				0x672 /* Expected no registered branches when clearing trunk */,
+				this.trunkBranches.isEmpty ||
+					// This handles the case when there are branches but they are already based off of the origin commit.
+					// TODO:#4918: Investigate if we can handle this case more gracefully by including the origin commit in `sequenceMap`
+					(this.trunkBranches.size === 1 &&
+						this.trunkBranches.minKey() === minimumPossibleSequenceNumber),
+				"Expected no outstanding branches when clearing trunk",
 			);
 			this.trunk.setHead(this.trunkBase);
 			this.sequenceMap.clear();

--- a/experimental/dds/tree2/src/shared-tree-core/index.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/index.ts
@@ -2,7 +2,12 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export { SharedTreeBranch, SharedTreeBranchChange, SharedTreeBranchEvents } from "./branch";
+export {
+	onForkTransitive,
+	SharedTreeBranch,
+	SharedTreeBranchChange,
+	SharedTreeBranchEvents,
+} from "./branch";
 
 export {
 	ChangeEvents,

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -170,8 +170,10 @@ export class SharedTree
 		return this.view.fork();
 	}
 
-	public merge(fork: SharedTreeView): void {
-		this.view.merge(fork);
+	public merge(view: SharedTreeView): void;
+	public merge(view: SharedTreeView, disposeView: boolean): void;
+	public merge(view: SharedTreeView, disposeView = true): void {
+		this.view.merge(view, disposeView);
 	}
 
 	public rebase(fork: SharedTreeView): void {

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
-import { SharedTreeBranch, SharedTreeBranchChange } from "../../shared-tree-core";
+import { onForkTransitive, SharedTreeBranch, SharedTreeBranchChange } from "../../shared-tree-core";
 import {
 	GraphCommit,
 	RevisionTag,
@@ -358,6 +358,7 @@ describe("Branches", () => {
 
 	it("cannot be mutated after disposal", () => {
 		const branch = create();
+		const fork = branch.fork();
 		branch.dispose();
 
 		function assertDisposed(fn: () => void): void {
@@ -366,14 +367,14 @@ describe("Branches", () => {
 
 		// These methods are not valid to call after disposal
 		assertDisposed(() => branch.fork());
-		assertDisposed(() => branch.rebaseOnto(branch));
+		assertDisposed(() => branch.rebaseOnto(fork));
 		assertDisposed(() => branch.merge(branch.fork()));
 		assertDisposed(() => branch.editor.apply(branch.changeFamily.rebaser.compose([])));
 		assertDisposed(() => branch.startTransaction());
 		assertDisposed(() => branch.commitTransaction());
 		assertDisposed(() => branch.abortTransaction());
 		assertDisposed(() => branch.abortTransaction());
-		assertDisposed(() => branch.dispose());
+		assertDisposed(() => fork.merge(branch));
 	});
 
 	it("correctly report whether they are in the middle of a transaction", () => {
@@ -504,6 +505,48 @@ describe("Branches", () => {
 					"Cannot merge a non-revertible branch into a revertible branch",
 				),
 		);
+	});
+
+	describe("transitive fork event", () => {
+		/** Creates forks at various "depths" and returns the number of forks created */
+		function forkTransitive<T extends { fork(): T }>(forkable: T): number {
+			forkable.fork();
+			const fork = forkable.fork();
+			fork.fork();
+			fork.fork().fork();
+			return 5;
+		}
+
+		it("registers listener on transitive forks", () => {
+			const branch = create();
+			const forks = new Set<DefaultBranch>();
+			onForkTransitive(branch, (fork) => forks.add(fork));
+			const expected = forkTransitive(branch);
+			assert.equal(forks.size, expected);
+		});
+
+		it("deregisters all listeners", () => {
+			const branch = create();
+			let forkCount = 0;
+			const deregister = onForkTransitive(branch, () => (forkCount += 1));
+			deregister();
+			forkTransitive(branch);
+			assert.equal(forkCount, 0);
+		});
+
+		it("registers listener on forks created inside of the listener", () => {
+			const branch = create();
+			let forkCount = 0;
+			onForkTransitive(branch, () => {
+				forkCount += 1;
+				assert(branch.hasListeners("fork"));
+				if (forkCount <= 1) {
+					branch.fork();
+				}
+			});
+			branch.fork();
+			assert.equal(forkCount, 2);
+		});
 	});
 
 	/** Creates a new root branch */

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -331,6 +331,13 @@ describe("EditManager", () => {
 				checkChangeList(manager, [3, 4]);
 			});
 
+			it("disregards branches which are already forked off of the origin commit", () => {
+				// This is a regression test for an assert in trunk eviction which would throw even during the following valid scenario:
+				// There are no sequenced commits that require eviction, but there are one or more outstanding branches which are already based off of the origin commit.
+				// See "TODO:#4918:" in editManager.ts
+				editManagerFactory({}).manager.localBranch.fork().fork().dispose();
+			});
+
 			// TODO:#4593: Add test to ensure that peer branches don't pass in incorrect repairDataStoreProviders when rebasing
 		});
 

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -28,10 +28,10 @@ describe("Editing", () => {
 			insert(addX, 1, "x");
 			insert(addY, 3, "y");
 
-			tree.merge(delAB);
-			tree.merge(delCD);
-			tree.merge(addX);
-			tree.merge(addY);
+			tree.merge(delAB, false);
+			tree.merge(delCD, false);
+			tree.merge(addX, false);
+			tree.merge(addY, false);
 
 			delAB.rebaseOnto(tree);
 			delCD.rebaseOnto(tree);
@@ -55,8 +55,8 @@ describe("Editing", () => {
 			const aEditor = tree3.editor.sequenceField({ parent: rootPath, field: brand("foo") });
 			aEditor.insert(0, singleTextCursor({ type: jsonString.name, value: "a" }));
 
-			tree1.merge(tree2);
-			tree1.merge(tree3);
+			tree1.merge(tree2, false);
+			tree1.merge(tree3, false);
 
 			tree2.rebaseOnto(tree1);
 			tree3.rebaseOnto(tree1);
@@ -76,9 +76,9 @@ describe("Editing", () => {
 				remove(tree2, index, 1);
 				remove(tree3, index, 1);
 
-				tree.merge(tree1);
-				tree.merge(tree2);
-				tree.merge(tree3);
+				tree.merge(tree1, false);
+				tree.merge(tree2, false);
+				tree.merge(tree3, false);
 
 				tree1.rebaseOnto(tree);
 				tree2.rebaseOnto(tree);
@@ -109,7 +109,7 @@ describe("Editing", () => {
 			const anchor = cursor.buildAnchor();
 			cursor.free();
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 
 			expectJsonTree([tree1, tree2], ["x", "y", "a", "b", "c"]);
@@ -131,7 +131,7 @@ describe("Editing", () => {
 			remove(delY, 1, 1);
 			insert(addW, 0, "w");
 
-			addW.merge(delY);
+			addW.merge(delY, false);
 			delY.rebaseOnto(addW);
 
 			expectJsonTree([addW, delY], ["w", "x"]);
@@ -147,9 +147,9 @@ describe("Editing", () => {
 			insert(rst, 0, "r", "s", "t");
 			insert(xyz, 0, "x", "y", "z");
 
-			tree.merge(xyz);
-			tree.merge(rst);
-			tree.merge(abc);
+			tree.merge(xyz, false);
+			tree.merge(rst, false);
+			tree.merge(abc, false);
 
 			xyz.rebaseOnto(tree);
 			rst.rebaseOnto(tree);
@@ -188,9 +188,9 @@ describe("Editing", () => {
 			tree.merge(s);
 			tree.merge(b);
 			tree.merge(y);
-			tree.merge(c);
-			tree.merge(z);
-			tree.merge(t);
+			tree.merge(c, false);
+			tree.merge(z, false);
+			tree.merge(t, false);
 
 			c.rebaseOnto(tree);
 			t.rebaseOnto(tree);
@@ -287,7 +287,7 @@ describe("Editing", () => {
 				})
 				.move(0, 1, 1);
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 			expectJsonTree(tree1, ["B", "A", "C"]);
 			expectJsonTree(tree2, ["B", "A", "C"]);
@@ -310,7 +310,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 
 			const expectedState: JsonCompatible = [{ foo: "C" }, "A"];
@@ -335,7 +335,7 @@ describe("Editing", () => {
 			const editor = tree1.editor.valueField({ parent, field: brand("foo") });
 			editor.set(singleTextCursor({ type: jsonString.name, value: "C" }));
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 
 			const expectedState: JsonCompatible = [{ foo: "C" }, "A"];
@@ -382,7 +382,7 @@ describe("Editing", () => {
 				},
 			];
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 
 			expectJsonTree([tree1, tree2], expectedState);
@@ -427,7 +427,7 @@ describe("Editing", () => {
 				},
 			];
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 			expectJsonTree([tree1, tree2], expectedState);
 		});
@@ -528,7 +528,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}]);
@@ -567,7 +567,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}]);
@@ -607,7 +607,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}, { bar: ["a"] }]);
@@ -649,7 +649,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}, {}]);
@@ -691,7 +691,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}]);
@@ -732,7 +732,7 @@ describe("Editing", () => {
 			// Undo move to bar
 			tree2.undo();
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}]);
@@ -773,7 +773,7 @@ describe("Editing", () => {
 			// Undo move to bar
 			tree2.undo();
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}]);
@@ -810,8 +810,8 @@ describe("Editing", () => {
 				.set(singleTextCursor({ type: jsonString.name, value: "b" }));
 			tree2.editor.sequenceField({ parent: foo1, field: brand("bar") }).delete(0, 1);
 
-			tree.merge(tree1);
-			tree.merge(tree2);
+			tree.merge(tree1, false);
+			tree.merge(tree2, false);
 			tree1.rebaseOnto(tree);
 			tree2.rebaseOnto(tree);
 
@@ -1056,7 +1056,7 @@ describe("Editing", () => {
 			const editor = tree2.editor.valueField({ parent: rootPath, field: brand("foo") });
 			editor.set(singleTextCursor({ type: jsonString.name, value: "43" }));
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 
 			expectJsonTree([tree1, tree2], [{ foo: "43" }]);
@@ -1084,7 +1084,7 @@ describe("Editing", () => {
 			const editor = tree2.editor.valueField({ parent: rootPath, field: brand("foo") });
 			editor.set(singleTextCursor({ type: jsonString.name, value: "42" }));
 
-			tree1.merge(tree2);
+			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
 
 			expectJsonTree([tree1, tree2], [{ foo: "42" }]);
@@ -1122,12 +1122,12 @@ describe("Editing", () => {
 				.optionalField({ parent: undefined, field: rootFieldKeySymbol })
 				.set(undefined, false);
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			tree2.undo();
 
-			tree.merge(tree2);
+			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], ["43"]);
@@ -1178,7 +1178,7 @@ describe("Editing", () => {
 				tree2Sequence.insert(1, singleJsonCursor("b"));
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], [{ foo: "bar" }, "b"]);
@@ -1223,7 +1223,7 @@ describe("Editing", () => {
 				tree2Sequence.insert(1, singleTextCursor({ type: jsonString.name, value: "b" }));
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], []);
@@ -1257,7 +1257,7 @@ describe("Editing", () => {
 				);
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], ["a"]);
@@ -1287,7 +1287,7 @@ describe("Editing", () => {
 				sequence.insert(0, singleTextCursor({ type: jsonString.name, value: "c" }));
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], ["c", "a", "b"]);
@@ -1324,7 +1324,7 @@ describe("Editing", () => {
 					.insert(0, singleJsonCursor(1));
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], [{}]);
@@ -1363,7 +1363,7 @@ describe("Editing", () => {
 					.insert(0, singleJsonCursor(1));
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], [{ foo: "x", bar: 1 }]);
@@ -1407,7 +1407,7 @@ describe("Editing", () => {
 					singleTextCursor({ type: jsonString.name, value: "c" }),
 				);
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], ["c", "a", "b"]);
@@ -1452,7 +1452,7 @@ describe("Editing", () => {
 				});
 				tree2Sequence.insert(1, singleTextCursor({ type: jsonString.name, value: "c" }));
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], [{ foo: "a" }, "c", "b"]);
@@ -1552,7 +1552,7 @@ describe("Editing", () => {
 				tree2RootSequence.insert(2, singleTextCursor({ type: jsonObject.name }));
 				tree2.transaction.commit();
 
-				tree.merge(tree2);
+				tree.merge(tree2, false);
 				tree2.rebaseOnto(tree);
 
 				expectJsonTree([tree, tree2], [{ foo2: ["a"] }, {}]);

--- a/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
@@ -126,12 +126,12 @@ describe("Undo and redo", () => {
 			// Perform the edits where the last edit is the one to undo
 			edit(view, fork);
 
-			view.merge(fork);
+			view.merge(fork, false);
 			expectJsonTree(view, editedState);
 
 			view.undo();
 
-			view.merge(fork);
+			view.merge(fork, false);
 			expectJsonTree(view, parentUndoState ?? initialState);
 
 			view.redo();


### PR DESCRIPTION
## Description

This makes some changes to the branching API, how it interacts with transactions, and related APIs. Namely:

* Branches that merge into other branches are now automatically disposed, unless explicitly told not to. If the target branch is in the middle of a transaction, the branch being merged in _must_ be automatically disposed.
* Merging a branch which is disposed now fails.
* If a branch is in the middle of a transaction and is merged into another branch, its transaction(s) is/are automatically committed.
* `SharedTreeBranch`'s `dispose` method can now be called multiple times (second calls have no effect).
 
This PR also fixes a bug in trunk eviction and adds a helper for registering listeners on a branch and all of its descendants.

An additional bug was discovered regarding branch merging during the detached phase, and a bug has been filed.

## Breaking Changes

Branches are now automatically disposed when merged; to prevent this and maintain the previous behavior, pass `false` as the second argument to the `merge` method.
