### PR TITLE
fix(protocol-base): Correct spelling of buildGitTreeHierarchy

### DIFF
--- a/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
@@ -9,7 +9,7 @@ import { stringToBuffer } from "@fluidframework/common-utils";
 import { INormalizedWholeSummary } from "./contracts";
 
 /**
- * Build a tree heirarchy from a flat tree.
+ * Build a tree hierarchy from a flat tree.
  *
  * @param flatTree - a flat tree
  * @param treePrefixToRemove - tree prefix to strip

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -289,7 +289,7 @@ function convertFullSummaryToWholeSummaryEntries(
 		});
 	});
 
-	// Inspired by `buildSummaryTreeHeirarchy` from services-client
+	// Inspired by `buildSummaryTreeHierarchy` from services-client
 	const lookup: { [path: string]: IWholeSummaryTreeValueEntry & { value: IWholeSummaryTree } } =
 		{};
 	const rootPath = ""; // This would normally be parentHandle, but only important when there are handles

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -22,7 +22,7 @@ import { SummaryObject } from '@fluidframework/protocol-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
-export function buildGitTreeHeirarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
+export function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
 
 // @public
 export function getGitMode(value: SummaryObject): string;

--- a/server/routerlicious/packages/protocol-base/src/gitHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/gitHelper.ts
@@ -51,7 +51,7 @@ export function getGitType(value: SummaryObject): "blob" | "tree" {
 }
 
 /**
- * NOTE: Renamed from `buildHierarchy` to `buildGitTreeHeirarchy`. There is usage of this function in loader and driver layer.
+ * NOTE: Renamed from `buildHierarchy` to `buildGitTreeHierarchy`. There is usage of this function in loader and driver layer.
  * Build a tree hierarchy base on a flat tree
  *
  * @param flatTree - a flat tree
@@ -59,7 +59,7 @@ export function getGitType(value: SummaryObject): "blob" | "tree" {
  * @param removeAppTreePrefix - Remove `.app/` from beginning of paths when present
  * @returns the hierarchical tree
  */
-export function buildGitTreeHeirarchy(
+export function buildGitTreeHierarchy(
 	flatTree: git.ITree,
 	blobsShaToPathCache: Map<string, string> = new Map<string, string>(),
 	removeAppTreePrefix = false,

--- a/server/routerlicious/packages/protocol-base/src/index.ts
+++ b/server/routerlicious/packages/protocol-base/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { buildGitTreeHeirarchy, getGitMode, getGitType } from "./gitHelper";
+export { buildGitTreeHierarchy, getGitMode, getGitType } from "./gitHelper";
 export { IProtocolHandler, IScribeProtocolState, ProtocolOpHandler } from "./protocol";
 export {
 	IQuorumSnapshot,

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import * as resources from "@fluidframework/gitresources";
-import { buildGitTreeHeirarchy } from "@fluidframework/protocol-base";
+import { buildGitTreeHierarchy } from "@fluidframework/protocol-base";
 import * as api from "@fluidframework/protocol-definitions";
 import { debug } from "./debug";
 import {
@@ -32,7 +32,7 @@ export class GitManager implements IGitManager {
 			this.blobCache.set(blob.sha, blob);
 		}
 
-		return buildGitTreeHeirarchy(header.tree);
+		return buildGitTreeHierarchy(header.tree);
 	}
 
 	public async getFullTree(sha: string): Promise<any> {

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -145,13 +145,13 @@ export function convertSummaryTreeToWholeSummaryTree(
 }
 
 /**
- * Build a tree heirarchy from a flat tree.
+ * Build a tree hierarchy from a flat tree.
  *
  * @param flatTree - a flat tree
  * @param treePrefixToRemove - tree prefix to strip
  * @returns the heirarchical tree
  */
-function buildSummaryTreeHeirarchy(
+function buildSummaryTreeHierarchy(
 	flatTree: IWholeFlatSummaryTree,
 	treePrefixToRemove: string,
 ): ISnapshotTree {
@@ -208,7 +208,7 @@ export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
 	}
 	const flatSummaryTree = flatSummary.trees?.[0];
 	const sequenceNumber = flatSummaryTree?.sequenceNumber;
-	const snapshotTree = buildSummaryTreeHeirarchy(flatSummaryTree, treePrefixToRemove);
+	const snapshotTree = buildSummaryTreeHierarchy(flatSummaryTree, treePrefixToRemove);
 
 	return {
 		blobs,


### PR DESCRIPTION
The buildGitTreeHierarchy function name was misspelled, so I corrected it. We haven't yet released any version with the misspelled name (though there is a prerelease version that contains it), so it's safe to just correct it. No need to export the old wrong name for backwards compat.

I also corrected some similar misspellings in other unexported APIs and in some comments.