### PR TITLE
Cleanup: Just throw, rather than return Promise.reject

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/src/templateValidator.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/templateValidator.ts
@@ -710,10 +710,10 @@ const _validateContextAsync = async function (in_template) {
 
 	const error = getInvalidContextError(context);
 	if (error) {
-		return Promise.reject(error);
+		throw error;
 	}
 	if (context === "map" && in_template.contextKeyType === "typeid") {
-		return Promise.reject(new Error(MSG.INVALID_OPTION_NONE_CONSTANTS));
+		throw new Error(MSG.INVALID_OPTION_NONE_CONSTANTS);
 	}
 	// If context is not 'set' validation doesn't apply
 	if (context !== "set") {
@@ -728,7 +728,7 @@ const _validateContextAsync = async function (in_template) {
 	} else {
 		// Since context is 'set' the template must eventually inherit from NamedProperty
 		if (in_template.inherits === undefined) {
-			return Promise.reject(new Error(MSG.SET_ONLY_NAMED_PROPS));
+			throw new Error(MSG.SET_ONLY_NAMED_PROPS);
 		}
 
 		// Since context is 'set' the template must eventually inherit from NamedProperty (same as above)
@@ -757,14 +757,14 @@ const _validateContextAsync = async function (in_template) {
 		.then(function (results) {
 			const foundNamedPropertyDescendant = find(results, (res) => res);
 			if (!foundNamedPropertyDescendant) {
-				return Promise.reject(Error(MSG.SET_ONLY_NAMED_PROPS));
+				throw Error(MSG.SET_ONLY_NAMED_PROPS);
 			}
 
 			return that._hasSchemaAsync(in_template.typeid);
 		})
 		.then(function (hasIt) {
 			if (!hasIt) {
-				return Promise.reject(new Error(MSG.SET_ONLY_NAMED_PROPS));
+				throw new Error(MSG.SET_ONLY_NAMED_PROPS);
 			}
 
 			return that._inheritsFromAsync(in_template.typeid, "NamedProperty");
@@ -774,7 +774,7 @@ const _validateContextAsync = async function (in_template) {
 				return undefined;
 			}
 
-			return Promise.reject(new Error(MSG.SET_ONLY_NAMED_PROPS));
+			throw new Error(MSG.SET_ONLY_NAMED_PROPS);
 		});
 };
 

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
@@ -76,9 +76,7 @@ async function initializeFluidOfficeOrOneNote(urlSource: URL): Promise<IOdspUrlP
 	const storageType = decodedSite.split(":")[0];
 	const expectedStorageType = "spo"; // Only support spo for now
 	if (storageType !== expectedStorageType) {
-		return Promise.reject(
-			new Error(`Unexpected storage type ${storageType}, expected: ${expectedStorageType}`),
-		);
+		throw new Error(`Unexpected storage type ${storageType}, expected: ${expectedStorageType}`);
 	}
 
 	// Since we have the drive and item, only take the host ignore the rest

--- a/packages/drivers/replay-driver/src/replayController.ts
+++ b/packages/drivers/replay-driver/src/replayController.ts
@@ -22,15 +22,15 @@ export abstract class ReadDocumentStorageServiceBase implements IDocumentStorage
 		summary: api.ISummaryTree,
 		context: ISummaryContext,
 	): Promise<string> {
-		return Promise.reject(new Error("Invalid operation"));
+		throw new Error("Invalid operation");
 	}
 
 	public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
-		return Promise.reject(new Error("Invalid operation"));
+		throw new Error("Invalid operation");
 	}
 
 	public async downloadSummary(handle: api.ISummaryHandle): Promise<api.ISummaryTree> {
-		return Promise.reject(new Error("Invalid operation"));
+		throw new Error("Invalid operation");
 	}
 
 	public get repositoryUrl(): string {

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -67,7 +67,7 @@ export class ReplayControllerStatic extends ReplayController {
 	}
 
 	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-		return Promise.reject(new Error("Invalid operation"));
+		throw new Error("Invalid operation");
 	}
 
 	public async getStartingOpSequence(): Promise<number> {

--- a/packages/drivers/routerlicious-driver/src/nullBlobStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/nullBlobStorageService.ts
@@ -27,17 +27,17 @@ export class NullBlobStorageService implements IDocumentStorageService {
 		summary: api.ISummaryTree,
 		context: ISummaryContext,
 	): Promise<string> {
-		return Promise.reject(new Error("Invalid operation"));
+		throw new Error("Invalid operation");
 	}
 
 	public async downloadSummary(handle: api.ISummaryHandle): Promise<api.ISummaryTree> {
-		return Promise.reject(new Error("Invalid operation"));
+		throw new Error("Invalid operation");
 	}
 
 	public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
-		return Promise.reject(new Error("Null blob storage can not create blob"));
+		throw new Error("Null blob storage can not create blob");
 	}
 	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-		return Promise.reject(new Error("Null blob storage can not read blob"));
+		throw new Error("Null blob storage can not read blob");
 	}
 }

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -254,7 +254,7 @@ async function fetchBlobsFromVersion(storage: IDocumentStorageService, version: 
 		storage.getSnapshotTree(version),
 	);
 	if (!tree) {
-		return Promise.reject(new Error("Failed to load snapshot tree"));
+		throw new Error("Failed to load snapshot tree");
 	}
 	return fetchBlobsFromSnapshotTree(storage, tree);
 }

--- a/packages/tools/replay-tool/src/replayLoaderObject.ts
+++ b/packages/tools/replay-tool/src/replayLoaderObject.ts
@@ -22,7 +22,7 @@ export class ReplayUrlResolver implements IUrlResolver {
 
 	public async resolve(request: IRequest): Promise<IResolvedUrl> {
 		if (!this.cache.has(request.url)) {
-			return Promise.reject(new Error(`ContainerUrlResolver can't resolve ${request}`));
+			throw new Error(`ContainerUrlResolver can't resolve ${request}`);
 		}
 		return this.cache.get(request.url);
 	}

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -380,10 +380,10 @@ export class ReplayTool {
 
 	private async setup() {
 		if (this.args.inDirName === undefined) {
-			return Promise.reject(new Error("Please provide --indir argument"));
+			throw new Error("Please provide --indir argument");
 		}
 		if (!fs.existsSync(this.args.inDirName)) {
-			return Promise.reject(new Error("File does not exist"));
+			throw new Error("File does not exist");
 		}
 
 		this.deltaStorageService = new FileDeltaStorageService(this.args.inDirName);
@@ -438,9 +438,7 @@ export class ReplayTool {
 				);
 			}
 			if (this.mainDocument.currentOp > this.args.to) {
-				return Promise.reject(
-					new Error("--to argument is below snapshot starting op. Nothing to do!"),
-				);
+				throw new Error("--to argument is below snapshot starting op. Nothing to do!");
 			}
 		}
 

--- a/packages/utils/odsp-doclib-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDrives.ts
@@ -88,7 +88,7 @@ export async function getDriveItemByServerRelativePath(
 		pathParts.shift();
 	}
 	if (pathParts.length === 0) {
-		return Promise.reject(new Error(`Invalid serverRelativePath ${serverRelativePath}`));
+		throw new Error(`Invalid serverRelativePath ${serverRelativePath}`);
 	}
 	if (
 		pathParts.length >= 2 &&

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -91,16 +91,16 @@ export class NodegitRepositoryManager extends RepositoryManagerBase {
 				try {
 					const result = await this.externalStorageManager.read(this.repoName, sha);
 					if (!result) {
-						return Promise.reject(err);
+						throw err;
 					}
 					return this.getCommits(sha, count, externalWriterConfig);
 				} catch (bridgeError) {
 					// If file does not exist or error trying to look up commit, return the original error.
 					Lumberjack.error("BridgeError", lumberjackProperties, bridgeError);
-					return Promise.reject(err);
+					throw err;
 				}
 			}
-			return Promise.reject(err);
+			throw err;
 		}
 	}
 
@@ -262,7 +262,7 @@ export class NodegitRepositoryManager extends RepositoryManagerBase {
 				try {
 					const result = await this.externalStorageManager.read(this.repoName, fileName);
 					if (!result) {
-						return Promise.reject(err);
+						throw err;
 					}
 					return this.getRef(refId, externalWriterConfig);
 				} catch (bridgeError) {
@@ -271,10 +271,10 @@ export class NodegitRepositoryManager extends RepositoryManagerBase {
 						lumberjackProperties,
 						bridgeError,
 					);
-					return Promise.reject(err);
+					throw err;
 				}
 			}
-			return Promise.reject(err);
+			throw err;
 		}
 	}
 

--- a/server/historian/packages/historian-base/src/services/redisCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisCache.ts
@@ -48,7 +48,7 @@ export class RedisCache implements ICache {
 			expireAfterSeconds,
 		);
 		if (result !== "OK") {
-			throw result;
+			throw new Error(result);
 		}
 	}
 

--- a/server/historian/packages/historian-base/src/services/redisCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisCache.ts
@@ -48,7 +48,7 @@ export class RedisCache implements ICache {
 			expireAfterSeconds,
 		);
 		if (result !== "OK") {
-			return Promise.reject(result);
+			throw result;
 		}
 	}
 

--- a/server/historian/packages/historian-base/src/services/redisTenantCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisTenantCache.ts
@@ -41,7 +41,7 @@ export class RedisTenantCache {
 	): Promise<void> {
 		const result = await this.client.set(this.getKey(key), value, "EX", expireAfterSeconds);
 		if (result !== "OK") {
-			return Promise.reject(result);
+			throw result;
 		}
 	}
 

--- a/server/historian/packages/historian-base/src/services/redisTenantCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisTenantCache.ts
@@ -41,7 +41,7 @@ export class RedisTenantCache {
 	): Promise<void> {
 		const result = await this.client.set(this.getKey(key), value, "EX", expireAfterSeconds);
 		if (result !== "OK") {
-			throw result;
+			throw new Error(result);
 		}
 	}
 

--- a/server/historian/packages/historian-base/src/test/utils/testTenantService.ts
+++ b/server/historian/packages/historian-base/src/test/utils/testTenantService.ts
@@ -24,6 +24,6 @@ export class TestTenantService implements ITenantService {
 	}
 
 	async deleteFromCache(tenantId: string, token: string): Promise<boolean> {
-		return Promise.reject(new Error("Method not implemented."));
+		throw new Error("Method not implemented.");
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -44,7 +44,7 @@ export class CheckpointManager {
 
 		// No recovery once entering an error state
 		if (this.error) {
-			return Promise.reject(this.error);
+			throw this.error;
 		}
 
 		// Exit early if already caught up
@@ -103,7 +103,7 @@ export class CheckpointManager {
 				if (this.pendingCheckpoint) {
 					this.pendingCheckpoint.reject(this.error);
 				}
-				return Promise.reject(error);
+				throw error;
 			},
 		);
 	}

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/testDocumentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/testDocumentLambda.ts
@@ -69,7 +69,7 @@ export class TestLambdaFactory extends EventEmitter implements IPartitionLambdaF
 		context: IContext,
 	): Promise<IPartitionLambda> {
 		if (this.failCreatelambda) {
-			return Promise.reject(new Error("Test failure"));
+			throw new Error("Test failure");
 		} else {
 			const lambda = new TestLambda(config, context);
 			this.lambdas.push(lambda);

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/testPartitionLambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/testPartitionLambdaFactory.ts
@@ -56,7 +56,7 @@ export class TestPartitionLambdaFactory extends EventEmitter implements IPartiti
 
 	public async create(config: undefined, context: IContext): Promise<IPartitionLambda> {
 		if (this.failCreate) {
-			return Promise.reject(new Error("Set to fail create"));
+			throw new Error("Set to fail create");
 		}
 
 		const lambda = new TestLambda(this, this.throwHandler, context);

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -282,6 +282,7 @@ export function configureWebSocketServices(
 				logger,
 			);
 			if (throttleErrorPerCluster) {
+				// eslint-disable-next-line @typescript-eslint/no-throw-literal
 				throw throttleErrorPerCluster;
 			}
 			const throttleErrorPerTenant = checkThrottleAndUsage(
@@ -291,6 +292,7 @@ export function configureWebSocketServices(
 				logger,
 			);
 			if (throttleErrorPerTenant) {
+				// eslint-disable-next-line @typescript-eslint/no-throw-literal
 				throw throttleErrorPerTenant;
 			}
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -282,7 +282,7 @@ export function configureWebSocketServices(
 				logger,
 			);
 			if (throttleErrorPerCluster) {
-				return Promise.reject(throttleErrorPerCluster);
+				throw throttleErrorPerCluster;
 			}
 			const throttleErrorPerTenant = checkThrottleAndUsage(
 				connectThrottlerPerTenant,
@@ -291,7 +291,7 @@ export function configureWebSocketServices(
 				logger,
 			);
 			if (throttleErrorPerTenant) {
-				return Promise.reject(throttleErrorPerTenant);
+				throw throttleErrorPerTenant;
 			}
 
 			if (!message.token) {

--- a/server/routerlicious/packages/lambdas/src/copier/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/copier/lambda.ts
@@ -95,7 +95,7 @@ export class CopierLambda implements IPartitionLambda {
 			// All other errors result in a rejected promise.
 			if (error.code !== 11000) {
 				// Needs to be a full rejection here
-				return Promise.reject(error);
+				throw error;
 			}
 		});
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -239,15 +239,15 @@ async function verifyTokenWrapper(
 ): Promise<void> {
 	const token = request.headers["access-token"] as string;
 	if (!token) {
-		return Promise.reject(new Error("Missing access token in request header."));
+		throw new Error("Missing access token in request header.");
 	}
 	const tenantId = getParam(request.params, "tenantId");
 	if (!tenantId) {
-		return Promise.reject(new Error("Missing tenantId in request."));
+		throw new Error("Missing tenantId in request.");
 	}
 	const documentId = getParam(request.params, "id");
 	if (!documentId) {
-		return Promise.reject(new Error("Missing documentId in request."));
+		throw new Error("Missing documentId in request.");
 	}
 	const claims = validateTokenClaims(token, documentId, tenantId);
 	if (isTokenExpiryEnabled) {
@@ -261,7 +261,7 @@ async function verifyTokenWrapper(
 			claims.jti,
 		);
 		if (tokenRevoked) {
-			return Promise.reject(new Error("Permission denied. Token is revoked."));
+			throw new Error("Permission denied. Token is revoked.");
 		}
 	}
 
@@ -289,11 +289,11 @@ async function checkDocumentExistence(
 	const tenantId = getParam(request.params, "tenantId");
 	const documentId = getParam(request.params, "id");
 	if (!tenantId || !documentId) {
-		return Promise.reject(new Error("Invalid tenant or document id"));
+		throw new Error("Invalid tenant or document id");
 	}
 	const document = await storage.getDocument(tenantId, documentId);
 	if (!document || document.scheduledDeletionTime) {
-		return Promise.reject(new Error("Cannot access document marked for deletion"));
+		throw new Error("Cannot access document marked for deletion");
 	}
 }
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -68,7 +68,7 @@ export class OrdererManager implements core.IOrdererManager {
 
 		if (tenant.orderer.url !== this.ordererUrl && !this.globalDbEnabled) {
 			Lumberjack.error(`Invalid ordering service endpoint`, { messageMetaData });
-			return Promise.reject(new Error("Invalid ordering service endpoint"));
+			throw new Error("Invalid ordering service endpoint");
 		}
 
 		switch (tenant.orderer.type) {

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -72,7 +72,7 @@ export async function runWithRetry<T>(
 						telemetryProperties,
 						error,
 					);
-					return Promise.reject(error);
+					throw error;
 				}
 				// if maxRetries is -1, we retry indefinitely
 				// unless shouldRetry returns false at some point.
@@ -83,7 +83,7 @@ export async function runWithRetry<T>(
 						error,
 					);
 					// Needs to be a full rejection here
-					return Promise.reject(error);
+					throw error;
 				}
 
 				const intervalMs = calculateIntervalMs(error, retryCount, retryAfterMs);
@@ -177,7 +177,7 @@ export async function requestWithRetry<T>(
 						telemetryProperties,
 						error,
 					);
-					return Promise.reject(error);
+					throw error;
 				}
 				// if maxRetries is -1, we retry indefinitely
 				// unless shouldRetry returns false at some point.
@@ -188,7 +188,7 @@ export async function requestWithRetry<T>(
 						error,
 					);
 					// Needs to be a full rejection here
-					return Promise.reject(error);
+					throw error;
 				}
 
 				// TODO: if error is a NetworkError, we should respect NetworkError.retryAfter

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -42,7 +42,7 @@ export async function run<T extends IResources>(
 			error.forceKill = true;
 			error.runnerStopException = innerError;
 		});
-		return Promise.reject(error);
+		throw error;
 	});
 
 	process.on("SIGTERM", () => {

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -465,7 +465,7 @@ export class DocumentStorage implements IDocumentStorage {
 				// Duplicate key errors are ignored
 				if (error.code !== 11000) {
 					// Needs to be a full rejection here
-					return Promise.reject(error);
+					throw error;
 				}
 			});
 			winston.info(`Inserted ${dbOps.length} ops into deltas DB`);

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -20,7 +20,7 @@ export async function deleteSummarizedOps(
 			`Operation deletion is not enabled`,
 			FluidServiceErrorCode.FeatureDisabled,
 		);
-		return Promise.reject(error);
+		throw error;
 	}
 
 	// Following code would nv

--- a/server/routerlicious/packages/services/src/nodeCodeLoader.ts
+++ b/server/routerlicious/packages/services/src/nodeCodeLoader.ts
@@ -51,7 +51,7 @@ export class NodeCodeLoader {
 	private async installOrWaitForPackages(pkg: string): Promise<string> {
 		const dataStores = pkg.match(/(.*)\/(.*)@(.*)/);
 		if (!dataStores) {
-			return Promise.reject(new Error("Invalid package"));
+			throw new Error("Invalid package");
 		}
 		const [, scope, name] = dataStores;
 

--- a/server/routerlicious/packages/services/src/redis.ts
+++ b/server/routerlicious/packages/services/src/redis.ts
@@ -51,7 +51,7 @@ export class RedisCache implements ICache {
 			expireAfterSeconds ?? this.expireAfterSeconds,
 		);
 		if (result !== "OK") {
-			return Promise.reject(result);
+			throw result;
 		}
 	}
 
@@ -64,7 +64,7 @@ export class RedisCache implements ICache {
 				undefined,
 				error,
 			);
-			return Promise.reject(error);
+			throw error;
 		}
 	}
 
@@ -77,7 +77,7 @@ export class RedisCache implements ICache {
 				undefined,
 				error,
 			);
-			return Promise.reject(error);
+			throw error;
 		}
 	}
 

--- a/server/routerlicious/packages/services/src/redis.ts
+++ b/server/routerlicious/packages/services/src/redis.ts
@@ -51,7 +51,7 @@ export class RedisCache implements ICache {
 			expireAfterSeconds ?? this.expireAfterSeconds,
 		);
 		if (result !== "OK") {
-			throw result;
+			throw new Error(result);
 		}
 	}
 

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -29,7 +29,7 @@ export class TestCollection implements ICollection<any> {
 	public async update(filter: any, set: any, addToSet: any): Promise<void> {
 		const value = this.findOneInternal(filter);
 		if (!value) {
-			return Promise.reject(new Error("Not found"));
+			throw new Error("Not found");
 		}
 		_.extend(value, set);
 	}
@@ -44,7 +44,7 @@ export class TestCollection implements ICollection<any> {
 				_.extend(value, set);
 			});
 		} catch (e) {
-			return Promise.reject(e);
+			throw e;
 		}
 	}
 

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -36,16 +36,12 @@ export class TestCollection implements ICollection<any> {
 
 	public async updateMany(filter: any, set: any, addToSet: any): Promise<void> {
 		const values = this.findInternal(filter);
-		try {
-			values.forEach((value) => {
-				if (!value) {
-					throw new Error("Not found");
-				}
-				_.extend(value, set);
-			});
-		} catch (e) {
-			throw e;
-		}
+		values.forEach((value) => {
+			if (!value) {
+				throw new Error("Not found");
+			}
+			_.extend(value, set);
+		});
 	}
 
 	public async upsert(filter: any, set: any, addToSet: any): Promise<void> {

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -46,7 +46,7 @@ export class TestConsumer implements IConsumer {
 		assert(partitionId === 0);
 
 		if (this.failOnCommit) {
-			return Promise.reject(new Error("TestConsumer set to fail on commit"));
+			throw new Error("TestConsumer set to fail on commit");
 		} else {
 			this.context.checkpoint(queuedMessage);
 			return;

--- a/server/tinylicious/src/services/inMemorycollection.ts
+++ b/server/tinylicious/src/services/inMemorycollection.ts
@@ -45,7 +45,7 @@ export class Collection<T> implements ICollection<T> {
 	public async update(filter: any, set: any, addToSet: any): Promise<void> {
 		const value = this.findOneInternal(filter);
 		if (!value) {
-			return Promise.reject(new Error("Not found"));
+			throw new Error("Not found");
 		}
 		_.extend(value, set);
 	}

--- a/server/tinylicious/src/services/levelDbCollection.ts
+++ b/server/tinylicious/src/services/levelDbCollection.ts
@@ -64,7 +64,7 @@ export class Collection<T> implements ICollection<T> {
 	public async update(filter: any, set: any, addToSet: any): Promise<void> {
 		const value = await this.findOneInternal(filter);
 		if (!value) {
-			return Promise.reject(new Error("Not found"));
+			throw new Error("Not found");
 		} else {
 			_.extend(value, set);
 			return this.insertOne(value);


### PR DESCRIPTION
Promise.reject should not generally be used, and almost never returned. This PR replaces `return Promise.reject(...)` with `throw ...` which is semantically equivalent, but takes less code, and more accurately matches intent.