### PR TITLE
Removed comment from GC trailing op test that says errors are unexpected

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -147,7 +147,6 @@ describeNoCompat("GC trailing ops tests", (getTestObjectProvider) => {
 			assert(blobTimestamp2 !== undefined, `Should have unreferenced blob`);
 		});
 
-		// Note: we should not need an itExpects here as this error should not have fired.
 		itExpects(
 			`A summary has a datastore and blob unreferenced, but trailing ops referenced them ${
 				tombstoneEnabled ? "after sweep timeout" : "before sweep timeout"


### PR DESCRIPTION
The test added by #13491 added a comment that the errors in `itExpects` block are not expected. However, these are expected because when the summarizer client loads from a snapshot, it initializes unreferenced state from it when it transitions to write mode. So, if any node is sweep ready, its usage will result in the sweep ready logs. 
However, note that these nodes won't be deleted until the next GC happens which will mark them as referenced because the trailing ops will be processed. So, it's just an issue with logging.

Removing the comment that says the errors are unexpected.

[AB#3141](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3141)