### PR TITLE
Compile ESM in @fluid-experimental/devtools-core

### DIFF
--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -15,10 +15,12 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",
+		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
+		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"ci:build:docs": "api-extractor run && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
-		"clean": "rimraf _api-extractor-temp nyc dist *.tsbuildinfo *.build.log",
+		"clean": "rimraf _api-extractor-temp nyc dist lib *.tsbuildinfo *.build.log",
 		"eslint": "eslint src",
 		"eslint:fix": "eslint src --fix",
 		"format": "npm run prettier:fix",

--- a/packages/tools/devtools/devtools-core/tsconfig.esnext.json
+++ b/packages/tools/devtools/devtools-core/tsconfig.esnext.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./lib",
+		"module": "esnext",
+	},
+}


### PR DESCRIPTION
#### Description 

https://dev.azure.com/fluidframework/internal/_workitems/edit/4725/


Fluid Framework adopts both ESM (https://nodejs.org/api/esm.html#modules-ecmascript-modules) and also provides CommonJS module format (for internal test purposes). This PR makes the `@fluid-experimental/devtools-core` to target ESM when compiling. 


Related PRs
https://github.com/microsoft/FluidFramework/pull/16331
https://github.com/microsoft/FluidFramework/pull/16308
