### PR TITLE
fix(protocol-base): Add misspelled API back to the package

### DIFF
--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -22,7 +22,9 @@ import { SummaryObject } from '@fluidframework/protocol-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
-export function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
+function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
+export { buildGitTreeHierarchy as buildGitTreeHeirarchy }
+export { buildGitTreeHierarchy }
 
 // @public
 export function getGitMode(value: SummaryObject): string;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -22,7 +22,7 @@ import { SummaryObject } from '@fluidframework/protocol-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public @deprecated
-export function buildGitTreeHeirarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
+export const buildGitTreeHeirarchy: typeof buildGitTreeHierarchy;
 
 // @public
 export function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -21,10 +21,11 @@ import { ISnapshotTreeEx } from '@fluidframework/protocol-definitions';
 import { SummaryObject } from '@fluidframework/protocol-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
+// @public @deprecated
+export function buildGitTreeHeirarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
+
 // @public
-function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
-export { buildGitTreeHierarchy as buildGitTreeHeirarchy }
-export { buildGitTreeHierarchy }
+export function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
 
 // @public
 export function getGitMode(value: SummaryObject): string;

--- a/server/routerlicious/packages/protocol-base/src/gitHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/gitHelper.ts
@@ -100,6 +100,12 @@ export function buildGitTreeHierarchy(
  * The buildGitTreeHierarchy was misspelled when originally implemented, so it is exported here with the misspelled name
  * so that code that expects the bad name can find it.
  *
- * @deprecated - Use buildGitTreeHierarchy instead.
+ * @deprecated Use buildGitTreeHierarchy instead.
  */
-export { buildGitTreeHierarchy as buildGitTreeHeirarchy };
+export function buildGitTreeHeirarchy(
+	flatTree: git.ITree,
+	blobsShaToPathCache: Map<string, string> = new Map<string, string>(),
+	removeAppTreePrefix = false,
+): ISnapshotTreeEx {
+	return buildGitTreeHierarchy(flatTree, blobsShaToPathCache, removeAppTreePrefix);
+}

--- a/server/routerlicious/packages/protocol-base/src/gitHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/gitHelper.ts
@@ -58,6 +58,9 @@ export function getGitType(value: SummaryObject): "blob" | "tree" {
  * @param blobsShaToPathCache - Map with blobs sha as keys and values as path of the blob.
  * @param removeAppTreePrefix - Remove `.app/` from beginning of paths when present
  * @returns the hierarchical tree
+ *
+ * @remarks
+ * This function is exported as two different names for backwards-compatibility.
  */
 export function buildGitTreeHierarchy(
 	flatTree: git.ITree,
@@ -92,3 +95,11 @@ export function buildGitTreeHierarchy(
 
 	return root;
 }
+
+/**
+ * The buildGitTreeHierarchy was misspelled when originally implemented, so it is exported here with the misspelled name
+ * so that code that expects the bad name can find it.
+ *
+ * @deprecated - Use buildGitTreeHierarchy instead.
+ */
+export { buildGitTreeHierarchy as buildGitTreeHeirarchy };

--- a/server/routerlicious/packages/protocol-base/src/gitHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/gitHelper.ts
@@ -102,10 +102,4 @@ export function buildGitTreeHierarchy(
  *
  * @deprecated Use buildGitTreeHierarchy instead.
  */
-export function buildGitTreeHeirarchy(
-	flatTree: git.ITree,
-	blobsShaToPathCache: Map<string, string> = new Map<string, string>(),
-	removeAppTreePrefix = false,
-): ISnapshotTreeEx {
-	return buildGitTreeHierarchy(flatTree, blobsShaToPathCache, removeAppTreePrefix);
-}
+export const buildGitTreeHeirarchy = buildGitTreeHierarchy;

--- a/server/routerlicious/packages/protocol-base/src/index.ts
+++ b/server/routerlicious/packages/protocol-base/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { buildGitTreeHierarchy, getGitMode, getGitType } from "./gitHelper";
+export { buildGitTreeHierarchy, buildGitTreeHeirarchy, getGitMode, getGitType } from "./gitHelper";
 export { IProtocolHandler, IScribeProtocolState, ProtocolOpHandler } from "./protocol";
 export {
 	IQuorumSnapshot,


### PR DESCRIPTION
Removing the misspelled buildGitTreeHierarchy API in #16323 caused a back-compat issue even though that change was never released to public npm. See [AB#4938](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4938) for more details.

I added back the old name. There are a few different ways to export a function with multiple names, and I don't know which is best. I put each option in a separate commit on this PR, so to see them individually, use these links:

- Option 1: https://github.com/microsoft/FluidFramework/pull/16339/commits/9659227330a3456180b36c599050354c1655b07d
- Option 2: https://github.com/microsoft/FluidFramework/pull/16339/files/d3378ac387d66918e01b085957082dd8b80e1385
- Option 3: https://github.com/microsoft/FluidFramework/pull/16339/files/8e88f2178629e5828ca5f053ee29e8c7ff7b1ab9