### PR TITLE
Fix the inconsistency between local delete and remote clear

### DIFF
--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -547,7 +547,8 @@ export class MapKernel {
 		// we will get the value for the pendingKeys and clear the map
 		const temp = new Map<string, ILocalValue>();
 		for (const key of this.pendingKeys.keys()) {
-			// Verify if the pending operation is a delete op, no need to retain it if so
+			// Verify if the most recent pending operation is a delete op, no need to retain it if so.
+			// This ensures the map size remains consistent.
 			if (this.data.has(key)) {
 				temp.set(key, this.data.get(key) as ILocalValue);
 			}

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -547,8 +547,10 @@ export class MapKernel {
 		// we will get the value for the pendingKeys and clear the map
 		const temp = new Map<string, ILocalValue>();
 		for (const key of this.pendingKeys.keys()) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			temp.set(key, this.data.get(key)!);
+			// Verify if the pending operation is a delete op, no need to retain it if so
+			if (this.data.has(key)) {
+				temp.set(key, this.data.get(key) as ILocalValue);
+			}
 		}
 		this.clearCore(false);
 		for (const [key, value] of temp.entries()) {

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -792,6 +792,19 @@ describe("Map", () => {
 					assert.equal(map2.size, 0);
 				});
 
+				it("should count the key with undefined value concurrent to a clear op", () => {
+					map1.clear();
+					map2.set("1", undefined);
+
+					containerRuntimeFactory.processSomeMessages(1);
+					assert.equal(map1.size, 0);
+					assert.equal(map2.size, 1);
+
+					containerRuntimeFactory.processSomeMessages(1);
+					assert.equal(map1.size, 1);
+					assert.equal(map2.size, 1);
+				});
+
 				it("should count keys correctly after local operations", () => {
 					map1.set("1", 1);
 					map1.set("2", 1);

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -784,11 +784,57 @@ describe("Map", () => {
 			});
 
 			describe(".size", () => {
-				// TODO:AB#4612: Enable this test
-				it.skip("shouldn't count keys deleted concurrent to a clear op", () => {
+				it("shouldn't count keys deleted concurrent to a clear op", () => {
 					map1.clear();
 					map2.delete("dummy");
 					containerRuntimeFactory.processAllMessages();
+					assert.equal(map1.size, 0);
+					assert.equal(map2.size, 0);
+				});
+
+				it("should count keys correctly after local operations", () => {
+					map1.set("1", 1);
+					map1.set("2", 1);
+					map2.set("3", 1);
+
+					assert.equal(map1.size, 2);
+					assert.equal(map2.size, 1);
+
+					map1.set("2", 2);
+					map1.delete("1");
+					map2.set("2", 1);
+
+					assert.equal(map1.size, 1);
+					assert.equal(map2.size, 2);
+
+					map1.delete("1");
+					map2.clear();
+
+					assert.equal(map1.size, 1);
+					assert.equal(map2.size, 0);
+				});
+
+				it("should count keys correctly after remote operations", () => {
+					map1.set("1", 1);
+					map1.set("2", 1);
+					map2.set("3", 1);
+
+					containerRuntimeFactory.processSomeMessages(2);
+					assert.equal(map1.size, 2);
+					assert.equal(map2.size, 3);
+
+					containerRuntimeFactory.processSomeMessages(1);
+					assert.equal(map1.size, 3);
+					assert.equal(map2.size, 3);
+
+					map1.delete("3");
+					map2.clear();
+
+					containerRuntimeFactory.processSomeMessages(1);
+					assert.equal(map1.size, 2);
+					assert.equal(map2.size, 0);
+
+					containerRuntimeFactory.processSomeMessages(1);
 					assert.equal(map1.size, 0);
 					assert.equal(map2.size, 0);
 				});


### PR DESCRIPTION
[AB#4612](https://dev.azure.com/fluidframework/internal/_workitems/edit/4612)

When encountering a remote clear operation, `clearExceptPendingKeys` will be called to retain the local modified but unack'd keys, however, it just treats all unack'd operations as `set`. For instance, if a local delete `delete("key1")` coincides with the remote clear, it will clear the map first, then force a `set("key1", undefined)`. It is necessary to determine if the unack'd operation is `delete` or `set` operation, this can be achieved by checking if the affected key still exists in the data or not. 
