### PR TITLE
Log Stashed Op Failures as DataProcessing

### DIFF
--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -49,7 +49,7 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
     static create(errorMessage: string, dataProcessingCodepath: string, sequencedMessage?: ISequencedDocumentMessage, props?: ITelemetryProperties): IFluidErrorBase;
     // (undocumented)
     readonly errorType = ContainerErrorType.dataProcessingError;
-    static wrapIfUnrecognized(originalError: any, dataProcessingCodepath: string, sequencedMessage?: ISequencedDocumentMessage): IFluidErrorBase;
+    static wrapIfUnrecognized(originalError: any, dataProcessingCodepath: string, messageLike?: Partial<Pick<ISequencedDocumentMessage, "clientId" | "sequenceNumber" | "clientSequenceNumber" | "referenceSequenceNumber" | "minimumSequenceNumber" | "timestamp">>): IFluidErrorBase;
 }
 
 // @public
@@ -98,13 +98,13 @@ export class DeltaManagerProxyBase extends EventForwarder<IDeltaManagerEvents> i
 }
 
 // @public (undocumented)
-export const extractSafePropertiesFromMessage: (message: ISequencedDocumentMessage) => {
-    messageClientId: string;
-    messageSequenceNumber: number;
-    messageClientSequenceNumber: number;
-    messageReferenceSequenceNumber: number;
-    messageMinimumSequenceNumber: number;
-    messageTimestamp: number;
+export const extractSafePropertiesFromMessage: (messageLike: Partial<Pick<ISequencedDocumentMessage, "clientId" | "sequenceNumber" | "clientSequenceNumber" | "referenceSequenceNumber" | "minimumSequenceNumber" | "timestamp">>) => {
+    messageClientId: string | undefined;
+    messageSequenceNumber: number | undefined;
+    messageClientSequenceNumber: number | undefined;
+    messageReferenceSequenceNumber: number | undefined;
+    messageMinimumSequenceNumber: number | undefined;
+    messageTimestamp: number | undefined;
 };
 
 // @public

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -140,20 +140,30 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
 	 * But an unrecognized error needs to be classified as DataProcessingError.
 	 * @param originalError - error to be converted
 	 * @param dataProcessingCodepath - which codepath failed while processing data
-	 * @param sequencedMessage - Sequenced message to include info about via telemetry props
+	 * @param messageLike - Sequenced message to include info about via telemetry props
 	 * @returns Either a new DataProcessingError, or (if wrapping is deemed unnecessary) the given error
 	 */
 	static wrapIfUnrecognized(
 		originalError: any,
 		dataProcessingCodepath: string,
-		sequencedMessage?: ISequencedDocumentMessage,
+		messageLike?: Partial<
+			Pick<
+				ISequencedDocumentMessage,
+				| "clientId"
+				| "sequenceNumber"
+				| "clientSequenceNumber"
+				| "referenceSequenceNumber"
+				| "minimumSequenceNumber"
+				| "timestamp"
+			>
+		>,
 	): IFluidErrorBase {
 		const props = {
 			dataProcessingError: 1,
 			dataProcessingCodepath,
-			...(sequencedMessage === undefined
+			...(messageLike === undefined
 				? undefined
-				: extractSafePropertiesFromMessage(sequencedMessage)),
+				: extractSafePropertiesFromMessage(messageLike)),
 		};
 
 		const normalizedError = normalizeError(originalError, { props });
@@ -178,11 +188,23 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
 	}
 }
 
-export const extractSafePropertiesFromMessage = (message: ISequencedDocumentMessage) => ({
-	messageClientId: message.clientId,
-	messageSequenceNumber: message.sequenceNumber,
-	messageClientSequenceNumber: message.clientSequenceNumber,
-	messageReferenceSequenceNumber: message.referenceSequenceNumber,
-	messageMinimumSequenceNumber: message.minimumSequenceNumber,
-	messageTimestamp: message.timestamp,
+export const extractSafePropertiesFromMessage = (
+	messageLike: Partial<
+		Pick<
+			ISequencedDocumentMessage,
+			| "clientId"
+			| "sequenceNumber"
+			| "clientSequenceNumber"
+			| "referenceSequenceNumber"
+			| "minimumSequenceNumber"
+			| "timestamp"
+		>
+	>,
+) => ({
+	messageClientId: messageLike.clientId,
+	messageSequenceNumber: messageLike.sequenceNumber,
+	messageClientSequenceNumber: messageLike.clientSequenceNumber,
+	messageReferenceSequenceNumber: messageLike.referenceSequenceNumber,
+	messageMinimumSequenceNumber: messageLike.minimumSequenceNumber,
+	messageTimestamp: messageLike.timestamp,
 });

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -210,9 +210,13 @@ export class PendingStateManager implements IDisposable {
 				}
 			}
 
-			// applyStashedOp will cause the DDS to behave as if it has sent the op but not actually send it
-			const localOpMetadata = await this.stateHandler.applyStashedOp(nextMessage.content);
-			nextMessage.localOpMetadata = localOpMetadata;
+			try {
+				// applyStashedOp will cause the DDS to behave as if it has sent the op but not actually send it
+				const localOpMetadata = await this.stateHandler.applyStashedOp(nextMessage.content);
+				nextMessage.localOpMetadata = localOpMetadata;
+			} catch (error) {
+				throw DataProcessingError.wrapIfUnrecognized(error, "applyStashedOp", nextMessage);
+			}
 
 			// then we push onto pendingMessages which will cause PendingStateManager to resubmit when we connect
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
Make failure during apply stashed ops data processing errors, as they represent errors processing locally saved data, and failures can result in local data loss. 

This should also help with debugging stashed op failures.

related to [AB#4926](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4926)