### PR TITLE
Stress: Clear stashed ops on error

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1061,6 +1061,11 @@ export class Container
 		if (!this.offlineLoadEnabled) {
 			throw new UsageError("Can't get pending local state unless offline load is enabled");
 		}
+		if (this.closed || this._disposed) {
+			throw new UsageError(
+				"Pending state cannot be retried if the container is closed or disposed",
+			);
+		}
 		assert(
 			this.attachState === AttachState.Attached,
 			0x0d1 /* "Container should be attached before close" */,

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -301,6 +301,8 @@ async function runnerProcess(
 			reset = false;
 			printStatus(runConfig, done ? `finished` : "closed");
 		} catch (error) {
+			// clear stashed op in case of error
+			stashedOpP = undefined;
 			runConfig.logger.sendErrorEvent(
 				{
 					eventName: "RunnerFailed",


### PR DESCRIPTION
Looking at the data it seems we are generally seeing 0x184 in the load following another failure, like disposed. My hunch is that the error is leading to a bad stashed ops object, which then leads to the assert. Regardless, i think it makes sense to clear the stashed ops object on failure. We likely need to do more work to ensure that the stashed ops object is only created when the container is healthy.

related to [AB#4926](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4926)