### PR TITLE
Only use cache for ops fetching in case the snapshot came from cache too

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -147,7 +147,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		) => Promise<ISequencedDocumentMessage[]>,
 		private readonly requestFromSocket: (from: number, to: number) => void,
 		private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
-		private readonly isFirstSnapshotFromCache?: boolean,
+		private readonly isFirstSnapshotFromNetwork?: boolean,
 	) {}
 
 	public fetchMessages(
@@ -191,7 +191,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 			// Cache in normal flow is continuous. Once there is a miss, stop consulting cache.
 			// This saves a bit of processing time. Also only consult cache, in case the
 			// snapshot came from cache.
-			if (!this.firstCacheMiss && this.isFirstSnapshotFromCache) {
+			if (!(this.firstCacheMiss || this.isFirstSnapshotFromNetwork)) {
 				const messagesFromCache = await this.getCached(from, to);
 				validateMessages("cached", messagesFromCache, from, this.logger);
 				// Set the firstCacheMiss as true in case we didn't get all the ops.

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -227,7 +227,7 @@ export class OdspDocumentService implements IDocumentService {
 				}
 			},
 			(ops: ISequencedDocumentMessage[]) => this.opsReceived(ops),
-			this.storageManager?.isFirstSnapshotFromNetwork,
+			() => this.storageManager,
 		);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -227,6 +227,7 @@ export class OdspDocumentService implements IDocumentService {
 				}
 			},
 			(ops: ISequencedDocumentMessage[]) => this.opsReceived(ops),
+			this.storageManager?.isFirstSnapshotFromCache,
 		);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -227,7 +227,7 @@ export class OdspDocumentService implements IDocumentService {
 				}
 			},
 			(ops: ISequencedDocumentMessage[]) => this.opsReceived(ops),
-			this.storageManager?.isFirstSnapshotFromCache,
+			this.storageManager?.isFirstSnapshotFromNetwork,
 		);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -340,12 +340,8 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					if (method === "network") {
 						props.cacheEntryAge = undefined;
 					}
-					if (
-						this.firstVersionCall &&
-						method === "network" &&
-						!this.hostPolicy.summarizerClient
-					) {
-						this._isFirstSnapshotFromNetwork = true;
+					if (this.firstVersionCall) {
+						this._isFirstSnapshotFromNetwork = method === "cache" ? false : true;
 					}
 					const prefetchStartTime: number | undefined = (
 						retrievedSnapshot as IPrefetchSnapshotContents

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -57,7 +57,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 	private odspSummaryUploadManager: OdspSummaryUploadManager | undefined;
 
 	private firstVersionCall = true;
-
+	private _isFirstSnapshotFromCache: boolean = false;
 	private readonly documentId: string;
 	private readonly snapshotUrl: string | undefined;
 	private readonly attachmentPOSTUrl: string | undefined;
@@ -92,6 +92,10 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		this.snapshotUrl = this.odspResolvedUrl.endpoints.snapshotStorageUrl;
 		this.attachmentPOSTUrl = this.odspResolvedUrl.endpoints.attachmentPOSTStorageUrl;
 		this.attachmentGETUrl = this.odspResolvedUrl.endpoints.attachmentGETStorageUrl;
+	}
+
+	public get isFirstSnapshotFromCache() {
+		return this._isFirstSnapshotFromCache;
 	}
 
 	public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
@@ -335,6 +339,8 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					}
 					if (method === "network") {
 						props.cacheEntryAge = undefined;
+					} else if (method === "cache") {
+						this._isFirstSnapshotFromCache = true;
 					}
 					const prefetchStartTime: number | undefined = (
 						retrievedSnapshot as IPrefetchSnapshotContents

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -339,7 +339,8 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					}
 					if (method === "network") {
 						props.cacheEntryAge = undefined;
-					} else if (method === "cache") {
+					}
+					if (this.firstVersionCall && method === "cache") {
 						this._isFirstSnapshotFromCache = true;
 					}
 					const prefetchStartTime: number | undefined = (

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -340,7 +340,11 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					if (method === "network") {
 						props.cacheEntryAge = undefined;
 					}
-					if (this.firstVersionCall && method === "network" && !this.hostPolicy.summarizerClient) {
+					if (
+						this.firstVersionCall &&
+						method === "network" &&
+						!this.hostPolicy.summarizerClient
+					) {
 						this._isFirstSnapshotFromNetwork = true;
 					}
 					const prefetchStartTime: number | undefined = (

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -57,7 +57,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 	private odspSummaryUploadManager: OdspSummaryUploadManager | undefined;
 
 	private firstVersionCall = true;
-	private _isFirstSnapshotFromCache: boolean = false;
+	private _isFirstSnapshotFromNetwork: boolean | undefined;
 	private readonly documentId: string;
 	private readonly snapshotUrl: string | undefined;
 	private readonly attachmentPOSTUrl: string | undefined;
@@ -94,8 +94,8 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		this.attachmentGETUrl = this.odspResolvedUrl.endpoints.attachmentGETStorageUrl;
 	}
 
-	public get isFirstSnapshotFromCache() {
-		return this._isFirstSnapshotFromCache;
+	public get isFirstSnapshotFromNetwork() {
+		return this._isFirstSnapshotFromNetwork;
 	}
 
 	public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
@@ -340,8 +340,8 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					if (method === "network") {
 						props.cacheEntryAge = undefined;
 					}
-					if (this.firstVersionCall && method === "cache") {
-						this._isFirstSnapshotFromCache = true;
+					if (this.firstVersionCall && method === "network" && !this.hostPolicy.summarizerClient) {
+						this._isFirstSnapshotFromNetwork = true;
 					}
 					const prefetchStartTime: number | undefined = (
 						retrievedSnapshot as IPrefetchSnapshotContents

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -11,6 +11,7 @@ import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { OdspDeltaStorageService, OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { LocalPersistentCache } from "../odspCache";
 import { EpochTracker } from "../epochTracker";
+import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 import { mockFetchOk } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache(2000);
@@ -233,6 +234,7 @@ describe("DeltaStorageService", () => {
 				async (from, to) => getCached(from, to),
 				(from, to) => [],
 				(ops) => {},
+				() => ({ isFirstSnapshotFromNetwork: false } as any as OdspDocumentStorageService),
 			);
 
 			const messages = odspDeltaStorageServiceWithCache.fetchMessages(1, undefined);

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -9,6 +9,7 @@ import { IStream } from "@fluidframework/driver-definitions";
 import { delay } from "@fluidframework/common-utils";
 import { OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { OpsCache, ICache, IMessage, CacheEntry } from "../opsCaching";
+import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 
 export type MyDataInput = IMessage & { data: string };
 
@@ -409,6 +410,7 @@ describe("OdspDeltaStorageWithCache", () => {
 			(from: number, to: number) => {},
 			// opsReceived
 			(ops: ISequencedDocumentMessage[]) => opsToCache.push(...ops),
+			() => ({ isFirstSnapshotFromNetwork: false } as any as OdspDocumentStorageService),
 		);
 
 		const stream = storage.fetchMessages(


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4303

Only use cache for ops fetching in case the snapshot came from cache too. This is intended to improve perf as we don't get any ops from cache in case the snapshot comes from network and consulting cache takes time. So supply that info to delta storage service and use that to decide whether we want to consult cache or not.