### PR TITLE
Add a function as mocha extensions to skip tests with specific conditions

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -19,7 +19,7 @@ import {
 	ChannelFactoryRegistry,
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { describeNoCompat, itSkipsOnFailure } from "@fluid-internal/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree";
@@ -122,9 +122,10 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 		},
 	});
 
-	it("Can attribute content from multiple collaborators", async function () {
-		// Skip the test if the error happens on tinylicious or t9s driver
-		try {
+	itSkipsOnFailure(
+		"Can attribute content from multiple collaborators",
+		["tinylicious", "t9s"],
+		async () => {
 			const attributor = createRuntimeAttributor();
 			const container1 = await provider.makeTestContainer(getTestConfig(attributor));
 			const sharedString1 = await sharedStringFromContainer(container1);
@@ -149,12 +150,8 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 			assertAttributionMatches(sharedString1, 13, attributor, {
 				user: container1.audience.getMember(container1.clientId)?.user,
 			});
-		} catch (error) {
-			if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
-				this.skip();
-			}
-		}
-	});
+		},
+	);
 
 	it("attributes content created in a detached state", async () => {
 		const attributor = createRuntimeAttributor();

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -123,34 +123,37 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 	});
 
 	it("Can attribute content from multiple collaborators", async function () {
-		// Tracked by AB#4130, the test run on the tinylicous driver is disabled temporarily to ensure normal operation of the build-client package pipeline
-		if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
-			this.skip();
+		// Skip the test if the error happens on tinylicious or t9s driver
+		try {
+			const attributor = createRuntimeAttributor();
+			const container1 = await provider.makeTestContainer(getTestConfig(attributor));
+			const sharedString1 = await sharedStringFromContainer(container1);
+			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const sharedString2 = await sharedStringFromContainer(container2);
+
+			const text = "client 1";
+			sharedString1.insertText(0, text);
+			assertAttributionMatches(sharedString1, 3, attributor, "local");
+			await provider.ensureSynchronized();
+			sharedString2.insertText(0, "client 2, ");
+			await provider.ensureSynchronized();
+			assert.equal(sharedString1.getText(), "client 2, client 1");
+
+			assert(
+				container1.clientId !== undefined && container2.clientId !== undefined,
+				"Both containers should have client ids.",
+			);
+			assertAttributionMatches(sharedString1, 3, attributor, {
+				user: container1.audience.getMember(container2.clientId)?.user,
+			});
+			assertAttributionMatches(sharedString1, 13, attributor, {
+				user: container1.audience.getMember(container1.clientId)?.user,
+			});
+		} catch (error) {
+			if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
+				this.skip();
+			}
 		}
-		const attributor = createRuntimeAttributor();
-		const container1 = await provider.makeTestContainer(getTestConfig(attributor));
-		const sharedString1 = await sharedStringFromContainer(container1);
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const sharedString2 = await sharedStringFromContainer(container2);
-
-		const text = "client 1";
-		sharedString1.insertText(0, text);
-		assertAttributionMatches(sharedString1, 3, attributor, "local");
-		await provider.ensureSynchronized();
-		sharedString2.insertText(0, "client 2, ");
-		await provider.ensureSynchronized();
-		assert.equal(sharedString1.getText(), "client 2, client 1");
-
-		assert(
-			container1.clientId !== undefined && container2.clientId !== undefined,
-			"Both containers should have client ids.",
-		);
-		assertAttributionMatches(sharedString1, 3, attributor, {
-			user: container1.audience.getMember(container2.clientId)?.user,
-		});
-		assertAttributionMatches(sharedString1, 13, attributor, {
-			user: container1.audience.getMember(container1.clientId)?.user,
-		});
 	});
 
 	it("attributes content created in a detached state", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -122,6 +122,10 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 		},
 	});
 
+	/**
+	 * Tracked by AB#4997, if no error event is detected within one sprint, we will remove
+	 * the skipping or take actions accordingly if it is.
+	 */
 	itSkipsOnFailure(
 		"Can attribute content from multiple collaborators",
 		["tinylicious", "t9s"],

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -19,7 +19,7 @@ import {
 	ChannelFactoryRegistry,
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { describeNoCompat, itSkipsOnFailure } from "@fluid-internal/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
@@ -108,9 +108,10 @@ describeNoCompat("Attributor for SharedCell", (getTestObjectProvider) => {
 		},
 	});
 
-	it("Can attribute content from multiple collaborators", async function () {
-		// Skip the test if the error happens on tinylicious or t9s driver
-		try {
+	itSkipsOnFailure(
+		"Can attribute content from multiple collaborators",
+		["tinylicious", "t9s"],
+		async () => {
 			const attributor = createRuntimeAttributor();
 			const container1 = await provider.makeTestContainer(getTestConfig(attributor));
 			const sharedCell1 = await sharedCellFromContainer(container1);
@@ -139,12 +140,8 @@ describeNoCompat("Attributor for SharedCell", (getTestObjectProvider) => {
 			assertAttributionMatches(sharedCell1, attributor, {
 				user: container2.audience.getMember(container1.clientId)?.user,
 			});
-		} catch (error) {
-			if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
-				this.skip();
-			}
-		}
-	});
+		},
+	);
 
 	it("attributes content created in a detached state", async () => {
 		const attributor = createRuntimeAttributor();

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -108,6 +108,10 @@ describeNoCompat("Attributor for SharedCell", (getTestObjectProvider) => {
 		},
 	});
 
+	/**
+	 * Tracked by AB#4997, if no error event is detected within one sprint, we will remove
+	 * the skipping or take actions accordingly if it is.
+	 */
 	itSkipsOnFailure(
 		"Can attribute content from multiple collaborators",
 		["tinylicious", "t9s"],

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -109,38 +109,41 @@ describeNoCompat("Attributor for SharedCell", (getTestObjectProvider) => {
 	});
 
 	it("Can attribute content from multiple collaborators", async function () {
-		// Tracked by AB#4130, the test run on the tinylicous driver is disabled temporarily to ensure normal operation of the build-client package pipeline
-		if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
-			this.skip();
+		// Skip the test if the error happens on tinylicious or t9s driver
+		try {
+			const attributor = createRuntimeAttributor();
+			const container1 = await provider.makeTestContainer(getTestConfig(attributor));
+			const sharedCell1 = await sharedCellFromContainer(container1);
+			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const sharedCell2 = await sharedCellFromContainer(container2);
+
+			assert(
+				container1.clientId !== undefined && container2.clientId !== undefined,
+				"Both containers should have client ids.",
+			);
+
+			sharedCell1.set(1);
+			assertAttributionMatches(sharedCell1, attributor, "local");
+			await provider.ensureSynchronized();
+
+			sharedCell2.set(2);
+			await provider.ensureSynchronized();
+
+			assertAttributionMatches(sharedCell1, attributor, {
+				user: container1.audience.getMember(container2.clientId)?.user,
+			});
+
+			sharedCell1.set(3);
+			await provider.ensureSynchronized();
+
+			assertAttributionMatches(sharedCell1, attributor, {
+				user: container2.audience.getMember(container1.clientId)?.user,
+			});
+		} catch (error) {
+			if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
+				this.skip();
+			}
 		}
-		const attributor = createRuntimeAttributor();
-		const container1 = await provider.makeTestContainer(getTestConfig(attributor));
-		const sharedCell1 = await sharedCellFromContainer(container1);
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const sharedCell2 = await sharedCellFromContainer(container2);
-
-		assert(
-			container1.clientId !== undefined && container2.clientId !== undefined,
-			"Both containers should have client ids.",
-		);
-
-		sharedCell1.set(1);
-		assertAttributionMatches(sharedCell1, attributor, "local");
-		await provider.ensureSynchronized();
-
-		sharedCell2.set(2);
-		await provider.ensureSynchronized();
-
-		assertAttributionMatches(sharedCell1, attributor, {
-			user: container1.audience.getMember(container2.clientId)?.user,
-		});
-
-		sharedCell1.set(3);
-		await provider.ensureSynchronized();
-
-		assertAttributionMatches(sharedCell1, attributor, {
-			user: container2.audience.getMember(container1.clientId)?.user,
-		});
 	});
 
 	it("attributes content created in a detached state", async () => {

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -47,3 +47,4 @@ export {
 	getDriverApi,
 	getLoaderApi,
 } from "./testApi.js";
+export { itSkipsOnFailure } from "./itSkipsOnFailure.js";

--- a/packages/test/test-version-utils/src/itSkipsOnFailure.ts
+++ b/packages/test/test-version-utils/src/itSkipsOnFailure.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TestObjectProvider } from "@fluidframework/test-utils";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Context } from "mocha";
+import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
+
+function createSkippedTestsWithDriverType(
+	skippedDrivers: TestDriverTypes[],
+	test: Mocha.AsyncFunc,
+) {
+	return async function (this: Context) {
+		const provider: TestObjectProvider | undefined = this.__fluidTestProvider;
+		if (provider === undefined) {
+			throw new Error("Expected __fluidTestProvider on this");
+		}
+		try {
+			await test.bind(this)();
+		} catch (error) {
+			if (skippedDrivers.includes(provider.driver.type)) {
+				provider.logger.sendErrorEvent({ eventName: "TestFailedbutSkipped" }, error);
+				this.skip();
+			} else {
+				throw error;
+			}
+		}
+	};
+}
+
+export type SkippedTestWithDriverType = (
+	name: string,
+	skippedDrivers: TestDriverTypes[],
+	test: Mocha.AsyncFunc,
+) => Mocha.Test;
+
+/**
+ * Similar to mocha's it function, but allow skipping for some if the error
+ * happens on the specific drivers
+ */
+export const itSkipsOnFailure: SkippedTestWithDriverType = (
+	name: string,
+	skippedDrivers: TestDriverTypes[],
+	test: Mocha.AsyncFunc,
+): Mocha.Test => it(name, createSkippedTestsWithDriverType(skippedDrivers, test));


### PR DESCRIPTION
[AB#4226](https://dev.azure.com/fluidframework/internal/_workitems/edit/4226), [AB#4997](https://dev.azure.com/fluidframework/internal/_workitems/edit/4997)

Utilize a try-catch block to handle two tests flaky but currently not reproducible in local runs and PR builds. If an error is caught during execution, the tests should only be skipped if the drive type is either `tinylicious` or `t9s`.

It's worth noting that these tests did not cause the PR build to fail (public pipeline), for reference: https://github.com/microsoft/FluidFramework/pull/16359

**07/14 update**: Add a function as the mocha extensions, allowing developers to handle the tests with specific skipped conditions in the future 