### PR TITLE
Set loader caching default to false

### DIFF
--- a/.changeset/fuzzy-ants-poke.md
+++ b/.changeset/fuzzy-ants-poke.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/container-definitions": major
+"@fluidframework/container-loader": major
+---
+
+Loader container caching off by default
+
+Loader container caching will now be off by default. If you wish to have it enabled, please set `ILoaderProps.options.cache` to `true` when constructing a `Loader` object (see the `ILoaderOptions` interface). The `[LoaderHeader.cache]` header can also be used to override the default caching option when requesting a container.
+
+**Note:** These caching options/headers are deprecated and will be removed in a future release, as well as all caching functionality of containers. Please try not to rely on caching and inform us if you cannot do so.

--- a/.changeset/fuzzy-ants-poke.md
+++ b/.changeset/fuzzy-ants-poke.md
@@ -5,6 +5,8 @@
 
 Loader container caching off by default
 
-Loader container caching will now be off by default. If you wish to have it enabled, please set `ILoaderProps.options.cache` to `true` when constructing a `Loader` object (see the `ILoaderOptions` interface). The `[LoaderHeader.cache]` header can also be used to override the default caching option when requesting a container.
+Loader container caching will now be off by default and the ability to control it is deprecated. Loader caching is deprecated and will be removed in a future release, as well as all caching functionality of containers. Please try not to rely on caching and inform us if you cannot do so.
 
-**Note:** These caching options/headers are deprecated and will be removed in a future release, as well as all caching functionality of containers. Please try not to rely on caching and inform us if you cannot do so.
+If you run into trouble with this behavior, please report it ASAP to the FluidFramework team and use the following options (available in this release only) to unblock you:
+-    set `ILoaderProps.options.cache` to `true` when constructing a `Loader` object (see the `ILoaderOptions` interface)
+-    set `[LoaderHeader.cache]` header to `true` when requesting a container

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -530,7 +530,7 @@ export type ILoaderOptions = {
 	 * false, always load a new container and don't cache it. If the container has already been
 	 * closed, it will not be cached. A cache option in the LoaderHeader for an individual
 	 * request will override the Loader's value.
-	 * Defaults to true.
+	 * Defaults to false.
 	 */
 	cache?: boolean;
 
@@ -554,7 +554,7 @@ export type ILoaderOptions = {
  */
 export enum LoaderHeader {
 	/**
-	 * @deprecated In next release, all caching functionality will be removed, and this is not useful anymore
+	 * @deprecated This header has been deprecated and will be removed in a future release
 	 * Override the Loader's default caching behavior for this container.
 	 */
 	cache = "fluid-cache",

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -623,7 +623,7 @@ export interface IContainerLoadMode {
  */
 export interface ILoaderHeader {
 	/**
-	 * @deprecated In next release, all caching functionality will be removed, and this is not useful anymore
+	 * @deprecated This header has been deprecated and will be removed in a future release
 	 */
 	[LoaderHeader.cache]: boolean;
 	[LoaderHeader.clientDetails]: IClientDetails;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -46,11 +46,7 @@ import { pkgVersion } from "./packageVersion";
 import { ProtocolHandlerBuilder } from "./protocol";
 
 function canUseCache(request: IRequest): boolean {
-	if (request.headers === undefined) {
-		return true;
-	}
-
-	return request.headers[LoaderHeader.cache] !== false;
+	return request.headers?.[LoaderHeader.cache] === true;
 }
 
 function ensureResolvedUrlDefined(
@@ -449,7 +445,7 @@ export class Loader implements IHostLoader {
 			parsed.version ?? request.headers[LoaderHeader.version];
 		const canCache =
 			this.cachingEnabled &&
-			request.headers[LoaderHeader.cache] !== false &&
+			request.headers[LoaderHeader.cache] === true &&
 			pendingLocalState === undefined;
 		const fromSequenceNumber = request.headers[LoaderHeader.sequenceNumber] ?? -1;
 
@@ -485,7 +481,7 @@ export class Loader implements IHostLoader {
 	}
 
 	private get cachingEnabled() {
-		return this.services.options.cache !== false;
+		return this.services.options.cache === true;
 	}
 
 	private async loadContainer(

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -443,9 +443,10 @@ export class Loader implements IHostLoader {
 		// If set in both query string and headers, use query string.  Also write the value from the query string into the header either way.
 		request.headers[LoaderHeader.version] =
 			parsed.version ?? request.headers[LoaderHeader.version];
+		const cacheHeader = request.headers[LoaderHeader.cache];
 		const canCache =
-			this.cachingEnabled &&
-			request.headers[LoaderHeader.cache] === true &&
+			// Take header value if present, else use ILoaderOptions.cache value
+			(cacheHeader !== undefined ? cacheHeader === true : this.cachingEnabled) &&
 			pendingLocalState === undefined;
 		const fromSequenceNumber = request.headers[LoaderHeader.sequenceNumber] ?? -1;
 

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { SharedCell } from "@fluidframework/cell";
 import { Deferred } from "@fluidframework/common-utils";
-import { AttachState, IContainer } from "@fluidframework/container-definitions";
+import { AttachState, IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
@@ -803,6 +803,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 	});
 
 	it("Load attached container from cache and check if they are same", async () => {
+		loader.services.options.cache = true;
 		const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 
 		// Now attach the container and get the sub dataStore.
@@ -811,7 +812,10 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 		// Create a new request url from the resolvedUrl of the first container.
 		assert(container.resolvedUrl);
 		const requestUrl2 = await provider.urlResolver.getAbsoluteUrl(container.resolvedUrl, "");
-		const container2 = await loader.resolve({ url: requestUrl2 });
+		const container2 = await loader.resolve({
+			url: requestUrl2,
+			headers: { [LoaderHeader.cache]: true },
+		});
 		assert.strictEqual(container, container2, "Both containers should be same");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -802,6 +802,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 		await defPromise.promise;
 	});
 
+	// TODO: remove this test when caching is removed (AB#5046)
 	it("Load attached container from cache and check if they are same", async () => {
 		loader.services.options.cache = true;
 		const container = await loader.createDetachedContainer(provider.defaultCodeDetails);

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -137,6 +137,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 	beforeEach(async () => {
 		provider = getTestObjectProvider();
 		loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]], {
+			// TODO: adjust to not rely on caching (AB#5046)
 			options: { cache: true },
 		});
 		container = await createAndAttachContainer(
@@ -191,6 +192,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		assert(url, "dataStore2 url is undefined");
 		const testDataStore = await requestFluidObject<TestSharedDataObject2>(loader, {
 			url,
+			// TODO: adjust this test to not rely on caching (AB#5046)
 			headers: { [LoaderHeader.cache]: true },
 		});
 
@@ -210,6 +212,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 	it("loaded container is paused using loader pause flags", async () => {
 		// load the container paused
 		const headers: IRequestHeader = {
+			// TODO: adjust this test to not rely on caching (AB#5046)
 			[LoaderHeader.cache]: false,
 			[LoaderHeader.loadMode]: { deltaConnection: "delayed" },
 		};
@@ -247,6 +250,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		);
 	});
 
+	// TODO: remove this test when caching is removed (AB#5046)
 	it("caches the loaded container across multiple requests as expected", async () => {
 		const url = await container.getAbsoluteUrl("");
 		assert(url, "url is undefined");
@@ -350,6 +354,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		const headers = {
 			wait: false,
 			[RuntimeHeaders.viaHandle]: true,
+			// TODO: adjust this test to not rely on caching (AB#5046)
 			[LoaderHeader.cache]: true,
 		};
 		// Request to the newly created data store with headers.

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -189,7 +189,10 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 	it("can create data object using url with second id, having distinct value from default", async () => {
 		const url = await container.getAbsoluteUrl(dataStore2.handle.absolutePath);
 		assert(url, "dataStore2 url is undefined");
-		const testDataStore = await requestFluidObject<TestSharedDataObject2>(loader, url);
+		const testDataStore = await requestFluidObject<TestSharedDataObject2>(loader, {
+			url,
+			headers: { [LoaderHeader.cache]: true },
+		});
 
 		dataStore1._root.set("color", "purple");
 		dataStore2._root.set("color", "pink");

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -136,7 +136,9 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 
 	beforeEach(async () => {
 		provider = getTestObjectProvider();
-		loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]]);
+		loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]], {
+			options: { cache: true },
+		});
 		container = await createAndAttachContainer(
 			provider.defaultCodeDetails,
 			loader,
@@ -246,7 +248,10 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		const url = await container.getAbsoluteUrl("");
 		assert(url, "url is undefined");
 		// load the containers paused
-		const headers: IRequestHeader = { [LoaderHeader.loadMode]: { deltaConnection: "delayed" } };
+		const headers: IRequestHeader = {
+			[LoaderHeader.loadMode]: { deltaConnection: "delayed" },
+			[LoaderHeader.cache]: true,
+		};
 		const container1 = await loader.resolve({ url, headers });
 		const container2 = await loader.resolve({ url, headers });
 

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -347,7 +347,11 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		const url = await container.getAbsoluteUrl(dataStoreWithRequestHeaders.id);
 		assert(url, "Container should return absolute url");
 
-		const headers = { wait: false, [RuntimeHeaders.viaHandle]: true };
+		const headers = {
+			wait: false,
+			[RuntimeHeaders.viaHandle]: true,
+			[LoaderHeader.cache]: true,
+		};
 		// Request to the newly created data store with headers.
 		const response = await loader.request({ url, headers });
 


### PR DESCRIPTION
## Description

Loader caching will now be off by default. This work is preparation for completely removing container caching in the Loader.

[AB#3118](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3118)

Continuation of: https://github.com/microsoft/FluidFramework/pull/14680

## Breaking Change

### Loader container caching off by default

Loader container caching will now be off by default and the ability to control it is deprecated. Loader caching is deprecated and will be removed in a future release, as well as all caching functionality of containers. Please try not to rely on caching and inform us if you cannot do so.

If you run into trouble with this behavior, please report it ASAP to the FluidFramework team and use the following options (available in this release only) to unblock you:
-    set `ILoaderProps.options.cache` to `true` when constructing a `Loader` object (see the `ILoaderOptions` interface)
-    set `[LoaderHeader.cache]` header to `true` when requesting a container