### PR TITLE
r11s: finding/fixing uncaught exceptions

### DIFF
--- a/server/routerlicious/packages/gitresources/.eslintrc.js
+++ b/server/routerlicious/packages/gitresources/.eslintrc.js
@@ -5,5 +5,7 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
-	rules: {},
+	rules: {
+		"promise/catch-or-return": ["error", { allowFinally: true }],
+	},
 };

--- a/server/routerlicious/packages/kafka-orderer/.eslintrc.js
+++ b/server/routerlicious/packages/kafka-orderer/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/lambdas-driver/.eslintrc.js
+++ b/server/routerlicious/packages/lambdas-driver/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -43,12 +43,13 @@ export class DocumentPartition {
 			try {
 				if (!this.corrupt) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const optionalPromise = this.lambda!.handler(message);
-					if (optionalPromise) {
-						optionalPromise.then(callback as any).catch((error) => {
+					const optionalPromise = this.lambda!.handler(message)
+						?.then(callback as any)
+						.catch((error) => {
 							this.markAsCorrupt(error, message);
 							callback();
 						});
+					if (optionalPromise) {
 						return;
 					}
 				} else {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -79,12 +79,12 @@ export class DocumentPartition {
 
 		// Create the lambda to handle the document messages
 		this.lambdaP = factory.create(documentConfig, context, this.updateActivityTime.bind(this));
-		this.lambdaP.then(
-			(lambda) => {
+		this.lambdaP
+			.then((lambda) => {
 				this.lambda = lambda;
 				this.q.resume();
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				// There is no need to pass the message to be checkpointed to markAsCorrupt().
 				// The message, in this case, would be the head in the DocumentContext. But the DocumentLambda
 				// that creates this DocumentPartition will also put the same message in the queue.
@@ -92,8 +92,7 @@ export class DocumentPartition {
 				// since the document was marked as corrupted.
 				this.markAsCorrupt(error);
 				this.q.resume();
-			},
-		);
+			});
 	}
 
 	public process(message: IQueuedMessage) {
@@ -118,14 +117,13 @@ export class DocumentPartition {
 		if (this.lambda) {
 			this.lambda.close(closeType);
 		} else {
-			this.lambdaP.then(
-				(lambda) => {
+			this.lambdaP
+				.then((lambda) => {
 					lambda.close(closeType);
-				},
-				(error) => {
+				})
+				.catch((error) => {
 					// Lambda was never created - ignoring
-				},
-			);
+				});
 		}
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -65,13 +65,13 @@ export class Partition extends EventEmitter {
 		this.q.pause();
 
 		this.lambdaP = factory.create(undefined, this.context);
-		this.lambdaP.then(
-			(lambda) => {
+		this.lambdaP
+			.then((lambda) => {
 				this.lambda = lambda;
 				this.lambdaP = undefined;
 				this.q.resume();
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				if (this.closed) {
 					return;
 				}
@@ -81,8 +81,7 @@ export class Partition extends EventEmitter {
 				};
 				this.emit("error", error, errorData);
 				this.q.kill();
-			},
-		);
+			});
 
 		this.q.error((error) => {
 			const errorData: IContextErrorData = {
@@ -117,14 +116,12 @@ export class Partition extends EventEmitter {
 		} else if (this.lambdaP) {
 			// asynchronously close the lambda since it's not created yet
 			this.lambdaP
-				.then(
-					(lambda) => {
-						lambda.close(closeType);
-					},
-					(error) => {
-						// Lambda never existed - no need to close
-					},
-				)
+				.then((lambda) => {
+					lambda.close(closeType);
+				})
+				.catch((error) => {
+					// Lambda never existed - no need to close
+				})
 				.finally(() => {
 					this.lambda = undefined;
 					this.lambdaP = undefined;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -50,9 +50,10 @@ export class Partition extends EventEmitter {
 		this.q = queue((message: IQueuedMessage, callback) => {
 			try {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const optionalPromise = this.lambda!.handler(message);
+				const optionalPromise = this.lambda!.handler(message)
+					?.then(callback as any)
+					.catch(callback);
 				if (optionalPromise) {
-					optionalPromise.then(callback as any).catch(callback);
 					return;
 				}
 

--- a/server/routerlicious/packages/lambdas/.eslintrc.js
+++ b/server/routerlicious/packages/lambdas/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
 		"@typescript-eslint/restrict-template-expressions": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/lambdas/src/copier/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/copier/lambda.ts
@@ -77,16 +77,15 @@ export class CopierLambda implements IPartitionLambda {
 			allProcessed.push(processP);
 		}
 
-		Promise.all(allProcessed).then(
-			() => {
+		Promise.all(allProcessed)
+			.then(() => {
 				this.currentJobs.clear();
 				this.context.checkpoint(batchOffset as IQueuedMessage);
 				this.sendPending();
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				this.context.error(error, { restart: true });
-			},
-		);
+			});
 	}
 
 	private async processMongoCore(kafkaBatches: IRawOperationMessageBatch[]): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1919,8 +1919,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		this.checkpointInfo.lastCheckpointTime = Date.now();
 		this.checkpointInfo.rawMessagesSinceCheckpoint = 0;
 
-		Promise.all([this.lastSendP, this.lastNoClientP]).then(
-			() => {
+		Promise.all([this.lastSendP, this.lastNoClientP])
+			.then(() => {
 				const checkpointParams = this.generateCheckpoint(reason);
 				if (reason === CheckpointReason.ClearCache) {
 					checkpointParams.clear = true;
@@ -1942,8 +1942,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					kafkaCheckpointPartition: checkpointParams.kafkaCheckpointMessage?.partition,
 				};
 				Lumberjack.info(checkpointResult, lumberjackProperties);
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				const errorMsg = `Could not send message to scriptorium`;
 				this.context.log?.error(`${errorMsg}: ${JSON.stringify(error)}`, {
 					messageMetaData: {
@@ -1961,8 +1961,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					tenantId: this.tenantId,
 					documentId: this.documentId,
 				});
-			},
-		);
+			});
 	}
 
 	/**

--- a/server/routerlicious/packages/lambdas/src/moira/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambda.ts
@@ -85,16 +85,15 @@ export class MoiraLambda implements IPartitionLambda {
 			allProcessed.push(processP);
 		}
 
-		Promise.all(allProcessed).then(
-			() => {
+		Promise.all(allProcessed)
+			.then(() => {
 				this.current.clear();
 				this.context.checkpoint(batchOffset as IQueuedMessage);
 				this.sendPending();
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				this.context.error(error, { restart: true });
-			},
-		);
+			});
 	}
 
 	private createDerivedGuid(referenceGuid: string, identifier: string) {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -586,8 +586,8 @@ export class ScribeLambda implements IPartitionLambda {
 		this.pendingP = clearCache
 			? this.checkpointManager.delete(this.protocolHead, true)
 			: this.writeCheckpoint(checkpoint);
-		this.pendingP.then(
-			() => {
+		this.pendingP
+			.then(() => {
 				this.pendingP = undefined;
 				this.context.checkpoint(queuedMessage, this.restartOnCheckpointFailure);
 
@@ -598,16 +598,15 @@ export class ScribeLambda implements IPartitionLambda {
 					this.pendingCheckpointOffset = undefined;
 					this.checkpointCore(pendingScribe, pendingOffset, clearCache);
 				}
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				const message = "Checkpoint error";
 				Lumberjack.error(
 					message,
 					getLumberBaseProperties(this.documentId, this.tenantId),
 					error,
 				);
-			},
-		);
+			});
 	}
 
 	private async writeCheckpoint(checkpoint: IScribe) {

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -165,8 +165,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			}
 		}
 
-		Promise.all(allProcessed).then(
-			() => {
+		Promise.all(allProcessed)
+			.then(() => {
 				this.current.clear();
 				status = ScriptoriumStatus.ProcessingComplete;
 				metric?.setProperty("timestampProcessingComplete", new Date().toISOString());
@@ -196,8 +196,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
 				// continue with next batch
 				this.sendPending();
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				// catches error if any of the promises failed in Promise.all, i.e. any of the ops failed to write to db
 				status = ScriptoriumStatus.ProcessingFailed;
 				metric?.setProperty("timestampProcessingFailed", new Date().toISOString());
@@ -206,8 +206,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
 				// Restart scriptorium
 				this.context.error(error, { restart: true });
-			},
-		);
+			});
 	}
 
 	private logErrorTelemetry(

--- a/server/routerlicious/packages/lambdas/src/utils/connectionCountLogger.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/connectionCountLogger.ts
@@ -40,30 +40,30 @@ export class ConnectionCountLogger implements IConnectionCountLogger {
 		const totalConnectionCountMetric = Lumberjack.newLumberMetric(
 			LumberEventName.TotalConnectionCount,
 		);
-		this.cache.incr(this.perNodeKeyName).then(
-			(val) => {
+		this.cache
+			.incr(this.perNodeKeyName)
+			.then((val) => {
 				connectionCountPerNodeMetric.setProperty("TotalConnectionCount", val);
 				connectionCountPerNodeMetric.success("Connection count incremented for node.");
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				connectionCountPerNodeMetric.error(
 					`Error while incrementing connection count for node.`,
 					error,
 				);
-			},
-		);
-		this.cache.incr(this.perClusterKeyName).then(
-			(val) => {
+			});
+		this.cache
+			.incr(this.perClusterKeyName)
+			.then((val) => {
 				totalConnectionCountMetric.setProperty("TotalConnectionCount", val);
 				totalConnectionCountMetric.success("Total connection count incremented.");
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				totalConnectionCountMetric.error(
 					`Error while incrementing total connection count for cluster.`,
 					error,
 				);
-			},
-		);
+			});
 	}
 
 	public decrementConnectionCount(): void {
@@ -76,29 +76,29 @@ export class ConnectionCountLogger implements IConnectionCountLogger {
 		const totalConnectionCountMetric = Lumberjack.newLumberMetric(
 			LumberEventName.TotalConnectionCount,
 		);
-		this.cache.decr(this.perNodeKeyName).then(
-			(val) => {
+		this.cache
+			.decr(this.perNodeKeyName)
+			.then((val) => {
 				connectionCountPerNodeMetric.setProperty("TotalConnectionCount", val);
 				connectionCountPerNodeMetric.success("Connection count decremented for node.");
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				connectionCountPerNodeMetric.error(
 					`Error while decrementing connection count for node`,
 					error,
 				);
-			},
-		);
-		this.cache.decr(this.perClusterKeyName).then(
-			(val) => {
+			});
+		this.cache
+			.decr(this.perClusterKeyName)
+			.then((val) => {
 				totalConnectionCountMetric.setProperty("TotalConnectionCount", val);
 				totalConnectionCountMetric.success("Total connection count decremented.");
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				totalConnectionCountMetric.error(
 					`Error while decrementing total connection count for cluster.`,
 					error,
 				);
-			},
-		);
+			});
 	}
 }

--- a/server/routerlicious/packages/local-server/.eslintrc.js
+++ b/server/routerlicious/packages/local-server/.eslintrc.js
@@ -6,6 +6,7 @@
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
 	parserOptions: {
-		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+		"project": ["./tsconfig.json", "./src/test/tsconfig.json"],
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/memory-orderer/.eslintrc.js
+++ b/server/routerlicious/packages/memory-orderer/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
 		"@typescript-eslint/restrict-template-expressions": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -294,13 +294,13 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
 					this.databaseManager,
 					this.timeoutLength,
 				);
-				updateP.then(
-					(newNode) => {
+				updateP
+					.then((newNode) => {
 						// Debug(`Successfully renewed expiration for ${this.node._id}`);
 						this.node = newNode;
 						this.scheduleHeartbeat();
-					},
-					(error) => {
+					})
+					.catch((error) => {
 						// Try again immediately.
 						debug(`Failed to renew expiration for ${this.node._id}`, error);
 						Lumberjack.error(
@@ -309,8 +309,7 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
 							error,
 						);
 						this.scheduleHeartbeat();
-					},
-				);
+					});
 			}, delta);
 		}
 	}

--- a/server/routerlicious/packages/memory-orderer/src/localOrderManager.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderManager.ts
@@ -62,16 +62,15 @@ export class LocalOrderManager {
 
 	private createLocalNode() {
 		this.localNodeP = this.nodeFactory.create();
-		this.localNodeP.then(
-			(localNode) => {
+		this.localNodeP
+			.then((localNode) => {
 				localNode.on("error", (error) => {
 					// Handle disconnects, error, etc... and create a new node
 				});
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				// Reconnect the node
-			},
-		);
+			});
 	}
 
 	private getKey(tenantId: string, documentId: string) {

--- a/server/routerlicious/packages/protocol-base/.eslintrc.js
+++ b/server/routerlicious/packages/protocol-base/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"no-case-declarations": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/routerlicious-base/.eslintrc.js
+++ b/server/routerlicious/packages/routerlicious-base/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -122,14 +122,13 @@ export function create(
 				content: blobData.content,
 				encoding: "base64",
 			};
-			uploadBlob(uri, requestBody).then(
-				(data: git.ICreateBlobResponse) => {
+			uploadBlob(uri, requestBody)
+				.then((data: git.ICreateBlobResponse) => {
 					response.status(200).json(data);
-				},
-				(err) => {
+				})
+				.catch((err) => {
 					response.status(400).end(err.toString());
-				},
-			);
+				});
 		},
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -116,17 +116,16 @@ export function create(
 				getParam(request.params, "tenantId") || appTenants[0].id,
 				getParam(request.params, "id"),
 			);
-			documentP.then(
-				(document) => {
+			documentP
+				.then((document) => {
 					if (!document || document.scheduledDeletionTime) {
 						response.status(404);
 					}
 					response.status(200).json(document);
-				},
-				(error) => {
+				})
+				.catch((error) => {
 					response.status(400).json(error);
-				},
-			);
+				});
 		},
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -148,7 +148,6 @@ export class AlfredRunner implements IRunner {
 		return this.runningDeferred.promise;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/promise-function-async
 	public async stop(caller?: string, uncaughtException?: any): Promise<void> {
 		if (this.stopped) {
 			return;

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -63,14 +63,14 @@ export class RiddlerRunner implements IRunner {
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
 	public stop(): Promise<void> {
 		// Close the underlying server and then resolve the runner once closed
-		this.server.close().then(
-			() => {
+		this.server
+			.close()
+			.then(() => {
 				this.runningDeferred.resolve();
-			},
-			(error) => {
+			})
+			.catch((error) => {
 				this.runningDeferred.reject(error);
-			},
-		);
+			});
 		return this.runningDeferred.promise;
 	}
 

--- a/server/routerlicious/packages/routerlicious/.eslintrc.js
+++ b/server/routerlicious/packages/routerlicious/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-client/.eslintrc.js
+++ b/server/routerlicious/packages/services-client/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-core/.eslintrc.js
+++ b/server/routerlicious/packages/services-core/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-ordering-zookeeper/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-zookeeper/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-shared/.eslintrc.js
+++ b/server/routerlicious/packages/services-shared/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-shared/src/http.ts
+++ b/server/routerlicious/packages/services-shared/src/http.ts
@@ -59,8 +59,8 @@ export function handleResponse<T>(
 	successStatus: number = 200,
 	onSuccess: (value: T) => void = () => {},
 ) {
-	resultP.then(
-		(result) => {
+	resultP
+		.then((result) => {
 			if (allowClientCache === true) {
 				response.setHeader("Cache-Control", "public, max-age=31536000");
 			} else if (allowClientCache === false) {
@@ -76,8 +76,8 @@ export function handleResponse<T>(
 			onSuccess(result);
 			// Express' json call below will set the content-length.
 			response.status(successStatus).json(result);
-		},
-		(error) => {
+		})
+		.catch((error) => {
 			// Only log unexpected errors on the assumption that explicitly thrown
 			// NetworkErrors have additional logging in place at the source.
 			if (error instanceof Error && error?.name === "NetworkError") {
@@ -90,6 +90,5 @@ export function handleResponse<T>(
 				Lumberjack.error("Unexpected error when processing HTTP Request", undefined, error);
 				response.status(errorStatus ?? 400).json(defaultErrorMessage);
 			}
-		},
-	);
+		});
 }

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -105,15 +105,15 @@ export function runService<T extends IResources>(
 	const runnerMetric = Lumberjack.newLumberMetric(LumberEventName.RunService);
 	const runningP = run(config, resourceFactory, runnerFactory, logger);
 
-	runningP.then(
-		async () => {
+	runningP
+		.then(async () => {
 			await executeAndWait(() => {
 				logger?.info("Exiting");
 				runnerMetric.success(`${group} exiting.`);
 			}, waitInMs);
 			process.exit(0);
-		},
-		async (error) => {
+		})
+		.catch(async (error) => {
 			if (error.uncaughtException) {
 				runnerMetric.setProperty(CommonProperties.restartReason, "uncaughtException");
 			}
@@ -127,8 +127,7 @@ export function runService<T extends IResources>(
 			} else {
 				process.exit(1);
 			}
-		},
-	);
+		});
 }
 
 /*

--- a/server/routerlicious/packages/services-telemetry/.eslintrc.js
+++ b/server/routerlicious/packages/services-telemetry/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
 	},
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services-utils/.eslintrc.js
+++ b/server/routerlicious/packages/services-utils/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services/.eslintrc.js
+++ b/server/routerlicious/packages/services/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };

--- a/server/routerlicious/packages/services/src/metricClient.ts
+++ b/server/routerlicious/packages/services/src/metricClient.ts
@@ -16,9 +16,12 @@ class TelegrafClient implements IMetricClient {
 			host: config.host,
 			port: config.port,
 		});
-		this.telegrafClient.connect().then(() => {
-			this.connected = true;
-		});
+		this.telegrafClient
+			.connect()
+			.then(() => {
+				this.connected = true;
+			})
+			.catch(() => {});
 	}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/services/src/nodeCodeLoader.ts
+++ b/server/routerlicious/packages/services/src/nodeCodeLoader.ts
@@ -43,8 +43,7 @@ export class NodeCodeLoader {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return entry;
 		} else {
-			// eslint-disable-next-line @typescript-eslint/no-floating-promises
-			Promise.reject(new Error("Invalid Package"));
+			throw new Error("Invalid Package");
 		}
 	}
 

--- a/server/routerlicious/packages/test-utils/.eslintrc.js
+++ b/server/routerlicious/packages/test-utils/.eslintrc.js
@@ -12,5 +12,6 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"import/no-nodejs-modules": "off",
 		"no-case-declarations": "off",
+		"promise/catch-or-return": ["error", { allowFinally: true }],
 	},
 };


### PR DESCRIPTION
## Description

We have been seeing many Uncaught Exceptions in lambdas like Deli and Scribe. From a code perspective, it looks like all of these locations are wrapped in try..catch blocks or .then.catch chains. However, sometimes these errors are getting bubbled up as uncaught and causing the services to restart.

### Change 1: make sure optionalPromise then/catch are set immediately

Coming up to the top of the stack, we see in DocumentPartition and Partition classes that we don't immediately set `.catch` on the lambda handler promise. I think it's possible this could be contributing, and it doesn't hurt to change it.

### Change 2: then(success, error) vs .then().catch()

Using `then(success, error)` does not handle errors thrown in the success handler. For example, the following will throw an uncaught exception.
```ts
myPromise.then(() => { throw new Error()}, (error) => console.error(error));
```
This pattern is used in a couple places in the R11s codebase. I have added the ESLint rule [promise/catch-or-return](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/catch-or-return.md#enforce-the-use-of-catch-on-un-returned-promises-promisecatch-or-return) to make sure this never happens again.