### PR TITLE
Prepare for removal of "contextChanged" from IContainerEvents

### DIFF
--- a/examples/data-objects/prosemirror/src/componentView.ts
+++ b/examples/data-objects/prosemirror/src/componentView.ts
@@ -45,13 +45,6 @@ export class ComponentView implements NodeView {
 
 	private load(url: string) {
 		this.attach(url);
-		const containerP = this.loader.resolve({ url });
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		containerP.then((container) => {
-			container.on("contextChanged", (value) => {
-				this.attach(url);
-			});
-		});
 	}
 
 	private attach(url: string) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2340,8 +2340,6 @@ export class Container
 		this._lifecycleEvents.emit("runtimeInstantiated");
 
 		this._loadedCodeDetails = codeDetails;
-
-		this.emit("contextChanged", codeDetails);
 	}
 
 	private readonly updateDirtyContainerState = (dirty: boolean) => {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1672,7 +1672,6 @@ export class Container
 			}, // IQuorumSnapShot
 		);
 
-		// The load context - given we seeded the quorum - will be great
 		await this.instantiateRuntime(codeDetails, undefined);
 
 		this.setLoaded();

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -152,10 +152,6 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
 						`containers[${i}] should not be closed yet`,
 					);
 				});
-
-				containers[i].once("contextChanged", () => {
-					throw Error(`context should not change for containers[${i}]`);
-				});
 			}
 
 			const res = await Promise.all([
@@ -172,11 +168,6 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
 	);
 
 	it("Code Proposal With Compatible Existing", async () => {
-		for (let i = 0; i < containers.length; i++) {
-			containers[i].once("contextChanged", () => {
-				throw Error(`context should not change for containers[${i}]`);
-			});
-		}
 		const proposal: IFluidCodeDetails = { package: packageV1dot5 };
 		const res = await Promise.all([
 			containers[0].proposeCodeDetails(proposal),

--- a/packages/tools/devtools/devtools-core/src/test/Utilities.ts
+++ b/packages/tools/devtools/devtools-core/src/test/Utilities.ts
@@ -91,10 +91,6 @@ class MockContainer
 		this.emit("connected");
 	}
 
-	public contextChanged(): void {
-		this.emit("contextChanged");
-	}
-
 	public disconnect(): void {
 		this.emit("disconnected");
 	}

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -318,10 +318,6 @@ export async function start(
 
 	// Load and render the Fluid object.
 	await getFluidObjectAndRender(container1, fluidObjectUrl, leftDiv);
-	// Handle the code upgrade scenario (which fires contextChanged)
-	container1.on("contextChanged", () => {
-		getFluidObjectAndRender(container1, fluidObjectUrl, leftDiv).catch(() => {});
-	});
 
 	// We have rendered the Fluid object. If the container is detached, attach it now.
 	if (container1.attachState === AttachState.Detached) {
@@ -363,11 +359,6 @@ export async function start(
 		containers.push(container2);
 
 		await getFluidObjectAndRender(container2, fluidObjectUrl, rightDiv);
-		// Handle the code upgrade scenario (which fires contextChanged)
-		container2.on("contextChanged", () => {
-			assert(rightDiv !== undefined, 0x31c /* rightDiv is undefined */);
-			getFluidObjectAndRender(container2, fluidObjectUrl, rightDiv).catch(() => {});
-		});
 	}
 }
 
@@ -483,12 +474,6 @@ async function attachContainer(
 				currentLeftDiv = newLeftDiv;
 				// Load and render the component.
 				await getFluidObjectAndRender(currentContainer, fluidObjectUrl, newLeftDiv);
-				// Handle the code upgrade scenario (which fires contextChanged)
-				currentContainer.on("contextChanged", () => {
-					getFluidObjectAndRender(currentContainer, fluidObjectUrl, newLeftDiv).catch(
-						() => {},
-					);
-				});
 			};
 		};
 


### PR DESCRIPTION
[AB#4998](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4998)

The "contextChanged" event dates back to when we had an idea of a "hot-swappable" context.  However this never really worked right, and we've slowly removed bits of the infrastructure over time.  The event is the main remaining piece, which has already been deprecated since 2.0.0-internal.2.2.0.

Furthermore, that infrastructure removal has gotten us to a point where the event only fires once and never in an observable fashion - it always fires before the container reference is handed back to the customer (in all paths), so it's impossible to listen for.  So we can go ahead and remove its firing entirely, since no one can observe it anyway.

This PR additionally removes any other attempts to listen for it from our repo.  It also does a little simplification in the Container instantiation flow, since the way the methods are split was originally intended to facilitate the "swappable" context idea but are now unnecessary.