### PR TITLE
tree2: remove some old schema APIs

### DIFF
--- a/.changeset/tidy-poets-enter.md
+++ b/.changeset/tidy-poets-enter.md
@@ -1,0 +1,5 @@
+---
+"@fluid-experimental/tree2": minor
+---
+
+Remove old SchemaBuilder APIs in favor of Schema2 design.

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1708,7 +1708,6 @@ export class SchemaBuilder {
     static fieldRecursive<Kind extends FieldKindTypes, T extends FlexList<RecursiveTreeSchema>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     static fieldSequence<T extends AllowedTypes>(...t: T): FieldSchema<typeof FieldKinds.sequence, T>;
     static fieldValue<T extends AllowedTypes>(...allowedTypes: T): FieldSchema<typeof FieldKinds.value, T>;
-    globalField<Kind extends FieldKindTypes, Types extends AllowedTypes>(key: string, field: FieldSchema<Kind, Types>): GlobalFieldSchema<Kind, Types>;
     intoDocumentSchema<Kind extends FieldKindTypes, Types extends AllowedTypes>(root: FieldSchema<Kind, Types>): TypedSchemaCollection<GlobalFieldSchema<Kind, Types>>;
     intoLibrary(): SchemaLibrary;
     leaf<Name extends string, T extends ValueSchema>(name: Name, t: T): TreeSchema<Name, {
@@ -1722,11 +1721,6 @@ export class SchemaBuilder {
     }>;
     // (undocumented)
     readonly name: string;
-    object<Name extends string, T extends TreeSchemaSpecification>(name: Name, t: T): TreeSchema<Name, T>;
-    objectRecursive<Name extends string, T extends RecursiveTreeSchemaSpecification>(name: Name, t: T): TreeSchema<Name, T>;
-    primitive<Name extends string, T extends PrimitiveValueSchema>(name: Name, t: T): TreeSchema<Name, {
-        value: T;
-    }>;
     struct<Name extends string, T extends RestrictiveReadonlyRecord<string, FieldSchema>>(name: Name, t: T): TreeSchema<Name, {
         local: T;
     }>;
@@ -1974,8 +1968,6 @@ export class TreeSchema<Name extends string = string, T extends RecursiveTreeSch
     // (undocumented)
     readonly builder: Named<string>;
     // (undocumented)
-    readonly extraGlobalFields: boolean;
-    // (undocumented)
     readonly extraLocalFields: FieldSchema;
     // (undocumented)
     get globalFields(): ReadonlySet<GlobalFieldKey>;
@@ -1994,8 +1986,6 @@ export class TreeSchema<Name extends string = string, T extends RecursiveTreeSch
 // @alpha
 export interface TreeSchemaBuilder {
     // (undocumented)
-    readonly extraGlobalFields?: boolean;
-    // (undocumented)
     readonly extraLocalFields: FieldStoredSchema;
     // (undocumented)
     readonly globalFields?: Iterable<GlobalFieldKey>;
@@ -2013,8 +2003,6 @@ export type TreeSchemaIdentifier = Brand<string, "tree.Schema">;
 // @alpha
 interface TreeSchemaSpecification {
     // (undocumented)
-    readonly extraGlobalFields?: boolean;
-    // (undocumented)
     readonly extraLocalFields?: FieldSchema;
     // (undocumented)
     readonly global?: FlexList<GlobalFieldSchema>;
@@ -2026,7 +2014,6 @@ interface TreeSchemaSpecification {
 
 // @alpha (undocumented)
 export interface TreeStoredSchema {
-    readonly extraGlobalFields: boolean;
     readonly extraLocalFields: FieldStoredSchema;
     readonly globalFields: ReadonlySet<GlobalFieldKey>;
     readonly localFields: ReadonlyMap<LocalFieldKey, FieldStoredSchema>;

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/schemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/schemaConverter.spec.ts
@@ -110,7 +110,6 @@ describe("schema converter", () => {
 						}
 					}
 					assert.deepEqual([...propertySchema.globalFields], []);
-					assert.equal(propertySchema.extraGlobalFields, false);
 					assert.equal(propertySchema.value, ValueSchema.Nothing);
 					assert(fullSchemaData.treeSchema.get(brand(`map<${typeName}>`)) !== undefined);
 					assert(
@@ -214,7 +213,6 @@ describe("schema converter", () => {
 				[],
 			);
 			assert.deepEqual([...(neverTreeSchema.globalFields ?? fail("expected empty set"))], []);
-			assert.equal(neverTreeSchema.extraGlobalFields, false);
 		});
 
 		it(`does not support types with nested properties`, () => {
@@ -297,7 +295,6 @@ describe("schema converter", () => {
 			const arraySchema = fullSchemaData.treeSchema.get(arrayTypeName);
 			assert(arraySchema !== undefined);
 			assert.deepEqual([...arraySchema.globalFields], []);
-			assert.equal(arraySchema.extraGlobalFields, false);
 			assert.equal(arraySchema.value, ValueSchema.Nothing);
 			assert.equal(arraySchema.localFields.size, 1);
 			const primary = getPrimaryField(arraySchema);
@@ -330,7 +327,6 @@ describe("schema converter", () => {
 			);
 			assert.deepEqual([...mapSchema.localFields], []);
 			assert.deepEqual([...mapSchema.globalFields], []);
-			assert.equal(mapSchema.extraGlobalFields, false);
 			assert.equal(mapSchema.value, ValueSchema.Nothing);
 		});
 

--- a/experimental/dds/tree2/docs/schema2.md
+++ b/experimental/dds/tree2/docs/schema2.md
@@ -91,15 +91,16 @@ and does not involve exposing any stored schema editing to users.
 Workstream 1
 
 1. (Done) Add the 4 node type builders to SchemaBuilder. Use the existing schema features, but just limit which features each can use (like is already done for primitive).
-2. (In progress) Update all schema to use new API.
-3. Remove old schema builder API.
+2. (Done) Update all schema to use new API.
+3. (Done) Remove old schema builder API.
 4. Capture which kind of node schema the view schema are in the data and type produced by the schema builder.
 
 Workstream 2
 
-1. Replace existing usages of global field keys with string constants.
-2. Remove support for global fields
-3. Cleanup code now that it can assume only local fields (ex: extra objects to separate local and global can be renamed or removed).
+1. (Done) Replace existing usages of global field keys with string constants.
+2. Implement alternative design for root field.
+3. Remove support for global fields.
+4. Cleanup code now that it can assume only local fields (ex: extra objects to separate local and global can be renamed or removed).
 
 Workstream 3
 

--- a/experimental/dds/tree2/src/core/schema-stored/Stored and View Schema.md
+++ b/experimental/dds/tree2/src/core/schema-stored/Stored and View Schema.md
@@ -173,10 +173,6 @@ Use edit primitives that avoid this?
 
 ex: swap instead of delete and insert. Maybe a version of detach that inserts a placeholder which has to be replaced with valid data before the transaction ends? That seems like it could make the tree reading API for the middle of transactions messy.
 
-### What to do with TreeStoredSchema.extraGlobalFields?
-
-Should TreeStoredSchema.extraGlobalFields exist, and if not, should be be unconditionally on or off? (See its doc comment).
-
 ### Do we need bounded open polymorphism?
 
 Definitions for adjectives used with polymorphism:

--- a/experimental/dds/tree2/src/core/schema-stored/builders.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/builders.ts
@@ -44,8 +44,6 @@ export function fieldSchema(
 	};
 }
 
-const defaultExtraGlobalFields = false;
-
 /**
  * See {@link TreeStoredSchema} for details.
  * @alpha
@@ -54,7 +52,6 @@ export interface TreeSchemaBuilder {
 	readonly localFields?: { [key: string]: FieldStoredSchema };
 	readonly globalFields?: Iterable<GlobalFieldKey>;
 	readonly extraLocalFields: FieldStoredSchema;
-	readonly extraGlobalFields?: boolean;
 	readonly value?: ValueSchema;
 }
 
@@ -75,7 +72,6 @@ export function treeSchema(data: TreeSchemaBuilder): TreeStoredSchema {
 		localFields,
 		globalFields: new Set(data.globalFields ?? []),
 		extraLocalFields: data.extraLocalFields,
-		extraGlobalFields: data.extraGlobalFields ?? defaultExtraGlobalFields,
 		value: data.value ?? ValueSchema.Nothing,
 	};
 }

--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -196,34 +196,6 @@ export interface TreeStoredSchema {
 	readonly extraLocalFields: FieldStoredSchema;
 
 	/**
-	 * If true,
-	 * GlobalFieldKeys other than the ones listed above in globalFields may be used to store data on this tree node.
-	 * Such fields must still be in schema with their global FieldStoredSchema.
-	 *
-	 * This allows for the "augmentations" pattern where
-	 * users can attach information they understand to any tree without risk of name collisions.
-	 * This is not the only way to do "augmentations":
-	 * another approach is for the applications that wish to add them to include
-	 * the augmentation in their view schema on the nodes they with to augment,
-	 * and update the stored schema to permit them as needed.
-	 *
-	 * This schema system could work with extraGlobalFields unconditionally on
-	 * (justified as allowing augmentations everywhere though requiring stored schema changes),
-	 * or unconditionally off (requiring augmentations to sometimes update stored schema).
-	 * Simplifying this system to not have extraGlobalFields and default it to on or off is a design decision which
-	 * doesn't impact the rest of this system,
-	 * and thus is being put off for now.
-	 *
-	 * Unlike with extraLocalFields, only non-empty global fields have to be in schema here,
-	 * so the existence of a global value field does not immediately make all TreeStoredSchema permitting extra global fields
-	 * out of schema if they are missing said field.
-	 *
-	 * TODO: this approach is inconsistent and should likely be redesigned
-	 * so global and local extra fields work more similarly.
-	 */
-	readonly extraGlobalFields: boolean;
-
-	/**
 	 * There are several approaches for how to store actual data in the tree
 	 * (special node types, special field contents, data on nodes etc.)
 	 * as well as several options about how the data should be modeled at this level

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -187,7 +187,7 @@ function tryShapeForSchema(
 		return cached;
 	}
 	const treeSchema = lookupTreeSchema(schema, type);
-	if (treeSchema.extraGlobalFields || treeSchema.extraLocalFields !== undefined) {
+	if (treeSchema.extraLocalFields !== undefined) {
 		return polymorphic;
 	}
 	const fieldsArray: FieldShape[] = [];

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultSchema.ts
@@ -26,7 +26,6 @@ export const neverTree: TreeStoredSchema = {
 	localFields: emptyMap,
 	globalFields: emptySet,
 	extraLocalFields: neverField,
-	extraGlobalFields: false,
 	value: ValueSchema.Nothing,
 };
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/utilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/utilities.ts
@@ -29,7 +29,6 @@ export function isPrimitive(schema: TreeStoredSchema): boolean {
 		schema.value !== ValueSchema.Nothing &&
 		schema.localFields.size === 0 &&
 		schema.globalFields.size === 0 &&
-		schema.extraGlobalFields === false &&
 		schema.extraLocalFields.kind.identifier === FieldKinds.forbidden.identifier
 	);
 }

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/comparison.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/comparison.ts
@@ -40,16 +40,12 @@ export function allowsTreeSuperset(
 	) {
 		return false;
 	}
-	if (original.extraGlobalFields && !superset.extraGlobalFields) {
-		return false;
-	}
 	if (
 		!compareSets({
 			a: original.globalFields,
 			b: superset.globalFields,
 			// true iff the original field must always be empty, or superset supports extra global fields.
 			aExtra: (originalField) =>
-				superset.extraGlobalFields ||
 				allowsFieldSuperset(
 					policy,
 					originalData,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/view.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/view.ts
@@ -165,7 +165,6 @@ export class ViewSchema extends ViewSchemaData<FullSchemaPolicy> {
 		return {
 			globalFields: original.globalFields,
 			extraLocalFields: original.extraLocalFields,
-			extraGlobalFields: original.extraGlobalFields,
 			value: original.value,
 			localFields,
 		};

--- a/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
@@ -57,7 +57,6 @@ const TreeSchemaFormat = Type.Object(
 		localFields: Type.Array(NamedLocalFieldSchemaFormat),
 		globalFields: Type.Array(GlobalFieldKeySchema),
 		extraLocalFields: FieldSchemaFormat,
-		extraGlobalFields: Type.Boolean(),
 		// TODO: don't use external type here.
 		value: Type.Enum(ValueSchema),
 	},
@@ -124,7 +123,6 @@ function compareNamed(a: Named<string>, b: Named<string>) {
 function encodeTree(name: TreeSchemaIdentifier, schema: TreeStoredSchema): TreeSchemaFormat {
 	const out: TreeSchemaFormat = {
 		name,
-		extraGlobalFields: schema.extraGlobalFields,
 		extraLocalFields: encodeField(schema.extraLocalFields),
 		globalFields: [...schema.globalFields].sort(),
 		localFields: [...schema.localFields]
@@ -178,7 +176,6 @@ function decodeField(schema: FieldSchemaFormat): FieldStoredSchema {
 
 function decodeTree(schema: TreeSchemaFormat): TreeStoredSchema {
 	const out: TreeStoredSchema = {
-		extraGlobalFields: schema.extraGlobalFields,
 		extraLocalFields: decodeField(schema.extraLocalFields),
 		globalFields: new Set(schema.globalFields),
 		localFields: new Map(

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaBuilder.ts
@@ -8,14 +8,13 @@ import {
 	Adapters,
 	FieldAdapter,
 	GlobalFieldKey,
-	PrimitiveValueSchema,
 	rootFieldKey,
 	TreeAdapter,
 	TreeSchemaIdentifier,
 	ValueSchema,
 } from "../../core";
 import { Sourced, SchemaCollection } from "../modular-schema";
-import { brand, requireAssignableTo, RestrictiveReadonlyRecord } from "../../util";
+import { requireAssignableTo, RestrictiveReadonlyRecord } from "../../util";
 import { FieldKindTypes, FieldKinds } from "../default-field-kinds";
 import { buildViewSchemaCollection } from "./buildViewSchemaCollection";
 import {
@@ -64,7 +63,6 @@ export type RecursiveTreeSchemaSpecification = unknown;
 export class SchemaBuilder {
 	private readonly libraries: Set<SchemaLibraryData>;
 	private finalized: boolean = false;
-	private readonly globalFieldSchema: Map<GlobalFieldKey, GlobalFieldSchema> = new Map();
 	private readonly treeSchema: Map<TreeSchemaIdentifier, TreeSchema> = new Map();
 	private readonly adapters: Adapters = {};
 
@@ -98,33 +96,6 @@ export class SchemaBuilder {
 	private addNodeSchema<T extends TreeSchema<string, any>>(schema: T): void {
 		assert(!this.treeSchema.has(schema.name), 0x6ab /* Conflicting TreeSchema names */);
 		this.treeSchema.set(schema.name, schema as TreeSchema);
-	}
-
-	/**
-	 * Define (and add to this library) a schema for an object.
-	 *
-	 * The name must be unique among all object schema in the the document schema.
-	 */
-	public object<Name extends string, T extends TreeSchemaSpecification>(
-		name: Name,
-		t: T,
-	): TreeSchema<Name, T> {
-		const schema = new TreeSchema(this, name, t);
-		this.addNodeSchema(schema);
-		return schema;
-	}
-
-	/**
-	 * Same as `object` but with less type safety and works for recursive objects.
-	 * Reduced type safety is a side effect of a workaround for a TypeScript limitation.
-	 *
-	 * See note on RecursiveTreeSchema for details.
-	 */
-	public objectRecursive<Name extends string, T extends RecursiveTreeSchemaSpecification>(
-		name: Name,
-		t: T,
-	): TreeSchema<Name, T> {
-		return this.object(name, t as TreeSchemaSpecification) as TreeSchema<Name, T>;
 	}
 
 	/**
@@ -268,20 +239,6 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define (and add to this library) a schema for an object that just wraps a primitive value.
-	 * Such objects will be implicitly unwrapped to the value in some APIs.
-	 *
-	 * This is just a shorthand for a common case of `object`. See {@link SchemaBuilder.object} for details.
-	 */
-	public primitive<Name extends string, T extends PrimitiveValueSchema>(
-		name: Name,
-		t: T,
-	): TreeSchema<Name, { value: T }> {
-		// TODO: add "primitive" metadata to schema, and set it here.
-		return this.object(name, { value: t });
-	}
-
-	/**
 	 * Define (and add to this library) a {@link TreeSchema} for a node that wraps a value.
 	 * Such nodes will be implicitly unwrapped to the value in some APIs.
 	 *
@@ -304,31 +261,13 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define (and add to this library) a schema for a global field.
-	 * Global fields can be included in the schema for multiple objects.
-	 *
-	 * The key must be unique among all object global fields in the the document schema.
-	 *
-	 * See {@link SchemaBuilder.field} for how to build the `field` parameter.
-	 */
-	public globalField<Kind extends FieldKindTypes, Types extends AllowedTypes>(
-		key: string,
-		field: FieldSchema<Kind, Types>,
-	): GlobalFieldSchema<Kind, Types> {
-		const schema = new GlobalFieldSchema(this, brand(key), field);
-		assert(!this.globalFieldSchema.has(schema.key), 0x6ac /* Conflicting global field keys */);
-		this.globalFieldSchema.set(schema.key, schema);
-		return schema;
-	}
-
-	/**
 	 * Define a schema for a field.
 	 *
 	 * @param kind - The [kind](https://en.wikipedia.org/wiki/Kind_(type_theory)) of this field.
 	 * Determine the multiplicity, viewing and editing APIs as well as the merge resolution policy.
 	 * @param allowedTypes - What types of children are allowed in this field.
-	 * @returns a field which can be used as a local field (see {@link SchemaBuilder.object}),
-	 * global fields (see {@link SchemaBuilder.globalField}) or the root field (see {@link SchemaBuilder.intoDocumentSchema}).
+	 * @returns a field which can be used as a struct field (see {@link SchemaBuilder.struct}),
+	 * a map field (see {@link SchemaBuilder.map}), or the root field (see {@link SchemaBuilder.intoDocumentSchema}).
 	 */
 	public static field<Kind extends FieldKindTypes, T extends AllowedTypes>(
 		kind: Kind,
@@ -408,7 +347,7 @@ export class SchemaBuilder {
 		this.finalized = true;
 		this.libraries.add({
 			name: this.name,
-			globalFieldSchema: this.globalFieldSchema,
+			globalFieldSchema: new Map(),
 			treeSchema: this.treeSchema,
 			adapters: this.adapters,
 		});

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -67,7 +67,6 @@ export class TreeSchema<
 	>;
 
 	public readonly extraLocalFields: FieldSchema;
-	public readonly extraGlobalFields: boolean;
 	public readonly value: WithDefault<
 		Assume<T, TreeSchemaSpecification>["value"],
 		ValueSchema.Nothing
@@ -85,7 +84,6 @@ export class TreeSchema<
 		);
 		this.localFields = objectToMapTyped(this.localFieldsObject);
 		this.extraLocalFields = normalizeField(this.info.extraLocalFields);
-		this.extraGlobalFields = this.info.extraGlobalFields ?? false;
 		this.value = (this.info.value ?? ValueSchema.Nothing) as WithDefault<
 			Assume<T, TreeSchemaSpecification>["value"],
 			ValueSchema.Nothing
@@ -180,7 +178,6 @@ export interface TreeSchemaSpecification {
 	readonly local?: RestrictiveReadonlyRecord<string, FieldSchema>;
 	readonly global?: FlexList<GlobalFieldSchema>;
 	readonly extraLocalFields?: FieldSchema;
-	readonly extraGlobalFields?: boolean;
 	readonly value?: ValueSchema;
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -592,7 +592,6 @@ describe("editable-tree: read-only", () => {
 		const simplePhonesSchema = simplePhonesNode[typeSymbol];
 		assert.deepEqual(simplePhonesSchema.extraLocalFields.types, new Set());
 		assert.deepEqual([...simplePhonesSchema.globalFields], []);
-		assert.equal(simplePhonesSchema.extraGlobalFields, false);
 		assert.equal(simplePhonesSchema.localFields.size, 1);
 		const simplePhonesPrimaryKey = [...simplePhonesSchema.localFields.keys()][0];
 		// primary key must be the same across the schema

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -54,7 +54,6 @@ describe("Schema Comparison", () => {
 		localFields: emptyMap,
 		globalFields: emptySet,
 		extraLocalFields: anyField,
-		extraGlobalFields: true,
 		value: ValueSchema.Serializable,
 	};
 
@@ -62,7 +61,6 @@ describe("Schema Comparison", () => {
 		localFields: new Map([[brand("x"), neverField]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
-		extraGlobalFields: true,
 		value: ValueSchema.Serializable,
 	};
 
@@ -71,7 +69,6 @@ describe("Schema Comparison", () => {
 		localFields: emptyMap,
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
-		extraGlobalFields: false,
 		value: ValueSchema.Nothing,
 	};
 
@@ -80,7 +77,6 @@ describe("Schema Comparison", () => {
 		localFields: new Map([[brand("x"), emptyField]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
-		extraGlobalFields: false,
 		value: ValueSchema.Nothing,
 	};
 
@@ -89,7 +85,6 @@ describe("Schema Comparison", () => {
 		localFields: new Map([[brand("x"), fieldSchema(FieldKinds.optional, [emptyTree.name])]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
-		extraGlobalFields: false,
 		value: ValueSchema.Nothing,
 	};
 
@@ -98,7 +93,6 @@ describe("Schema Comparison", () => {
 		localFields: new Map([[brand("x"), fieldSchema(FieldKinds.value, [emptyTree.name])]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
-		extraGlobalFields: false,
 		value: ValueSchema.Nothing,
 	};
 
@@ -161,7 +155,6 @@ describe("Schema Comparison", () => {
 				localFields: emptyMap,
 				globalFields: emptySet,
 				extraLocalFields: neverField,
-				extraGlobalFields: false,
 				value: ValueSchema.Nothing,
 			}),
 		);
@@ -172,7 +165,6 @@ describe("Schema Comparison", () => {
 				localFields: emptyMap,
 				globalFields: new Set([brand("never")]),
 				extraLocalFields: emptyField,
-				extraGlobalFields: true,
 				value: ValueSchema.Serializable,
 			}),
 		);
@@ -181,7 +173,6 @@ describe("Schema Comparison", () => {
 				localFields: emptyMap,
 				globalFields: emptySet,
 				extraLocalFields: emptyField,
-				extraGlobalFields: false,
 				value: ValueSchema.Nothing,
 			}),
 			false,

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -197,10 +197,8 @@ describe("Node Key Index", () => {
 
 	it("is disabled if node type is not in the tree schema", () => {
 		const builder2 = new SchemaBuilder("node key index test");
-		const nodeSchemaNoKey = builder2.objectRecursive("node", {
-			local: {
-				child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchemaNoKey),
-			},
+		const nodeSchemaNoKey = builder2.structRecursive("node", {
+			child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchemaNoKey),
 		});
 		// This is missing the global node key field
 		const nodeSchemaDataNoKey = builder2.intoDocumentSchema(

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -278,8 +278,8 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 	// Test simple recursive cases:
 	{
 		const builder2 = new SchemaBuilder("Schema Aware recursive");
-		const rec = builder2.objectRecursive("rec", {
-			local: { x: SchemaBuilder.fieldRecursive(optional, () => rec) },
+		const rec = builder2.structRecursive("rec", {
+			x: SchemaBuilder.fieldRecursive(optional, () => rec),
 		});
 
 		type RecObjectSchema = typeof rec;

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
@@ -27,14 +27,8 @@ const invalidChildSchema = ballSchema.localFields.get("z");
 
 // Declare an recursive aggregate type via local fields.
 // Note that the type name can be used instead of the schema to allow recursion.
-const diagramSchema = builder.objectRecursive("Diagram", {
-	local: {
-		children: SchemaBuilder.fieldRecursive(
-			FieldKinds.sequence,
-			() => diagramSchema,
-			ballSchema,
-		),
-	},
+const diagramSchema = builder.structRecursive("Diagram", {
+	children: SchemaBuilder.fieldRecursive(FieldKinds.sequence, () => diagramSchema, ballSchema),
 });
 
 const rootField = SchemaBuilder.fieldOptional(diagramSchema);

--- a/experimental/dds/tree2/src/test/schema-stored/examples/schemaExamples.ts
+++ b/experimental/dds/tree2/src/test/schema-stored/examples/schemaExamples.ts
@@ -27,7 +27,6 @@ export const codePoint: NamedTreeSchema = {
 	localFields: emptyMap,
 	globalFields: emptySet,
 	extraLocalFields: emptyField,
-	extraGlobalFields: false,
 	value: ValueSchema.Number,
 };
 
@@ -37,7 +36,6 @@ export const codePoint: NamedTreeSchema = {
 export const string: TreeStoredSchema = {
 	globalFields: emptySet,
 	extraLocalFields: emptyField,
-	extraGlobalFields: false,
 	localFields: new Map([[brand("children"), fieldSchema(FieldKinds.sequence, [codePoint.name])]]),
 	value: ValueSchema.Nothing,
 };

--- a/experimental/dds/tree2/src/test/snapshots/files/summary_snapshot.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/summary_snapshot.json
@@ -19,7 +19,7 @@
                         "tree": {
                             "SchemaString": {
                                 "type": 2,
-                                "content": "{\"version\":\"1.0.0\",\"treeSchema\":[{\"name\":\"TestValue\",\"extraGlobalFields\":false,\"extraLocalFields\":{\"kind\":\"Sequence\"},\"globalFields\":[\"globalFieldKey\"],\"localFields\":[{\"kind\":\"Optional\",\"types\":[\"TestValue\"],\"name\":\"optionalChild\"}],\"value\":0}],\"globalFieldSchema\":[{\"kind\":\"Value\",\"name\":\"globalFieldKey\"},{\"kind\":\"Value\",\"name\":\"rootFieldKey\"}]}"
+                                "content": "{\"version\":\"1.0.0\",\"treeSchema\":[{\"name\":\"TestValue\",\"extraLocalFields\":{\"kind\":\"Sequence\"},\"globalFields\":[\"globalFieldKey\"],\"localFields\":[{\"kind\":\"Optional\",\"types\":[\"TestValue\"],\"name\":\"optionalChild\"}],\"value\":0}],\"globalFieldSchema\":[{\"kind\":\"Value\",\"name\":\"globalFieldKey\"},{\"kind\":\"Value\",\"name\":\"rootFieldKey\"}]}"
                             }
                         }
                     },
@@ -40,7 +40,7 @@
         "treeNodeCount": 5,
         "blobNodeCount": 3,
         "handleNodeCount": 0,
-        "totalBlobSize": 38526,
+        "totalBlobSize": 38500,
         "unreferencedBlobSize": 0
     }
 }


### PR DESCRIPTION
## Description

Remove non-schema2 builder APIs and support for extra global fields.

## Breaking Changes

Support for the old (schema1) APIs is being removed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
