### PR TITLE
refactor(devtools): Simplify DevtoolsLogger

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -15,7 +15,6 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
-import { TelemetryLogger } from '@fluidframework/telemetry-utils';
 
 // @internal
 export interface AudienceChangeLogEntry extends LogEntry {
@@ -202,7 +201,7 @@ export namespace DevtoolsFeatures {
 }
 
 // @public @sealed
-export class DevtoolsLogger extends TelemetryLogger {
+export class DevtoolsLogger implements ITelemetryBaseLogger {
     constructor(baseLogger?: ITelemetryBaseLogger);
     send(event: ITelemetryBaseEvent): void;
 }

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -74,8 +74,7 @@
 		"@fluidframework/matrix": "workspace:~",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@fluidframework/sequence": "workspace:~",
-		"@fluidframework/shared-object-base": "workspace:~",
-		"@fluidframework/telemetry-utils": "workspace:~"
+		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
 		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.5.2.0",
@@ -85,6 +84,7 @@
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
+		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/chai": "^4.0.0",
@@ -116,6 +116,13 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_DevtoolsLogger": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_FluidDevtoolsProps": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
+++ b/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
@@ -4,7 +4,6 @@
  */
 
 import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { TelemetryLogger } from "@fluidframework/telemetry-utils";
 
 import {
 	GetTelemetryHistory,
@@ -43,7 +42,7 @@ import { ITimestampedTelemetryEvent } from "./TelemetryMetadata";
  * @sealed
  * @public
  */
-export class DevtoolsLogger extends TelemetryLogger {
+export class DevtoolsLogger implements ITelemetryBaseLogger {
 	/**
 	 * Base telemetry logger provided by the consumer.
 	 * All messages sent to the Devtools logger will be forwarded to this.
@@ -97,8 +96,6 @@ export class DevtoolsLogger extends TelemetryLogger {
 	// #endregion
 
 	public constructor(baseLogger?: ITelemetryBaseLogger) {
-		super();
-
 		this.baseLogger = baseLogger;
 
 		this._telemetryLog = [];
@@ -118,7 +115,7 @@ export class DevtoolsLogger extends TelemetryLogger {
 
 		try {
 			const newEvent: ITimestampedTelemetryEvent = {
-				logContent: this.prepareEvent(event),
+				logContent: event,
 				timestamp: Date.now(),
 			};
 

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -1235,6 +1235,7 @@ declare function get_current_ClassDeclaration_DevtoolsLogger():
 declare function use_old_ClassDeclaration_DevtoolsLogger(
     use: TypeOnly<old.DevtoolsLogger>);
 use_old_ClassDeclaration_DevtoolsLogger(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DevtoolsLogger());
 
 /*
@@ -1355,6 +1356,7 @@ declare function get_current_InterfaceDeclaration_FluidDevtoolsProps():
 declare function use_old_InterfaceDeclaration_FluidDevtoolsProps(
     use: TypeOnly<old.FluidDevtoolsProps>);
 use_old_InterfaceDeclaration_FluidDevtoolsProps(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_FluidDevtoolsProps());
 
 /*

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -100,6 +100,16 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_DevtoolsLogger": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_DevtoolsProps": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_FluidDevtoolsProps": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -83,6 +83,7 @@ declare function get_current_ClassDeclaration_DevtoolsLogger():
 declare function use_old_ClassDeclaration_DevtoolsLogger(
     use: TypeOnly<old.DevtoolsLogger>);
 use_old_ClassDeclaration_DevtoolsLogger(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DevtoolsLogger());
 
 /*
@@ -107,6 +108,7 @@ declare function get_current_InterfaceDeclaration_DevtoolsProps():
 declare function use_old_InterfaceDeclaration_DevtoolsProps(
     use: TypeOnly<old.DevtoolsProps>);
 use_old_InterfaceDeclaration_DevtoolsProps(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_DevtoolsProps());
 
 /*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11019,7 +11019,6 @@ importers:
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/sequence': link:../../../dds/sequence
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
-      '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
     devDependencies:
       '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.5.2.0
       '@fluid-tools/build-cli': 0.21.0
@@ -11028,6 +11027,7 @@ importers:
       '@fluidframework/driver-definitions': link:../../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
+      '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
       '@fluidframework/test-runtime-utils': link:../../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9
       '@types/chai': 4.3.5
@@ -19290,7 +19290,7 @@ packages:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      tslib: 2.5.0
+      tslib: 2.6.0
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -41576,6 +41576,7 @@ packages:
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: false
 
   /tslib/2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}


### PR DESCRIPTION
## Description

`DevtoolsLogger` is an implementation of an "external" logger so it only needs to implement `ITelemetryBaseLogger`. The only thing it was using from `TelemetryLogger` was the `this.prepare()` method which it shouldn't need because it already receives "prepared" events generated by `TelemetryLogger` inside the framework.

## Breaking Changes

Technically breaking for the API but this is still experimental and has no widespread use, so safe to do this in main.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The change to `DevtoolsLogger` makes `@fluidframework/telemetry-utils` now only necessary as a dev-dependency in the devtools-core package.

The Props interfaces break because they have a property of type `DevtoolsLogger`.