### PR TITLE
feat: Add nyc paths to VSCode search exclusions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,6 +76,7 @@
 		"**/_api-extractor-temp": true,
 		"**/dist/*": true,
 		"**/lib/*": true,
+		"**/nyc/*": true,
 		"**/*.log": true,
 		"**/DS_Store": true,
 	},


### PR DESCRIPTION
## Description

Add directories for test report files to the exclusion patterns for VSCode search.