### PR TITLE
Add disposed property to IContainer

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -142,6 +142,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     disconnect(): void;
     dispose(error?: ICriticalContainerError): void;
+    readonly disposed?: boolean;
     // @alpha
     forceReadonly?(readonly: boolean): any;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -339,9 +339,14 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 	getLoadedCodeDetails(): IFluidCodeDetails | undefined;
 
 	/**
-	 * Returns true if the container has been closed, otherwise false.
+	 * Returns true if the container has been closed and/or disposed, otherwise false.
 	 */
 	readonly closed: boolean;
+
+	/**
+	 * Returns true if the container has been disposed, otherwise false.
+	 */
+	readonly disposed?: boolean;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -523,11 +523,12 @@ export class Container
 
 	public get closed(): boolean {
 		return (
-			this._lifecycleState === "closing" ||
-			this._lifecycleState === "closed" ||
-			this._lifecycleState === "disposing" ||
-			this._lifecycleState === "disposed"
+			this._lifecycleState === "closing" || this._lifecycleState === "closed" || this.disposed
 		);
+	}
+
+	public get disposed(): boolean {
+		return this._lifecycleState === "disposing" || this._lifecycleState === "disposed";
 	}
 
 	private _attachState = AttachState.Detached;


### PR DESCRIPTION
Consumers of `IContainer` currently have no way to know if the container was disposed outside of observing the `"disposed"` event.