### PR TITLE
refactor compose vs individual fuzz test

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -8,7 +8,7 @@ import { DDSFuzzTestState } from "@fluid-internal/test-dds-utils";
 import { singleTextCursor } from "../../../feature-libraries";
 import { brand, fail } from "../../../util";
 import { toJsonableTree } from "../../utils";
-import { ISharedTree, SharedTreeFactory } from "../../../shared-tree";
+import { ISharedTree, ISharedTreeView, SharedTreeFactory } from "../../../shared-tree";
 import { FieldUpPath } from "../../../core";
 import {
 	FieldEdit,
@@ -17,6 +17,7 @@ import {
 	FuzzTransactionType,
 	Operation,
 } from "./operationTypes";
+import { BranchedTreeFuzzTestState } from "./targetedFuzz.spec";
 
 export const fuzzReducer = combineReducersAsync<Operation, DDSFuzzTestState<SharedTreeFactory>>({
 	edit: async (state, operation) => {
@@ -24,6 +25,29 @@ export const fuzzReducer = combineReducersAsync<Operation, DDSFuzzTestState<Shar
 		switch (contents.type) {
 			case "fieldEdit": {
 				const tree = state.channel;
+				applyFieldEdit(tree, contents);
+				break;
+			}
+			default:
+				break;
+		}
+		return state;
+	},
+	transaction: async (state, operation) => {
+		const { contents } = operation;
+		const tree = state.channel;
+		applyTransactionEdit(tree, contents);
+		return state;
+	},
+});
+
+export const fuzzComposedVsIndividualReducer = combineReducersAsync<Operation, BranchedTreeFuzzTestState>({
+	edit: async (state, operation) => {
+		const { contents } = operation;
+		switch (contents.type) {
+			case "fieldEdit": {
+				const tree = state.branch;
+				assert(tree!== undefined)
 				applyFieldEdit(tree, contents);
 				break;
 			}
@@ -50,7 +74,7 @@ export function checkTreesAreSynchronized(trees: readonly ISharedTree[]) {
 	}
 }
 
-function applyFieldEdit(tree: ISharedTree, fieldEdit: FieldEdit): void {
+function applyFieldEdit(tree: ISharedTree | ISharedTreeView, fieldEdit: FieldEdit): void {
 	switch (fieldEdit.change.type) {
 		case "sequence":
 			applySequenceFieldEdit(tree, fieldEdit.change.edit);
@@ -66,7 +90,7 @@ function applyFieldEdit(tree: ISharedTree, fieldEdit: FieldEdit): void {
 	}
 }
 
-function applySequenceFieldEdit(tree: ISharedTree, change: FuzzFieldChange): void {
+function applySequenceFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzFieldChange): void {
 	switch (change.type) {
 		case "insert": {
 			const field = tree.editor.sequenceField({ parent: change.parent, field: change.field });
@@ -89,7 +113,7 @@ function applySequenceFieldEdit(tree: ISharedTree, change: FuzzFieldChange): voi
 	}
 }
 
-function applyValueFieldEdit(tree: ISharedTree, change: FuzzDelete): void {
+function applyValueFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzDelete): void {
 	const fieldPath: FieldUpPath = {
 		parent: change.firstNode?.parent,
 		field: change.firstNode?.parentField,
@@ -98,7 +122,7 @@ function applyValueFieldEdit(tree: ISharedTree, change: FuzzDelete): void {
 	field.delete(change.firstNode?.parentIndex, change.count);
 }
 
-function applyOptionalFieldEdit(tree: ISharedTree, change: FuzzFieldChange): void {
+function applyOptionalFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzFieldChange): void {
 	switch (change.type) {
 		case "insert": {
 			const fieldPath: FieldUpPath = {
@@ -123,7 +147,7 @@ function applyOptionalFieldEdit(tree: ISharedTree, change: FuzzFieldChange): voi
 	}
 }
 
-function applyTransactionEdit(tree: ISharedTree, contents: FuzzTransactionType): void {
+function applyTransactionEdit(tree: ISharedTree | ISharedTreeView, contents: FuzzTransactionType): void {
 	switch (contents.fuzzType) {
 		case "transactionStart": {
 			tree.transaction.start();

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -17,7 +17,6 @@ import {
 	FuzzTransactionType,
 	Operation,
 } from "./operationTypes";
-import { BranchedTreeFuzzTestState } from "./targetedFuzz.spec";
 
 export const fuzzReducer = combineReducersAsync<Operation, DDSFuzzTestState<SharedTreeFactory>>({
 	edit: async (state, operation) => {
@@ -25,29 +24,6 @@ export const fuzzReducer = combineReducersAsync<Operation, DDSFuzzTestState<Shar
 		switch (contents.type) {
 			case "fieldEdit": {
 				const tree = state.channel;
-				applyFieldEdit(tree, contents);
-				break;
-			}
-			default:
-				break;
-		}
-		return state;
-	},
-	transaction: async (state, operation) => {
-		const { contents } = operation;
-		const tree = state.channel;
-		applyTransactionEdit(tree, contents);
-		return state;
-	},
-});
-
-export const fuzzComposedVsIndividualReducer = combineReducersAsync<Operation, BranchedTreeFuzzTestState>({
-	edit: async (state, operation) => {
-		const { contents } = operation;
-		switch (contents.type) {
-			case "fieldEdit": {
-				const tree = state.branch;
-				assert(tree!== undefined)
 				applyFieldEdit(tree, contents);
 				break;
 			}
@@ -74,7 +50,7 @@ export function checkTreesAreSynchronized(trees: readonly ISharedTree[]) {
 	}
 }
 
-function applyFieldEdit(tree: ISharedTree | ISharedTreeView, fieldEdit: FieldEdit): void {
+export function applyFieldEdit(tree: ISharedTreeView, fieldEdit: FieldEdit): void {
 	switch (fieldEdit.change.type) {
 		case "sequence":
 			applySequenceFieldEdit(tree, fieldEdit.change.edit);
@@ -90,7 +66,7 @@ function applyFieldEdit(tree: ISharedTree | ISharedTreeView, fieldEdit: FieldEdi
 	}
 }
 
-function applySequenceFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzFieldChange): void {
+function applySequenceFieldEdit(tree: ISharedTreeView, change: FuzzFieldChange): void {
 	switch (change.type) {
 		case "insert": {
 			const field = tree.editor.sequenceField({ parent: change.parent, field: change.field });
@@ -113,7 +89,7 @@ function applySequenceFieldEdit(tree: ISharedTree | ISharedTreeView, change: Fuz
 	}
 }
 
-function applyValueFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzDelete): void {
+function applyValueFieldEdit(tree: ISharedTreeView, change: FuzzDelete): void {
 	const fieldPath: FieldUpPath = {
 		parent: change.firstNode?.parent,
 		field: change.firstNode?.parentField,
@@ -122,7 +98,7 @@ function applyValueFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzDe
 	field.delete(change.firstNode?.parentIndex, change.count);
 }
 
-function applyOptionalFieldEdit(tree: ISharedTree | ISharedTreeView, change: FuzzFieldChange): void {
+function applyOptionalFieldEdit(tree: ISharedTreeView, change: FuzzFieldChange): void {
 	switch (change.type) {
 		case "insert": {
 			const fieldPath: FieldUpPath = {
@@ -147,7 +123,7 @@ function applyOptionalFieldEdit(tree: ISharedTree | ISharedTreeView, change: Fuz
 	}
 }
 
-function applyTransactionEdit(tree: ISharedTree | ISharedTreeView, contents: FuzzTransactionType): void {
+export function applyTransactionEdit(tree: ISharedTreeView, contents: FuzzTransactionType): void {
 	switch (contents.fuzzType) {
 		case "transactionStart": {
 			tree.transaction.start();

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
@@ -139,7 +139,7 @@ describe("Fuzz - Targeted", () => {
 		commit: 0,
 	};
 
-	describe.only("Composed vs individual changes converge to the same tree", () => {
+	describe("Composed vs individual changes converge to the same tree", () => {
 		const generatorFactory = (): AsyncGenerator<TreeOperation, BranchedTreeFuzzTestState> =>
 			takeAsync(opsPerRun, makeOpGenerator(composeVsIndividualWeights));
 


### PR DESCRIPTION
## Description

This PR refactors the targeted fuzz test for composed vs individual changes, as recent refactors to the way our transactions work would break our current test.
