### PR TITLE
Minor update on failure-skip function for more precise expression

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -19,7 +19,10 @@ import {
 	ChannelFactoryRegistry,
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeNoCompat, itSkipsOnFailure } from "@fluid-internal/test-version-utils";
+import {
+	describeNoCompat,
+	itSkipsFailureOnSpecificDrivers,
+} from "@fluid-internal/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree";
@@ -126,7 +129,7 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 	 * Tracked by AB#4997, if no error event is detected within one sprint, we will remove
 	 * the skipping or take actions accordingly if it is.
 	 */
-	itSkipsOnFailure(
+	itSkipsFailureOnSpecificDrivers(
 		"Can attribute content from multiple collaborators",
 		["tinylicious", "t9s"],
 		async () => {

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -19,7 +19,10 @@ import {
 	ChannelFactoryRegistry,
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeNoCompat, itSkipsOnFailure } from "@fluid-internal/test-version-utils";
+import {
+	describeNoCompat,
+	itSkipsFailureOnSpecificDrivers,
+} from "@fluid-internal/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
@@ -112,7 +115,7 @@ describeNoCompat("Attributor for SharedCell", (getTestObjectProvider) => {
 	 * Tracked by AB#4997, if no error event is detected within one sprint, we will remove
 	 * the skipping or take actions accordingly if it is.
 	 */
-	itSkipsOnFailure(
+	itSkipsFailureOnSpecificDrivers(
 		"Can attribute content from multiple collaborators",
 		["tinylicious", "t9s"],
 		async () => {

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -47,4 +47,4 @@ export {
 	getDriverApi,
 	getLoaderApi,
 } from "./testApi.js";
-export { itSkipsOnFailure } from "./itSkipsOnFailure.js";
+export { itSkipsFailureOnSpecificDrivers } from "./itSkipsOnFailure.js";

--- a/packages/test/test-version-utils/src/itSkipsOnFailure.ts
+++ b/packages/test/test-version-utils/src/itSkipsOnFailure.ts
@@ -40,7 +40,7 @@ export type SkippedTestWithDriverType = (
  * Similar to mocha's it function, but allow skipping for some if the error
  * happens on the specific drivers
  */
-export const itSkipsOnFailure: SkippedTestWithDriverType = (
+export const itSkipsFailureOnSpecificDrivers: SkippedTestWithDriverType = (
 	name: string,
 	skippedDrivers: TestDriverTypes[],
 	test: Mocha.AsyncFunc,


### PR DESCRIPTION
[AB#4226](https://dev.azure.com/fluidframework/internal/_workitems/edit/4226)

According to the comment https://github.com/microsoft/FluidFramework/pull/16360#discussion_r1265720298, rename the function for more precise expression and purposes. Additionally, we could implement similar functions `itSkipsFailureOnXXX` with distinct skipping conditions, in the same file. 
