### PR TITLE
Change maxBatchDeltas to 2k ops for frs driver

### DIFF
--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -22,10 +22,13 @@ import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry
 import { DocumentStorageService } from "./documentStorageService";
 import { RestWrapper } from "./restWrapperBase";
 
-// Maximum number of ops we can fetch at a time. This should be kept at 2k, as
-// server determines whether to try to fallback to long-term storage if the ops range requested is larger than
-// what they have locally available in short-term storage. So if we request 2k ops, they know it is not a
-// specific request and they don't fall to long term storage which takes time.
+/**
+ * Maximum number of ops we can fetch at a time. This should be kept at 2k, as
+ * server determines whether to try to fallback to long-term storage if the ops range requested is larger than
+ * what they have locally available in short-term storage. So if we request 2k ops, they know it is not a
+ * specific request and they don't fall to long term storage which takes time.
+ * Please coordinate to AFR team if this value need to be changed.
+ */
 const MaxBatchDeltas = 2000;
 
 /**

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -22,7 +22,11 @@ import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry
 import { DocumentStorageService } from "./documentStorageService";
 import { RestWrapper } from "./restWrapperBase";
 
-const MaxBatchDeltas = 2000; // Maximum number of ops we can fetch at a time
+// Maximum number of ops we can fetch at a time. This should be kept at 2k, as
+// server determines whether to try to fallback to long-term storage if the ops range requested is larger than
+// what they have locally available in short-term storage. So if we request 2k ops, they know it is not a
+// specific request and they don't fall to long term storage which takes time.
+const MaxBatchDeltas = 2000;
 
 /**
  * Storage service limited to only being able to fetch documents for a specific document

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -22,7 +22,7 @@ import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry
 import { DocumentStorageService } from "./documentStorageService";
 import { RestWrapper } from "./restWrapperBase";
 
-const MaxBatchDeltas = 5000; // Maximum number of ops we can fetch at a time
+const MaxBatchDeltas = 2000; // Maximum number of ops we can fetch at a time
 
 /**
  * Storage service limited to only being able to fetch documents for a specific document


### PR DESCRIPTION
## Description

Change maxBatchDeltas to 2k ops for frs driver. Server has same optimization around 2k ops to determine that whether ops should be fetched from long permanent storage or not.