### PR TITLE
(Frs driver)Rename terminology: summary to snapshot on download

### DIFF
--- a/packages/drivers/routerlicious-driver/src/contracts.ts
+++ b/packages/drivers/routerlicious-driver/src/contracts.ts
@@ -5,10 +5,54 @@
 
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 
+/*
+ *
+ * Whole Snapshot Download Data Structures
+ *
+ */
+
+export interface IWholeFlatSnapshotTreeEntryTree {
+	path: string;
+	type: "tree";
+	// Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
+	unreferenced?: true;
+}
+
+export interface IWholeFlatSnapshotTreeEntryBlob {
+	id: string;
+	path: string;
+	type: "blob";
+}
+
+export type IWholeFlatSnapshotTreeEntry =
+	| IWholeFlatSnapshotTreeEntryTree
+	| IWholeFlatSnapshotTreeEntryBlob;
+
+export interface IWholeFlatSnapshotTree {
+	entries: IWholeFlatSnapshotTreeEntry[];
+	id: string;
+	sequenceNumber: number;
+}
+
+export interface IWholeFlatSnapshotBlob {
+	content: string;
+	encoding: "base64" | "utf-8";
+	id: string;
+	size: number;
+}
+
+export interface IWholeFlatSnapshot {
+	// The same as the id of the first snapshot tree in the trees array.
+	id: string;
+	// Receive an array of snapshot trees for future-proofing, however, always length 1 for now.
+	trees: IWholeFlatSnapshotTree[];
+	blobs?: IWholeFlatSnapshotBlob[];
+}
+
 /**
  * Normalized Whole Summary with decoded blobs and unflattened snapshot tree.
  */
-export interface INormalizedWholeSummary {
+export interface INormalizedWholeSnapshot {
 	blobs: Map<string, ArrayBuffer>;
 	snapshotTree: ISnapshotTree;
 	sequenceNumber: number | undefined;

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -27,7 +27,7 @@ import { pkgVersion as driverVersion } from "./packageVersion";
 import { GitManager } from "./gitManager";
 import { Historian } from "./historian";
 import { RestWrapper } from "./restWrapperBase";
-import { INormalizedWholeSummary } from "./contracts";
+import { INormalizedWholeSnapshot } from "./contracts";
 
 /**
  * Amount of time between discoveries within which we don't need to rediscover on re-connect.
@@ -67,7 +67,7 @@ export class DocumentService implements api.IDocumentService {
 		private readonly documentStorageServicePolicies: api.IDocumentStorageServicePolicies,
 		private readonly driverPolicies: IRouterliciousDriverPolicies,
 		private readonly blobCache: ICache<ArrayBufferLike>,
-		private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSummary>,
+		private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSnapshot>,
 		private readonly shreddedSummaryTreeCache: ICache<ISnapshotTreeVersion>,
 		private readonly discoverFluidResolvedUrl: () => Promise<api.IResolvedUrl>,
 		private storageRestWrapper: RouterliciousStorageRestWrapper,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -37,7 +37,7 @@ import { parseFluidUrl, replaceDocumentIdInPath, getDiscoveredFluidResolvedUrl }
 import { ICache, InMemoryCache, NullCache } from "./cache";
 import { pkgVersion as driverVersion } from "./packageVersion";
 import { ISnapshotTreeVersion } from "./definitions";
-import { INormalizedWholeSummary } from "./contracts";
+import { INormalizedWholeSnapshot } from "./contracts";
 
 const maximumSnapshotCacheDurationMs: FiveDaysMs = 432_000_000; // 5 days in ms
 
@@ -60,7 +60,7 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
 	private readonly driverPolicies: IRouterliciousDriverPolicies;
 	private readonly blobCache: ICache<ArrayBufferLike>;
-	private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSummary> = new NullCache();
+	private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSnapshot> = new NullCache();
 	private readonly shreddedSummaryTreeCache: ICache<ISnapshotTreeVersion> = new NullCache();
 
 	constructor(
@@ -77,7 +77,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 		this.blobCache = new InMemoryCache<ArrayBufferLike>();
 		if (this.driverPolicies.enableInternalSummaryCaching) {
 			if (this.driverPolicies.enableWholeSummaryUpload) {
-				this.wholeSnapshotTreeCache = new InMemoryCache<INormalizedWholeSummary>(
+				this.wholeSnapshotTreeCache = new InMemoryCache<INormalizedWholeSnapshot>(
 					snapshotCacheExpiryMs,
 				);
 			} else {

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -20,7 +20,7 @@ import { WholeSummaryDocumentStorageService } from "./wholeSummaryDocumentStorag
 import { ShreddedSummaryDocumentStorageService } from "./shreddedSummaryDocumentStorageService";
 import { GitManager } from "./gitManager";
 import { ISnapshotTreeVersion } from "./definitions";
-import { INormalizedWholeSummary } from "./contracts";
+import { INormalizedWholeSnapshot } from "./contracts";
 
 export class DocumentStorageService extends DocumentStorageServiceProxy {
 	private _logTailSha: string | undefined = undefined;
@@ -36,7 +36,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
-		snapshotTreeCache?: ICache<INormalizedWholeSummary>,
+		snapshotTreeCache?: ICache<INormalizedWholeSnapshot>,
 		shreddedSummaryTreeCache?: ICache<ISnapshotTreeVersion>,
 		noCacheGitManager?: GitManager,
 		getStorageManager?: (disableCache?: boolean) => Promise<GitManager>,
@@ -80,7 +80,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
-		snapshotTreeCache?: ICache<INormalizedWholeSummary>,
+		snapshotTreeCache?: ICache<INormalizedWholeSnapshot>,
 		shreddedSummaryTreeCache?: ICache<ISnapshotTreeVersion>,
 		public noCacheGitManager?: GitManager,
 		getStorageManager?: (disableCache?: boolean) => Promise<GitManager>,

--- a/packages/drivers/routerlicious-driver/src/gitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/gitManager.ts
@@ -5,12 +5,12 @@
 
 import * as resources from "@fluidframework/gitresources";
 import {
-	IWholeFlatSummary,
 	IWholeSummaryPayload,
 	IWriteSummaryResponse,
 } from "@fluidframework/server-services-client";
 import { IGitManager, IHistorian } from "./storageContracts";
 import { IR11sResponse, createR11sResponseFromContent } from "./restWrapper";
+import { IWholeFlatSnapshot } from "./contracts";
 
 export class GitManager implements IGitManager {
 	private readonly blobCache = new Map<string, resources.IBlob>();
@@ -110,7 +110,7 @@ export class GitManager implements IGitManager {
 		return this.historian.createSummary(summary, initial);
 	}
 
-	public async getSummary(sha: string): Promise<IR11sResponse<IWholeFlatSummary>> {
-		return this.historian.getSummary(sha);
+	public async getSnapshot(sha: string): Promise<IR11sResponse<IWholeFlatSnapshot>> {
+		return this.historian.getSnapshot(sha);
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/historian.ts
+++ b/packages/drivers/routerlicious-driver/src/historian.ts
@@ -6,13 +6,13 @@
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import {
-	IWholeFlatSummary,
 	IWholeSummaryPayload,
 	IWriteSummaryResponse,
 } from "@fluidframework/server-services-client";
 import { QueryStringType, RestWrapper } from "./restWrapperBase";
 import { IR11sResponse } from "./restWrapper";
 import { IHistorian } from "./storageContracts";
+import { IWholeFlatSnapshot } from "./contracts";
 
 export interface ICredentials {
 	user: string;
@@ -98,8 +98,8 @@ export class Historian implements IHistorian {
 		);
 	}
 
-	public async getSummary(sha: string): Promise<IR11sResponse<IWholeFlatSummary>> {
-		return this.restWrapper.get<IWholeFlatSummary>(
+	public async getSnapshot(sha: string): Promise<IR11sResponse<IWholeFlatSnapshot>> {
+		return this.restWrapper.get<IWholeFlatSnapshot>(
 			`/git/summaries/${sha}`,
 			this.getQueryString(),
 		);

--- a/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
@@ -4,9 +4,8 @@
  */
 
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { IWholeFlatSummary, IWholeFlatSummaryTree } from "@fluidframework/server-services-client";
 import { stringToBuffer } from "@fluidframework/common-utils";
-import { INormalizedWholeSummary } from "./contracts";
+import { INormalizedWholeSnapshot, IWholeFlatSnapshot, IWholeFlatSnapshotTree } from "./contracts";
 
 /**
  * Build a tree hierarchy from a flat tree.
@@ -16,7 +15,7 @@ import { INormalizedWholeSummary } from "./contracts";
  * @returns the heirarchical tree
  */
 function buildHierarchy(
-	flatTree: IWholeFlatSummaryTree,
+	flatTree: IWholeFlatSnapshotTree,
 	treePrefixToRemove: string,
 ): ISnapshotTree {
 	const lookup: { [path: string]: ISnapshotTree } = {};
@@ -54,30 +53,30 @@ function buildHierarchy(
 }
 
 /**
- * Converts existing IWholeFlatSummary to snapshot tree, blob array, and sequence number.
+ * Converts existing IWholeFlatSnapshot to snapshot tree, blob array, and sequence number.
  *
- * @param flatSummary - flat summary
+ * @param flatSnapshot - flat snapshot
  * @param treePrefixToRemove - tree prefix to strip. By default we are stripping ".app" prefix
  * @returns snapshot tree, blob array, and sequence number
  */
-export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
-	flatSummary: IWholeFlatSummary,
+export function convertWholeFlatSnapshotToSnapshotTreeAndBlobs(
+	flatSnapshot: IWholeFlatSnapshot,
 	treePrefixToRemove: string = ".app",
-): INormalizedWholeSummary {
+): INormalizedWholeSnapshot {
 	const blobs = new Map<string, ArrayBuffer>();
-	if (flatSummary.blobs) {
-		flatSummary.blobs.forEach((blob) => {
+	if (flatSnapshot.blobs) {
+		flatSnapshot.blobs.forEach((blob) => {
 			blobs.set(blob.id, stringToBuffer(blob.content, blob.encoding ?? "utf-8"));
 		});
 	}
-	const flatSummaryTree = flatSummary.trees?.[0];
-	const sequenceNumber = flatSummaryTree?.sequenceNumber;
-	const snapshotTree = buildHierarchy(flatSummaryTree, treePrefixToRemove);
+	const flatSnapshotTree = flatSnapshot.trees?.[0];
+	const sequenceNumber = flatSnapshotTree?.sequenceNumber;
+	const snapshotTree = buildHierarchy(flatSnapshotTree, treePrefixToRemove);
 
 	return {
 		blobs,
 		snapshotTree,
 		sequenceNumber,
-		id: flatSummary.id,
+		id: flatSnapshot.id,
 	};
 }

--- a/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
@@ -5,7 +5,6 @@
 
 import type * as git from "@fluidframework/gitresources";
 import {
-	IWholeFlatSummary,
 	IWholeSummaryPayload,
 	IWriteSummaryResponse,
 } from "@fluidframework/server-services-client";
@@ -13,6 +12,7 @@ import { runWithRetry } from "@fluidframework/driver-utils";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { IGitManager } from "./storageContracts";
 import { IR11sResponse } from "./restWrapper";
+import { IWholeFlatSnapshot } from "./contracts";
 
 export class RetriableGitManager implements IGitManager {
 	constructor(
@@ -70,9 +70,9 @@ export class RetriableGitManager implements IGitManager {
 		);
 	}
 
-	public async getSummary(sha: string): Promise<IR11sResponse<IWholeFlatSummary>> {
+	public async getSnapshot(sha: string): Promise<IR11sResponse<IWholeFlatSnapshot>> {
 		return this.runWithRetry(
-			async () => this.internalGitManager.getSummary(sha),
+			async () => this.internalGitManager.getSnapshot(sha),
 			"gitManager_getSummary",
 		);
 	}

--- a/packages/drivers/routerlicious-driver/src/storageContracts.ts
+++ b/packages/drivers/routerlicious-driver/src/storageContracts.ts
@@ -6,12 +6,12 @@
 import * as git from "@fluidframework/gitresources";
 import * as api from "@fluidframework/protocol-definitions";
 import {
-	IWholeFlatSummary,
 	IWholeSummaryPayload,
 	IWholeSummaryPayloadType,
 	IWriteSummaryResponse,
 } from "@fluidframework/server-services-client";
 import { IR11sResponse } from "./restWrapper";
+import { IWholeFlatSnapshot } from "./contracts";
 
 /**
  * Interface to a generic Git provider
@@ -26,7 +26,7 @@ export interface IHistorian {
 		summary: IWholeSummaryPayload,
 		initial?: boolean,
 	): Promise<IR11sResponse<IWriteSummaryResponse>>;
-	getSummary(sha: string): Promise<IR11sResponse<IWholeFlatSummary>>;
+	getSnapshot(sha: string): Promise<IR11sResponse<IWholeFlatSnapshot>>;
 }
 
 export interface IGitManager {
@@ -39,7 +39,7 @@ export interface IGitManager {
 		summary: IWholeSummaryPayload,
 		initial?: boolean,
 	): Promise<IR11sResponse<IWriteSummaryResponse>>;
-	getSummary(sha: string): Promise<IR11sResponse<IWholeFlatSummary>>;
+	getSnapshot(sha: string): Promise<IR11sResponse<IWholeFlatSnapshot>>;
 }
 
 /**

--- a/packages/drivers/routerlicious-driver/src/test/wholeSummaryDocumentStorageService.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/wholeSummaryDocumentStorageService.spec.ts
@@ -6,16 +6,16 @@
 import assert from "assert";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
 import { SummaryType, ISummaryTree } from "@fluidframework/protocol-definitions";
-import {
-	IWholeFlatSummary,
-	IWholeFlatSummaryBlob,
-	IWholeFlatSummaryTreeEntry,
-} from "@fluidframework/server-services-client";
 import { WholeSummaryDocumentStorageService } from "../wholeSummaryDocumentStorageService";
 import { IR11sResponse } from "../restWrapper";
+import {
+	IWholeFlatSnapshot,
+	IWholeFlatSnapshotBlob,
+	IWholeFlatSnapshotTreeEntry,
+} from "../contracts";
 
-/* Blobs contained within source summary tree returned by git manager */
-const summaryBlobs: IWholeFlatSummaryBlob[] = [
+/* Blobs contained within source snapshot tree returned by git manager */
+const summaryBlobs: IWholeFlatSnapshotBlob[] = [
 	{
 		id: "bARCTBK4PQiMLVK2gR5hPRkId",
 		content: "[]",
@@ -38,8 +38,8 @@ const summaryBlobs: IWholeFlatSummaryBlob[] = [
 	},
 ];
 
-/* Tree entries contained within source summary tree returned by git manager */
-const treeEntries: IWholeFlatSummaryTreeEntry[] = [
+/* Tree entries contained within source snapshot tree returned by git manager */
+const treeEntries: IWholeFlatSnapshotTreeEntry[] = [
 	{
 		path: ".protocol",
 		type: "tree",
@@ -73,8 +73,8 @@ const treeEntries: IWholeFlatSummaryTreeEntry[] = [
 	},
 ];
 
-/* Source summary returned by git manager */
-const flatSummary: IWholeFlatSummary = {
+/* Source snapshot returned by git manager */
+const flatSnapshot: IWholeFlatSnapshot = {
 	id: "bBwAAAAAHAAAA",
 	trees: [
 		{
@@ -132,9 +132,9 @@ const expectedSummary: ISummaryTree = {
 };
 
 class MockGitManager {
-	public async getSummary(sha: string): Promise<IR11sResponse<IWholeFlatSummary>> {
+	public async getSnapshot(sha: string): Promise<IR11sResponse<IWholeFlatSnapshot>> {
 		return {
-			content: flatSummary,
+			content: flatSnapshot,
 			headers: new Map(),
 			propsToLog: {},
 			requestUrl: "",

--- a/packages/drivers/routerlicious-driver/src/treeUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/treeUtils.ts
@@ -10,7 +10,7 @@ import {
 	ISummaryTree,
 	SummaryObject,
 } from "@fluidframework/protocol-definitions";
-import { INormalizedWholeSummary } from "./contracts";
+import { INormalizedWholeSnapshot } from "./contracts";
 
 /**
  * Summary tree assembler props
@@ -107,7 +107,7 @@ export function convertSnapshotAndBlobsToSummaryTree(
 	return assembler.summary;
 }
 
-export function evalBlobsAndTrees(snapshot: INormalizedWholeSummary) {
+export function evalBlobsAndTrees(snapshot: INormalizedWholeSnapshot) {
 	const trees = countTreesInSnapshotTree(snapshot.snapshotTree);
 	const numBlobs = snapshot.blobs.size;
 	let encodedBlobsSize = 0;


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4036

(Frs driver)Rename terminology: summary to snapshot on download
Some of these interfaces are also moved from server to client repo for faster development just like we moved some other interfaces before.

- IWholeFlatSummary -> IWholeFlatSnapshot
- IWholeFlatSummaryTree -> IWholeFlatSnapshotTree
- IWholeFlatSummaryBlob -> IWholeFlatSnapshotBlob
- IWholeFlatSummaryTreeEntryTree -> IWholeFlatSnapshotTreeEntryTree
- IWholeFlatSummaryTreeEntryBlob -> IWholeFlatSnapshotTreeEntryBlob
- IHistorian.getSummary() -> IHistorian.getSnapshot()
- IGitManager.getSummary() -> IGitManager.getSnapshot()