### PR TITLE
test(tree): expose longest branch length

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -404,6 +404,25 @@ export class EditManager<
 	}
 
 	/**
+	 * @returns The length of the longest branch maintained by this EditManager.
+	 * This may be the length of a peer branch or the local branch.
+	 * The length is counted from the lowest common ancestor with the trunk such that a fully sequenced branch would
+	 * have length zero.
+	 */
+	public getLongestBranchLength(): number {
+		let max = 0;
+		const trunkHead = this.trunk.getHead();
+		for (const branch of this.peerLocalBranches.values()) {
+			const branchPath = getPathFromBase(branch.getHead(), trunkHead);
+			if (branchPath.length > max) {
+				max = branchPath.length;
+			}
+		}
+		const localPath = getPathFromBase(this.localBranch.getHead(), trunkHead);
+		return Math.max(max, localPath.length);
+	}
+
+	/**
 	 * Needs to be called after a summary is loaded.
 	 * @remarks This is necessary to keep the trunk's repairDataStoreProvider up to date with the
 	 * local's after a summary load.

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -392,6 +392,73 @@ describe("EditManager", () => {
 			);
 			assert.equal(manager.localBranch.getHead(), manager.getTrunkHead());
 		});
+
+		describe("Reports correct max branch length", () => {
+			it("When there are no branches", () => {
+				const { manager } = editManagerFactory({ rebaser: new NoOpChangeRebaser() });
+				assert.equal(manager.getLongestBranchLength(), 0);
+			});
+			it("When the local branch is longest", () => {
+				const { manager } = editManagerFactory({ rebaser: new NoOpChangeRebaser() });
+				const sequencedLocalChange = mintRevisionTag();
+				manager.localBranch.apply(TestChange.emptyChange, sequencedLocalChange);
+				manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+				manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+				manager.addSequencedChange(
+					{
+						change: TestChange.emptyChange,
+						revision: mintRevisionTag(),
+						sessionId: peer1,
+					},
+					brand(1),
+					brand(0),
+				);
+				manager.addSequencedChange(
+					{
+						change: TestChange.emptyChange,
+						revision: sequencedLocalChange,
+						sessionId: manager.localSessionId,
+					},
+					brand(2),
+					brand(0),
+				);
+				assert.equal(manager.getLongestBranchLength(), 2);
+			});
+			it("When a peer branch is longest", () => {
+				const { manager } = editManagerFactory({ rebaser: new NoOpChangeRebaser() });
+				const sequencedLocalChange = mintRevisionTag();
+				manager.localBranch.apply(TestChange.emptyChange, sequencedLocalChange);
+				manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+				manager.addSequencedChange(
+					{
+						change: TestChange.emptyChange,
+						revision: sequencedLocalChange,
+						sessionId: manager.localSessionId,
+					},
+					brand(1),
+					brand(0),
+				);
+				manager.addSequencedChange(
+					{
+						change: TestChange.emptyChange,
+						revision: mintRevisionTag(),
+						sessionId: peer1,
+					},
+					brand(2),
+					brand(0),
+				);
+				manager.addSequencedChange(
+					{
+						change: TestChange.emptyChange,
+						revision: mintRevisionTag(),
+						sessionId: peer1,
+					},
+					brand(3),
+					brand(0),
+				);
+				assert.equal(manager.getLongestBranchLength(), 2);
+			});
+		});
 	});
 
 	describe("Perf", () => {


### PR DESCRIPTION
Adds a method on `EditManager` to report the length of the longest branch maintained by the instance.

This is useful to track whether clients are producing large numbers of edits concurrently.