### PR TITLE
Enable workflow_dispatch for sync branches workflow

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -3,6 +3,7 @@ name: Sync branches
 on:
   schedule:
     - cron: "0 */2 * * 1-5" # Cron timezone is in UTC
+  workflow_dispatch:
 
 env:
   TARGET_BRANCH: next


### PR DESCRIPTION
This change will allow us to trigger the job manually using the GitHub UI. See <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch> for more info.