### PR TITLE
Allow lambda instance to provide an activity timeout time

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -164,6 +164,7 @@ export class DocumentPartition {
 	}
 
 	private updateActivityTime() {
-		this.activityTimeoutTime = Date.now() + (this.lambda?.activityTimeout ?? this.activityTimeout);
+		this.activityTimeoutTime =
+			Date.now() + (this.lambda?.activityTimeout ?? this.activityTimeout);
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -164,6 +164,6 @@ export class DocumentPartition {
 	}
 
 	private updateActivityTime() {
-		this.activityTimeoutTime = Date.now() + this.activityTimeout;
+		this.activityTimeoutTime = Date.now() + (this.lambda?.activityTimeout ?? this.activityTimeout);
 	}
 }

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -75,6 +75,12 @@ export interface IContext {
 
 export interface IPartitionLambda {
 	/**
+	 * Expire document partition after this long of no activity.
+	 * When undefined, the default global IDocumentLambdaServerConfiguration.partitionActivityTimeout is used.
+	 */
+	readonly activityTimeout?: number;
+
+	/**
 	 * Processes an incoming message
 	 */
 	handler(message: IQueuedMessage): Promise<void> | undefined;


### PR DESCRIPTION
`partitionActivityTimeout` is currently a global value [defined in service configuration](https://github.com/microsoft/FluidFramework/blob/ffaf71a37141680592ad865945f94d21aa0f2a75/server/routerlicious/packages/services-core/src/configuration.ts#L133) for controlling when a lambda / document partition is closed.
ODSP wants to be able to adjust the activity timeout per session. This change allows a specific lambda instance to set the activity timeout it wants to use.