### PR TITLE
Improve skipping for timeout and expects tests

### DIFF
--- a/packages/test/test-version-utils/src/itExpects.ts
+++ b/packages/test/test-version-utils/src/itExpects.ts
@@ -13,7 +13,7 @@ export type ExpectedEvents =
 	| ITelemetryGenericEvent[]
 	| Partial<Record<TestDriverTypes, ITelemetryGenericEvent[]>>;
 
-function createExpectsTest(orderedExpectedEvents: ExpectedEvents, test: Mocha.AsyncFunc) {
+export function createExpectsTest(orderedExpectedEvents: ExpectedEvents, test: Mocha.AsyncFunc) {
 	return async function (this: Context) {
 		const provider: TestObjectProvider | undefined = this.__fluidTestProvider;
 		if (provider === undefined) {

--- a/packages/test/test-version-utils/src/itSkipsOnFailure.ts
+++ b/packages/test/test-version-utils/src/itSkipsOnFailure.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { TestObjectProvider } from "@fluidframework/test-utils";
+import { TestObjectProvider, timeoutAwait } from "@fluidframework/test-utils";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Context } from "mocha";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
-import { ExpectedEvents, itExpects } from "./itExpects.js";
+import { ExpectedEvents, createExpectsTest } from "./itExpects.js";
 
 function createSkippedTestsWithDriverType(
 	skippedDrivers: TestDriverTypes[],
@@ -19,7 +19,7 @@ function createSkippedTestsWithDriverType(
 			throw new Error("Expected __fluidTestProvider on this");
 		}
 		try {
-			await test.bind(this)();
+			await timeoutAwait(test.bind(this)());
 		} catch (error) {
 			if (skippedDrivers.includes(provider.driver.type)) {
 				provider.logger.sendErrorEvent({ eventName: "TestFailedbutSkipped" }, error);
@@ -64,4 +64,10 @@ export const itExpectsSkipsFailureOnSpecificDrivers: SkippedErrorExpectingTestWi
 	skippedDrivers: TestDriverTypes[],
 	test: Mocha.AsyncFunc,
 ): Mocha.Test =>
-	itExpects(name, orderedExpectedEvents, createSkippedTestsWithDriverType(skippedDrivers, test));
+	it(
+		name,
+		createSkippedTestsWithDriverType(
+			skippedDrivers,
+			createExpectsTest(orderedExpectedEvents, test),
+		),
+	);


### PR DESCRIPTION
Adds a timeoutAwait to the skip function to capture test timeouts, and captures itExpects type error in the skip function