### PR TITLE
Only use cache for ops fetching in case the snapshot came from cache too

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -165,7 +165,9 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		assert(!cachedOnly || toTotal === undefined, 0x1e3);
 
 		// Don't use cache for ops is snapshot is fetched from network or if it was not fetched at all.
-		this.useCacheForOps = this.storageManagerGetter()?.isFirstSnapshotFromNetwork === false;
+		this.useCacheForOps =
+			this.useCacheForOps &&
+			this.storageManagerGetter()?.isFirstSnapshotFromNetwork === false;
 		let opsFromSnapshot = 0;
 		let opsFromCache = 0;
 		let opsFromStorage = 0;

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -164,13 +164,8 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		// Better implementation would be to return only what we have in cache, but that also breaks API
 		assert(!cachedOnly || toTotal === undefined, 0x1e3);
 
-		const isFirstSnapshotFromNetwork = this.storageManagerGetter()?.isFirstSnapshotFromNetwork;
-		assert(
-			isFirstSnapshotFromNetwork !== undefined,
-			"snapshot should have been fetched by now!",
-		);
-		// Don't use cache for ops is snapshot is fetched from network.
-		this.useCacheForOps = !isFirstSnapshotFromNetwork;
+		// Don't use cache for ops is snapshot is fetched from network or if it was not fetched at all.
+		this.useCacheForOps = this.storageManagerGetter()?.isFirstSnapshotFromNetwork === false;
 		let opsFromSnapshot = 0;
 		let opsFromCache = 0;
 		let opsFromStorage = 0;

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -19,6 +19,7 @@ import { requestOps, streamObserver } from "@fluidframework/driver-utils";
 import { IDeltaStorageGetResponse, ISequencedDeltaOpMessage } from "./contracts";
 import { EpochTracker } from "./epochTracker";
 import { getWithRetryForTokenRefresh } from "./odspUtils";
+import { OdspDocumentStorageService } from "./odspDocumentStorageManager";
 
 /**
  * Provides access to the underlying delta storage on the server for sharepoint driver.
@@ -128,7 +129,7 @@ export class OdspDeltaStorageService {
 }
 
 export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
-	private firstCacheMiss = false;
+	private useCacheForOps = true;
 
 	public constructor(
 		private snapshotOps: ISequencedDocumentMessage[] | undefined,
@@ -147,6 +148,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		) => Promise<ISequencedDocumentMessage[]>,
 		private readonly requestFromSocket: (from: number, to: number) => void,
 		private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
+		private readonly storageManagerGetter: () => OdspDocumentStorageService | undefined,
 	) {}
 
 	public fetchMessages(
@@ -162,6 +164,13 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		// Better implementation would be to return only what we have in cache, but that also breaks API
 		assert(!cachedOnly || toTotal === undefined, 0x1e3);
 
+		const isFirstSnapshotFromNetwork = this.storageManagerGetter()?.isFirstSnapshotFromNetwork;
+		assert(
+			isFirstSnapshotFromNetwork !== undefined,
+			"snapshot should have been fetched by now!",
+		);
+		// Don't use cache for ops is snapshot is fetched from network.
+		this.useCacheForOps = !isFirstSnapshotFromNetwork;
 		let opsFromSnapshot = 0;
 		let opsFromCache = 0;
 		let opsFromStorage = 0;
@@ -188,13 +197,13 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 			this.requestFromSocket(from, to);
 
 			// Cache in normal flow is continuous. Once there is a miss, stop consulting cache.
-			// This saves a bit of processing time
-			if (!this.firstCacheMiss) {
+			// This saves a bit of processing time.
+			if (this.useCacheForOps) {
 				const messagesFromCache = await this.getCached(from, to);
 				validateMessages("cached", messagesFromCache, from, this.logger);
 				// Set the firstCacheMiss as true in case we didn't get all the ops.
 				// This will save an extra cache read on "DocumentOpen" or "PostDocumentOpen".
-				this.firstCacheMiss = from + messagesFromCache.length < to;
+				this.useCacheForOps = from + messagesFromCache.length >= to;
 				if (messagesFromCache.length !== 0) {
 					opsFromCache += messagesFromCache.length;
 					return {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -227,6 +227,7 @@ export class OdspDocumentService implements IDocumentService {
 				}
 			},
 			(ops: ISequencedDocumentMessage[]) => this.opsReceived(ops),
+			() => this.storageManager,
 		);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -57,7 +57,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 	private odspSummaryUploadManager: OdspSummaryUploadManager | undefined;
 
 	private firstVersionCall = true;
-
+	private _isFirstSnapshotFromNetwork: boolean | undefined;
 	private readonly documentId: string;
 	private readonly snapshotUrl: string | undefined;
 	private readonly attachmentPOSTUrl: string | undefined;
@@ -92,6 +92,10 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		this.snapshotUrl = this.odspResolvedUrl.endpoints.snapshotStorageUrl;
 		this.attachmentPOSTUrl = this.odspResolvedUrl.endpoints.attachmentPOSTStorageUrl;
 		this.attachmentGETUrl = this.odspResolvedUrl.endpoints.attachmentGETStorageUrl;
+	}
+
+	public get isFirstSnapshotFromNetwork() {
+		return this._isFirstSnapshotFromNetwork;
 	}
 
 	public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
@@ -335,6 +339,9 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					}
 					if (method === "network") {
 						props.cacheEntryAge = undefined;
+					}
+					if (this.firstVersionCall) {
+						this._isFirstSnapshotFromNetwork = method === "cache" ? false : true;
 					}
 					const prefetchStartTime: number | undefined = (
 						retrievedSnapshot as IPrefetchSnapshotContents

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -11,6 +11,7 @@ import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { OdspDeltaStorageService, OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { LocalPersistentCache } from "../odspCache";
 import { EpochTracker } from "../epochTracker";
+import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 import { mockFetchOk } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache(2000);
@@ -233,6 +234,7 @@ describe("DeltaStorageService", () => {
 				async (from, to) => getCached(from, to),
 				(from, to) => [],
 				(ops) => {},
+				() => ({ isFirstSnapshotFromNetwork: false } as any as OdspDocumentStorageService),
 			);
 
 			const messages = odspDeltaStorageServiceWithCache.fetchMessages(1, undefined);

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -9,6 +9,7 @@ import { IStream } from "@fluidframework/driver-definitions";
 import { delay } from "@fluidframework/common-utils";
 import { OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { OpsCache, ICache, IMessage, CacheEntry } from "../opsCaching";
+import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 
 export type MyDataInput = IMessage & { data: string };
 
@@ -409,6 +410,7 @@ describe("OdspDeltaStorageWithCache", () => {
 			(from: number, to: number) => {},
 			// opsReceived
 			(ops: ISequencedDocumentMessage[]) => opsToCache.push(...ops),
+			() => ({ isFirstSnapshotFromNetwork: false } as any as OdspDocumentStorageService),
 		);
 
 		const stream = storage.fetchMessages(


### PR DESCRIPTION
## Description

Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4303

Only use cache for ops fetching in case the snapshot came from cache too. This is intended to improve perf as we don't get any ops from cache in case the snapshot comes from network and consulting cache takes time. So supply that info to delta storage service and use that to decide whether we want to consult cache or not.
There could be scenario where snapshot is not even fetched, like loading container from pendingLocalState etc, in that case too we don't want to use cache for ops since we don't expect to find anything.