### PR TITLE
refactor(server): Add caller in getDeltas call + fix for undefined from/to values

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -117,7 +117,8 @@ data:
             "enforceServerGeneratedDocumentId": {{ .Values.alfred.enforceServerGeneratedDocumentId }},
             "socketIo" : {
                 "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
-            }
+            },
+            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }}
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -48,6 +48,7 @@ alfred:
   enforceServerGeneratedDocumentId: false
   socketIo:
     perMessageDeflate: true
+  getDeltasRequestMaxOpsRange: 2000
 
 storage:
   enableWholeSummaryUpload: false

--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -59,6 +59,7 @@ export class CheckpointManager implements ICheckpointManager {
 					this.documentId,
 					expectedSequenceNumber - 1,
 					expectedSequenceNumber + 1,
+					"scribe",
 				);
 
 				// If we don't get the expected delta, retry after a delay
@@ -82,6 +83,7 @@ export class CheckpointManager implements ICheckpointManager {
 						this.documentId,
 						expectedSequenceNumber - 1,
 						expectedSequenceNumber + 1,
+						"scribe",
 					);
 
 					if (

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -318,6 +318,8 @@ export class ScribeLambdaFactory
 				tenantId,
 				documentId,
 				lastCheckpoint.protocolState.sequenceNumber,
+				undefined,
+				"scribe",
 			);
 		}
 		return opMessages;

--- a/server/routerlicious/packages/lambdas/src/scribe/pendingMessageReader.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/pendingMessageReader.ts
@@ -26,6 +26,7 @@ export class PendingMessageReader implements IPendingMessageReader {
 			this.documentId,
 			from - 1,
 			to + 1,
+			"scribe",
 		);
 		return deltasP;
 	}

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -713,7 +713,14 @@ export class SummaryWriter implements ISummaryWriter {
 		let logTail: ISequencedDocumentMessage[] = [];
 
 		if (this.getDeltasViaAlfred) {
-			logTail = await this.deltaService.getDeltas("", this.tenantId, this.documentId, gt, lt);
+			logTail = await this.deltaService.getDeltas(
+				"",
+				this.tenantId,
+				this.documentId,
+				gt,
+				lt,
+				"scribe",
+			);
 		} else {
 			const query = {
 				"documentId": this.documentId,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -36,7 +36,8 @@ export function create(
 ): Router {
 	const deltasCollectionName = config.get("mongo:collectionNames:deltas");
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");
-	const defaultUnknownOpCount = 2000;
+	const getDeltasRequestMaxOpsRange =
+		(config.get("alfred:getDeltasRequestMaxOpsRange") as number) ?? 2000;
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -149,11 +150,11 @@ export function create(
 			let to = stringToSequenceNumber(request.query.to);
 			if (from === undefined && to === undefined) {
 				from = 0;
-				to = from + defaultUnknownOpCount + 1;
+				to = from + getDeltasRequestMaxOpsRange + 1;
 			} else if (to === undefined) {
-				to = from + defaultUnknownOpCount + 1;
+				to = from + getDeltasRequestMaxOpsRange + 1;
 			} else if (from === undefined) {
-				from = Math.max(0, to - defaultUnknownOpCount - 1);
+				from = Math.max(0, to - getDeltasRequestMaxOpsRange - 1);
 			}
 
 			const tenantId = getParam(request.params, "tenantId") || appTenants[0].id;

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -114,7 +114,8 @@
 		},
 		"jwtTokenCache": {
 			"enable": true
-		}
+		},
+		"getDeltasRequestMaxOpsRange": 2000
 	},
 	"client": {
 		"type": "browser",

--- a/server/routerlicious/packages/services-core/src/delta.ts
+++ b/server/routerlicious/packages/services-core/src/delta.ts
@@ -12,6 +12,7 @@ export interface IDeltaService {
 		documentId: string,
 		from?: number,
 		to?: number,
+		caller?: string,
 	): Promise<ISequencedDocumentMessage[]>;
 
 	getDeltasFromStorage(

--- a/server/routerlicious/packages/services/src/deltaManager.ts
+++ b/server/routerlicious/packages/services/src/deltaManager.ts
@@ -22,12 +22,13 @@ export class DeltaManager implements IDeltaService {
 		documentId: string,
 		from: number,
 		to: number,
+		caller?: string,
 	): Promise<ISequencedDocumentMessage[]> {
 		const baseUrl = `${this.internalAlfredUrl}`;
 		const restWrapper = await this.getBasicRestWrapper(tenantId, documentId, baseUrl);
 		const resultP = restWrapper.get<ISequencedDocumentMessage[]>(
 			`/deltas/${tenantId}/${documentId}`,
-			{ from, to },
+			{ from, to, caller },
 		);
 		return resultP;
 	}


### PR DESCRIPTION
## Description

- Adding "caller" property to the telemetry to identify internal vs external calls.
- In case from / to are undefined in getDeltas API call, use the default values.