### PR TITLE
Enable pong event e2e test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -20,8 +20,7 @@ import { describeNoCompat } from "@fluid-internal/test-version-utils";
 const codeDetails: IFluidCodeDetails = { package: "test" };
 const timeoutMs = 500;
 
-// TODO: enable this test in "next" (after server versions get bumped)
-describe.skip("Pong", () => {
+describe("Pong", () => {
 	describeNoCompat("Pong", (getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
 		const loaderContainerTracker = new LoaderContainerTracker();


### PR DESCRIPTION
This test was added in main but skipped because the server version needed to be bumped. Server version bumps can only happen in `next`.
Original PR: https://github.com/microsoft/FluidFramework/pull/15069

[AB#4951](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4951)