### PR TITLE
ci: Accept batch size as input to sync-branch workflow

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -1,8 +1,30 @@
+# This workflow is used to create PRs to merge changes from the main branch to the next branch. It's mostly a front-end
+# to `flub merge branches`, which is where the source code can be found. This also means you can replicate this workflow
+# manually by running `flub merge branches` locally and providing a PAT.
+#
+# When run, the workflow executes `flub merge branches`, which first checks if a main/next merge PR is already open. If
+# it is, the workflow exits with no error.
+#
+# If there is no PR, then the tool will open one by following this logic
+#
+# - Find the commits that need to be merged into next.
+# - Take a batch of commits and iterate over them.
+# - Test each commit for mergeability into next.
+# - If all commits merge cleanly, open a PR at the last commit in the batch.
+# - If a commit cannot be merged cleanly, open a PR at the _previous_ commit.
+# - Once that PR is merged, then the next time the workflow runs, it will detect the conflicting commit and open a PR
+#   with that commit only.
+# 
+# Each time the workflow runs, the tool will determine the commits to merge based entirely on the git repo state.
+
 name: Sync branches
 
 on:
   schedule:
-    - cron: "0 */2 * * 1-5" # Cron timezone is in UTC
+    # At 0 minutes past the hour, every 2 hours, Monday through Friday. Cron timezone is in UTC.
+    - cron: "0 */2 * * 1-5"
+  
+  # Support running the workflow manually through the GitHub UI.
   workflow_dispatch:
     inputs:
       batchSize:

--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -4,13 +4,19 @@ on:
   schedule:
     - cron: "0 */2 * * 1-5" # Cron timezone is in UTC
   workflow_dispatch:
+    inputs:
+      batchSize:
+        description: The maximum number of commits to include in a single PR.
+        type: number
+        default: 10
+        required: true
 
 env:
   TARGET_BRANCH: next
   SOURCE_BRANCH: main
   USERNAME: msfluid-bot
   EMAIL: banana-bot@outlook.com
-  BATCH: 10
+  BATCH: ${{ inputs.batchSize }}
   REVIEWER1: sonalideshpandemsft
 
 jobs:


### PR DESCRIPTION
This change makes it possible for us to run the sync-branch workflows manually from the GitHub UI and provide a different batch size. We can use this to run on larger batch sizes manually when we have a large backlog of commits.

Also added some documentation to the workflow file.