### PR TITLE
Remove deprecated Client.getSlideToSegment

### DIFF
--- a/.changeset/all-weeks-sin.md
+++ b/.changeset/all-weeks-sin.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/merge-tree": major
+---
+
+Client.getSlideToSegment removed
+
+Client.getSlideToSegment was deprecated in 2.0.0-internal.5.3.0 and has been removed. Use getSlideToSegoff function instead.

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -145,14 +145,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
     };
     // (undocumented)
     getShortClientId(longClientId: string): number;
-    // @deprecated
-    getSlideToSegment(segoff: {
-        segment: ISegment | undefined;
-        offset: number | undefined;
-    }): {
-        segment: ISegment | undefined;
-        offset: number | undefined;
-    };
     // (undocumented)
     getStackContext(startPos: number, rangeLabels: string[]): RangeStackMap;
     // (undocumented)

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -110,6 +110,9 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"ClassDeclaration_Client": {
+				"backCompat": false
+			},
 			"RemovedInterfaceDeclaration_BlockAction": {
 				"forwardCompat": false,
 				"backCompat": false

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -61,7 +61,7 @@ import { SnapshotLoader } from "./snapshotLoader";
 import { IMergeTreeTextHelper } from "./textSegment";
 import { SnapshotV1 } from "./snapshotV1";
 import { ReferencePosition, RangeStackMap, DetachedReferencePosition } from "./referencePositions";
-import { MergeTree, getSlideToSegoff } from "./mergeTree";
+import { MergeTree } from "./mergeTree";
 import { MergeTreeTextHelper } from "./MergeTreeTextHelper";
 import { walkAllChildSegments } from "./mergeTreeNodeWalk";
 import { IMergeTreeClientSequenceArgs, IMergeTreeDeltaOpArgs } from "./index";
@@ -1098,16 +1098,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 			clientId,
 			localSeq,
 		);
-	}
-
-	/**
-	 * Returns the position to slide a reference to if a slide is required.
-	 * @param segoff - The segment and offset to slide from
-	 * @returns - segment and offset to slide the reference to
-	 * @deprecated Use getSlideToSegoff function instead.
-	 */
-	getSlideToSegment(segoff: { segment: ISegment | undefined; offset: number | undefined }) {
-		return getSlideToSegoff(segoff);
 	}
 
 	getPropertiesAtPosition(pos: number) {

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -107,6 +107,7 @@ declare function get_current_ClassDeclaration_Client():
 declare function use_old_ClassDeclaration_Client(
     use: TypeOnly<old.Client>);
 use_old_ClassDeclaration_Client(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Client());
 
 /*


### PR DESCRIPTION
Client.getSlideToSegment has been deprecated and replaced with getSlideToSegoff in main branch. Removing it in next branch.