### PR TITLE
add complex move tests

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1179,110 +1179,95 @@ describe("Editing", () => {
 		});
 
 		it("can move a node out from under its parent, and delete that parent from its containing sequence field", () => {
-			const tree = makeTreeFromJson({ foo: ["A"] });
+			const tree = makeTreeFromJson({ src: ["A"], dst: ["B"] });
 			const rootPath = {
 				parent: undefined,
 				parentField: rootFieldKeySymbol,
 				parentIndex: 0,
 			};
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
 
 			tree.transaction.start();
-			tree.editor
-				.sequenceField({
-					parent: fooList,
-					field: brand(""),
-				})
-				.insert(0, singleJsonCursor({ foo: ["B"] }));
 			// Move node from foo into rootField.
 			tree.editor.move(
-				{ parent: fooList, field: brand("") },
+				{ parent: srcList, field: brand("") },
 				0,
 				1,
-				{ parent: undefined, field: rootFieldKeySymbol },
-				1,
+				{ parent: dstList, field: brand("") },
+				0,
 			);
 			// Deletes parent node
 			const field = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKeySymbol,
+				parent: rootPath,
+				field: brand("src"),
 			});
 			field.delete(0, 1);
 			tree.transaction.commit();
 
-			const expectedState: JsonCompatible = [{ foo: ["B"] }];
+			const expectedState: JsonCompatible = [{ dst: ["A", "B"] }];
 			expectJsonTree(tree, expectedState);
 		});
 
 		it("can move a node out from under its parent, and delete that parent from its containing optional field", () => {
-			const tree = makeTreeFromJson({ foo: ["A"] });
+			const tree = makeTreeFromJson({ src: ["A"], dst: ["B"] });
 			const rootPath = {
 				parent: undefined,
 				parentField: rootFieldKeySymbol,
 				parentIndex: 0,
 			};
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
 
 			tree.transaction.start();
-			tree.editor
-				.optionalField({
-					parent: fooList,
-					field: brand(""),
-				})
-				.set(singleJsonCursor({ foo: ["B"] }), false);
 			// Move node from foo into rootField.
 			tree.editor.move(
-				{ parent: fooList, field: brand("") },
+				{ parent: srcList, field: brand("") },
 				0,
 				1,
-				{ parent: undefined, field: rootFieldKeySymbol },
-				1,
+				{ parent: dstList, field: brand("") },
+				0,
 			);
 			// Deletes parent node
-			const field = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKeySymbol,
+			const field = tree.editor.optionalField({
+				parent: rootPath,
+				field: brand("src"),
 			});
-			field.delete(0, 1);
+			field.set(undefined, false);
 			tree.transaction.commit();
 
-			const expectedState: JsonCompatible = [{ foo: ["B"] }];
+			const expectedState: JsonCompatible = [{ dst: ["A", "B"] }];
 			expectJsonTree(tree, expectedState);
 		});
 
 		it("can move a node out from under its parent, and delete that parent from its containing value field", () => {
-			const tree = makeTreeFromJson({ foo: ["A"] });
+			const tree = makeTreeFromJson({ src: ["A"], dst: ["B"] });
 			const rootPath = {
 				parent: undefined,
 				parentField: rootFieldKeySymbol,
 				parentIndex: 0,
 			};
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
 
 			tree.transaction.start();
-			tree.editor
-				.valueField({
-					parent: fooList,
-					field: brand(""),
-				})
-				.set(singleJsonCursor({ foo: ["B"] }));
 			// Move node from foo into rootField.
 			tree.editor.move(
-				{ parent: fooList, field: brand("") },
+				{ parent: srcList, field: brand("") },
 				0,
 				1,
-				{ parent: undefined, field: rootFieldKeySymbol },
-				1,
+				{ parent: dstList, field: brand("") },
+				0,
 			);
 			// Deletes parent node
-			const field = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKeySymbol,
+			const field = tree.editor.valueField({
+				parent: rootPath,
+				field: brand("src"),
 			});
-			field.delete(0, 1);
+			field.set(singleTextCursor({ type: jsonObject.name }));
 			tree.transaction.commit();
 
-			const expectedState: JsonCompatible = [{ foo: ["B"] }];
+			const expectedState: JsonCompatible = [{ src: {}, dst: ["A", "B"] }];
 			expectJsonTree(tree, expectedState);
 		});
 

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1133,23 +1133,20 @@ describe("Editing", () => {
 			expectJsonTree(tree, expectedState);
 		});
 
-		it("can move node to root field, and delete the source's parent node", () => {
-			const tree = makeTreeFromJson([]);
-
-			tree.editor
-				.sequenceField({
-					parent: undefined,
-					field: rootFieldKeySymbol,
-				})
-				.insert(0, singleJsonCursor({ foo: ["A", "B", "C"] }));
-
+		it("can move sequence field to root field, and delete its previous parent node", () => {
+			const tree = makeTreeFromJson({ foo: ["A"] });
 			const rootPath = {
 				parent: undefined,
 				parentField: rootFieldKeySymbol,
 				parentIndex: 0,
 			};
-
 			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			tree.editor
+				.sequenceField({
+					parent: fooList,
+					field: brand(""),
+				})
+				.insert(0, singleJsonCursor({ foo: ["B"] }));
 
 			// Move node from foo into rootField.
 			tree.editor.move(
@@ -1166,9 +1163,75 @@ describe("Editing", () => {
 				field: rootFieldKeySymbol,
 			});
 			field.delete(0, 1);
+			const expectedState: JsonCompatible = [{ foo: ["B"] }];
+			expectJsonTree(tree, expectedState);
+		});
 
-			const expectedState: JsonCompatible = ["A"];
+		it("can move optional field to root field, and delete its previous parent node", () => {
+			const tree = makeTreeFromJson({ foo: ["A"] });
+			const rootPath = {
+				parent: undefined,
+				parentField: rootFieldKeySymbol,
+				parentIndex: 0,
+			};
+			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			tree.editor
+				.optionalField({
+					parent: fooList,
+					field: brand(""),
+				})
+				.set(singleJsonCursor({ foo: ["B"] }), false);
 
+			// Move node from foo into rootField.
+			tree.editor.move(
+				{ parent: fooList, field: brand("") },
+				0,
+				1,
+				{ parent: undefined, field: rootFieldKeySymbol },
+				1,
+			);
+
+			// Deletes parent node
+			const field = tree.editor.sequenceField({
+				parent: undefined,
+				field: rootFieldKeySymbol,
+			});
+			field.delete(0, 1);
+			const expectedState: JsonCompatible = [{ foo: ["B"] }];
+			expectJsonTree(tree, expectedState);
+		});
+
+		it("can move valueField to root field, and delete its previous parent node", () => {
+			const tree = makeTreeFromJson({ foo: ["A"] });
+			const rootPath = {
+				parent: undefined,
+				parentField: rootFieldKeySymbol,
+				parentIndex: 0,
+			};
+			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			tree.editor
+				.valueField({
+					parent: fooList,
+					field: brand(""),
+				})
+				.set(singleJsonCursor({ foo: ["B"] }));
+
+			// Move node from foo into rootField.
+			tree.editor.move(
+				{ parent: fooList, field: brand("") },
+				0,
+				1,
+				{ parent: undefined, field: rootFieldKeySymbol },
+				1,
+			);
+
+			// Deletes parent node
+			const field = tree.editor.sequenceField({
+				parent: undefined,
+				field: rootFieldKeySymbol,
+			});
+			field.delete(0, 1);
+			const expectedState: JsonCompatible = [{ foo: ["B"] }];
 			expectJsonTree(tree, expectedState);
 		});
 
@@ -1727,44 +1790,6 @@ describe("Editing", () => {
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], ["43"]);
-		});
-		it("can move node to root field, and delete its previous parent node", () => {
-			const tree = makeTreeFromJson([]);
-
-			tree.editor
-				.optionalField({
-					parent: undefined,
-					field: rootFieldKeySymbol,
-				})
-				.set(singleJsonCursor({ foo: ["A"] }), true);
-
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKeySymbol,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-
-			// Move node from foo into rootField.
-			tree.editor.move(
-				{ parent: fooList, field: brand("") },
-				0,
-				1,
-				{ parent: undefined, field: rootFieldKeySymbol },
-				1,
-			);
-
-			// Deletes parent node
-			const field = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKeySymbol,
-			});
-			field.delete(0, 1);
-
-			const expectedState: JsonCompatible = ["A"];
-
-			expectJsonTree(tree, expectedState);
 		});
 	});
 


### PR DESCRIPTION
## Description

This PR adds more complex move tests to the file `editing.spec.ts`

## Reviewer Guidance
### Questions
1. Currently some of the tests that involve deeper trees are using the `TestTreeProviderLite` as I cannot seem to get the `makeTreeFromJson` to work with deeper trees. For example, I have tried the following to move a node from field `foo` to field `bar`

```
const tree = makeTreeFromJson({
	foo: [{ foo: ["A", "B"] }, {bar: ["C", "D"]}],
});

const rootPath = {
	parent: undefined,
	parentField: rootFieldKeySymbol,
	parentIndex: 0,
};

const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
const barList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 1 };

const fooChild: UpPath = { parent: fooList, parentField: brand(""), parentIndex: 0 };
const barChild: UpPath = { parent: barList, parentField: brand(""), parentIndex: 0 };

// Move node from child branch foo to child branch bar.
tree.editor.move(
	{ parent: fooChild, field: brand("foo") },
	0,
	1,
	{ parent: barChild, field: brand("bar") },
	0,
);
``` 

Is there a suggested change I could make to fix this?