### PR TITLE
Persist corrupt docs

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -533,6 +533,9 @@ export class ScribeLambda implements IPartitionLambda {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const message = this.pendingMessages.shift()!;
 			try {
+				if (!this.isDocumentCorrupt) {
+					throw new Error(`Test Error`);
+				}
 				if (
 					message.contents &&
 					typeof message.contents === "string" &&

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -61,6 +61,7 @@ const DefaultScribe: IScribe = {
 	sequenceNumber: 0,
 	lastSummarySequenceNumber: 0,
 	validParentSummaries: undefined,
+	isCorrupt: false,
 };
 
 export class ScribeLambdaFactory
@@ -123,6 +124,16 @@ export class ScribeLambdaFactory
 				undefined /* shouldIgnoreError */,
 				(error) => true /* shouldRetry */,
 			)) as IDocument;
+
+			if (document.scribe) {
+				if (JSON.parse(document.scribe).isCorrupt) {
+					Lumberjack.info(
+						`Received attempt to connect to a corrupted document.`,
+						lumberProperties,
+					);
+					return new NoOpLambda(context);
+				}
+			}
 
 			if (!isDocumentValid(document)) {
 				// Document sessions can be joined (via Alfred) after a document is functionally deleted.
@@ -202,7 +213,13 @@ export class ScribeLambdaFactory
 				"scribe",
 				document,
 			)) as IScribe;
+			console.log(`****IS_CORRUPT: ${lastCheckpoint.isCorrupt}`);
 			opMessages = await this.getOpMessages(documentId, tenantId, lastCheckpoint);
+		}
+
+		if (lastCheckpoint.isCorrupt) {
+			Lumberjack.info(`Attempt to connect to a corrupted document.`, lumberProperties);
+			return new NoOpLambda(context);
 		}
 
 		// Filter and keep ops after protocol state

--- a/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
@@ -12,6 +12,7 @@ export enum CheckpointReason {
 	MaxMessages,
 	ClearCache,
 	NoClients,
+	MarkAsCorrupt,
 }
 
 // Used to control checkpoint logic

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -54,6 +54,7 @@ const DefaultScribe: IScribe = {
 	sequenceNumber: -1,
 	lastSummarySequenceNumber: 0,
 	validParentSummaries: undefined,
+	isCorrupt: false,
 };
 
 const DefaultDeli: IDeliState = {

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -90,6 +90,9 @@
 			},
 			"InterfaceDeclaration_ITokenRevocationManager": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IScribe": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -115,6 +115,9 @@ export interface IScribe {
 
 	// Refs of the service summaries generated since the last client generated summary.
 	validParentSummaries: string[] | undefined;
+
+	// Is document corrupted?
+	isCorrupt: boolean;
 }
 
 export interface IDocument {

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -1730,6 +1730,7 @@ declare function get_old_InterfaceDeclaration_IScribe():
 declare function use_current_InterfaceDeclaration_IScribe(
     use: TypeOnly<current.IScribe>);
 use_current_InterfaceDeclaration_IScribe(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IScribe());
 
 /*

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -237,6 +237,7 @@ export class DocumentStorage implements IDocumentStorage {
 			// the initial summary would not be accepted as a valid parent because lastClientSummaryHead is undefined and latest
 			// summary is a service summary. However, initial summary _is_ a valid parent in this scenario.
 			validParentSummaries: [initialSummaryVersionId],
+			isCorrupt: false,
 		};
 
 		const session: ISession = {

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -139,6 +139,7 @@ export class TestDocumentStorage implements IDocumentStorage {
 			lastClientSummaryHead: undefined,
 			lastSummarySequenceNumber: 0,
 			validParentSummaries: undefined,
+			isCorrupt: false,
 		};
 
 		const collection = await this.databaseManager.getDocumentCollection();


### PR DESCRIPTION
In scribe, when we encounter a protocol error, it causes document corruption. However, when scribe restarts, we try to reprocess corrupted documents since the document corruption is stored in memory. This change is to persist the corrupted documents in our checkpoints (which are stored in the database) so that we can avoid this reprocessing.