### PR TITLE
Remove test-client-utils from docs rollup

### DIFF
--- a/docs/data/packages.yaml
+++ b/docs/data/packages.yaml
@@ -6,4 +6,3 @@ serviceClients:
   - "@fluidframework/tinylicious-client"
 utilities:
   - "@fluidframework/azure-service-utils"
-  - "@fluidframework/test-client-utils"

--- a/docs/rollup-api-data.js
+++ b/docs/rollup-api-data.js
@@ -49,10 +49,6 @@ const memberCombineInstructions = [
 			],
 		]),
 	},
-	{
-		package: "@fluidframework/test-client-utils",
-		sourceImports: new Map([["@fluidframework/test-runtime-utils", ["InsecureTokenProvider"]]]),
-	},
 ];
 
 /**


### PR DESCRIPTION
## Description

#16079 removed test-client-utils but left some dangling references to it in the docs folder.
