### PR TITLE
Fix local driver logging

### DIFF
--- a/api-report/local-driver.api.md
+++ b/api-report/local-driver.api.md
@@ -38,7 +38,7 @@ import { NackErrorType } from '@fluidframework/protocol-definitions';
 import type { Socket } from 'socket.io-client';
 
 // @public
-export function createLocalDocumentService(resolvedUrl: IResolvedUrl, localDeltaConnectionServer: ILocalDeltaConnectionServer, tokenProvider: ITokenProvider, tenantId: string, documentId: string, documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>, policies?: IDocumentServicePolicies, innerDocumentService?: IDocumentService): IDocumentService;
+export function createLocalDocumentService(resolvedUrl: IResolvedUrl, localDeltaConnectionServer: ILocalDeltaConnectionServer, tokenProvider: ITokenProvider, tenantId: string, documentId: string, documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>, policies?: IDocumentServicePolicies, innerDocumentService?: IDocumentService, logger?: ITelemetryBaseLogger): IDocumentService;
 
 // @public (undocumented)
 export function createLocalResolverCreateNewRequest(documentId: string): IRequest;
@@ -62,7 +62,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 
 // @public
 export class LocalDocumentService implements IDocumentService {
-    constructor(resolvedUrl: IResolvedUrl, localDeltaConnectionServer: ILocalDeltaConnectionServer, tokenProvider: ITokenProvider, tenantId: string, documentId: string, documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>, policies?: IDocumentServicePolicies, innerDocumentService?: IDocumentService | undefined);
+    constructor(resolvedUrl: IResolvedUrl, localDeltaConnectionServer: ILocalDeltaConnectionServer, tokenProvider: ITokenProvider, tenantId: string, documentId: string, documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>, policies?: IDocumentServicePolicies, innerDocumentService?: IDocumentService | undefined, logger?: ITelemetryBaseLogger | undefined);
     connectToDeltaStorage(): Promise<IDocumentDeltaStorageService>;
     connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
     connectToStorage(): Promise<IDocumentStorageService>;

--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -16,6 +16,7 @@ import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 import { GitManager } from "@fluidframework/server-services-client";
 import { TestHistorian } from "@fluidframework/server-test-utils";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { LocalDocumentStorageService } from "./localDocumentStorageService";
 import { LocalDocumentDeltaConnection } from "./localDocumentDeltaConnection";
 import { LocalDeltaStorageService } from "./localDeltaStorageService";
@@ -39,6 +40,7 @@ export class LocalDocumentService implements IDocumentService {
 		private readonly documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>,
 		public readonly policies: IDocumentServicePolicies = {},
 		private readonly innerDocumentService?: IDocumentService,
+		private readonly logger?: ITelemetryBaseLogger,
 	) {}
 
 	public dispose() {}
@@ -96,6 +98,8 @@ export class LocalDocumentService implements IDocumentService {
 			ordererToken.jwt,
 			client,
 			this.localDeltaConnectionServer.webSocketServer,
+			undefined,
+			this.logger,
 		);
 		const clientId = documentDeltaConnection.clientId;
 
@@ -127,6 +131,7 @@ export function createLocalDocumentService(
 	documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>,
 	policies?: IDocumentServicePolicies,
 	innerDocumentService?: IDocumentService,
+	logger?: ITelemetryBaseLogger,
 ): IDocumentService {
 	return new LocalDocumentService(
 		resolvedUrl,
@@ -137,5 +142,6 @@ export function createLocalDocumentService(
 		documentDeltaConnectionsMap,
 		policies,
 		innerDocumentService,
+		logger,
 	);
 }

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -85,6 +85,7 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
 			this.documentDeltaConnectionsMap,
 			this.policies,
 			this.innerDocumentService,
+			logger,
 		);
 	}
 


### PR DESCRIPTION
Previously there was no logger passed to the local driver createLocalDocumentService, which lead to the DeltaStream not having a real logger, which could result in missed logs. This change correctly plumbs the logger through.