### PR TITLE
Breakdown scribe's getdelta requests into chunks of maxSize

### DIFF
--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -62,12 +62,18 @@ export async function scribeCreate(
 		(config.get("scribe:restartOnCheckpointFailure") as boolean) ?? true;
 	const kafkaCheckpointOnReprocessingOp =
 		(config.get("checkpoints:kafkaCheckpointOnReprocessingOp") as boolean) ?? true;
+	const getDeltasRequestMaxOpsRange =
+		(config.get("alfred:getDeltasRequestMaxOpsRange") as number) ?? 2000;
 
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
 	const tenantManager = new TenantManager(authEndpoint, internalHistorianUrl);
 
-	const deltaManager = new DeltaManager(authEndpoint, internalAlfredUrl);
+	const deltaManager = new DeltaManager(
+		authEndpoint,
+		internalAlfredUrl,
+		getDeltasRequestMaxOpsRange,
+	);
 	const factory = await getDbFactory(config);
 
 	const checkpointHeuristics = config.get(

--- a/server/routerlicious/packages/services/src/deltaManager.ts
+++ b/server/routerlicious/packages/services/src/deltaManager.ts
@@ -31,7 +31,11 @@ export class DeltaManager implements IDeltaService {
 		const baseUrl = `${this.internalAlfredUrl}`;
 		const restWrapper = await this.getBasicRestWrapper(tenantId, documentId, baseUrl);
 		// if requested size > getDeltasRequestMaxOpsRange, breakdown into chunks of size getDeltasRequestMaxOpsRange
-		if (to - from - 1 > this.getDeltasRequestMaxOpsRange) {
+		if (
+			to != undefined &&
+			from != undefined &&
+			to - from - 1 > this.getDeltasRequestMaxOpsRange
+		) {
 			let getDeltasFrom = from;
 			let getDeltasTo = from + this.getDeltasRequestMaxOpsRange + 1;
 			const chunkResultP: Promise<ISequencedDocumentMessage[]>[] = [];


### PR DESCRIPTION
## Description

When sending getDelta requests from scribe, break it down into chunks of getDeltasRequestMaxOpsRange. This is because getDelta API's perf is optimized for 2k range of ops (getDeltasRequestMaxOpsRange). 