### PR TITLE
Lumberjack: fixing how property map is set

### DIFF
--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -82,7 +82,7 @@ export class Lumber<T extends string = LumberEventName> {
 	public setProperties(properties: Map<string, any> | Record<string, any>): this {
 		if (properties instanceof Map) {
 			if (this._properties.size === 0) {
-				this._properties = properties;
+				this._properties = new Map(properties);
 			} else {
 				properties.forEach((value: any, key: string) => {
 					this.setProperty(key, value);


### PR DESCRIPTION
## Description

@yunho-microsoft found an interesting behavior with Lumberjack. If using Lumberjack to either log or emit metrics, there is an edge case in which a properties object passed as parameter could be modified by Lumberjack.

For example: suppose you have the following Map and give it to Lumberjack.
```ts
const testMap = new Map();
map.set("a", 1);
Lumberjack.info("Test", testMap);
// Suppose the Lumberjack engine could add default properties on top of the ones known
// to the underlying object. Example:
...
lumber.setProperty("b", 2);
...

// Accessing testMap later would show that it has been modified,
// when we only expected the Lumber properties to be modified
console.log(testMap.size); // would print 2, while we only expected 1
```

The above happens because the underlying Lumber object had an empty `this._properties` map, originally. And the bug was that in such cases, the `properties` parameter (in this case, `testMap`) would not be copied element by element to `this._properties`. Instead, `this._properties` would be a reference to `testMap`.

This PR addresses that bug.
