### PR TITLE
Wait for pending ops to be saved before summarization

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2975,7 +2975,7 @@ export class ContainerRuntime
 			// The timeout for waiting for pending ops can be overridden via configurations.
 			const pendingOpsTimeout =
 				this.mc.config.getNumber(
-					"Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeout",
+					"Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeoutMs",
 				) ?? defaultPendingOpsWaitTimeoutMs;
 			await new Promise<void>((resolve, reject) => {
 				const timeoutId = setTimeout(() => resolve(), pendingOpsTimeout);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2973,7 +2973,7 @@ export class ContainerRuntime
 				this.deltaManager.lastSequenceNumber,
 				this.deltaManager.minimumSequenceNumber,
 				finalAttempt,
-				true /* beforeGenerate */,
+				true /* beforeSummaryGeneration */,
 			);
 			if (pendingMessagesFailResult !== undefined) {
 				return pendingMessagesFailResult;
@@ -3094,7 +3094,7 @@ export class ContainerRuntime
 					this.deltaManager.lastSequenceNumber,
 					this.deltaManager.minimumSequenceNumber,
 					finalAttempt,
-					false /* beforeGenerate */,
+					false /* beforeSummaryGeneration */,
 				);
 				if (pendingMessagesFailResult !== undefined) {
 					return pendingMessagesFailResult;
@@ -3246,7 +3246,7 @@ export class ContainerRuntime
 	 * unless this is the final summarize attempt and SkipFailingIncorrectSummary option is set.
 	 * @param logger - The logger to be used for sending telemetry.
 	 * @param referenceSequenceNumber - The reference sequence number of the summary attempt.
-	 * @param minimumSequenceNumber  - The minimum sequence number of the summary attempt.
+	 * @param minimumSequenceNumber - The minimum sequence number of the summary attempt.
 	 * @param finalAttempt - Whether this is the final summary attempt.
 	 * @param beforeSummaryGeneration - Whether this is called before summary generation or after.
 	 * @returns failed summarize result (IBaseSummarizeResult) if summary should be failed, undefined otherwise.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3123,8 +3123,8 @@ export class ContainerRuntime
 
 				const pendingMessagesFailResult = await this.shouldFailSummaryOnPendingOps(
 					summaryNumberLogger,
-					this.deltaManager.lastSequenceNumber,
-					this.deltaManager.minimumSequenceNumber,
+					summaryRefSeqNum,
+					minimumSequenceNumber,
 					finalAttempt,
 					false /* beforeSummaryGeneration */,
 				);

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { createSandbox } from "sinon";
+import { createSandbox, SinonFakeTimers, useFakeTimers } from "sinon";
 import {
 	AttachState,
 	ContainerErrorType,
@@ -12,14 +12,20 @@ import {
 	IContainerContext,
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
-import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import {
+	ISequencedDocumentMessage,
+	ISummaryTree,
+	MessageType,
+} from "@fluidframework/protocol-definitions";
 import {
 	FlushMode,
 	FlushModeExperimental,
+	ISummaryTreeWithStats,
 	NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import {
 	ConfigTypes,
+	createChildLogger,
 	IConfigProviderBase,
 	isFluidError,
 	isILoggingError,
@@ -35,15 +41,18 @@ import {
 	FluidObject,
 	IGenericError,
 } from "@fluidframework/core-interfaces";
+import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
 import {
 	CompressionAlgorithms,
 	ContainerMessageType,
 	ContainerRuntime,
 	ContainerRuntimeMessage,
+	defaultPendingOpsWaitTimeoutMs,
 	IContainerRuntimeOptions,
 } from "../containerRuntime";
 import { IPendingMessageNew, PendingStateManager } from "../pendingStateManager";
 import { DataStores } from "../dataStores";
+import { ISummaryCancellationToken, neverCancelledSummaryToken } from "../summary";
 
 describe("Runtime", () => {
 	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
@@ -52,30 +61,69 @@ describe("Runtime", () => {
 
 	let submittedOps: any[] = [];
 	let opFakeSequenceNumber = 1;
+	let clock: SinonFakeTimers;
+
+	before(() => {
+		clock = useFakeTimers();
+	});
 
 	beforeEach(() => {
 		submittedOps = [];
 		opFakeSequenceNumber = 1;
 	});
 
+	afterEach(() => {
+		clock.reset();
+	});
+
+	after(() => {
+		clock.restore();
+	});
+
 	const getMockContext = (
 		settings: Record<string, ConfigTypes> = {},
 		logger = new MockLogger(),
-	): Partial<IContainerContext> => ({
-		attachState: AttachState.Attached,
-		deltaManager: new MockDeltaManager(),
-		quorum: new MockQuorumClients(),
-		taggedLogger: mixinMonitoringContext(logger, configProvider(settings)).logger,
-		clientDetails: { capabilities: { interactive: true } },
-		closeFn: (_error?: ICriticalContainerError): void => {},
-		updateDirtyContainerState: (_dirty: boolean) => {},
-		getLoadedFromVersion: () => undefined,
-		submitFn: (_type: MessageType, contents: any, _batch: boolean, appData?: any) => {
-			submittedOps.push(contents);
-			return opFakeSequenceNumber++;
-		},
-		clientId: "fakeClientId",
-	});
+	): Partial<IContainerContext> => {
+		const mockClientId = "mockClientId";
+
+		// Mock the storage layer so "submitSummary" works.
+		const mockStorage: Partial<IDocumentStorageService> = {
+			uploadSummaryWithContext: async (summary: ISummaryTree, context: ISummaryContext) => {
+				return "fakeHandle";
+			},
+		};
+		const mockContext = {
+			attachState: AttachState.Attached,
+			deltaManager: new MockDeltaManager(),
+			quorum: new MockQuorumClients(),
+			taggedLogger: mixinMonitoringContext(logger, configProvider(settings)).logger,
+			clientDetails: { capabilities: { interactive: true } },
+			closeFn: (_error?: ICriticalContainerError): void => {},
+			updateDirtyContainerState: (_dirty: boolean) => {},
+			getLoadedFromVersion: () => undefined,
+			submitFn: (_type: MessageType, contents: any, _batch: boolean, appData?: any) => {
+				submittedOps.push(contents);
+				return opFakeSequenceNumber++;
+			},
+			clientId: mockClientId,
+			connected: true,
+			storage: mockStorage as IDocumentStorageService,
+		};
+
+		// Update the delta manager's last message which is used for validation during summarization.
+		mockContext.deltaManager.lastMessage = {
+			clientId: mockClientId,
+			type: MessageType.Operation,
+			sequenceNumber: 0,
+			timestamp: Date.now(),
+			minimumSequenceNumber: 0,
+			referenceSequenceNumber: 0,
+			clientSequenceNumber: 0,
+			contents: undefined,
+			term: undefined,
+		};
+		return mockContext;
+	};
 
 	describe("Container Runtime", () => {
 		describe("flushMode setting", () => {
@@ -1461,6 +1509,173 @@ describe("Runtime", () => {
 					{
 						eventName: "ContainerRuntime:FlushModeFallback",
 						category: "error",
+					},
+				]);
+			});
+		});
+
+		describe("Summarization", () => {
+			let containerRuntime: ContainerRuntime;
+
+			async function yieldEventLoop(): Promise<void> {
+				const yieldP = new Promise<void>((resolve) => {
+					setTimeout(resolve);
+				});
+				clock.tick(1);
+				await yieldP;
+			}
+
+			beforeEach(async () => {
+				const settings = {};
+				settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
+				containerRuntime = await ContainerRuntime.loadRuntime({
+					context: getMockContext(settings) as IContainerContext,
+					registryEntries: [],
+					existing: false,
+				});
+			});
+
+			it("summary is submitted successfully", async () => {
+				const summarizeResult = await containerRuntime.submitSummary({
+					summaryLogger: createChildLogger(),
+					cancellationToken: neverCancelledSummaryToken,
+				});
+				assert(summarizeResult.stage === "submit", "Summary did not succeed");
+			});
+
+			it("summary fails if summary token is canceled", async () => {
+				const cancelledSummaryToken: ISummaryCancellationToken = {
+					cancelled: true,
+					waitCancelled: new Promise(() => {}),
+				};
+				const summarizeResult = await containerRuntime.submitSummary({
+					summaryLogger: createChildLogger(),
+					cancellationToken: cancelledSummaryToken,
+				});
+				assert(summarizeResult.stage === "base", "Summary did not fail");
+				assert.strictEqual(
+					summarizeResult.error,
+					"disconnected",
+					"Summary was not canceled",
+				);
+			});
+
+			it("summary fails before generate if there are pending ops", async () => {
+				// Submit an op and yield for it to be flushed from outbox to pending state manager.
+				containerRuntime.submitDataStoreOp("fakeId", "fakeContents");
+				await yieldEventLoop();
+
+				const summarizeResultP = containerRuntime.submitSummary({
+					summaryLogger: createChildLogger(),
+					cancellationToken: neverCancelledSummaryToken,
+				});
+
+				// Advance the clock by the time that container runtime would wait for pending ops to be processed.
+				clock.tick(defaultPendingOpsWaitTimeoutMs);
+				const summarizeResult = await summarizeResultP;
+				assert(summarizeResult.stage === "base", "Summary did not fail");
+				assert.strictEqual(
+					summarizeResult.error.message,
+					"PendingOpsWhileSummarizing",
+					"Summary did not fail with the right error",
+				);
+				assert.strictEqual(
+					summarizeResult.error.beforeGenerate,
+					true,
+					"It should have failed before generating summary",
+				);
+			});
+
+			it("summary fails after generate if there are pending ops", async () => {
+				// Patch the summarize function to submit messages during it. This way there will be pending
+				// messages after generating the summary.
+				const patch = (fn: (...args) => Promise<ISummaryTreeWithStats>) => {
+					const boundFn = fn.bind(containerRuntime);
+					return async (...args: any[]) => {
+						// Submit an op and yield for it to be flushed from outbox to pending state manager.
+						containerRuntime.submitDataStoreOp("fakeId", "fakeContents");
+						await yieldEventLoop();
+						return boundFn(...args);
+					};
+				};
+				containerRuntime.summarize = patch(containerRuntime.summarize);
+
+				const summarizeResult = await containerRuntime.submitSummary({
+					summaryLogger: createChildLogger(),
+					cancellationToken: neverCancelledSummaryToken,
+				});
+				assert(summarizeResult.stage === "base", "Summary did not fail");
+				assert.strictEqual(
+					summarizeResult.error.message,
+					"PendingOpsWhileSummarizing",
+					"Summary did not fail with the right error",
+				);
+				assert.strictEqual(
+					summarizeResult.error.beforeGenerate,
+					false,
+					"It should have failed after generating summary",
+				);
+			});
+
+			it("summary passes if pending ops are processed during pending op processing timeout", async () => {
+				// Create a container runtime type where the submit method is public. This makes it easier to test
+				// submission and processing of ops. The other option is to send data store or alias ops whose
+				// processing requires creation of data store context and runtime as well.
+				type ContainerRuntimeWithSubmit = Omit<ContainerRuntime, "submit"> & {
+					submit(
+						containerRuntimeMessage: ContainerRuntimeMessage,
+						localOpMetadata: unknown,
+						metadata: Record<string, unknown> | undefined,
+					): void;
+				};
+				const containerRuntimeWithSubmit =
+					containerRuntime as unknown as ContainerRuntimeWithSubmit;
+				// Submit a rejoin op and yield for it to be flushed from outbox to pending state manager.
+				containerRuntimeWithSubmit.submit(
+					{
+						type: ContainerMessageType.Rejoin,
+						contents: "something",
+					},
+					undefined,
+					undefined,
+				);
+				await yieldEventLoop();
+
+				// Create a mock logger to validate that pending ops event is generated with correct params.
+				const mockLogger = new MockLogger();
+				const summaryLogger = createChildLogger({ logger: mockLogger });
+				const summarizeResultP = containerRuntime.submitSummary({
+					summaryLogger,
+					cancellationToken: neverCancelledSummaryToken,
+				});
+
+				// Advance the clock by 1 ms less than the time waited for pending ops to be processed. This will allow
+				// summarization to proceed far enough to wait for pending ops.
+				clock.tick(defaultPendingOpsWaitTimeoutMs - 1);
+				// Process the rejoin op so that there are no pending ops.
+				containerRuntime.process(
+					{
+						type: "op",
+						clientId: "fakeClientId",
+						sequenceNumber: 0,
+						contents: {
+							type: ContainerMessageType.Rejoin,
+							contents: "something",
+						},
+					} as any as ISequencedDocumentMessage,
+					true /* local */,
+				);
+				// Advance the clock by the remaining time so that pending ops wait is completed.
+				clock.tick(1);
+
+				const summarizeResult = await summarizeResultP;
+				assert(summarizeResult.stage === "submit", "Summary did not succeed");
+				mockLogger.assertMatch([
+					{
+						eventName: "PendingOpsWhileSummarizing",
+						countBefore: 1,
+						countAfter: 0,
+						saved: true,
 					},
 				]);
 			});

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -173,13 +173,13 @@ const createContainer = async (
 	if (disableSummary) {
 		summaryConfigOverrides = { state: "disabled" };
 	} else {
-		const IdleDetectionTime = 20;
+		const IdleDetectionTimeMs = 20;
 		summaryConfigOverrides = {
 			...DefaultSummaryConfiguration,
 			...{
-				minIdleTime: IdleDetectionTime,
-				maxIdleTime: IdleDetectionTime * 2,
-				maxTime: IdleDetectionTime * 12,
+				minIdleTime: IdleDetectionTimeMs,
+				maxIdleTime: IdleDetectionTimeMs * 2,
+				maxTime: IdleDetectionTimeMs * 12,
 				initialSummarizerDelayMs: 0,
 			},
 		};
@@ -222,7 +222,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 		if (provider.driver.type !== "local") {
 			this.skip();
 		}
-		settings = [];
+		settings = {};
 		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 0;
 		settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
 		settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
@@ -332,9 +332,9 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 		],
 		async () => {
 			// Wait for 100 ms for pending ops to be saved.
-			const pendingOpsTimeout = 100;
-			settings["Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeout"] =
-				pendingOpsTimeout;
+			const pendingOpsTimeoutMs = 100;
+			settings["Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeoutMs"] =
+				pendingOpsTimeoutMs;
 			const mockLogger = new MockLogger();
 			const container1 = await provider.makeTestContainer();
 			const { summarizer, container: summarizerContainer } = await createSummarizer(
@@ -378,7 +378,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 					saved: false,
 					countBefore: pendingOpCount,
 					countAfter: pendingOpCount,
-					timeout: pendingOpsTimeout,
+					timeout: pendingOpsTimeoutMs,
 				},
 			]);
 		},
@@ -400,6 +400,9 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 			await waitForContainerConnection(container);
 
 			const rootDataObject = await requestFluidObject<RootTestDataObject>(container, "/");
+
+			// This data object will send ops during summarization because the factory uses mixinSummaryHandler
+			// to do so on every summarize.
 			const dataObject2 = await dataStoreFactory2.createInstance(
 				rootDataObject.containerRuntime,
 			);


### PR DESCRIPTION
## Description
There can be pending (unacked) ops in the summarizer client during summarization. This leads to eventually inconsistent and incorrect summaries. #16961 added failing summarization if there are pending ops **_after_** summary has been generated.
This change adds failing summarization if there are pending ops **_before_** generating summary. Additionally, it will fail for some time (default 1 second) for pending ops to be processed before starting to generate summary. The idea behind this change is that if there are pending ops before we even start to generate summary, it will fail anyway. So, might as well fail early and the wait is an optimization to give it a chance to start with a clean state.

## Key points
- The logic to wait for pending ops is behind a feature flag so that we can experiment with it and look at data before turning it on.
- Waiting for pending ops to be saved will happen with a timeout so that we don't end up waiting for a long time. The behavior when the timeout expires is to continue with summarization to keep the behavior same as today. Otherwise, it can lead to documents being stuck, i.e., not summarizing (maybe for a long time). We can tweak this behavior based on the data we see with the experiment.

[AB#4903](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4903)