### PR TITLE
Decouple from TelemetryUTLogger

### DIFF
--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { IDeltasFetchResult } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { OdspDeltaStorageService, OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { LocalPersistentCache } from "../odspCache";
@@ -37,7 +37,7 @@ describe("DeltaStorageService", () => {
 	const fileEntry = { docId: "docId", resolvedUrl };
 
 	it("Should build the correct sharepoint delta url with auth", async () => {
-		const logger = new TelemetryUTLogger();
+		const logger = new MockLogger();
 		const deltaStorageService = new OdspDeltaStorageService(
 			testDeltaStorageUrl,
 			async (_refresh) => "?access_token=123",
@@ -47,6 +47,7 @@ describe("DeltaStorageService", () => {
 		const actualDeltaUrl = deltaStorageService.buildUrl(3, 8);
 		const expectedDeltaUrl = `${deltaStorageBasePath}/drives/testdrive/items/testitem/opStream?ump=1&filter=sequenceNumber%20ge%203%20and%20sequenceNumber%20le%207`;
 		assert.equal(actualDeltaUrl, expectedDeltaUrl, "The constructed delta url is invalid");
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 
 	describe("Get Returns Response With Op Envelope", () => {
@@ -86,14 +87,18 @@ describe("DeltaStorageService", () => {
 		};
 
 		let deltaStorageService: OdspDeltaStorageService;
+		const logger = new MockLogger();
 		before(() => {
-			const logger = new TelemetryUTLogger();
 			deltaStorageService = new OdspDeltaStorageService(
 				testDeltaStorageUrl,
 				async (_refresh) => "",
 				createUtEpochTracker(fileEntry, logger),
 				logger,
 			);
+		});
+		afterEach(() => {
+			logger.assertMatchNone([{ category: "error" }]);
+			logger.clear();
 		});
 
 		it("Should deserialize the delta feed response correctly", async () => {
@@ -156,14 +161,18 @@ describe("DeltaStorageService", () => {
 		};
 
 		let deltaStorageService: OdspDeltaStorageService;
+		const logger = new MockLogger();
 		before(() => {
-			const logger = new TelemetryUTLogger();
 			deltaStorageService = new OdspDeltaStorageService(
 				testDeltaStorageUrl,
 				async (_refresh) => "",
 				createUtEpochTracker(fileEntry, logger),
 				logger,
 			);
+		});
+		afterEach(() => {
+			logger.assertMatchNone([{ category: "error" }]);
+			logger.clear();
 		});
 
 		it("Should deserialize the delta feed response correctly", async () => {
@@ -196,7 +205,11 @@ describe("DeltaStorageService", () => {
 	});
 
 	describe("DeltaStorageServiceWith Cache Tests", () => {
-		const logger = new TelemetryUTLogger();
+		const logger = new MockLogger();
+		afterEach(() => {
+			logger.assertMatchNone([{ category: "error" }]);
+			logger.clear();
+		});
 
 		it("FirstCacheMiss should update to first miss op seq number correctly", async () => {
 			const deltasFetchResult: IDeltasFetchResult = { messages: [], partialResult: false };

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -98,7 +98,6 @@ describe("DeltaStorageService", () => {
 		});
 		afterEach(() => {
 			logger.assertMatchNone([{ category: "error" }]);
-			logger.clear();
 		});
 
 		it("Should deserialize the delta feed response correctly", async () => {
@@ -172,7 +171,6 @@ describe("DeltaStorageService", () => {
 		});
 		afterEach(() => {
 			logger.assertMatchNone([{ category: "error" }]);
-			logger.clear();
 		});
 
 		it("Should deserialize the delta feed response correctly", async () => {
@@ -208,7 +206,6 @@ describe("DeltaStorageService", () => {
 		const logger = new MockLogger();
 		afterEach(() => {
 			logger.assertMatchNone([{ category: "error" }]);
-			logger.clear();
 		});
 
 		it("FirstCacheMiss should update to first miss op seq number correctly", async () => {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { Deferred } from "@fluidframework/common-utils";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { IOdspResolvedUrl, IEntry, snapshotKey } from "@fluidframework/odsp-driver-definitions";
 import { EpochTrackerWithRedemption } from "../epochTracker";
@@ -34,6 +34,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
 	const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
 	const driveId = "driveId";
 	const itemId = "itemId";
+	const logger = new MockLogger();
 	let epochTracker: EpochTrackerWithRedemption;
 	let hashedDocumentId: string;
 	let epochCallback: DeferralWithCallback;
@@ -55,12 +56,14 @@ describe("Tests for Epoch Tracker With Redemption", () => {
 				docId: hashedDocumentId,
 				resolvedUrl,
 			},
-			new TelemetryUTLogger(),
+			logger,
 		);
 	});
 
 	afterEach(async () => {
 		await epochTracker.removeEntries().catch(() => {});
+		logger.assertMatchNone([{ category: "error" }]);
+		logger.clear();
 	});
 
 	describe("Test Suite 1", () => {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -63,7 +63,6 @@ describe("Tests for Epoch Tracker With Redemption", () => {
 	afterEach(async () => {
 		await epochTracker.removeEntries().catch(() => {});
 		logger.assertMatchNone([{ category: "error" }]);
-		logger.clear();
 	});
 
 	describe("Test Suite 1", () => {

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -4,20 +4,25 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { getFileLink } from "../getFileLink";
 import { mockFetchSingle, mockFetchMultiple, okResponse, notFound } from "./mockFetch";
 
 describe("getFileLink", () => {
 	const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
 	const driveId = "driveId";
-	const logger = new TelemetryUTLogger();
+	const logger = new MockLogger();
 	const storageTokenFetcher = async () => "StorageToken";
 	const fileItemResponse = {
 		webDavUrl: "fetchDavUrl",
 		webUrl: "fetchWebUrl",
 		sharepointIds: { listItemUniqueId: "fetchFileId" },
 	};
+
+	afterEach(() => {
+		logger.assertMatchNone([{ category: "error" }]);
+		logger.clear();
+	});
 
 	it("should return share link with existing access", async () => {
 		const result = await mockFetchMultiple(

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -21,7 +21,6 @@ describe("getFileLink", () => {
 
 	afterEach(() => {
 		logger.assertMatchNone([{ category: "error" }]);
-		logger.clear();
 	});
 
 	it("should return share link with existing access", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -85,7 +85,6 @@ describe("Odsp Create Container Test", () => {
 	});
 	afterEach(() => {
 		logger.assertMatchNone([{ category: "error" }]);
-		logger.clear();
 	});
 
 	it("Check Document Service Successfully", async () => {

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IStream } from "@fluidframework/driver-definitions";
 import { delay } from "@fluidframework/common-utils";
@@ -104,10 +104,10 @@ async function runTestNoTimer(
 	initialWritesExpected: number,
 ) {
 	const mockCache = new MockCache();
-
+	const logger = new MockLogger();
 	const cache = new OpsCache(
 		initialSeq,
-		new TelemetryUTLogger(),
+		logger,
 		mockCache,
 		batchSize,
 		-1, // timerGranularity
@@ -133,6 +133,7 @@ async function runTestNoTimer(
 	cache.addOps(mockData);
 	cache.flushOps();
 	assert.equal(mockCache.opsWritten, mockData.length);
+	logger.assertMatchNone([{ category: "error" }]);
 }
 
 export async function runTestWithTimer(
@@ -144,10 +145,10 @@ export async function runTestWithTimer(
 	totalWritesExpected: number,
 ) {
 	const mockCache = new MockCache();
-
+	const logger = new MockLogger();
 	const cache = new OpsCache(
 		initialSeq,
-		new TelemetryUTLogger(),
+		logger,
 		mockCache,
 		batchSize,
 		1, // timerGranularity
@@ -163,6 +164,7 @@ export async function runTestWithTimer(
 	}
 	assert.equal(mockCache.writeCount, totalWritesExpected);
 	assert.equal(mockCache.opsWritten, mockData.length);
+	logger.assertMatchNone([{ category: "error" }]);
 }
 
 export async function runTest(
@@ -307,10 +309,10 @@ describe("OpsCache", () => {
 			{ sequenceNumber: 110, data: "110" },
 			{ sequenceNumber: 111, data: "111" },
 		];
-
+		const logger = new MockLogger();
 		const cache = new OpsCache(
 			initialSeq,
-			new TelemetryUTLogger(),
+			logger,
 			mockCache,
 			5 /* batchSize */,
 			-1, // timerGranularity
@@ -329,6 +331,7 @@ describe("OpsCache", () => {
 			{ sequenceNumber: 105, data: "105" },
 			{ sequenceNumber: 106, data: "106" },
 		]);
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 });
 
@@ -393,10 +396,10 @@ describe("OdspDeltaStorageWithCache", () => {
 		totalOps = Math.min(totalOps, askingOps);
 
 		let opsToCache: ISequencedDocumentMessage[] = [];
-
+		const logger = new MockLogger();
 		const storage = new OdspDeltaStorageWithCache(
 			snapshotOps,
-			new TelemetryUTLogger(),
+			logger,
 			batchSize,
 			concurrency,
 			// getFromStorage
@@ -431,6 +434,7 @@ describe("OdspDeltaStorageWithCache", () => {
 				fromTotal + totalOps,
 			);
 		}
+		logger.assertMatchNone([{ category: "error" }]);
 	}
 
 	it("basic permutations", async () => {

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { stringToBuffer } from "@fluidframework/common-utils";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 import { convertToCompactSnapshot } from "../compactSnapshotWriter";
 import { ISnapshotContents } from "../odspPublicUtils";
@@ -129,8 +129,9 @@ describe("Snapshot Format Conversion Tests", () => {
 			sequenceNumber: 0,
 			latestSequenceNumber: 2,
 		};
+		const logger = new MockLogger();
 		const compactSnapshot = convertToCompactSnapshot(snapshotContents);
-		const result = parseCompactSnapshotResponse(compactSnapshot, new TelemetryUTLogger());
+		const result = parseCompactSnapshotResponse(compactSnapshot, logger);
 		assert.deepStrictEqual(result.snapshotTree, snapshotTree, "Tree structure should match");
 		assert.deepStrictEqual(result.blobs, blobs, "Blobs content should match");
 		assert.deepStrictEqual(result.ops, ops, "Ops should match");
@@ -147,6 +148,7 @@ describe("Snapshot Format Conversion Tests", () => {
 			compactSnapshot.buffer,
 			"Compact representation should remain same",
 		);
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 
 	it("Conversion test with empty ops", async () => {
@@ -157,8 +159,9 @@ describe("Snapshot Format Conversion Tests", () => {
 			sequenceNumber: 0,
 			latestSequenceNumber: 2,
 		};
+		const logger = new MockLogger();
 		const compactSnapshot = convertToCompactSnapshot(snapshotContents);
-		const result = parseCompactSnapshotResponse(compactSnapshot, new TelemetryUTLogger());
+		const result = parseCompactSnapshotResponse(compactSnapshot, logger);
 		assert.deepStrictEqual(result.snapshotTree, snapshotTree, "Tree structure should match");
 		assert.deepStrictEqual(result.blobs, blobs, "Blobs content should match");
 		assert.deepStrictEqual(result.ops, [], "Ops should match");
@@ -175,5 +178,6 @@ describe("Snapshot Format Conversion Tests", () => {
 			compactSnapshot.buffer,
 			"Compact representation should remain same",
 		);
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
@@ -65,7 +65,6 @@ describe("Tree Representation tests", () => {
 	});
 	afterEach(() => {
 		logger.assertMatchNone([{ category: "error" }]);
-		logger.clear();
 	});
 
 	function validate(length = -1) {

--- a/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { Uint8ArrayToString } from "@fluidframework/common-utils";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ReadBuffer } from "../ReadBufferUtils";
 import { TreeBuilderSerializer } from "../WriteBufferUtils";
 import {
@@ -59,15 +59,19 @@ function createLongBuffer(length: number) {
 
 describe("Tree Representation tests", () => {
 	let builder: TreeBuilderSerializer;
-
+	const logger = new MockLogger();
 	beforeEach(() => {
 		builder = new TreeBuilderSerializer();
+	});
+	afterEach(() => {
+		logger.assertMatchNone([{ category: "error" }]);
+		logger.clear();
 	});
 
 	function validate(length = -1) {
 		const buffer = builder.serialize();
 		assert.strictEqual(buffer.length, length, "buffer size not equal");
-		const builder2 = TreeBuilder.load(new ReadBuffer(buffer), new TelemetryUTLogger()).builder;
+		const builder2 = TreeBuilder.load(new ReadBuffer(buffer), logger).builder;
 		compareNodes(builder, builder2);
 	}
 

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter } from "@fluidframework/driver-utils";
 import nock from "nock";
@@ -44,7 +44,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 	}
 
 	let restWrapper: RouterliciousOrdererRestWrapper;
-
+	const logger = new MockLogger();
 	beforeEach(async () => {
 		// reset auth mocking
 		tokenQueue = [token1, token2, token3];
@@ -60,7 +60,6 @@ describe("RouterliciousDriverRestWrapper", () => {
 			return newToken;
 		};
 
-		const logger = new TelemetryUTLogger();
 		restWrapper = await RouterliciousOrdererRestWrapper.load(
 			toInstrumentedR11sOrdererTokenFetcher(
 				"dummytenantid",
@@ -75,6 +74,10 @@ describe("RouterliciousDriverRestWrapper", () => {
 	});
 	after(() => {
 		nock.restore();
+	});
+	afterEach(() => {
+		logger.assertMatchNone([{ category: "error" }]);
+		logger.clear();
 	});
 
 	describe("get()", () => {

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -77,7 +77,6 @@ describe("RouterliciousDriverRestWrapper", () => {
 	});
 	afterEach(() => {
 		logger.assertMatchNone([{ category: "error" }]);
-		logger.clear();
 	});
 
 	describe("get()", () => {

--- a/packages/loader/driver-utils/src/test/parallelRequests.spec.ts
+++ b/packages/loader/driver-utils/src/test/parallelRequests.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { unreachableCase } from "@fluidframework/common-utils";
 import { ParallelRequests } from "../parallelRequests";
 
@@ -28,11 +28,13 @@ describe("Parallel Requests", () => {
 		let requests = 0;
 		let dispatches = 0;
 
+		const logger = new MockLogger();
+
 		const manager = new ParallelRequests<number>(
 			from,
 			knownTo ? to : undefined,
 			payloadSize,
-			new TelemetryUTLogger(),
+			logger,
 			async (request: number, _from: number, _to: number) => {
 				let length = _to - _from;
 				requests++;
@@ -84,6 +86,7 @@ describe("Parallel Requests", () => {
 		assert(nextElement === to);
 		assert(!knownTo || dispatches === requests);
 		assert.equal(requests, expectedRequests, "expected requests");
+		logger.assertMatchNone([{ category: "error" }]);
 	}
 
 	async function testCancel(
@@ -96,12 +99,13 @@ describe("Parallel Requests", () => {
 		let nextElement = from;
 		let requests = 0;
 		let dispatches = 0;
+		const logger = new MockLogger();
 
 		const manager = new ParallelRequests<number>(
 			from,
 			to,
 			payloadSize,
-			new TelemetryUTLogger(),
+			logger,
 			async (request: number, _from: number, _to: number) => {
 				const length = _to - _from;
 				requests++;
@@ -136,6 +140,7 @@ describe("Parallel Requests", () => {
 
 		assert(dispatches <= requests);
 		assert(requests === expectedRequests);
+		logger.assertMatchNone([{ category: "error" }]);
 	}
 
 	it("no concurrency, single request, over", async () => {
@@ -197,11 +202,13 @@ describe("Parallel Requests", () => {
 	});
 
 	it("exception in request", async () => {
+		const logger = new MockLogger();
+
 		const manager = new ParallelRequests<number>(
 			1,
 			100,
 			10,
-			new TelemetryUTLogger(),
+			logger,
 			async (request: number, _from: number, _to: number) => {
 				throw new Error("request");
 			},
@@ -218,14 +225,17 @@ describe("Parallel Requests", () => {
 			assert(error.message === "request");
 		}
 		assert(!success);
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 
 	it("exception in response", async () => {
+		const logger = new MockLogger();
+
 		const manager = new ParallelRequests<number>(
 			1,
 			100,
 			10,
-			new TelemetryUTLogger(),
+			logger,
 			async (request: number, _from: number, _to: number) => {
 				return { cancel: false, partial: false, payload: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] };
 			},
@@ -242,5 +252,6 @@ describe("Parallel Requests", () => {
 			assert(error.message === "response");
 		}
 		assert(!success);
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 });

--- a/packages/runtime/datastore/src/test/channelStorageService.spec.ts
+++ b/packages/runtime/datastore/src/test/channelStorageService.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { stringToBuffer } from "@fluidframework/common-utils";
-import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ChannelStorageService } from "../channelStorageService";
@@ -21,10 +21,12 @@ describe("ChannelStorageService", () => {
 				throw new Error("not implemented");
 			},
 		};
-		const ss = new ChannelStorageService(tree, storage, new TelemetryUTLogger());
+		const logger = new MockLogger();
+		const ss = new ChannelStorageService(tree, storage, logger);
 
 		assert.strictEqual(await ss.contains("/"), false);
 		assert.deepStrictEqual(await ss.list(""), []);
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 
 	it("Top Level Blob", async () => {
@@ -39,11 +41,13 @@ describe("ChannelStorageService", () => {
 				return stringToBuffer(id, "utf8");
 			},
 		};
-		const ss = new ChannelStorageService(tree, storage, new TelemetryUTLogger());
+		const logger = new MockLogger();
+		const ss = new ChannelStorageService(tree, storage, logger);
 
 		assert.strictEqual(await ss.contains("foo"), true);
 		assert.deepStrictEqual(await ss.list(""), ["foo"]);
 		assert.deepStrictEqual(await ss.readBlob("foo"), stringToBuffer("bar", "utf8"));
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 
 	it("Nested Blob", async () => {
@@ -63,10 +67,12 @@ describe("ChannelStorageService", () => {
 				return stringToBuffer(id, "utf8");
 			},
 		};
-		const ss = new ChannelStorageService(tree, storage, new TelemetryUTLogger());
+		const logger = new MockLogger();
+		const ss = new ChannelStorageService(tree, storage, logger);
 
 		assert.strictEqual(await ss.contains("nested/foo"), true);
 		assert.deepStrictEqual(await ss.list("nested/"), ["foo"]);
 		assert.deepStrictEqual(await ss.readBlob("nested/foo"), stringToBuffer("bar", "utf8"));
+		logger.assertMatchNone([{ category: "error" }]);
 	});
 });


### PR DESCRIPTION
TelemetryUTLogger is deprecated. This change moves existing usages to the MockLogger.