### PR TITLE
Remove getCodeDetailsFromQuorumValues

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -111,7 +111,7 @@ import {
 } from "./containerStorageAdapter";
 import { IConnectionStateHandler, createConnectionStateHandler } from "./connectionStateHandler";
 import { getProtocolSnapshotTree, getSnapshotTreeFromSerializedContainer } from "./utils";
-import { initQuorumValuesFromCodeDetails, getCodeDetailsFromQuorumValues } from "./quorum";
+import { initQuorumValuesFromCodeDetails } from "./quorum";
 import { NoopHeuristic } from "./noopHeuristic";
 import { ConnectionManager } from "./connectionManager";
 import { ConnectionState } from "./connectionState";
@@ -1699,16 +1699,15 @@ export class Container
 			this.storageAdapter,
 			baseTree.blobs.quorumValues,
 		);
-		const codeDetails = getCodeDetailsFromQuorumValues(qValues);
 		this.initializeProtocolState(
 			attributes,
 			{
 				members: [],
 				proposals: [],
-				values:
-					codeDetails !== undefined ? initQuorumValuesFromCodeDetails(codeDetails) : [],
+				values: qValues,
 			}, // IQuorumSnapShot
 		);
+		const codeDetails = this.getCodeDetailsFromQuorum();
 
 		await this.instantiateRuntime(codeDetails, snapshotTree);
 

--- a/packages/loader/container-loader/src/quorum.ts
+++ b/packages/loader/container-loader/src/quorum.ts
@@ -2,18 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { assert } from "@fluidframework/common-utils";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { ICommittedProposal } from "@fluidframework/protocol-definitions";
-
-export function getCodeDetailsFromQuorumValues(
-	quorumValues: [string, ICommittedProposal][],
-): IFluidCodeDetails {
-	const qValuesMap = new Map(quorumValues);
-	const proposal = qValuesMap.get("code");
-	assert(proposal !== undefined, 0x2dc /* "Cannot find code proposal" */);
-	return proposal?.value as IFluidCodeDetails;
-}
 
 export function initQuorumValuesFromCodeDetails(
 	source: IFluidCodeDetails,


### PR DESCRIPTION
[AB#5036](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5036)

In general, data structures should own and hide their summary format.  But currently the knowledge of the Quorum's summary format is spread across several classes/layers (Quorum, ProtocolHandler, Container).

This change reduces Container's involvement with the format - initQuorumValuesFromCodeDetails is still a problem, but fixing that will require a cross-layer public API change.  This change is simpler and can happen in `main`.  It also aligns the rehydrate flow more with the load flow - trusting the Quorum to initialize itself properly from the snapshot contents and then using it to find values.