### PR TITLE
fix(routerlicious): Fix invalid trailing comma in JSON

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -74,7 +74,7 @@ data:
             "kafkaCheckpointOnReprocessingOp": {{ .Values.checkpoints.kafkaCheckpointOnReprocessingOp }}
         },
         "apiCounters": {
-            "fetchTenantKeyMetricMs": 60000,
+            "fetchTenantKeyMetricMs": 60000
         },
         "alfred": {
             "kafkaClientId": "{{ template "alfred.fullname" . }}",


### PR DESCRIPTION
## Description

Remove trailing comma in JSON syntax that results in the Helm chart producing a containers that cannot start successfully.

This kind of error has happened several times in the past. If anyone has ideas on what we can do to prevent it from happening again (build the chart and deploying it somewhere to validate the json seems impractical), they'd be most welcome.