### PR TITLE
fix(merge:branches): Merge source into target branch instead of the other way

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -14,16 +14,16 @@
 # - If a commit cannot be merged cleanly, open a PR at the _previous_ commit.
 # - Once that PR is merged, then the next time the workflow runs, it will detect the conflicting commit and open a PR
 #   with that commit only.
-# 
+#
 # Each time the workflow runs, the tool will determine the commits to merge based entirely on the git repo state.
 
 name: Sync branches
 
 on:
   schedule:
-    # At 0 minutes past the hour, every 2 hours, Monday through Friday. Cron timezone is in UTC.
+    # At 0 minutes past the hour, every 1 hour, Monday through Friday. Cron timezone is in UTC.
     - cron: "0 */1 * * 1-5"
-  
+
   # Each commit to next should trigger a run, so we create new PRs as quickly as possible.
   push:
     branches:
@@ -52,7 +52,7 @@ jobs:
   sync-branches:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'microsoft'
-    steps: 
+    steps:
       - run: |
           echo "TARGET_BRANCH: $TARGET_BRANCH"
           echo "SOURCE_BRANCH: $SOURCE_BRANCH"
@@ -71,7 +71,7 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
-      
+
       - name: Install Fluid build tools
         continue-on-error: true
         run: |
@@ -82,20 +82,20 @@ jobs:
           cd packages/build-cli/bin
           echo "$(pwd)" >> $GITHUB_PATH
 
-      # the `url.https://${secret}@github.com/.insteadOf` configuration is used to substitute the default GitHub URL 
-      # with a custom URL that includes a secret token for secure authentication and authorization during Git operations, 
+      # the `url.https://${secret}@github.com/.insteadOf` configuration is used to substitute the default GitHub URL
+      # with a custom URL that includes a secret token for secure authentication and authorization during Git operations,
       # such as pushing to a remote repository on GitHub.
       # https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
       - name: Set Git config
-        env: 
+        env:
           TOKEN: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
         run: |
           git config user.name $USERNAME
           git config user.email $EMAIL
-          git config url.https://${{ env.TOKEN }}@github.com/.insteadOf https://github.com/ 
-      
+          git config url.https://${{ env.TOKEN }}@github.com/.insteadOf https://github.com/
+
       - name: Run merge command
-        env: 
+        env:
           # PAT is loaded automatically from env variable
           GITHUB_PAT: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
         run: |

--- a/build-tools/packages/build-cli/docs/merge.md
+++ b/build-tools/packages/build-cli/docs/merge.md
@@ -18,7 +18,8 @@ FLAGS
   -b, --batchSize=<value>  (required) Maximum number of commits to include in the pull request
   -p, --pat=<value>        (required) GitHub Personal Access Token. This parameter should be passed using the GITHUB_PAT
                            environment variable for security purposes.
-  -r, --remote=<value>     [default: origin]
+  -r, --remote=<value>     The name of the upstream remote to use to check for PRs. If not provided, the remote matching
+                           the microsoft/FluidFramework repo will be used.
   -s, --source=<value>     (required) Source branch name
   -t, --target=<value>     (required) Target branch name
   --reviewers=<value>...   (required) Add reviewers to PR

--- a/build-tools/packages/build-cli/src/commands/merge/branches.ts
+++ b/build-tools/packages/build-cli/src/commands/merge/branches.ts
@@ -166,12 +166,28 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 		/**
 		 * tempBranchToCheckConflicts is used to check the conflicts of each commit with the target branch.
 		 */
-		const tempBranchToCheckConflicts = `${flags.target}-automation`;
-		this.branchesToCleanup.push({
-			branch: tempBranchToCheckConflicts,
-			local: true,
-			remote: false,
-		});
+		const tempBranchToCheckConflicts = `${flags.target}-check-conflicts`;
+
+		/**
+		 * tempTargetBranch is a local branch created from the target branch. We use this instead of the
+		 * target branch itself because the repo might already have a tracking branch for the target and we don't want to
+		 * change that.
+		 */
+		const tempTargetBranch = `${flags.target}-merge-head`;
+
+		// Clean up these branches on failure.
+		this.branchesToCleanup.push(
+			{
+				branch: tempBranchToCheckConflicts,
+				local: true,
+				remote: false,
+			},
+			{
+				branch: tempTargetBranch,
+				local: true,
+				remote: false,
+			},
+		);
 
 		// Check out a new temp branch at the same commit as the target branch.
 		await this.gitRepo.gitClient.checkoutBranch(tempBranchToCheckConflicts, remoteTargetBranch);
@@ -230,14 +246,26 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 		this.verbose(`Deleting temp branch: ${tempBranchToCheckConflicts}`);
 		await this.gitRepo.gitClient.branch(["--delete", tempBranchToCheckConflicts, "--force"]);
 
-		// If we determined that the PR won't conflict, merge the remote target branch with the HEAD (which is mergeBranch
-		// that we created and checked out earlier). We will create the PR at the new commit; in other words, the PR will
-		// already contain a merge, and once CI has passed, the target branch can be fast-forwarded directly to it to close
-		// and merge the PR.
+		// If we determined that the PR won't conflict, check out the target branch (with a temp branch) and merge that with
+		// mergeBranch, which is the source branch we want to merge. We will create the PR at the new merge commit; in other
+		// words, the PR will already contain a merge, and once CI has passed, the target branch can be fast-forwarded
+		// directly to it to close and merge the PR.
+		//
+		// Importantly, we merge source INTO target, not the other way around. While the results are the same, merging
+		// changes IN from the source branch (main) makes the history a lot cleaner. See
+		// <https://stackoverflow.com/a/45973607/551579> for more details.
 		if (prWillConflict === false) {
 			await this.gitRepo.gitClient
+				// Fetch the latest remote refs
 				.fetch(this.remote)
-				.merge([remoteTargetBranch, "-m", prTitle]);
+				// create tempTargetBranch locally so we have a merge base
+				.checkoutBranch(tempTargetBranch, remoteTargetBranch)
+				// Merge the source branch changes into the tempTargetBranch
+				.merge([mergeBranch, "-m", prTitle])
+				// checkout the mergeBranch so we can fast-forward it to the tempTargetBranch
+				.checkout(mergeBranch)
+				// fast-forward the mergeBranch to the merged commit; this is the branch we'll push to the remote.
+				.merge([tempTargetBranch, "--ff-only"]);
 		}
 
 		// To determine who to assign the PR to, we look up the commit details on GitHub.
@@ -257,8 +285,10 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 		const description: string = getDescription({
 			source: flags.source,
 			target: flags.target,
+			tempTarget: tempTargetBranch,
 			mergeBranch,
 			prTitle,
+			remote: this.remote,
 		});
 
 		// label the conflicting PRs and the merged-OK PRs with different labels
@@ -398,26 +428,33 @@ function shortCommit(commit: string): string {
 function getMergeConflictsDescription(props: {
 	source: string;
 	target: string;
+	tempTarget: string;
 	mergeBranch: string;
+	remote: string;
 	prTitle: string;
 }): string {
-	const { source, target, mergeBranch, prTitle } = props;
+	const { source, target, tempTarget, mergeBranch, prTitle, remote } = props;
 	return `
 ## ${source}-${target} integrate PR
 
 The aim of this pull request is to sync ${source} and ${target} branch. This branch has **MERGE CONFLICTS** with ${target} due to this commit. If this PR is assigned to you, you need to do the following:
 
-- Acknowledge the pull request by adding a comment -- "Actively working on it".
-- Merge ${target} into this branch, ${mergeBranch}.
-- Resolve any merge conflicts between ${mergeBranch} and ${target} and then push the results to upstream. **Do NOT rebase or squash this branch: its history must be preserved**.
-- Address any CI failures.
-- Recommended git commands:
-  - \`git checkout ${mergeBranch}\` -- check out the PR branch.
-  - \`git merge ${target}\` -- merge ${target} into ${mergeBranch}
-  - **RESOLVE MERGE CONFLICTS**
+1. Acknowledge the pull request by adding a comment -- "Actively working on it".
+2. Merge ${mergeBranch} into the target branch, ${target}. **The direction of the merge matters!** You need to checkout ${target} and merge ${mergeBranch} into it, then fast-forward ${mergeBranch} to the merge commit. To do that use the following git commands:
+  - \`git fetch --all\` -- this ensures your remote refs are updated
+  - \`git checkout -b ${tempTarget} ${target}\` -- make a temporary branch at ${target}.
+  - \`git merge ${remote}/${mergeBranch}\` -- merge ${target} into ${mergeBranch}
+3. Resolve any merge conflicts between the branches, then commit all the changes using the following commands:
   - \`git add .\` -- stage all the local changes
   - \`git commit -m ${prTitle}\` -- commit the merge
-  - \`git push upstream\` -- and push it to upstream (your upstream remote name may be different)`;
+4. Fast-forward the ${mergeBranch} branch to the merge commit and push to the remote.
+  - \`git checkout ${mergeBranch}\` -- check out the mergeBranch locally
+  - \`git merge ${tempTarget} --ff-only\` -- fast-forward to the merge commit
+  - \`git push upstream\` -- and push it to upstream (your upstream remote name may be different)
+5. Address any CI failures. If you need to make additional changes to the PR, **always amend the commit** using the following git commands:
+  - \`git commit --amend -m "${prTitle}"\`
+  - \`git push --force-with-lease\`
+`;
 }
 
 /**
@@ -426,7 +463,9 @@ The aim of this pull request is to sync ${source} and ${target} branch. This bra
 function getMaybeCiFailuresDescription(props: {
 	source: string;
 	target: string;
+	tempTarget: string;
 	mergeBranch: string;
+	remote: string;
 	prTitle: string;
 }): string {
 	const { source, target, mergeBranch, prTitle } = props;
@@ -435,12 +474,12 @@ function getMaybeCiFailuresDescription(props: {
 
 The aim of this pull request is to sync ${source} and ${target} branch. If this PR is assigned to you, you need to do the following:
 
-- Acknowledge the pull request by adding a comment -- "Actively working on it".
-- Resolve any CI failures between ${mergeBranch} and ${target} and push the results to upstream. **Do NOT rebase or squash this branch: its history must be preserved**.
-- Address any CI failures. Ignore any **Real service e2e test** and **Stress test** failures because they are **non-required** CI workflows.
-- Recommended git commands:
-  - \`git checkout ${mergeBranch}\` -- check out the PR branch.
-  - **FIX ANY CI FAILURES**
-  - git commit --amend -m ${prTitle}
-  - git push --force-with-lease`;
+1. Acknowledge the pull request by adding a comment -- "Actively working on it".
+2. If there are no CI failures, add the "msftbot: merge-next" label to the PR and one of the people with merge permissions will merge it in.
+3. If there ***are*** CI failures, check out the ${mergeBranch} branch and make code changes to fix the failures.
+  - You can ignore any failures in the **Real service e2e test** and **Stress test** pipelines. These pipelines are not required to pass to merge changes.
+4. **Do NOT rebase or squash the ${mergeBranch} branch: its history must be preserved**. Always amend the HEAD commit using the following git commands:
+  - \`git commit --amend -m "${prTitle}"\`
+  - \`git push --force-with-lease\`
+`;
 }

--- a/build-tools/packages/build-cli/src/commands/merge/branches.ts
+++ b/build-tools/packages/build-cli/src/commands/merge/branches.ts
@@ -258,7 +258,7 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 		if (prWillConflict === false) {
 			await this.gitRepo.gitClient
 				// Fetch the latest remote refs
-				.fetch(remote)
+				.fetch(this.remote)
 				// create tempTargetBranch locally so we have a merge base
 				.checkoutBranch(tempTargetBranch, remoteTargetBranch)
 				// Merge the source branch changes into the tempTargetBranch
@@ -289,7 +289,7 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 			tempTarget: tempTargetBranch,
 			mergeBranch,
 			prTitle,
-			remote,
+			remote: this.remote,
 		});
 
 		// label the conflicting PRs and the merged-OK PRs with different labels

--- a/build-tools/packages/build-cli/src/commands/merge/branches.ts
+++ b/build-tools/packages/build-cli/src/commands/merge/branches.ts
@@ -48,7 +48,8 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 			required: true,
 		}),
 		remote: Flags.string({
-			description: "",
+			description:
+				"The name of the upstream remote to use to check for PRs. If not provided, the remote matching the microsoft/FluidFramework repo will be used.",
 			char: "r",
 		}),
 		reviewers: Flags.string({

--- a/build-tools/packages/build-cli/src/commands/merge/branches.ts
+++ b/build-tools/packages/build-cli/src/commands/merge/branches.ts
@@ -10,8 +10,6 @@ import { strict as assert } from "node:assert";
 import { BaseCommand } from "../../base";
 import { Repository, createPullRequest, getCommitInfo, pullRequestExists } from "../../lib";
 
-const DEFAULT_REMOTE = "origin";
-
 interface CleanupBranch {
 	branch: string;
 	local: boolean;
@@ -106,9 +104,6 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 			this.error("gitRepo is undefined", { exit: 1 });
 		}
 
-		// const remote =
-		// 	flags.remote ?? (await this.gitRepo.getRemote(context.originRemotePartialUrl));
-
 		const [owner, repo] = context.originRemotePartialUrl.split("/");
 		this.verbose(`owner: ${owner} and repo: ${repo}`);
 
@@ -117,10 +112,10 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch> {
 
 		this.remote =
 			flags.remote ?? (await this.gitRepo.getRemote(context.originRemotePartialUrl));
-		this.warning(`Remote is: ${this.remote}`);
 		if (this.remote === undefined) {
 			this.error("Remote for upstream repo not found", { exit: 1 });
 		}
+		this.info(`Remote is: ${this.remote}`);
 
 		if (flags.checkPr) {
 			// Check if a branch integration PR exists already, based on its **name**.


### PR DESCRIPTION
In the existing logic and recommended steps for developers to follow, we merge `next` into `main`. While the resulting merge commit is the same regardless of direction, the direction _does_ matter when using tools to review history, especially visual tools (e.g. GitKraken, SourceTree, etc.). See [this StackOverflow answer](https://stackoverflow.com/a/45973607/551579) for details.

I updated the logic we use to change the direction of the merge. That will fix the PRs with no conflicts. For conflicting PRs, developers have to do it themselves I updated the instructions we include with more details about what to do. They need to check out `next`, then merge that with the temporary merge branch, then checkout the merge branch again and fast-forward it to the merge commit. That is:

- `git checkout -b temp-next upstream/next` -- make a temporary branch.
- `git merge upstream/main-next-abc1234` -- merge the main commits into the next branch.
- Resolve any merge conflicts between the branches, then commit all the changes
- `git checkout main-next-abc1234` -- check out the mergeBranch locally
- `git merge temp-next --ff-only` -- fast-forward to the merge commit
- `git push upstream` -- and push it to upstream

This is more complicated, but it's necessary to make our commit history legible.