### PR TITLE
Remove closeAndGetPendingLocalState from IContainer

### DIFF
--- a/.changeset/blue-camels-worry.md
+++ b/.changeset/blue-camels-worry.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/container-definitions": major
+"@fluidframework/container-loader": major
+---
+
+Remove closeAndGetPendingLocalState from IContainer
+
+This change removes the deprecated and experimental method closeAndGetPendingLocalState from IContainer. It continues to exist on IContainerExperimental.
+IContainerExperimental is an interface that is easily casted to, which enables partners to access experimental features for testing and evaluation.
+Moving the experimental method off IContainer will reduce exposure and churn on that production interface as we iterate on and finalize our experimental features.
+Experimental features should not be used in production environments.

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -120,8 +120,6 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     readonly audience: IAudience;
     readonly clientId?: string | undefined;
     close(error?: ICriticalContainerError): void;
-    // @deprecated (undocumented)
-    closeAndGetPendingLocalState(): string;
     readonly closed: boolean;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -42,7 +42,7 @@ export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComp
 
 // @public
 export interface IContainerExperimental extends IContainer {
-    closeAndGetPendingLocalState(): string;
+    closeAndGetPendingLocalState?(): string;
     getPendingLocalState?(): string;
 }
 

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -40,7 +40,7 @@ import {
 	SessionId,
 	StableNodeId,
 } from '../../Identifiers';
-import { assertNotUndefined, fail, identity, ReplaceRecursive } from '../../Common';
+import { fail, identity, ReplaceRecursive } from '../../Common';
 import { IdCompressor } from '../../id-compressor';
 import { createSessionId } from '../../id-compressor/NumericUuid';
 import { getChangeNodeFromViewNode } from '../../SerializationUtilities';
@@ -683,6 +683,7 @@ export async function withContainerOffline<TReturn>(
 	await provider.ensureSynchronized();
 	await provider.opProcessingController.pauseProcessing(container);
 	const actionReturn = action();
-	const pendingLocalState = assertNotUndefined(container.closeAndGetPendingLocalState)();
+	const pendingLocalState = container.closeAndGetPendingLocalState?.();
+	assert(pendingLocalState !== undefined, 'pendingLocalState should be defined');
 	return { actionReturn, pendingLocalState };
 }

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -40,7 +40,7 @@ import {
 	SessionId,
 	StableNodeId,
 } from '../../Identifiers';
-import { fail, identity, ReplaceRecursive } from '../../Common';
+import { assertNotUndefined, fail, identity, ReplaceRecursive } from '../../Common';
 import { IdCompressor } from '../../id-compressor';
 import { createSessionId } from '../../id-compressor/NumericUuid';
 import { getChangeNodeFromViewNode } from '../../SerializationUtilities';
@@ -683,6 +683,6 @@ export async function withContainerOffline<TReturn>(
 	await provider.ensureSynchronized();
 	await provider.opProcessingController.pauseProcessing(container);
 	const actionReturn = action();
-	const pendingLocalState = container.closeAndGetPendingLocalState();
+	const pendingLocalState = assertNotUndefined(container.closeAndGetPendingLocalState)();
 	return { actionReturn, pendingLocalState };
 }

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "@fluidframework/test-runtime-utils";
 import { ITestFluidObject, waitForContainerConnection } from "@fluidframework/test-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { IContainerExperimental } from "@fluidframework/container-loader";
 import {
 	FieldKinds,
 	singleTextCursor,
@@ -1327,13 +1328,13 @@ describe("SharedTree", () => {
 			insert(provider.trees[0], 0, "a");
 			await provider.ensureSynchronized();
 
-			const pausedContainer = provider.containers[0];
+			const pausedContainer: IContainerExperimental = provider.containers[0];
 			const url = (await pausedContainer.getAbsoluteUrl("")) ?? fail("didn't get url");
 			const pausedTree = provider.trees[0];
 			await provider.opProcessingController.pauseProcessing(pausedContainer);
 			insert(pausedTree, 1, "b");
 			insert(pausedTree, 2, "c");
-			const pendingOps = pausedContainer.closeAndGetPendingLocalState();
+			const pendingOps = pausedContainer.closeAndGetPendingLocalState?.();
 			provider.opProcessingController.resumeProcessing();
 
 			const otherLoadedTree = provider.trees[1];

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -371,16 +371,6 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 	close(error?: ICriticalContainerError): void;
 
 	/**
-	 * @deprecated - This is moved to the IContainerExperimental interface. To access you should cast IContainerExperimental before attempting to use
-	 *
-	 * Closes the container and returns serialized local state intended to be
-	 * given to a newly loaded container.
-	 * @experimental
-	 * {@link https://github.com/microsoft/FluidFramework/blob/main/packages/loader/container-loader/closeAndGetPendingLocalState.md}
-	 */
-	closeAndGetPendingLocalState(): string;
-
-	/**
 	 * Propose new code details that define the code to be loaded for this container's runtime.
 	 *
 	 * The returned promise will be true when the proposal is accepted, and false if the proposal is rejected.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2392,5 +2392,5 @@ export interface IContainerExperimental extends IContainer {
 	 * @experimental
 	 * {@link https://github.com/microsoft/FluidFramework/blob/main/packages/loader/container-loader/closeAndGetPendingLocalState.md}
 	 */
-	closeAndGetPendingLocalState(): string;
+	closeAndGetPendingLocalState?(): string;
 }

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -26,6 +26,7 @@ import {
 import { describeNoCompat } from "@fluid-internal/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { IContainerExperimental } from "@fluidframework/container-loader";
 
 const map1Id = "map1Key";
 const map2Id = "map2Key";
@@ -624,11 +625,12 @@ describeNoCompat("Flushing ops", (getTestObjectProvider) => {
 			await setupContainers();
 		});
 		it("cannot capture the pending local state during ordersequentially", async () => {
+			const container: IContainerExperimental = container1;
 			dataObject1.context.containerRuntime.orderSequentially(() => {
 				dataObject1map1.set("key1", "value1");
 				dataObject1map2.set("key2", "value2");
 				assert.throws(
-					() => container1.closeAndGetPendingLocalState(),
+					() => container.closeAndGetPendingLocalState?.(),
 					/can't get state during orderSequentially/,
 				);
 				dataObject1map1.set("key3", "value3");

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -335,10 +335,9 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 		const container: IContainerExperimental = await localTestObjectProvider.makeTestContainer(
 			testContainerConfig,
 		);
-
-		const pendingLocalState: IPendingLocalState = JSON.parse(
-			container.closeAndGetPendingLocalState(),
-		);
+		const pendingString = container.closeAndGetPendingLocalState?.();
+		assert.ok(pendingString);
+		const pendingLocalState: IPendingLocalState = JSON.parse(pendingString);
 		assert.strictEqual(container.closed, true);
 		assert.strictEqual(pendingLocalState.url, (container.resolvedUrl as IFluidResolvedUrl).url);
 	});

--- a/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
@@ -48,7 +48,7 @@ type MapCallback = (
 const getPendingStateWithoutClose = (container: IContainerExperimental): string => {
 	const containerClose = container.close;
 	container.close = (message) => assert(message === undefined);
-	const pendingState = container.closeAndGetPendingLocalState();
+	const pendingState = container.closeAndGetPendingLocalState?.();
 	assert(typeof pendingState === "string");
 	container.close = containerClose;
 	return pendingState;
@@ -56,7 +56,7 @@ const getPendingStateWithoutClose = (container: IContainerExperimental): string 
 
 // load container, pause, create (local) ops from callback, then optionally send ops before closing container
 const getPendingOps = async (args: ITestObjectProvider, send: boolean, cb: MapCallback) => {
-	const container = await args.loadTestContainer(testContainerConfig);
+	const container: IContainerExperimental = await args.loadTestContainer(testContainerConfig);
 	await waitForContainerConnection(container);
 	const dataStore = await requestFluidObject<ITestFluidObject>(container, "default");
 	const map = await dataStore.getSharedObject<SharedMap>(mapId);
@@ -71,13 +71,13 @@ const getPendingOps = async (args: ITestObjectProvider, send: boolean, cb: MapCa
 
 	await cb(container, dataStore, map);
 
-	let pendingState: string;
+	let pendingState: string | undefined;
 	if (send) {
 		pendingState = getPendingStateWithoutClose(container);
 		await args.ensureSynchronized();
 		container.close();
 	} else {
-		pendingState = container.closeAndGetPendingLocalState();
+		pendingState = container.closeAndGetPendingLocalState?.();
 	}
 
 	args.opProcessingController.resumeProcessing();

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -490,7 +490,8 @@ async function scheduleOffline(
 				}
 				if (
 					runConfig.loaderConfig?.enableOfflineLoad === true &&
-					random.real() < stashPercent
+					random.real() < stashPercent &&
+					container.closeAndGetPendingLocalState
 				) {
 					printStatus(runConfig, "closing offline container!");
 					return container.closeAndGetPendingLocalState();

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -122,6 +122,9 @@
 			},
 			"InterfaceDeclaration_FluidDevtoolsProps": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_ContainerDevtoolsProps": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -539,6 +539,7 @@ declare function get_current_InterfaceDeclaration_ContainerDevtoolsProps():
 declare function use_old_InterfaceDeclaration_ContainerDevtoolsProps(
     use: TypeOnly<old.ContainerDevtoolsProps>);
 use_old_InterfaceDeclaration_ContainerDevtoolsProps(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ContainerDevtoolsProps());
 
 /*


### PR DESCRIPTION

This change removes the deprecated and experimental method closeAndGetPendingLocalState from IContainer. It continues to exist on IContainerExperimental.
IContainerExperimental is an interface that is easily casted to, which enables partners to access experimental features for testing and evaluation.
Moving the experimental method off IContainer will reduce exposure and churn on that production interface as we iterate on and finalize our experimental features.
Experimental features should not be used in production environments.