### PR TITLE
Prevent interval start > end in revertLocalSequenceRemove

### DIFF
--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -428,15 +428,16 @@ function revertLocalDelete(
 	const type = revertible.interval.intervalType;
 	// reusing the id causes eventual consistency bugs, so it is removed here and recreated in add
 	const { intervalId, ...props } = revertible.interval.properties;
-	if (!isValidRange(startSlidePos, endSlidePos, string)) return;
-	const int = collection.add(startSlidePos, endSlidePos, type, props);
+	if (isValidRange(startSlidePos, endSlidePos, string)) {
+		const int = collection.add(startSlidePos, endSlidePos, type, props);
 
-	idMap.forEach((newId, oldId) => {
-		if (intervalId === newId) {
-			idMap.set(oldId, getUpdatedIdFromInterval(int));
-		}
-	});
-	idMap.set(intervalId, int.getIntervalId());
+		idMap.forEach((newId, oldId) => {
+			if (intervalId === newId) {
+				idMap.set(oldId, getUpdatedIdFromInterval(int));
+			}
+		});
+		idMap.set(intervalId, int.getIntervalId());
+	}
 
 	string.removeLocalReferencePosition(revertible.start);
 	string.removeLocalReferencePosition(revertible.end);

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -453,8 +453,9 @@ function revertLocalChange(
 	const startSlidePos = getSlidePosition(string, revertible.start, start);
 	const end = string.localReferencePositionToPosition(revertible.end);
 	const endSlidePos = getSlidePosition(string, revertible.end, end);
-	if (!isValidRange(startSlidePos, endSlidePos, string)) return;
-	collection.change(id, startSlidePos, endSlidePos);
+	if (isValidRange(startSlidePos, endSlidePos, string)) {
+		collection.change(id, startSlidePos, endSlidePos);
+	}
 
 	string.removeLocalReferencePosition(revertible.start);
 	string.removeLocalReferencePosition(revertible.end);
@@ -545,7 +546,16 @@ function revertLocalSequenceRemove(
 				restoredRanges,
 				sharedString,
 			);
-			if (newStart !== undefined || newEnd !== undefined) {
+			// only move interval if start <= end
+			if (
+				(newStart === undefined &&
+					newEnd !== undefined &&
+					sharedString.localReferencePositionToPosition(interval.start) <= newEnd) ||
+				(newEnd === undefined &&
+					newStart !== undefined &&
+					sharedString.localReferencePositionToPosition(interval.end) >= newStart) ||
+				(newStart !== undefined && newEnd !== undefined && newStart <= newEnd)
+			) {
 				intervalCollection.change(intervalId, newStart, newEnd);
 			}
 		}

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -770,6 +770,30 @@ describe("Undo/redo for string remove containing intervals", () => {
 			const interval = collection.add(6, 8, IntervalType.SlideOnRemove);
 			containerRuntimeFactory.processAllMessages();
 
+			sharedString2.getIntervalCollection("test").change(interval.getIntervalId(), 1, 9);
+			sharedString.removeRange(5, 7);
+			containerRuntimeFactory.processAllMessages();
+
+			assert.equal(revertibles.length, 1, "revertibles.length is not 1");
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 6, end: 9 }]);
+			containerRuntimeFactory.processAllMessages();
+			assertIntervals(sharedString2, collection2, [{ start: 6, end: 9 }]);
+		});
+		it("does not restore start that would be after end", () => {
+			sharedString.insertText(0, "hello world");
+
+			sharedString.on("sequenceDelta", (op) => {
+				if (op.isLocal) {
+					appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+				}
+			});
+
+			const interval = collection.add(6, 8, IntervalType.SlideOnRemove);
+			containerRuntimeFactory.processAllMessages();
+
 			sharedString2.getIntervalCollection("test").change(interval.getIntervalId(), 1, 3);
 			sharedString.removeRange(5, 7);
 			containerRuntimeFactory.processAllMessages();
@@ -778,12 +802,34 @@ describe("Undo/redo for string remove containing intervals", () => {
 			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
 
 			assert.equal(sharedString.getText(), "hello world");
-			// Intervals don't currently enforce that start >= end,
-			// so this happens since only start was within the restored range
-			assertIntervals(sharedString, collection, [{ start: 6, end: 3 }]);
+			assertIntervals(sharedString, collection, [{ start: 1, end: 3 }]);
 			containerRuntimeFactory.processAllMessages();
-			assertIntervals(sharedString2, collection2, [{ start: 6, end: 3 }]);
-		});
+			assertIntervals(sharedString2, collection2, [{ start: 1, end: 3 }]);
+		})
+		it("does not restore end that would be before start", () => {
+			sharedString.insertText(0, "hello world");
+
+			sharedString.on("sequenceDelta", (op) => {
+				if (op.isLocal) {
+					appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+				}
+			});
+
+			const interval = collection.add(4, 6, IntervalType.SlideOnRemove);
+			containerRuntimeFactory.processAllMessages();
+
+			sharedString2.getIntervalCollection("test").change(interval.getIntervalId(), 8, 9);
+			sharedString.removeRange(5, 7);
+			containerRuntimeFactory.processAllMessages();
+
+			assert.equal(revertibles.length, 1, "revertibles.length is not 1");
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 8, end: 9 }]);
+			containerRuntimeFactory.processAllMessages();
+			assertIntervals(sharedString2, collection2, [{ start: 8, end: 9 }]);
+		})
 	});
 
 	it("has an interval contained within the deleted range", () => {

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -805,7 +805,7 @@ describe("Undo/redo for string remove containing intervals", () => {
 			assertIntervals(sharedString, collection, [{ start: 1, end: 3 }]);
 			containerRuntimeFactory.processAllMessages();
 			assertIntervals(sharedString2, collection2, [{ start: 1, end: 3 }]);
-		})
+		});
 		it("does not restore end that would be before start", () => {
 			sharedString.insertText(0, "hello world");
 
@@ -829,7 +829,7 @@ describe("Undo/redo for string remove containing intervals", () => {
 			assertIntervals(sharedString, collection, [{ start: 8, end: 9 }]);
 			containerRuntimeFactory.processAllMessages();
 			assertIntervals(sharedString2, collection2, [{ start: 8, end: 9 }]);
-		})
+		});
 	});
 
 	it("has an interval contained within the deleted range", () => {


### PR DESCRIPTION
In revertLocalSequenceRemove, it's possible to revert interval positions such that start > end, which is probably not the intent of the undo. This can happen if only one endpoint was in the deleted text range, and then another client moved the interval in the meantime. Or if the interval was already reversed. In this change, it won't move the interval if that will result in start > end.

I tried to prevent start > end in IntervalCollection.change, but it broke 126 tests (mostly fuzz) and fixing all of them was taking longer than a day. So I'm tabling that for now.