### PR TITLE
Limiting logtail length

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -152,7 +152,8 @@ data:
             "getDeltasViaAlfred": {{ .Values.scribe.getDeltasViaAlfred }},
             "verifyLastOpPersistence": {{ .Values.scribe.verifyLastOpPersistence }},
             "restartOnCheckpointFailure": {{ .Values.scribe.restartOnCheckpointFailure }},
-            "disableTransientTenantFiltering": {{ .Values.scribe.disableTransientTenantFiltering }}
+            "disableTransientTenantFiltering": {{ .Values.scribe.disableTransientTenantFiltering }},
+            "maxLogtailLength: {{ .Values.scribe.maxLogtailLength }}
         },
         "system": {
             "httpServer": {

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -81,6 +81,7 @@ scribe:
   name: scribe
   replicas: 8
   getDeltasViaAlfred: true
+  maxLogtailLength: 2000
   verifyLastOpPersistence: false
   disableTransientTenantFiltering: true
   checkpointHeuristics:

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -83,6 +83,7 @@ export class ScribeLambdaFactory
 		private readonly checkpointService: ICheckpointService,
 		private readonly restartOnCheckpointFailure: boolean,
 		private readonly kafkaCheckpointOnReprocessingOp: boolean,
+		private readonly maxLogtailLength: number,
 	) {
 		super();
 	}
@@ -244,6 +245,7 @@ export class ScribeLambdaFactory
 			this.enableWholeSummaryUpload,
 			lastSummaryMessages,
 			this.getDeltasViaAlfred,
+			this.maxLogtailLength,
 		);
 		const checkpointManager = new CheckpointManager(
 			context,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -320,7 +320,7 @@ export class ScribeLambdaFactory
 				tenantId,
 				documentId,
 				lastCheckpoint.protocolState.sequenceNumber,
-				undefined,
+				lastCheckpoint.protocolState.sequenceNumber + this.maxLogtailLength,
 				"scribe",
 			);
 		}

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -320,7 +320,7 @@ export class ScribeLambdaFactory
 				tenantId,
 				documentId,
 				lastCheckpoint.protocolState.sequenceNumber,
-				lastCheckpoint.protocolState.sequenceNumber + this.maxLogtailLength,
+				lastCheckpoint.protocolState.sequenceNumber + this.maxLogtailLength + 1,
 				"scribe",
 			);
 		}

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -591,7 +591,7 @@ export class SummaryWriter implements ISummaryWriter {
 		const LogtailRequestedLength = to - from - 1;
 
 		if (LogtailRequestedLength > this.maxLogtailLength) {
-			Lumberjack.info(`Limiting logtail length`, this.lumberProperties);
+			Lumberjack.warning(`Limiting logtail length`, this.lumberProperties);
 			to = from + this.maxLogtailLength + 1;
 		}
 		const logTail = await this.getLogTail(from, to, pending);

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -588,11 +588,11 @@ export class SummaryWriter implements ISummaryWriter {
 	): Promise<ITreeEntry[]> {
 		let to = lt;
 		const from = gt;
-		const LogtailRequestedLength = to - from;
+		const LogtailRequestedLength = to - from - 1;
 
 		if (LogtailRequestedLength > this.maxLogtailLength) {
 			Lumberjack.info(`Limiting logtail length`, this.lumberProperties);
-			to = from + this.maxLogtailLength;
+			to = from + this.maxLogtailLength + 1;
 		}
 		const logTail = await this.getLogTail(from, to, pending);
 

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -143,6 +143,7 @@ describe("Routerlicious", () => {
 					testCheckpointService,
 					true,
 					true,
+					2000,
 				);
 
 				testContext = new TestContext();

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -149,7 +149,8 @@
 		"getDeltasViaAlfred": true,
 		"verifyLastOpPersistence": false,
 		"restartOnCheckpointFailure": true,
-		"disableTransientTenantFiltering": true
+		"disableTransientTenantFiltering": true,
+		"maxLogtailLength": 2000
 	},
 	"system": {
 		"httpServer": {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -52,6 +52,7 @@ export async function scribeCreate(
 	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
 	const internalAlfredUrl = config.get("worker:alfredUrl");
 	const getDeltasViaAlfred = config.get("scribe:getDeltasViaAlfred") as boolean;
+	const maxLogtailLength = (config.get("scribe:maxLogtailLength") as number) ?? 2000;
 	const verifyLastOpPersistence =
 		(config.get("scribe:verifyLastOpPersistence") as boolean) ?? false;
 	const transientTenants = config.get("shared:transientTenants") as string[];
@@ -167,6 +168,7 @@ export async function scribeCreate(
 		checkpointService,
 		restartOnCheckpointFailure,
 		kafkaCheckpointOnReprocessingOp,
+		maxLogtailLength,
 	);
 }
 


### PR DESCRIPTION
## Description

We use logtails as an optimization to avoid too many get delta calls. But, in rare cases, the logtail is growing very big which is causing OOM restarts in gitrest and breaking some of the scenarios where we use redis to cache summaries. With this PR, we limit logtails to 2000 (configurable) ops

## Testing

Tested that both client summaries and service summaries without full logtails will work without issues. The driver ends up making a get delta call to fetch the trailing ops.
