### PR TITLE
fix(ci): Run bundle size generation for every commit in main/next/lts/release branches

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -13,27 +13,6 @@ trigger:
     - next
     - lts
     - release/*
-  paths:
-    include:
-    - packages
-    - components
-    - examples
-    - package.json
-    - package-lock.json
-    - lerna.json
-    - lerna-package-lock.json
-    - pnpm-lock.yaml
-    - pnpm-workspace.yaml
-    - tools/pipelines/build-bundle-size-artifacts.yml
-    - tools/pipelines/build-client.yml
-    - tools/pipelines/templates/build-npm-package.yml
-    - tools/pipelines/templates/include-set-package-version.yml
-    - tools/pipelines/templates/include-vars.yml
-    - tools/pipelines/templates/include-install-pnpm.yml
-    - tools/pipelines/templates/include-publish-npm-package.yml
-    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
-    - tools/pipelines/templates/include-publish-npm-package-steps.yml
-    - tools/pipelines/templates/include-git-tag-steps.yml
 
 extends:
   template: templates/build-npm-package.yml


### PR DESCRIPTION
## Description

This makes it so the pipeline that computes the bundle size runs for every commit in the relevant branches, regardless of which paths in the repo were updated. Since every commit in those branches could be the merge base for a PR, we want this information for every one of them so that the bundle size check in PRs can always find the bundle size for the correct baseline instead of falling back to the pipeline run for another recent commit.

This should fix (or alleviate) the issue with bundle size reports in PRs using the wrong baseline; in particular when the baseline was a commit that only touched server/ (or some other path not previously included as a trigger for the pipeline), a bundle size report was never going to get generated for that commit.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
