### PR TITLE
Persist corrupt documents in scribe

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -46,6 +46,7 @@ export class CheckpointManager implements ICheckpointManager {
 		pending: ISequencedOperationMessage[],
 		noActiveClients: boolean,
 		globalCheckpointOnly: boolean,
+		markAsCorrupt: boolean = false,
 	) {
 		const isLocalCheckpoint = !noActiveClients && !globalCheckpointOnly;
 		if (this.getDeltasViaAlfred) {
@@ -106,6 +107,7 @@ export class CheckpointManager implements ICheckpointManager {
 				"scribe",
 				checkpoint,
 				isLocalCheckpoint,
+				markAsCorrupt,
 			);
 		} else {
 			// The order of the three operations below is important.
@@ -142,6 +144,7 @@ export class CheckpointManager implements ICheckpointManager {
 				"scribe",
 				checkpoint,
 				isLocalCheckpoint,
+				markAsCorrupt,
 			);
 
 			// And then delete messagses that were already summarized.

--- a/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
@@ -72,7 +72,8 @@ export interface ICheckpointManager {
 		protocolHead: number,
 		pendingCheckpointMessages: ISequencedOperationMessage[],
 		noActiveClients: boolean,
-		globalCheckpointOnly,
+		globalCheckpointOnly: boolean,
+		markAsCorrupt: boolean,
 	): Promise<void>;
 
 	delete(sequenceNumber: number, lte: boolean): Promise<void>;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -557,7 +557,7 @@ export class ScribeLambda implements IPartitionLambda {
 
 	private markDocumentAsCorrupt(message: IQueuedMessage) {
 		this.isDocumentCorrupt = true;
-		this.prepareCheckpoint(message, CheckpointReason.MarkAsCorrupt, true);
+		this.prepareCheckpoint(message, CheckpointReason.MarkAsCorrupt, this.isDocumentCorrupt);
 	}
 
 	private revertProtocolState(

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -533,6 +533,9 @@ export class ScribeLambda implements IPartitionLambda {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const message = this.pendingMessages.shift()!;
 			try {
+				if (!this.isDocumentCorrupt) {
+					throw new Error(`Test Error`);
+				}
 				if (
 					message.contents &&
 					typeof message.contents === "string" &&

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -213,7 +213,6 @@ export class ScribeLambdaFactory
 				"scribe",
 				document,
 			)) as IScribe;
-			console.log(`****IS_CORRUPT: ${lastCheckpoint.isCorrupt}`);
 			opMessages = await this.getOpMessages(documentId, tenantId, lastCheckpoint);
 		}
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -61,6 +61,7 @@ const DefaultScribe: IScribe = {
 	sequenceNumber: 0,
 	lastSummarySequenceNumber: 0,
 	validParentSummaries: undefined,
+	isCorrupt: false,
 };
 
 export class ScribeLambdaFactory
@@ -123,6 +124,16 @@ export class ScribeLambdaFactory
 				undefined /* shouldIgnoreError */,
 				(error) => true /* shouldRetry */,
 			)) as IDocument;
+
+			if (document.scribe) {
+				if (JSON.parse(document.scribe).isCorrupt) {
+					Lumberjack.info(
+						`Received attempt to connect to a corrupted document.`,
+						lumberProperties,
+					);
+					return new NoOpLambda(context);
+				}
+			}
 
 			if (!isDocumentValid(document)) {
 				// Document sessions can be joined (via Alfred) after a document is functionally deleted.
@@ -202,7 +213,13 @@ export class ScribeLambdaFactory
 				"scribe",
 				document,
 			)) as IScribe;
+			console.log(`****IS_CORRUPT: ${lastCheckpoint.isCorrupt}`);
 			opMessages = await this.getOpMessages(documentId, tenantId, lastCheckpoint);
+		}
+
+		if (lastCheckpoint.isCorrupt) {
+			Lumberjack.info(`Attempt to connect to a corrupted document.`, lumberProperties);
+			return new NoOpLambda(context);
 		}
 
 		// Filter and keep ops after protocol state

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -125,14 +125,12 @@ export class ScribeLambdaFactory
 				(error) => true /* shouldRetry */,
 			)) as IDocument;
 
-			if (document.scribe) {
-				if (JSON.parse(document.scribe).isCorrupt) {
-					Lumberjack.info(
-						`Received attempt to connect to a corrupted document.`,
-						lumberProperties,
-					);
-					return new NoOpLambda(context);
-				}
+			if (JSON.parse(document.scribe)?.isCorrupt) {
+				Lumberjack.info(
+					`Received attempt to connect to a corrupted document.`,
+					lumberProperties,
+				);
+				return new NoOpLambda(context);
 			}
 
 			if (!isDocumentValid(document)) {

--- a/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
@@ -12,6 +12,7 @@ export enum CheckpointReason {
 	MaxMessages,
 	ClearCache,
 	NoClients,
+	MarkAsCorrupt,
 }
 
 // Used to control checkpoint logic

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -54,6 +54,7 @@ const DefaultScribe: IScribe = {
 	sequenceNumber: -1,
 	lastSummarySequenceNumber: 0,
 	validParentSummaries: undefined,
+	isCorrupt: false,
 };
 
 const DefaultDeli: IDeliState = {

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -90,6 +90,9 @@
 			},
 			"InterfaceDeclaration_ITokenRevocationManager": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IScribe": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -31,62 +31,102 @@ export class CheckpointService implements ICheckpointService {
 		service: DocumentLambda,
 		checkpoint: IScribe | IDeliState,
 		isLocal: boolean = false,
+		markAsCorrupt: boolean = false,
+	) {
+		// services may not be able to process documents in corrupted state
+		// so we write to local and global databases when marking document as corrupt
+		if (markAsCorrupt) {
+			await this.writeGlobalCheckpoint(
+				documentId,
+				tenantId,
+				service,
+				checkpoint,
+				this.localCheckpointEnabled,
+			);
+			if (this.localCheckpointEnabled && this.checkpointRepository) {
+				await this.writeLocalCheckpoint(documentId, tenantId, checkpoint);
+			}
+			return;
+		}
+
+		if (!this.localCheckpointEnabled || !this.checkpointRepository) {
+			// Write to global collection when local checkpoints are disabled or there is no checkpoint repository
+			await this.writeGlobalCheckpoint(
+				documentId,
+				tenantId,
+				service,
+				checkpoint,
+				this.localCheckpointEnabled,
+			);
+			return;
+		}
+
+		await (isLocal
+			? this.writeLocalCheckpoint(documentId, tenantId, checkpoint)
+			: this.writeGlobalCheckpoint(
+					documentId,
+					tenantId,
+					service,
+					checkpoint,
+					this.localCheckpointEnabled,
+			  ));
+	}
+
+	private async writeLocalCheckpoint(
+		documentId: string,
+		tenantId: string,
+		checkpoint: IScribe | IDeliState,
+	) {
+		await this.checkpointRepository
+			.writeCheckpoint(documentId, tenantId, checkpoint)
+			.catch((error) => {
+				Lumberjack.error(
+					`Error writing checkpoint to local database`,
+					getLumberBaseProperties(documentId, tenantId),
+					error,
+				);
+			});
+	}
+
+	private async writeGlobalCheckpoint(
+		documentId: string,
+		tenantId: string,
+		service: string,
+		checkpoint: IScribe | IDeliState,
+		localCheckpointEnabled: boolean,
 	) {
 		const lumberProperties = getLumberBaseProperties(documentId, tenantId);
+
 		const checkpointFilter = {
 			documentId,
 			tenantId,
 		};
-
 		const checkpointData = {
 			// stored as stringified JSON
 			[service]: JSON.stringify(checkpoint),
 		};
 
-		if (!this.localCheckpointEnabled || !this.checkpointRepository) {
-			// Write to global collection when local checkpoints are disabled or there is no checkpoint repository
-			await this.documentRepository
-				.updateOne(checkpointFilter, checkpointData, null)
+		await this.documentRepository
+			.updateOne(checkpointFilter, checkpointData, null)
+			.catch((error) => {
+				Lumberjack.error(
+					`Error writing checkpoint to the global database.`,
+					lumberProperties,
+					error,
+				);
+			});
+
+		if (localCheckpointEnabled) {
+			await this.checkpointRepository
+				.deleteCheckpoint(documentId, tenantId)
 				.catch((error) => {
 					Lumberjack.error(
-						`Error writing checkpoint to global collection.`,
+						`Error removing checkpoint data from the local database.`,
 						lumberProperties,
 						error,
 					);
 				});
-			return;
 		}
-
-		await (isLocal
-			? this.checkpointRepository
-					.writeCheckpoint(documentId, tenantId, checkpoint)
-					.catch((error) => {
-						Lumberjack.error(
-							`Error writing checkpoint to local database`,
-							lumberProperties,
-							error,
-						);
-					})
-			: Promise.all([
-					this.checkpointRepository
-						.deleteCheckpoint(documentId, tenantId)
-						.catch((error) => {
-							Lumberjack.error(
-								`Error removing checkpoint data from the local database.`,
-								lumberProperties,
-								error,
-							);
-						}),
-					this.documentRepository
-						.updateOne(checkpointFilter, checkpointData, null)
-						.catch((error) => {
-							Lumberjack.error(
-								`Error writing checkpoint to the global database.`,
-								lumberProperties,
-								error,
-							);
-						}),
-			  ]));
 	}
 
 	async clearCheckpoint(
@@ -251,6 +291,7 @@ export interface ICheckpointService {
 		service: string,
 		checkpoint: IScribe | IDeliState,
 		isLocal: boolean,
+		markAsCorrupt?: boolean,
 	): Promise<void>;
 	clearCheckpoint(
 		documentId: string,

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -115,6 +115,9 @@ export interface IScribe {
 
 	// Refs of the service summaries generated since the last client generated summary.
 	validParentSummaries: string[] | undefined;
+
+	// Is document corrupted?
+	isCorrupt: boolean;
 }
 
 export interface IDocument {

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -1730,6 +1730,7 @@ declare function get_old_InterfaceDeclaration_IScribe():
 declare function use_current_InterfaceDeclaration_IScribe(
     use: TypeOnly<current.IScribe>);
 use_current_InterfaceDeclaration_IScribe(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IScribe());
 
 /*

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -237,6 +237,7 @@ export class DocumentStorage implements IDocumentStorage {
 			// the initial summary would not be accepted as a valid parent because lastClientSummaryHead is undefined and latest
 			// summary is a service summary. However, initial summary _is_ a valid parent in this scenario.
 			validParentSummaries: [initialSummaryVersionId],
+			isCorrupt: false,
 		};
 
 		const session: ISession = {

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -139,6 +139,7 @@ export class TestDocumentStorage implements IDocumentStorage {
 			lastClientSummaryHead: undefined,
 			lastSummarySequenceNumber: 0,
 			validParentSummaries: undefined,
+			isCorrupt: false,
 		};
 
 		const collection = await this.databaseManager.getDocumentCollection();


### PR DESCRIPTION
## Overview
Currently, corrupted document status is stored in memory. When our microservices restart, we lose this information. In order to prevent reprocessing of corrupted documents, this change makes it possible if a document is corrupted in our checkpoints. In this case, we are persisting if a document is corrupt when there is a protocol error in scribe.

### Checkpointing
When we mark a document as corrupted in the database, if local checkpointing is enabled, we will write the updated checkpoint to both the local and global databases. After the document is marked as corrupt, we can no longer write checkpoints. Therefore, it is necessary to persist this information in the global database at this time. Local checkpoints that are outdated will eventually be removed by the local collection's TTL.

### Testing
The following scenarios were tested:
- Create a new document that throws a protocol error. Document is marked as corrupt (in both local and global checkpoints). Other documents are processed as expected.
- Restart scribe and open a document that is marked as corrupt. NoOpLambda is created. Other documents are processed as expected.
- Mark an existing document (that was using the old checkpoint schema without `isCorrupt`) as corrupted