### PR TITLE
Remove nilUuid

### DIFF
--- a/packages/runtime/container-runtime/src/id-compressor/uuidUtilities.ts
+++ b/packages/runtime/container-runtime/src/id-compressor/uuidUtilities.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { StableId, UuidString } from "@fluidframework/runtime-definitions";
-import { v4, NIL } from "uuid";
+import { v4 } from "uuid";
 
 const hexadecimalCharCodes = Array.from("09afAF").map((c) => c.charCodeAt(0)) as [
 	zero: number,
@@ -23,9 +23,6 @@ function isHexadecimalCharacter(charCode: number): boolean {
 		(charCode >= hexadecimalCharCodes[4] && charCode <= hexadecimalCharCodes[5])
 	);
 }
-
-/** The null (lowest/all-zeros) UUID */
-export const nilUuid = assertIsUuidString(NIL);
 
 /**
  * Asserts that the given string is a UUID


### PR DESCRIPTION
## Description
NIL is used in experimental/legacy SharedTree for versioning but isn't needed for the runtime compressor. This matters because consumers of the container runtime will now end up importing this type and some older versions of the `uuid` package don't export NIL. 


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).