### PR TITLE
Increase maxListeners on Audience.

### DIFF
--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -13,6 +13,12 @@ import { IClient } from "@fluidframework/protocol-definitions";
 export class Audience extends EventEmitter implements IAudienceOwner {
 	private readonly members = new Map<string, IClient>();
 
+	constructor() {
+		super();
+		// We are expecting this class to have many listeners, so we suppress noisy "MaxListenersExceededWarning" logging.
+		super.setMaxListeners(0);
+	}
+
 	public on(
 		event: "addMember" | "removeMember",
 		listener: (clientId: string, client: IClient) => void,


### PR DESCRIPTION
## Description

This is a follow-up PR to #16216 . In testing the fix with teams, I discovered one more noisy event listener warning that was due to registrations on the `Audience` class. In the context of a table component, we would register one "addMember" event listener per cell which quickly exceeds the default "warn" limit of 10 with a reasonable-sized table. The warnings look like this:

![image](https://github.com/microsoft/FluidFramework/assets/1000369/411039ac-2c9c-4c0d-b567-26f39b2e9a9c)

Because these errors mention "Memory Leak" they have been a source of confusion with our partners. Ironically, until we patched our console object to stringify all error objects, the warning message itself being logged to the console was a source of memory leaks.

This change removes the maxSafeListener check on the `Audience` class.