### PR TITLE
ci: Skip labelling based on PR title

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,10 @@ jobs:
     # Skip labeling main-next merge PRs. The area labels are noisy and distracting for main-next PRs because they can
     # contain many commits, and thus touch nearly the whole repo in a single commit. Skipping these labels makes it
     # easier to focus on the more relevant main-next labels.
-    if: "!contains(github.event.issue.labels.*.name, 'main-next-integrate')"
+    #
+    # This is implemented by comparing the PR title because at creation time, the PR has no labels (and the GItHub API
+    # does not have a way to set labels at creation either), so skipping based on labels does not work.
+    if: "github.event.pull_request.title != 'Automation: main-next integrate'"
     steps:
       - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
         with:


### PR DESCRIPTION
This is now implemented by comparing the PR title because at creation time, the PR has no labels (and the GItHub API does not have a way to set labels at creation either), so skipping based on labels does not work.