### PR TITLE
ci: Skip step instead of job in workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,7 +14,8 @@ jobs:
     #
     # This is implemented by comparing the PR title because at creation time, the PR has no labels (and the GItHub API
     # does not have a way to set labels at creation either), so skipping based on labels does not work.
-    if: "github.event.pull_request.title != 'Automation: main-next integrate'"
+    if: |
+      ${{ github.event.pull_request.title != 'Automation: main-next integrate' }}
     steps:
       - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
         with:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
         if: |
-          ${{ github.event.pull_request.title != 'Automation: main-next integrate' }}
+          github.event.pull_request.title != "Automation: main-next integrate"
         with:
           configuration-path: ".github/actions-labeler.yml"
           repo-token: "${{ github.token }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,10 +14,10 @@ jobs:
     #
     # This is implemented by comparing the PR title because at creation time, the PR has no labels (and the GItHub API
     # does not have a way to set labels at creation either), so skipping based on labels does not work.
-    if: |
-      ${{ github.event.pull_request.title != 'Automation: main-next integrate' }}
     steps:
       - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
+        if: |
+          ${{ github.event.pull_request.title != 'Automation: main-next integrate' }}
         with:
           configuration-path: ".github/actions-labeler.yml"
           repo-token: "${{ github.token }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,8 +16,7 @@ jobs:
     # does not have a way to set labels at creation either), so skipping based on labels does not work.
     steps:
       - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
-        if: |
-          github.event.pull_request.title != "Automation: main-next integrate"
+        if: "github.event.pull_request.title != 'Automation: main-next integrate'"
         with:
           configuration-path: ".github/actions-labeler.yml"
           repo-token: "${{ github.token }}"


### PR DESCRIPTION
Apparently skipping the job doesn't work, but skipping the step does. Verified on my fork.