### PR TITLE
Add mongo layer monitoring

### DIFF
--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -50,4 +50,5 @@ export enum LumberEventName {
 	ConnectionCountPerNode = "ConnectionCountPerNode",
 	RestoreFromCheckpoint = "RestoreFromCheckpoint",
 	ReprocessOps = "ReprocessOps",
+	MongoMonitoring = "MongoMonitoring",
 }

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -14,7 +14,11 @@ import {
 	MongoClientOptions,
 	OptionalUnlessRequiredId,
 } from "mongodb";
-import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
+import {
+	BaseTelemetryProperties,
+	Lumberjack,
+	LumberEventName,
+} from "@fluidframework/server-services-telemetry";
 import { MongoErrorRetryAnalyzer } from "./mongoExceptionRetryRules";
 
 const MaxFetchSize = 2000;
@@ -579,7 +583,13 @@ export class MongoDbFactory implements core.IDbFactory {
 		);
 		for (const monitoringEvent of this.dbMonitoringEventsList) {
 			connection.on(monitoringEvent, (event) => {
-				Lumberjack.info(`Mongo DB event received: ${monitoringEvent}`, event);
+				// Using an event here so that we can use geneva monitoring in the future if we want to build alerts.
+				const eventWithName = { ...event, MonitoringEventName: monitoringEvent };
+				const metric = Lumberjack.newLumberMetric(
+					LumberEventName.MongoMonitoring,
+					eventWithName,
+				);
+				metric.success(`Event recorded for ${monitoringEvent}`);
 			});
 		}
 		Lumberjack.info("Added event listeners", this.dbMonitoringEventsList);


### PR DESCRIPTION
## Description

1. Added a list of event listeners for mongo side monitoring to better understand product status
2. Made some existing and default values timeout configurable

## Breaking Changes
None

## Reviewer Guidance
Some sample output:
> 2023-07-24 14:05:29 info: Mongo DB event received: serverHeartbeatStarted {"eventName":"LogMessage","id":"7cb601d5-9fe7-4b65-8b44-96ba30125041","label":"winston","properties":"{\"connectionId\":\"mongodb:27017\"}","timestamp":"2023-07-24T18:05:29.349Z","type":"Log"}
2023-07-24 14:05:59 info: Mongo DB event received: serverHeartbeatSucceeded {"eventName":"LogMessage","id":"6aa294cd-aa21-42a0-8f2e-e139033fd832","label":"winston","properties":"{\"connectionId\":\"mongodb:27017\",\"duration\":1,\"reply\":{\"isWritablePrimary\":true,\"topologyVersion\":{\"processId\":\"64bebbb09b72d8776d764b87\",\"counter\":0},\"maxBsonObjectSize\":16777216,\"maxMessageSizeBytes\":48000000,\"maxWriteBatchSize\":100000,\"localTime\":\"2023-07-24T18:05:59.378Z\",\"logicalSessionTimeoutMinutes\":30,\"connectionId\":13,\"minWireVersion\":0,\"maxWireVersion\":9,\"readOnly\":false,\"ok\":1}}","timestamp":"2023-07-24T18:05:59.379Z","type":"Log"}