### PR TITLE
fix(build-tools): Support unscoped package names

### DIFF
--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -141,14 +141,13 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 		const shouldInstall: boolean = flags.install && !flags.skipChecks;
 		const shouldCommit: boolean = flags.commit && !flags.skipChecks;
 
-		const rgOrPackageName = args.package_or_release_group;
-		if (rgOrPackageName === undefined) {
+		if (args.package_or_release_group === undefined) {
 			this.error("No dependency provided.");
 		}
 
-		const rgOrPackage = findPackageOrReleaseGroup(rgOrPackageName, context);
+		const rgOrPackage = findPackageOrReleaseGroup(args.package_or_release_group, context);
 		if (rgOrPackage === undefined) {
-			this.error(`Package not found: ${rgOrPackageName}`);
+			this.error(`Package not found: ${args.package_or_release_group}`);
 		}
 
 		if (bumpType === undefined && flags.exact === undefined) {
@@ -167,7 +166,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 
 		if (rgOrPackage instanceof MonoRepo) {
 			const releaseRepo = rgOrPackage;
-			assert(releaseRepo !== undefined, `Release repo not found for ${rgOrPackageName}`);
+			assert(releaseRepo !== undefined, `Release repo not found for ${rgOrPackage.name}`);
 
 			repoVersion = releaseRepo.version;
 			scheme = flags.scheme ?? detectVersionScheme(repoVersion);
@@ -216,7 +215,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 		scheme = flags.scheme ?? detectVersionScheme(newVersion);
 
 		this.logHr();
-		this.log(`Release group: ${chalk.blueBright(rgOrPackageName)}`);
+		this.log(`Release group/package: ${chalk.blueBright(rgOrPackage.name)}`);
 		this.log(`Bump type: ${chalk.blue(bumpType ?? "exact")}`);
 		this.log(`Scheme: ${chalk.cyan(scheme)}`);
 		this.log(`Workspace protocol: ${workspaceProtocol === true ? chalk.green("yes") : "no"}`);
@@ -265,14 +264,14 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 
 		if (shouldCommit) {
 			const commitMessage = generateBumpVersionCommitMessage(
-				rgOrPackageName,
+				rgOrPackage.name,
 				bumpArg,
 				repoVersion,
 				scheme,
 			);
 
 			const bumpBranch = generateBumpVersionBranchName(
-				rgOrPackageName,
+				rgOrPackage.name,
 				bumpArg,
 				repoVersion,
 				scheme,

--- a/build-tools/packages/build-cli/src/commands/release.ts
+++ b/build-tools/packages/build-cli/src/commands/release.ts
@@ -6,6 +6,7 @@ import { VersionBumpType, detectVersionScheme } from "@fluid-tools/version-tools
 import { Config } from "@oclif/core";
 import { MonoRepoKind } from "@fluidframework/build-tools";
 import chalk from "chalk";
+import { strict as assert } from "node:assert";
 
 import { findPackageOrReleaseGroup } from "../args";
 import {
@@ -68,14 +69,19 @@ export default class ReleaseCommand extends StateMachineCommand<typeof ReleaseCo
 		const flags = this.flags;
 
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const releaseGroup = flags.releaseGroup ?? flags.package!;
-		const packageOrReleaseGroup = findPackageOrReleaseGroup(releaseGroup, context);
+		const rgOrPackageName = flags.releaseGroup ?? flags.package!;
+		assert(
+			rgOrPackageName !== undefined,
+			"Either release group and package flags must be provided.",
+		);
+
+		const packageOrReleaseGroup = findPackageOrReleaseGroup(rgOrPackageName, context);
 		if (packageOrReleaseGroup === undefined) {
-			this.error(`Could not find release group or package: ${releaseGroup}`, {
+			this.error(`Could not find release group or package: ${rgOrPackageName}`, {
 				exit: 1,
 			});
 		}
-
+		const releaseGroup = packageOrReleaseGroup.name;
 		const releaseVersion = packageOrReleaseGroup.version;
 
 		// eslint-disable-next-line no-warning-comments

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ux, Flags, Interfaces, Command } from "@oclif/core";
+import { ux, Flags, Command } from "@oclif/core";
 import { strict as assert } from "assert";
 import chalk from "chalk";
 import { differenceInBusinessDays, formatDistanceToNow } from "date-fns";
@@ -93,7 +93,7 @@ export abstract class ReleaseReportBaseCommand<T extends typeof Command> extends
 	/**
 	 * The release group or package that is being reported on.
 	 */
-	protected abstract releaseGroupOrPackage: ReleaseGroup | ReleasePackage | undefined;
+	protected abstract releaseGroupName: ReleaseGroup | ReleasePackage | undefined;
 
 	/**
 	 * Returns true if the `date` is within `days` days of the current date.
@@ -395,7 +395,7 @@ export default class ReleaseReportCommand extends ReleaseReportBaseCommand<
 	};
 
 	defaultMode: ReleaseSelectionMode = "inRepo";
-	releaseGroupOrPackage: ReleaseGroup | ReleasePackage | undefined;
+	releaseGroupName: ReleaseGroup | ReleasePackage | undefined;
 
 	public async run(): Promise<void> {
 		const flags = this.flags;
@@ -413,14 +413,14 @@ export default class ReleaseReportCommand extends ReleaseReportBaseCommand<
 				: this.defaultMode;
 		assert(mode !== undefined, `mode is undefined`);
 
-		this.releaseGroupOrPackage = flags.releaseGroup;
+		this.releaseGroupName = flags.releaseGroup;
 		const context = await this.getContext();
 
 		// Collect the release version data from the history
 		this.releaseData = await this.collectReleaseData(
 			context,
 			mode,
-			this.releaseGroupOrPackage,
+			this.releaseGroupName,
 			/* includeDeps */ mode === "inRepo",
 		);
 

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -77,6 +77,11 @@ export class MonoRepo {
 	public readonly packages: Package[] = [];
 	public readonly version: string;
 	public readonly workspaceGlobs: string[];
+
+	public get name(): string {
+		return this.kind;
+	}
+
 	private _packageJson: PackageJson;
 
 	static load(group: string, repoPackage: IFluidRepoPackage, log: Logger) {


### PR DESCRIPTION
Several commands, such as `flub release`, did not fully work with unscoped package name arguments. This was caused by some commands saving the argument name and treating it as the full package name. Instead, this PR fixes that limitation by determining the full name of the package and updating relevant variables with the scoped name.