### PR TITLE
Remove Interface IFluidResolvedUrl

### DIFF
--- a/.changeset/lazy-crabs-hope.md
+++ b/.changeset/lazy-crabs-hope.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/driver-definitions": major
+---
+
+Remove Interface IFluidResolvedUrl
+
+IFluidResolvedUrl was deprecated and is now removed. All usages should use IResolvedUrl instead

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -213,23 +213,6 @@ export interface IDriverHeader {
     [DriverHeader.createNew]: any;
 }
 
-// @public @deprecated (undocumented)
-export interface IFluidResolvedUrl {
-    // (undocumented)
-    endpoints: {
-        [name: string]: string;
-    };
-    id: string;
-    // (undocumented)
-    tokens: {
-        [name: string]: string;
-    };
-    // (undocumented)
-    type: "fluid";
-    // (undocumented)
-    url: string;
-}
-
 // @public (undocumented)
 export interface IGenericNetworkError extends IDriverErrorBase {
     // (undocumented)
@@ -247,7 +230,21 @@ export interface ILocationRedirectionError extends IDriverErrorBase {
 }
 
 // @public (undocumented)
-export type IResolvedUrl = IFluidResolvedUrl;
+export interface IResolvedUrl {
+    // (undocumented)
+    endpoints: {
+        [name: string]: string;
+    };
+    id: string;
+    // (undocumented)
+    tokens: {
+        [name: string]: string;
+    };
+    // (undocumented)
+    type: "fluid";
+    // (undocumented)
+    url: string;
+}
 
 // @public
 export interface IStream<T> {

--- a/api-report/local-driver.api.md
+++ b/api-report/local-driver.api.md
@@ -18,7 +18,6 @@ import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
 import { IDocumentServicePolicies } from '@fluidframework/driver-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions';
-import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
 import { ILocalDeltaConnectionServer } from '@fluidframework/server-local-server';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
@@ -86,7 +85,7 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
 
 // @public (undocumented)
 export class LocalDocumentStorageService implements IDocumentStorageService {
-    constructor(id: string, manager: GitManager, policies: IDocumentStorageServicePolicies, localDeltaConnectionServer?: ILocalDeltaConnectionServer | undefined, resolvedUrl?: IFluidResolvedUrl | undefined);
+    constructor(id: string, manager: GitManager, policies: IDocumentStorageServicePolicies, localDeltaConnectionServer?: ILocalDeltaConnectionServer | undefined, resolvedUrl?: IResolvedUrl | undefined);
     // (undocumented)
     protected readonly blobsShaCache: Map<string, string>;
     // (undocumented)

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -6,7 +6,6 @@
 
 import { DriverError } from '@fluidframework/driver-definitions';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions';
-import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 
 // @public (undocumented)
@@ -62,7 +61,7 @@ export interface IEntry {
 // @public (undocumented)
 export interface IFileEntry {
     docId: string;
-    resolvedUrl: IFluidResolvedUrl;
+    resolvedUrl: IResolvedUrl;
 }
 
 // @public (undocumented)
@@ -82,7 +81,7 @@ export interface IOdspErrorAugmentations {
 }
 
 // @public (undocumented)
-export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
+export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
     // (undocumented)
     codeHint?: {
         containerPackageName?: string;

--- a/azure/packages/azure-client/src/AzureUrlResolver.ts
+++ b/azure/packages/azure-client/src/AzureUrlResolver.ts
@@ -3,12 +3,7 @@
  * Licensed under the MIT License.
  */
 import { IRequest } from "@fluidframework/core-interfaces";
-import {
-	DriverHeader,
-	IFluidResolvedUrl,
-	IResolvedUrl,
-	IUrlResolver,
-} from "@fluidframework/driver-definitions";
+import { DriverHeader, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 
 /**
  * Implementation of {@link @fluidframework/driver-definitions#IUrlResolver} to resolve documents stored using the
@@ -20,7 +15,7 @@ import {
 export class AzureUrlResolver implements IUrlResolver {
 	public constructor() {}
 
-	public async resolve(request: IRequest): Promise<IFluidResolvedUrl> {
+	public async resolve(request: IRequest): Promise<IResolvedUrl> {
 		const { ordererUrl, storageUrl, tenantId, containerId } = decodeAzureUrl(request.url);
 		// determine whether the request is for creating of a new container.
 		// such request has the `createNew` header set to true and doesn't have a container ID.

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -64,6 +64,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterfaceDeclaration_IFluidResolvedUrl": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/common/driver-definitions/src/index.ts
+++ b/packages/common/driver-definitions/src/index.ts
@@ -37,7 +37,6 @@ export {
 	DriverHeader,
 	IContainerPackageInfo,
 	IDriverHeader,
-	IFluidResolvedUrl,
 	IResolvedUrl,
 	IUrlResolver,
 } from "./urlResolver";

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
@@ -544,26 +544,14 @@ use_old_InterfaceDeclaration_IDriverHeader(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IFluidResolvedUrl": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IFluidResolvedUrl": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IFluidResolvedUrl():
-    TypeOnly<old.IFluidResolvedUrl>;
-declare function use_current_InterfaceDeclaration_IFluidResolvedUrl(
-    use: TypeOnly<current.IFluidResolvedUrl>);
-use_current_InterfaceDeclaration_IFluidResolvedUrl(
-    get_old_InterfaceDeclaration_IFluidResolvedUrl());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IFluidResolvedUrl": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IFluidResolvedUrl": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IFluidResolvedUrl():
-    TypeOnly<current.IFluidResolvedUrl>;
-declare function use_old_InterfaceDeclaration_IFluidResolvedUrl(
-    use: TypeOnly<old.IFluidResolvedUrl>);
-use_old_InterfaceDeclaration_IFluidResolvedUrl(
-    get_current_InterfaceDeclaration_IFluidResolvedUrl());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -616,26 +604,26 @@ use_old_InterfaceDeclaration_ILocationRedirectionError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IResolvedUrl": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_IResolvedUrl": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_IResolvedUrl():
     TypeOnly<old.IResolvedUrl>;
-declare function use_current_TypeAliasDeclaration_IResolvedUrl(
+declare function use_current_RemovedTypeAliasDeclaration_IResolvedUrl(
     use: TypeOnly<current.IResolvedUrl>);
-use_current_TypeAliasDeclaration_IResolvedUrl(
+use_current_RemovedTypeAliasDeclaration_IResolvedUrl(
     get_old_TypeAliasDeclaration_IResolvedUrl());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IResolvedUrl": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_IResolvedUrl": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_IResolvedUrl():
+declare function get_current_RemovedTypeAliasDeclaration_IResolvedUrl():
     TypeOnly<current.IResolvedUrl>;
 declare function use_old_TypeAliasDeclaration_IResolvedUrl(
     use: TypeOnly<old.IResolvedUrl>);
 use_old_TypeAliasDeclaration_IResolvedUrl(
-    get_current_TypeAliasDeclaration_IResolvedUrl());
+    get_current_RemovedTypeAliasDeclaration_IResolvedUrl());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -4,12 +4,7 @@
  */
 import { IRequest } from "@fluidframework/core-interfaces";
 
-export type IResolvedUrl = IFluidResolvedUrl;
-
-/**
- * @deprecated Use IResolvedUrl instead.
- */
-export interface IFluidResolvedUrl {
+export interface IResolvedUrl {
 	type: "fluid";
 	/**
 	 * The id of the container this resolved url is for.

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 /**
  * Describes what kind of content is stored in cache entry.
@@ -28,7 +28,7 @@ export interface IFileEntry {
 	 * a file if user requests so.
 	 * This is IOdspResolvedUrl in case of ODSP driver.
 	 */
-	resolvedUrl: IFluidResolvedUrl;
+	resolvedUrl: IResolvedUrl;
 }
 
 /**

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 export interface IOdspUrlParts {
 	siteUrl: string;
@@ -98,7 +98,7 @@ export interface ShareLinkInfoType {
 	 */
 	sharingLinkToRedeem?: string;
 }
-export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
+export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 	type: "fluid";
 	odspResolvedUrl: true;
 

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ISession } from "@fluidframework/server-services-client";
 import { getDiscoveredFluidResolvedUrl, parseFluidUrl, replaceDocumentIdInPath } from "../urlUtils";
 
@@ -63,7 +63,7 @@ describe("UrlUtils", () => {
 	});
 
 	describe("getDiscoveredFluidResolvedUrl()", () => {
-		let testResolvedURL: IFluidResolvedUrl;
+		let testResolvedURL: IResolvedUrl;
 		let testSession: ISession;
 
 		before(() => {

--- a/packages/drivers/routerlicious-urlResolver/src/test/routerlicious-urlResolver.spec.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/test/routerlicious-urlResolver.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { Provider } from "nconf";
 import { RouterliciousUrlResolver } from "../urlResolver";
@@ -20,7 +20,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		const url: string =
 			"https://www.wu2.prague.office-int.com/loader/fluid/thinkable-list?chaincode=@fluid-example/shared-text@0.11.14146";
-		const resolved = (await urlResolver.resolve({ url })) as IFluidResolvedUrl;
+		const resolved = (await urlResolver.resolve({ url })) as IResolvedUrl;
 		assert.equal(resolved.tokens.jwt, token, "Token does not match");
 		assert.equal(
 			resolved.endpoints.storageUrl,
@@ -52,7 +52,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		const url: string =
 			"http://localhost:3000/loader/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0";
-		const resolved = (await urlResolver.resolve({ url })) as IFluidResolvedUrl;
+		const resolved = (await urlResolver.resolve({ url })) as IResolvedUrl;
 		assert.equal(resolved.tokens.jwt, token, "Token does not match");
 		assert.equal(
 			resolved.endpoints.storageUrl,
@@ -104,7 +104,7 @@ describe("Routerlicious Url Resolver", () => {
 			hostUrl,
 		);
 
-		const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+		const { endpoints, url } = (await urlResolver.resolve(request)) as IResolvedUrl;
 
 		assert.equal(
 			endpoints.storageUrl,
@@ -151,7 +151,7 @@ describe("Routerlicious Url Resolver", () => {
 			async () => Promise.resolve(token),
 			hostUrl,
 		);
-		const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+		const { endpoints, url } = (await urlResolver.resolve(request)) as IResolvedUrl;
 
 		assert.equal(
 			endpoints.storageUrl,
@@ -197,7 +197,7 @@ describe("Routerlicious Url Resolver", () => {
 			async () => Promise.resolve(token),
 			hostUrl,
 		);
-		const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+		const { endpoints, url } = (await urlResolver.resolve(request)) as IResolvedUrl;
 
 		assert.equal(
 			endpoints.storageUrl,
@@ -248,7 +248,7 @@ describe("Routerlicious Url Resolver", () => {
 			async () => Promise.resolve(token),
 			hostUrl,
 		);
-		const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+		const { endpoints, url } = (await urlResolver.resolve(request)) as IResolvedUrl;
 
 		assert.equal(
 			endpoints.storageUrl,
@@ -280,7 +280,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		const url: string =
 			"http://localhost:3000/loader/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0";
-		const resolved = (await urlResolver.resolve({ url })) as IFluidResolvedUrl;
+		const resolved = (await urlResolver.resolve({ url })) as IResolvedUrl;
 		const absoluteUrl = await urlResolver.getAbsoluteUrl(resolved, "relative");
 		assert.strictEqual(
 			absoluteUrl,

--- a/packages/loader/driver-utils/src/test/insecureUrlResolverTest.spec.ts
+++ b/packages/loader/driver-utils/src/test/insecureUrlResolverTest.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { DriverHeader, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { DriverHeader, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { InsecureUrlResolver } from "../insecureUrlResolver";
 
@@ -42,7 +42,7 @@ describe("Insecure Url Resolver Test", () => {
 	});
 
 	it("Resolved CreateNew Request", async () => {
-		const resolvedUrl = (await resolver.resolve(request)) as IFluidResolvedUrl;
+		const resolvedUrl = (await resolver.resolve(request)) as IResolvedUrl;
 		const documentUrl = `fluid://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
 		assert.strictEqual(
 			resolvedUrl.endpoints.ordererUrl,

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -26,7 +26,7 @@ import {
 	FiveDaysMs,
 	IAnyDriverError,
 	IDocumentServiceFactory,
-	IFluidResolvedUrl,
+	IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import {
 	LocalCodeLoader,
@@ -339,7 +339,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 		assert.ok(pendingString);
 		const pendingLocalState: IPendingLocalState = JSON.parse(pendingString);
 		assert.strictEqual(container.closed, true);
-		assert.strictEqual(pendingLocalState.url, (container.resolvedUrl as IFluidResolvedUrl).url);
+		assert.strictEqual(pendingLocalState.url, (container.resolvedUrl as IResolvedUrl).url);
 	});
 
 	it("can call connect() and disconnect() on Container", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -12,7 +12,7 @@ import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { DataStoreMessageType } from "@fluidframework/datastore";
-import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { Ink, IColor } from "@fluidframework/ink";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { SharedMatrix } from "@fluidframework/matrix";
@@ -146,7 +146,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 			0,
 			"Inbound queue should be empty",
 		);
-		const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+		const containerId = (container.resolvedUrl as IResolvedUrl).id;
 		assert.ok(container, "No container ID");
 		if (provider.driver.type === "local") {
 			assert.strictEqual(containerId, provider.documentId, "Doc id is not matching!!");
@@ -1015,7 +1015,7 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
 			0,
 			"Inbound queue should be empty",
 		);
-		const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+		const containerId = (container.resolvedUrl as IResolvedUrl).id;
 		assert.ok(containerId, "No container ID");
 		if (provider.driver.type === "local") {
 			assert.strictEqual(containerId, provider.documentId, "Doc id is not matching!!");


### PR DESCRIPTION
IFluidResolvedUrl was deprecated and is now removed. All usages should use IResolvedUrl instead.