### PR TITLE
Remove packagePathToTelemetryProperty function

### DIFF
--- a/.changeset/true-crews-marry.md
+++ b/.changeset/true-crews-marry.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/runtime-utils": major
+---
+
+Remove packagePathToTelemetryProperty Function
+
+packagePathToTelemetryProperty was previously deprecated and is now removed. Use tagCodeArtifacts instead.

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -25,7 +25,6 @@ import { ISummaryBlob } from '@fluidframework/protocol-definitions';
 import { ISummaryStats } from '@fluidframework/runtime-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { ITaggedTelemetryPropertyType } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { SummaryObject } from '@fluidframework/protocol-definitions';
@@ -118,9 +117,6 @@ export class ObjectStoragePartition implements IChannelStorageService {
     // (undocumented)
     readBlob(path: string): Promise<ArrayBufferLike>;
 }
-
-// @public @deprecated
-export function packagePathToTelemetryProperty(packagePath: readonly string[] | undefined): ITaggedTelemetryPropertyType | undefined;
 
 // @public
 export type ReadAndParseBlob = <T>(id: string) => Promise<T>;

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -5,7 +5,6 @@
 
 import { ITelemetryGenericEvent } from "@fluidframework/core-interfaces";
 import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
-import { packagePathToTelemetryProperty } from "@fluidframework/runtime-utils";
 import {
 	generateStack,
 	ITelemetryLoggerExt,
@@ -211,7 +210,7 @@ export class GCTelemetryTracker {
 				const { id: taggedId, fromId: taggedFromId, ...otherProps } = eventProps;
 				const event = {
 					eventName: `${state}Object_${nodeUsageProps.usageType}`,
-					pkg: packagePathToTelemetryProperty(nodeUsageProps.packagePath),
+					pkg: tagCodeArtifacts({ pkg: nodeUsageProps.packagePath?.join("/") }).pkg,
 					stack: generateStack(),
 					id: taggedId,
 					fromId: taggedFromId,

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -96,6 +96,11 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedFunctionDeclaration_packagePathToTelemetryProperty": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -4,19 +4,13 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import {
-	ITaggedTelemetryPropertyType,
-	FluidObject,
-	IFluidRouter,
-	IRequest,
-	IResponse,
-} from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidRouter, IRequest, IResponse } from "@fluidframework/core-interfaces";
 import {
 	IFluidDataStoreFactory,
 	IFluidDataStoreRegistry,
 	IProvideFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions";
-import { generateErrorWithStack, TelemetryDataTag } from "@fluidframework/telemetry-utils";
+import { generateErrorWithStack } from "@fluidframework/telemetry-utils";
 
 interface IResponseException extends Error {
 	errorFromRequestFluidObject: true;
@@ -69,18 +63,6 @@ export function responseToException(response: IResponse, request: IRequest): Err
 	};
 
 	return responseErr;
-}
-
-/**
- * Takes a set of packages and joins them pkg1/pkg2... etc. Tags the field as a code artifact
- * @deprecated - use tagCodeArtifacts instead
- */
-export function packagePathToTelemetryProperty(
-	packagePath: readonly string[] | undefined,
-): ITaggedTelemetryPropertyType | undefined {
-	return packagePath
-		? { value: packagePath.join("/"), tag: TelemetryDataTag.CodeArtifact }
-		: undefined;
 }
 
 export async function requestFluidObject<T = FluidObject>(

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -10,7 +10,6 @@ export {
 	createResponseError,
 	exceptionToResponse,
 	Factory,
-	packagePathToTelemetryProperty,
 	requestFluidObject,
 	responseToException,
 } from "./dataStoreHelpers";

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -616,26 +616,14 @@ use_old_FunctionDeclaration_mergeStats(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_packagePathToTelemetryProperty": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_packagePathToTelemetryProperty": {"forwardCompat": false}
 */
-declare function get_old_FunctionDeclaration_packagePathToTelemetryProperty():
-    TypeOnly<typeof old.packagePathToTelemetryProperty>;
-declare function use_current_FunctionDeclaration_packagePathToTelemetryProperty(
-    use: TypeOnly<typeof current.packagePathToTelemetryProperty>);
-use_current_FunctionDeclaration_packagePathToTelemetryProperty(
-    get_old_FunctionDeclaration_packagePathToTelemetryProperty());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_packagePathToTelemetryProperty": {"backCompat": false}
+* "RemovedFunctionDeclaration_packagePathToTelemetryProperty": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_packagePathToTelemetryProperty():
-    TypeOnly<typeof current.packagePathToTelemetryProperty>;
-declare function use_old_FunctionDeclaration_packagePathToTelemetryProperty(
-    use: TypeOnly<typeof old.packagePathToTelemetryProperty>);
-use_old_FunctionDeclaration_packagePathToTelemetryProperty(
-    get_current_FunctionDeclaration_packagePathToTelemetryProperty());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
packagePathToTelemetryProperty was previously deprecated and is now removed. Use tagCodeArtifacts instead.