### PR TITLE
Remove Merge Tree Deprecations

### DIFF
--- a/.changeset/orange-bushes-work.md
+++ b/.changeset/orange-bushes-work.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/merge-tree": major
+---
+
+Segments Property Removed from TrackingGroup
+
+Tracking groups can contain more than just segments, so the deprecated segments property has been removed. Use the tracked property instead to see all tracked objects.

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1025,8 +1025,6 @@ export interface SegmentGroup {
 // @public (undocumented)
 export class SegmentGroupCollection {
     constructor(segment: ISegment);
-    // @deprecated (undocumented)
-    clear(): void;
     // (undocumented)
     copyTo(segment: ISegment): void;
     // (undocumented)
@@ -1177,8 +1175,6 @@ export class TrackingGroup implements ITrackingGroup {
     has(trackable: Trackable): boolean;
     // (undocumented)
     link(trackable: Trackable): void;
-    // @deprecated (undocumented)
-    get segments(): readonly ISegment[];
     // (undocumented)
     get size(): number;
     // (undocumented)

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -191,6 +191,36 @@
 			"RemovedFunctionDeclaration_ordinalToArray": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"ClassDeclaration_BaseSegment": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IConsensusInfo": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITrackingGroup": {
+				"backCompat": false
+			},
+			"ClassDeclaration_Marker": {
+				"backCompat": false
+			},
+			"TypeAliasDeclaration_MergeTreeDeltaRevertible": {
+				"backCompat": false
+			},
+			"ClassDeclaration_SegmentGroupCollection": {
+				"backCompat": false
+			},
+			"TypeAliasDeclaration_SortedSegmentSetItem": {
+				"backCompat": false
+			},
+			"TypeAliasDeclaration_Trackable": {
+				"backCompat": false
+			},
+			"ClassDeclaration_TrackingGroup": {
+				"backCompat": false
+			},
+			"ClassDeclaration_TextSegment": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -412,7 +412,6 @@ class HierMergeBlock extends MergeBlock implements IHierBlock {
 }
 
 /**
- * @deprecated For internal use only. public export will be removed.
  * @internal
  */
 export interface ClientSeq {
@@ -515,7 +514,6 @@ export interface AttributionPolicy {
 }
 
 /**
- * @deprecated For internal use only. public export will be removed.
  * @internal
  */
 export const clientSeqComparer: Comparer<ClientSeq> = {

--- a/packages/dds/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/dds/merge-tree/src/mergeTreeTracking.ts
@@ -24,16 +24,6 @@ export class TrackingGroup implements ITrackingGroup {
 		this.trackedSet = new SortedSegmentSet<Trackable>();
 	}
 
-	/**
-	 * @deprecated - use tracked instead.
-	 * For references positions this will return the underlying segment,
-	 * which may not match the intention
-	 */
-	public get segments(): readonly ISegment[] {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this.trackedSet.items.map((v) => (v.isLeaf() ? v : v.getSegment()!));
-	}
-
 	public get tracked(): readonly Trackable[] {
 		return this.trackedSet.items;
 	}

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -34,15 +34,6 @@ export class SegmentGroupCollection {
 		return this.segmentGroups.pop ? this.segmentGroups.pop()?.data : undefined;
 	}
 
-	/**
-	 * @deprecated - method is unused and will be removed.
-	 */
-	public clear() {
-		while (!this.segmentGroups.empty) {
-			this.segmentGroups.remove(this.segmentGroups.first);
-		}
-	}
-
 	public copyTo(segment: ISegment) {
 		walkList(this.segmentGroups, (sg) =>
 			segment.segmentGroups.enqueueOnCopy(sg.data, this.segment),

--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -65,11 +65,6 @@ export interface IJSONSegmentWithMergeInfo {
 	json: IJSONSegment;
 	client?: string;
 	seq?: number;
-	/**
-	 * @deprecated Use {@link IJSONSegmentWithMergeInfo.removedClientIds} instead.
-	 * This only exists for backwards compatability.
-	 */
-	removedClient?: string;
 	removedClientIds?: string[];
 	removedSeq?: number;
 }

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -106,8 +106,11 @@ export class SnapshotLoader {
 			// this is for back compat, so we change the singular id to an array
 			// this will only cause problems if there is an overlapping delete
 			// spanning the snapshot, which should be rare
-			if (spec.removedClient !== undefined) {
-				seg.removedClientIds = [this.client.getOrAddShortClientId(spec.removedClient)];
+			const specAsBuggyFormat: IJSONSegmentWithMergeInfo & { removedClient?: string } = spec;
+			if (specAsBuggyFormat.removedClient !== undefined) {
+				seg.removedClientIds = [
+					this.client.getOrAddShortClientId(specAsBuggyFormat.removedClient),
+				];
 			}
 			if (spec.removedClientIds !== undefined) {
 				seg.removedClientIds = spec.removedClientIds?.map((sid) =>

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -261,7 +261,9 @@ export class SnapshotV1 {
 					segment.properties = undefined;
 					segment.propertyManager = undefined;
 				}
-				const raw: IJSONSegmentWithMergeInfo = { json: segment.toJSONObject() };
+				const raw: IJSONSegmentWithMergeInfo & { removedClient?: string } = {
+					json: segment.toJSONObject(),
+				};
 				// If the segment insertion is above the MSN, record the insertion merge info.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				if (segment.seq! > minSeq) {
@@ -277,6 +279,12 @@ export class SnapshotV1 {
 						0x065 /* "On removal info preservation, segment has invalid removed sequence number!" */,
 					);
 					raw.removedSeq = segment.removedSeq;
+
+					// back compat for when we split overlap and removed client
+					raw.removedClient =
+						segment.removedClientIds !== undefined
+							? this.getLongClientId(segment.removedClientIds[0])
+							: undefined;
 
 					raw.removedClientIds = segment.removedClientIds?.map((id) =>
 						this.getLongClientId(id),

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -278,12 +278,6 @@ export class SnapshotV1 {
 					);
 					raw.removedSeq = segment.removedSeq;
 
-					// back compat for when we split overlap and removed client
-					raw.removedClient =
-						segment.removedClientIds !== undefined
-							? this.getLongClientId(segment.removedClientIds[0])
-							: undefined;
-
 					raw.removedClientIds = segment.removedClientIds?.map((id) =>
 						this.getLongClientId(id),
 					);
@@ -292,7 +286,7 @@ export class SnapshotV1 {
 				// Sanity check that we are preserving either the seq < minSeq or a removed segment's info.
 				assert(
 					(raw.seq !== undefined && raw.client !== undefined) ||
-						(raw.removedSeq !== undefined && raw.removedClient !== undefined),
+						(raw.removedSeq !== undefined && raw.removedClientIds !== undefined),
 					0x066 /* "Corrupted preservation of segment metadata!" */,
 				);
 

--- a/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
+++ b/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
@@ -46,23 +46,6 @@ describe("segmentGroupCollection", () => {
 		assert.equal(dequeuedSegmentGroup, segmentGroup);
 	});
 
-	it(".clear", () => {
-		const segmentGroup = { segments: [], localSeq: 1, refSeq: 0 };
-		segment.segmentGroups.enqueue(segmentGroup);
-		const segmentGroupCount = 6;
-		while (segment.segmentGroups.size < segmentGroupCount) {
-			segment.segmentGroups.enqueue({ segments: [], localSeq: 1, refSeq: 0 });
-		}
-
-		segment.segmentGroups.clear();
-
-		assert(segment.segmentGroups.empty);
-		assert.equal(segment.segmentGroups.size, 0);
-
-		assert.equal(segmentGroup.segments.length, 1);
-		assert.equal(segmentGroup.segments[0], segment);
-	});
-
 	it(".copyTo", () => {
 		const segmentGroupCount = 6;
 		while (segment.segmentGroups.size < segmentGroupCount) {

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -59,6 +59,7 @@ declare function get_current_ClassDeclaration_BaseSegment():
 declare function use_old_ClassDeclaration_BaseSegment(
     use: TypeOnly<old.BaseSegment>);
 use_old_ClassDeclaration_BaseSegment(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_BaseSegment());
 
 /*
@@ -324,6 +325,7 @@ declare function get_current_InterfaceDeclaration_IConsensusInfo():
 declare function use_old_InterfaceDeclaration_IConsensusInfo(
     use: TypeOnly<old.IConsensusInfo>);
 use_old_InterfaceDeclaration_IConsensusInfo(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConsensusInfo());
 
 /*
@@ -1093,6 +1095,7 @@ declare function get_current_InterfaceDeclaration_ITrackingGroup():
 declare function use_old_InterfaceDeclaration_ITrackingGroup(
     use: TypeOnly<old.ITrackingGroup>);
 use_old_InterfaceDeclaration_ITrackingGroup(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITrackingGroup());
 
 /*
@@ -1309,6 +1312,7 @@ declare function get_current_ClassDeclaration_Marker():
 declare function use_old_ClassDeclaration_Marker(
     use: TypeOnly<old.Marker>);
 use_old_ClassDeclaration_Marker(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Marker());
 
 /*
@@ -1453,6 +1457,7 @@ declare function get_current_TypeAliasDeclaration_MergeTreeDeltaRevertible():
 declare function use_old_TypeAliasDeclaration_MergeTreeDeltaRevertible(
     use: TypeOnly<old.MergeTreeDeltaRevertible>);
 use_old_TypeAliasDeclaration_MergeTreeDeltaRevertible(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_MergeTreeDeltaRevertible());
 
 /*
@@ -2077,6 +2082,7 @@ declare function get_current_ClassDeclaration_SegmentGroupCollection():
 declare function use_old_ClassDeclaration_SegmentGroupCollection(
     use: TypeOnly<old.SegmentGroupCollection>);
 use_old_ClassDeclaration_SegmentGroupCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_SegmentGroupCollection());
 
 /*
@@ -2245,6 +2251,7 @@ declare function get_current_TypeAliasDeclaration_SortedSegmentSetItem():
 declare function use_old_TypeAliasDeclaration_SortedSegmentSetItem(
     use: TypeOnly<old.SortedSegmentSetItem>);
 use_old_TypeAliasDeclaration_SortedSegmentSetItem(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_SortedSegmentSetItem());
 
 /*
@@ -2317,6 +2324,7 @@ declare function get_current_ClassDeclaration_TextSegment():
 declare function use_old_ClassDeclaration_TextSegment(
     use: TypeOnly<old.TextSegment>);
 use_old_ClassDeclaration_TextSegment(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TextSegment());
 
 /*
@@ -2341,6 +2349,7 @@ declare function get_current_TypeAliasDeclaration_Trackable():
 declare function use_old_TypeAliasDeclaration_Trackable(
     use: TypeOnly<old.Trackable>);
 use_old_TypeAliasDeclaration_Trackable(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_Trackable());
 
 /*
@@ -2365,6 +2374,7 @@ declare function get_current_ClassDeclaration_TrackingGroup():
 declare function use_old_ClassDeclaration_TrackingGroup(
     use: TypeOnly<old.TrackingGroup>);
 use_old_ClassDeclaration_TrackingGroup(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TrackingGroup());
 
 /*


### PR DESCRIPTION
This change removes most of the existing merge tree deprecations. Only one of the changes is consumer impacting, removing segments from TrackingGroups. 