### PR TITLE
Miscellaneous merge-tree clean-up

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -691,11 +691,9 @@ export class MergeTree {
 		for (let i = 0; i < block.childCount; i++) {
 			const child = block.children[i];
 			if (child.isLeaf()) {
-				const segment = this.segmentClone(child);
+				const segment = child.clone();
 				bBlock.assignChild(segment, i);
-				if (segments) {
-					segments.push(segment);
-				}
+				segments?.push(segment);
 			} else {
 				bBlock.assignChild(this.blockClone(child, segments), i);
 			}
@@ -703,11 +701,6 @@ export class MergeTree {
 		this.nodeUpdateLengthNewStructure(bBlock);
 		this.nodeUpdateOrdinals(bBlock);
 		return bBlock;
-	}
-
-	private segmentClone(segment: ISegment) {
-		const b = segment.clone();
-		return b;
 	}
 
 	/**
@@ -1075,8 +1068,6 @@ export class MergeTree {
 	 * Compute local partial length information
 	 *
 	 * Public only for use by internal tests
-	 *
-	 * @internal
 	 */
 	public computeLocalPartials(refSeq: number) {
 		if (this.localPartialsComputed) {
@@ -1174,9 +1165,7 @@ export class MergeTree {
 	}
 
 	public addMinSeqListener(minRequired: number, onMinGE: (minSeq: number) => void) {
-		if (!this.minSeqListeners) {
-			this.minSeqListeners = new Heap<MinListener>([], minListenerComparer);
-		}
+		this.minSeqListeners ??= new Heap<MinListener>([], minListenerComparer);
 		this.minSeqListeners.add({ minRequired, onMinGE });
 	}
 
@@ -1322,20 +1311,17 @@ export class MergeTree {
 		clientData: TClientData,
 		localSeq?: number,
 	): ISegment | undefined {
+		const { pre, post, contains, leaf, shift } = actions ?? {};
 		let _pos = pos;
 		let _segpos = segpos;
 		const children = block.children;
-		if (actions && actions.pre) {
-			actions.pre(block, _segpos, refSeq, clientId, undefined, undefined, clientData);
-		}
-		const contains = actions && actions.contains;
+		pre?.(block, _segpos, refSeq, clientId, undefined, undefined, clientData);
 		for (let childIndex = 0; childIndex < block.childCount; childIndex++) {
 			const child = children[childIndex];
 			const len = this.nodeLength(child, refSeq, clientId, localSeq) ?? 0;
 			if (
 				(!contains && _pos < len) ||
-				(contains &&
-					contains(child, _pos, refSeq, clientId, undefined, undefined, clientData))
+				contains?.(child, _pos, refSeq, clientId, undefined, undefined, clientData)
 			) {
 				// Found entry containing pos
 				if (!child.isLeaf()) {
@@ -1350,22 +1336,16 @@ export class MergeTree {
 						localSeq,
 					);
 				} else {
-					if (actions && actions.leaf) {
-						actions.leaf(child, _segpos, refSeq, clientId, _pos, -1, clientData);
-					}
+					leaf?.(child, _segpos, refSeq, clientId, _pos, -1, clientData);
 					return child;
 				}
 			} else {
-				if (actions && actions.shift) {
-					actions.shift(child, _segpos, refSeq, clientId, _pos, undefined, clientData);
-				}
+				shift?.(child, _segpos, refSeq, clientId, _pos, undefined, clientData);
 				_pos -= len;
 				_segpos += len;
 			}
 		}
-		if (actions && actions.post) {
-			actions.post(block, _segpos, refSeq, clientId, undefined, undefined, clientData);
-		}
+		post?.(block, _segpos, refSeq, clientId, undefined, undefined, clientData);
 	}
 
 	private backwardSearch<TClientData>(
@@ -1391,20 +1371,17 @@ export class MergeTree {
 		actions: SegmentActions<TClientData> | undefined,
 		clientData: TClientData,
 	): ISegment | undefined {
+		const { pre, post, contains, leaf, shift } = actions ?? {};
 		let _segEnd = segEnd;
 		const children = block.children;
-		if (actions && actions.pre) {
-			actions.pre(block, _segEnd, refSeq, clientId, undefined, undefined, clientData);
-		}
-		const contains = actions && actions.contains;
+		pre?.(block, _segEnd, refSeq, clientId, undefined, undefined, clientData);
 		for (let childIndex = block.childCount - 1; childIndex >= 0; childIndex--) {
 			const child = children[childIndex];
 			const len = this.nodeLength(child, refSeq, clientId) ?? 0;
 			const segpos = _segEnd - len;
 			if (
 				(!contains && pos >= segpos) ||
-				(contains &&
-					contains(child, pos, refSeq, clientId, undefined, undefined, clientData))
+				contains?.(child, pos, refSeq, clientId, undefined, undefined, clientData)
 			) {
 				// Found entry containing pos
 				if (!child.isLeaf()) {
@@ -1418,21 +1395,15 @@ export class MergeTree {
 						clientData,
 					);
 				} else {
-					if (actions && actions.leaf) {
-						actions.leaf(child, segpos, refSeq, clientId, pos, -1, clientData);
-					}
+					leaf?.(child, segpos, refSeq, clientId, pos, -1, clientData);
 					return child;
 				}
 			} else {
-				if (actions && actions.shift) {
-					actions.shift(child, segpos, refSeq, clientId, pos, undefined, clientData);
-				}
+				shift?.(child, segpos, refSeq, clientId, pos, undefined, clientData);
 				_segEnd = segpos;
 			}
 		}
-		if (actions && actions.post) {
-			actions.post(block, _segEnd, refSeq, clientId, undefined, undefined, clientData);
-		}
+		post?.(block, _segEnd, refSeq, clientId, undefined, undefined, clientData);
 	}
 
 	private updateRoot(splitNode: IMergeBlock | undefined) {
@@ -1489,7 +1460,6 @@ export class MergeTree {
 			const clientId = this.collabWindow.clientId;
 			for (const node of nodesToUpdate) {
 				this.blockUpdatePathLengths(node, seq, clientId, overwrite);
-				// NodeUpdatePathLengths(node, seq, clientId, true);
 			}
 		}
 		if (MergeTree.options.zamboniSegments) {
@@ -2309,7 +2279,7 @@ export class MergeTree {
 				} /* op.type === MergeTreeDeltaType.ANNOTATE */ else {
 					const props = pendingSegmentGroup.previousProps![i];
 					const rollbackType =
-						op.combiningOp && op.combiningOp.name === "rewrite"
+						op.combiningOp?.name === "rewrite"
 							? PropertiesRollback.Rewrite
 							: PropertiesRollback.Rollback;
 					const annotateOp = createAnnotateRangeOp(
@@ -2661,16 +2631,9 @@ export class MergeTree {
 				return;
 			}
 			if (state.childIndex === 0) {
-				if (state.start === undefined) {
-					state.start = 0;
-				}
-				if (state.end === undefined) {
-					state.end = this.blockLength(state.block, state.refSeq, state.clientId);
-				}
-
-				if (state.actions.pre) {
-					state.actions.pre(state);
-				}
+				state.start ??= 0;
+				state.end ??= this.blockLength(state.block, state.refSeq, state.clientId);
+				state.actions.pre?.(state);
 			}
 			if (state.op === IncrementalExecOp.Go && state.childIndex < state.block.childCount) {
 				const child = state.block.children[state.childIndex];
@@ -2699,8 +2662,8 @@ export class MergeTree {
 				state.childIndex++;
 			} else {
 				if (state.childIndex === state.block.childCount) {
-					if (state.op === IncrementalExecOp.Go && state.actions.post) {
-						state.actions.post(state);
+					if (state.op === IncrementalExecOp.Go) {
+						state.actions.post?.(state);
 					}
 					stateStack.pop();
 				}

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -470,12 +470,8 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 		collabWindow?: CollaborationWindow,
 		rollback: PropertiesRollback = PropertiesRollback.None,
 	) {
-		if (!this.propertyManager) {
-			this.propertyManager = new PropertiesManager();
-		}
-		if (!this.properties) {
-			this.properties = createMap<any>();
-		}
+		this.propertyManager ??= new PropertiesManager();
+		this.properties ??= createMap<any>();
 		return this.propertyManager.addProperties(
 			this.properties,
 			newProps,
@@ -691,9 +687,7 @@ export class Marker extends BaseSegment implements ReferencePosition {
 	}
 
 	getId(): string | undefined {
-		if (this.properties && this.properties[reservedMarkerIdKey]) {
-			return this.properties[reservedMarkerIdKey] as string;
-		}
+		return this.properties?.[reservedMarkerIdKey] as string;
 	}
 
 	toString() {

--- a/packages/dds/merge-tree/src/referencePositions.ts
+++ b/packages/dds/merge-tree/src/referencePositions.ts
@@ -35,26 +35,12 @@ export const refGetRangeLabels = (refPos: ReferencePosition): string[] | undefin
 
 export function refHasTileLabel(refPos: ReferencePosition, label: string): boolean {
 	const tileLabels = refGetTileLabels(refPos);
-	if (tileLabels) {
-		for (const refLabel of tileLabels) {
-			if (label === refLabel) {
-				return true;
-			}
-		}
-	}
-	return false;
+	return tileLabels?.includes(label) ?? false;
 }
 
 export function refHasRangeLabel(refPos: ReferencePosition, label: string): boolean {
 	const rangeLabels = refGetRangeLabels(refPos);
-	if (rangeLabels) {
-		for (const refLabel of rangeLabels) {
-			if (label === refLabel) {
-				return true;
-			}
-		}
-	}
-	return false;
+	return rangeLabels?.includes(label) ?? false;
 }
 export function refHasTileLabels(refPos: ReferencePosition): boolean {
 	return refGetTileLabels(refPos) !== undefined;

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -30,7 +30,7 @@ export class PropertiesManager {
 	}
 
 	public ackPendingProperties(annotateOp: IMergeTreeAnnotateMsg) {
-		const rewrite = !!annotateOp.combiningOp && annotateOp.combiningOp.name === "rewrite";
+		const rewrite = annotateOp.combiningOp?.name === "rewrite";
 		this.decrementPendingCounts(rewrite, annotateOp.props);
 	}
 
@@ -65,9 +65,7 @@ export class PropertiesManager {
 		collaborating: boolean = false,
 		rollback: PropertiesRollback = PropertiesRollback.None,
 	): PropertySet | undefined {
-		if (!this.pendingKeyUpdateCount) {
-			this.pendingKeyUpdateCount = createMap<number>();
-		}
+		this.pendingKeyUpdateCount ??= createMap<number>();
 
 		// There are outstanding local rewrites, so block all non-local changes
 		if (

--- a/packages/dds/merge-tree/src/sortedSet.ts
+++ b/packages/dds/merge-tree/src/sortedSet.ts
@@ -19,9 +19,7 @@ export abstract class SortedSet<T, U extends string | number> {
 	public addOrUpdate(newItem: T, update?: (existingItem: T, newItem: T) => void) {
 		const position = this.findItemPosition(newItem);
 		if (position.exists) {
-			if (update) {
-				update(this.keySortedItems[position.index], newItem);
-			}
+			update?.(this.keySortedItems[position.index], newItem);
 		} else {
 			this.keySortedItems.splice(position.index, 0, newItem);
 		}


### PR DESCRIPTION
## Description

Tweaks a number of places in merge-tree code to better leverage [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and other more compact constructs (such as `Array.includes` to replace idiomatic for loops). I wasn't particularly aggressive on using nullish coalescing/optional chaining everywhere, as it can cause behavioral changes--i.e. `if (!a) { return 'foo'; } return a;` is different from `return a ?? 'foo';` due to details with JS truthiness.

I also refactored `scourNode` to require less nesting, as it gets quite unwieldy to read.

Main goal of this PR is to make the code a bit more readable and reduce bundle size. Perf impact for reasons other than bundle size I'd expect to be negligible.