### PR TITLE
Add the Cluster Urls to Alfred Ping Endpoints

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -75,12 +75,10 @@ export function create(
 			throttleIdPrefix: "ping",
 		}),
 		async (request, response) => {
-			response
-				.json({
-					ordererUrl: config.get("worker:serverUrl") ?? "",
-					historianUrl: config.get("worker:blobStorageUrl") ?? "",
-				})
-				.sendStatus(200);
+			response.status(200).json({
+				ordererUrl: config.get("worker:serverUrl") ?? "",
+				historianUrl: config.get("worker:blobStorageUrl") ?? "",
+			});
 		},
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -75,7 +75,12 @@ export function create(
 			throttleIdPrefix: "ping",
 		}),
 		async (request, response) => {
-			response.sendStatus(200);
+			response
+				.json({
+					ordererUrl: config.get("worker:serverUrl") ?? "",
+					historianUrl: config.get("worker:blobStorageUrl") ?? "",
+				})
+				.sendStatus(200);
 		},
 	);
 


### PR DESCRIPTION
We are going to do the private link in FRS clusters. Before the client officially uses the private link to talk to FRS clusters, the client needs to get the exposed ping endpoint to specific cluster URLs to establish the private link. 