### PR TITLE
refactor(devtools-core,devtools): Remove data visualization extensibility options until we settle on a long term design

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -12,7 +12,6 @@ import { IDisposable } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
-import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 
@@ -94,7 +93,6 @@ export namespace ContainerDevtoolsFeatures {
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IContainer;
     containerData?: Record<string, IFluidLoadable>;
-    dataVisualizers?: Record<string, VisualizeSharedObject>;
 }
 
 // @public
@@ -222,12 +220,11 @@ export namespace DisconnectContainer {
 
 // @public
 export interface FluidDevtoolsProps {
-    dataVisualizers?: Record<string, VisualizeSharedObject>;
     initialContainers?: ContainerDevtoolsProps[];
     logger?: DevtoolsLogger;
 }
 
-// @public
+// @internal
 export interface FluidHandleNode extends VisualNodeBase {
     fluidObjectId: string;
     nodeKind: VisualNodeKind.FluidHandleNode;
@@ -236,25 +233,25 @@ export interface FluidHandleNode extends VisualNodeBase {
 // @public
 export type FluidObjectId = string;
 
-// @public
+// @internal
 export type FluidObjectNode = FluidObjectTreeNode | FluidObjectValueNode | FluidUnknownObjectNode;
 
-// @public
+// @internal
 export interface FluidObjectNodeBase extends VisualNodeBase {
     fluidObjectId: FluidObjectId;
 }
 
-// @public
+// @internal
 export interface FluidObjectTreeNode extends TreeNodeBase, FluidObjectNodeBase {
     nodeKind: VisualNodeKind.FluidTreeNode;
 }
 
-// @public
+// @internal
 export interface FluidObjectValueNode extends ValueNodeBase, FluidObjectNodeBase {
     nodeKind: VisualNodeKind.FluidValueNode;
 }
 
-// @public
+// @internal
 export interface FluidUnknownObjectNode extends FluidObjectNodeBase {
     nodeKind: VisualNodeKind.FluidUnknownObjectNode;
 }
@@ -412,7 +409,7 @@ export interface MessageLoggingOptions {
     context?: string;
 }
 
-// @public
+// @internal
 export type Primitive = bigint | number | boolean | null | string | symbol | undefined;
 
 // @internal
@@ -427,7 +424,7 @@ export namespace RootDataVisualizations {
     }
 }
 
-// @public
+// @internal
 export type RootHandleNode = FluidHandleNode | UnknownObjectNode;
 
 // @internal
@@ -459,41 +456,35 @@ export namespace TelemetryHistory {
     }
 }
 
-// @public
+// @internal
 export interface TreeNodeBase extends VisualNodeBase {
     children: Record<string, VisualChildNode>;
 }
 
-// @public
+// @internal
 export interface UnknownObjectNode extends VisualNodeBase {
     nodeKind: VisualNodeKind.UnknownObjectNode;
 }
 
-// @public
+// @internal
 export interface ValueNodeBase extends VisualNodeBase {
     value: Primitive;
 }
 
-// @public
+// @internal
 export type VisualChildNode = VisualTreeNode | VisualValueNode | FluidHandleNode | UnknownObjectNode;
 
-// @public
-export type VisualizeChildData = (data: unknown) => Promise<VisualChildNode>;
-
-// @public
-export type VisualizeSharedObject = (sharedObject: ISharedObject, visualizeChildData: VisualizeChildData) => Promise<FluidObjectNode>;
-
-// @public
+// @internal
 export type VisualNode = VisualTreeNode | VisualValueNode | FluidHandleNode | FluidObjectTreeNode | FluidObjectValueNode | FluidUnknownObjectNode | UnknownObjectNode;
 
-// @public
+// @internal
 export interface VisualNodeBase {
     metadata?: Record<string, Primitive>;
     nodeKind: VisualNodeKind | string;
     typeMetadata?: string;
 }
 
-// @public
+// @internal
 export enum VisualNodeKind {
     // (undocumented)
     FluidHandleNode = "FluidHandleNode",
@@ -511,12 +502,12 @@ export enum VisualNodeKind {
     ValueNode = "ValueNode"
 }
 
-// @public
+// @internal
 export interface VisualTreeNode extends TreeNodeBase {
     nodeKind: VisualNodeKind.TreeNode;
 }
 
-// @public
+// @internal
 export interface VisualValueNode extends ValueNodeBase {
     nodeKind: VisualNodeKind.ValueNode;
 }

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -230,7 +230,7 @@ export interface FluidHandleNode extends VisualNodeBase {
     nodeKind: VisualNodeKind.FluidHandleNode;
 }
 
-// @public
+// @internal
 export type FluidObjectId = string;
 
 // @internal

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -123,6 +123,14 @@
 			},
 			"InterfaceDeclaration_FluidDevtoolsProps": {
 				"backCompat": false
+			},
+			"RemovedTypeAliasDeclaration_VisualizeChildData": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedTypeAliasDeclaration_VisualizeSharedObject": {
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
@@ -29,7 +29,7 @@ export interface HasContainerKey {
 /**
  * A unique ID for a Fluid object
  *
- * @public
+ * @internal
  */
 export type FluidObjectId = string;
 

--- a/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
@@ -15,7 +15,6 @@ import {
 	defaultVisualizers,
 	FluidObjectNode,
 	RootHandleNode,
-	VisualizeSharedObject,
 } from "./data-visualization";
 import { IContainerDevtools } from "./IContainerDevtools";
 import { AudienceChangeLogEntry, ConnectionStateChangeLogEntry } from "./Logs";
@@ -70,19 +69,7 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
 	 */
 	containerData?: Record<string, IFluidLoadable>;
 
-	/**
-	 * (optional) Configurations for generating visual representations of
-	 * {@link @fluidframework/shared-object-base#ISharedObject}s under {@link ContainerDevtoolsProps.containerData}.
-	 *
-	 * @remarks
-	 *
-	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
-	 * default visualization implementations.
-	 *
-	 * Any visualizer configurations specified here will take precedence over system defaults, as well as any
-	 * provided when initializing the Devtools.
-	 */
-	dataVisualizers?: Record<string, VisualizeSharedObject>;
+	// TODO: Add ability for customers to specify custom visualizer overrides
 }
 
 /**
@@ -460,10 +447,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 		this.dataVisualizer =
 			props.containerData === undefined
 				? undefined
-				: new DataVisualizerGraph(props.containerData, {
-						...defaultVisualizers,
-						...props.dataVisualizers, // User-specified visualizers take precedence over system defaults
-				  });
+				: new DataVisualizerGraph(props.containerData, defaultVisualizers);
 		this.dataVisualizer?.on("update", this.dataUpdateHandler);
 
 		// Bind Container events required for change-logging

--- a/packages/tools/devtools/devtools-core/src/FluidDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/FluidDevtools.ts
@@ -22,7 +22,6 @@ import {
 import { IFluidDevtools } from "./IFluidDevtools";
 import { DevtoolsFeature, DevtoolsFeatureFlags } from "./Features";
 import { DevtoolsLogger } from "./DevtoolsLogger";
-import { VisualizeSharedObject } from "./data-visualization";
 import { ContainerKey } from "./CommonInterfaces";
 import { pkgVersion as devtoolsVersion } from "./packageVersion";
 
@@ -86,19 +85,7 @@ export interface FluidDevtoolsProps {
 	 */
 	initialContainers?: ContainerDevtoolsProps[];
 
-	/**
-	 * (optional) Configurations for generating visual representations of
-	 * {@link @fluidframework/shared-object-base#ISharedObject}s associated with individual Containers.
-	 *
-	 * @remarks
-	 *
-	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
-	 * default visualization implementations.
-	 *
-	 * Any visualizer configurations specified here will take precedence over system defaults.
-	 * They can also be overridden on a per-Container basis when registering individual Containers.
-	 */
-	dataVisualizers?: Record<string, VisualizeSharedObject>;
+	// TODO: Add ability for customers to specify custom data visualizer overrides
 }
 
 /**
@@ -139,13 +126,6 @@ export class FluidDevtools implements IFluidDevtools {
 	 * Maps from a {@link ContainerKey} to the corresponding {@link ContainerDevtools} instance.
 	 */
 	private readonly containers: Map<ContainerKey, ContainerDevtools>;
-
-	/**
-	 * Global data visualizers to apply to all {@link IContainerDevtools} instances registered with this object.
-	 *
-	 * @remarks If the user specifies data visualizers alongside a specific Container, those will take precedence over these.
-	 */
-	private readonly dataVisualizers?: Record<string, VisualizeSharedObject>;
 
 	/**
 	 * Private {@link FluidDevtools.disposed} tracking.
@@ -240,7 +220,6 @@ export class FluidDevtools implements IFluidDevtools {
 		}
 
 		this.logger = props?.logger;
-		this.dataVisualizers = props?.dataVisualizers;
 
 		// Register listener for inbound messages from the Window (globalThis)
 		globalThis.addEventListener?.("message", this.windowMessageHandler);
@@ -301,17 +280,14 @@ export class FluidDevtools implements IFluidDevtools {
 			throw new UsageError(useAfterDisposeErrorText);
 		}
 
-		const { containerKey, dataVisualizers: containerVisualizers } = props;
+		const { containerKey } = props;
 
 		if (this.containers.has(containerKey)) {
 			throw new UsageError(getContainerAlreadyRegisteredErrorText(containerKey));
 		}
 
-		const dataVisualizers = mergeDataVisualizers(this.dataVisualizers, containerVisualizers);
-
 		const containerDevtools = new ContainerDevtools({
 			...props,
-			dataVisualizers,
 		});
 		this.containers.set(containerKey, containerDevtools);
 
@@ -407,26 +383,6 @@ export class FluidDevtools implements IFluidDevtools {
 			[DevtoolsFeature.Telemetry]: this.logger !== undefined,
 		};
 	}
-}
-
-/**
- * Merges an optional set of global visualizers with an optional set of Container-local visualizers, such that
- * Container-level visualizers take precedence when present.
- */
-function mergeDataVisualizers(
-	globalVisualizers?: Record<string, VisualizeSharedObject>,
-	containerVisualizers?: Record<string, VisualizeSharedObject>,
-): Record<string, VisualizeSharedObject> | undefined {
-	if (globalVisualizers === undefined) {
-		return containerVisualizers;
-	}
-	if (containerVisualizers === undefined) {
-		return globalVisualizers;
-	}
-	return {
-		...globalVisualizers,
-		...containerVisualizers,
-	};
 }
 
 /**

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
@@ -52,7 +52,7 @@ export type SharedObjectType = string;
  *
  * @returns A visual tree representation of the provided `sharedObject`.
  *
- * @public
+ * @internal
  */
 export type VisualizeSharedObject = (
 	sharedObject: ISharedObject,
@@ -73,7 +73,7 @@ export type VisualizeSharedObject = (
  *
  * @returns A visual tree representation of the input `data`.
  *
- * @public
+ * @internal
  */
 export type VisualizeChildData = (data: unknown) => Promise<VisualChildNode>;
 

--- a/packages/tools/devtools/devtools-core/src/data-visualization/VisualTree.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/VisualTree.ts
@@ -20,7 +20,7 @@ import { FluidObjectId } from "../CommonInterfaces";
  * Note: for forwards compatability reasons, consumers of this should not assume it is exhaustive.
  * I.e. consumers should gracefully handle the case where
  *
- * @public
+ * @internal
  */
 export enum VisualNodeKind {
 	FluidTreeNode = "FluidTreeNode",
@@ -37,7 +37,7 @@ export enum VisualNodeKind {
  *
  * @remarks Used for data / metadata in {@link VisualNodeBase}s.
  *
- * @public
+ * @internal
  */
 // eslint-disable-next-line @rushstack/no-new-null
 export type Primitive = bigint | number | boolean | null | string | symbol | undefined;
@@ -45,7 +45,7 @@ export type Primitive = bigint | number | boolean | null | string | symbol | und
 /**
  * Base interface for all {@link VisualNode}s.
  *
- * @public
+ * @internal
  */
 export interface VisualNodeBase {
 	/**
@@ -73,7 +73,7 @@ export interface VisualNodeBase {
 /**
  * Base interface for visual leaf nodes containing an inline value.
  *
- * @public
+ * @internal
  */
 export interface ValueNodeBase extends VisualNodeBase {
 	/**
@@ -85,7 +85,7 @@ export interface ValueNodeBase extends VisualNodeBase {
 /**
  * Base interface for visual parent nodes containing child nodes.
  *
- * @public
+ * @internal
  */
 export interface TreeNodeBase extends VisualNodeBase {
 	/**
@@ -98,7 +98,7 @@ export interface TreeNodeBase extends VisualNodeBase {
 /**
  * A visual tree with children, which should be displayed beneath this item in the visual tree.
  *
- * @public
+ * @internal
  */
 export interface VisualTreeNode extends TreeNodeBase {
 	/**
@@ -110,7 +110,7 @@ export interface VisualTreeNode extends TreeNodeBase {
 /**
  * Terminal node containing a simple value to display.
  *
- * @public
+ * @internal
  */
 export interface VisualValueNode extends ValueNodeBase {
 	/**
@@ -124,7 +124,7 @@ export interface VisualValueNode extends ValueNodeBase {
  *
  * @remarks I.e. it is not a {@link @fluidframework/shared-object-base#ISharedObject}.
  *
- * @public
+ * @internal
  */
 export interface UnknownObjectNode extends VisualNodeBase {
 	/**
@@ -136,7 +136,7 @@ export interface UnknownObjectNode extends VisualNodeBase {
 /**
  * Base interface for nodes referencing Fluid objects.
  *
- * @public
+ * @internal
  */
 export interface FluidObjectNodeBase extends VisualNodeBase {
 	/**
@@ -153,7 +153,7 @@ export interface FluidObjectNodeBase extends VisualNodeBase {
  * A DDS like {@link @fluidframework/map#SharedMap}, which stores a series of "child" entries might use this
  * to display each of its entries nested under it.
  *
- * @public
+ * @internal
  */
 export interface FluidObjectTreeNode extends TreeNodeBase, FluidObjectNodeBase {
 	/**
@@ -170,7 +170,7 @@ export interface FluidObjectTreeNode extends TreeNodeBase, FluidObjectNodeBase {
  * A DDS like {@link @fluidframework/counter#SharedCounter}, which strictly stores a simple primitive value might use
  * this to inline its value (rather than creating unnecessary visual nesting).
  *
- * @public
+ * @internal
  */
 export interface FluidObjectValueNode extends ValueNodeBase, FluidObjectNodeBase {
 	/**
@@ -184,7 +184,7 @@ export interface FluidObjectValueNode extends ValueNodeBase, FluidObjectNodeBase
  *
  * @remarks Allows consumers to add special handling for unknown data.
  *
- * @public
+ * @internal
  */
 export interface FluidUnknownObjectNode extends FluidObjectNodeBase {
 	/**
@@ -196,7 +196,7 @@ export interface FluidUnknownObjectNode extends FluidObjectNodeBase {
 /**
  * Node pointing to another Fluid object via a unique identifier.
  *
- * @public
+ * @internal
  */
 export interface FluidHandleNode extends VisualNodeBase {
 	/**
@@ -215,7 +215,7 @@ export interface FluidHandleNode extends VisualNodeBase {
 /**
  * A node in a visual metadata tree.
  *
- * @public
+ * @internal
  */
 export type VisualNode =
 	| VisualTreeNode
@@ -229,14 +229,14 @@ export type VisualNode =
 /**
  * A visual tree describing a Fluid object.
  *
- * @public
+ * @internal
  */
 export type FluidObjectNode = FluidObjectTreeNode | FluidObjectValueNode | FluidUnknownObjectNode;
 
 /**
  * A visual tree that can be the child of a {@link FluidObjectNodeBase}.
  *
- * @public
+ * @internal
  */
 export type VisualChildNode =
 	| VisualTreeNode
@@ -247,7 +247,7 @@ export type VisualChildNode =
 /**
  * A visual tree node representing a root data object provided to the devtools at initialization time.
  *
- * @public
+ * @internal
  */
 export type RootHandleNode = FluidHandleNode | UnknownObjectNode;
 

--- a/packages/tools/devtools/devtools-core/src/index.ts
+++ b/packages/tools/devtools/devtools-core/src/index.ts
@@ -43,8 +43,6 @@ export {
 	VisualNodeKind,
 	VisualTreeNode,
 	VisualValueNode,
-	VisualizeChildData,
-	VisualizeSharedObject,
 	UnknownObjectNode,
 } from "./data-visualization";
 export {

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -3090,50 +3090,26 @@ use_old_InterfaceDeclaration_VisualValueNode(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_VisualizeChildData": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_VisualizeChildData": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_VisualizeChildData():
-    TypeOnly<old.VisualizeChildData>;
-declare function use_current_TypeAliasDeclaration_VisualizeChildData(
-    use: TypeOnly<current.VisualizeChildData>);
-use_current_TypeAliasDeclaration_VisualizeChildData(
-    get_old_TypeAliasDeclaration_VisualizeChildData());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_VisualizeChildData": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_VisualizeChildData": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_VisualizeChildData():
-    TypeOnly<current.VisualizeChildData>;
-declare function use_old_TypeAliasDeclaration_VisualizeChildData(
-    use: TypeOnly<old.VisualizeChildData>);
-use_old_TypeAliasDeclaration_VisualizeChildData(
-    get_current_TypeAliasDeclaration_VisualizeChildData());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_VisualizeSharedObject": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_VisualizeSharedObject": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_VisualizeSharedObject():
-    TypeOnly<old.VisualizeSharedObject>;
-declare function use_current_TypeAliasDeclaration_VisualizeSharedObject(
-    use: TypeOnly<current.VisualizeSharedObject>);
-use_current_TypeAliasDeclaration_VisualizeSharedObject(
-    get_old_TypeAliasDeclaration_VisualizeSharedObject());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_VisualizeSharedObject": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_VisualizeSharedObject": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_VisualizeSharedObject():
-    TypeOnly<current.VisualizeSharedObject>;
-declare function use_old_TypeAliasDeclaration_VisualizeSharedObject(
-    use: TypeOnly<old.VisualizeSharedObject>);
-use_old_TypeAliasDeclaration_VisualizeSharedObject(
-    get_current_TypeAliasDeclaration_VisualizeSharedObject());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/tools/devtools/devtools-example/src/App.tsx
+++ b/packages/tools/devtools/devtools-example/src/App.tsx
@@ -216,7 +216,6 @@ function registerContainerWithDevtools(
 	devtools.registerContainerDevtools({
 		container,
 		containerKey,
-		dataVisualizers: undefined, // Use defaults
 	});
 }
 

--- a/packages/tools/devtools/devtools/api-report/devtools.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.api.md
@@ -9,12 +9,10 @@ import { DevtoolsLogger } from '@fluid-experimental/devtools-core';
 import { HasContainerKey } from '@fluid-experimental/devtools-core';
 import { IDisposable } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
-import { VisualizeSharedObject } from '@fluid-experimental/devtools-core';
 
 // @public
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
-    dataVisualizers?: Record<string, VisualizeSharedObject>;
 }
 
 export { ContainerKey }
@@ -23,7 +21,6 @@ export { DevtoolsLogger }
 
 // @public
 export interface DevtoolsProps {
-    dataVisualizers?: Record<string, VisualizeSharedObject>;
     initialContainers?: ContainerDevtoolsProps[];
     logger?: DevtoolsLogger;
 }
@@ -38,7 +35,5 @@ export interface IDevtools extends IDisposable {
 
 // @public (undocumented)
 export function initializeDevtools(props: DevtoolsProps): IDevtools;
-
-export { VisualizeSharedObject }
 
 ```

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -23,7 +23,6 @@ import {
 	IFluidDevtools as IDevtoolsBase,
 	initializeDevtools as initializeDevtoolsBase,
 	DevtoolsLogger,
-	VisualizeSharedObject,
 	HasContainerKey,
 } from "@fluid-experimental/devtools-core";
 import { IDisposable } from "@fluidframework/core-interfaces";
@@ -54,20 +53,7 @@ export interface DevtoolsProps {
 	 */
 	initialContainers?: ContainerDevtoolsProps[];
 
-	/**
-	 * (optional) Configurations for generating visual representations of
-	 * {@link @fluidframework/shared-object-base#ISharedObject}s under each Container's
-	 * {@link @fluidframework/fluid-static#IFluidContainer.initialObjects}.
-	 *
-	 * @remarks
-	 *
-	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
-	 * default visualization implementations.
-	 *
-	 * Any visualizer configurations specified here will take precedence over system defaults.
-	 * They can also be overridden on a per-Container basis when registering individual Containers.
-	 */
-	dataVisualizers?: Record<string, VisualizeSharedObject>;
+	// TODO: Add ability for customers to specify custom data visualizer overrides
 }
 
 /**
@@ -81,20 +67,7 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
 	 */
 	container: IFluidContainer;
 
-	/**
-	 * (optional) Configurations for generating visual representations of
-	 * {@link @fluidframework/shared-object-base#ISharedObject}s under each Container's
-	 * {@link @fluidframework/fluid-static#IFluidContainer.initialObjects}.
-	 *
-	 * @remarks
-	 *
-	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
-	 * default visualization implementations.
-	 *
-	 * Any visualizer configurations specified here will take precedence over system defaults, as well as any
-	 * provided when initializing the Devtools.
-	 */
-	dataVisualizers?: Record<string, VisualizeSharedObject>;
+	// TODO: Add ability for customers to specify custom data visualizer overrides
 }
 
 /**
@@ -202,7 +175,7 @@ export function initializeDevtools(props: DevtoolsProps): IDevtools {
 function mapContainerProps(
 	containerProps: ContainerDevtoolsProps,
 ): ContainerDevtoolsPropsBase | undefined {
-	const { container, containerKey, dataVisualizers } = containerProps;
+	const { container, containerKey } = containerProps;
 	const fluidContainer = container as FluidContainer;
 
 	if (fluidContainer.INTERNAL_CONTAINER_DO_NOT_USE === undefined) {
@@ -215,18 +188,11 @@ function mapContainerProps(
 		container: innerContainer,
 		containerKey,
 		containerData: container.initialObjects,
-		dataVisualizers,
 	};
 }
 
 // Convenience re-exports. Need to cover the things we export form this package,
 // so consumers don't need to import from this one *and* devtools-core.
 // DevtoolsLogger is necessary for consumers to set up Devtools.
-// DevtoolsProps and ContainerDevtoolsProps both use VisualizeSharedObject.
 // ContainerDevtoolsProps extends HasContainerKey, so it needs ContainerKey.
-export {
-	DevtoolsLogger,
-	VisualizeSharedObject,
-	ContainerKey,
-	HasContainerKey,
-} from "@fluid-experimental/devtools-core";
+export { DevtoolsLogger, ContainerKey, HasContainerKey } from "@fluid-experimental/devtools-core";

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -162,30 +162,6 @@ use_old_InterfaceDeclaration_IDevtools(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_VisualizeSharedObject": {"forwardCompat": false}
-*/
-declare function get_old_TypeAliasDeclaration_VisualizeSharedObject():
-    TypeOnly<old.VisualizeSharedObject>;
-declare function use_current_TypeAliasDeclaration_VisualizeSharedObject(
-    use: TypeOnly<current.VisualizeSharedObject>);
-use_current_TypeAliasDeclaration_VisualizeSharedObject(
-    get_old_TypeAliasDeclaration_VisualizeSharedObject());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_VisualizeSharedObject": {"backCompat": false}
-*/
-declare function get_current_TypeAliasDeclaration_VisualizeSharedObject():
-    TypeOnly<current.VisualizeSharedObject>;
-declare function use_old_TypeAliasDeclaration_VisualizeSharedObject(
-    use: TypeOnly<old.VisualizeSharedObject>);
-use_old_TypeAliasDeclaration_VisualizeSharedObject(
-    get_current_TypeAliasDeclaration_VisualizeSharedObject());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_initializeDevtools": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_initializeDevtools():


### PR DESCRIPTION
Removes data visualization overriding capabilities from initialization APIs. We will re-add in the future once we have settled on a long-term design that allows for data editing, etc.

## Breaking Changes

This breaks any existing usages of data visualization overrides.

Also marks a number of related types as `@internal`.

