### PR TITLE
refactor(tree): refactor sequence test utils

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFormat.ts
@@ -26,7 +26,7 @@ export const EncodedChangeAtomId = Type.Object(
 		/**
 		 * Uniquely identifies the changeset within which the change was made.
 		 */
-		revision: Type.Union([RevisionTagSchema, Type.Undefined()]),
+		revision: Type.Optional(RevisionTagSchema),
 		/**
 		 * Uniquely identifies, in the scope of the changeset, the change made to the field.
 		 */

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeTypes.ts
@@ -23,7 +23,7 @@ export interface ChangeAtomId {
 	 * Uniquely identifies the changeset within which the change was made.
 	 * Only undefined when referring to an anonymous changesets.
 	 */
-	readonly revision: RevisionTag | undefined;
+	readonly revision?: RevisionTag;
 	/**
 	 * Uniquely identifies, in the scope of the changeset, the change made to the field.
 	 */

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -10,7 +10,7 @@ import { deepFreeze, fakeRepair } from "../../utils";
 import { brand } from "../../../util";
 import { ChangesetLocalId } from "../../../feature-libraries";
 import { composeAnonChanges, invert as invertChange } from "./utils";
-import { ChangeMaker as Change, TestChangeset } from "./testEdits";
+import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits";
 
 function invert(change: TestChangeset): TestChangeset {
 	deepFreeze(change);
@@ -243,24 +243,12 @@ describe("SequenceField - Invert", () => {
 
 		it("return-from + redundant return-to => skip + skip", () => {
 			const input: TestChangeset = [
-				{
-					type: "ReturnFrom",
-					count: 1,
-					id: brand(0),
-					isDstConflicted: true,
-					changes: childChange1,
-				},
-				{
-					type: "ReturnTo",
-					count: 1,
-					id: brand(0),
-					cellId: { revision: tag2, localId: brand(0) },
+				Mark.returnFrom(1, brand(0), { isDstConflicted: true, changes: childChange1 }),
+				Mark.returnTo(1, brand(0), {
 					inverseOf: tag1,
-				},
-				{
-					type: "Modify",
-					changes: childChange2,
-				},
+					cellId: { revision: tag2, localId: brand(0) },
+				}),
+				Mark.modify(childChange2),
 			];
 			const actual = invert(input);
 			const expected = composeAnonChanges([
@@ -303,27 +291,13 @@ describe("SequenceField - Invert", () => {
 
 		it("redundant return-from + return to => nil + nil", () => {
 			const input: TestChangeset = [
-				{
-					type: "ReturnFrom",
-					count: 1,
-					id: brand(0),
-					cellId: { revision: tag2, localId: brand(0) },
-				},
-				{
-					type: "Modify",
-					changes: childChange1,
-				},
-				{
-					type: "ReturnTo",
-					count: 1,
-					id: brand(0),
-					cellId: { revision: tag1, localId: brand(0) },
+				Mark.returnFrom(1, brand(0), { cellId: { revision: tag2, localId: brand(0) } }),
+				Mark.modify(childChange1),
+				Mark.returnTo(1, brand(0), {
 					isSrcConflicted: true,
-				},
-				{
-					type: "Modify",
-					changes: childChange2,
-				},
+					cellId: { revision: tag2, localId: brand(0) },
+				}),
+				Mark.modify(childChange2),
 			];
 			const actual = invert(input);
 			const expected = composeAnonChanges([
@@ -335,27 +309,15 @@ describe("SequenceField - Invert", () => {
 
 		it("redundant return-from + redundant return-to => nil + skip", () => {
 			const input: TestChangeset = [
-				{
-					type: "ReturnFrom",
-					count: 1,
-					id: brand(0),
-					cellId: { revision: tag2, localId: brand(0) },
+				Mark.returnFrom(1, brand(0), {
 					isDstConflicted: true,
-				},
-				{
-					type: "Modify",
-					changes: childChange1,
-				},
-				{
-					type: "ReturnTo",
-					count: 1,
-					id: brand(0),
+					cellId: { revision: tag2, localId: brand(0) },
+				}),
+				Mark.modify(childChange1),
+				Mark.returnTo(1, brand(0), {
 					isSrcConflicted: true,
-				},
-				{
-					type: "Modify",
-					changes: childChange2,
-				},
+				}),
+				Mark.modify(childChange2),
 			];
 			const actual = invert(input);
 			const expected = composeAnonChanges([

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -8,8 +8,9 @@ import { mintRevisionTag, RevisionTag, TreeSchemaIdentifier } from "../../../cor
 import { ChangesetLocalId, SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
+import { MarkMaker as Mark } from "./testEdits";
 
-const dummyMark: SF.Detach = { type: "Delete", id: brand(0), count: 1 };
+const dummyMark = Mark.delete(1, brand(0));
 const type: TreeSchemaIdentifier = brand("Node");
 const detachedBy: RevisionTag = mintRevisionTag();
 
@@ -48,37 +49,36 @@ describe("SequenceField - MarkListFactory", () => {
 		const id1: ChangesetLocalId = brand(1);
 		const id2: ChangesetLocalId = brand(2);
 		const factory = new SF.MarkListFactory();
-		const insert1: SF.Insert = { type: "Insert", content: [{ type, value: 1 }], id: id1 };
-		const insert2: SF.Insert = { type: "Insert", content: [{ type, value: 2 }], id: id2 };
+		const insert1 = Mark.insert([{ type, value: 1 }], id1);
+		const insert2 = Mark.insert([{ type, value: 2 }], id2);
 		factory.pushContent(insert1);
 		factory.pushContent(insert2);
 		assert.deepStrictEqual(factory.list, [
-			{
-				type: "Insert",
-				content: [
+			Mark.insert(
+				[
 					{ type, value: 1 },
 					{ type, value: 2 },
 				],
-				id: id1,
-			},
+				id1,
+			),
 		]);
 	});
 
 	it("Can merge consecutive deletes", () => {
 		const factory = new SF.MarkListFactory();
-		const delete1: SF.Detach = { type: "Delete", id: brand(0), count: 1 };
-		const delete2: SF.Detach = { type: "Delete", id: brand(1), count: 1 };
+		const delete1 = Mark.delete(1, brand(0));
+		const delete2 = Mark.delete(1, brand(1));
 		factory.pushContent(delete1);
 		factory.pushContent(delete2);
-		assert.deepStrictEqual(factory.list, [{ type: "Delete", id: 0, count: 2 }]);
+		assert.deepStrictEqual(factory.list, [Mark.delete(2, brand(0))]);
 	});
 
 	it("Can merge adjacent moves ", () => {
 		const factory = new SF.MarkListFactory();
-		const moveOut1: SF.Detach = { type: "MoveOut", id: brand(0), count: 1 };
-		const moveOut2: SF.Detach = { type: "MoveOut", id: brand(1), count: 1 };
-		const moveIn1: SF.Mark = { type: "MoveIn", id: brand(0), count: 1 };
-		const moveIn2: SF.Mark = { type: "MoveIn", id: brand(1), count: 1 };
+		const moveOut1 = Mark.moveOut(1, brand(0));
+		const moveOut2 = Mark.moveOut(1, brand(1));
+		const moveIn1 = Mark.moveIn(1, brand(0));
+		const moveIn2 = Mark.moveIn(1, brand(1));
 		factory.pushContent(moveOut1);
 		factory.pushContent(moveOut2);
 		factory.pushOffset(3);
@@ -86,9 +86,9 @@ describe("SequenceField - MarkListFactory", () => {
 		factory.pushContent(moveIn2);
 
 		assert.deepStrictEqual(factory.list, [
-			{ type: "MoveOut", id: 0, count: 2 },
+			Mark.moveOut(2, brand(0)),
 			{ count: 3 },
-			{ type: "MoveIn", id: 0, count: 2 },
+			Mark.moveIn(2, brand(0)),
 		]);
 	});
 
@@ -109,51 +109,41 @@ describe("SequenceField - MarkListFactory", () => {
 		factory.pushContent(moveIn3);
 
 		assert.deepStrictEqual(factory.list, [
-			{ type: "MoveOut", id: 0, count: 3 },
+			Mark.moveOut(3, brand(0)),
 			{ count: 3 },
-			{ type: "MoveIn", id: 0, count: 3 },
+			Mark.moveIn(3, brand(0)),
 		]);
 	});
 
 	it("Can merge consecutive revives", () => {
 		const factory = new SF.MarkListFactory();
-		const revive1: SF.Reattach = {
-			type: "Revive",
-			cellId: { revision: detachedBy, localId: brand(0) },
-			content: fakeRepair(detachedBy, 0, 1),
-			count: 1,
-		};
-		const revive2: SF.Reattach = {
-			type: "Revive",
-			cellId: { revision: detachedBy, localId: brand(1) },
-			content: fakeRepair(detachedBy, 1, 1),
-			count: 1,
-		};
+		const revive1 = Mark.revive(fakeRepair(detachedBy, 0, 1), {
+			revision: detachedBy,
+			localId: brand(0),
+		});
+		const revive2 = Mark.revive(fakeRepair(detachedBy, 1, 1), {
+			revision: detachedBy,
+			localId: brand(1),
+		});
 		factory.pushContent(revive1);
 		factory.pushContent(revive2);
-		const expected: SF.Reattach = {
-			type: "Revive",
-			cellId: { revision: detachedBy, localId: brand(0) },
-			content: fakeRepair(detachedBy, 0, 2),
-			count: 2,
-		};
+		const expected = Mark.revive(fakeRepair(detachedBy, 0, 2), {
+			revision: detachedBy,
+			localId: brand(0),
+		});
 		assert.deepStrictEqual(factory.list, [expected]);
 	});
 
 	it("Does not merge revives with gaps", () => {
 		const factory = new SF.MarkListFactory();
-		const revive1: SF.Reattach = {
-			type: "Revive",
-			cellId: { revision: detachedBy, localId: brand(0) },
-			content: fakeRepair(detachedBy, 0, 1),
-			count: 1,
-		};
-		const revive2: SF.Reattach = {
-			type: "Revive",
-			cellId: { revision: detachedBy, localId: brand(2) },
-			content: fakeRepair(detachedBy, 2, 1),
-			count: 1,
-		};
+		const revive1 = Mark.revive(fakeRepair(detachedBy, 0, 1), {
+			revision: detachedBy,
+			localId: brand(0),
+		});
+		const revive2 = Mark.revive(fakeRepair(detachedBy, 2, 1), {
+			revision: detachedBy,
+			localId: brand(2),
+		});
 		factory.pushContent(revive1);
 		factory.pushContent(revive2);
 		assert.deepStrictEqual(factory.list, [revive1, revive2]);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/randomChangeGenerator.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/randomChangeGenerator.spec.ts
@@ -8,6 +8,7 @@ import { NodeChangeset } from "../../../feature-libraries";
 import { FieldKey } from "../../../core";
 import { brand } from "../../../util";
 import { generateRandomChange } from "./randomChangeGenerator";
+import { MarkMaker as Mark } from "./testEdits";
 
 const testSeed = 432167897;
 const maxIndex = 3;
@@ -39,7 +40,7 @@ describe("SequenceField - generateRandomChange", () => {
 
 	it("Generates a change", () => {
 		const change = generateRandomChange(testSeed, maxIndex, childGen);
-		const expected = [{ count: 2 }, { type: "Delete", id: 0, count: 5 }];
+		const expected = [{ count: 2 }, Mark.delete(5, brand(0))];
 		assert.deepStrictEqual(change, expected);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -10,7 +10,7 @@ import { createFakeRepair, fakeRepair } from "../../utils";
 import { TestChange } from "../../testChange";
 import { brand } from "../../../util";
 import { checkDeltaEquality, composeAnonChanges, rebaseTagged, rebase as rebaseI } from "./utils";
-import { cases, ChangeMaker as Change, TestChangeset } from "./testEdits";
+import { cases, ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits";
 
 const tag1: RevisionTag = mintRevisionTag();
 const tag2: RevisionTag = mintRevisionTag();
@@ -176,25 +176,13 @@ describe("SequenceField - Rebase", () => {
 		const deletion = Change.delete(1, 1);
 		const actual = rebase(revive, deletion, tag3);
 		const expected: SF.Changeset = [
-			{
-				type: "Revive",
-				content: fakeRepair(tag1, 1, 1),
-				count: 1,
-				inverseOf: tag1,
-			},
-			{
-				type: "Revive",
-				content: fakeRepair(tag1, 2, 1),
-				count: 1,
-				inverseOf: tag1,
-				cellId: { revision: tag3, localId: brand(0) },
-			},
-			{
-				type: "Revive",
-				content: fakeRepair(tag1, 3, 1),
-				count: 1,
-				inverseOf: tag1,
-			},
+			Mark.revive(fakeRepair(tag1, 1, 1), undefined, { inverseOf: tag1 }),
+			Mark.revive(
+				fakeRepair(tag1, 2, 1),
+				{ revision: tag3, localId: brand(0) },
+				{ inverseOf: tag1 },
+			),
+			Mark.revive(fakeRepair(tag1, 3, 1), undefined, { inverseOf: tag1 }),
 		];
 		assert.deepEqual(actual, expected);
 	});
@@ -210,26 +198,17 @@ describe("SequenceField - Rebase", () => {
 		const revive2 = Change.revive(0, 1, { revision: tag2, localId: brand(2) }, fakeRepair);
 		const actual = rebase(revive1, revive2, tag2);
 		const expected: SF.Changeset = [
-			{
-				type: "Revive",
-				content: fakeRepair(tag1, 0, 1),
-				count: 1,
-				inverseOf: tag1,
-				cellId: { revision: tag2, localId: brand(1) },
-			},
-			{
-				type: "Revive",
-				content: fakeRepair(tag1, 1, 1),
-				count: 1,
-				inverseOf: tag1,
-			},
-			{
-				type: "Revive",
-				content: fakeRepair(tag1, 2, 1),
-				count: 1,
-				inverseOf: tag1,
-				cellId: { revision: tag2, localId: brand(3) },
-			},
+			Mark.revive(
+				fakeRepair(tag1, 0, 1),
+				{ revision: tag2, localId: brand(1) },
+				{ inverseOf: tag1 },
+			),
+			Mark.revive(fakeRepair(tag1, 1, 1), undefined, { inverseOf: tag1 }),
+			Mark.revive(
+				fakeRepair(tag1, 2, 1),
+				{ revision: tag2, localId: brand(3) },
+				{ inverseOf: tag1 },
+			),
 		];
 		assert.deepEqual(actual, expected);
 	});
@@ -291,26 +270,11 @@ describe("SequenceField - Rebase", () => {
 		// Deletes --E-G
 		const expected: SF.Changeset<never> = [
 			{ count: 2 },
-			{
-				type: "Delete",
-				id: brand(0),
-				count: 1,
-				cellId: { revision: tag1, localId: brand(1) },
-			},
-			{ type: "Delete", id: brand(1), count: 1 },
-			{
-				type: "Delete",
-				id: brand(2),
-				count: 1,
-				cellId: { revision: tag1, localId: brand(2) },
-			},
-			{ type: "Delete", id: brand(3), count: 1 },
-			{
-				type: "Delete",
-				id: brand(4),
-				count: 1,
-				cellId: { revision: tag1, localId: brand(3) },
-			},
+			Mark.delete(1, brand(0), { cellId: { revision: tag1, localId: brand(1) } }),
+			Mark.delete(1, brand(1)),
+			Mark.delete(1, brand(2), { cellId: { revision: tag1, localId: brand(2) } }),
+			Mark.delete(1, brand(3)),
+			Mark.delete(1, brand(4), { cellId: { revision: tag1, localId: brand(3) } }),
 		];
 		checkDeltaEquality(actual, expected);
 	});
@@ -347,41 +311,30 @@ describe("SequenceField - Rebase", () => {
 		const actual = rebase(move, deletion, tag1);
 
 		// Moves --E-G
-		const expected: SF.Changeset<never> = [
-			{ type: "MoveIn", count: 1, id: brand(0), isSrcConflicted: true },
-			{ type: "MoveIn", count: 1, id: brand(1) },
-			{ type: "MoveIn", count: 1, id: brand(2), isSrcConflicted: true },
-			{ type: "MoveIn", count: 1, id: brand(3) },
-			{ type: "MoveIn", count: 1, id: brand(4), isSrcConflicted: true },
+		const expected = [
+			Mark.moveIn(1, brand(0), { isSrcConflicted: true }),
+			Mark.moveIn(1, brand(1)),
+			Mark.moveIn(1, brand(2), { isSrcConflicted: true }),
+			Mark.moveIn(1, brand(3)),
+			Mark.moveIn(1, brand(4), { isSrcConflicted: true }),
 			{ count: 2 },
-			{
-				type: "MoveOut",
-				count: 1,
-				id: brand(0),
+			Mark.moveOut(1, brand(0), {
 				cellId: {
 					revision: tag1,
 					localId: brand(1),
 					lineage: [{ revision: tag1, id: brand(0), count: 1, offset: 1 }],
 				},
-			},
-			{ type: "MoveOut", count: 1, id: brand(1) },
-			{
-				type: "MoveOut",
-				count: 1,
-				id: brand(2),
-				cellId: { revision: tag1, localId: brand(2) },
-			},
-			{ type: "MoveOut", count: 1, id: brand(3) },
-			{
-				type: "MoveOut",
-				count: 1,
-				id: brand(4),
+			}),
+			Mark.moveOut(1, brand(1)),
+			Mark.moveOut(1, brand(2), { cellId: { revision: tag1, localId: brand(2) } }),
+			Mark.moveOut(1, brand(3)),
+			Mark.moveOut(1, brand(4), {
 				cellId: {
 					revision: tag1,
 					localId: brand(3),
 					lineage: [{ revision: tag1, id: brand(4), count: 1, offset: 0 }],
 				},
-			},
+			}),
 		];
 		assert.deepEqual(actual, expected);
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -175,7 +175,7 @@ describe("SequenceField - Rebase", () => {
 		);
 		const deletion = Change.delete(1, 1);
 		const actual = rebase(revive, deletion, tag3);
-		const expected: SF.Changeset = [
+		const expected = [
 			Mark.revive(fakeRepair(tag1, 1, 1), undefined, { inverseOf: tag1 }),
 			Mark.revive(
 				fakeRepair(tag1, 2, 1),
@@ -197,7 +197,7 @@ describe("SequenceField - Rebase", () => {
 		);
 		const revive2 = Change.revive(0, 1, { revision: tag2, localId: brand(2) }, fakeRepair);
 		const actual = rebase(revive1, revive2, tag2);
-		const expected: SF.Changeset = [
+		const expected = [
 			Mark.revive(
 				fakeRepair(tag1, 0, 1),
 				{ revision: tag2, localId: brand(1) },
@@ -268,7 +268,7 @@ describe("SequenceField - Rebase", () => {
 		]);
 		const actual = rebase(deleteA, deleteB, tag1);
 		// Deletes --E-G
-		const expected: SF.Changeset<never> = [
+		const expected = [
 			{ count: 2 },
 			Mark.delete(1, brand(0), { cellId: { revision: tag1, localId: brand(1) } }),
 			Mark.delete(1, brand(1)),

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -27,7 +27,7 @@ import {
 	rebaseTagged,
 	toDelta,
 } from "./utils";
-import { ChangeMaker as Change } from "./testEdits";
+import { ChangeMaker as Change, MarkMaker as Mark } from "./testEdits";
 
 const type: TreeSchemaIdentifier = brand("Node");
 const tag1: RevisionTag = mintRevisionTag();
@@ -77,12 +77,9 @@ const testChanges: [string, (index: number, maxIndex: number) => SF.Changeset<Te
 		"TransientInsert",
 		(i) => [
 			{ count: i },
-			{
-				type: "Insert",
-				content: [singleTextCursor({ type, value: 1 })],
-				id: brand(0),
+			Mark.insert([singleTextCursor({ type, value: 1 })], brand(0), {
 				transientDetach: { revision: tag1, localId: brand(0) },
-			},
+			}),
 		],
 	],
 	["Delete", (i) => Change.delete(i, 2)],
@@ -99,13 +96,14 @@ const testChanges: [string, (index: number, maxIndex: number) => SF.Changeset<Te
 		"TransientRevive",
 		(i) => [
 			{ count: i },
-			{
-				type: "Revive",
-				count: 1,
-				cellId: { revision: tag1, localId: brand(0) },
-				content: [singleTextCursor({ type, value: 1 })],
-				transientDetach: { revision: tag1, localId: brand(0) },
-			},
+			Mark.revive(
+				[singleTextCursor({ type, value: 1 })],
+				{
+					revision: tag1,
+					localId: brand(0),
+				},
+				{ transientDetach: { revision: tag1, localId: brand(0) } },
+			),
 		],
 	],
 	[

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
@@ -13,7 +13,7 @@ import {
 import { brand } from "../../../util";
 import { deepFreeze } from "../../utils";
 import { TestChange } from "../../testChange";
-import { TestChangeset } from "./testEdits";
+import { TestChangeset, MarkMaker as Mark } from "./testEdits";
 
 const id: ChangesetLocalId = brand(0);
 const nodeX = { type: jsonString.name, value: "X" };
@@ -26,28 +26,25 @@ describe("SequenceField - Editor", () => {
 		const childChange = TestChange.mint([0], 1);
 		deepFreeze(childChange);
 		const actual = SF.sequenceFieldEditor.buildChildChange(42, childChange);
-		const expected: TestChangeset = [{ count: 42 }, { type: "Modify", changes: childChange }];
+		const expected: TestChangeset = [{ count: 42 }, Mark.modify(childChange)];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("insert one node", () => {
 		const actual = SF.sequenceFieldEditor.insert(42, [content[0]], id);
-		const expected: SF.Changeset = [{ count: 42 }, { type: "Insert", content: [nodeX], id }];
+		const expected: SF.Changeset = [{ count: 42 }, Mark.insert([nodeX], id)];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("insert multiple nodes", () => {
 		const actual = SF.sequenceFieldEditor.insert(42, content, id);
-		const expected: SF.Changeset = [
-			{ count: 42 },
-			{ type: "Insert", content: [nodeX, nodeY], id },
-		];
+		const expected: SF.Changeset = [{ count: 42 }, Mark.insert([nodeX, nodeY], id)];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("delete", () => {
 		const actual = SF.sequenceFieldEditor.delete(42, 3, id);
-		const expected: SF.Changeset = [{ count: 42 }, { type: "Delete", id, count: 3 }];
+		const expected: SF.Changeset = [{ count: 42 }, Mark.delete(3, id)];
 		assert.deepEqual(actual, expected);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -23,7 +23,7 @@ import {
 import { brand, brandOpaque, makeArray } from "../../../util";
 import { TestChange } from "../../testChange";
 import { assertMarkListEqual, deepFreeze } from "../../utils";
-import { ChangeMaker as Change, TestChangeset } from "./testEdits";
+import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits";
 import { composeAnonChanges } from "./utils";
 
 const type: TreeSchemaIdentifier = brand("Node");
@@ -109,21 +109,15 @@ describe("SequenceField - toDelta", () => {
 			fieldKind: FieldKinds.sequence.identifier,
 			change: brand("Dummy Child Change"),
 		};
-		const nodeChange = {
+		const changes = {
 			fieldChanges: new Map([[fooField, nestedChange]]),
 		};
-		const changeset: SF.Changeset = [
-			{
-				type: "Revive",
-				content: contentCursor,
-				count: 1,
-				cellId: { revision: tag, localId: brand(0) },
-				changes: nodeChange,
-			},
+		const changeset = [
+			Mark.revive(contentCursor, { revision: tag, localId: brand(0) }, { changes }),
 		];
 		const fieldChanges = new Map([[fooField, [{ type: Delta.MarkType.Insert, content: [] }]]]);
 		const deltaFromChild = (child: NodeChangeset): Delta.Modify => {
-			assert.deepEqual(child, nodeChange);
+			assert.deepEqual(child, changes);
 			return { type: Delta.MarkType.Modify, fields: fieldChanges };
 		};
 		const actual = SF.sequenceFieldToDelta(changeset, deltaFromChild);
@@ -149,19 +143,11 @@ describe("SequenceField - toDelta", () => {
 	});
 
 	it("move", () => {
-		const changeset: TestChangeset = [
+		const changeset = [
 			{ count: 42 },
-			{
-				type: "MoveOut",
-				id: moveId,
-				count: 10,
-			},
+			Mark.moveOut(10, moveId),
 			{ count: 8 },
-			{
-				type: "MoveIn",
-				id: moveId,
-				count: 10,
-			},
+			Mark.moveIn(10, moveId),
 		];
 		const moveOut: Delta.MoveOut = {
 			type: Delta.MarkType.MoveOut,
@@ -251,9 +237,7 @@ describe("SequenceField - toDelta", () => {
 	});
 
 	it("modify and delete => delete", () => {
-		const changeset: TestChangeset = [
-			{ type: "Delete", id: brand(0), count: 1, changes: childChange1 },
-		];
+		const changeset = [Mark.delete(1, brand(0), { changes: childChange1 })];
 		const mark: Delta.Delete = {
 			type: Delta.MarkType.Delete,
 			count: 1,
@@ -281,9 +265,7 @@ describe("SequenceField - toDelta", () => {
 	});
 
 	it("modify and move-out => move-out", () => {
-		const changeset: TestChangeset = [
-			{ type: "MoveOut", count: 1, id: moveId, changes: childChange1 },
-		];
+		const changeset = [Mark.moveOut(1, moveId, { changes: childChange1 })];
 		const mark: Delta.MoveOut = {
 			type: Delta.MarkType.MoveOut,
 			moveId: deltaMoveId,
@@ -314,23 +296,12 @@ describe("SequenceField - toDelta", () => {
 	it("insert and modify w/ move-in => insert", () => {
 		const nestedChange: FieldChange = {
 			fieldKind: FieldKinds.sequence.identifier,
-			change: brand({
-				type: "MoveIn",
-				id: moveId,
-				count: 42,
-			}),
+			change: brand([Mark.moveIn(42, moveId)]),
 		};
 		const nodeChange = {
 			fieldChanges: new Map([[fooField, nestedChange]]),
 		};
-		const changeset: SF.Changeset = [
-			{
-				type: "Insert",
-				content,
-				changes: nodeChange,
-				id: brand(0),
-			},
-		];
+		const changeset = [Mark.insert(content, brand(0), { changes: nodeChange })];
 		const nestedMoveDelta = new Map([
 			[fooField, [{ type: Delta.MarkType.MoveIn, moveId: deltaMoveId, count: 42 }]],
 		]);
@@ -349,17 +320,10 @@ describe("SequenceField - toDelta", () => {
 	});
 
 	describe("Muted changes", () => {
-		const detachEvent = { revision: tag1, localId: brand<ChangesetLocalId>(0) };
+		const cellId = { revision: tag1, localId: brand<ChangesetLocalId>(0) };
 
 		it("delete", () => {
-			const deletion: TestChangeset = [
-				{
-					type: "Delete",
-					id: brand(0),
-					count: 2,
-					cellId: detachEvent,
-				},
-			];
+			const deletion = [Mark.delete(2, brand(0), { cellId })];
 
 			const actual = toDelta(deletion);
 			const expected: Delta.MarkList = [];
@@ -367,9 +331,7 @@ describe("SequenceField - toDelta", () => {
 		});
 
 		it("modify", () => {
-			const modify: TestChangeset = [
-				{ type: "Modify", changes: childChange1, cellId: detachEvent },
-			];
+			const modify = [Mark.modify(childChange1, cellId)];
 
 			const actual = toDelta(modify);
 			const expected: Delta.MarkList = [];
@@ -377,10 +339,10 @@ describe("SequenceField - toDelta", () => {
 		});
 
 		it("move", () => {
-			const move: TestChangeset = [
-				{ type: "MoveIn", id: brand(0), count: 1, isSrcConflicted: true },
+			const move = [
+				Mark.moveIn(1, brand(0), { isSrcConflicted: true }),
 				{ count: 1 },
-				{ type: "MoveOut", id: brand(0), count: 1, cellId: detachEvent },
+				Mark.moveOut(1, brand(0), { cellId }),
 			];
 
 			const actual = toDelta(move);
@@ -389,14 +351,9 @@ describe("SequenceField - toDelta", () => {
 		});
 
 		it("redundant revive", () => {
-			const changeset: TestChangeset = [
-				{ type: "Revive", count: 1, content: fakeRepairData(tag, 0, 1) },
-				{
-					type: "Revive",
-					count: 1,
-					changes: childChange1,
-					content: fakeRepairData(tag, 1, 1),
-				},
+			const changeset = [
+				Mark.revive(fakeRepairData(tag, 0, 1)),
+				Mark.revive(fakeRepairData(tag, 1, 1), undefined, { changes: childChange1 }),
 			];
 			const actual = toDelta(changeset);
 			const expected: Delta.MarkList = [1, childChange1Delta];
@@ -404,22 +361,17 @@ describe("SequenceField - toDelta", () => {
 		});
 
 		it("blocked revive", () => {
-			const changeset: TestChangeset = [
-				{
-					type: "Revive",
-					count: 1,
-					content: fakeRepairData(tag, 0, 1),
-					inverseOf: tag1,
-					cellId: { revision: tag2, localId: brand(0) },
-				},
-				{
-					type: "Revive",
-					count: 1,
-					changes: childChange1,
-					content: fakeRepairData(tag, 1, 1),
-					inverseOf: tag1,
-					cellId: { revision: tag2, localId: brand(1) },
-				},
+			const changeset = [
+				Mark.revive(
+					fakeRepairData(tag, 0, 1),
+					{ revision: tag2, localId: brand(0) },
+					{ inverseOf: tag1 },
+				),
+				Mark.revive(
+					fakeRepairData(tag, 1, 1),
+					{ revision: tag2, localId: brand(1) },
+					{ inverseOf: tag1, changes: childChange1 },
+				),
 			];
 			const actual = toDelta(changeset);
 			const expected: Delta.MarkList = [];

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -218,7 +218,7 @@ export function createInsertMark<TChange = never>(
 
 export function createReviveMark<TChange = never>(
 	countOrContent: number | ITreeCursorSynchronous[],
-	cellId: SF.CellId,
+	cellId?: SF.CellId,
 	overrides?: Partial<SF.Revive<TChange>>,
 ): SF.Revive<TChange> {
 	const content = Array.isArray(countOrContent)
@@ -228,10 +228,15 @@ export function createReviveMark<TChange = never>(
 		type: "Revive",
 		count: content.length,
 		content,
-		cellId,
+	};
+	if (cellId !== undefined) {
+		mark.cellId = cellId;
+	}
+	const withOverrides: SF.Revive<TChange> = {
+		...mark,
 		...overrides,
 	};
-	return mark;
+	return withOverrides;
 }
 
 export function createDeleteMark<TChange = never>(

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -10,7 +10,13 @@ import {
 } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
-import { mintRevisionTag, RevisionTag, TreeSchemaIdentifier } from "../../../core";
+import {
+	ITreeCursorSynchronous,
+	JsonableTree,
+	mintRevisionTag,
+	RevisionTag,
+	TreeSchemaIdentifier,
+} from "../../../core";
 import { TestChange } from "../../testChange";
 // eslint-disable-next-line import/no-internal-modules
 import { ChangeAtomId } from "../../../feature-libraries/modular-schema";
@@ -50,15 +56,20 @@ function createInsertChangeset(
 	startingValue: number = 0,
 	id?: ChangesetLocalId,
 ): SF.Changeset<never> {
-	const content = [];
-	while (content.length < size) {
-		content.push({ type, value: startingValue + content.length });
-	}
+	const content = generateJsonables(size, startingValue);
 	return SF.sequenceFieldEditor.insert(
 		index,
 		content.map(singleTextCursor),
 		id ?? brand(startingValue),
 	);
+}
+
+function generateJsonables(size: number, startingValue: number = 0) {
+	const content = [];
+	while (content.length < size) {
+		content.push({ type, value: startingValue + content.length });
+	}
+	return content;
 }
 
 function createDeleteChangeset(
@@ -180,6 +191,161 @@ function createModifyDetachedChangeset<TNodeChange>(
 	modify.cellId = detachEvent;
 	return changeset;
 }
+
+export function createInsertMark<TChange = never>(
+	countOrContent: number | JsonableTree[],
+	id: ChangesetLocalId | SF.CellId,
+	overrides?: Partial<SF.Insert<TChange>>,
+): SF.Insert<TChange> {
+	const content = Array.isArray(countOrContent)
+		? countOrContent
+		: generateJsonables(countOrContent);
+	const cellId: SF.CellId = typeof id === "object" ? id : { localId: id };
+	const mark: SF.Insert<TChange> = {
+		type: "Insert",
+		content,
+		id: cellId.localId,
+	};
+	if (cellId.revision !== undefined) {
+		mark.revision = cellId.revision;
+	}
+	const withOverrides: SF.Insert<TChange> = {
+		...mark,
+		...overrides,
+	};
+	return withOverrides;
+}
+
+export function createReviveMark<TChange = never>(
+	countOrContent: number | ITreeCursorSynchronous[],
+	cellId: SF.CellId,
+	overrides?: Partial<SF.Revive<TChange>>,
+): SF.Revive<TChange> {
+	const content = Array.isArray(countOrContent)
+		? countOrContent
+		: generateJsonables(countOrContent).map(singleTextCursor);
+	const mark: SF.Revive<TChange> = {
+		type: "Revive",
+		count: content.length,
+		content,
+		cellId,
+		...overrides,
+	};
+	return mark;
+}
+
+export function createDeleteMark<TChange = never>(
+	count: number,
+	id: ChangesetLocalId | ChangeAtomId,
+	overrides?: Partial<SF.Delete<TChange>>,
+): SF.Delete<TChange> {
+	const cellId: ChangeAtomId = typeof id === "object" ? id : { localId: id };
+	const mark: SF.Delete<TChange> = {
+		type: "Delete",
+		count,
+		id: cellId.localId,
+	};
+	if (cellId.revision !== undefined) {
+		mark.revision = cellId.revision;
+	}
+	const withOverrides: SF.Delete<TChange> = {
+		...mark,
+		...overrides,
+	};
+	return withOverrides;
+}
+
+export function createMoveOutMark<TChange = never>(
+	count: number,
+	id: ChangesetLocalId,
+	overrides?: Partial<SF.MoveOut<TChange>>,
+): SF.MoveOut<TChange> {
+	const mark: SF.MoveOut<TChange> = {
+		type: "MoveOut",
+		count,
+		id,
+		...overrides,
+	};
+	return mark;
+}
+
+export function createMoveInMark(
+	count: number,
+	id: ChangesetLocalId | ChangeAtomId,
+	overrides?: Partial<SF.MoveIn>,
+): SF.MoveIn {
+	const cellId: ChangeAtomId = typeof id === "object" ? id : { localId: id };
+	const mark: SF.MoveIn = {
+		type: "MoveIn",
+		id: cellId.localId,
+		count,
+	};
+	if (cellId.revision !== undefined) {
+		mark.revision = cellId.revision;
+	}
+	const withOverrides: SF.MoveIn = {
+		...mark,
+		...overrides,
+	};
+	return withOverrides;
+}
+
+export function createReturnFromMark<TChange = never>(
+	count: number,
+	id: ChangesetLocalId,
+	overrides?: Partial<SF.ReturnFrom<TChange>>,
+): SF.ReturnFrom<TChange> {
+	const mark: SF.ReturnFrom<TChange> = {
+		type: "ReturnFrom",
+		count,
+		id,
+		...overrides,
+	};
+	return mark;
+}
+
+export function createReturnToMark(
+	count: number,
+	id: ChangesetLocalId | ChangeAtomId,
+	overrides?: Partial<SF.ReturnTo>,
+): SF.ReturnTo {
+	const cellId: ChangeAtomId = typeof id === "object" ? id : { localId: id };
+	const mark: SF.ReturnTo = {
+		type: "ReturnTo",
+		id: cellId.localId,
+		count,
+	};
+	if (cellId.revision !== undefined) {
+		mark.revision = cellId.revision;
+	}
+	const withOverrides: SF.ReturnTo = {
+		...mark,
+		...overrides,
+	};
+	return withOverrides;
+}
+
+export function createModifyMark<TChange>(changes: TChange, id?: SF.CellId): SF.Modify<TChange> {
+	const mark: SF.Modify<TChange> = {
+		type: "Modify",
+		changes,
+	};
+	if (id !== undefined) {
+		mark.cellId = id;
+	}
+	return mark;
+}
+
+export const MarkMaker = {
+	insert: createInsertMark,
+	revive: createReviveMark,
+	delete: createDeleteMark,
+	modify: createModifyMark,
+	moveOut: createMoveOutMark,
+	moveIn: createMoveInMark,
+	returnFrom: createReturnFromMark,
+	returnTo: createReturnToMark,
+};
 
 export const ChangeMaker = {
 	insert: createInsertChangeset,


### PR DESCRIPTION
Make the test code less dependent on the details format. This paves the way for a refactor of the format.