### PR TITLE
skip kafka checkpoint on database checkpoint failure

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -147,7 +147,6 @@ export class CheckpointContext {
 			);
 		}
 
-		// Retry the checkpoint on error
 		// eslint-disable-next-line @typescript-eslint/promise-function-async
 		return updateP.catch((error) => {
 			this.context.log?.error(

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -603,6 +603,11 @@ export class ScribeLambda implements IPartitionLambda {
 			? this.checkpointManager.delete(this.protocolHead, true)
 			: this.writeCheckpoint(checkpoint).catch((error) => {
 					databaseCheckpointFailed = true;
+					Lumberjack.error(
+						`Error writing database checkpoint.`,
+						getLumberBaseProperties(this.documentId, this.tenantId),
+						error,
+					);
 			  });
 		this.pendingP
 			.then(() => {

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -226,6 +226,7 @@ export class CheckpointService implements ICheckpointService {
 						(error) => true,
 					);
 				} catch (error) {
+					checkpoint = undefined;
 					Lumberjack.error(
 						`Error retrieving local checkpoint`,
 						getLumberBaseProperties(documentId, tenantId),

--- a/server/routerlicious/packages/services-core/src/mongoDocumentRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoDocumentRepository.ts
@@ -14,6 +14,10 @@ export class MongoDocumentRepository implements IDocumentRepository {
 	}
 
 	async updateOne(filter: any, update: any, options: any): Promise<void> {
+		const test = true;
+		if (test) {
+			throw new Error("Test Error");
+		}
 		const addToSet = undefined; // AddToSet is not used anywhere. Change the behavior in the future if things changed.
 		await (options?.upsert
 			? this.collection.upsert(filter, update, addToSet, options)

--- a/server/routerlicious/packages/services-core/src/mongoDocumentRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoDocumentRepository.ts
@@ -14,10 +14,6 @@ export class MongoDocumentRepository implements IDocumentRepository {
 	}
 
 	async updateOne(filter: any, update: any, options: any): Promise<void> {
-		const test = true;
-		if (test) {
-			throw new Error("Test Error");
-		}
 		const addToSet = undefined; // AddToSet is not used anywhere. Change the behavior in the future if things changed.
 		await (options?.upsert
 			? this.collection.upsert(filter, update, addToSet, options)


### PR DESCRIPTION
## Description

>  Currently, if a database checkpoint fails, we still proceed with a kafka checkpoint. This difference caused some unnecessary reprocessing of ops by our microservices. The update made is:
- When a database checkpoint fails, skip the kafka checkpoint. This will keep the checkpoints at the same sequence number. Future checkpoints will continue to be attempted as normal.

## Testing

>Threw test errors when writing local and global database checkpoints.
> Confirmed errors were being processed correctly in scribe and deli, and that we skipped kafka checkpoints when the local checkpoint failed.
