### PR TITLE
Refactor the intervalindex-related API

### DIFF
--- a/.changeset/happy-dreams-sing.md
+++ b/.changeset/happy-dreams-sing.md
@@ -1,0 +1,26 @@
+---
+"@fluidframework/sequence": minor
+---
+
+1. Deprecate API `findOverlappingIntervals` and `gatherIterationResults` from `IntervalCollection`, these functionalities are moved to the `OverlappingIntervalsIndex`. Users are advised to independently attach the index to the collection and utilize the API accordingly, for instance:
+
+```typescript
+const overlappingIntervalsIndex = createOverlappingIntervalsIndex(client, helpers);
+collection.attachIndex(overlappingIntervalsIndex)
+const result1 = overlappingIntervalsIndex.findOverlappingIntervals(start, end);
+
+const result2 = [];
+overlappingIntervalsIndex.gatherIterationResults(result2, true);
+```
+
+2. Deprecate API `previousInterval` and `nextInterval` from `IntervalCollection`, these functionalities are moved to the `OverlappingIntervalsIndex`. Users are advised to independently attach the index to the collection and utilize the API accordingly, for instance:
+
+```typescript
+const endpointIndex = createEndpointIndex(client, helpers);
+collection.attachIndex(endpointIndex);
+
+const result1 = endpointIndex.previousInterval(pos);
+const result2 = endpointIndex.nextInterval(pos);
+```
+
+3. Deprecate API `CreateBackwardIteratorWithEndPosition`, `CreateBackwardIteratorWithStartPosition`, `CreateForwardIteratorWithEndPosition` and `CreateForwardIteratorWithStartPosition` from `IntervalCollection`. Only the default iterator will be supported in the future, and it will no longer maintain the sequence.

--- a/.changeset/happy-dreams-sing.md
+++ b/.changeset/happy-dreams-sing.md
@@ -23,4 +23,6 @@ const result1 = endpointIndex.previousInterval(pos);
 const result2 = endpointIndex.nextInterval(pos);
 ```
 
-3. Deprecate API `CreateBackwardIteratorWithEndPosition`, `CreateBackwardIteratorWithStartPosition`, `CreateForwardIteratorWithEndPosition` and `CreateForwardIteratorWithStartPosition` from `IntervalCollection`. Only the default iterator will be supported in the future, and it will no longer maintain the sequence.
+3. Deprecate API `CreateBackwardIteratorWithEndPosition`, `CreateBackwardIteratorWithStartPosition`, `CreateForwardIteratorWithEndPosition` and `CreateForwardIteratorWithStartPosition` from `IntervalCollection`. Only the default iterator will be supported in the future, and it will no longer preserve sequence order.
+
+Equivalent functionality to these three methods is provided by `IOverlappingIntervalIndex.gatherIterationResults`.

--- a/.changeset/happy-dreams-sing.md
+++ b/.changeset/happy-dreams-sing.md
@@ -13,7 +13,7 @@ const result2 = [];
 overlappingIntervalsIndex.gatherIterationResults(result2, true);
 ```
 
-2. Deprecate API `previousInterval` and `nextInterval` from `IntervalCollection`, these functionalities are moved to the `OverlappingIntervalsIndex`. Users are advised to independently attach the index to the collection and utilize the API accordingly, for instance:
+2. Deprecate API `previousInterval` and `nextInterval` from `IntervalCollection`, these functionalities are moved to the `EndpointIndex`. Users are advised to independently attach the index to the collection and utilize the API accordingly, for instance:
 
 ```typescript
 const endpointIndex = createEndpointIndex(client, helpers);

--- a/.changeset/happy-dreams-sing.md
+++ b/.changeset/happy-dreams-sing.md
@@ -25,4 +25,4 @@ const result2 = endpointIndex.nextInterval(pos);
 
 3. Deprecate API `CreateBackwardIteratorWithEndPosition`, `CreateBackwardIteratorWithStartPosition`, `CreateForwardIteratorWithEndPosition` and `CreateForwardIteratorWithStartPosition` from `IntervalCollection`. Only the default iterator will be supported in the future, and it will no longer preserve sequence order.
 
-Equivalent functionality to these three methods is provided by `IOverlappingIntervalIndex.gatherIterationResults`.
+Equivalent functionality to these four methods is provided by `IOverlappingIntervalIndex.gatherIterationResults`.

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -66,7 +66,13 @@ export function appendIntervalPropertyChangedToRevertibles(interval: SequenceInt
 export function appendSharedStringDeltaToRevertibles(string: SharedString, delta: SequenceDeltaEvent, revertibles: SharedStringRevertible[]): void;
 
 // @public (undocumented)
+export function createEndpointIndex<TInterval extends ISerializableInterval>(client: Client, helpers: IIntervalHelpers<TInterval>): IEndpointIndex<TInterval>;
+
+// @public (undocumented)
 export function createEndpointInRangeIndex<TInterval extends ISerializableInterval>(helpers: IIntervalHelpers<TInterval>, client: Client): IEndpointInRangeIndex<TInterval>;
+
+// @public (undocumented)
+export function createIdIntervalIndex<TInterval extends ISerializableInterval>(): IIdIntervalIndex<TInterval>;
 
 // @public (undocumented)
 export function createOverlappingIntervalsIndex<TInterval extends ISerializableInterval>(client: Client, helpers: IIntervalHelpers<TInterval>): IOverlappingIntervalsIndex<TInterval>;
@@ -89,10 +95,26 @@ export function getTextAndMarkers(sharedString: SharedString, label: string, sta
     parallelMarkers: Marker[];
 };
 
+// @public (undocumented)
+export interface IEndpointIndex<TInterval extends ISerializableInterval> extends IntervalIndex<TInterval> {
+    // (undocumented)
+    nextInterval(pos: number): TInterval | undefined;
+    // (undocumented)
+    previousInterval(pos: number): TInterval | undefined;
+}
+
 // @public
 export interface IEndpointInRangeIndex<TInterval extends ISerializableInterval> extends IntervalIndex<TInterval> {
     // (undocumented)
     findIntervalsWithEndpointInRange(start: number, end: number): any;
+}
+
+// @public (undocumented)
+export interface IIdIntervalIndex<TInterval extends ISerializableInterval> extends IntervalIndex<TInterval>, Iterable<TInterval> {
+    // (undocumented)
+    [Symbol.iterator](): Iterator<TInterval>;
+    // (undocumented)
+    getIntervalById(id: string): TInterval | undefined;
 }
 
 // @public
@@ -122,24 +144,25 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
     attachIndex(index: IntervalIndex<TInterval>): void;
     change(id: string, start?: number, end?: number): TInterval | undefined;
     changeProperties(id: string, props: PropertySet): any;
-    // (undocumented)
+    // @deprecated (undocumented)
     CreateBackwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
-    // (undocumented)
+    // @deprecated (undocumented)
     CreateBackwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
-    // (undocumented)
+    // @deprecated (undocumented)
     CreateForwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
-    // (undocumented)
+    // @deprecated (undocumented)
     CreateForwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
     detachIndex(index: IntervalIndex<TInterval>): boolean;
-    // (undocumented)
+    // @deprecated (undocumented)
     findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[];
+    // @deprecated
     gatherIterationResults(results: TInterval[], iteratesForward: boolean, start?: number, end?: number): void;
     // (undocumented)
     getIntervalById(id: string): TInterval | undefined;
     map(fn: (interval: TInterval) => void): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     nextInterval(pos: number): TInterval | undefined;
-    // (undocumented)
+    // @deprecated (undocumented)
     previousInterval(pos: number): TInterval | undefined;
     removeIntervalById(id: string): TInterval | undefined;
 }

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -32,21 +32,25 @@ export {
 export {
 	DeserializeCallback,
 	IIntervalCollectionEvent,
-	IntervalIndex,
 	IIntervalCollection,
 	IntervalLocator,
 	intervalLocatorFromEndpoint,
-	IEndpointInRangeIndex,
-	IStartpointInRangeIndex,
-	createEndpointInRangeIndex,
-	createStartpointInRangeIndex,
 } from "./intervalCollection";
 export { IntervalConflictResolver } from "./intervalTree";
 export {
+	IntervalIndex,
 	SequenceIntervalIndexes,
 	IOverlappingIntervalsIndex,
 	createOverlappingIntervalsIndex,
 	createOverlappingSequenceIntervalsIndex,
+	IEndpointInRangeIndex,
+	IStartpointInRangeIndex,
+	createEndpointInRangeIndex,
+	createStartpointInRangeIndex,
+	IIdIntervalIndex,
+	createIdIntervalIndex,
+	IEndpointIndex,
+	createEndpointIndex,
 } from "./intervalIndex";
 export {
 	appendAddIntervalToRevertibles,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1608,7 +1608,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateForwardIteratorWithStartPosition}
-	 * 
+	 *
 	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateForwardIteratorWithStartPosition(
@@ -1620,7 +1620,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateBackwardIteratorWithStartPosition}
-	 * 
+	 *
 	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateBackwardIteratorWithStartPosition(
@@ -1632,7 +1632,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateForwardIteratorWithEndPosition}
-	 * 
+	 *
 	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateForwardIteratorWithEndPosition(
@@ -1649,7 +1649,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateBackwardIteratorWithEndPosition}
-	 * 
+	 *
 	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateBackwardIteratorWithEndPosition(

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1608,6 +1608,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateForwardIteratorWithStartPosition}
+	 * 
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateForwardIteratorWithStartPosition(
 		startPosition: number,
@@ -1618,6 +1620,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateBackwardIteratorWithStartPosition}
+	 * 
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateBackwardIteratorWithStartPosition(
 		startPosition: number,
@@ -1628,6 +1632,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateForwardIteratorWithEndPosition}
+	 * 
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateForwardIteratorWithEndPosition(
 		endPosition: number,
@@ -1643,6 +1649,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.CreateBackwardIteratorWithEndPosition}
+	 * 
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	public CreateBackwardIteratorWithEndPosition(
 		endPosition: number,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -16,14 +16,12 @@ import {
 	ISegment,
 	MergeTreeDeltaType,
 	PropertySet,
-	RedBlackTree,
 	LocalReferencePosition,
 	ReferenceType,
 	refTypeIncludesFlag,
 	reservedRangeLabelsKey,
 	UnassignedSequenceNumber,
 	DetachedReferencePosition,
-	PropertyAction,
 } from "@fluidframework/merge-tree";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { LoggingError } from "@fluidframework/telemetry-utils";
@@ -55,7 +53,15 @@ import {
 	sequenceIntervalHelpers,
 	createInterval,
 } from "./intervals";
-import { IOverlappingIntervalsIndex, createOverlappingIntervalsIndex } from "./intervalIndex";
+import {
+	IEndpointIndex,
+	IIdIntervalIndex,
+	IOverlappingIntervalsIndex,
+	IntervalIndex,
+	createEndpointIndex,
+	createIdIntervalIndex,
+	createOverlappingIntervalsIndex,
+} from "./intervalIndex";
 
 const reservedIntervalIdKey = "intervalId";
 
@@ -116,336 +122,11 @@ export function createIntervalIndex() {
 	return lc;
 }
 
-/**
- * Collection of intervals.
- *
- * Implementers of this interface will typically implement additional APIs to support efficiently querying a collection
- * of intervals in some manner, for example:
- * - "find all intervals with start endpoint between these two points"
- * - "find all intervals which overlap this range"
- * etc.
- */
-export interface IntervalIndex<TInterval extends ISerializableInterval> {
-	/**
-	 * Adds an interval to the index.
-	 * @remarks - Application code should never need to invoke this method on their index for production scenarios:
-	 * Fluid handles adding and removing intervals from an index in response to sequence or interval changes.
-	 */
-	add(interval: TInterval): void;
-
-	/**
-	 * Removes an interval from the index.
-	 * @remarks - Application code should never need to invoke this method on their index for production scenarios:
-	 * Fluid handles adding and removing intervals from an index in response to sequence or interval changes.
-	 */
-	remove(interval: TInterval): void;
-}
-
-class IdIntervalIndex<TInterval extends ISerializableInterval>
-	implements IntervalIndex<TInterval>, Iterable<TInterval>
-{
-	private readonly intervalIdMap: Map<string, TInterval> = new Map();
-
-	public add(interval: TInterval) {
-		const id = interval.getIntervalId();
-		assert(
-			id !== undefined,
-			0x2c0 /* "ID must be created before adding interval to collection" */,
-		);
-		// Make the ID immutable.
-		Object.defineProperty(interval.properties, reservedIntervalIdKey, {
-			configurable: false,
-			enumerable: true,
-			writable: false,
-		});
-		this.intervalIdMap.set(id, interval);
-	}
-
-	public remove(interval: TInterval) {
-		const id = interval.getIntervalId();
-		assert(id !== undefined, 0x311 /* expected id to exist on interval */);
-		this.intervalIdMap.delete(id);
-	}
-
-	public getIntervalById(id: string) {
-		return this.intervalIdMap.get(id);
-	}
-
-	public [Symbol.iterator]() {
-		return this.intervalIdMap.values();
-	}
-}
-
-class EndpointIndex<TInterval extends ISerializableInterval> implements IntervalIndex<TInterval> {
-	private readonly endIntervalTree: RedBlackTree<TInterval, TInterval>;
-
-	constructor(
-		private readonly client: Client,
-		private readonly helpers: IIntervalHelpers<TInterval>,
-	) {
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		this.endIntervalTree = new RedBlackTree<TInterval, TInterval>(helpers.compareEnds);
-	}
-
-	public previousInterval(pos: number) {
-		const transientInterval = this.helpers.create(
-			"transient",
-			pos,
-			pos,
-			this.client,
-			IntervalType.Transient,
-		);
-		const rbNode = this.endIntervalTree.floor(transientInterval);
-		if (rbNode) {
-			return rbNode.data;
-		}
-	}
-
-	public nextInterval(pos: number) {
-		const transientInterval = this.helpers.create(
-			"transient",
-			pos,
-			pos,
-			this.client,
-			IntervalType.Transient,
-		);
-		const rbNode = this.endIntervalTree.ceil(transientInterval);
-		if (rbNode) {
-			return rbNode.data;
-		}
-	}
-
-	public add(interval: TInterval): void {
-		this.endIntervalTree.put(interval, interval);
-	}
-
-	public remove(interval: TInterval): void {
-		this.endIntervalTree.remove(interval);
-	}
-}
-
-/**
- * Collection of intervals.
- *
- * Provide additional APIs to support efficiently querying a collection of intervals whose endpoints fall within a specified range.
- */
-export interface IEndpointInRangeIndex<TInterval extends ISerializableInterval>
-	extends IntervalIndex<TInterval> {
-	/**
-	 * @returns an array of all intervals contained in this collection whose endpoints locate in the range [start, end] (includes both ends)
-	 */
-	findIntervalsWithEndpointInRange(start: number, end: number);
-}
-
-/**
- * Collection of intervals.
- *
- * Provide additional APIs to support efficiently querying a collection of intervals whose startpoints fall within a specified range.
- */
-export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval>
-	extends IntervalIndex<TInterval> {
-	/**
-	 * @returns an array of all intervals contained in this collection whose startpoints locate in the range [start, end] (includes both ends)
-	 */
-	findIntervalsWithStartpointInRange(start: number, end: number);
-}
-
-/**
- * Interface for intervals that have comparison override properties.
- */
-const forceCompare = Symbol();
-
-interface HasComparisonOverride {
-	[forceCompare]: number;
-}
-
-/**
- * Compares two objects based on their comparison override properties.
- * @returns A number indicating the order of the intervals (negative for a is lower than b, 0 for tie, positive for a is greater than b).
- */
-function compareOverrideables(
-	a: Partial<HasComparisonOverride>,
-	b: Partial<HasComparisonOverride>,
-): number {
-	const forceCompareA = a[forceCompare] ?? 0;
-	const forceCompareB = b[forceCompare] ?? 0;
-
-	return forceCompareA - forceCompareB;
-}
-
-class EndpointInRangeIndex<TInterval extends ISerializableInterval>
-	implements IEndpointInRangeIndex<TInterval>
-{
-	private readonly intervalTree;
-
-	constructor(
-		private readonly helpers: IIntervalHelpers<TInterval>,
-		private readonly client: Client,
-	) {
-		this.intervalTree = new RedBlackTree<TInterval, TInterval>((a: TInterval, b: TInterval) => {
-			const compareEndsResult = helpers.compareEnds(a, b);
-			if (compareEndsResult !== 0) {
-				return compareEndsResult;
-			}
-
-			const overrideablesComparison = compareOverrideables(
-				a as Partial<HasComparisonOverride>,
-				b as Partial<HasComparisonOverride>,
-			);
-			if (overrideablesComparison !== 0) {
-				return overrideablesComparison;
-			}
-
-			const aId = a.getIntervalId();
-			const bId = b.getIntervalId();
-			if (aId !== undefined && bId !== undefined) {
-				return aId.localeCompare(bId);
-			}
-			return 0;
-		});
-	}
-
-	public add(interval: TInterval): void {
-		this.intervalTree.put(interval, interval);
-	}
-
-	public remove(interval: TInterval): void {
-		this.intervalTree.remove(interval);
-	}
-
-	public findIntervalsWithEndpointInRange(start: number, end: number) {
-		if (start <= 0 || start > end || this.intervalTree.isEmpty()) {
-			return [];
-		}
-		const results: TInterval[] = [];
-		const action: PropertyAction<TInterval, TInterval> = (node) => {
-			results.push(node.data);
-			return true;
-		};
-
-		const transientStartInterval = this.helpers.create(
-			"transient",
-			start,
-			start,
-			this.client,
-			IntervalType.Transient,
-		);
-
-		const transientEndInterval = this.helpers.create(
-			"transient",
-			end,
-			end,
-			this.client,
-			IntervalType.Transient,
-		);
-
-		// Add comparison overrides to the transient intervals
-		(transientStartInterval as Partial<HasComparisonOverride>)[forceCompare] = -1;
-		(transientEndInterval as Partial<HasComparisonOverride>)[forceCompare] = 1;
-
-		this.intervalTree.mapRange(action, results, transientStartInterval, transientEndInterval);
-		return results;
-	}
-}
-
-class StartpointInRangeIndex<TInterval extends ISerializableInterval>
-	implements IStartpointInRangeIndex<TInterval>
-{
-	private readonly intervalTree;
-
-	constructor(
-		private readonly helpers: IIntervalHelpers<TInterval>,
-		private readonly client: Client,
-	) {
-		this.intervalTree = new RedBlackTree<TInterval, TInterval>((a: TInterval, b: TInterval) => {
-			assert(
-				typeof helpers.compareStarts === "function",
-				0x6d1 /* compareStarts does not exist in the helpers */,
-			);
-
-			const compareStartsResult = helpers.compareStarts(a, b);
-			if (compareStartsResult !== 0) {
-				return compareStartsResult;
-			}
-
-			const overrideablesComparison = compareOverrideables(
-				a as Partial<HasComparisonOverride>,
-				b as Partial<HasComparisonOverride>,
-			);
-			if (overrideablesComparison !== 0) {
-				return overrideablesComparison;
-			}
-			const aId = a.getIntervalId();
-			const bId = b.getIntervalId();
-			if (aId !== undefined && bId !== undefined) {
-				return aId.localeCompare(bId);
-			}
-			return 0;
-		});
-	}
-
-	public add(interval: TInterval): void {
-		this.intervalTree.put(interval, interval);
-	}
-
-	public remove(interval: TInterval): void {
-		this.intervalTree.remove(interval);
-	}
-
-	public findIntervalsWithStartpointInRange(start: number, end: number) {
-		if (start <= 0 || start > end || this.intervalTree.isEmpty()) {
-			return [];
-		}
-		const results: TInterval[] = [];
-		const action: PropertyAction<TInterval, TInterval> = (node) => {
-			results.push(node.data);
-			return true;
-		};
-
-		const transientStartInterval = this.helpers.create(
-			"transient",
-			start,
-			start,
-			this.client,
-			IntervalType.Transient,
-		);
-
-		const transientEndInterval = this.helpers.create(
-			"transient",
-			end,
-			end,
-			this.client,
-			IntervalType.Transient,
-		);
-
-		// Add comparison overrides to the transient intervals
-		(transientStartInterval as Partial<HasComparisonOverride>)[forceCompare] = -1;
-		(transientEndInterval as Partial<HasComparisonOverride>)[forceCompare] = 1;
-
-		this.intervalTree.mapRange(action, results, transientStartInterval, transientEndInterval);
-		return results;
-	}
-}
-
-export function createEndpointInRangeIndex<TInterval extends ISerializableInterval>(
-	helpers: IIntervalHelpers<TInterval>,
-	client: Client,
-): IEndpointInRangeIndex<TInterval> {
-	return new EndpointInRangeIndex<TInterval>(helpers, client);
-}
-
-export function createStartpointInRangeIndex<TInterval extends ISerializableInterval>(
-	helpers: IIntervalHelpers<TInterval>,
-	client: Client,
-): IStartpointInRangeIndex<TInterval> {
-	return new StartpointInRangeIndex<TInterval>(helpers, client);
-}
-
 export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 	private static readonly legacyIdPrefix = "legacy";
 	public readonly overlappingIntervalsIndex: IOverlappingIntervalsIndex<TInterval>;
-	public readonly idIntervalIndex: IdIntervalIndex<TInterval>;
-	public readonly endIntervalIndex: EndpointIndex<TInterval>;
+	public readonly idIntervalIndex: IIdIntervalIndex<TInterval>;
+	public readonly endIntervalIndex: IEndpointIndex<TInterval>;
 	private readonly indexes: Set<IntervalIndex<TInterval>>;
 
 	constructor(
@@ -459,8 +140,8 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 		) => void,
 	) {
 		this.overlappingIntervalsIndex = createOverlappingIntervalsIndex(client, helpers);
-		this.idIntervalIndex = new IdIntervalIndex();
-		this.endIntervalIndex = new EndpointIndex(client, helpers);
+		this.idIntervalIndex = createIdIntervalIndex<TInterval>();
+		this.endIntervalIndex = createEndpointIndex(client, helpers);
 		this.indexes = new Set([
 			this.overlappingIntervalsIndex,
 			this.idIntervalIndex,
@@ -997,21 +678,29 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * @returns a forward iterator over all intervals in this collection with start point equal to `startPosition`.
+	 *
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	CreateForwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
 
 	/**
 	 * @returns a backward iterator over all intervals in this collection with start point equal to `startPosition`.
+	 *
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	CreateBackwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
 
 	/**
 	 * @returns a forward iterator over all intervals in this collection with end point equal to `endPosition`.
+	 *
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	CreateForwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
 
 	/**
 	 * @returns a backward iterator over all intervals in this collection with end point equal to `endPosition`.
+	 *
+	 * @deprecated - The sequence order of collection order will not be supported
 	 */
 	CreateBackwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
 
@@ -1022,6 +711,9 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	 * @param iteratesForward - whether or not iteration should be in the forward direction
 	 * @param start - If provided, only match intervals whose start point is equal to `start`.
 	 * @param end - If provided, only match intervals whose end point is equal to `end`.
+	 *
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `OverlappingIntervalsIndex`.
+	 * We would like the user to attach the index to the collection on their own.
 	 */
 	gatherIterationResults(
 		results: TInterval[],
@@ -1033,6 +725,9 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	/**
 	 * @returns an array of all intervals in this collection that overlap with the interval
 	 * `[startPosition, endPosition]`.
+	 *
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `OverlappingIntervalsIndex`.
+	 * We would like the user to attach the index to the collection on their own.
 	 */
 	findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[];
 
@@ -1041,8 +736,16 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	 */
 	map(fn: (interval: TInterval) => void): void;
 
+	/**
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `EndpointIndex`.
+	 * We would like the user to attach the index to the collection on their own.
+	 */
 	previousInterval(pos: number): TInterval | undefined;
 
+	/**
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `EndpointIndex`.
+	 * We would like the user to attach the index to the collection on their own.
+	 */
 	nextInterval(pos: number): TInterval | undefined;
 }
 
@@ -1278,7 +981,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 	/**
 	 * {@inheritdoc IIntervalCollection.getIntervalById}
 	 */
-	public getIntervalById(id: string) {
+	public getIntervalById(id: string): TInterval | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("attach must be called before accessing intervals");
 		}
@@ -1366,7 +1069,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 	/**
 	 * {@inheritdoc IIntervalCollection.removeIntervalById}
 	 */
-	public removeIntervalById(id: string) {
+	public removeIntervalById(id: string): TInterval | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("Attach must be called before accessing intervals");
 		}
@@ -1955,6 +1658,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.gatherIterationResults}
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `OverlappingIntervalsIndex`.
+	 * We would like the user to attach the index to the collection on their own.
 	 */
 	public gatherIterationResults(
 		results: TInterval[],
@@ -1976,6 +1681,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.findOverlappingIntervals}
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `OverlappingIntervalsIndex`.
+	 * We would like the user to attach the index to the collection on their own.
 	 */
 	public findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[] {
 		if (!this.localCollection) {
@@ -2003,6 +1710,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.previousInterval}
+	 *
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `EndpointIndex`.
+	 * We would like the user to attach the index to the collection on their own.
 	 */
 	public previousInterval(pos: number): TInterval | undefined {
 		if (!this.localCollection) {
@@ -2014,6 +1724,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.nextInterval}
+	 *
+	 * @deprecated - This API will be deprecated as its functionality will be moved to the `EndpointIndex`.
+	 * We would like the user to attach the index to the collection on their own.
 	 */
 	public nextInterval(pos: number): TInterval | undefined {
 		if (!this.localCollection) {

--- a/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
@@ -1,0 +1,104 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Client, PropertyAction, RedBlackTree } from "@fluidframework/merge-tree";
+import { IIntervalHelpers, ISerializableInterval, IntervalType } from "../intervals";
+import { IntervalIndex } from "./intervalIndex";
+import { HasComparisonOverride, compareOverrideables, forceCompare } from "./intervalIndexUtils";
+
+/**
+ * Collection of intervals.
+ *
+ * Provide additional APIs to support efficiently querying a collection of intervals whose endpoints fall within a specified range.
+ */
+export interface IEndpointInRangeIndex<TInterval extends ISerializableInterval>
+	extends IntervalIndex<TInterval> {
+	/**
+	 * @returns an array of all intervals contained in this collection whose endpoints locate in the range [start, end] (includes both ends)
+	 */
+	findIntervalsWithEndpointInRange(start: number, end: number);
+}
+
+class EndpointInRangeIndex<TInterval extends ISerializableInterval>
+	implements IEndpointInRangeIndex<TInterval>
+{
+	private readonly intervalTree;
+
+	constructor(
+		private readonly helpers: IIntervalHelpers<TInterval>,
+		private readonly client: Client,
+	) {
+		this.intervalTree = new RedBlackTree<TInterval, TInterval>((a: TInterval, b: TInterval) => {
+			const compareEndsResult = helpers.compareEnds(a, b);
+			if (compareEndsResult !== 0) {
+				return compareEndsResult;
+			}
+
+			const overrideablesComparison = compareOverrideables(
+				a as Partial<HasComparisonOverride>,
+				b as Partial<HasComparisonOverride>,
+			);
+			if (overrideablesComparison !== 0) {
+				return overrideablesComparison;
+			}
+
+			const aId = a.getIntervalId();
+			const bId = b.getIntervalId();
+			if (aId !== undefined && bId !== undefined) {
+				return aId.localeCompare(bId);
+			}
+			return 0;
+		});
+	}
+
+	public add(interval: TInterval): void {
+		this.intervalTree.put(interval, interval);
+	}
+
+	public remove(interval: TInterval): void {
+		this.intervalTree.remove(interval);
+	}
+
+	public findIntervalsWithEndpointInRange(start: number, end: number) {
+		if (start <= 0 || start > end || this.intervalTree.isEmpty()) {
+			return [];
+		}
+		const results: TInterval[] = [];
+		const action: PropertyAction<TInterval, TInterval> = (node) => {
+			results.push(node.data);
+			return true;
+		};
+
+		const transientStartInterval = this.helpers.create(
+			"transient",
+			start,
+			start,
+			this.client,
+			IntervalType.Transient,
+		);
+
+		const transientEndInterval = this.helpers.create(
+			"transient",
+			end,
+			end,
+			this.client,
+			IntervalType.Transient,
+		);
+
+		// Add comparison overrides to the transient intervals
+		(transientStartInterval as Partial<HasComparisonOverride>)[forceCompare] = -1;
+		(transientEndInterval as Partial<HasComparisonOverride>)[forceCompare] = 1;
+
+		this.intervalTree.mapRange(action, results, transientStartInterval, transientEndInterval);
+		return results;
+	}
+}
+
+export function createEndpointInRangeIndex<TInterval extends ISerializableInterval>(
+	helpers: IIntervalHelpers<TInterval>,
+	client: Client,
+): IEndpointInRangeIndex<TInterval> {
+	return new EndpointInRangeIndex<TInterval>(helpers, client);
+}

--- a/packages/dds/sequence/src/intervalIndex/endpointIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointIndex.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Client, RedBlackTree } from "@fluidframework/merge-tree";
+import { IIntervalHelpers, ISerializableInterval, IntervalType } from "../intervals";
+import { IntervalIndex } from "./intervalIndex";
+
+export interface IEndpointIndex<TInterval extends ISerializableInterval>
+	extends IntervalIndex<TInterval> {
+	/**
+	 * @returns the previous interval based on the given position number.
+	 * If no such interval exists in this index, returns `undefined`
+	 */
+	previousInterval(pos: number): TInterval | undefined;
+
+	/**
+	 * @returns the next interval based on the given position number.
+	 * If no such interval exists in this index, returns `undefined`
+	 */
+	nextInterval(pos: number): TInterval | undefined;
+}
+
+class EndpointIndex<TInterval extends ISerializableInterval> implements IEndpointIndex<TInterval> {
+	private readonly endIntervalTree: RedBlackTree<TInterval, TInterval>;
+
+	constructor(
+		private readonly client: Client,
+		private readonly helpers: IIntervalHelpers<TInterval>,
+	) {
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		this.endIntervalTree = new RedBlackTree<TInterval, TInterval>(helpers.compareEnds);
+	}
+
+	public previousInterval(pos: number): TInterval | undefined {
+		const transientInterval = this.helpers.create(
+			"transient",
+			pos,
+			pos,
+			this.client,
+			IntervalType.Transient,
+		);
+		const rbNode = this.endIntervalTree.floor(transientInterval);
+		if (rbNode) {
+			return rbNode.data;
+		}
+	}
+
+	public nextInterval(pos: number): TInterval | undefined {
+		const transientInterval = this.helpers.create(
+			"transient",
+			pos,
+			pos,
+			this.client,
+			IntervalType.Transient,
+		);
+		const rbNode = this.endIntervalTree.ceil(transientInterval);
+		if (rbNode) {
+			return rbNode.data;
+		}
+	}
+
+	public add(interval: TInterval): void {
+		this.endIntervalTree.put(interval, interval);
+	}
+
+	public remove(interval: TInterval): void {
+		this.endIntervalTree.remove(interval);
+	}
+}
+
+export function createEndpointIndex<TInterval extends ISerializableInterval>(
+	client: Client,
+	helpers: IIntervalHelpers<TInterval>,
+): IEndpointIndex<TInterval> {
+	return new EndpointIndex<TInterval>(client, helpers);
+}

--- a/packages/dds/sequence/src/intervalIndex/idIntervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/idIntervalIndex.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/common-utils";
+import { ISerializableInterval } from "../intervals";
+import { IntervalIndex } from "./intervalIndex";
+
+const reservedIntervalIdKey = "intervalId";
+
+export interface IIdIntervalIndex<TInterval extends ISerializableInterval>
+	extends IntervalIndex<TInterval>,
+		Iterable<TInterval> {
+	getIntervalById(id: string): TInterval | undefined;
+
+	[Symbol.iterator](): Iterator<TInterval>;
+}
+class IdIntervalIndex<TInterval extends ISerializableInterval>
+	implements IIdIntervalIndex<TInterval>, Iterable<TInterval>
+{
+	private readonly intervalIdMap: Map<string, TInterval> = new Map();
+
+	public add(interval: TInterval) {
+		const id = interval.getIntervalId();
+		assert(
+			id !== undefined,
+			0x2c0 /* "ID must be created before adding interval to collection" */,
+		);
+		// Make the ID immutable.
+		Object.defineProperty(interval.properties, reservedIntervalIdKey, {
+			configurable: false,
+			enumerable: true,
+			writable: false,
+		});
+		this.intervalIdMap.set(id, interval);
+	}
+
+	public remove(interval: TInterval) {
+		const id = interval.getIntervalId();
+		assert(id !== undefined, 0x311 /* expected id to exist on interval */);
+		this.intervalIdMap.delete(id);
+	}
+
+	public getIntervalById(id: string): TInterval | undefined {
+		return this.intervalIdMap.get(id);
+	}
+
+	public [Symbol.iterator](): IterableIterator<TInterval> {
+		return this.intervalIdMap.values();
+	}
+}
+
+export function createIdIntervalIndex<
+	TInterval extends ISerializableInterval,
+>(): IIdIntervalIndex<TInterval> {
+	return new IdIntervalIndex<TInterval>();
+}

--- a/packages/dds/sequence/src/intervalIndex/index.ts
+++ b/packages/dds/sequence/src/intervalIndex/index.ts
@@ -3,6 +3,11 @@
  * Licensed under the MIT License.
  */
 
+export { IntervalIndex } from "./intervalIndex";
+export { IIdIntervalIndex, createIdIntervalIndex } from "./idIntervalIndex";
+export { IEndpointIndex, createEndpointIndex } from "./endpointIndex";
+export { IEndpointInRangeIndex, createEndpointInRangeIndex } from "./endpointInRangeIndex";
+export { IStartpointInRangeIndex, createStartpointInRangeIndex } from "./startpointInRangeIndex";
 export { SequenceIntervalIndexes } from "./sequenceIntervalIndexes";
 export {
 	IOverlappingIntervalsIndex,

--- a/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ISerializableInterval } from "../intervals";
+
+/**
+ * Collection of intervals.
+ *
+ * Implementers of this interface will typically implement additional APIs to support efficiently querying a collection
+ * of intervals in some manner, for example:
+ * - "find all intervals with start endpoint between these two points"
+ * - "find all intervals which overlap this range"
+ * etc.
+ */
+export interface IntervalIndex<TInterval extends ISerializableInterval> {
+	/**
+	 * Adds an interval to the index.
+	 * @remarks - Application code should never need to invoke this method on their index for production scenarios:
+	 * Fluid handles adding and removing intervals from an index in response to sequence or interval changes.
+	 */
+	add(interval: TInterval): void;
+
+	/**
+	 * Removes an interval from the index.
+	 * @remarks - Application code should never need to invoke this method on their index for production scenarios:
+	 * Fluid handles adding and removing intervals from an index in response to sequence or interval changes.
+	 */
+	remove(interval: TInterval): void;
+}

--- a/packages/dds/sequence/src/intervalIndex/intervalIndexUtils.ts
+++ b/packages/dds/sequence/src/intervalIndex/intervalIndexUtils.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Interface for intervals that have comparison override properties.
+ */
+export const forceCompare = Symbol();
+
+export interface HasComparisonOverride {
+	[forceCompare]: number;
+}
+
+/**
+ * Compares two objects based on their comparison override properties.
+ * @returns A number indicating the order of the intervals (negative for a is lower than b, 0 for tie, positive for a is greater than b).
+ */
+export function compareOverrideables(
+	a: Partial<HasComparisonOverride>,
+	b: Partial<HasComparisonOverride>,
+): number {
+	const forceCompareA = a[forceCompare] ?? 0;
+	const forceCompareB = b[forceCompare] ?? 0;
+
+	return forceCompareA - forceCompareB;
+}

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -4,9 +4,9 @@
  */
 
 import { Client } from "@fluidframework/merge-tree";
-import { IntervalIndex } from "../intervalCollection";
 import { IntervalType, IIntervalHelpers, ISerializableInterval } from "../intervals";
 import { IntervalNode, IntervalTree } from "../intervalTree";
+import { IntervalIndex } from "./intervalIndex";
 
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {

--- a/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
@@ -1,0 +1,109 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Client, PropertyAction, RedBlackTree } from "@fluidframework/merge-tree";
+import { assert } from "@fluidframework/common-utils";
+import { IIntervalHelpers, ISerializableInterval, IntervalType } from "../intervals";
+import { IntervalIndex } from "./intervalIndex";
+import { HasComparisonOverride, compareOverrideables, forceCompare } from "./intervalIndexUtils";
+
+/**
+ * Collection of intervals.
+ *
+ * Provide additional APIs to support efficiently querying a collection of intervals whose startpoints fall within a specified range.
+ */
+export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval>
+	extends IntervalIndex<TInterval> {
+	/**
+	 * @returns an array of all intervals contained in this collection whose startpoints locate in the range [start, end] (includes both ends)
+	 */
+	findIntervalsWithStartpointInRange(start: number, end: number);
+}
+
+class StartpointInRangeIndex<TInterval extends ISerializableInterval>
+	implements IStartpointInRangeIndex<TInterval>
+{
+	private readonly intervalTree;
+
+	constructor(
+		private readonly helpers: IIntervalHelpers<TInterval>,
+		private readonly client: Client,
+	) {
+		this.intervalTree = new RedBlackTree<TInterval, TInterval>((a: TInterval, b: TInterval) => {
+			assert(
+				typeof helpers.compareStarts === "function",
+				0x6d1 /* compareStarts does not exist in the helpers */,
+			);
+
+			const compareStartsResult = helpers.compareStarts(a, b);
+			if (compareStartsResult !== 0) {
+				return compareStartsResult;
+			}
+
+			const overrideablesComparison = compareOverrideables(
+				a as Partial<HasComparisonOverride>,
+				b as Partial<HasComparisonOverride>,
+			);
+			if (overrideablesComparison !== 0) {
+				return overrideablesComparison;
+			}
+			const aId = a.getIntervalId();
+			const bId = b.getIntervalId();
+			if (aId !== undefined && bId !== undefined) {
+				return aId.localeCompare(bId);
+			}
+			return 0;
+		});
+	}
+
+	public add(interval: TInterval): void {
+		this.intervalTree.put(interval, interval);
+	}
+
+	public remove(interval: TInterval): void {
+		this.intervalTree.remove(interval);
+	}
+
+	public findIntervalsWithStartpointInRange(start: number, end: number) {
+		if (start <= 0 || start > end || this.intervalTree.isEmpty()) {
+			return [];
+		}
+		const results: TInterval[] = [];
+		const action: PropertyAction<TInterval, TInterval> = (node) => {
+			results.push(node.data);
+			return true;
+		};
+
+		const transientStartInterval = this.helpers.create(
+			"transient",
+			start,
+			start,
+			this.client,
+			IntervalType.Transient,
+		);
+
+		const transientEndInterval = this.helpers.create(
+			"transient",
+			end,
+			end,
+			this.client,
+			IntervalType.Transient,
+		);
+
+		// Add comparison overrides to the transient intervals
+		(transientStartInterval as Partial<HasComparisonOverride>)[forceCompare] = -1;
+		(transientEndInterval as Partial<HasComparisonOverride>)[forceCompare] = 1;
+
+		this.intervalTree.mapRange(action, results, transientStartInterval, transientEndInterval);
+		return results;
+	}
+}
+
+export function createStartpointInRangeIndex<TInterval extends ISerializableInterval>(
+	helpers: IIntervalHelpers<TInterval>,
+	client: Client,
+): IStartpointInRangeIndex<TInterval> {
+	return new StartpointInRangeIndex<TInterval>(helpers, client);
+}

--- a/packages/dds/sequence/src/test/endpointInRangeIndex.spec.ts
+++ b/packages/dds/sequence/src/test/endpointInRangeIndex.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { Client } from "@fluidframework/merge-tree";
-import { IEndpointInRangeIndex, createEndpointInRangeIndex } from "../intervalCollection";
+import { IEndpointInRangeIndex, createEndpointInRangeIndex } from "../intervalIndex";
 import { Interval, intervalHelpers } from "../intervals";
 import {
 	assertPlainNumberIntervals,

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -21,7 +21,8 @@ import {
 import { LoggingError } from "@fluidframework/telemetry-utils";
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
-import { IIntervalCollection, IntervalIndex } from "../intervalCollection";
+import { IIntervalCollection } from "../intervalCollection";
+import { IntervalIndex } from "../intervalIndex";
 import {
 	IntervalStickiness,
 	IntervalType,

--- a/packages/dds/sequence/src/test/startpointInRangeIndex.spec.ts
+++ b/packages/dds/sequence/src/test/startpointInRangeIndex.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { Client } from "@fluidframework/merge-tree";
-import { IStartpointInRangeIndex, createStartpointInRangeIndex } from "../intervalCollection";
+import { IStartpointInRangeIndex, createStartpointInRangeIndex } from "../intervalIndex";
 import { Interval, intervalHelpers } from "../intervals";
 import {
 	assertPlainNumberIntervals,

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -40,26 +40,26 @@ use_old_TypeAliasDeclaration_DeserializeCallback(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IEndpointInRangeIndex": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IEndpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IEndpointInRangeIndex():
     TypeOnly<old.IEndpointInRangeIndex<any>>;
-declare function use_current_InterfaceDeclaration_IEndpointInRangeIndex(
+declare function use_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex(
     use: TypeOnly<current.IEndpointInRangeIndex<any>>);
-use_current_InterfaceDeclaration_IEndpointInRangeIndex(
+use_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex(
     get_old_InterfaceDeclaration_IEndpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IEndpointInRangeIndex": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IEndpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IEndpointInRangeIndex():
+declare function get_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex():
     TypeOnly<current.IEndpointInRangeIndex<any>>;
 declare function use_old_InterfaceDeclaration_IEndpointInRangeIndex(
     use: TypeOnly<old.IEndpointInRangeIndex<any>>);
 use_old_InterfaceDeclaration_IEndpointInRangeIndex(
-    get_current_InterfaceDeclaration_IEndpointInRangeIndex());
+    get_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -376,26 +376,26 @@ use_old_InterfaceDeclaration_ISharedString(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IStartpointInRangeIndex": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IStartpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IStartpointInRangeIndex():
     TypeOnly<old.IStartpointInRangeIndex<any>>;
-declare function use_current_InterfaceDeclaration_IStartpointInRangeIndex(
+declare function use_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex(
     use: TypeOnly<current.IStartpointInRangeIndex<any>>);
-use_current_InterfaceDeclaration_IStartpointInRangeIndex(
+use_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex(
     get_old_InterfaceDeclaration_IStartpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IStartpointInRangeIndex": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IStartpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IStartpointInRangeIndex():
+declare function get_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex():
     TypeOnly<current.IStartpointInRangeIndex<any>>;
 declare function use_old_InterfaceDeclaration_IStartpointInRangeIndex(
     use: TypeOnly<old.IStartpointInRangeIndex<any>>);
 use_old_InterfaceDeclaration_IStartpointInRangeIndex(
-    get_current_InterfaceDeclaration_IStartpointInRangeIndex());
+    get_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -472,26 +472,26 @@ use_old_TypeAliasDeclaration_IntervalConflictResolver(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IntervalIndex": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IntervalIndex": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IntervalIndex():
     TypeOnly<old.IntervalIndex<any>>;
-declare function use_current_InterfaceDeclaration_IntervalIndex(
+declare function use_current_RemovedInterfaceDeclaration_IntervalIndex(
     use: TypeOnly<current.IntervalIndex<any>>);
-use_current_InterfaceDeclaration_IntervalIndex(
+use_current_RemovedInterfaceDeclaration_IntervalIndex(
     get_old_InterfaceDeclaration_IntervalIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IntervalIndex": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IntervalIndex": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IntervalIndex():
+declare function get_current_RemovedInterfaceDeclaration_IntervalIndex():
     TypeOnly<current.IntervalIndex<any>>;
 declare function use_old_InterfaceDeclaration_IntervalIndex(
     use: TypeOnly<old.IntervalIndex<any>>);
 use_old_InterfaceDeclaration_IntervalIndex(
-    get_current_InterfaceDeclaration_IntervalIndex());
+    get_current_RemovedInterfaceDeclaration_IntervalIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1144,26 +1144,26 @@ use_old_FunctionDeclaration_appendSharedStringDeltaToRevertibles(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_createEndpointInRangeIndex": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_createEndpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_createEndpointInRangeIndex():
     TypeOnly<typeof old.createEndpointInRangeIndex>;
-declare function use_current_FunctionDeclaration_createEndpointInRangeIndex(
+declare function use_current_RemovedFunctionDeclaration_createEndpointInRangeIndex(
     use: TypeOnly<typeof current.createEndpointInRangeIndex>);
-use_current_FunctionDeclaration_createEndpointInRangeIndex(
+use_current_RemovedFunctionDeclaration_createEndpointInRangeIndex(
     get_old_FunctionDeclaration_createEndpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_createEndpointInRangeIndex": {"backCompat": false}
+* "RemovedFunctionDeclaration_createEndpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_createEndpointInRangeIndex():
+declare function get_current_RemovedFunctionDeclaration_createEndpointInRangeIndex():
     TypeOnly<typeof current.createEndpointInRangeIndex>;
 declare function use_old_FunctionDeclaration_createEndpointInRangeIndex(
     use: TypeOnly<typeof old.createEndpointInRangeIndex>);
 use_old_FunctionDeclaration_createEndpointInRangeIndex(
-    get_current_FunctionDeclaration_createEndpointInRangeIndex());
+    get_current_RemovedFunctionDeclaration_createEndpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1216,26 +1216,26 @@ use_old_FunctionDeclaration_createOverlappingSequenceIntervalsIndex(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_createStartpointInRangeIndex": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_createStartpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_createStartpointInRangeIndex():
     TypeOnly<typeof old.createStartpointInRangeIndex>;
-declare function use_current_FunctionDeclaration_createStartpointInRangeIndex(
+declare function use_current_RemovedFunctionDeclaration_createStartpointInRangeIndex(
     use: TypeOnly<typeof current.createStartpointInRangeIndex>);
-use_current_FunctionDeclaration_createStartpointInRangeIndex(
+use_current_RemovedFunctionDeclaration_createStartpointInRangeIndex(
     get_old_FunctionDeclaration_createStartpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_createStartpointInRangeIndex": {"backCompat": false}
+* "RemovedFunctionDeclaration_createStartpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_createStartpointInRangeIndex():
+declare function get_current_RemovedFunctionDeclaration_createStartpointInRangeIndex():
     TypeOnly<typeof current.createStartpointInRangeIndex>;
 declare function use_old_FunctionDeclaration_createStartpointInRangeIndex(
     use: TypeOnly<typeof old.createStartpointInRangeIndex>);
 use_old_FunctionDeclaration_createStartpointInRangeIndex(
-    get_current_FunctionDeclaration_createStartpointInRangeIndex());
+    get_current_RemovedFunctionDeclaration_createStartpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -40,26 +40,26 @@ use_old_TypeAliasDeclaration_DeserializeCallback(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IEndpointInRangeIndex": {"forwardCompat": false}
+* "InterfaceDeclaration_IEndpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IEndpointInRangeIndex():
     TypeOnly<old.IEndpointInRangeIndex<any>>;
-declare function use_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex(
+declare function use_current_InterfaceDeclaration_IEndpointInRangeIndex(
     use: TypeOnly<current.IEndpointInRangeIndex<any>>);
-use_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex(
+use_current_InterfaceDeclaration_IEndpointInRangeIndex(
     get_old_InterfaceDeclaration_IEndpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IEndpointInRangeIndex": {"backCompat": false}
+* "InterfaceDeclaration_IEndpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex():
+declare function get_current_InterfaceDeclaration_IEndpointInRangeIndex():
     TypeOnly<current.IEndpointInRangeIndex<any>>;
 declare function use_old_InterfaceDeclaration_IEndpointInRangeIndex(
     use: TypeOnly<old.IEndpointInRangeIndex<any>>);
 use_old_InterfaceDeclaration_IEndpointInRangeIndex(
-    get_current_RemovedInterfaceDeclaration_IEndpointInRangeIndex());
+    get_current_InterfaceDeclaration_IEndpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -376,26 +376,26 @@ use_old_InterfaceDeclaration_ISharedString(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IStartpointInRangeIndex": {"forwardCompat": false}
+* "InterfaceDeclaration_IStartpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IStartpointInRangeIndex():
     TypeOnly<old.IStartpointInRangeIndex<any>>;
-declare function use_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex(
+declare function use_current_InterfaceDeclaration_IStartpointInRangeIndex(
     use: TypeOnly<current.IStartpointInRangeIndex<any>>);
-use_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex(
+use_current_InterfaceDeclaration_IStartpointInRangeIndex(
     get_old_InterfaceDeclaration_IStartpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IStartpointInRangeIndex": {"backCompat": false}
+* "InterfaceDeclaration_IStartpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex():
+declare function get_current_InterfaceDeclaration_IStartpointInRangeIndex():
     TypeOnly<current.IStartpointInRangeIndex<any>>;
 declare function use_old_InterfaceDeclaration_IStartpointInRangeIndex(
     use: TypeOnly<old.IStartpointInRangeIndex<any>>);
 use_old_InterfaceDeclaration_IStartpointInRangeIndex(
-    get_current_RemovedInterfaceDeclaration_IStartpointInRangeIndex());
+    get_current_InterfaceDeclaration_IStartpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -472,26 +472,26 @@ use_old_TypeAliasDeclaration_IntervalConflictResolver(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IntervalIndex": {"forwardCompat": false}
+* "InterfaceDeclaration_IntervalIndex": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IntervalIndex():
     TypeOnly<old.IntervalIndex<any>>;
-declare function use_current_RemovedInterfaceDeclaration_IntervalIndex(
+declare function use_current_InterfaceDeclaration_IntervalIndex(
     use: TypeOnly<current.IntervalIndex<any>>);
-use_current_RemovedInterfaceDeclaration_IntervalIndex(
+use_current_InterfaceDeclaration_IntervalIndex(
     get_old_InterfaceDeclaration_IntervalIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IntervalIndex": {"backCompat": false}
+* "InterfaceDeclaration_IntervalIndex": {"backCompat": false}
 */
-declare function get_current_RemovedInterfaceDeclaration_IntervalIndex():
+declare function get_current_InterfaceDeclaration_IntervalIndex():
     TypeOnly<current.IntervalIndex<any>>;
 declare function use_old_InterfaceDeclaration_IntervalIndex(
     use: TypeOnly<old.IntervalIndex<any>>);
 use_old_InterfaceDeclaration_IntervalIndex(
-    get_current_RemovedInterfaceDeclaration_IntervalIndex());
+    get_current_InterfaceDeclaration_IntervalIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1144,26 +1144,26 @@ use_old_FunctionDeclaration_appendSharedStringDeltaToRevertibles(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_createEndpointInRangeIndex": {"forwardCompat": false}
+* "FunctionDeclaration_createEndpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_createEndpointInRangeIndex():
     TypeOnly<typeof old.createEndpointInRangeIndex>;
-declare function use_current_RemovedFunctionDeclaration_createEndpointInRangeIndex(
+declare function use_current_FunctionDeclaration_createEndpointInRangeIndex(
     use: TypeOnly<typeof current.createEndpointInRangeIndex>);
-use_current_RemovedFunctionDeclaration_createEndpointInRangeIndex(
+use_current_FunctionDeclaration_createEndpointInRangeIndex(
     get_old_FunctionDeclaration_createEndpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_createEndpointInRangeIndex": {"backCompat": false}
+* "FunctionDeclaration_createEndpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_RemovedFunctionDeclaration_createEndpointInRangeIndex():
+declare function get_current_FunctionDeclaration_createEndpointInRangeIndex():
     TypeOnly<typeof current.createEndpointInRangeIndex>;
 declare function use_old_FunctionDeclaration_createEndpointInRangeIndex(
     use: TypeOnly<typeof old.createEndpointInRangeIndex>);
 use_old_FunctionDeclaration_createEndpointInRangeIndex(
-    get_current_RemovedFunctionDeclaration_createEndpointInRangeIndex());
+    get_current_FunctionDeclaration_createEndpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1216,26 +1216,26 @@ use_old_FunctionDeclaration_createOverlappingSequenceIntervalsIndex(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_createStartpointInRangeIndex": {"forwardCompat": false}
+* "FunctionDeclaration_createStartpointInRangeIndex": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_createStartpointInRangeIndex():
     TypeOnly<typeof old.createStartpointInRangeIndex>;
-declare function use_current_RemovedFunctionDeclaration_createStartpointInRangeIndex(
+declare function use_current_FunctionDeclaration_createStartpointInRangeIndex(
     use: TypeOnly<typeof current.createStartpointInRangeIndex>);
-use_current_RemovedFunctionDeclaration_createStartpointInRangeIndex(
+use_current_FunctionDeclaration_createStartpointInRangeIndex(
     get_old_FunctionDeclaration_createStartpointInRangeIndex());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_createStartpointInRangeIndex": {"backCompat": false}
+* "FunctionDeclaration_createStartpointInRangeIndex": {"backCompat": false}
 */
-declare function get_current_RemovedFunctionDeclaration_createStartpointInRangeIndex():
+declare function get_current_FunctionDeclaration_createStartpointInRangeIndex():
     TypeOnly<typeof current.createStartpointInRangeIndex>;
 declare function use_old_FunctionDeclaration_createStartpointInRangeIndex(
     use: TypeOnly<typeof old.createStartpointInRangeIndex>);
 use_old_FunctionDeclaration_createStartpointInRangeIndex(
-    get_current_RemovedFunctionDeclaration_createStartpointInRangeIndex());
+    get_current_FunctionDeclaration_createStartpointInRangeIndex());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
[AB#5050](https://dev.azure.com/fluidframework/internal/_workitems/edit/5050)

1. Move the interfaces and implementations of different IntervalIndex to `./intervalIndex`, make the `intervalCollection.ts` solely focuses on the `IntervalCollection` itself
2. Deprecate some APIs related to the intervalIndex, We would like the user to attach the index to the collection on their own.