### PR TITLE
Fix issue where ops are sent out of order on connect

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1606,8 +1606,6 @@ export class ContainerRuntime
 				!readonly || !this.connected,
 				0x125 /* "Unsafe to transition to read-only state!" */,
 			);
-
-			this.replayPendingStates();
 		});
 
 		// logging hardware telemetry
@@ -2039,6 +2037,12 @@ export class ContainerRuntime
 		// There might be no change of state due to Container calling this API after loading runtime.
 		const changeOfState = this._connected !== connected;
 		const reconnection = changeOfState && !connected;
+
+		// We need to flush the ops currently collected by Outbox to the PendingStateManager to preserve original order upon calling "replayPendingStates"
+		if (changeOfState && connected) {
+			this.flush();
+		}
+
 		this._connected = connected;
 
 		if (!connected) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1606,6 +1606,8 @@ export class ContainerRuntime
 				!readonly || !this.connected,
 				0x125 /* "Unsafe to transition to read-only state!" */,
 			);
+
+			this.replayPendingStates();
 		});
 
 		// logging hardware telemetry

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2038,7 +2038,9 @@ export class ContainerRuntime
 		const changeOfState = this._connected !== connected;
 		const reconnection = changeOfState && !connected;
 
-		// We need to flush the ops currently collected by Outbox to the PendingStateManager to preserve original order upon calling "replayPendingStates"
+		// We need to flush the ops currently collected by Outbox to preserve original order.
+		// This flush NEEDS to happen before we set the ContainerRuntime to "connected".
+		// We want these ops to get to the PendingStateManager without sending to service and have them return to the Outbox upon calling "replayPendingStates".
 		if (changeOfState && connected) {
 			this.flush();
 		}

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -132,8 +132,8 @@ describe("Runtime", () => {
 				(containerRuntime as any).flush();
 
 				assert.strictEqual(submittedOps.length, 2);
-				assert.strictEqual(submittedOps[0].contents.address, "2");
-				assert.strictEqual(submittedOps[1].contents.address, "1");
+				assert.strictEqual(submittedOps[0].contents.address, "1");
+				assert.strictEqual(submittedOps[1].contents.address, "2");
 			});
 		});
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -43,6 +43,14 @@ describe("Runtime", () => {
 		getRawConfig: (name: string): ConfigTypes => settings[name],
 	});
 
+	let submittedOps: any[] = [];
+	let opFakeSequenceNumber = 1;
+
+	beforeEach(() => {
+		submittedOps = [];
+		opFakeSequenceNumber = 1;
+	});
+
 	const getMockContext = (
 		settings: Record<string, ConfigTypes> = {},
 		logger: ITelemetryLoggerExt = new MockLogger(),
@@ -58,14 +66,17 @@ describe("Runtime", () => {
 		closeFn: (_error?: ICriticalContainerError): void => {},
 		updateDirtyContainerState: (_dirty: boolean) => {},
 		getLoadedFromVersion: () => undefined,
+		submitFn: (_type: MessageType, contents: any, _batch: boolean, appData?: any) => {
+			submittedOps.push(contents);
+			return opFakeSequenceNumber++;
+		},
+		clientId: "fakeClientId",
 	});
 
 	describe("Container Runtime", () => {
 		describe("flushMode setting", () => {
-			let containerRuntime: ContainerRuntime;
-
 			it("Default flush mode", async () => {
-				containerRuntime = await ContainerRuntime.loadRuntime({
+				const containerRuntime = await ContainerRuntime.loadRuntime({
 					context: getMockContext() as IContainerContext,
 					registryEntries: [],
 					existing: false,
@@ -76,7 +87,7 @@ describe("Runtime", () => {
 			});
 
 			it("Override default flush mode using options", async () => {
-				containerRuntime = await ContainerRuntime.loadRuntime({
+				const containerRuntime = await ContainerRuntime.loadRuntime({
 					context: getMockContext() as IContainerContext,
 					registryEntries: [],
 					existing: false,
@@ -86,6 +97,43 @@ describe("Runtime", () => {
 				});
 
 				assert.strictEqual(containerRuntime.flushMode, FlushMode.Immediate);
+			});
+
+			it("Replaying ops should resend in correct order", async () => {
+				const containerRuntime = await ContainerRuntime.loadRuntime({
+					context: getMockContext() as IContainerContext,
+					registryEntries: [],
+					existing: false,
+					runtimeOptions: {
+						flushMode: FlushMode.TurnBased,
+					},
+				});
+
+				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+				(containerRuntime as any).dataStores = {
+					setConnectionState: (_connected: boolean, _clientId?: string) => {},
+					// Pass data store op right back to ContainerRuntime
+					resubmitDataStoreOp: (envelope, localOpMetadata) => {
+						containerRuntime.submitDataStoreOp(
+							envelope.address,
+							envelope.contents,
+							localOpMetadata,
+						);
+					},
+				} as DataStores;
+
+				containerRuntime.setConnectionState(false);
+
+				containerRuntime.submitDataStoreOp("1", "test");
+				(containerRuntime as any).flush();
+
+				containerRuntime.submitDataStoreOp("2", "test");
+				containerRuntime.setConnectionState(true);
+				(containerRuntime as any).flush();
+
+				assert.strictEqual(submittedOps.length, 2);
+				assert.strictEqual(submittedOps[0].contents.address, "2");
+				assert.strictEqual(submittedOps[1].contents.address, "1");
 			});
 		});
 
@@ -102,7 +150,6 @@ describe("Runtime", () => {
 					let mockContext: Partial<IContainerContext>;
 					const submittedOpsMetdata: any[] = [];
 					const containerErrors: ICriticalContainerError[] = [];
-					let opFakeSequenceNumber = 1;
 					const getMockContextForOrderSequentially = (): Partial<IContainerContext> => {
 						return {
 							attachState: AttachState.Attached,
@@ -163,7 +210,6 @@ describe("Runtime", () => {
 						});
 						containerErrors.length = 0;
 						submittedOpsMetdata.length = 0;
-						opFakeSequenceNumber = 1;
 					});
 
 					it("Can't call flush() inside orderSequentially's callback", () => {


### PR DESCRIPTION
There are observed cases where ops are sent out of order upon connecting. To fix this, we need to flush the Outbox when connecting so the ops are replayed in the original order.

The sequence of events is the following:
1. ContainerRuntime is disconnected (whether from the start or not doesn't matter)
2. ops are submitted to Outbox
3. batch is flushed and ops are stored in PendingStateManager
4. ops are not sent over wire since we are disconnected
5. more ops are submitted to Outbox
6. we receive join op for our client
7. we replay pending ops before the current batch is flushed
8. when resubmitting an op, we see that the Outbox's mainBatch has a lower ref sqn than the DeltaManager (last op was the "join")

[AB#4004](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4004)