### PR TITLE
Remove container from loader cache in case of error.

### DIFF
--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -418,7 +418,10 @@ export class Loader implements IHostLoader {
 					});
 				}
 			})
-			.catch((error) => {});
+			.catch((error) => {
+				// If an error occured while resolving the container request, then remove it from the cache.
+				this.containers.delete(key);
+			});
 	}
 
 	private async resolveCore(

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -409,11 +409,15 @@ export class Loader implements IHostLoader {
 		this.containers.set(key, containerP);
 		containerP
 			.then((container) => {
-				// If the container is closed or becomes closed after we resolve it, remove it from the cache.
-				if (container.closed) {
+				// If the container is closed/disposed or becomes closed/disposed after we resolve it,
+				// remove it from the cache.
+				if (container.closed || container.disposed) {
 					this.containers.delete(key);
 				} else {
 					container.once("closed", () => {
+						this.containers.delete(key);
+					});
+					container.once("disposed", () => {
 						this.containers.delete(key);
 					});
 				}


### PR DESCRIPTION
## Description

If an error occurs while resolving the container request, then remove it from the cache, otherwise we will keep getting that error.