### PR TITLE
add api counter for riddler requests

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -74,7 +74,8 @@ data:
             "kafkaCheckpointOnReprocessingOp": {{ .Values.checkpoints.kafkaCheckpointOnReprocessingOp }}
         },
         "apiCounters": {
-            "fetchTenantKeyMetricMs": 60000
+            "fetchTenantKeyMetricMs": 60000,
+            "riddlerStorageRequestMetricMs": 60000
         },
         "alfred": {
             "kafkaClientId": "{{ template "alfred.fullname" . }}",

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -25,6 +25,7 @@ export function create(
 	defaultInternalHistorianUrl: string,
 	secretManager: ISecretManager,
 	fetchTenantKeyMetricInterval: number,
+	riddlerStorageRequestMetricInterval: number,
 	cache?: ICache,
 ): Router {
 	const router: Router = Router();
@@ -36,6 +37,7 @@ export function create(
 		defaultInternalHistorianUrl,
 		secretManager,
 		fetchTenantKeyMetricInterval,
+		riddlerStorageRequestMetricInterval,
 		cache,
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -24,6 +24,7 @@ export function create(
 	defaultInternalHistorianUrl: string,
 	secretManager: ISecretManager,
 	fetchTenantKeyMetricInterval: number,
+	riddlerStorageRequestMetricInterval: number,
 	cache?: ICache,
 ) {
 	// Express app configuration
@@ -58,6 +59,7 @@ export function create(
 			defaultInternalHistorianUrl,
 			secretManager,
 			fetchTenantKeyMetricInterval,
+			riddlerStorageRequestMetricInterval,
 			cache,
 		),
 	);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -31,6 +31,7 @@ export class RiddlerRunner implements IRunner {
 		private readonly defaultInternalHistorianUrl: string,
 		private readonly secretManager: ISecretManager,
 		private readonly fetchTenantKeyMetricInterval: number,
+		private readonly riddlerStorageRequestMetricInterval: number,
 		private readonly cache?: ICache,
 	) {}
 
@@ -48,6 +49,7 @@ export class RiddlerRunner implements IRunner {
 			this.defaultInternalHistorianUrl,
 			this.secretManager,
 			this.fetchTenantKeyMetricInterval,
+			this.riddlerStorageRequestMetricInterval,
 			this.cache,
 		);
 		riddler.set("port", this.port);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -38,6 +38,7 @@ export class RiddlerResources implements IResources {
 		public readonly defaultInternalHistorianUrl: string,
 		public readonly secretManager: ISecretManager,
 		public readonly fetchTenantKeyMetricIntervalMs: number,
+		public readonly riddlerStorageRequestMetricIntervalMs: number,
 		public readonly cache: RedisCache,
 	) {
 		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
@@ -140,6 +141,9 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 			config.get("worker:internalBlobStorageUrl") || defaultHistorianUrl;
 
 		const fetchTenantKeyMetricIntervalMs = config.get("apiCounters:fetchTenantKeyMetricMs");
+		const riddlerStorageRequestMetricIntervalMs = config.get(
+			"apiCounters:riddlerStorageRequestMetricMs",
+		);
 
 		return new RiddlerResources(
 			config,
@@ -152,6 +156,7 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 			defaultInternalHistorianUrl,
 			secretManager,
 			fetchTenantKeyMetricIntervalMs,
+			riddlerStorageRequestMetricIntervalMs,
 			cache,
 		);
 	}
@@ -170,6 +175,7 @@ export class RiddlerRunnerFactory implements IRunnerFactory<RiddlerResources> {
 			resources.defaultInternalHistorianUrl,
 			resources.secretManager,
 			resources.fetchTenantKeyMetricIntervalMs,
+			resources.riddlerStorageRequestMetricIntervalMs,
 			resources.cache,
 		);
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -63,10 +63,25 @@ enum FetchTenantKeyMetric {
 	SetKeyInCacheFailure = "settingKeyInCacheFailed",
 }
 
+enum StorageRequestMetric {
+	// Cache requests
+	CacheRequestStarted = "cacheRequestStarted",
+	CacheRequestCompleted = "cacheRequestCompleted",
+	// Database requests
+	DatabaseRequestStarted = "databaseRequestStarted",
+	DatabaseRequestCompleted = "databaseRequestCompleted",
+	// errors
+	CacheError = "cacheError",
+	DatabaseError = "databaseError",
+}
+
 export class TenantManager {
 	private readonly isCacheEnabled;
-	private readonly apiCounter: IApiCounters = new InMemoryApiCounters(
+	private readonly fetchTenantKeyApiCounter: IApiCounters = new InMemoryApiCounters(
 		Object.values(FetchTenantKeyMetric),
+	);
+	private readonly storageRequestApiCounter: IApiCounters = new InMemoryApiCounters(
+		Object.values(StorageRequestMetric),
 	);
 	constructor(
 		private readonly mongoManager: MongoManager,
@@ -76,17 +91,34 @@ export class TenantManager {
 		private readonly defaultInternalHistorianUrl: string,
 		private readonly secretManager: ISecretManager,
 		private readonly fetchTenantKeyMetricInterval: number,
+		private readonly riddlerStorageRequestMetricInterval: number,
 		private readonly cache?: ICache,
 	) {
 		this.isCacheEnabled = this.cache ? true : false;
 		if (fetchTenantKeyMetricInterval) {
 			setInterval(() => {
-				if (!this.apiCounter.countersAreActive) {
+				if (!this.fetchTenantKeyApiCounter.countersAreActive) {
 					return;
 				}
-				Lumberjack.info("Fetch tenant key api counters", this.apiCounter.getCounters());
-				this.apiCounter.resetAllCounters();
+				Lumberjack.info(
+					"Fetch tenant key api counters",
+					this.fetchTenantKeyApiCounter.getCounters(),
+				);
+				this.fetchTenantKeyApiCounter.resetAllCounters();
 			}, this.fetchTenantKeyMetricInterval);
+		}
+
+		if (riddlerStorageRequestMetricInterval) {
+			setInterval(() => {
+				if (!this.storageRequestApiCounter.countersAreActive) {
+					return;
+				}
+				Lumberjack.info(
+					"Riddler storage request api counters",
+					this.storageRequestApiCounter.getCounters(),
+				);
+				this.storageRequestApiCounter.resetAllCounters();
+			}, this.riddlerStorageRequestMetricInterval);
 		}
 	}
 
@@ -285,15 +317,17 @@ export class TenantManager {
 			customData.encryptionKeyVersion = latestKeyVersion;
 		}
 
-		const id = await collection.insertOne({
-			_id: tenantId,
-			key: encryptedTenantKey1,
-			secondaryKey: encryptedTenantKey2,
-			orderer,
-			storage,
-			customData,
-			disabled: false,
-		});
+		const id = await this.runWithDatabaseRequestCounter(async () =>
+			collection.insertOne({
+				_id: tenantId,
+				key: encryptedTenantKey1,
+				secondaryKey: encryptedTenantKey2,
+				orderer,
+				storage,
+				customData,
+				disabled: false,
+			}),
+		);
 
 		const tenant = await this.getTenant(id);
 		return _.extend(tenant, { key: tenantKey1, secondaryKey: tenantKey2 });
@@ -306,7 +340,9 @@ export class TenantManager {
 		const db = await this.mongoManager.getDatabase();
 		const collection = db.collection<ITenantDocument>(this.collectionName);
 
-		await collection.update({ _id: tenantId }, { storage }, null);
+		await this.runWithDatabaseRequestCounter(async () =>
+			collection.update({ _id: tenantId }, { storage }, null),
+		);
 
 		return (await this.getTenantDocument(tenantId)).storage;
 	}
@@ -336,7 +372,9 @@ export class TenantManager {
 		if (accessInfo) {
 			customData.externalStorageData.accessInfo = this.encryptAccessInfo(accessInfo);
 		}
-		await collection.update({ _id: tenantId }, { customData }, null);
+		await this.runWithDatabaseRequestCounter(async () =>
+			collection.update({ _id: tenantId }, { customData }, null),
+		);
 		const tenantDocument = await this.getTenantDocument(tenantId, true);
 		if (tenantDocument.disabled) {
 			Lumberjack.info("Updated custom data of a disabled tenant", {
@@ -498,7 +536,9 @@ export class TenantManager {
 				: { key: encryptedNewTenantKey };
 		const db = await this.mongoManager.getDatabase();
 		const collection = db.collection<ITenantDocument>(this.collectionName);
-		await collection.update({ _id: tenantId }, updateKey, null);
+		await this.runWithDatabaseRequestCounter(async () =>
+			collection.update({ _id: tenantId }, updateKey, null),
+		);
 
 		return tenantKeys;
 	}
@@ -625,7 +665,9 @@ export class TenantManager {
 		const db = await this.mongoManager.getDatabase();
 		const collection = db.collection<ITenantDocument>(this.collectionName);
 
-		const found = await collection.findOne({ _id: tenantId });
+		const found = await this.runWithDatabaseRequestCounter(async () =>
+			collection.findOne({ _id: tenantId }),
+		);
 		if (!found || (found.disabled && !includeDisabledTenant)) {
 			return null;
 		}
@@ -642,7 +684,7 @@ export class TenantManager {
 		const db = await this.mongoManager.getDatabase();
 		const collection = db.collection<ITenantDocument>(this.collectionName);
 
-		const allFound = await collection.findAll();
+		const allFound = await this.runWithDatabaseRequestCounter(async () => collection.findAll());
 
 		allFound.forEach((found) => {
 			this.attachDefaultsToTenantDocument(found);
@@ -666,16 +708,21 @@ export class TenantManager {
 				_id: tenantId,
 				disabled: false,
 			};
-			await collection.update(
-				query,
-				{
-					disabled: true,
-					scheduledDeletionTime: scheduledDeletionTime?.toJSON(),
-				},
-				null,
+
+			await this.runWithDatabaseRequestCounter(async () =>
+				collection.update(
+					query,
+					{
+						disabled: true,
+						scheduledDeletionTime: scheduledDeletionTime?.toJSON(),
+					},
+					null,
+				),
 			);
 		} else {
-			await collection.deleteOne({ _id: tenantId });
+			await this.runWithDatabaseRequestCounter(async () =>
+				collection.deleteOne({ _id: tenantId }),
+			);
 		}
 		// invalidate cache
 		await this.deleteKeyFromCache(tenantId);
@@ -705,35 +752,80 @@ export class TenantManager {
 			  };
 	}
 
+	private async runWithCacheRequestCounter<T>(api: () => Promise<T>) {
+		this.storageRequestApiCounter.incrementCounter(StorageRequestMetric.CacheRequestStarted);
+		try {
+			const result = await api();
+			this.storageRequestApiCounter.incrementCounter(
+				StorageRequestMetric.CacheRequestCompleted,
+			);
+			return result;
+		} catch (error) {
+			this.storageRequestApiCounter.incrementCounter(StorageRequestMetric.CacheError);
+			throw error;
+		}
+	}
+
+	private async runWithDatabaseRequestCounter<T>(api: () => Promise<T>) {
+		this.storageRequestApiCounter.incrementCounter(StorageRequestMetric.DatabaseRequestStarted);
+		try {
+			const result = await api();
+			this.storageRequestApiCounter.incrementCounter(
+				StorageRequestMetric.DatabaseRequestCompleted,
+			);
+			return result;
+		} catch (error) {
+			this.storageRequestApiCounter.incrementCounter(StorageRequestMetric.DatabaseError);
+			throw error;
+		}
+	}
+
 	private async getKeyFromCache(tenantId: string): Promise<string> {
 		try {
-			const cachedKey = await this.cache?.get(`tenantKeys:${tenantId}`);
+			const cachedKey = await this.runWithCacheRequestCounter(async () =>
+				this.cache?.get(`tenantKeys:${tenantId}`),
+			);
+
 			if (cachedKey == null) {
-				this.apiCounter.incrementCounter(FetchTenantKeyMetric.NotFoundInCache);
+				this.fetchTenantKeyApiCounter.incrementCounter(
+					FetchTenantKeyMetric.NotFoundInCache,
+				);
 			} else {
-				this.apiCounter.incrementCounter(FetchTenantKeyMetric.RetrieveFromCacheSucess);
+				this.fetchTenantKeyApiCounter.incrementCounter(
+					FetchTenantKeyMetric.RetrieveFromCacheSucess,
+				);
 			}
 			return cachedKey;
 		} catch (error) {
 			Lumberjack.error(`Error trying to retreive tenant keys from the cache.`, error);
-			this.apiCounter.incrementCounter(FetchTenantKeyMetric.RetrieveFromCacheError);
+			this.fetchTenantKeyApiCounter.incrementCounter(
+				FetchTenantKeyMetric.RetrieveFromCacheError,
+			);
 			throw error;
 		}
 	}
 
 	private async deleteKeyFromCache(tenantId: string): Promise<boolean> {
-		return this.cache?.delete(`tenantKeys:${tenantId}`);
+		return this.runWithCacheRequestCounter(async () =>
+			this.cache?.delete(`tenantKeys:${tenantId}`),
+		);
 	}
 
 	private async setKeyInCache(tenantId: string, value: IEncryptedTenantKeys): Promise<boolean> {
 		const lumberProperties = { [BaseTelemetryProperties.tenantId]: tenantId };
 		try {
-			await this.cache?.set(`tenantKeys:${tenantId}`, JSON.stringify(value));
-			this.apiCounter.incrementCounter(FetchTenantKeyMetric.SetKeyInCacheSuccess);
+			await this.runWithCacheRequestCounter(async () =>
+				this.cache?.set(`tenantKeys:${tenantId}`, JSON.stringify(value)),
+			);
+			this.fetchTenantKeyApiCounter.incrementCounter(
+				FetchTenantKeyMetric.SetKeyInCacheSuccess,
+			);
 			return true;
 		} catch (error) {
 			Lumberjack.error(`Setting tenant key in the cache failed`, lumberProperties, error);
-			this.apiCounter.incrementCounter(FetchTenantKeyMetric.SetKeyInCacheFailure);
+			this.fetchTenantKeyApiCounter.incrementCounter(
+				FetchTenantKeyMetric.SetKeyInCacheFailure,
+			);
 			return false;
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/api.spec.ts
@@ -83,6 +83,7 @@ describe("Routerlicious", () => {
 					);
 					Sinon.useFakeTimers();
 					const testFetchTenantKeyMetricIntervalMs = 60000;
+					const testRiddlerStorageRequestMetricIntervalMs = 60000;
 
 					app = riddlerApp.create(
 						testCollectionName,
@@ -93,6 +94,7 @@ describe("Routerlicious", () => {
 						testIntHistorianUrl,
 						testSecretManager,
 						testFetchTenantKeyMetricIntervalMs,
+						testRiddlerStorageRequestMetricIntervalMs,
 					);
 					supertest = request(app);
 				});

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -59,7 +59,8 @@
 		"ignoreCheckpointFlushException": false
 	},
 	"apiCounters": {
-		"fetchTenantKeyMetricMs": 60000
+		"fetchTenantKeyMetricMs": 60000,
+		"riddlerStorageRequestMetricMs": 60000
 	},
 	"alfred": {
 		"kafkaClientId": "alfred",


### PR DESCRIPTION
## Description

> We want to improve riddler logging around our API requests.
> This change implements a new apiCounter in Riddler to track the number of requests that were started, how many successfully completed, and how many encountered errors.