### PR TITLE
refactor: Extract the "no devtools found" error bar logic into its own module/component

### DIFF
--- a/packages/tools/devtools/devtools-view/.eslintrc.js
+++ b/packages/tools/devtools/devtools-view/.eslintrc.js
@@ -37,6 +37,10 @@ module.exports = {
 				],
 			},
 		],
+
+		// Forbid new imports from legacy FluentUI react package.
+		// We have a couple of components that still use it, but new usages should not be added without due consideration.
+		"no-restricted-imports": ["error", "@fluentui/react"],
 	},
 	overrides: [
 		{

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import React from "react";
 
 import {
@@ -12,12 +13,10 @@ import {
 	tokens,
 	Tooltip,
 } from "@fluentui/react-components";
-import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { createChildLogger } from "@fluidframework/telemetry-utils";
-import { Link, MessageBar, MessageBarType, initializeIcons } from "@fluentui/react";
-
 import { ArrowSync24Regular } from "@fluentui/react-icons";
 
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
 import {
 	ContainerKey,
 	ContainerList,
@@ -31,14 +30,16 @@ import {
 	InboundHandlers,
 	ISourcedDevtoolsMessage,
 } from "@fluid-experimental/devtools-core";
+
 import {
 	ContainerDevtoolsView,
-	TelemetryView,
 	LandingView,
-	SettingsView,
-	Waiting,
 	MenuSection,
 	MenuItem,
+	NoDevtoolsErrorBar,
+	SettingsView,
+	TelemetryView,
+	Waiting,
 } from "./components";
 import { useMessageRelay } from "./MessageRelayContext";
 import {
@@ -128,19 +129,6 @@ const useDevtoolsStyles = makeStyles({
 			textOverflow: "ellipsis",
 		},
 	},
-	icon: {
-		"& .ms-MessageBar-icon": {
-			marginTop: "10px",
-		},
-	},
-	retryButton: {
-		marginLeft: "5px",
-	},
-	debugNote: {
-		fontWeight: "normal",
-		marginTop: "0px",
-		marginBottom: "0px",
-	},
 });
 
 /**
@@ -178,7 +166,6 @@ export function DevtoolsView(props: DevtoolsViewProps): React.ReactElement {
 	const [isMessageDismissed, setIsMessageDismissed] = React.useState(false);
 	const queryTimeoutInMilliseconds = 30_000; // 30 seconds
 	const messageRelay = useMessageRelay();
-	const styles = useDevtoolsStyles();
 
 	const consoleLogger = React.useMemo(
 		() => new ConsoleVerboseLogger(usageTelemetryLogger),
@@ -258,7 +245,6 @@ export function DevtoolsView(props: DevtoolsViewProps): React.ReactElement {
 		setQueryTimedOut(false);
 		messageRelay.postMessage(getSupportedFeaturesMessage);
 	}
-	initializeIcons();
 
 	return (
 		<LoggerContext.Provider value={topLevelLogger}>
@@ -268,39 +254,10 @@ export function DevtoolsView(props: DevtoolsViewProps): React.ReactElement {
 						<>
 							{!queryTimedOut && <Waiting />}
 							{queryTimedOut && !isMessageDismissed && (
-								<MessageBar
-									messageBarType={MessageBarType.error}
-									isMultiline={true}
+								<NoDevtoolsErrorBar
 									onDismiss={(): void => setIsMessageDismissed(true)}
-									dismissButtonAriaLabel="Close"
-									className={styles.icon}
-								>
-									It seems that Fluid Devtools has not been initialized in the
-									current tab, or it did not respond in a timely manner.
-									<Tooltip
-										content="Retry communicating with Fluid Devtools in the current tab."
-										relationship="description"
-									>
-										<Button
-											className={styles.retryButton}
-											size="small"
-											onClick={retryQuery}
-										>
-											Try again
-										</Button>
-									</Tooltip>
-									<br />
-									<h4 className={styles.debugNote}>
-										Need help? Please refer to our
-										<Link
-											href="https://aka.ms/fluid/devtool/docs"
-											target="_blank"
-										>
-											documentation page
-										</Link>{" "}
-										for guidance on getting the extension working.{" "}
-									</h4>
-								</MessageBar>
+									retrySearch={(): void => retryQuery()}
+								/>
 							)}
 							<_DevtoolsView supportedFeatures={{}} />
 						</>

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -255,7 +255,7 @@ export function DevtoolsView(props: DevtoolsViewProps): React.ReactElement {
 							{!queryTimedOut && <Waiting />}
 							{queryTimedOut && !isMessageDismissed && (
 								<NoDevtoolsErrorBar
-									onDismiss={(): void => setIsMessageDismissed(true)}
+									dismiss={(): void => setIsMessageDismissed(true)}
 									retrySearch={(): void => retryQuery()}
 								/>
 							)}

--- a/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
@@ -39,7 +39,7 @@ export interface NoDevtoolsErrorBarProps {
 	/**
 	 * Call to dismiss error notice bar.
 	 */
-	onDismiss(): void;
+	dismiss(): void;
 
 	/**
 	 * Reattempt to find devtools on the page.
@@ -51,7 +51,7 @@ export interface NoDevtoolsErrorBarProps {
  * TODO
  */
 export function NoDevtoolsErrorBar(props: NoDevtoolsErrorBarProps): React.ReactElement {
-	const { onDismiss, retrySearch } = props;
+	const { dismiss, retrySearch } = props;
 
 	const styles = useStyles();
 
@@ -59,7 +59,7 @@ export function NoDevtoolsErrorBar(props: NoDevtoolsErrorBarProps): React.ReactE
 		<MessageBar
 			messageBarType={MessageBarType.error}
 			isMultiline={true}
-			onDismiss={onDismiss}
+			onDismiss={dismiss}
 			dismissButtonAriaLabel="Close"
 			className={styles.root}
 		>

--- a/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
@@ -6,6 +6,11 @@
 import React from "react";
 
 import { Button, Link, makeStyles, Tooltip } from "@fluentui/react-components";
+
+// The `MessageBar` component was removed in FluentUI React v9 with no replacement offered.
+// In the future, we will want to re-write this component to use something else, but for now this import is required.
+// When these imports are removed, the `@fluentui/react` dependency should be removed from this package.
+// eslint-disable-next-line no-restricted-imports
 import { initializeIcons, MessageBar, MessageBarType } from "@fluentui/react";
 
 // NoDevtoolsErrorBar uses legacy @fluentui/react, which requires explicit icon initialization.

--- a/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
@@ -33,6 +33,21 @@ const useStyles = makeStyles({
 });
 
 /**
+ * Core message displayed in the error notice bar.
+ *
+ * @remarks Note: this is only exported for testing purposes.
+ */
+export const coreErrorMessage =
+	"It seems that Fluid Devtools has not been initialized in the current tab, or it did not respond in a timely manner.";
+
+/**
+ * URL pointing to help documentation for the Devtools.
+ *
+ * @remarks Note: this is only exported for testing purposes.
+ */
+export const docsLinkUrl = "https://aka.ms/fluid/devtool/docs";
+
+/**
  * {@link NoDevtoolsErrorBar} input props.
  */
 export interface NoDevtoolsErrorBarProps {
@@ -63,20 +78,24 @@ export function NoDevtoolsErrorBar(props: NoDevtoolsErrorBarProps): React.ReactE
 			dismissButtonAriaLabel="Close"
 			className={styles.root}
 		>
-			It seems that Fluid Devtools has not been initialized in the current tab, or it did not
-			respond in a timely manner.
+			{coreErrorMessage}
 			<Tooltip
 				content="Retry communicating with Fluid Devtools in the current tab."
 				relationship="description"
 			>
-				<Button className={styles.retryButton} size="small" onClick={retrySearch}>
+				<Button
+					className={styles.retryButton}
+					size="small"
+					onClick={retrySearch}
+					data-testid="retry-search-button"
+				>
 					Try again
 				</Button>
 			</Tooltip>
 			<br />
 			<h4 className={styles.debugNote}>
 				Need help? Please refer to our
-				<Link href="https://aka.ms/fluid/devtool/docs" target="_blank">
+				<Link href={docsLinkUrl} target="_blank">
 					documentation page
 				</Link>{" "}
 				for guidance on getting the extension working.{" "}

--- a/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
@@ -1,0 +1,81 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+import { Button, Link, makeStyles, Tooltip } from "@fluentui/react-components";
+import { initializeIcons, MessageBar, MessageBarType } from "@fluentui/react";
+
+// NoDevtoolsErrorBar uses legacy @fluentui/react, which requires explicit icon initialization.
+initializeIcons();
+
+const useStyles = makeStyles({
+	root: {
+		"& .ms-MessageBar-icon": {
+			marginTop: "10px",
+		},
+	},
+	retryButton: {
+		marginLeft: "5px",
+	},
+	debugNote: {
+		fontWeight: "normal",
+		marginTop: "0px",
+		marginBottom: "0px",
+	},
+});
+
+/**
+ * {@link NoDevtoolsErrorBar} input props.
+ */
+export interface NoDevtoolsErrorBarProps {
+	/**
+	 * Call to dismiss error notice bar.
+	 */
+	onDismiss(): void;
+
+	/**
+	 * Reattempt to find devtools on the page.
+	 */
+	retrySearch(): void;
+}
+
+/**
+ * TODO
+ */
+export function NoDevtoolsErrorBar(props: NoDevtoolsErrorBarProps): React.ReactElement {
+	const { onDismiss, retrySearch } = props;
+
+	const styles = useStyles();
+
+	return (
+		<MessageBar
+			messageBarType={MessageBarType.error}
+			isMultiline={true}
+			onDismiss={onDismiss}
+			dismissButtonAriaLabel="Close"
+			className={styles.root}
+		>
+			It seems that Fluid Devtools has not been initialized in the current tab, or it did not
+			respond in a timely manner.
+			<Tooltip
+				content="Retry communicating with Fluid Devtools in the current tab."
+				relationship="description"
+			>
+				<Button className={styles.retryButton} size="small" onClick={retrySearch}>
+					Try again
+				</Button>
+			</Tooltip>
+			<br />
+			<h4 className={styles.debugNote}>
+				Need help? Please refer to our
+				<Link href="https://aka.ms/fluid/devtool/docs" target="_blank">
+					documentation page
+				</Link>{" "}
+				for guidance on getting the extension working.{" "}
+			</h4>
+		</MessageBar>
+	);
+}

--- a/packages/tools/devtools/devtools-view/src/components/index.ts
+++ b/packages/tools/devtools/devtools-view/src/components/index.ts
@@ -16,6 +16,7 @@ export * from "./ContainerHistoryView";
 export * from "./ContainerSummaryView";
 export * from "./LandingView";
 export * from "./Menu";
+export * from "./NoDevtoolsErrorBar";
 export * from "./TelemetryView";
 export * from "./SettingsView";
 export * from "./Waiting";

--- a/packages/tools/devtools/devtools-view/src/test/NoDevtoolsErrorBar.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/NoDevtoolsErrorBar.test.tsx
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+// eslint-disable-next-line import/no-unassigned-import
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { coreErrorMessage, docsLinkUrl, NoDevtoolsErrorBar } from "../components";
+
+describe("NoDevtoolsErrorBar component tests", () => {
+	it("Displays expected text and contains expected link", async (): Promise<void> => {
+		render(<NoDevtoolsErrorBar dismiss={(): void => {}} retrySearch={(): void => {}} />);
+
+		await screen.findByText(coreErrorMessage); // Will throw if exact text not found
+
+		const helpLink = await screen.findByRole("link");
+		expect(helpLink).toHaveTextContent("documentation page");
+		expect(helpLink).toHaveAttribute("href", docsLinkUrl);
+	});
+
+	it("Clicking close button invokes `dismiss`", async (): Promise<void> => {
+		const dismiss = jest.fn();
+		render(<NoDevtoolsErrorBar dismiss={dismiss} retrySearch={(): void => {}} />);
+
+		const dismissButton = await screen.findByRole("button"); // Dismiss button is first button rendered
+		await userEvent.click(dismissButton);
+		expect(dismiss).toHaveBeenCalled();
+	});
+
+	it("Clicking retry button invokes `retrySearch`", async (): Promise<void> => {
+		const retrySearch = jest.fn();
+		render(<NoDevtoolsErrorBar dismiss={(): void => {}} retrySearch={retrySearch} />);
+
+		const retrySearchButton = await screen.findByTestId("retry-search-button");
+		await userEvent.click(retrySearchButton);
+		expect(retrySearch).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
This is the only component using the legacy fluentui react package. Hoping to isolate it from the other components so we don't add more imports from this package.

This will also make it easier for us to refactor in the future.

Also adds a linter rule to prevent future imports from `@fluentui/react`, and adds simple component tests.