### PR TITLE
refactor(tree): tweak sequence test helpers

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
@@ -32,6 +32,7 @@ export {
 	HasReattachFields,
 	CellSpanningMark,
 	CellId,
+	CellTargetingMark,
 	HasLineage,
 } from "./format";
 export {

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -481,7 +481,7 @@ describe("SequenceField - Compose", () => {
 		const insert = Change.insert(0, 1, 2);
 		// TODO: test with merge-right policy as well
 		const expected = [
-			Mark.insert([{ type, value: 2 }], brand(2), { revision: tag2 }),
+			Mark.insert([{ type, value: 2 }], { localId: brand(2), revision: tag2 }),
 			Mark.delete(3, brand(0), { revision: tag1 }),
 		];
 		const actual = shallowCompose([tagChange(deletion, tag1), tagChange(insert, tag2)]);
@@ -829,8 +829,8 @@ describe("SequenceField - Compose", () => {
 		const move2 = Change.move(0, 1, 1);
 		const expected = [
 			{ count: 1 },
-			Mark.moveIn(1, brand(0), { revision: tag2 }),
-			Mark.moveOut(1, brand(0), { revision: tag2 }),
+			Mark.moveIn(1, { localId: brand(0), revision: tag2 }),
+			Mark.moveOut(1, { localId: brand(0), revision: tag2 }),
 		];
 		const actual = shallowCompose([tagChange(move1, tag1), tagChange(move2, tag2)]);
 		assert.deepEqual(actual, expected);
@@ -840,8 +840,8 @@ describe("SequenceField - Compose", () => {
 		const move1 = Change.move(0, 1, 1);
 		const move2 = Change.move(1, 1, 0);
 		const expected = [
-			Mark.moveIn(1, brand(0), { revision: tag2 }),
-			Mark.moveOut(1, brand(0), { revision: tag2 }),
+			Mark.moveIn(1, { localId: brand(0), revision: tag2 }),
+			Mark.moveOut(1, { localId: brand(0), revision: tag2 }),
 		];
 		const actual = shallowCompose([tagChange(move1, tag1), tagChange(move2, tag2)]);
 		assert.deepEqual(actual, expected);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -94,12 +94,12 @@ describe("SequenceField - MarkListFactory", () => {
 
 	it("Can merge three adjacent moves ", () => {
 		const factory = new SF.MarkListFactory();
-		const moveOut1: SF.Detach = { type: "MoveOut", id: brand(0), count: 1 };
-		const moveOut2: SF.Detach = { type: "MoveOut", id: brand(1), count: 1 };
-		const moveOut3: SF.Detach = { type: "MoveOut", id: brand(2), count: 1 };
-		const moveIn1: SF.Mark = { type: "MoveIn", id: brand(0), count: 1 };
-		const moveIn2: SF.Mark = { type: "MoveIn", id: brand(1), count: 1 };
-		const moveIn3: SF.Mark = { type: "MoveIn", id: brand(2), count: 1 };
+		const moveOut1 = Mark.moveOut(1, brand(0));
+		const moveOut2 = Mark.moveOut(1, brand(1));
+		const moveOut3 = Mark.moveOut(1, brand(2));
+		const moveIn1 = Mark.moveIn(1, brand(0));
+		const moveIn2 = Mark.moveIn(1, brand(1));
+		const moveIn3 = Mark.moveIn(1, brand(2));
 		factory.pushContent(moveOut1);
 		factory.pushContent(moveOut2);
 		factory.pushContent(moveOut3);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -270,11 +270,11 @@ describe("SequenceField - Rebase", () => {
 		// Deletes --E-G
 		const expected = [
 			{ count: 2 },
-			Mark.delete(1, brand(0), { cellId: { revision: tag1, localId: brand(1) } }),
+			Mark.onEmptyCell({ revision: tag1, localId: brand(1) }, Mark.delete(1, brand(0))),
 			Mark.delete(1, brand(1)),
-			Mark.delete(1, brand(2), { cellId: { revision: tag1, localId: brand(2) } }),
+			Mark.onEmptyCell({ revision: tag1, localId: brand(2) }, Mark.delete(1, brand(2))),
 			Mark.delete(1, brand(3)),
-			Mark.delete(1, brand(4), { cellId: { revision: tag1, localId: brand(3) } }),
+			Mark.onEmptyCell({ revision: tag1, localId: brand(3) }, Mark.delete(1, brand(4))),
 		];
 		checkDeltaEquality(actual, expected);
 	});
@@ -318,23 +318,25 @@ describe("SequenceField - Rebase", () => {
 			Mark.moveIn(1, brand(3)),
 			Mark.moveIn(1, brand(4), { isSrcConflicted: true }),
 			{ count: 2 },
-			Mark.moveOut(1, brand(0), {
-				cellId: {
+			Mark.onEmptyCell(
+				{
 					revision: tag1,
 					localId: brand(1),
 					lineage: [{ revision: tag1, id: brand(0), count: 1, offset: 1 }],
 				},
-			}),
+				Mark.moveOut(1, brand(0)),
+			),
 			Mark.moveOut(1, brand(1)),
-			Mark.moveOut(1, brand(2), { cellId: { revision: tag1, localId: brand(2) } }),
+			Mark.onEmptyCell({ revision: tag1, localId: brand(2) }, Mark.moveOut(1, brand(2))),
 			Mark.moveOut(1, brand(3)),
-			Mark.moveOut(1, brand(4), {
-				cellId: {
+			Mark.onEmptyCell(
+				{
 					revision: tag1,
 					localId: brand(3),
 					lineage: [{ revision: tag1, id: brand(4), count: 1, offset: 0 }],
 				},
-			}),
+				Mark.moveOut(1, brand(4)),
+			),
 		];
 		assert.deepEqual(actual, expected);
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -323,7 +323,7 @@ describe("SequenceField - toDelta", () => {
 		const cellId = { revision: tag1, localId: brand<ChangesetLocalId>(0) };
 
 		it("delete", () => {
-			const deletion = [Mark.delete(2, brand(0), { cellId })];
+			const deletion = [Mark.onEmptyCell(cellId, Mark.delete(2, brand(0)))];
 
 			const actual = toDelta(deletion);
 			const expected: Delta.MarkList = [];
@@ -342,7 +342,7 @@ describe("SequenceField - toDelta", () => {
 			const move = [
 				Mark.moveIn(1, brand(0), { isSrcConflicted: true }),
 				{ count: 1 },
-				Mark.moveOut(1, brand(0), { cellId }),
+				Mark.onEmptyCell(cellId, Mark.moveOut(1, brand(0))),
 			];
 
 			const actual = toDelta(move);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -193,7 +193,7 @@ function createModifyDetachedChangeset<TNodeChange>(
 }
 
 /**
- * @param countOrContent - The content to revive.
+ * @param countOrContent - The content to insert.
  * If a number is passed, that many dummy nodes will be generated.
  * @param cellId - The first cell to insert the content into (potentially includes lineage information).
  * Also defines the ChangeAtomId to associate with the mark.

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -192,31 +192,45 @@ function createModifyDetachedChangeset<TNodeChange>(
 	return changeset;
 }
 
-export function createInsertMark<TChange = never>(
+/**
+ * @param countOrContent - The content to revive.
+ * If a number is passed, that many dummy nodes will be generated.
+ * @param cellId - The first cell to insert the content into (potentially includes lineage information).
+ * Also defines the ChangeAtomId to associate with the mark.
+ * @param overrides - Any additional properties to add to the mark.
+ */
+function createInsertMark<TChange = never>(
 	countOrContent: number | JsonableTree[],
-	id: ChangesetLocalId | SF.CellId,
+	cellId: ChangesetLocalId | SF.CellId,
 	overrides?: Partial<SF.Insert<TChange>>,
 ): SF.Insert<TChange> {
 	const content = Array.isArray(countOrContent)
 		? countOrContent
 		: generateJsonables(countOrContent);
-	const cellId: SF.CellId = typeof id === "object" ? id : { localId: id };
+	const cellIdObject: SF.CellId = typeof cellId === "object" ? cellId : { localId: cellId };
 	const mark: SF.Insert<TChange> = {
 		type: "Insert",
 		content,
-		id: cellId.localId,
+		id: cellIdObject.localId,
 	};
-	if (cellId.revision !== undefined) {
-		mark.revision = cellId.revision;
+	if (cellIdObject.revision !== undefined) {
+		mark.revision = cellIdObject.revision;
 	}
-	const withOverrides: SF.Insert<TChange> = {
-		...mark,
-		...overrides,
-	};
-	return withOverrides;
+	if (cellIdObject.lineage !== undefined) {
+		mark.lineage = cellIdObject.lineage;
+	}
+	return { ...mark, ...overrides };
 }
 
-export function createReviveMark<TChange = never>(
+/**
+ * @param countOrContent - The content to revive.
+ * If a number is passed, that many dummy nodes will be generated.
+ * @param cellId - The first cell to revive content into.
+ * If undefined, the revive targets populated cells and is therefore muted.
+ * @param overrides - Any additional properties to add to the mark.
+ * Use this to give the mark a `RevisionTag`
+ */
+function createReviveMark<TChange = never>(
 	countOrContent: number | ITreeCursorSynchronous[],
 	cellId?: SF.CellId,
 	overrides?: Partial<SF.Revive<TChange>>,
@@ -232,19 +246,21 @@ export function createReviveMark<TChange = never>(
 	if (cellId !== undefined) {
 		mark.cellId = cellId;
 	}
-	const withOverrides: SF.Revive<TChange> = {
-		...mark,
-		...overrides,
-	};
-	return withOverrides;
+	return { ...mark, ...overrides };
 }
 
-export function createDeleteMark<TChange = never>(
+/**
+ * @param count - The number of nodes to delete.
+ * @param markId - The id to associate with the mark.
+ * Defines how later edits refer the emptied cells.
+ * @param overrides - Any additional properties to add to the mark.
+ */
+function createDeleteMark<TChange = never>(
 	count: number,
-	id: ChangesetLocalId | ChangeAtomId,
+	markId: ChangesetLocalId | ChangeAtomId,
 	overrides?: Partial<SF.Delete<TChange>>,
 ): SF.Delete<TChange> {
-	const cellId: ChangeAtomId = typeof id === "object" ? id : { localId: id };
+	const cellId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
 	const mark: SF.Delete<TChange> = {
 		type: "Delete",
 		count,
@@ -253,95 +269,131 @@ export function createDeleteMark<TChange = never>(
 	if (cellId.revision !== undefined) {
 		mark.revision = cellId.revision;
 	}
-	const withOverrides: SF.Delete<TChange> = {
-		...mark,
-		...overrides,
-	};
-	return withOverrides;
+	return { ...mark, ...overrides };
 }
 
-export function createMoveOutMark<TChange = never>(
+/**
+ * @param count - The number of nodes to move out.
+ * @param markId - The id to associate with the mark.
+ * Defines how later edits refer the emptied cells.
+ * @param overrides - Any additional properties to add to the mark.
+ */
+function createMoveOutMark<TChange = never>(
 	count: number,
-	id: ChangesetLocalId,
+	markId: ChangesetLocalId | ChangeAtomId,
 	overrides?: Partial<SF.MoveOut<TChange>>,
 ): SF.MoveOut<TChange> {
+	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
 	const mark: SF.MoveOut<TChange> = {
 		type: "MoveOut",
 		count,
-		id,
-		...overrides,
+		id: atomId.localId,
 	};
-	return mark;
+	if (atomId.revision !== undefined) {
+		mark.revision = atomId.revision;
+	}
+	return { ...mark, ...overrides };
 }
 
-export function createMoveInMark(
+/**
+ * @param count - The number of nodes moved in.
+ * @param cellId - The first cell to move the content into (potentially includes lineage information).
+ * Also defines the ChangeAtomId to associate with the mark.
+ * @param overrides - Any additional properties to add to the mark.
+ */
+function createMoveInMark(
 	count: number,
-	id: ChangesetLocalId | ChangeAtomId,
+	cellId: ChangesetLocalId | SF.CellId,
 	overrides?: Partial<SF.MoveIn>,
 ): SF.MoveIn {
-	const cellId: ChangeAtomId = typeof id === "object" ? id : { localId: id };
+	const cellIdObject: SF.CellId = typeof cellId === "object" ? cellId : { localId: cellId };
 	const mark: SF.MoveIn = {
 		type: "MoveIn",
-		id: cellId.localId,
+		id: cellIdObject.localId,
 		count,
 	};
-	if (cellId.revision !== undefined) {
-		mark.revision = cellId.revision;
+	if (cellIdObject.revision !== undefined) {
+		mark.revision = cellIdObject.revision;
 	}
-	const withOverrides: SF.MoveIn = {
-		...mark,
-		...overrides,
-	};
-	return withOverrides;
+	if (cellIdObject.lineage !== undefined) {
+		mark.lineage = cellIdObject.lineage;
+	}
+	return { ...mark, ...overrides };
 }
 
-export function createReturnFromMark<TChange = never>(
+/**
+ * @param count - The number of nodes to be detached.
+ * @param markId - The id to associate with the mark.
+ * Defines how later edits refer the emptied cells.
+ * @param overrides - Any additional properties to add to the mark.
+ */
+function createReturnFromMark<TChange = never>(
 	count: number,
-	id: ChangesetLocalId,
+	markId: ChangesetLocalId | ChangeAtomId,
 	overrides?: Partial<SF.ReturnFrom<TChange>>,
 ): SF.ReturnFrom<TChange> {
+	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
 	const mark: SF.ReturnFrom<TChange> = {
 		type: "ReturnFrom",
 		count,
-		id,
-		...overrides,
+		id: atomId.localId,
 	};
-	return mark;
+	if (atomId.revision !== undefined) {
+		mark.revision = atomId.revision;
+	}
+	return { ...mark, ...overrides };
 }
 
-export function createReturnToMark(
+/**
+ * @param count - The number of nodes to attach.
+ * @param markId - The id to associate with the mark.
+ * @param cellId - The cell to return the nodes to.
+ * If undefined, the mark targets populated cells and is therefore muted.
+ * @param overrides - Any additional properties to add to the mark.
+ */
+function createReturnToMark(
 	count: number,
-	id: ChangesetLocalId | ChangeAtomId,
+	markId: ChangesetLocalId | ChangeAtomId,
+	cellId?: SF.CellId,
 	overrides?: Partial<SF.ReturnTo>,
 ): SF.ReturnTo {
-	const cellId: ChangeAtomId = typeof id === "object" ? id : { localId: id };
+	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
 	const mark: SF.ReturnTo = {
 		type: "ReturnTo",
-		id: cellId.localId,
+		id: atomId.localId,
 		count,
 	};
-	if (cellId.revision !== undefined) {
-		mark.revision = cellId.revision;
+	if (cellId !== undefined) {
+		mark.cellId = cellId;
 	}
-	const withOverrides: SF.ReturnTo = {
-		...mark,
-		...overrides,
-	};
-	return withOverrides;
+	if (atomId.revision !== undefined) {
+		mark.revision = atomId.revision;
+	}
+	return { ...mark, ...overrides };
 }
 
-export function createModifyMark<TChange>(changes: TChange, id?: SF.CellId): SF.Modify<TChange> {
+/**
+ * @param changes - The changes to apply to the node.
+ * @param cellId - Describes the cell that the target node used to reside in. Used when the target node is removed.
+ */
+function createModifyMark<TChange>(changes: TChange, cellId?: SF.CellId): SF.Modify<TChange> {
 	const mark: SF.Modify<TChange> = {
 		type: "Modify",
 		changes,
 	};
-	if (id !== undefined) {
-		mark.cellId = id;
+	if (cellId !== undefined) {
+		mark.cellId = cellId;
 	}
 	return mark;
 }
 
+function overrideCellId<TMark extends SF.CellTargetingMark>(cellId: SF.CellId, mark: TMark): TMark {
+	mark.cellId = cellId;
+	return mark;
+}
+
 export const MarkMaker = {
+	onEmptyCell: overrideCellId,
 	insert: createInsertMark,
 	revive: createReviveMark,
 	delete: createDeleteMark,


### PR DESCRIPTION
Tweaks and documents the API for the sequence test helpers. Most notably introduces `Mark.onEmptyCell` to describe a mark that targets empty cells when it typically wouldn't (e.g., a "delete" mark).

Updates some tests to avoid using the override feature when not strictly necessary.

Fixes an invert test (input and expectations were wrong).