### PR TITLE
refactor(tree): Tidy sequence format

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -14,16 +14,7 @@ import {
 	IdAllocator,
 	RevisionMetadataSource,
 } from "../modular-schema";
-import {
-	Changeset,
-	Mark,
-	MarkList,
-	EmptyInputCellMark,
-	Modify,
-	MoveId,
-	NoopMarkType,
-	CellId,
-} from "./format";
+import { Changeset, Mark, MarkList, Modify, MoveId, NoopMarkType, CellId } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import { MarkQueue } from "./markQueue";
 import {
@@ -58,10 +49,10 @@ import {
 	markEmptiesCells,
 	splitMark,
 	markIsTransient,
-	GenerativeMark,
 	isGenerativeMark,
 	areOverlappingIdRanges,
 } from "./utils";
+import { GenerativeMark, EmptyInputCellMark } from "./helperTypes";
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/helperTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/helperTypes.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	CellId,
+	CellTargetingMark,
+	Delete,
+	Detach,
+	Insert,
+	Mark,
+	Modify,
+	MoveOut,
+	MovePlaceholder,
+	NewAttach,
+	NoopMark,
+	ReturnFrom,
+	ReturnTo,
+	Revive,
+	Transient,
+} from "./format";
+
+/**
+ * A mark which extends `CellTargetingMark`.
+ */
+export type ExistingCellMark<TNodeChange> =
+	| NoopMark
+	| MovePlaceholder<TNodeChange>
+	| Delete<TNodeChange>
+	| MoveOut<TNodeChange>
+	| ReturnFrom<TNodeChange>
+	| Modify<TNodeChange>
+	| Revive<TNodeChange>
+	| ReturnTo;
+
+export type EmptyInputCellMark<TNodeChange> =
+	| NewAttach<TNodeChange>
+	| (DetachedCellMark & ExistingCellMark<TNodeChange>);
+
+/**
+ * A mark that spans one or more cells.
+ * The spanned cells may be populated (e.g., "Delete") or not (e.g., "Revive").
+ */
+export type CellSpanningMark<TNodeChange> = Exclude<Mark<TNodeChange>, NewAttach<TNodeChange>>;
+
+export interface DetachedCellMark extends CellTargetingMark {
+	cellId: CellId;
+}
+
+export type GenerativeMark<TNodeChange> = Insert<TNodeChange> | Revive<TNodeChange>;
+
+export type TransientMark<TNodeChange> = GenerativeMark<TNodeChange> & Transient;
+
+export type EmptyOutputCellMark<TNodeChange> = TransientMark<TNodeChange> | Detach<TNodeChange>;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
@@ -22,7 +22,6 @@ export {
 	NodeCount,
 	MoveId,
 	ProtoNode,
-	RangeType,
 	Reattach,
 	ReturnFrom,
 	ReturnTo,
@@ -30,7 +29,6 @@ export {
 	NoopMark,
 	LineageEvent,
 	HasReattachFields,
-	CellSpanningMark,
 	CellId,
 	HasLineage,
 } from "./format";

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -39,11 +39,9 @@ import {
 	Changeset,
 	Mark,
 	MarkList,
-	ExistingCellMark,
 	NoopMark,
 	MoveId,
 	Modify,
-	EmptyInputCellMark,
 	NoopMarkType,
 	HasLineage,
 } from "./format";
@@ -58,6 +56,7 @@ import {
 	PairedMarkUpdate,
 } from "./moveEffectTable";
 import { MarkQueue } from "./markQueue";
+import { ExistingCellMark, EmptyInputCellMark } from "./helperTypes";
 
 /**
  * Rebases `change` over `base` assuming they both apply to the same initial state.

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeHandler.ts
@@ -4,11 +4,12 @@
  */
 
 import { FieldChangeHandler } from "../modular-schema";
-import { Changeset, isEmpty } from "./format";
+import { Changeset } from "./format";
 import { sequenceFieldChangeRebaser } from "./sequenceFieldChangeRebaser";
 import { sequenceFieldChangeCodecFactory } from "./sequenceFieldChangeEncoder";
 import { SequenceFieldEditor, sequenceFieldEditor } from "./sequenceFieldEditor";
 import { sequenceFieldToDelta } from "./sequenceFieldToDelta";
+import { isEmpty } from "./utils";
 
 export type SequenceFieldChangeHandler = FieldChangeHandler<Changeset, SequenceFieldEditor>;
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -35,17 +35,25 @@ import {
 	MoveId,
 	Revive,
 	Delete,
-	EmptyInputCellMark,
-	ExistingCellMark,
 	NoopMarkType,
 	Transient,
-	DetachedCellMark,
 	CellTargetingMark,
 	CellId,
 	HasReattachFields,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import { isMoveMark, MoveEffectTable } from "./moveEffectTable";
+import {
+	GenerativeMark,
+	TransientMark,
+	ExistingCellMark,
+	EmptyInputCellMark,
+	DetachedCellMark,
+} from "./helperTypes";
+
+export function isEmpty<T>(change: Changeset<T>): boolean {
+	return change.length === 0;
+}
 
 export function isModify<TNodeChange>(mark: Mark<TNodeChange>): mark is Modify<TNodeChange> {
 	return mark.type === "Modify";
@@ -54,12 +62,6 @@ export function isModify<TNodeChange>(mark: Mark<TNodeChange>): mark is Modify<T
 export function isNewAttach<TNodeChange>(mark: Mark<TNodeChange>): mark is NewAttach<TNodeChange> {
 	return mark.type === "Insert" || mark.type === "MoveIn";
 }
-
-export type GenerativeMark<TNodeChange> = Insert<TNodeChange> | Revive<TNodeChange>;
-
-export type TransientMark<TNodeChange> = GenerativeMark<TNodeChange> & Transient;
-
-export type EmptyOutputCellMark<TNodeChange> = TransientMark<TNodeChange> | Detach<TNodeChange>;
 
 export function isGenerativeMark<TNodeChange>(
 	mark: Mark<TNodeChange>,


### PR DESCRIPTION
Separates format types that actually describe the format from types that are merely helpers over the former.
Also fixes a set of missing fields in the `LineageEvent` persistence schema.

This paves the way for a true refactor by making it clearer which parts of the format will be impacted and how. It also makes it easier to tackle [AB#4259](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4259) in the future.