### PR TITLE
tree2: Fix root schema handling

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1360,9 +1360,6 @@ export type NameFromBranded<T extends BrandedType<any, string>> = T extends Bran
 export type NestedMap<Key1, Key2, Value> = Map<Key1, Map<Key2, Value>>;
 
 // @alpha
-export const neverTree: TreeStoredSchema;
-
-// @alpha
 export type NewFieldContent = ITreeCursor | readonly ITreeCursor[] | ContextuallyTypedFieldData;
 
 // @alpha (undocumented)

--- a/experimental/dds/tree2/docs/schema2.md
+++ b/experimental/dds/tree2/docs/schema2.md
@@ -98,9 +98,9 @@ Workstream 1
 Workstream 2
 
 1. (Done) Replace existing usages of global field keys with string constants.
-2. Implement alternative design for root field.
-3. Remove support for global fields.
-4. Cleanup code now that it can assume only local fields (ex: extra objects to separate local and global can be renamed or removed).
+2. (Done) Implement alternative design for root field.
+3. (Done) Remove support for global fields.
+4. (Done) Cleanup code now that it can assume only local fields (ex: extra objects to separate local and global can be renamed or removed).
 
 Workstream 3
 

--- a/experimental/dds/tree2/src/core/forest/editableForest.ts
+++ b/experimental/dds/tree2/src/core/forest/editableForest.ts
@@ -63,7 +63,7 @@ export function isFieldLocation(range: FieldLocation | DetachedField): range is 
 }
 
 /**
- * Wrapper around DetachedField that can be detected at runtime.
+ * Location of a field within a tree that is not a detached/root field.
  * @alpha
  */
 export interface FieldLocation {

--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -189,8 +189,6 @@ export interface TreeStoredSchema {
 	 * Usually `FieldKind.Value` should NOT be used here
 	 * since no nodes can ever be in schema are in schema if you use `FieldKind.Value` here
 	 * (that would require infinite children).
-	 * This pattern, which produces a schema which can never be met, is used by {@link neverTree},
-	 * and can be useful in special cases (like a default stored schema when none is specified).
 	 */
 	readonly mapFields: FieldStoredSchema;
 

--- a/experimental/dds/tree2/src/core/tree/cursor.ts
+++ b/experimental/dds/tree2/src/core/tree/cursor.ts
@@ -38,6 +38,7 @@ export interface ITreeCursor {
 	 * Marks this object as a cursor.
 	 */
 	readonly [CursorMarker]: true;
+
 	/**
 	 * What kind of place the cursor is at.
 	 * Determines which operations are allowed.

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultSchema.ts
@@ -3,14 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { fieldSchema, emptyMap, ValueSchema, TreeStoredSchema } from "../../core";
+import { fieldSchema } from "../../core";
 import { FullSchemaPolicy } from "../modular-schema";
-import { value, forbidden, fieldKinds } from "./defaultFieldKinds";
-
-/**
- * FieldStoredSchema which is impossible for any data to be in schema with.
- */
-export const neverField = fieldSchema(value, []);
+import { forbidden, fieldKinds } from "./defaultFieldKinds";
 
 /**
  * FieldStoredSchema which is impossible to put anything in.
@@ -19,21 +14,7 @@ export const neverField = fieldSchema(value, []);
 export const emptyField = fieldSchema(forbidden, []);
 
 /**
- * TreeStoredSchema which is impossible for any data to be in schema with.
- * @alpha
- */
-// TODO: remove need for this.
-export const neverTree: TreeStoredSchema = {
-	structFields: emptyMap,
-	mapFields: neverField,
-	value: ValueSchema.Nothing,
-};
-
-/**
- * FullSchemaPolicy the default field kinds, empty default fields and neverTree for the default tree schema.
- *
- * This requires new node types to have explicit stored schema to exist in documents,
- * and allows adding new global fields along with their schema at any point.
+ * FullSchemaPolicy with the default field kinds.
  * @alpha
  */
 export const defaultSchemaPolicy: FullSchemaPolicy = {

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
@@ -24,4 +24,4 @@ export {
 	SequenceFieldEditBuilder,
 } from "./defaultChangeFamily";
 
-export { defaultSchemaPolicy, emptyField, neverField, neverTree } from "./defaultSchema";
+export { defaultSchemaPolicy, emptyField } from "./defaultSchema";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -198,7 +198,11 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 			if (key === rootFieldKey) {
 				fieldSchema = this.context.schema.rootFieldSchema;
 			} else {
-				// Treat all detached sequences other than the special default root as sequences of any.
+				// All fields (in the editable tree API) have a schema.
+				// Since currently there is no known schema for detached sequences other than the special default root:
+				// give all other detached fields a schema of sequence of any.
+				// That schema is the only one that is safe since its the only field schema that allows any possible field content.
+				//
 				// TODO:
 				// if any of the following are done this schema will need to be more specific:
 				// 1. Editing APIs start exposing user created detached sequences.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -19,12 +19,13 @@ import {
 	anchorSlot,
 	AnchorNode,
 	inCursorField,
+	rootFieldKey,
 } from "../../core";
 import { brand, fail } from "../../util";
 import { FieldKind } from "../modular-schema";
 import { getFieldKind, getFieldSchema, typeNameSymbol, valueSymbol } from "../contextuallyTyped";
 import { LocalNodeKey } from "../node-key";
-import { neverTree } from "../default-field-kinds";
+import { FieldKinds } from "../default-field-kinds";
 import { AdaptingProxyHandler, adaptWithProxy, getStableNodeKey } from "./utilities";
 import { ProxyContext } from "./editableTreeContext";
 import {
@@ -182,20 +183,43 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 
 	public get parentField(): { readonly parent: EditableField; readonly index: number } {
 		const cursor = this.cursor;
-		const index = cursor.fieldIndex;
+		const index = this.anchorNode.parentIndex;
+		assert(this.cursor.fieldIndex === index, "mismatched indexes");
+		const key = this.anchorNode.parentField;
+
 		cursor.exitNode();
-		const key = cursor.getFieldKey();
-		// TODO: make this work properly for root
-		cursor.exitField();
-		const parentType = cursor.type;
-		cursor.enterField(key);
-		// TODO: this should error if schema is not found.
-		// For now this suppresses the error to work around root handling issues.
-		const fieldSchema = getFieldSchema(
-			key,
-			this.context.schema.treeSchema.get(parentType) ?? neverTree,
-			// fail("requested schema that does not exist"),
-		);
+		assert(key === cursor.getFieldKey(), "mismatched keys");
+		let fieldSchema: FieldStoredSchema;
+
+		// Check if the current node is in a detached sequence.
+		if (this.anchorNode.parent === undefined) {
+			// Parent field is a detached sequence, and thus needs special handling for its schema.
+			// eslint-disable-next-line unicorn/prefer-ternary
+			if (key === rootFieldKey) {
+				fieldSchema = this.context.schema.rootFieldSchema;
+			} else {
+				// Treat all detached sequences other than the special default root as sequences of any.
+				// TODO:
+				// if any of the following are done this schema will need to be more specific:
+				// 1. Editing APIs start exposing user created detached sequences.
+				// 2. Remove (and its inverse) start working on subsequences or fields contents (like everything in a sequence or optional field) and not just single nodes.
+				// 3. Possibly other unknown cases.
+				// Additionally this approach makes it possible for a user to take an EditableTree node, get its parent, check its schema, down cast based on that, then edit that detached field (ex: removing the node in it).
+				// This MIGHT work properly with existing merge resolution logic (it must keep client in sync and be unable to violate schema), but this either needs robust testing or to be explicitly banned (error before s3ending the op).
+				// Issues like replacing a node in the a removed sequenced then undoing the remove could easily violate schema if not everything works exactly right!
+				fieldSchema = { kind: FieldKinds.sequence };
+			}
+		} else {
+			cursor.exitField();
+			const parentType = cursor.type;
+			cursor.enterField(key);
+			fieldSchema = getFieldSchema(
+				key,
+				this.context.schema.treeSchema.get(parentType) ??
+					fail("requested schema that does not exist"),
+			);
+		}
+
 		const proxifiedField = makeField(this.context, fieldSchema, this.cursor);
 		this.cursor.enterNode(index);
 

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -196,8 +196,6 @@ export {
 	SequenceFieldEditBuilder,
 	defaultSchemaPolicy,
 	emptyField,
-	neverField,
-	neverTree,
 } from "./default-field-kinds";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/view.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/view.ts
@@ -17,7 +17,6 @@ import {
 	NamedTreeSchema,
 	TreeTypeSet,
 } from "../../core";
-import { neverTree } from "../default-field-kinds";
 import { FieldKind, FullSchemaPolicy } from "./fieldKind";
 import { allowsRepoSuperset, isNeverTree } from "./comparison";
 
@@ -99,13 +98,7 @@ export class ViewSchema {
 		// and its impossible for an adapter to be correctly implemented if its output type is never
 		// (unless its input is also never).
 		for (const adapter of this.adapters?.tree ?? []) {
-			if (
-				isNeverTree(
-					this.policy,
-					this.schema,
-					this.schema.treeSchema.get(adapter.output) ?? neverTree,
-				)
-			) {
+			if (isNeverTree(this.policy, this.schema, this.schema.treeSchema.get(adapter.output))) {
 				fail("tree adapter for stored adapter.output should not be never");
 			}
 		}

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -128,7 +128,6 @@ export {
 	ChangesetLocalId,
 	emptyField,
 	IdAllocator,
-	neverTree,
 	ModularChangeset,
 	EditDescription,
 	FieldChangeHandler,

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -54,9 +54,7 @@ describe("Schema Comparison", () => {
 
 	/**
 	 * TreeStoredSchema which is impossible for any data to be in schema with.
-	 * @alpha
 	 */
-	// TODO: remove need for this.
 	const neverTree: TreeStoredSchema = {
 		structFields: emptyMap,
 		mapFields: neverField,

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -28,13 +28,7 @@ import {
 	treeSchema,
 } from "../../../core";
 import { brand } from "../../../util";
-import {
-	defaultSchemaPolicy,
-	emptyField,
-	FieldKinds,
-	neverField,
-	neverTree,
-} from "../../../feature-libraries";
+import { defaultSchemaPolicy, emptyField, FieldKinds } from "../../../feature-libraries";
 
 describe("Schema Comparison", () => {
 	/**
@@ -51,6 +45,22 @@ describe("Schema Comparison", () => {
 		structFields: emptyMap,
 		mapFields: anyField,
 		value: ValueSchema.Serializable,
+	};
+
+	/**
+	 * FieldStoredSchema which is impossible for any data to be in schema with.
+	 */
+	const neverField = fieldSchema(FieldKinds.value, []);
+
+	/**
+	 * TreeStoredSchema which is impossible for any data to be in schema with.
+	 * @alpha
+	 */
+	// TODO: remove need for this.
+	const neverTree: TreeStoredSchema = {
+		structFields: emptyMap,
+		mapFields: neverField,
+		value: ValueSchema.Nothing,
 	};
 
 	const neverTree2: TreeStoredSchema = {


### PR DESCRIPTION
## Description

Fix incorrect handling of detached field schema in EditableTree when accessing parent fields.

Also removes neverTree and neverField schema which are no longer used, and does some misc small cleanups.


## Breaking Changes

Remove "neverTree" schema from public API.
There arn't good use cases for it, and it was mainly exported since it was linked in documentation that no longer mentions it.
If needed anyone can trivially create their own equivalent schema.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

