### PR TITLE
ci(sync-branch): Check out main branch by default

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           fetch-depth: "0" # all history
           persist-credentials: false
+          # always check out the main branch by default. Otherwise the starting branch is based on the
+          # triggering event which can seem unpredictable when the workflow is triggered in different branches.
+          ref: main
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # ratchet:pnpm/action-setup@v2
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:


### PR DESCRIPTION
In GitHub Actions, the starting branch when the repo is cloned is based on the triggering event, which can seem unpredictable when the workflow is triggered in different branches. This change normalizes the workflow so that it always checks out the main branch to start.

This will fix the broken runs in the `next` branch.