### PR TITLE
quorumProposal change to first-write-wins

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -224,6 +224,7 @@ export interface IContainerEvents extends IEvent {
     (event: "readonly", listener: (readonly: boolean) => void): void;
     (event: "connected", listener: (clientId: string) => void): any;
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: ISequencedProposal) => void): any;
+    (event: "approveProposal", listener: (sequenceNumber: number | undefined, key: string, codeDetails: IFluidCodeDetails) => void): any;
     // @deprecated (undocumented)
     (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void): any;
     (event: "disconnected", listener: () => void): any;

--- a/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
@@ -360,58 +360,27 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		});
 
 		this._anyQuorumProposalSeenP = new Promise<void>((resolve) => {
-			// Here we want to watch the quorum and resolve on the first sequenced proposal.
-			// This is also awkward because the only clean eventing is on the QuorumProposals itself, or the Container.
-			// For now, spying on the deltaManager and using insider knowledge about how the QuorumProposals works.
-			// TODO: Consider if there is any better way to watch this happen
-			const watchForQuorumProposal = (op: ISequencedDocumentMessage) => {
-				if (
-					op.type === MessageType.Propose &&
-					(op.contents as { key?: unknown }).key === "code"
-				) {
-					// TODO Is this also where I want to emit an internal state event of the proposal coming in to help with abort flows?
-					// Or maybe set that up in ensureQuorumCodeDetails().
-					this.context.deltaManager.off("op", watchForQuorumProposal);
-					this._anyQuorumProposalSeen = true;
-					console.log("Resolving this._anyQuorumProposalSeenP");
-					resolve();
-				}
+			const container = await this._containerP;
+			const watchForCodeDetailsProposed = () => {
+				container.off("codeDetailsProposed", watchForCodeDetailsProposed);
+				this._anyQuorumProposalSeen = true;
+				console.log("Resolving this._anyQuorumProposalSeenP");
+				resolve();
 			};
-			// TODO: Consider if watching container.on("codeDetailsProposed", ...) might be more appropriate.
-			this.context.deltaManager.on("op", watchForQuorumProposal);
+			
+			container.on("codeDetailsProposed", watchForCodeDetailsProposed);
 		});
 
 		this._quorumApprovalCompleteP = new Promise<void>((resolve) => {
-			// Here we want to watch the quorum and track all proposals, and resolve on the MSN advancing past the last one's sequence number.
-			// This is even more awkward than the proposal tracking, because there is no event for proposal acceptance on the Container, only on the QuorumProposals.
-			// Again for now, spying on the deltaManager and using insider knowledge.
-			// TODO: Consider if there is any better way to watch this happen
-			const proposalSequenceNumbers: number[] = [];
-			const watchForLastQuorumAccept = (op: ISequencedDocumentMessage) => {
-				if (
-					op.type === MessageType.Propose &&
-					(op.contents as { key?: unknown }).key === "code"
-				) {
-					proposalSequenceNumbers.push(op.sequenceNumber);
-				}
-				if (
-					proposalSequenceNumbers.length > 0 &&
-					proposalSequenceNumbers.every(
-						(sequenceNumber) => sequenceNumber <= op.minimumSequenceNumber,
-					)
-				) {
-					this.context.deltaManager.off("op", watchForLastQuorumAccept);
-					this._quorumApprovalComplete = true;
-					console.log("Resolving this._quorumApprovalCompleteP");
-					resolve();
-				}
+			const container = await this._containerP;
+			const watchForApproveProposal = () => {
+				container.off("approveProposal", watchForApproveProposal);
+				this._quorumApprovalComplete = true;
+				console.log("Resolving this._quorumApprovalCompleteP");
+				resolve();
 			};
-			// TODO: Consider if watching container.on("codeDetailsProposed", ...) might be more appropriate.
-			// Note container.on("codeDetailsProposed", (, proposal) => { proposal.sequenceNumber })
-			// This will let us learn the sequence number of each proposal that comes in.
-			// Unfortunately no event on proposal acceptance (from the container) but we can still watch the MSN
-			// ourselves to know when we're done processing them?
-			this.context.deltaManager.on("op", watchForLastQuorumAccept);
+
+			container.on("approveProposal", watchForApproveProposal);
 		});
 
 		this._v2SummaryP = new Promise<void>((resolve) => {

--- a/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
@@ -291,6 +291,10 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		// * The summaryAcks aren't inspectable after they've been processed
 		// * The quorum eventing makes it challenging to understand state when proposals are racing.
 
+		// NOTE: awaiting container here could result in missed events since ops may be processed while waiting for the container to load
+		// TODO: consider adding asserts to verify container state after loading as outlined in Task 5058
+		const container = await this._containerP;
+
 		this._pendingP = new Promise<void>((resolve) => {
 			if (
 				this.pactMap.get(newVersionKey) !== undefined ||
@@ -360,7 +364,6 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		});
 
 		this._anyQuorumProposalSeenP = new Promise<void>((resolve) => {
-			const container = await this._containerP;
 			const watchForCodeDetailsProposed = () => {
 				container.off("codeDetailsProposed", watchForCodeDetailsProposed);
 				this._anyQuorumProposalSeen = true;
@@ -372,7 +375,6 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		});
 
 		this._quorumApprovalCompleteP = new Promise<void>((resolve) => {
-			const container = await this._containerP;
 			const watchForApproveProposal = () => {
 				container.off("approveProposal", watchForApproveProposal);
 				this._quorumApprovalComplete = true;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -142,6 +142,24 @@ export interface IContainerEvents extends IEvent {
 	);
 
 	/**
+	 * Fires when a proposal is approved
+	 *
+	 * @remarks Listener parameters:
+	 *
+	 * - `codeDetails`: The code details being proposed.
+	 *
+	 * - `sequenceNumber`: Proposal sequence number.
+	 * 
+	 * - `key`: Proposal key.
+	 *
+	 * @see {@link QuorumProposals.updateMinimumSequenceNumber}
+	 */
+	(
+		event: "approveProposal",
+		listener: (sequenceNumber: number | undefined, key: string, codeDetails: IFluidCodeDetails) => void,
+	);
+
+	/**
 	 * @deprecated No replacement API recommended.
 	 */
 	(event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1806,7 +1806,9 @@ export class Container
 						eventName: "CodeProposalNotIFluidCodeDetails",
 					});
 				}
-				this.processCodeProposal().catch((error) => {
+				this.processCodeProposal().then(() => {
+					this.emit("approveProposal", sequenceNumber, key, value);
+				}).catch((error) => {
 					const normalizedError = normalizeError(error);
 					this.close(normalizedError);
 					throw error;

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -254,15 +254,7 @@ export class QuorumProposals
 					thisProposalSequenceNumber = sequenceNumber;
 					this.stateEvents.off("localProposalSequenced", localProposalSequencedHandler);
 					this.stateEvents.off("disconnected", disconnectedHandler);
-					this.stateEvents.on("localProposalApproved", localProposalApprovedHandler);
 					this.stateEvents.on("proposalApproved", proposalApprovedHandler);
-				}
-			};
-			const localProposalApprovedHandler = (sequenceNumber: number) => {
-				// Proposals can be uniquely identified by the sequenceNumber they were assigned.
-				if (sequenceNumber === thisProposalSequenceNumber) {
-					resolve();
-					removeListeners();
 				}
 			};
 
@@ -304,7 +296,6 @@ export class QuorumProposals
 			// Convenience function to clean up our listeners.
 			const removeListeners = () => {
 				this.stateEvents.off("localProposalSequenced", localProposalSequencedHandler);
-				this.stateEvents.off("localProposalApproved", localProposalApprovedHandler);
 				this.stateEvents.off("proposalApproved", proposalApprovedHandler);
 				this.stateEvents.off("disconnected", disconnectedHandler);
 				this.stateEvents.off("disposed", disposedHandler);
@@ -398,9 +389,6 @@ export class QuorumProposals
 
 			// clear the proposals cache
 			this.proposalsSnapshotCache = undefined;
-			if (proposal.local) {
-				this.stateEvents.emit("localProposalApproved", proposal.sequenceNumber);
-			}
 		}
 	}
 


### PR DESCRIPTION
updated quorumProposal to accept first proposal
event listeners now watch for any proposal to be accepted with a specific key instead of waiting for its own proposal to resolve

TODO:
- localProposalSequenced event listener/handler may not be needed in the workflow