### PR TITLE
Fix missing colon in the workspace dep in devtools-browser-extension package.json

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -72,7 +72,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluid-example/example-utils": "workspace~",
+		"@fluid-example/example-utils": "workspace:~",
 		"@fluid-experimental/devtools": "workspace:~",
 		"@fluid-experimental/react-inputs": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41138,7 +41138,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.17.4
-      webpack: 5.88.1_webpack-cli@4.10.0
+      webpack: 5.88.1
     dev: true
 
   /terser/4.8.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10845,7 +10845,7 @@ importers:
   packages/tools/devtools/devtools-browser-extension:
     specifiers:
       '@fluentui/react': ^8.109.4
-      '@fluid-example/example-utils': workspace~
+      '@fluid-example/example-utils': workspace:~
       '@fluid-experimental/devtools': workspace:~
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-experimental/devtools-view': workspace:~


### PR DESCRIPTION
Although I think it may still works without the colon, the [doc](https://pnpm.io/workspaces) says it should be `workspace:`