### PR TITLE
Log savedOpsCount in scriptorium every 1 minute

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -194,7 +194,8 @@ data:
             "groupId": "{{ template "scriptorium.fullname" . }}",
             "checkpointBatchSize": 1,
             "checkpointTimeIntervalMsec": 1000,
-            "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }}
+            "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }},
+            "logSavedOpsTimeIntervalMs": {{ .Values.scriptorium.logSavedOpsTimeIntervalMs }}
         },
         "paparazzi": {
             "queue": "paparazziQueue"

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -76,6 +76,7 @@ scriptorium:
   name: scriptorium
   replicas: 8
   restartOnCheckpointFailure: true
+  logSavedOpsTimeIntervalMs: 60000
 
 scribe:
   name: scribe

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -41,6 +41,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	private pendingMetric: Lumber<LumberEventName.ScriptoriumProcessBatch> | undefined;
 	private readonly maxDbBatchSize: number;
 	private readonly restartOnCheckpointFailure: boolean;
+	private readonly logSavedOpsTimeIntervalMs: number;
+	private savedOpsCount: number = 0;
 
 	constructor(
 		private readonly opCollection: ICollection<any>,
@@ -51,9 +53,20 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		this.telemetryEnabled = this.providerConfig?.enableTelemetry;
 		this.maxDbBatchSize = this.providerConfig?.maxDbBatchSize ?? 1000;
 		this.restartOnCheckpointFailure = this.providerConfig?.restartOnCheckpointFailure;
+		this.logSavedOpsTimeIntervalMs = this.providerConfig?.logSavedOpsTimeIntervalMs ?? 60000;
 	}
 
 	public handler(message: IQueuedMessage) {
+		setInterval(() => {
+			if (this.savedOpsCount > 0) {
+				Lumberjack.info("Scriptorium: Ops saved to db.", {
+					savedOpsCount: this.savedOpsCount,
+					timeIntervalMs: this.logSavedOpsTimeIntervalMs,
+				});
+				this.savedOpsCount = 0;
+			}
+		}, this.logSavedOpsTimeIntervalMs);
+
 		const boxcar = extractBoxcar(message);
 
 		for (const baseMessage of boxcar.contents) {
@@ -156,11 +169,15 @@ export class ScriptoriumLambda implements IPartitionLambda {
 					const messagesBatch = messages.slice(startIndex, endIndex);
 					startIndex = endIndex;
 
-					const processP = this.processMongoCore(messagesBatch, metric?.id);
+					const processP = this.processMongoCore(messagesBatch, metric?.id).then(() => {
+						this.savedOpsCount += messagesBatch.length;
+					});
 					allProcessed.push(processP);
 				}
 			} else {
-				const processP = this.processMongoCore(messages, metric?.id);
+				const processP = this.processMongoCore(messages, metric?.id).then(() => {
+					this.savedOpsCount += messages.length;
+				});
 				allProcessed.push(processP);
 			}
 		}

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -205,7 +205,8 @@
 		"checkpointTimeIntervalMsec": 1000,
 		"enableTelemetry": true,
 		"maxDbBatchSize": 1000,
-		"restartOnCheckpointFailure": true
+		"restartOnCheckpointFailure": true,
+		"logSavedOpsTimeIntervalMs": 60000
 	},
 	"copier": {
 		"topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -42,6 +42,8 @@ export async function create(
 	const maxDbBatchSize = config.get("scriptorium:maxDbBatchSize") as number;
 	const restartOnCheckpointFailure =
 		(config.get("scriptorium:restartOnCheckpointFailure") as boolean) ?? true;
+	const logSavedOpsTimeIntervalMs =
+		(config.get("scriptorium:logSavedOpsTimeIntervalMs") as number) ?? 60000;
 
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
@@ -121,5 +123,6 @@ export async function create(
 		enableTelemetry,
 		maxDbBatchSize,
 		restartOnCheckpointFailure,
+		logSavedOpsTimeIntervalMs,
 	});
 }


### PR DESCRIPTION
## Description

RunWithRetry logs are often missing from scriptorium kusto logs, which makes it unreliable to monitor data loss situations, i.e. when ops are genuinely not saved to db by scriptorium.

Thus, adding a log to write savedOpsCount every 1 minute (configurable), which can be used to monitor data loss. Since it is emitted every 1 minute (as compared to RunWithRetry logs emitted every few milliseconds), it should be more reliable.