### PR TITLE
Stop listening to DeltaManager op event for summary heuristics

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2186,9 +2186,7 @@ export class ContainerRuntime
 					}
 			}
 
-			if (runtimeMessage || this.groupedBatchingEnabled) {
-				this.emit("op", message, runtimeMessage);
-			}
+			this.emit("op", message, runtimeMessage);
 
 			this.scheduleManager.afterOpProcessing(undefined, message);
 


### PR DESCRIPTION
Running summarizer should listen to ContainerRuntime "op" event explicitly, but this requires all ops to be passed from loader to runtime (version "2.0.0-internal.1.2.0" or later https://github.com/microsoft/FluidFramework/pull/11832).

99.9% of sessions are now running on a loader version of at least "2.0.0-internal.1.2.0".

[AB#3883](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3883)