### PR TITLE
Fix incorrect handling of detached commits in EditManager

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -89,8 +89,11 @@ export class EditManager<
 		Set<SharedTreeBranch<TEditor, TChangeset>>
 	>();
 
-	/** The sequence number of the newest commit on the trunk that has been received by all peers */
-	private minimumSequenceNumber: SeqNumber = brand(-1);
+	/**
+	 * The sequence number of the newest commit on the trunk that has been received by all peers.
+	 * Defaults to {@link minimumPossibleSequenceNumber} if no commits have been received.
+	 */
+	private minimumSequenceNumber = minimumPossibleSequenceNumber;
 
 	/**
 	 * An immutable "origin" commit singleton on which the trunk is based.
@@ -300,7 +303,7 @@ export class EditManager<
 			this.trunk.getHead() === this.trunkBase &&
 			this.peerLocalBranches.size === 0 &&
 			this.localBranch.getHead() === this.trunk.getHead() &&
-			this.minimumSequenceNumber === -1
+			this.minimumSequenceNumber === minimumPossibleSequenceNumber
 		);
 	}
 
@@ -440,6 +443,10 @@ export class EditManager<
 		sequenceNumber: SeqNumber,
 		referenceSequenceNumber: SeqNumber,
 	): void {
+		assert(
+			sequenceNumber > this.minimumSequenceNumber,
+			"Expected change sequence number to exceed the last known minimum sequence number",
+		);
 		if (newCommit.sessionId === this.localSessionId) {
 			const [firstLocalCommit] = getPathFromBase(
 				this.localBranch.getHead(),

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -269,24 +269,24 @@ describe("EditManager", () => {
 
 			it("Evicts trunk commits according to a provided minimum sequence number", () => {
 				const { manager } = editManagerFactory({});
-				for (let i = 0; i < 10; ++i) {
+				for (let i = 1; i <= 10; ++i) {
 					manager.addSequencedChange(applyLocalCommit(manager), brand(i), brand(i - 1));
 				}
 
 				assert.equal(manager.getTrunkChanges().length, 10);
 				manager.advanceMinimumSequenceNumber(brand(5));
-				assert.equal(manager.getTrunkChanges().length, 5);
+				assert.equal(manager.getTrunkChanges().length, 6);
 				manager.advanceMinimumSequenceNumber(brand(10));
-				assert.equal(manager.getTrunkChanges().length, 0);
-				for (let i = 10; i < 20; ++i) {
+				assert.equal(manager.getTrunkChanges().length, 1);
+				for (let i = 11; i <= 20; ++i) {
 					manager.addSequencedChange(applyLocalCommit(manager), brand(i), brand(i - 1));
 				}
 
-				assert.equal(manager.getTrunkChanges().length, 10);
+				assert.equal(manager.getTrunkChanges().length, 11);
 				manager.advanceMinimumSequenceNumber(brand(15));
-				assert.equal(manager.getTrunkChanges().length, 5);
+				assert.equal(manager.getTrunkChanges().length, 6);
 				manager.advanceMinimumSequenceNumber(brand(20));
-				assert.equal(manager.getTrunkChanges().length, 0);
+				assert.equal(manager.getTrunkChanges().length, 1);
 			});
 
 			it("Evicts trunk commits after but not exactly at the minimum sequence number", () => {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -1806,8 +1806,7 @@ describe("SharedTree", () => {
 				child.transaction.start();
 				pushTestValueDirect(child, "C");
 				child.transaction.commit();
-				// TODO:#4925: It should not be necessary to keep the child undisposed here.
-				parent.merge(child, false);
+				parent.merge(child);
 				assert.deepEqual(getTestValues(parent), ["A", "B", "C"]);
 			};
 			const provider = await TestTreeProvider.create(


### PR DESCRIPTION
## Description

Before a SharedTree is attached, any local commits are "round tripped" to the EditManager locally by immediately marking them as sequenced. These commits use "fake" sequence numbers that are very large negative integers. However, the EditManager expects its sequenced commits to have positive integers for the sake of trunk eviction. This caused a problem; commits submitted before attach were getting tracked as having occurred _before_ the latest known minimum sequence number, and thus when trunk eviction occurred, it considered them to already have been evicted even though they weren't yet. Essentially, an implicit invariant had been broken in the EditManager: sequenced commits must have a sequence number that is greater than the last known minimum sequence number.

This implicit invariant has been made explicit to prevent this error from happening again in the future, and the default minimum sequence number in EditManager has been aligned with the one in SharedTreeCore so that they work together.