### PR TITLE
test(tree): add sequence changeset persisted format coverage

### DIFF
--- a/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change.json
@@ -9,7 +9,7 @@
                     "tree": {
                         "String": {
                             "type": 2,
-                            "content": "{\"trunk\":[{\"change\":{\"maxId\":1,\"changes\":[{\"fieldKey\":\"rootFieldKey\",\"fieldKind\":\"Sequence\",\"change\":[{\"type\":\"Insert\",\"content\":[{\"type\":\"Node\"}],\"id\":0,\"changes\":{\"fieldChanges\":[{\"fieldKey\":\"foo\",\"fieldKind\":\"Sequence\",\"change\":[{\"type\":\"Insert\",\"content\":[{\"type\":\"Node\"}],\"id\":1}]}]}}]}]},\"revision\":\"beefbeef-beef-4000-8000-000000000004\",\"sequenceNumber\":-9007199254740990,\"sessionId\":\"beefbeef-beef-4000-8000-000000000001\"}],\"branches\":[]}"
+                            "content": "{\"trunk\":[{\"change\":{\"maxId\":1,\"changes\":[{\"fieldKey\":\"rootFieldKey\",\"fieldKind\":\"Sequence\",\"change\":[{\"type\":\"Insert\",\"content\":[{\"type\":\"SeqMap\"}],\"id\":0,\"changes\":{\"fieldChanges\":[{\"fieldKey\":\"foo\",\"fieldKind\":\"Sequence\",\"change\":[{\"type\":\"Insert\",\"content\":[{\"type\":\"SeqMap\"}],\"id\":1}]}]}}]}]},\"revision\":\"beefbeef-beef-4000-8000-000000000004\",\"sequenceNumber\":-9007199254740990,\"sessionId\":\"beefbeef-beef-4000-8000-000000000001\"}],\"branches\":[]}"
                         }
                     }
                 },
@@ -18,7 +18,7 @@
                     "tree": {
                         "SchemaString": {
                             "type": 2,
-                            "content": "{\"version\":\"1.0.0\",\"treeSchema\":[{\"name\":\"Node\",\"mapFields\":{\"kind\":\"Sequence\"},\"structFields\":[],\"value\":0}],\"rootFieldSchema\":{\"kind\":\"Sequence\"}}"
+                            "content": "{\"version\":\"1.0.0\",\"treeSchema\":[{\"name\":\"SeqMap\",\"mapFields\":{\"kind\":\"Sequence\",\"types\":[\"SeqMap\"]},\"structFields\":[],\"value\":0}],\"rootFieldSchema\":{\"kind\":\"Sequence\",\"types\":[\"SeqMap\"]}}"
                         }
                     }
                 },
@@ -27,7 +27,7 @@
                     "tree": {
                         "ForestTree": {
                             "type": 2,
-                            "content": "\"[{\\\"type\\\":\\\"Node\\\",\\\"fields\\\":{\\\"foo\\\":[{\\\"type\\\":\\\"Node\\\"}]}}]\""
+                            "content": "\"[{\\\"type\\\":\\\"SeqMap\\\",\\\"fields\\\":{\\\"foo\\\":[{\\\"type\\\":\\\"SeqMap\\\"}]}}]\""
                         }
                     }
                 }

--- a/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change.json
@@ -1,0 +1,37 @@
+{
+    "type": 1,
+    "tree": {
+        "indexes": {
+            "type": 1,
+            "tree": {
+                "EditManager": {
+                    "type": 1,
+                    "tree": {
+                        "String": {
+                            "type": 2,
+                            "content": "{\"trunk\":[{\"change\":{\"maxId\":1,\"changes\":[{\"fieldKey\":\"rootFieldKey\",\"fieldKind\":\"Sequence\",\"change\":[{\"type\":\"Insert\",\"content\":[{\"type\":\"Node\"}],\"id\":0,\"changes\":{\"fieldChanges\":[{\"fieldKey\":\"foo\",\"fieldKind\":\"Sequence\",\"change\":[{\"type\":\"Insert\",\"content\":[{\"type\":\"Node\"}],\"id\":1}]}]}}]}]},\"revision\":\"beefbeef-beef-4000-8000-000000000004\",\"sequenceNumber\":-9007199254740990,\"sessionId\":\"beefbeef-beef-4000-8000-000000000001\"}],\"branches\":[]}"
+                        }
+                    }
+                },
+                "Schema": {
+                    "type": 1,
+                    "tree": {
+                        "SchemaString": {
+                            "type": 2,
+                            "content": "{\"version\":\"1.0.0\",\"treeSchema\":[{\"name\":\"Node\",\"mapFields\":{\"kind\":\"Sequence\"},\"structFields\":[],\"value\":0}],\"rootFieldSchema\":{\"kind\":\"Sequence\"}}"
+                        }
+                    }
+                },
+                "Forest": {
+                    "type": 1,
+                    "tree": {
+                        "ForestTree": {
+                            "type": 2,
+                            "content": "\"[{\\\"type\\\":\\\"Node\\\",\\\"fields\\\":{\\\"foo\\\":[{\\\"type\\\":\\\"Node\\\"}]}}]\""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a test to ensure we detect persisted format changes for sequence changesets. Specifically adding a test for how sequence changesets represent nested changes.