### PR TITLE
Clean up deprecated Interval functions/methods

### DIFF
--- a/.changeset/evil-days-walk.md
+++ b/.changeset/evil-days-walk.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/sequence": major
+"fluid-framework": major
+---
+
+IntervalConflictResolver removed
+
+IntervalConflictResolver has been removed. Any lingering usages in application code can be removed as well. This change also marks APIs deprecated in #14318 as internal.

--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -42,7 +42,6 @@ import { ILocalValue } from '@fluidframework/map';
 import { IMapMessageLocalMetadata } from '@fluidframework/sequence';
 import { IMember } from '@fluidframework/fluid-static';
 import { Interval } from '@fluidframework/sequence';
-import { IntervalConflictResolver } from '@fluidframework/sequence';
 import { IntervalLocator } from '@fluidframework/sequence';
 import { intervalLocatorFromEndpoint } from '@fluidframework/sequence';
 import { IntervalType } from '@fluidframework/sequence';
@@ -163,8 +162,6 @@ export { IMapMessageLocalMetadata }
 export { IMember }
 
 export { Interval }
-
-export { IntervalConflictResolver }
 
 export { IntervalLocator }
 

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -199,7 +199,7 @@ export interface IMapMessageLocalMetadata {
 // @public
 export class Interval implements ISerializableInterval {
     constructor(start: number, end: number, props?: PropertySet);
-    // @deprecated (undocumented)
+    // @internal (undocumented)
     addProperties(newProps: PropertySet, collaborating?: boolean, seq?: number, op?: ICombiningOp): PropertySet | undefined;
     addPropertySet(props: PropertySet): void;
     // @internal (undocumented)
@@ -216,23 +216,20 @@ export class Interval implements ISerializableInterval {
     getIntervalId(): string;
     // (undocumented)
     getProperties(): PropertySet;
-    // @deprecated
+    // @internal
     modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage): Interval | undefined;
     // (undocumented)
     overlaps(b: Interval): boolean;
     properties: PropertySet;
-    // @deprecated (undocumented)
+    // @internal (undocumented)
     propertyManager: PropertiesManager;
     // @internal (undocumented)
     serialize(): ISerializedInterval;
     // (undocumented)
     start: number;
-    // @deprecated
+    // @internal
     union(b: Interval): Interval;
 }
-
-// @public @deprecated (undocumented)
-export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) => TInterval;
 
 // @public
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
@@ -417,7 +414,7 @@ export class SequenceInterval implements ISerializableInterval {
     end: LocalReferencePosition, intervalType: IntervalType, props?: PropertySet, stickiness?: IntervalStickiness);
     // @internal
     addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
-    // @deprecated (undocumented)
+    // @internal (undocumented)
     addProperties(newProps: PropertySet, collab?: boolean, seq?: number, op?: ICombiningOp): PropertySet | undefined;
     // (undocumented)
     clone(): SequenceInterval;
@@ -428,14 +425,14 @@ export class SequenceInterval implements ISerializableInterval {
     getIntervalId(): string;
     // (undocumented)
     intervalType: IntervalType;
-    // @deprecated
+    // @internal
     modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage, localSeq?: number, stickiness?: IntervalStickiness): SequenceInterval;
     // (undocumented)
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)
     overlapsPos(bstart: number, bend: number): boolean;
     properties: PropertySet;
-    // @deprecated (undocumented)
+    // @internal (undocumented)
     propertyManager: PropertiesManager;
     // @internal
     removePositionChangeListeners(): void;
@@ -444,7 +441,7 @@ export class SequenceInterval implements ISerializableInterval {
     start: LocalReferencePosition;
     // (undocumented)
     readonly stickiness: IntervalStickiness;
-    // @deprecated
+    // @internal
     union(b: SequenceInterval): SequenceInterval;
 }
 

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -125,6 +125,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedTypeAliasDeclaration_IntervalConflictResolver": {
+				"backCompat": false,
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -36,7 +36,6 @@ export {
 	IntervalLocator,
 	intervalLocatorFromEndpoint,
 } from "./intervalCollection";
-export { IntervalConflictResolver } from "./intervalTree";
 export {
 	IntervalIndex,
 	SequenceIntervalIndexes,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -35,7 +35,6 @@ import {
 	IValueTypeOperationValue,
 	SequenceOptions,
 } from "./defaultMapInterfaces";
-import { IntervalConflictResolver } from "./intervalTree";
 import {
 	CompressedSerializedInterval,
 	IIntervalHelpers,
@@ -1294,19 +1293,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			if (changedProperties) {
 				this.emit("propertyChanged", interval, deltaProps, local, op);
 			}
-		}
-	}
-
-	/**
-	 * @deprecated - This functionality was useful when adding two intervals at the same start/end positions resulted
-	 * in a conflict. This is no longer the case (as of PR#6407), as interval collections support multiple intervals
-	 * at the same location and gives each interval a unique id.
-	 *
-	 * As such, the conflict resolver is never invoked and unnecessary. This API will be removed in an upcoming release.
-	 */
-	public addConflictResolver(_: IntervalConflictResolver<TInterval>): void {
-		if (!this.localCollection) {
-			throw new LoggingError("attachSequence must be called");
 		}
 	}
 

--- a/packages/dds/sequence/src/intervals/interval.ts
+++ b/packages/dds/sequence/src/intervals/interval.ts
@@ -28,7 +28,7 @@ export class Interval implements ISerializableInterval {
 	public auxProps: PropertySet[] | undefined;
 	/**
 	 * {@inheritDoc ISerializableInterval.propertyManager}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public propertyManager: PropertiesManager;
 	constructor(public start: number, public end: number, props?: PropertySet) {
@@ -144,7 +144,7 @@ export class Interval implements ISerializableInterval {
 
 	/**
 	 * {@inheritDoc IInterval.union}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public union(b: Interval) {
 		return new Interval(
@@ -160,7 +160,7 @@ export class Interval implements ISerializableInterval {
 
 	/**
 	 * {@inheritDoc ISerializableInterval.addProperties}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public addProperties(
 		newProps: PropertySet,
@@ -182,7 +182,7 @@ export class Interval implements ISerializableInterval {
 
 	/**
 	 * {@inheritDoc IInterval.modify}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage) {
 		const startPos = start ?? this.start;

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -66,7 +66,7 @@ export class SequenceInterval implements ISerializableInterval {
 	public properties: PropertySet;
 	/**
 	 * {@inheritDoc ISerializableInterval.propertyManager}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public propertyManager: PropertiesManager;
 
@@ -227,7 +227,7 @@ export class SequenceInterval implements ISerializableInterval {
 
 	/**
 	 * {@inheritDoc IInterval.union}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public union(b: SequenceInterval) {
 		return new SequenceInterval(
@@ -240,7 +240,7 @@ export class SequenceInterval implements ISerializableInterval {
 
 	/**
 	 * {@inheritDoc ISerializableInterval.addProperties}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public addProperties(
 		newProps: PropertySet,
@@ -263,7 +263,7 @@ export class SequenceInterval implements ISerializableInterval {
 
 	/**
 	 * {@inheritDoc IInterval.modify}
-	 * @deprecated - This API was never intended to be public and will be marked internal in a future release.
+	 * @internal
 	 */
 	public modify(
 		label: string,

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -448,26 +448,14 @@ use_old_ClassDeclaration_Interval(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IntervalConflictResolver": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_IntervalConflictResolver": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_IntervalConflictResolver():
-    TypeOnly<old.IntervalConflictResolver<any>>;
-declare function use_current_TypeAliasDeclaration_IntervalConflictResolver(
-    use: TypeOnly<current.IntervalConflictResolver<any>>);
-use_current_TypeAliasDeclaration_IntervalConflictResolver(
-    get_old_TypeAliasDeclaration_IntervalConflictResolver());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IntervalConflictResolver": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_IntervalConflictResolver": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_IntervalConflictResolver():
-    TypeOnly<current.IntervalConflictResolver<any>>;
-declare function use_old_TypeAliasDeclaration_IntervalConflictResolver(
-    use: TypeOnly<old.IntervalConflictResolver<any>>);
-use_old_TypeAliasDeclaration_IntervalConflictResolver(
-    get_current_TypeAliasDeclaration_IntervalConflictResolver());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -77,7 +77,6 @@ export {
 	IMapMessageLocalMetadata,
 	Interval,
 	IIntervalCollection,
-	IntervalConflictResolver,
 	IntervalLocator,
 	intervalLocatorFromEndpoint,
 	IntervalType,


### PR DESCRIPTION
## Description

Removes `IntervalConflictResolver` and marks deprecations from #14318 as internal.