### PR TITLE
Document JsonValidator behavior w.r.t fluid handles

### DIFF
--- a/experimental/dds/tree2/src/codec/codec.ts
+++ b/experimental/dds/tree2/src/codec/codec.ts
@@ -47,6 +47,11 @@ export interface JsonValidator {
 	/**
 	 * Compiles the provided JSON schema into a validator for that schema.
 	 * @param schema - A valid draft 6 JSON schema
+	 * @remarks - Fluid handles--which have circular property references--are used in various places in the persisted
+	 * format. Handles should only be contained in sections of data which are validated against the empty schema `{}`
+	 * (see https://datatracker.ietf.org/doc/html/draft-wright-json-schema-01#section-4.4).
+	 *
+	 * Implementations of `JsonValidator` must therefore tolerate these values, despite the input not being valid JSON.
 	 */
 	compile<Schema extends TSchema>(schema: Schema): SchemaValidationFunction<Schema>;
 }


### PR DESCRIPTION
## Description

Documents the requirement that `JsonValidator` implementations must allow non-JSON data (specifically, Fluid handles) in sections of the input which are marked with the empty schema. This is true for Typebox's validator, which is why tests added in #16386 work.

[AB#4761](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4761)