### PR TITLE
tree2: Fix chunk bugs

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -51,6 +51,12 @@ export function makeTreeChunker(
 	);
 }
 
+/**
+ * Extends ChunkPolicy to include stateful details required by ChunkedForest.
+ *
+ * This extra complexity is mostly due to the fact that schema can change over time,
+ * and that chunk policy uses caching which thus needs invalidation.
+ */
 export interface IChunker extends ChunkPolicy, Disposable {
 	readonly schema: StoredSchemaRepository;
 	clone(schema: StoredSchemaRepository): IChunker;
@@ -111,6 +117,8 @@ export class Chunker implements IChunker {
 	}
 
 	public clone(schema: StoredSchemaRepository): IChunker {
+		// This does not preserve the cache.
+		// This is probably fine, but is a potential way it could be optimized in the future (with care to ensure invalidation work properly).
 		return new Chunker(
 			schema,
 			this.policy,

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -63,7 +63,7 @@ export interface IChunker extends ChunkPolicy, Disposable {
 }
 
 /**
- * Indicates that there are multiple possible `TreeShapes` trees with a given type can have.
+ * Indicates that there are multiple possible `TreeShape` trees with a given type can have.
  *
  * @remarks
  * For example, a schema transitively containing a sequence field, optional field, or allowing multiple child types will be Polymorphic.

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -18,6 +18,7 @@ import {
 	StoredSchemaRepository,
 	CursorLocationType,
 	SchemaData,
+	forbiddenFieldKindIdentifier,
 } from "../../core";
 import { FullSchemaPolicy, Multiplicity } from "../modular-schema";
 import { fail } from "../../util";
@@ -201,8 +202,6 @@ export function shapesFromSchema(
  * If `schema` has only one shape, return it.
  *
  * Note that this does not tolerate optional or sequence fields, nor does it optimize for patterns of specific values.
- *
- * TODO: tests for this
  */
 export function tryShapeForSchema(
 	schema: SchemaData,
@@ -215,7 +214,7 @@ export function tryShapeForSchema(
 		return cached;
 	}
 	const treeSchema = schema.treeSchema.get(type) ?? fail("missing schema");
-	if (treeSchema.mapFields !== undefined) {
+	if (treeSchema.mapFields.kind.identifier !== forbiddenFieldKindIdentifier) {
 		return polymorphic;
 	}
 	const fieldsArray: FieldShape[] = [];
@@ -237,7 +236,7 @@ export function tryShapeForSchema(
  *
  * Note that this does not tolerate optional or sequence fields, nor does it optimize for patterns of specific values.
  */
-function tryShapeForFieldSchema(
+export function tryShapeForFieldSchema(
 	schema: SchemaData,
 	policy: FullSchemaPolicy,
 	type: FieldStoredSchema,

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -24,12 +24,12 @@ import {
 	ForestEvents,
 	ITreeSubscriptionCursorState,
 	rootFieldKey,
+	mapCursorField,
 } from "../../core";
 import { brand, fail, getOrAddEmptyToMap } from "../../util";
 import { createEmitter } from "../../events";
-import { FullSchemaPolicy } from "../modular-schema";
 import { BasicChunk, BasicChunkCursor, SiblingsOrKey } from "./basicChunk";
-import { basicChunkTree, ChunkPolicy, chunkTree, Disposable, makeTreeChunker } from "./chunkTree";
+import { basicChunkTree, chunkTree, IChunker } from "./chunkTree";
 import { ChunkedCursor, TreeChunk } from "./chunk";
 
 function makeRoot(): BasicChunk {
@@ -48,27 +48,24 @@ interface StackNode {
  */
 class ChunkedForest extends SimpleDependee implements IEditableForest {
 	private readonly dependent = new SimpleObservingDependent(() => this.invalidateDependents());
-	// TODO: dispose of this when forest is disposed.
-	private readonly chunker: Disposable & ChunkPolicy;
 
 	private readonly events = createEmitter<ForestEvents>();
 
 	/**
 	 * @param roots - dummy node above the root under which detached fields are stored. All content of the forest is reachable from this.
 	 * @param schema - schema which all content in this forest is assumed to comply with.
-	 * @param policy - provides information needed to interpret the schema, mainly multiplicities for each field kind which are used for chunking policy.
+	 * @param chunker - Chunking policy. TODO: dispose of this when forest is disposed.
 	 * @param anchors - anchorSet used to track location in this forest across changes. Callers of applyDelta must ensure this is updated accordingly.
 	 */
 	public constructor(
 		public roots: BasicChunk,
 		public readonly schema: StoredSchemaRepository,
-		public readonly policy: FullSchemaPolicy,
+		public readonly chunker: IChunker,
 		public readonly anchors: AnchorSet = new AnchorSet(),
 	) {
 		super("object-forest.ChunkedForest");
 		// Invalidate forest if schema change.
 		recordDependency(this.dependent, this.schema);
-		this.chunker = makeTreeChunker(schema, policy);
 	}
 
 	public on<K extends keyof ForestEvents>(eventName: K, listener: ForestEvents[K]): () => void {
@@ -77,7 +74,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 
 	public clone(schema: StoredSchemaRepository, anchors: AnchorSet): ChunkedForest {
 		this.roots.referenceAdded();
-		return new ChunkedForest(this.roots, schema, this.policy, anchors);
+		return new ChunkedForest(this.roots, schema, this.chunker.clone(schema), anchors);
 	}
 
 	public forgetAnchor(anchor: Anchor): void {
@@ -177,11 +174,15 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 					// 2. Support traversing sequence chunks.
 					//
 					// Maybe build path when visitor navigates then lazily sync to chunk tree when editing?
-
-					const newChunk = basicChunkTree(found.cursor(), this.chunker);
-					chunks[indexOfChunk] = newChunk;
+					const newChunks = mapCursorField(found.cursor(), (cursor) =>
+						basicChunkTree(cursor, this.chunker),
+					);
+					// TODO: this could fail for really long chunks being split (due to argument count limits).
+					// CUrrent implementations of chunks shouldn't ever be that long, but it could be an issue if they get bigger.
+					chunks.splice(indexOfChunk, 1, ...newChunks);
 					found.referenceRemoved();
-					found = newChunk;
+
+					found = newChunks[indexWithinChunk];
 				}
 				assert(found instanceof BasicChunk, 0x536 /* chunk should have been normalized */);
 				if (found.isShared()) {
@@ -355,6 +356,7 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 		this.index = 0;
 		this.indexOfChunk = 0;
 		this.indexWithinChunk = 0;
+		this.nestedCursor = undefined;
 	}
 
 	public override fork(): Cursor {
@@ -400,10 +402,6 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
  */
-export function buildChunkedForest(
-	schema: StoredSchemaRepository,
-	policy: FullSchemaPolicy,
-	anchors?: AnchorSet,
-): IEditableForest {
-	return new ChunkedForest(makeRoot(), schema, policy, anchors);
+export function buildChunkedForest(chunker: IChunker, anchors?: AnchorSet): IEditableForest {
+	return new ChunkedForest(makeRoot(), chunker.schema, chunker, anchors);
 }

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -178,7 +178,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 						basicChunkTree(cursor, this.chunker),
 					);
 					// TODO: this could fail for really long chunks being split (due to argument count limits).
-					// CUrrent implementations of chunks shouldn't ever be that long, but it could be an issue if they get bigger.
+					// Current implementations of chunks shouldn't ever be that long, but it could be an issue if they get bigger.
 					chunks.splice(indexOfChunk, 1, ...newChunks);
 					found.referenceRemoved();
 

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -32,6 +32,7 @@ import {
 import {
 	basicChunkTree,
 	defaultChunkPolicy,
+	makeTreeChunker,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
 import { jsonRoot } from "../../../domains";
@@ -113,7 +114,9 @@ function bench(
 				[
 					"chunked-forest Cursor",
 					() => {
-						const forest = buildChunkedForest(schema, defaultSchemaPolicy);
+						const forest = buildChunkedForest(
+							makeTreeChunker(schema, defaultSchemaPolicy),
+						);
 						initializeForest(forest, [singleTextCursor(encodedTree)]);
 						const cursor = forest.allocateCursor();
 						moveToDetachedField(forest, cursor);

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -25,8 +25,8 @@ import {
 	insertValues,
 	polymorphic,
 	ShapeInfo,
-	tryShapeForFieldSchema,
-	tryShapeForSchema,
+	tryShapeFromFieldSchema,
+	tryShapeFromSchema,
 	uniformChunkFromCursor,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
@@ -176,7 +176,7 @@ describe("chunkTree", () => {
 				sequenceChunkSplitThreshold: 2,
 				sequenceChunkInlineThreshold: Number.POSITIVE_INFINITY,
 				uniformChunkNodeCount: 0,
-				schemaToShape: () => polymorphic,
+				shapeFromSchema: () => polymorphic,
 			};
 
 			const cursor = fieldCursorFromJsonableTrees(numberSequenceField(4));
@@ -225,7 +225,7 @@ describe("chunkTree", () => {
 						sequenceChunkSplitThreshold: threshold,
 						sequenceChunkInlineThreshold: Number.POSITIVE_INFINITY,
 						uniformChunkNodeCount: 0,
-						schemaToShape: () => polymorphic,
+						shapeFromSchema: () => polymorphic,
 					};
 					const field = numberSequenceField(fieldLength);
 					const cursor = fieldCursorFromJsonableTrees(field);
@@ -270,17 +270,17 @@ describe("chunkTree", () => {
 		});
 	});
 
-	describe("tryShapeForSchema", () => {
+	describe("tryShapeFromSchema", () => {
 		it("leaf", () => {
-			const info = tryShapeForSchema(schema, defaultSchemaPolicy, leaf.name, new Map());
+			const info = tryShapeFromSchema(schema, defaultSchemaPolicy, leaf.name, new Map());
 			expectEqual(info, new TreeShape(leaf.name, true, []));
 		});
 		it("empty", () => {
-			const info = tryShapeForSchema(schema, defaultSchemaPolicy, empty.name, new Map());
+			const info = tryShapeFromSchema(schema, defaultSchemaPolicy, empty.name, new Map());
 			expectEqual(info, new TreeShape(empty.name, false, []));
 		});
 		it("structValue", () => {
-			const info = tryShapeForSchema(
+			const info = tryShapeFromSchema(
 				schema,
 				defaultSchemaPolicy,
 				structValue.name,
@@ -294,7 +294,7 @@ describe("chunkTree", () => {
 			);
 		});
 		it("structOptional", () => {
-			const info = tryShapeForSchema(
+			const info = tryShapeFromSchema(
 				schema,
 				defaultSchemaPolicy,
 				structOptional.name,
@@ -304,9 +304,9 @@ describe("chunkTree", () => {
 		});
 	});
 
-	describe("tryShapeForFieldSchema", () => {
+	describe("tryShapeFromFieldSchema", () => {
 		it("valueField", () => {
-			const info = tryShapeForFieldSchema(
+			const info = tryShapeFromFieldSchema(
 				schema,
 				defaultSchemaPolicy,
 				valueField,
@@ -316,7 +316,7 @@ describe("chunkTree", () => {
 			assert.deepEqual(info, ["key", new TreeShape(leaf.name, true, []), 1]);
 		});
 		it("optionalField", () => {
-			const info = tryShapeForFieldSchema(
+			const info = tryShapeFromFieldSchema(
 				schema,
 				defaultSchemaPolicy,
 				optionalField,

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -4,9 +4,15 @@
  */
 
 import { strict as assert } from "assert";
-import { CursorLocationType, EmptyKey, mapCursorField, Value } from "../../../core";
+import { CursorLocationType, EmptyKey, mapCursorField, Value, ValueSchema } from "../../../core";
 import { jsonNull, jsonObject } from "../../../domains";
-import { jsonableTreeFromCursor, singleTextCursor, TreeChunk } from "../../../feature-libraries";
+import {
+	defaultSchemaPolicy,
+	jsonableTreeFromCursor,
+	SchemaBuilder,
+	singleTextCursor,
+	TreeChunk,
+} from "../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { BasicChunk } from "../../../feature-libraries/chunked-forest/basicChunk";
 // eslint-disable-next-line import/no-internal-modules
@@ -18,6 +24,9 @@ import {
 	defaultChunkPolicy,
 	insertValues,
 	polymorphic,
+	ShapeInfo,
+	tryShapeForFieldSchema,
+	tryShapeForSchema,
 	uniformChunkFromCursor,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
@@ -33,6 +42,24 @@ import {
 	numberSequenceField,
 } from "./fieldCursorTestUtilities";
 import { polygonTree, testData } from "./uniformChunkTestData";
+
+const builder = new SchemaBuilder("chunkTree");
+const leaf = builder.leaf("leaf", ValueSchema.Serializable);
+const empty = builder.struct("empty", {});
+const valueField = SchemaBuilder.fieldValue(leaf);
+const structValue = builder.struct("structValue", { x: valueField });
+const optionalField = SchemaBuilder.fieldOptional(leaf);
+const structOptional = builder.struct("structOptional", { x: optionalField });
+const schema = builder.intoLibrary();
+
+function expectEqual(a: ShapeInfo, b: ShapeInfo): void {
+	assert.deepEqual(a, b);
+	if (a instanceof TreeShape) {
+		assert(b instanceof TreeShape);
+		assert(a.equals(b));
+		assert(b.equals(a));
+	}
+}
 
 describe("chunkTree", () => {
 	// Ensure handling of various shapes works properly
@@ -240,6 +267,63 @@ describe("chunkTree", () => {
 			const chunks = chunkRange(cursor, defaultChunkPolicy, 1, false);
 			assert(chunk.isShared());
 			assert.equal(chunks[0], chunk);
+		});
+	});
+
+	describe("tryShapeForSchema", () => {
+		it("leaf", () => {
+			const info = tryShapeForSchema(schema, defaultSchemaPolicy, leaf.name, new Map());
+			expectEqual(info, new TreeShape(leaf.name, true, []));
+		});
+		it("empty", () => {
+			const info = tryShapeForSchema(schema, defaultSchemaPolicy, empty.name, new Map());
+			expectEqual(info, new TreeShape(empty.name, false, []));
+		});
+		it("structValue", () => {
+			const info = tryShapeForSchema(
+				schema,
+				defaultSchemaPolicy,
+				structValue.name,
+				new Map(),
+			);
+			expectEqual(
+				info,
+				new TreeShape(structValue.name, false, [
+					[brand("x"), new TreeShape(leaf.name, true, []), 1],
+				]),
+			);
+		});
+		it("structOptional", () => {
+			const info = tryShapeForSchema(
+				schema,
+				defaultSchemaPolicy,
+				structOptional.name,
+				new Map(),
+			);
+			expectEqual(info, polymorphic);
+		});
+	});
+
+	describe("tryShapeForFieldSchema", () => {
+		it("valueField", () => {
+			const info = tryShapeForFieldSchema(
+				schema,
+				defaultSchemaPolicy,
+				valueField,
+				brand("key"),
+				new Map(),
+			);
+			assert.deepEqual(info, ["key", new TreeShape(leaf.name, true, []), 1]);
+		});
+		it("optionalField", () => {
+			const info = tryShapeForFieldSchema(
+				schema,
+				defaultSchemaPolicy,
+				optionalField,
+				brand("key"),
+				new Map(),
+			);
+			assert.equal(info, undefined);
 		});
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+// This lint is broken in intellisense, causing needless errors.
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
 import { strict as assert } from "assert";
 
 // Allow importing from this specific file which is being tested:
@@ -11,8 +14,15 @@ import { buildChunkedForest } from "../../../feature-libraries/chunked-forest/ch
 // eslint-disable-next-line import/no-internal-modules
 import { tryGetChunk } from "../../../feature-libraries/chunked-forest/chunk";
 import {
+	IChunker,
 	basicChunkTree,
 	basicOnlyChunkPolicy,
+	makeTreeChunker,
+	Chunker,
+	polymorphic,
+	ShapeInfo,
+	defaultChunkPolicy,
+	tryShapeForSchema,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
 
@@ -26,73 +36,140 @@ import {
 	rootFieldKey,
 	Delta,
 	IForestSubscription,
+	StoredSchemaRepository,
 } from "../../../core";
-import { jsonSchema } from "../../../domains";
+import { jsonSchema, jsonRoot, jsonObject } from "../../../domains";
 import {
 	ForestRepairDataStore,
+	SchemaBuilder,
 	defaultSchemaPolicy,
 	jsonableTreeFromCursor,
 	singleTextCursor,
 } from "../../../feature-libraries";
 import { testForest } from "../../forestTestSuite";
-import { brand } from "../../../util";
 import { mockIntoDelta } from "../../utils";
 
+const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
+	[
+		"basic",
+		(schema): IChunker =>
+			new Chunker(
+				schema,
+				defaultSchemaPolicy,
+				Number.POSITIVE_INFINITY,
+				Number.POSITIVE_INFINITY,
+				0,
+				() => polymorphic,
+			),
+	],
+	["default", (schema) => makeTreeChunker(schema, defaultSchemaPolicy)],
+	[
+		"sequences",
+		(schema): IChunker =>
+			new Chunker(schema, defaultSchemaPolicy, 2, 1, 0, (): ShapeInfo => polymorphic),
+	],
+	[
+		"minimal-uniform",
+		(schema): IChunker =>
+			new Chunker(
+				schema,
+				defaultSchemaPolicy,
+				Number.POSITIVE_INFINITY,
+				Number.POSITIVE_INFINITY,
+				1,
+				tryShapeForSchema,
+			),
+	],
+	[
+		"uniform",
+		(schema): IChunker =>
+			new Chunker(
+				schema,
+				defaultSchemaPolicy,
+				Number.POSITIVE_INFINITY,
+				Number.POSITIVE_INFINITY,
+				defaultChunkPolicy.uniformChunkNodeCount,
+				tryShapeForSchema,
+			),
+	],
+	[
+		"mixed",
+		(schema): IChunker =>
+			new Chunker(
+				schema,
+				defaultSchemaPolicy,
+				2,
+				1,
+				defaultChunkPolicy.uniformChunkNodeCount,
+				tryShapeForSchema,
+			),
+	],
+];
+
+const jsonDocumentSchema = new SchemaBuilder("jsonDocumentSchema", jsonSchema).intoDocumentSchema(
+	SchemaBuilder.fieldSequence(...jsonRoot),
+);
+
 describe("ChunkedForest", () => {
-	testForest({
-		suiteName: "ChunkedForest forest suite",
-		factory: (schema) => buildChunkedForest(schema, defaultSchemaPolicy),
-		skipCursorErrorCheck: true,
-	});
+	for (const [name, chunker] of chunkers) {
+		describe(name, () => {
+			testForest({
+				suiteName: "ChunkedForest forest suite",
+				factory: (schema) => buildChunkedForest(chunker(schema)),
+				skipCursorErrorCheck: true,
+			});
 
-	it("doesn't copy data when capturing and restoring repair data", () => {
-		const initialState: JsonableTree = { type: brand("Node") };
-		const forest = buildChunkedForest(
-			new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-			defaultSchemaPolicy,
-		);
-		const chunk = basicChunkTree(singleTextCursor(initialState), basicOnlyChunkPolicy);
+			it("doesn't copy data when capturing and restoring repair data", () => {
+				const initialState: JsonableTree = { type: jsonObject.name };
+				const schema = new InMemoryStoredSchemaRepository(
+					defaultSchemaPolicy,
+					jsonDocumentSchema,
+				);
+				const forest = buildChunkedForest(chunker(schema));
+				const chunk = basicChunkTree(singleTextCursor(initialState), basicOnlyChunkPolicy);
 
-		// Insert chunk into forest
-		{
-			const chunkCursor = chunk.cursor();
-			chunkCursor.firstNode();
-			initializeForest(forest, [chunkCursor]);
-			assert(chunk.isShared());
-			chunk.referenceRemoved(); // chunkCursor
-		}
-		// forest should hold the only ref to chunk.
-		assert(!chunk.isShared());
-		compareForest(forest, [initialState]);
+				// Insert chunk into forest
+				{
+					const chunkCursor = chunk.cursor();
+					chunkCursor.firstNode();
+					initializeForest(forest, [chunkCursor]);
+					assert(chunk.isShared());
+					chunk.referenceRemoved(); // chunkCursor
+				}
+				// forest should hold the only ref to chunk.
+				assert(!chunk.isShared());
+				compareForest(forest, [initialState]);
 
-		const repairStore = new ForestRepairDataStore(forest, mockIntoDelta);
-		const delta: Delta.Root = new Map([
-			[rootFieldKey, [{ type: Delta.MarkType.Delete, count: 1 }]],
-		]);
+				const repairStore = new ForestRepairDataStore(forest, mockIntoDelta);
+				const delta: Delta.Root = new Map([
+					[rootFieldKey, [{ type: Delta.MarkType.Delete, count: 1 }]],
+				]);
 
-		const revision = mintRevisionTag();
-		// Capture reference to content before delete.
-		repairStore.capture(delta, revision);
-		// Captured reference owns a ref count making it shared.
-		assert(chunk.isShared());
-		// Delete from forest, removing the forest's ref, making chunk not shared again.
-		forest.applyDelta(delta);
-		assert(!chunk.isShared());
-		compareForest(forest, []);
+				const revision = mintRevisionTag();
+				// Capture reference to content before delete.
+				repairStore.capture(delta, revision);
+				// Captured reference owns a ref count making it shared.
+				assert(chunk.isShared());
+				// Delete from forest, removing the forest's ref, making chunk not shared again.
+				forest.applyDelta(delta);
+				assert(!chunk.isShared());
+				compareForest(forest, []);
 
-		// Confirm the data from the repair store is chunk
-		const data = repairStore.getNodes(revision, undefined, rootFieldKey, 0, 1);
-		const chunk2 = tryGetChunk(data[0]);
-		assert(chunk === chunk2);
+				// Confirm the data from the repair store is chunk
+				const data = repairStore.getNodes(revision, undefined, rootFieldKey, 0, 1);
+				const chunk2 = tryGetChunk(data[0]);
+				assert(chunk === chunk2);
 
-		// Put it back in the forest, which adds a ref again
-		initializeForest(forest, data);
-		assert(
-			chunk.isShared(),
-			"chunk should be shared after storing as repair data and reinserting",
-		);
-		compareForest(forest, [initialState]);
-	});
+				// Put it back in the forest, which adds a ref again
+				initializeForest(forest, data);
+				assert(
+					chunk.isShared(),
+					"chunk should be shared after storing as repair data and reinserting",
+				);
+				compareForest(forest, [initialState]);
+			});
+		});
+	}
 });
 
 function compareForest(forest: IForestSubscription, expected: JsonableTree[]): void {

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -22,7 +22,7 @@ import {
 	polymorphic,
 	ShapeInfo,
 	defaultChunkPolicy,
-	tryShapeForSchema,
+	tryShapeFromSchema,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
 
@@ -77,7 +77,7 @@ const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
 				Number.POSITIVE_INFINITY,
 				Number.POSITIVE_INFINITY,
 				1,
-				tryShapeForSchema,
+				tryShapeFromSchema,
 			),
 	],
 	[
@@ -89,7 +89,7 @@ const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
 				Number.POSITIVE_INFINITY,
 				Number.POSITIVE_INFINITY,
 				defaultChunkPolicy.uniformChunkNodeCount,
-				tryShapeForSchema,
+				tryShapeFromSchema,
 			),
 	],
 	[
@@ -101,7 +101,7 @@ const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
 				2,
 				1,
 				defaultChunkPolicy.uniformChunkNodeCount,
-				tryShapeForSchema,
+				tryShapeFromSchema,
 			),
 	],
 ];

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -23,6 +23,7 @@ import {
 	ITreeCursor,
 	EmptyKey,
 	ValueSchema,
+	FieldUpPath,
 } from "../core";
 import {
 	cursorToJsonObject,
@@ -43,7 +44,7 @@ import {
 	SchemaBuilder,
 	cursorForTypedTreeData,
 } from "../feature-libraries";
-import { MockDependent } from "./utils";
+import { MockDependent, expectEqualFieldPaths } from "./utils";
 import { testGeneralPurposeTreeCursor, testTreeSchema } from "./cursorTestSuite";
 
 /**
@@ -158,7 +159,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			assert.equal(cursor.firstNode(), false);
 		});
 
-		it("tryMoveCursorToField", () => {
+		it("tryMoveCursorToNode", () => {
 			const forest = factory(
 				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
 			);
@@ -194,6 +195,45 @@ export function testForest(config: ForestTestConfiguration): void {
 			assert.equal(cursor.value, 1);
 			assert.equal(forest.tryMoveCursorToNode(childAnchor2, cursor), TreeNavigationResult.Ok);
 			assert.equal(cursor.value, 2);
+		});
+
+		it("tryMoveCursorToField", () => {
+			const forest = factory(
+				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
+			);
+
+			initializeForest(forest, [singleJsonCursor([1, 2])]);
+
+			const parentPath: FieldUpPath = {
+				parent: undefined,
+				field: rootFieldKey,
+			};
+
+			const parentNodePath: UpPath = {
+				parent: undefined,
+				parentField: rootFieldKey,
+				parentIndex: 0,
+			};
+
+			const childPath: FieldUpPath = {
+				parent: parentNodePath,
+				field: EmptyKey,
+			};
+
+			const parentAnchor = forest.anchors.track(parentNodePath);
+
+			const cursor = forest.allocateCursor();
+			assert.equal(
+				forest.tryMoveCursorToField({ fieldKey: rootFieldKey, parent: undefined }, cursor),
+				TreeNavigationResult.Ok,
+			);
+
+			expectEqualFieldPaths(cursor.getFieldPath(), parentPath);
+			assert.equal(
+				forest.tryMoveCursorToField({ fieldKey: EmptyKey, parent: parentAnchor }, cursor),
+				TreeNavigationResult.Ok,
+			);
+			expectEqualFieldPaths(cursor.getFieldPath(), childPath);
 		});
 
 		it("anchors creation and use", () => {


### PR DESCRIPTION
## Description

Fix 2 bugs in chunked forest, and improve test coverage.

Note that bug in tryShapeForSchema was preventing the existing coverage for using uniform chunks in the forest by detecting all schema as polymorphic fixing that was enough to make the coverage expose the other bug, but coverage of that area was increased anyway.

Note that chunked forest is not currently used by the tree in the public API, so this has no impact on users of this package.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

