### PR TITLE
fix(fluid-build): Load server root path from settings

### DIFF
--- a/build-tools/packages/build-tools/src/common/fluidUtils.ts
+++ b/build-tools/packages/build-tools/src/common/fluidUtils.ts
@@ -33,7 +33,9 @@ async function isFluidRootLerna(dir: string, log: Logger = defaultLogger) {
 	const rootPackageManifest = getFluidBuildConfig(dir);
 	if (rootPackageManifest.repoPackages.server !== undefined) {
 		if (Array.isArray(rootPackageManifest.repoPackages.server)) {
-			log.warning(`InferRoot: fluid-build settings for the server release proup are an array, which is not expected.`);
+			log.warning(
+				`InferRoot: fluid-build settings for the server release proup are an array, which is not expected.`,
+			);
 			return false;
 		}
 
@@ -46,9 +48,9 @@ async function isFluidRootLerna(dir: string, log: Logger = defaultLogger) {
 			log.verbose(`InferRoot: ${dir}/${serverPath}/lerna.json not found`);
 			return false;
 		}
-
-		return true;
 	}
+
+	return true;
 }
 
 async function isFluidRootPackage(dir: string, log: Logger = defaultLogger) {

--- a/build-tools/packages/build-tools/src/common/fluidUtils.ts
+++ b/build-tools/packages/build-tools/src/common/fluidUtils.ts
@@ -14,6 +14,16 @@ import { Logger, defaultLogger } from "./logging";
 import { realpathAsync } from "./utils";
 import { readJson } from "fs-extra";
 
+/**
+ * This function checks that there is a lerna.json file in root of the client and server release groups.
+ *
+ * Long term we want to get rid of this file, since we no longer use lerna. However, that is a larger change that will
+ * be done later. For now, the file must be in the root for both the client and server release groups.
+ *
+ * Client is needed because it's the root of the repo, and server needs it because the server CI pipeline is built using
+ * docker, and the docker context is rooted at the release group root, so it doesn't have access to any files outside
+ * the root of the server release group.
+ */
 async function isFluidRootLerna(dir: string, log: Logger = defaultLogger) {
 	const filename = path.join(dir, "lerna.json");
 	if (!existsSync(filename)) {
@@ -21,19 +31,24 @@ async function isFluidRootLerna(dir: string, log: Logger = defaultLogger) {
 		return false;
 	}
 	const rootPackageManifest = getFluidBuildConfig(dir);
-	if (
-		rootPackageManifest.repoPackages.server !== undefined &&
-		!existsSync(path.join(dir, rootPackageManifest.repoPackages.server as string, "lerna.json"))
-	) {
-		log.verbose(
-			`InferRoot: ${dir}/${
-				rootPackageManifest.repoPackages.server as string
-			}/lerna.json not found`,
-		);
-		return false;
-	}
+	if (rootPackageManifest.repoPackages.server !== undefined) {
+		if (Array.isArray(rootPackageManifest.repoPackages.server)) {
+			log.warning(`InferRoot: fluid-build settings for the server release proup are an array, which is not expected.`);
+			return false;
+		}
 
-	return true;
+		const serverPath =
+			typeof rootPackageManifest.repoPackages.server === "string"
+				? rootPackageManifest.repoPackages.server
+				: rootPackageManifest.repoPackages.server.directory;
+
+		if (!existsSync(path.join(dir, serverPath, "lerna.json"))) {
+			log.verbose(`InferRoot: ${dir}/${serverPath}/lerna.json not found`);
+			return false;
+		}
+
+		return true;
+	}
 }
 
 async function isFluidRootPackage(dir: string, log: Logger = defaultLogger) {

--- a/build-tools/packages/build-tools/src/common/fluidUtils.ts
+++ b/build-tools/packages/build-tools/src/common/fluidUtils.ts
@@ -34,7 +34,7 @@ async function isFluidRootLerna(dir: string, log: Logger = defaultLogger) {
 	if (rootPackageManifest.repoPackages.server !== undefined) {
 		if (Array.isArray(rootPackageManifest.repoPackages.server)) {
 			log.warning(
-				`InferRoot: fluid-build settings for the server release proup are an array, which is not expected.`,
+				`InferRoot: fluid-build settings for the server release group are an array, which is not expected.`,
 			);
 			return false;
 		}


### PR DESCRIPTION
fluid-build is failing because the settings for the server release group were changed. This fixes it and adds a comment explaining why the code exists.