### PR TITLE
AzureClient: Add JUnit reporting option to Azure End-to-end Tests

### DIFF
--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -27,7 +27,7 @@
 		"test": "npm run test:realsvc",
 		"test:realsvc": "npm run test:realsvc:tinylicious",
 		"test:realsvc:azure": "cross-env FLUID_CLIENT=azure npm run test:realsvc:azure:run",
-		"test:realsvc:azure:run": "mocha --unhandled-rejections=strict --recursive dist/test/**/*.spec.js --exit --timeout 20000",
+		"test:realsvc:azure:run": "mocha --unhandled-rejections=strict --recursive dist/test/**/*.spec.js --exit --timeout 20000 --config src/test/.mocharc.js",
 		"test:realsvc:run": "mocha dist/test --config src/test/.mocharc.js",
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7071 test:realsvc:azure:run",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
@@ -61,6 +61,7 @@
 		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/matrix": "workspace:~",
+		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/azure/packages/test/end-to-end-tests/src/test/.mocharc.js
+++ b/azure/packages/test/end-to-end-tests/src/test/.mocharc.js
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+"use strict";
+
+const packageDir = `${__dirname}/../..`;
+const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common.js");
+const config = getFluidTestMochaConfig(packageDir);
+module.exports = config;

--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -52,5 +52,9 @@ export function createAzureClient(
 				endpoint: "http://localhost:7071",
 				type: "local",
 		  };
-	return new AzureClient({ connection: connectionProps, logger, configProvider });
+	return new AzureClient({
+		connection: connectionProps,
+		logger: logger ?? getTestLogger?.(),
+		configProvider,
+	});
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,7 @@ importers:
       '@fluidframework/fluid-static': workspace:~
       '@fluidframework/map': workspace:~
       '@fluidframework/matrix': workspace:~
+      '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -372,6 +373,7 @@ importers:
       '@fluidframework/fluid-static': link:../../../../packages/framework/fluid-static
       '@fluidframework/map': link:../../../../packages/dds/map
       '@fluidframework/matrix': link:../../../../packages/dds/matrix
+      '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@fluidframework/sequence': link:../../../../packages/dds/sequence
       '@fluidframework/telemetry-utils': link:../../../../packages/utils/telemetry-utils
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils


### PR DESCRIPTION
## Description

Similar to other E2E tests in the FF repo, it would be nice to have JUnit reports output from the Azure End-to-end test suite. With this change, setting `FLUID_TEST_REPORT=1` causes tests to output a nyc/junit-report.xml file.

Additionally, mocha-test-setup adds the ability for us to easily plug in a test logger (e.g. ff-internal/aria-logger) for better log output reporting. I added `getTestLogger` as the logger for AzureClient when the mockLogger is not defined. As far as I can tell, there is currently no usage of MockLogger in these tests, so this shouldn't change anything. In the future, we can use a mix-in to output to both as needed, I think.