### PR TITLE
 Add logs and timeout in runner.stop()

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -119,7 +119,6 @@ data:
                 "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
             },
             "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }},
-            "serverCloseTimeoutMs": {{ .Values.alfred.serverCloseTimeoutMs }}
         },
         "client": {
             "type": "browser",
@@ -168,7 +167,8 @@ data:
             "signalUsageCountingEnabled": {{ .Values.usage.signalUsageCountingEnabled }}
         },
         "shared": {
-            "transientTenants": {{ toJson .Values.shared.transientTenants }}
+            "transientTenants": {{ toJson .Values.shared.transientTenants }},
+            "runnerServerCloseTimeoutMs": {{ .Values.shared.runnerServerCloseTimeoutMs }}
         },
         "auth": {
             "endpoint": "http://{{ template "riddler.fullname" . }}",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -118,7 +118,7 @@ data:
             "socketIo" : {
                 "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
             },
-            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }},
+            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }}
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -118,7 +118,8 @@ data:
             "socketIo" : {
                 "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
             },
-            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }}
+            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }},
+            "serverCloseTimeoutMs": {{ .Values.alfred.serverCloseTimeoutMs }}
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -49,6 +49,7 @@ alfred:
   socketIo:
     perMessageDeflate: true
   getDeltasRequestMaxOpsRange: 2000
+  serverCloseTimeoutMs: 30000
 
 storage:
   enableWholeSummaryUpload: false

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -49,7 +49,6 @@ alfred:
   socketIo:
     perMessageDeflate: true
   getDeltasRequestMaxOpsRange: 2000
-  serverCloseTimeoutMs: 30000
 
 storage:
   enableWholeSummaryUpload: false
@@ -114,6 +113,7 @@ usage:
 
 shared:
   transientTenants: []
+  runnerServerCloseTimeoutMs: 30000
 
 mongodb:
   operationsDbEndpoint: mongodb_url

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -106,10 +106,12 @@ export class KafkaRunner implements IRunner {
 	 */
 	public async stop(caller?: string, uncaughtException?: any): Promise<void> {
 		if (this.stopped) {
+			Lumberjack.info("KafkaRunner.stop already called, returning early.");
 			return;
 		}
 
 		this.stopped = true;
+		Lumberjack.info("KafkaRunner.stop starting.");
 		try {
 			// Stop listening for new updates
 			await this.consumer.pause();

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -158,9 +158,10 @@ export class AlfredRunner implements IRunner {
 		Lumberjack.info("AlfredRunner.stop starting.");
 
 		try {
-			const serverCloseTimeoutMs = this.config.get("alfred:serverCloseTimeoutMs") ?? 30000;
+			const runnerServerCloseTimeoutMs =
+				this.config.get("shared:runnerServerCloseTimeoutMs") ?? 30000;
 			// Close the underlying server and then resolve the runner once closed
-			await promiseTimeout(serverCloseTimeoutMs, this.server.close());
+			await promiseTimeout(runnerServerCloseTimeoutMs, this.server.close());
 			if (caller === "uncaughtException") {
 				this.runningDeferred?.reject({
 					uncaughtException: serializeError(uncaughtException),

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -158,8 +158,9 @@ export class AlfredRunner implements IRunner {
 		Lumberjack.info("AlfredRunner.stop starting.");
 
 		try {
+			const serverCloseTimeoutMs = this.config.get("alfred:serverCloseTimeoutMs") ?? 30000;
 			// Close the underlying server and then resolve the runner once closed
-			await promiseTimeout(30000, this.server.close());
+			await promiseTimeout(serverCloseTimeoutMs, this.server.close());
 			if (caller === "uncaughtException") {
 				this.runningDeferred?.reject({
 					uncaughtException: serializeError(uncaughtException),

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -115,8 +115,7 @@
 		"jwtTokenCache": {
 			"enable": true
 		},
-		"getDeltasRequestMaxOpsRange": 2000,
-		"serverCloseTimeoutMs": 30000
+		"getDeltasRequestMaxOpsRange": 2000
 	},
 	"client": {
 		"type": "browser",
@@ -165,7 +164,8 @@
 		"signalUsageCountingEnabled": false
 	},
 	"shared": {
-		"transientTenants": []
+		"transientTenants": [],
+		"runnerServerCloseTimeoutMs": 30000
 	},
 	"auth": {
 		"endpoint": "http://riddler:5000",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -115,7 +115,8 @@
 		"jwtTokenCache": {
 			"enable": true
 		},
-		"getDeltasRequestMaxOpsRange": 2000
+		"getDeltasRequestMaxOpsRange": 2000,
+		"serverCloseTimeoutMs": 30000
 	},
 	"client": {
 		"type": "browser",


### PR DESCRIPTION
## Description

Xin found an issue where pods are sometimes not shutting down in case of sigterm. So adding some logs to runner.stop() method and also adding a timeout to server.close() call to avoid waiting for it indefinitely.

