### PR TITLE
Move tree2 op encoding to a codec

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -882,7 +882,7 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 }
 
 // @alpha (undocumented)
-export interface IJsonCodec<TDecoded, TEncoded extends JsonCompatibleReadOnly = JsonCompatibleReadOnly> extends IEncoder<TDecoded, TEncoded>, IDecoder<TDecoded, TEncoded> {
+export interface IJsonCodec<TDecoded, TEncoded = JsonCompatibleReadOnly> extends IEncoder<TDecoded, TEncoded>, IDecoder<TDecoded, TEncoded> {
     // (undocumented)
     encodedSchema?: TAnySchema;
 }

--- a/experimental/dds/tree2/src/codec/codec.ts
+++ b/experimental/dds/tree2/src/codec/codec.ts
@@ -69,11 +69,12 @@ export interface ICodecOptions {
 
 /**
  * @alpha
+ * @remarks - `TEncoded` should always be valid Json (i.e. not contain functions), but due to Typescript's handling
+ * of index signatures and `JsonCompatibleReadOnly`'s index signature in the Json object case, specifying this as a
+ * type-system level constraint makes code that uses this interface more difficult to write.
  */
-export interface IJsonCodec<
-	TDecoded,
-	TEncoded extends JsonCompatibleReadOnly = JsonCompatibleReadOnly,
-> extends IEncoder<TDecoded, TEncoded>,
+export interface IJsonCodec<TDecoded, TEncoded = JsonCompatibleReadOnly>
+	extends IEncoder<TDecoded, TEncoded>,
 		IDecoder<TDecoded, TEncoded> {
 	encodedSchema?: TAnySchema;
 }
@@ -293,11 +294,15 @@ export function makeValueCodec<Schema extends TSchema>(
  * Wraps a codec with JSON schema validation for its encoded type.
  * @returns An {@link IJsonCodec} which validates the data it encodes and decodes matches the provided schema.
  */
-export function withSchemaValidation<TInMemoryFormat, EncodedSchema extends TSchema>(
+export function withSchemaValidation<
+	TInMemoryFormat,
+	EncodedSchema extends TSchema,
+	TEncodedFormat = JsonCompatibleReadOnly,
+>(
 	schema: EncodedSchema,
-	codec: IJsonCodec<TInMemoryFormat>,
+	codec: IJsonCodec<TInMemoryFormat, TEncodedFormat>,
 	validator?: JsonValidator,
-): IJsonCodec<TInMemoryFormat> {
+): IJsonCodec<TInMemoryFormat, TEncodedFormat> {
 	if (!validator) {
 		return codec;
 	}
@@ -310,7 +315,7 @@ export function withSchemaValidation<TInMemoryFormat, EncodedSchema extends TSch
 			}
 			return encoded;
 		},
-		decode: (encoded: JsonCompatibleReadOnly) => {
+		decode: (encoded: TEncodedFormat) => {
 			if (!compiledFormat.check(encoded)) {
 				fail("Encoded schema should validate");
 			}

--- a/experimental/dds/tree2/src/shared-tree-core/messageCodecs.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/messageCodecs.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TAnySchema, Type } from "@sinclair/typebox";
+import { JsonCompatibleReadOnly } from "../util";
+import { IJsonCodec, withSchemaValidation } from "../codec";
+import { DecodedMessage } from "./messageTypes";
+import { Message } from "./messageFormat";
+
+export function makeMessageCodec<TChangeset>(
+	changesetCodec: IJsonCodec<TChangeset>,
+): IJsonCodec<DecodedMessage<TChangeset>, unknown> {
+	return withSchemaValidation<DecodedMessage<TChangeset>, TAnySchema, unknown>(
+		Message(changesetCodec.encodedSchema ?? Type.Any()),
+		{
+			encode: ({ commit, sessionId }: DecodedMessage<TChangeset>) => {
+				const message: Message = {
+					revision: commit.revision,
+					originatorId: sessionId,
+					changeset: changesetCodec.encode(commit.change),
+				};
+				return message as unknown as JsonCompatibleReadOnly;
+			},
+			decode: (encoded: JsonCompatibleReadOnly) => {
+				const { revision, originatorId, changeset } = encoded as unknown as Message;
+				return {
+					commit: {
+						revision,
+						change: changesetCodec.decode(changeset),
+					},
+					sessionId: originatorId,
+				};
+			},
+		},
+	);
+}

--- a/experimental/dds/tree2/src/shared-tree-core/messageFormat.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/messageFormat.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Type, TSchema } from "@sinclair/typebox";
+import { JsonCompatibleReadOnly } from "../util";
+import { RevisionTag, RevisionTagSchema, SessionIdSchema } from "../core";
+
+/**
+ * The format of messages that SharedTree sends and receives.
+ */
+export interface Message {
+	/**
+	 * The revision tag for the change in this message
+	 */
+	readonly revision: RevisionTag;
+	/**
+	 * The stable ID that identifies the originator of the message.
+	 */
+	readonly originatorId: string;
+	/**
+	 * The changeset to be applied.
+	 */
+	readonly changeset: JsonCompatibleReadOnly;
+}
+
+export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
+	Type.Object({
+		revision: RevisionTagSchema,
+		originatorId: SessionIdSchema,
+		changeset: tChange,
+	});

--- a/experimental/dds/tree2/src/shared-tree-core/messageTypes.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/messageTypes.ts
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { GraphCommit, SessionId } from "../core";
+
+export interface DecodedMessage<TChange> {
+	commit: GraphCommit<TChange>;
+	sessionId: SessionId;
+}


### PR DESCRIPTION
## Description

Refactors the way `tree2` submits ops such that it references a codec. This sets us up better for any changes to the format.

[AB#4500](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4500)