### PR TITLE
Improve findCommonAncestor asymptotics

### DIFF
--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -407,9 +407,10 @@ export function findAncestor<T extends { parent?: T }>(
 	}
 	for (let cur = d; cur !== undefined; cur = cur.parent) {
 		if (predicate(cur)) {
+			path?.reverse();
 			return cur;
 		}
-		path?.unshift(cur);
+		path?.push(cur);
 	}
 
 	if (path !== undefined) {
@@ -465,31 +466,36 @@ export function findCommonAncestor<T extends { parent?: T }>(
 		return a;
 	}
 
+	const reversePaths = () => {
+		pathA?.reverse();
+		pathB?.reverse();
+	};
+
 	const visited = new Set();
 	while (a !== undefined || b !== undefined) {
 		if (a !== undefined) {
 			if (visited.has(a)) {
 				if (pathB !== undefined) {
-					const indexInPathB = pathB.findIndex((r) => Object.is(r, a));
-					pathB.splice(0, indexInPathB + 1);
+					pathB.length = pathB.findIndex((r) => Object.is(r, a));
 				}
+				reversePaths();
 				return a;
 			}
 			visited.add(a);
-			pathA?.unshift(a);
+			pathA?.push(a);
 			a = a.parent;
 		}
 
 		if (b !== undefined) {
 			if (visited.has(b)) {
 				if (pathA !== undefined) {
-					const indexInPathA = pathA.findIndex((r) => Object.is(r, b));
-					pathA.splice(0, indexInPathA + 1);
+					pathA.length = pathA.findIndex((r) => Object.is(r, b));
 				}
+				reversePaths();
 				return b;
 			}
 			visited.add(b);
-			pathB?.unshift(b);
+			pathB?.push(b);
 			b = b.parent;
 		}
 	}


### PR DESCRIPTION
## Description

Resolves O(n^2) asymptotics due to `.unshift` in `findAncestor` and `findCommonAncestor`.
