### PR TITLE
Azure E2E: ContainerLoadStats event changed

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -8,10 +8,15 @@ import {
 	AzureClient,
 	AzureLocalConnectionConfig,
 	AzureRemoteConnectionConfig,
+	ITelemetryBaseLogger,
 } from "@fluidframework/azure-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 
-import { IConfigProviderBase, MockLogger } from "@fluidframework/telemetry-utils";
+import {
+	IConfigProviderBase,
+	MockLogger,
+	createMultiSinkLogger,
+} from "@fluidframework/telemetry-utils";
 import { createAzureTokenProvider } from "./AzureTokenFactory";
 
 /**
@@ -52,9 +57,19 @@ export function createAzureClient(
 				endpoint: "http://localhost:7071",
 				type: "local",
 		  };
+	const getLogger = (): ITelemetryBaseLogger | undefined => {
+		const testLogger = getTestLogger?.();
+		if (!logger && !testLogger) {
+			return undefined;
+		}
+		if (logger && testLogger) {
+			return createMultiSinkLogger({ loggers: [logger, testLogger] });
+		}
+		return logger ?? testLogger;
+	};
 	return new AzureClient({
 		connection: connectionProps,
-		logger: logger ?? getTestLogger?.(),
+		logger: getLogger(),
 		configProvider,
 	});
 }

--- a/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
@@ -181,9 +181,7 @@ describe("Container create with feature flags", () => {
 	 */
 	it("can create containers with feature gates", async () => {
 		await client.createContainer(schema);
-		const event = mockLogger.events.find(
-			(e) => e.eventName === "fluid:telemetry:ContainerLoadStats",
-		);
+		const event = mockLogger.events.find((e) => e.eventName.endsWith("ContainerLoadStats"));
 		assert(event !== undefined, "ContainerLoadStats event should exist");
 		const featureGates = event.featureGates as string;
 		assert(featureGates.includes('"disableOpReentryCheck":true'));


### PR DESCRIPTION
## Description

The "ContainerLoadStats" event now has additional context "ContainerRuntime" in the eventName. This broke the Azure E2E test suite.

Instead of just updating to the new eventName, I changed the search to look for `endswith("ContainerLoadStats")` which should be more resilient to future changes.

### Bonus

When `MockLogger` and `getTestLogger()` were defined, only `MockLogger` would receive logs. This PR adds the ability to log to both using `MultiSinkLogger` when necessary.