### PR TITLE
build(devtools-browser-extension): Bump extension version for publishing

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
+++ b/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Fluid Framework Developer Tools
 
+# 0.0.4
+
+-   Adds opt-in usage telemetry generation.
+
 # 0.0.3
 
 -   Fixed a number of styling and accessibility issues.

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Fluid Framework Developer Tools (Preview)",
 	"description": "Devtools extension for viewing live data about your Fluid application.",
 	"author": "Microsoft",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"action": {
 		"default_icon": {
 			"16": "icons/icon_16.png",


### PR DESCRIPTION
Bumps the extension version from `0.0.3` to `0.0.4` in preparation for publishing. Also updates extension changelog.