### PR TITLE
Skip non single commit test for odsp

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -516,7 +516,10 @@ describeNoCompat("SingleCommit Summaries Tests", (getTestObjectProvider) => {
 		};
 	});
 
-	it("Non single commit summary/Match last summary ackHandle  with current summary parent", async () => {
+	it("Non single commit summary/Match last summary ackHandle  with current summary parent", async function () {
+		if (provider.driver.type === "odsp") {
+			this.skip();
+		}
 		const { summarizer } = await createMainContainerAndSummarizer(provider);
 
 		// Summarize
@@ -556,7 +559,10 @@ describeNoCompat("SingleCommit Summaries Tests", (getTestObjectProvider) => {
 		);
 	});
 
-	it("Non single commit summary/Last summary should be discarded due to missing SummaryOp", async () => {
+	it("Non single commit summary/Last summary should be discarded due to missing SummaryOp", async function () {
+		if (provider.driver.type === "odsp") {
+			this.skip();
+		}
 		const { mainContainer, summarizer } = await createMainContainerAndSummarizer(provider);
 
 		// Summarize


### PR DESCRIPTION
## Description

Skip non single commit test for odsp as we have moved to single commit summaries.
