### PR TITLE
Allow delaying kafka offset commits

### DIFF
--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -20,8 +20,16 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 	consumeLoopTimeoutDelay: number;
 	optimizedRebalance: boolean;
 	commitRetryDelay: number;
+
+	/**
+	 * Amount of milliseconds to delay after a successful offset commit.
+	 * This allows slowing down how often commits are done.
+	 */
+	commitSuccessDelay: number;
+
 	automaticConsume: boolean;
 	maxConsumerCommitRetries: number;
+
 	zooKeeperClientConstructor?: ZookeeperClientConstructor;
 
 	/**
@@ -69,6 +77,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			consumeLoopTimeoutDelay: options?.consumeLoopTimeoutDelay ?? 100,
 			optimizedRebalance: options?.optimizedRebalance ?? false,
 			commitRetryDelay: options?.commitRetryDelay ?? 1000,
+			commitSuccessDelay: options?.commitSuccessDelay ?? 0,
 			automaticConsume: options?.automaticConsume ?? true,
 			maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
 		};
@@ -373,6 +382,13 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
 			const result = await deferredCommit.promise;
 			const latency = Date.now() - startTime;
+
+			if (this.consumerOptions.commitSuccessDelay > 0) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, this.consumerOptions.commitSuccessDelay),
+				);
+			}
+
 			this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
 			return result;
 		} catch (ex) {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -383,7 +383,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			const result = await deferredCommit.promise;
 			const latency = Date.now() - startTime;
 
-			if (this.consumerOptions.commitSuccessDelay > 0) {
+			if (
+				this.consumerOptions.commitSuccessDelay !== undefined &&
+				this.consumerOptions.commitSuccessDelay > 0
+			) {
 				await new Promise((resolve) =>
 					setTimeout(resolve, this.consumerOptions.commitSuccessDelay),
 				);

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -25,7 +25,7 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 	 * Amount of milliseconds to delay after a successful offset commit.
 	 * This allows slowing down how often commits are done.
 	 */
-	commitSuccessDelay: number;
+	commitSuccessDelay?: number;
 
 	automaticConsume: boolean;
 	maxConsumerCommitRetries: number;


### PR DESCRIPTION
We're currently checkpointing (committing Kafka offsets) as fast as possible. That might not be needed and some folks say that Kafka commits are an expensive operation ([ref1](https://quarkus.io/blog/kafka-commit-strategies/), [ref2](https://medium.com/opendoor-labs/how-we-improved-reliability-of-kafka-consumers-441ccec1416d))

Depending on how fast the lambdas are consuming, we may be committing dozens of offsets per partition per second - that might be overkill. So I want to try playing with batching for the commits. 

By default, Kafka's built-in auto commit logic would have applied a 5 second delay for the commits ([ref](https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#auto-commit-interval-ms)) - we are not leveraging that auto-commit logic so we have no such delay in our system. This new `commitSuccessDelay` property will allow us to artificially introduce a delay. I'm defaulting it to 0 so it's no-op when checked-in.