### PR TITLE
Parse the response in try/catch as it can throw in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -25,6 +25,7 @@ import {
 	isRuntimeMessage,
 	NonRetryableError,
 } from "@fluidframework/driver-utils";
+import { fetchIncorrectResponse, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import {
 	IOdspSnapshot,
 	ISnapshotCachedEntry,
@@ -309,7 +310,15 @@ async function fetchLatestSnapshotCore(
 					case "application/json": {
 						let text: string;
 						[text, receiveContentTime] = await measureP(async () =>
-							odspResponse.content.text(),
+							odspResponse.content.text().catch((err) =>
+								// Parsing can fail and message could contain full request URI, including
+								// tokens, etc. So do not log error object itself.
+								throwOdspNetworkError(
+									"Error while parsing fetch response",
+									fetchIncorrectResponse,
+									odspResponse.content, // response
+								),
+							),
 						);
 						propsToLog.bodySize = text.length;
 						let content: IOdspSnapshot;
@@ -329,7 +338,15 @@ async function fetchLatestSnapshotCore(
 					case "application/ms-fluid": {
 						let content: ArrayBuffer;
 						[content, receiveContentTime] = await measureP(async () =>
-							odspResponse.content.arrayBuffer(),
+							odspResponse.content.arrayBuffer().catch((err) =>
+								// Parsing can fail and message could contain full request URI, including
+								// tokens, etc. So do not log error object itself.
+								throwOdspNetworkError(
+									"Error while parsing fetch response",
+									fetchIncorrectResponse,
+									odspResponse.content, // response
+								),
+							),
 						);
 						propsToLog.bodySize = content.byteLength;
 						let snapshotContents: ISnapshotContentsWithProps;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -317,6 +317,8 @@ async function fetchLatestSnapshotCore(
 									"Error while parsing fetch response",
 									fetchIncorrectResponse,
 									odspResponse.content, // response
+									undefined, // response text
+									propsToLog,
 								),
 							),
 						);
@@ -345,6 +347,8 @@ async function fetchLatestSnapshotCore(
 									"Error while parsing fetch response",
 									fetchIncorrectResponse,
 									odspResponse.content, // response
+									undefined, // response text
+									propsToLog,
 								),
 							),
 						);

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -209,6 +209,8 @@ export async function fetchArray(
 			"Error while parsing fetch response",
 			fetchIncorrectResponse,
 			content, // response
+			undefined, // response text
+			propsToLog,
 		);
 	}
 
@@ -246,6 +248,7 @@ export async function fetchAndParseAsJSONHelper<T>(
 			fetchIncorrectResponse,
 			content, // response
 			text,
+			propsToLog,
 		);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -199,8 +199,19 @@ export async function fetchArray(
 	requestInit: RequestInit | undefined,
 ): Promise<IOdspResponse<ArrayBuffer>> {
 	const { content, headers, propsToLog, duration } = await fetchHelper(requestInfo, requestInit);
+	let arrayBuffer: ArrayBuffer;
+	try {
+		arrayBuffer = await content.arrayBuffer();
+	} catch (e) {
+		// Parsing can fail and message could contain full request URI, including
+		// tokens, etc. So do not log error object itself.
+		throwOdspNetworkError(
+			"Error while parsing fetch response",
+			fetchIncorrectResponse,
+			content, // response
+		);
+	}
 
-	const arrayBuffer = await content.arrayBuffer();
 	propsToLog.bodySize = arrayBuffer.byteLength;
 	return {
 		headers,


### PR DESCRIPTION
## Description

Item: [TASK 5159](https://dev.azure.com/fluidframework/internal/_workitems/edit/5159)

Parse the response in try/catch as it can throw due to parsing the contents. This is similar to what we do when parsing the text in fetchAndParseAsJSONHelper in odsp driver.