### PR TITLE
Change assert to account for no ops in snapshpot in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -84,8 +84,11 @@ function readOpsSection(node: NodeTypes) {
 	for (let i = 0; i < records.deltas.length; ++i) {
 		ops.push(JSON.parse(records.deltas.getString(i)));
 	}
+	// Due to a bug at service side, in an edge case service was serializing deltas even
+	// when there are no ops. So just make the code resilient to that bug. Service has also
+	// fixed that bug.
 	assert(
-		records.firstSequenceNumber.valueOf() === ops[0].sequenceNumber,
+		ops.length === 0 || records.firstSequenceNumber.valueOf() === ops[0].sequenceNumber,
 		0x280 /* "Validate first op seq number" */,
 	);
 	return ops;


### PR DESCRIPTION
# Breaking Changes

Item: [TASK 5159](https://dev.azure.com/fluidframework/internal/_workitems/edit/5159)

Change assert to account for no ops in snapshot in odsp driver due to a bug at service side.