### PR TITLE
Remove dead concepts around blob aggregation

### DIFF
--- a/.changeset/green-forks-invite.md
+++ b/.changeset/green-forks-invite.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/container-loader": major
+"@fluidframework/driver-definitions": major
+"@fluidframework/local-driver": major
+"@fluidframework/odsp-driver": major
+"@fluidframework/routerlicious-driver": major
+---
+
+"Removing dead concepts around blob aggregation"
+
+"Removing dead concepts like aggregateBlobsSmallerThanBytes and minBlobSize around blob aggregation"

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -186,7 +186,6 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
 export interface IDocumentStorageServicePolicies {
     readonly caching?: LoaderCachingPolicy;
     readonly maximumCacheDurationMs?: FiveDaysMs;
-    readonly minBlobSize?: number;
 }
 
 // @public

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -301,7 +301,6 @@ export class PrefetchDocumentStorageService extends DocumentStorageServiceProxy 
     // (undocumented)
     get policies(): {
         caching: LoaderCachingPolicy;
-        minBlobSize?: number | undefined;
         maximumCacheDurationMs?: 432000000 | undefined;
     } | undefined;
     // (undocumented)

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -33,7 +33,6 @@ export class DocumentPostCreateError extends Error {
 
 // @public (undocumented)
 export interface IRouterliciousDriverPolicies {
-    aggregateBlobsSmallerThanBytes: number | undefined;
     enableDiscovery?: boolean;
     enableInternalSummaryCaching: boolean;
     enableLongPollingDowngrade: boolean;

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -111,12 +111,6 @@ export interface IDocumentStorageServicePolicies {
 	readonly caching?: LoaderCachingPolicy;
 
 	/**
-	 * If this policy is provided, it tells runtime on ideal size for blobs.
-	 * Blobs that are smaller than that size should be aggregated into bigger blobs.
-	 */
-	readonly minBlobSize?: number;
-
-	/**
 	 * IMPORTANT: This policy MUST be set to 5 days and PROPERLY ENFORCED for drivers that are used
 	 * in applications where Garbage Collection is enabled. Otherwise data loss may occur.
 	 *

--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -55,7 +55,6 @@ export class LocalDocumentService implements IDocumentService {
 				new TestHistorian(this.localDeltaConnectionServer.testDbFactory.testDatabase),
 			),
 			{
-				minBlobSize: 2048, // Test blob aggregation
 				maximumCacheDurationMs: 432_000_000, // 5 days in ms. Not actually enforced but shouldn't matter for any local driver scenario
 			},
 			this.localDeltaConnectionServer,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -131,18 +131,6 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 		this.policies = {
 			// By default, ODSP tells the container not to prefetch/cache.
 			caching: LoaderCachingPolicy.NoCaching,
-
-			// ODSP storage works better if it has less number of blobs / edges
-			// Runtime creating many small blobs results in sub-optimal perf.
-			// 2K seems like the sweat spot:
-			// The smaller the number, less blobs we aggregate. Most storages are very likely to have notion
-			// of minimal "cluster" size, so having small blobs is wasteful
-			// At the same time increasing the limit ensure that more blobs with user content are aggregated,
-			// reducing possibility for de-duping of same blobs (i.e. .attributes rolled into aggregate blob
-			// are not reused across data stores, or even within data store, resulting in duplication of content)
-			// Note that duplication of content should not have significant impact for bytes over wire as
-			// compression of http payload mostly takes care of it, but it does impact storage size and in-memory sizes.
-			minBlobSize: 2048,
 			maximumCacheDurationMs: maximumCacheDurationMsInEffect,
 		};
 	}

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -109,6 +109,10 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IRouterliciousDriverPolicies": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -47,7 +47,6 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
 	enablePrefetch: true,
 	maxConcurrentStorageRequests: 100,
 	maxConcurrentOrdererRequests: 100,
-	aggregateBlobsSmallerThanBytes: undefined,
 	enableDiscovery: false,
 	enableWholeSummaryUpload: false,
 	enableRestLess: true,
@@ -337,7 +336,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			caching: this.driverPolicies.enablePrefetch
 				? LoaderCachingPolicy.Prefetch
 				: LoaderCachingPolicy.NoCaching,
-			minBlobSize: this.driverPolicies.aggregateBlobsSmallerThanBytes,
 			maximumCacheDurationMs: maximumSnapshotCacheDurationMs,
 		};
 

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -20,14 +20,6 @@ export interface IRouterliciousDriverPolicies {
 	 */
 	maxConcurrentOrdererRequests: number;
 	/**
-	 * Give hosts the option to change blob aggregation behavior to suit their needs.
-	 * Larger number means fewer blob individual requests, but less blob-deduping.
-	 * Smaller number means more blob individual requests, but more blob-deduping.
-	 * Setting to `undefined` disables blob aggregration.
-	 * Default: undefined
-	 */
-	aggregateBlobsSmallerThanBytes: number | undefined;
-	/**
 	 * Enable uploading entire summary tree as a IWholeSummaryPayload to storage.
 	 * Default: false
 	 */

--- a/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
+++ b/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
@@ -83,6 +83,7 @@ declare function get_current_InterfaceDeclaration_IRouterliciousDriverPolicies()
 declare function use_old_InterfaceDeclaration_IRouterliciousDriverPolicies(
     use: TypeOnly<old.IRouterliciousDriverPolicies>);
 use_old_InterfaceDeclaration_IRouterliciousDriverPolicies(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRouterliciousDriverPolicies());
 
 /*

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -98,12 +98,6 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 				this.addProtocolSummaryIfMissing,
 			);
 		}
-
-		// ensure we did not lose that policy in the process of wrapping
-		assert(
-			storageService.policies?.minBlobSize === this._storageService.policies?.minBlobSize,
-			0x0e0 /* "lost minBlobSize policy" */,
-		);
 	}
 
 	public loadSnapshotForRehydratingContainer(snapshotTree: ISnapshotTreeWithBlobContents) {


### PR DESCRIPTION
## Description

Item: [Dead concepts around blob aggregation in FF repo](https://dev.azure.com/fluidframework/internal/_workitems/edit/4946)

Remove concepts/policies like aggregateBlobsSmallerThanBytes and minBlobSize storage policies which are not used anymore.