### PR TITLE
Block uploading blobs while getting pending state

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1222,8 +1222,8 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 		const parsedChanges = JSON.parse(stashedChanges);
 		const pendingBlobs = parsedChanges.pendingRuntimeState.pendingAttachmentBlobs;
 		const pendingOps = parsedChanges.pendingRuntimeState.pending;
-		assert.strictEqual(pendingBlobs, 0);
-		assert.strictEqual(pendingOps, 0);
+		assert.strictEqual(Object.keys(pendingBlobs).length, 0);
+		assert.strictEqual(Object.keys(pendingOps).length, 0);
 	});
 
 	it("close while uploading multiple blob", async function () {


### PR DESCRIPTION
## Description

[Bug](https://dev.azure.com/fluidframework/internal/_workitems/edit/5214)

Assert in sendBlobAttachOp is hitting. The stack trace indicates we are trying to resubmit a blobAttach op while not having its corresponding blob in the pending list. There could be a mismatch between the op pending list and the blob pending list now that the latter is async if we keep uploading blobs while being in shutdown phase. This PR blocks uploading blobs during that process. 