### PR TITLE
Simplify summarizable implementations

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
@@ -14,8 +14,8 @@ import {
 	ISummaryTreeWithStats,
 	IGarbageCollectionData,
 } from "@fluidframework/runtime-definitions";
-import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
 import { ICodecOptions, IJsonCodec } from "../codec";
 import {
 	cachedValue,
@@ -34,7 +34,6 @@ import {
 import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
 import { isJsonObject, JsonCompatibleReadOnly } from "../util";
 import { makeSchemaCodec } from "./schemaIndexFormat";
-import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
 
 /**
  * The storage key for the blob in the summary containing schema data

--- a/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
@@ -34,6 +34,7 @@ import {
 import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
 import { isJsonObject, JsonCompatibleReadOnly } from "../util";
 import { makeSchemaCodec } from "./schemaIndexFormat";
+import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
 
 /**
  * The storage key for the blob in the summary containing schema data
@@ -72,10 +73,8 @@ export class SchemaSummarizer implements Summarizable {
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
-		const builder = new SummaryTreeBuilder();
 		const dataString = this.codec.encode(this.schema);
-		builder.addBlob(schemaStringKey, dataString);
-		return builder.getSummaryTree();
+		return createSingleBlobSummary(schemaStringKey, dataString);
 	}
 
 	public async summarize(
@@ -85,9 +84,7 @@ export class SchemaSummarizer implements Summarizable {
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
 		const schemaBlobHandle = await this.schemaBlob.get();
-		const builder = new SummaryTreeBuilder();
-		builder.addBlob(schemaBlobKey, stringify(schemaBlobHandle));
-		return builder.getSummaryTree();
+		return createSingleBlobSummary(schemaBlobKey, stringify(schemaBlobHandle));
 	}
 
 	public getGCData(fullGC?: boolean): IGarbageCollectionData {

--- a/experimental/dds/tree2/src/shared-tree-core/editManagerSummarizer.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManagerSummarizer.ts
@@ -3,12 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { assert, bufferToString, IsoBuffer } from "@fluidframework/common-utils";
+import { assert, bufferToString } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import {
-	IChannelStorageService,
-	IFluidDataStoreRuntime,
-} from "@fluidframework/datastore-definitions";
+import { IChannelStorageService } from "@fluidframework/datastore-definitions";
 import {
 	IGarbageCollectionData,
 	ISummaryTreeWithStats,
@@ -16,13 +13,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
 import { ICodecOptions, IJsonCodec } from "../codec";
-import {
-	cachedValue,
-	ChangeFamily,
-	ICachedValue,
-	recordDependency,
-	ChangeFamilyEditor,
-} from "../core";
+import { ChangeFamily, ChangeFamilyEditor } from "../core";
 import { JsonCompatibleReadOnly } from "../util";
 import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "./sharedTreeCore";
 import { EditManager, SummaryData } from "./editManager";
@@ -43,8 +34,6 @@ const formatVersion = 0;
 export class EditManagerSummarizer<TChangeset> implements Summarizable {
 	public readonly key = "EditManager";
 
-	private readonly editDataBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;
-
 	// Note: since there is only one format, this can just be cached on the class.
 	// With more write formats active, it may make sense to keep around the "usual" format codec
 	// (the one for the current persisted configuration) and resolve codecs for different versions
@@ -52,7 +41,6 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 	// and an op needs to be interpreted which isn't written with the current configuration).
 	private readonly codec: IJsonCodec<SummaryData<TChangeset>>;
 	public constructor(
-		private readonly runtime: IFluidDataStoreRuntime,
 		private readonly editManager: EditManager<
 			ChangeFamilyEditor,
 			TChangeset,
@@ -62,13 +50,6 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 	) {
 		const changesetCodec = this.editManager.changeFamily.codecs.resolve(formatVersion);
 		this.codec = makeEditManagerCodec(changesetCodec, options);
-		this.editDataBlob = cachedValue(async (observer) => {
-			recordDependency(observer, this.editManager);
-			const encodedSummary = this.codec.encode(this.editManager.getSummaryData());
-			// For now we are not chunking the edit data, but still put it in a reusable blob:
-			// TODO:#4632: Using JSON.stringify here doesn't properly handle `IFluidHandle`s, which the encoded summary may contain.
-			return this.runtime.uploadBlob(IsoBuffer.from(JSON.stringify(encodedSummary)));
-		});
 	}
 
 	public getAttachSummary(
@@ -77,9 +58,7 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
-		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData());
-		const dataString = stringify(jsonCompatible);
-		return createSingleBlobSummary(stringKey, dataString);
+		return this.summarizeCore(stringify);
 	}
 
 	public async summarize(
@@ -88,9 +67,13 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
-		const editDataBlobHandle = await this.editDataBlob.get();
-		const content = stringify(editDataBlobHandle);
-		return createSingleBlobSummary(blobKey, content);
+		return this.summarizeCore(stringify);
+	}
+
+	private summarizeCore(stringify: SummaryElementStringifier): ISummaryTreeWithStats {
+		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData());
+		const dataString = stringify(jsonCompatible);
+		return createSingleBlobSummary(stringKey, dataString);
 	}
 
 	public getGCData(fullGC?: boolean): IGarbageCollectionData {

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -196,7 +196,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		});
 
 		this.summarizables = [
-			new EditManagerSummarizer(runtime, this.editManager, options),
+			new EditManagerSummarizer(this.editManager, options),
 			...summarizables,
 		];
 		assert(
@@ -345,7 +345,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	}
 
 	public override getGCData(fullGC?: boolean): IGarbageCollectionData {
-		const gcNodes: IGarbageCollectionData["gcNodes"] = {};
+		const gcNodes: IGarbageCollectionData["gcNodes"] = super.getGCData(fullGC).gcNodes;
 		for (const s of this.summarizables) {
 			for (const [id, routes] of Object.entries(s.getGCData(fullGC).gcNodes)) {
 				gcNodes[id] ??= [];

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -88,7 +88,7 @@ export class SharedTree
 		const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
 		const forest = buildForest(schema, new AnchorSet());
 		const schemaSummarizer = new SchemaSummarizer(runtime, schema, options);
-		const forestSummarizer = new ForestSummarizer(runtime, forest);
+		const forestSummarizer = new ForestSummarizer(forest);
 		const changeFamily = new DefaultChangeFamily(options);
 		const repairProvider = new ForestRepairDataStoreProvider(
 			forest,

--- a/experimental/dds/tree2/src/test/snapshots/files/complete-3x3.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/complete-3x3.json
@@ -27,7 +27,7 @@
                     "tree": {
                         "ForestTree": {
                             "type": 2,
-                            "content": "\"[]\""
+                            "content": "[]"
                         }
                     }
                 }

--- a/experimental/dds/tree2/src/test/snapshots/files/has-handle.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/has-handle.json
@@ -27,7 +27,7 @@
                     "tree": {
                         "ForestTree": {
                             "type": 2,
-                            "content": "\"[{\\\"type\\\":\\\"Handle\\\",\\\"value\\\":{\\\"type\\\":\\\"__fluid_handle__\\\",\\\"url\\\":\\\"/tree-provider-lite-data-store/TestSharedTree\\\"}}]\""
+                            "content": "[{\"type\":\"Handle\",\"value\":{\"type\":\"__fluid_handle__\",\"url\":\"/tree-provider-lite-data-store/TestSharedTree\"}}]"
                         }
                     }
                 }

--- a/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change.json
@@ -27,7 +27,7 @@
                     "tree": {
                         "ForestTree": {
                             "type": 2,
-                            "content": "\"[{\\\"type\\\":\\\"SeqMap\\\",\\\"fields\\\":{\\\"foo\\\":[{\\\"type\\\":\\\"SeqMap\\\"}]}}]\""
+                            "content": "[{\"type\":\"SeqMap\",\"fields\":{\"foo\":[{\"type\":\"SeqMap\"}]}}]"
                         }
                     }
                 }

--- a/experimental/dds/tree2/src/test/util/testTreeProvider.spec.ts
+++ b/experimental/dds/tree2/src/test/util/testTreeProvider.spec.ts
@@ -18,7 +18,8 @@ describe("TestTreeProvider", () => {
 		const summaries = summaryCount;
 		await provider.summarize();
 
-		assert.strictEqual(summaryCount, summaries + 1);
+		// summarizeCore is invoked as part of getGCData, hence why this is +2 and not +1
+		assert.strictEqual(summaryCount, summaries + 2);
 		unspy();
 	});
 
@@ -54,7 +55,9 @@ describe("TestTreeProvider", () => {
 
 		const summaries = summaryCount;
 		await provider.summarize();
-		assert.strictEqual(summaryCount, summaries + 1);
+
+		// summarizeCore is invoked as part of getGCData, hence why this is +2 and not +1
+		assert.strictEqual(summaryCount, summaries + 2);
 		unspy();
 	});
 });


### PR DESCRIPTION
## Description

This removes the reusable blob pattern for `ForestSummarizer` and `EditManagerSummarizer`, which are unlikely to ever have the exact same summary data and thus unlikely to benefit from it. They also didn't correctly implement `load` anyway. Conveniently, this cleans up bad JSON.stringify usages which don't behave well with GC.

Removes double-stringification from `ForestSummarizer`.

I converted all summarizables to use `createSingleBlobSummary` when possible.

Lastly, this modifies SharedTreeCore's `getGCData` implementation to delegate to the base implementation and extend it with the summarizables' implementations, which should make it correct for the time being (though we still have a testing gap here).

[AB#5062](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5062)
