### PR TITLE
Adding deny list capability to Historian

### DIFF
--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -23,7 +23,7 @@ import {
 import { BaseTelemetryProperties, HttpProperties } from "@fluidframework/server-services-telemetry";
 import { RestLessServer } from "@fluidframework/server-services-shared";
 import * as routes from "./routes";
-import { ICache, ITenantService } from "./services";
+import { ICache, IDenyList, ITenantService } from "./services";
 import { Constants, getDocumentIdFromRequest, getTenantIdFromRequest } from "./utils";
 
 export function create(
@@ -35,6 +35,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ) {
 	// Express app configuration
 	const app: express.Express = express();
@@ -93,6 +94,7 @@ export function create(
 		cache,
 		asyncLocalStorage,
 		revokedTokenChecker,
+		denyList,
 	);
 	app.use(apiRoutes.git.blobs);
 	app.use(apiRoutes.git.refs);

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -54,6 +55,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.createBlob(body);
 	}
@@ -72,6 +74,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getBlob(sha, useCache);
 	}

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -54,6 +55,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.createCommit(params);
 	}
@@ -72,6 +74,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getCommit(sha, useCache);
 	}

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -22,7 +22,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -34,6 +34,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -54,6 +55,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getRefs();
 	}
@@ -67,6 +69,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getRef(ref);
 	}
@@ -84,6 +87,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.createRef(params);
 	}
@@ -102,6 +106,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.updateRef(ref, params);
 	}
@@ -115,6 +120,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.deleteRef(ref);
 	}

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -54,6 +55,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.createTag(params);
 	}
@@ -67,6 +69,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getTag(tag);
 	}

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -54,6 +55,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.createTree(params);
 	}
@@ -73,6 +75,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getTree(sha, recursive, useCache);
 	}

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { Router } from "express";
 import * as nconf from "nconf";
-import { ICache, ITenantService } from "../services";
+import { ICache, IDenyList, ITenantService } from "../services";
 /* eslint-disable import/no-internal-modules */
 import * as blobs from "./git/blobs";
 import * as commits from "./git/commits";
@@ -49,6 +49,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): IRoutes {
 	return {
 		git: {
@@ -60,6 +61,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 			commits: commits.create(
 				config,
@@ -69,6 +71,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 			refs: refs.create(
 				config,
@@ -78,6 +81,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 			tags: tags.create(
 				config,
@@ -87,6 +91,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 			trees: trees.create(
 				config,
@@ -96,6 +101,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 		},
 		repository: {
@@ -107,6 +113,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 			contents: contents.create(
 				config,
@@ -116,6 +123,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 			headers: headers.create(
 				config,
@@ -125,6 +133,7 @@ export function create(
 				cache,
 				asyncLocalStorage,
 				revokedTokenChecker,
+				denyList,
 			),
 		},
 		summaries: summaries.create(
@@ -136,6 +145,7 @@ export function create(
 			cache,
 			asyncLocalStorage,
 			revokedTokenChecker,
+			denyList,
 		),
 	};
 }

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -55,6 +56,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getCommits(sha, count);
 	}

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -17,7 +17,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -29,6 +29,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -54,6 +55,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getContent(path, ref);
 	}

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 
@@ -55,6 +56,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getHeader(sha, useCache);
 	}
@@ -73,6 +75,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getFullTree(sha, useCache);
 	}

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -23,7 +23,7 @@ import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
 import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICache, ITenantService } from "../services";
+import { ICache, IDenyList, ITenantService } from "../services";
 import { parseToken, Constants } from "../utils";
 import * as utils from "./utils";
 
@@ -36,6 +36,7 @@ export function create(
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
 ): Router {
 	const router: Router = Router();
 	const ignoreIsEphemeralFlag: boolean = config.get("ignoreEphemeralFlag") ?? true;
@@ -98,6 +99,7 @@ export function create(
 			storageNameRetriever,
 			cache,
 			asyncLocalStorage,
+			denyList,
 		});
 		return service.getSummary(sha, useCache);
 	}
@@ -123,6 +125,7 @@ export function create(
 			storageName,
 			isEphemeralContainer,
 			ignoreEphemeralFlag,
+			denyList,
 		});
 		return service.createSummary(params, initial);
 	}
@@ -141,6 +144,7 @@ export function create(
 			cache,
 			asyncLocalStorage,
 			allowDisabledTenant: true,
+			denyList,
 		});
 		const deletionPs = [service.deleteSummary(softDelete)];
 		if (!softDelete) {

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -16,7 +16,7 @@ import {
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICache, ITenantService } from "./services";
+import { ICache, IDenyList, ITenantService } from "./services";
 import * as app from "./app";
 
 export class HistorianRunner implements IRunner {
@@ -34,6 +34,7 @@ export class HistorianRunner implements IRunner {
 		private readonly cache?: ICache,
 		private readonly asyncLocalStorage?: AsyncLocalStorage<string>,
 		private readonly revokedTokenChecker?: IRevokedTokenChecker,
+		private readonly denyList?: IDenyList,
 	) {}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -49,6 +50,7 @@ export class HistorianRunner implements IRunner {
 			this.cache,
 			this.asyncLocalStorage,
 			this.revokedTokenChecker,
+			this.denyList,
 		);
 		historian.set("port", this.port);
 

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -27,6 +27,7 @@ export class HistorianResources implements core.IResources {
 		public readonly cache?: historianServices.RedisCache,
 		public readonly asyncLocalStorage?: AsyncLocalStorage<string>,
 		public revokedTokenChecker?: core.IRevokedTokenChecker,
+		public readonly denyList?: historianServices.IDenyList,
 	) {
 		this.webServerFactory = new services.BasicWebServerFactory();
 	}
@@ -210,6 +211,11 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 		const revokedTokenChecker: core.IRevokedTokenChecker | undefined =
 			customizations?.revokedTokenChecker ?? new utils.DummyRevokedTokenChecker();
 
+		const denyListConfig = config.get("denyList");
+		const denyList: historianServices.IDenyList = new historianServices.DenyList(
+			denyListConfig,
+		);
+
 		return new HistorianResources(
 			config,
 			port,
@@ -220,6 +226,7 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 			gitCache,
 			asyncLocalStorage,
 			revokedTokenChecker,
+			denyList,
 		);
 	}
 }
@@ -237,6 +244,7 @@ export class HistorianRunnerFactory implements core.IRunnerFactory<HistorianReso
 			resources.cache,
 			resources.asyncLocalStorage,
 			resources.revokedTokenChecker,
+			resources.denyList,
 		);
 	}
 }

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -211,7 +211,7 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 		const revokedTokenChecker: core.IRevokedTokenChecker | undefined =
 			customizations?.revokedTokenChecker ?? new utils.DummyRevokedTokenChecker();
 
-		const denyListConfig = config.get("denyList");
+		const denyListConfig = config.get("documentDenyList");
 		const denyList: historianServices.IDenyList = new historianServices.DenyList(
 			denyListConfig,
 		);

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -97,3 +97,19 @@ export interface IOauthAccessInfo {
 	refreshToken: string;
 	expiresAt: string;
 }
+
+/*
+ * Interface for a deny list. The goal is to deny requests for given tenantId, documentId pairs
+ * that have potential to cause service disruption.
+ * That could happen, for example, due to very large summary sizes. While we should always
+ * identify and fix causes that lead a document to get into such state, this is a protection
+ * mechanism to avoid a DoS situation happening because of a few documents. E.g.: when documents
+ * have accumulated very large summary sizes, they can cause Historian and/or GitRest to crash
+ * due to OOM, especially given retries from the client and service (Scribe).
+ */
+export interface IDenyList {
+	/**
+	 * Checks if a given tenantId, documentId pair is denied.
+	 */
+	isDenied(tenantId: string, documentId: string): boolean;
+}

--- a/server/historian/packages/historian-base/src/services/denyList.ts
+++ b/server/historian/packages/historian-base/src/services/denyList.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDenyList } from "./definitions";
+
+export class DenyList implements IDenyList {
+	// Key of the map is a tenantID
+	// Value of the map is a set with documentIDs
+	private readonly deniedMap: Map<string, Set<string>>;
+	constructor(denyList?: { [key: string]: string[] }) {
+		this.deniedMap = new Map();
+		if (denyList) {
+			for (const [tenantId, documentIds] of Object.entries(denyList)) {
+				this.deniedMap.set(tenantId, new Set(documentIds));
+			}
+		}
+	}
+
+	public isDenied(tenantId: string, documentId: string): boolean {
+		const documentIdsForTenantId = this.deniedMap.get(tenantId);
+		if (!documentIdsForTenantId) {
+			return false;
+		}
+		return documentIdsForTenantId.has(documentId);
+	}
+}

--- a/server/historian/packages/historian-base/src/services/index.ts
+++ b/server/historian/packages/historian-base/src/services/index.ts
@@ -7,6 +7,7 @@ export {
 	ICache,
 	IConnectionString,
 	ICredentials,
+	IDenyList,
 	IExternalStorage,
 	IOauthAccessInfo,
 	IStorage,
@@ -14,6 +15,7 @@ export {
 	ITenantCustomDataExternal,
 	ITenantService,
 } from "./definitions";
+export { DenyList } from "./denyList";
 export { RedisCache } from "./redisCache";
 export { RedisTenantCache } from "./redisTenantCache";
 export { IDocument, RestGitService } from "./restGitService";

--- a/server/historian/packages/historian-base/src/test/denyList.spec.ts
+++ b/server/historian/packages/historian-base/src/test/denyList.spec.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { DenyList } from "../services";
+
+describe("denyList", () => {
+	describe("shouldDenyIfDocumentIsInList", () => {
+		it("singleDocumentInList", () => {
+			const deniedDocuments = {
+				tenantId1: ["documentId1"],
+			};
+			const denyList = new DenyList(deniedDocuments);
+			const result = denyList.isDenied("tenantId1", "documentId1");
+			const expected = true;
+			assert.strictEqual(result, expected);
+		});
+		it("multipleDocumentsInList", () => {
+			const deniedDocuments = {
+				tenantId1: ["documentId1", "documentId2"],
+			};
+			const denyList = new DenyList(deniedDocuments);
+			const result1 = denyList.isDenied("tenantId1", "documentId1");
+			const expected1 = true;
+			assert.strictEqual(result1, expected1);
+			const result2 = denyList.isDenied("tenantId1", "documentId2");
+			const expected2 = true;
+			assert.strictEqual(result2, expected2);
+		});
+		it("multipleDocumentsInList", () => {
+			const deniedDocuments = {
+				tenantId1: ["documentId1", "documentId2"],
+				tenantId2: ["documentId3", "documentId4"],
+			};
+			const denyList = new DenyList(deniedDocuments);
+
+			const result1 = denyList.isDenied("tenantId1", "documentId1");
+			const expected1 = true;
+			assert.strictEqual(result1, expected1);
+
+			const result2 = denyList.isDenied("tenantId2", "documentId3");
+			const expected2 = true;
+			assert.strictEqual(result2, expected2);
+		});
+	});
+	describe("shouldNotDenyIfDocumentNotInList", () => {
+		it("undefinedMap", () => {
+			const denyList = new DenyList();
+			const result = denyList.isDenied("tenantId1", "documentId1");
+			const expected = false;
+			assert.strictEqual(result, expected);
+		});
+		it("emptyMap", () => {
+			const deniedDocuments = {};
+			const denyList = new DenyList(deniedDocuments);
+			const result = denyList.isDenied("tenantId1", "documentId1");
+			const expected = false;
+			assert.strictEqual(result, expected);
+		});
+		it("emptyListForTenant", () => {
+			const deniedDocuments = {
+				tenantId1: [],
+			};
+			const denyList = new DenyList(deniedDocuments);
+			const result1 = denyList.isDenied("tenantId1", "documentId1");
+			const expected1 = false;
+			assert.strictEqual(result1, expected1);
+		});
+		it("documentNotInTenantList", () => {
+			const deniedDocuments = {
+				tenantId1: ["documentId1", "documentId2"],
+				tenantId2: ["documentId3", "documentId4"],
+			};
+			const denyList = new DenyList(deniedDocuments);
+
+			const result1 = denyList.isDenied("tenantId1", "documentId3");
+			const expected1 = false;
+			assert.strictEqual(result1, expected1);
+
+			const result2 = denyList.isDenied("tenantId2", "documentId2");
+			const expected2 = false;
+			assert.strictEqual(result2, expected2);
+		});
+	});
+});


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
## Description

In Azure Fluid Relay, we noticed that some documents have potential to cause issues to the service. Ultimately, we need to improve the service implementation so we can prevent documents from getting into that state in the first place. We have done significant work on that front recently. One of those improvements was with respect to large documents that could lead Historian and GitRest to OOM. To give us an immediate mitigation tool if new issues happen again, this PR implements a "deny list" strategy in Historian to deny requests for certain documents that are known to cause issues.

This could be extended to routerlicious, both in the HTTP request flow and websocket flow with necessary. For agility reasons, we are implementing it here first.

## Breaking Changes

None.

## Testing
- Validation through unit tests
- Validation through DEV cluster, testing documents before and after putting them in the deny list and confirming that (i) documents in the list start having Historian requests denied and (ii) other documents, regardless if for other or same tenants, have no change in behavior

![Screenshot 2023-08-08 at 4 05 28 PM](https://github.com/microsoft/FluidFramework/assets/41453887/237f6b65-c866-4977-ae27-fbc81d1dc135)
![Screenshot 2023-08-08 at 4 05 36 PM](https://github.com/microsoft/FluidFramework/assets/41453887/1db114a0-bb45-42c8-b123-bf760dd56129)

