### PR TITLE
Allow enforcement of too large summary errors

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -36,7 +36,7 @@ import {
 	logAndThrowApiError,
 	persistLatestFullSummaryInStorage,
 	retrieveLatestFullSummaryFromStorage,
-    SystemErrors,
+	SystemErrors,
 } from "../utils";
 
 function getFullSummaryDirectory(repoManager: IRepositoryManager, documentId: string): string {
@@ -76,9 +76,9 @@ async function getSummary(
 				error,
 			);
 			if (enforceStrictPersistedFullSummaryReads) {
-                if (isNetworkError(error) && error.code === 413) {
-                    throw error;
-                }
+				if (isNetworkError(error) && error.code === 413) {
+					throw error;
+				}
 				if (
 					typeof (error as any).code === "string" &&
 					(error as any).code === SystemErrors.EFBIG.code
@@ -274,7 +274,8 @@ export function create(
 	const enableOptimizedInitialSummary: boolean =
 		store.get("git:enableOptimizedInitialSummary") ?? false;
 	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
-    const enforceStrictPersistedFullSummaryReads: boolean = store.get("git:enforceStrictPersistedFullSummaryReads") ?? false;
+	const enforceStrictPersistedFullSummaryReads: boolean =
+		store.get("git:enforceStrictPersistedFullSummaryReads") ?? false;
 
 	/**
 	 * Retrieves a summary.
@@ -318,7 +319,7 @@ export function create(
 					repoManagerParams,
 					getExternalWriterParams(request.query?.config as string | undefined),
 					persistLatestFullSummary,
-                    enforceStrictPersistedFullSummaryReads,
+					enforceStrictPersistedFullSummaryReads,
 				);
 			})
 			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));

--- a/server/gitrest/packages/gitrest-base/src/utils/fileSystemHelper.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/fileSystemHelper.ts
@@ -39,6 +39,10 @@ export const SystemErrors: Record<string, ISystemError> = {
 		code: "ENOTEMPTY",
 		description: "Directory not empty",
 	},
+	EFBIG: {
+		code: "EFBIG",
+		description: "File too large",
+	},
 	UNKNOWN: {
 		code: "UNKNOWN",
 		description: "Unknown error",

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -18,6 +18,7 @@ export {
 	IStorageDirectoryConfig,
 	IStorageRoutingId,
 } from "./definitions";
+export { SystemErrors } from "./fileSystemHelper";
 export { MemFsManagerFactory, NodeFsManagerFactory, RedisFsManagerFactory } from "./filesystems";
 export {
 	BaseGitRestTelemetryProperties,

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -1,46 +1,47 @@
 {
-	"logger": {
-		"colorize": true,
-		"morganFormat": "json",
-		"json": false,
-		"level": "info",
-		"timestamp": true
-	},
-	"requestSizeLimit": "1gb",
-	"storageDir": {
-		"baseDir": "/home/node/documents",
-		"useRepoOwner": true
-	},
-	"externalStorage": {
-		"enabled": false,
-		"endpoint": "http://externalStorage:3005"
-	},
-	"git": {
-		"lib": {
-			"name": "nodegit"
-		},
-		"filesystem": {
-			"name": "nodeFs"
-		},
-		"ephemeralfilesystem": {
-			"name": "redisFs"
-		},
-		"persistLatestFullSummary": false,
-		"repoPerDocEnabled": false,
-		"enableRepositoryManagerMetrics": false,
-		"apiMetricsSamplingPeriod": 100,
-		"enableLowIoWrite": false,
-		"enableOptimizedInitialSummary": false,
-		"enableSlimGitInit": false,
-		"enableRedisFsMetrics": true,
-		"redisApiMetricsSamplingPeriod": 0
-	},
-	"redis": {
-		"host": "redis",
-		"port": 6379,
-		"connectTimeout": 10000,
-		"maxRetriesPerRequest": 20,
-		"enableAutoPipelining": false,
-		"enableOfflineQueue": true
-	}
+    "logger": {
+        "colorize": true,
+        "morganFormat": "json",
+        "json": false,
+        "level": "info",
+        "timestamp": true
+    },
+    "requestSizeLimit": "1gb",
+    "storageDir": {
+        "baseDir": "/home/node/documents",
+        "useRepoOwner": true
+    },
+    "externalStorage": {
+        "enabled": false,
+        "endpoint": "http://externalStorage:3005"
+    },
+    "git": {
+        "lib": {
+            "name": "nodegit"
+        },
+        "filesystem": {
+            "name": "nodeFs"
+        },
+        "ephemeralfilesystem": {
+            "name": "redisFs"
+        },
+        "persistLatestFullSummary": false,
+        "repoPerDocEnabled": false,
+        "enableRepositoryManagerMetrics": false,
+        "apiMetricsSamplingPeriod": 100,
+        "enableLowIoWrite": false,
+        "enableOptimizedInitialSummary": false,
+        "enableSlimGitInit": false,
+        "enableRedisFsMetrics": true,
+        "redisApiMetricsSamplingPeriod": 0,
+        "enforceStrictPersistedFullSummaryReads": false
+    },
+    "redis": {
+        "host": "redis",
+        "port": 6379,
+        "connectTimeout": 10000,
+        "maxRetriesPerRequest": 20,
+        "enableAutoPipelining": false,
+        "enableOfflineQueue": true
+    }
 }

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -1,47 +1,47 @@
 {
-    "logger": {
-        "colorize": true,
-        "morganFormat": "json",
-        "json": false,
-        "level": "info",
-        "timestamp": true
-    },
-    "requestSizeLimit": "1gb",
-    "storageDir": {
-        "baseDir": "/home/node/documents",
-        "useRepoOwner": true
-    },
-    "externalStorage": {
-        "enabled": false,
-        "endpoint": "http://externalStorage:3005"
-    },
-    "git": {
-        "lib": {
-            "name": "nodegit"
-        },
-        "filesystem": {
-            "name": "nodeFs"
-        },
-        "ephemeralfilesystem": {
-            "name": "redisFs"
-        },
-        "persistLatestFullSummary": false,
-        "repoPerDocEnabled": false,
-        "enableRepositoryManagerMetrics": false,
-        "apiMetricsSamplingPeriod": 100,
-        "enableLowIoWrite": false,
-        "enableOptimizedInitialSummary": false,
-        "enableSlimGitInit": false,
-        "enableRedisFsMetrics": true,
-        "redisApiMetricsSamplingPeriod": 0,
-        "enforceStrictPersistedFullSummaryReads": false
-    },
-    "redis": {
-        "host": "redis",
-        "port": 6379,
-        "connectTimeout": 10000,
-        "maxRetriesPerRequest": 20,
-        "enableAutoPipelining": false,
-        "enableOfflineQueue": true
-    }
+	"logger": {
+		"colorize": true,
+		"morganFormat": "json",
+		"json": false,
+		"level": "info",
+		"timestamp": true
+	},
+	"requestSizeLimit": "1gb",
+	"storageDir": {
+		"baseDir": "/home/node/documents",
+		"useRepoOwner": true
+	},
+	"externalStorage": {
+		"enabled": false,
+		"endpoint": "http://externalStorage:3005"
+	},
+	"git": {
+		"lib": {
+			"name": "nodegit"
+		},
+		"filesystem": {
+			"name": "nodeFs"
+		},
+		"ephemeralfilesystem": {
+			"name": "redisFs"
+		},
+		"persistLatestFullSummary": false,
+		"repoPerDocEnabled": false,
+		"enableRepositoryManagerMetrics": false,
+		"apiMetricsSamplingPeriod": 100,
+		"enableLowIoWrite": false,
+		"enableOptimizedInitialSummary": false,
+		"enableSlimGitInit": false,
+		"enableRedisFsMetrics": true,
+		"redisApiMetricsSamplingPeriod": 0,
+		"enforceStrictPersistedFullSummaryReads": false
+	},
+	"redis": {
+		"host": "redis",
+		"port": 6379,
+		"connectTimeout": 10000,
+		"maxRetriesPerRequest": 20,
+		"enableAutoPipelining": false,
+		"enableOfflineQueue": true
+	}
 }

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -108,6 +108,8 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 	const customData: ITenantCustomDataExternal = details.customData;
 	const writeToExternalStorage = !!customData?.externalStorageData;
 	const storageUrl = config.get("storageUrl") as string | undefined;
+	const maxCacheableSummarySize: number =
+		config.get("restGitService:maxCacheableSummarySize") ?? 1_000_000_000; // default: 1gb
 
 	let isEphemeral = isEphemeralContainer;
 	if (!ignoreEphemeralFlag) {
@@ -132,6 +134,7 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 		calculatedStorageName,
 		storageUrl,
 		isEphemeral,
+		maxCacheableSummarySize,
 	);
 	return service;
 }

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -64,6 +64,7 @@ export class RestGitService {
 		private readonly storageName?: string,
 		private readonly storageUrl?: string,
 		private readonly isEphemeralContainer?: boolean,
+		private readonly maxCacheableSummarySize?: number,
 	) {
 		const defaultHeaders: AxiosRequestHeaders =
 			storageName !== undefined
@@ -236,9 +237,12 @@ export class RestGitService {
 			summaryParams,
 			initial !== undefined ? { initial } : undefined,
 		);
+		// JSON.stringify is not ideal for performance here, but it is better than crashing the cache service.
+		const summarySize = JSON.stringify(summaryResponse).length;
 		if (
 			summaryParams.type === "container" &&
-			(summaryResponse as IWholeFlatSummary).trees !== undefined
+			(summaryResponse as IWholeFlatSummary).trees !== undefined &&
+			summarySize <= this.maxCacheableSummarySize
 		) {
 			// Cache the written summary for future retrieval. If this fails, next summary retrieval
 			// will receive an older version, but that is OK. Client will catch up with ops.

--- a/server/historian/packages/historian/config.json
+++ b/server/historian/packages/historian/config.json
@@ -81,7 +81,8 @@
 		}
 	},
 	"restGitService": {
-		"disableGitCache": false
+		"disableGitCache": false,
+		"maxCacheableSummarySize": 100000000
 	},
 	"storageUrl": "",
 	"tokenRevocation": {


### PR DESCRIPTION
## Description
 
We need to be able to block downloads of Too Large summaries in Gitrest. FRS has an internal FS mechanism for blocking downloads over a certain size, so we need to throw that error instead of failing over to smaller blobs.
