### PR TITLE
added approveProposalComplete event to QuorumProposal

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -368,6 +368,24 @@ export class QuorumProposals
 			// clear the values cache
 			this.valuesSnapshotCache = undefined;
 
+			// check if there are multiple proposals with matching keys
+			let proposalSettled = false;
+			let proposalKeySeen = false;
+			for (const [, p] of this.proposals) {
+				if (p.key === committedProposal.key) {
+					if(!proposalKeySeen){
+						// set proposalSettled to true if the proposal key match is unique thus far
+						proposalSettled = true;
+					}
+					else {
+						// set proposalSettled to false if matching proposal key is not unique
+						proposalSettled = false;
+						break;
+					}
+					proposalKeySeen = true;
+				}
+			}
+
 			this.emit(
 				"approveProposal",
 				committedProposal.sequenceNumber,
@@ -375,6 +393,17 @@ export class QuorumProposals
 				committedProposal.value,
 				committedProposal.approvalSequenceNumber,
 			);
+
+			// emit approveProposalComplete when all pending proposals are processed
+			if (proposalSettled) {
+				this.emit(
+					"approveProposalComplete",
+					committedProposal.sequenceNumber,
+					committedProposal.key,
+					committedProposal.value,
+					committedProposal.approvalSequenceNumber,
+				);
+			}
 
 			this.proposals.delete(proposal.sequenceNumber);
 

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -373,11 +373,10 @@ export class QuorumProposals
 			let proposalKeySeen = false;
 			for (const [, p] of this.proposals) {
 				if (p.key === committedProposal.key) {
-					if(!proposalKeySeen){
+					if (!proposalKeySeen) {
 						// set proposalSettled to true if the proposal key match is unique thus far
 						proposalSettled = true;
-					}
-					else {
+					} else {
 						// set proposalSettled to false if matching proposal key is not unique
 						proposalSettled = false;
 						break;


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_workitems/edit/4749/
The goal of this item is to remove the usage of the deltaManager in the sameContainerMigrationTool. The root cause of the migration tool's reliance on the deltaManager is the lack of conflict resolution and eventing in the QuorumProposal. 
Improving the conflict resolution and eventing in the QuorumProposal will provide the migration tool with information regarding the proposal state without having to spy on the op stream. 

This PR covers the first segment addressing the conflict resolution and eventing. It checks that a pending proposal is unique before emitting an "approveProposalComplete" event. By verifying that the proposal is unique, we can be certain that there won't be conflicts after approval. 

A follow up PR will consume the updated protocol-base and update the sameContainerMigrationTool to make use of this new eventing. 