### PR TITLE
Change DefaultApiMinimumCountToEnableTermination to 30

### DIFF
--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -547,7 +547,7 @@ const DefaultMinHeartbeatFrequencyMS = 10000;
 const DefaultApiCounterIntervalMS = 60000;
 // 1 means 100%, using 2 just for safety for incorrect calculations and meaning this feature disabled
 const DefaultApiFailureRateTerminationThreshold = 2;
-const DefaultApiMinimumCountToEnableTermination = 100;
+const DefaultApiMinimumCountToEnableTermination = 30;
 const DefaultServerSelectionTimeoutMS = 30000;
 
 interface IMongoDBConfig {


### PR DESCRIPTION
<img width="1303" alt="image" src="https://github.com/microsoft/FluidFramework/assets/3719246/3b9cba9e-9894-47f1-abf9-2fca1057998b">

As a result, change the default setting to a lower number if not configured