### PR TITLE
Use ADO feed for @fluid-tools in include-test-real-service.yml

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -206,6 +206,7 @@ jobs:
 
             echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
+            echo "@fluid-tools:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
             echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc
             echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc


### PR DESCRIPTION
## Description

This makes the real service tests and the DDS stress pipeline install @fluid-tools packages from the appropriate ADO feed rather than npmjs.