### PR TITLE
Split SharedString and Interval Fuzz Tests

### DIFF
--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -32,15 +32,15 @@ import {
 	ChangeProperties,
 	FuzzTestState,
 	makeReducer,
-	OperationGenerationConfig,
-	defaultOperationGenerationConfig,
-	createBaseGeneratorOperations,
+	IntervalOperationGenerationConfig,
+	defaultIntervalOperationGenerationConfig,
+	createSharedStringGeneratorOperations,
 } from "./intervalCollection.fuzzUtils";
 import { minimizeTestFromFailureFile } from "./intervalCollection.fuzzMinimization";
 
 type ClientOpState = FuzzTestState;
 export function makeOperationGenerator(
-	optionsParam?: OperationGenerationConfig,
+	optionsParam?: IntervalOperationGenerationConfig,
 	alwaysLeaveChar: boolean = false,
 ): Generator<Operation, ClientOpState> {
 	const {
@@ -51,9 +51,9 @@ export function makeOperationGenerator(
 		lengthSatisfies,
 		hasNonzeroLength,
 		isShorterThanMaxLength,
-	} = createBaseGeneratorOperations(optionsParam);
+	} = createSharedStringGeneratorOperations(optionsParam);
 
-	const options = { ...defaultOperationGenerationConfig, ...(optionsParam ?? {}) };
+	const options = { ...defaultIntervalOperationGenerationConfig, ...(optionsParam ?? {}) };
 
 	function isNonEmpty(collection: IIntervalCollection<SequenceInterval>): boolean {
 		for (const _ of collection) {
@@ -163,7 +163,7 @@ export function makeOperationGenerator(
 		<T>(...clauses: AcceptanceCondition<T>[]): AcceptanceCondition<T> =>
 		(t: T) =>
 			clauses.reduce<boolean>((prev, cond) => prev && cond(t), true);
-	const usableWeights = optionsParam?.weights ?? defaultOperationGenerationConfig.weights;
+	const usableWeights = optionsParam?.weights ?? defaultIntervalOperationGenerationConfig.weights;
 	return createWeightedGenerator<Operation, ClientOpState>([
 		[addText, usableWeights.addText, isShorterThanMaxLength],
 		[
@@ -186,7 +186,8 @@ const baseModel: Omit<
 	DDSFuzzModel<SharedStringFactory, Operation, FuzzTestState>,
 	"workloadName"
 > = {
-	generatorFactory: () => take(100, makeOperationGenerator(defaultOperationGenerationConfig)),
+	generatorFactory: () =>
+		take(100, makeOperationGenerator(defaultIntervalOperationGenerationConfig)),
 	reducer:
 		// makeReducer supports a param for logging output which tracks the provided intervalId over time:
 		// { intervalId: "00000000-0000-0000-0000-000000000000", clientIds: ["A", "B", "C"] }

--- a/packages/dds/sequence/src/test/intervalRevertibles.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRevertibles.fuzz.spec.ts
@@ -41,7 +41,7 @@ import {
 	makeReducer,
 	RevertibleSharedString,
 	isRevertibleSharedString,
-	OperationGenerationConfig,
+	IntervalOperationGenerationConfig,
 	RevertSharedStringRevertibles,
 } from "./intervalCollection.fuzzUtils";
 import { makeOperationGenerator } from "./intervalCollection.fuzz.spec";
@@ -150,7 +150,7 @@ const optionsWithEmitter: Partial<DDSFuzzSuiteOptions> = {
 
 type ClientOpState = FuzzTestState;
 function operationGenerator(
-	optionsParam: OperationGenerationConfig,
+	optionsParam: IntervalOperationGenerationConfig,
 ): Generator<RevertOperation, ClientOpState> {
 	async function revertSharedStringRevertibles(
 		state: ClientOpState,

--- a/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as path from "path";
+import { readdirSync } from "fs";
+import {
+	createWeightedAsyncGenerator as createWeightedGenerator,
+	AsyncGenerator as Generator,
+	takeAsync as take,
+} from "@fluid-internal/stochastic-test-utils";
+import {
+	createDDSFuzzSuite,
+	DDSFuzzModel,
+	DDSFuzzSuiteOptions,
+} from "@fluid-internal/test-dds-utils";
+import { FlushMode } from "@fluidframework/runtime-definitions";
+import { SharedStringFactory } from "../sequenceFactory";
+import { assertEquivalentSharedStrings } from "./intervalUtils";
+import {
+	Operation,
+	FuzzTestState,
+	makeReducer,
+	defaultOperationGenerationConfig,
+	createBaseGeneratorOperations,
+	OperationGenerationConfig,
+} from "./intervalCollection.fuzzUtils";
+import { minimizeTestFromFailureFile } from "./intervalCollection.fuzzMinimization";
+
+type ClientOpState = FuzzTestState;
+export function makeSharedStringOperationGenerator(
+	optionsParam?: OperationGenerationConfig,
+	alwaysLeaveChar: boolean = false,
+): Generator<Operation, ClientOpState> {
+	const {
+		addText,
+		removeRange,
+		removeRangeLeaveChar,
+		lengthSatisfies,
+		hasNonzeroLength,
+		isShorterThanMaxLength,
+	} = createBaseGeneratorOperations(optionsParam);
+
+	const usableWeights = optionsParam?.weights ?? defaultOperationGenerationConfig.weights;
+	return createWeightedGenerator<Operation, ClientOpState>([
+		[addText, usableWeights.addText, isShorterThanMaxLength],
+		[
+			alwaysLeaveChar ? removeRangeLeaveChar : removeRange,
+			usableWeights.removeRange,
+			alwaysLeaveChar
+				? lengthSatisfies((length) => {
+						return length > 1;
+				  })
+				: hasNonzeroLength,
+		],
+	]);
+}
+
+const baseModel: Omit<
+	DDSFuzzModel<SharedStringFactory, Operation, FuzzTestState>,
+	"workloadName"
+> = {
+	generatorFactory: () =>
+		take(100, makeSharedStringOperationGenerator(defaultOperationGenerationConfig)),
+	reducer:
+		// makeReducer supports a param for logging output which tracks the provided intervalId over time:
+		// { intervalId: "00000000-0000-0000-0000-000000000000", clientIds: ["A", "B", "C"] }
+		makeReducer(),
+	validateConsistency: assertEquivalentSharedStrings,
+	factory: new SharedStringFactory(),
+};
+
+const defaultFuzzOptions: Partial<DDSFuzzSuiteOptions> = {
+	validationStrategy: { type: "fixedInterval", interval: 10 },
+	reconnectProbability: 0.1,
+	numberOfClients: 3,
+	clientJoinOptions: {
+		maxNumberOfClients: 6,
+		clientAddProbability: 0.1,
+	},
+	defaultTestCount: 100,
+	saveFailures: { directory: path.join(__dirname, "../../src/test/results") },
+	parseOperations: (serialized: string) => {
+		const operations: Operation[] = JSON.parse(serialized);
+		// Replace this value with some other interval ID and uncomment to filter replay of the test
+		// suite to only include interval operations with this ID.
+		// const filterIntervalId = "00000000-0000-0000-0000-000000000000";
+		// if (filterIntervalId) {
+		// 	return operations.filter((entry) =>
+		// 		[undefined, filterIntervalId].includes((entry as any).id),
+		// 	);
+		// }
+		return operations;
+	},
+};
+
+describe("SharedString no reconnect fuzz testing", () => {
+	const noReconnectNoIntervalsModel = {
+		...baseModel,
+		workloadName: "SharedString without reconnects",
+		generatorFactory: () =>
+			take(
+				100,
+				makeSharedStringOperationGenerator({
+					...defaultOperationGenerationConfig,
+				}),
+			),
+	};
+
+	const options = {
+		...defaultFuzzOptions,
+		reconnectProbability: 0.0,
+		numberOfClients: 3,
+		clientJoinOptions: {
+			maxNumberOfClients: 3,
+			clientAddProbability: 0.0,
+		},
+	};
+
+	createDDSFuzzSuite(noReconnectNoIntervalsModel, {
+		...options,
+		// Uncomment this line to replay a specific seed from its failure file:
+		// replay: 0,
+	});
+});
+
+/**
+ * Disabled as all tests are failing due to eventual consistency issues.
+ * ADO:5083 to deal with the failures.
+ */
+describe.skip("SharedString fuzz testing with rebased batches", () => {
+	const noReconnectWithRebaseModel = {
+		...baseModel,
+		workloadName: "SharedString with rebasing",
+	};
+
+	createDDSFuzzSuite(noReconnectWithRebaseModel, {
+		...defaultFuzzOptions,
+		reconnectProbability: 0.0,
+		numberOfClients: 3,
+		clientJoinOptions: {
+			maxNumberOfClients: 3,
+			clientAddProbability: 0.0,
+		},
+		rebaseProbability: 0.2,
+		containerRuntimeOptions: {
+			flushMode: FlushMode.TurnBased,
+			enableGroupedBatching: true,
+		},
+		// Uncomment this line to replay a specific seed from its failure file:
+		// replay: 0,
+	});
+});
+
+describe.skip("minimize specific seed", () => {
+	const seedToMinimize = 0;
+	minimizeTestFromFailureFile(seedToMinimize);
+});
+
+describe.skip("minimize all seeds", () => {
+	let files;
+	try {
+		files = readdirSync("./results");
+	} catch {
+		return;
+	}
+
+	for (const file of files) {
+		const seedToMinimize = parseInt(file.substring(0, file.length - ".json".length), 10);
+		minimizeTestFromFailureFile(seedToMinimize);
+	}
+});

--- a/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
@@ -22,15 +22,15 @@ import {
 	Operation,
 	FuzzTestState,
 	makeReducer,
-	defaultOperationGenerationConfig,
-	createBaseGeneratorOperations,
-	OperationGenerationConfig,
+	defaultIntervalOperationGenerationConfig,
+	createSharedStringGeneratorOperations,
+	SharedStringOperationGenerationConfig,
 } from "./intervalCollection.fuzzUtils";
 import { minimizeTestFromFailureFile } from "./intervalCollection.fuzzMinimization";
 
 type ClientOpState = FuzzTestState;
 export function makeSharedStringOperationGenerator(
-	optionsParam?: OperationGenerationConfig,
+	optionsParam?: SharedStringOperationGenerationConfig,
 	alwaysLeaveChar: boolean = false,
 ): Generator<Operation, ClientOpState> {
 	const {
@@ -40,9 +40,9 @@ export function makeSharedStringOperationGenerator(
 		lengthSatisfies,
 		hasNonzeroLength,
 		isShorterThanMaxLength,
-	} = createBaseGeneratorOperations(optionsParam);
+	} = createSharedStringGeneratorOperations(optionsParam);
 
-	const usableWeights = optionsParam?.weights ?? defaultOperationGenerationConfig.weights;
+	const usableWeights = optionsParam?.weights ?? defaultIntervalOperationGenerationConfig.weights;
 	return createWeightedGenerator<Operation, ClientOpState>([
 		[addText, usableWeights.addText, isShorterThanMaxLength],
 		[
@@ -62,7 +62,7 @@ const baseModel: Omit<
 	"workloadName"
 > = {
 	generatorFactory: () =>
-		take(100, makeSharedStringOperationGenerator(defaultOperationGenerationConfig)),
+		take(100, makeSharedStringOperationGenerator(defaultIntervalOperationGenerationConfig)),
 	reducer:
 		// makeReducer supports a param for logging output which tracks the provided intervalId over time:
 		// { intervalId: "00000000-0000-0000-0000-000000000000", clientIds: ["A", "B", "C"] }
@@ -103,7 +103,7 @@ describe("SharedString no reconnect fuzz testing", () => {
 			take(
 				100,
 				makeSharedStringOperationGenerator({
-					...defaultOperationGenerationConfig,
+					...defaultIntervalOperationGenerationConfig,
 				}),
 			),
 	};


### PR DESCRIPTION
This change moves the shared string fuzz tests to a new file, and moves around some operations for easy sharing