### PR TITLE
Decimal sequence numbers when grouping batches - EXPERIMENTAL

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { UsageError } from "@fluidframework/container-utils";
 import { ICompressionRuntimeOptions } from "../containerRuntime";
-import { BatchMessage, IBatch, IBatchCheckpoint } from "./definitions";
+import { BatchMessage, IBatch, IBatchCheckpoint, MaxMessagesInABatch } from "./definitions";
 
 export interface IBatchManagerOptions {
 	readonly hardLimit: number;
@@ -94,6 +95,11 @@ export class BatchManager {
 
 		this.batchContentSize = contentSize;
 		this.pendingBatch.push(message);
+
+		if (this.pendingBatch.length > MaxMessagesInABatch) {
+			throw new UsageError("This batch is very large");
+		}
+
 		return true;
 	}
 

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -7,6 +7,8 @@ import { IBatchMessage } from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { CompressionAlgorithms, ContainerMessageType } from "..";
 
+export const MaxMessagesInABatch = 10000000000;
+
 /**
  * Batch message type used internally by the runtime
  */

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -10,6 +10,7 @@ export {
 	IBatchCheckpoint,
 	IChunkedOp,
 	IMessageProcessingResult,
+	MaxMessagesInABatch,
 } from "./definitions";
 export { Outbox, getLongStack } from "./outbox";
 export { OpCompressor } from "./opCompressor";

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ContainerMessageType } from "..";
-import { IBatch } from "./definitions";
+import { IBatch, MaxMessagesInABatch } from "./definitions";
 
 /**
  * Grouping makes assumptions about the shape of message contents. This interface codifies those assumptions, but does not validate them.
@@ -77,8 +77,12 @@ export class OpGroupingManager {
 
 		const messages = (op.contents as IGroupedBatchMessageContents).contents;
 		let fakeCsn = 1;
+		const fakeSn = 1 / MaxMessagesInABatch;
+		let multiplier = 0;
+		const baseSn = op.sequenceNumber;
 		return messages.map((subMessage) => ({
 			...op,
+			sequenceNumber: baseSn + fakeSn * multiplier++,
 			clientSequenceNumber: fakeCsn++,
 			contents: subMessage.contents,
 			metadata: subMessage.metadata,

--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -261,6 +261,14 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 			};
 
 			areDirectoriesEqual(sharedDirectory1, sharedDirectory2);
+			assert.strictEqual(
+				sharedDirectory1.get(directory),
+				{
+					concurrentValue: finalConcurrentValue,
+					newValue: "foobar",
+				},
+				"Unexpected final value",
+			);
 		});
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -195,7 +195,7 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 			},
 		);
 
-		it.only(`Eventual consistency for shared directories with op reentry - ${
+		it(`Eventual consistency for shared directories with op reentry - ${
 			enableGroupedBatching ? "Grouped" : "Regular"
 		} batches`, async () => {
 			await setupContainers({


### PR DESCRIPTION
## Description

What happens if we don't use whole numbers for message sequence numbers at the runtime layer?