### PR TITLE
tree2: Defer schema compatibility error, and more testing

### DIFF
--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -142,7 +142,7 @@ export function schematizeView(
 			// TODO:
 			// Ideally this would run at the end of the batch containing the schema change, but currently schema changes don't trigger afterBatch.
 			// Fortunately this works out ok, since the tree can't actually become out of schema until its actually edited, which should trigger after batch.
-			// When batching properly handles schema edits, which documentation and related tests should be updated.
+			// When batching properly handles schema edits, this documentation and related tests should be updated.
 			// TODO:
 			// This seems like the correct policy, but more clarity on how schematized views are updating during batches is needed.
 			afterBatchCheck ??= tree.events.on("afterBatch", () => {

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -126,6 +126,10 @@ export function schematizeView(
 		}
 	}
 
+	// Callback to cleanup afterBatch schema checking.
+	// Set only when such a callback is pending.
+	let afterBatchCheck: undefined | (() => void);
+
 	// TODO: errors thrown by this will usually be in response to remote edits, and thus may not surface to the app.
 	// Two fixes should be done related to this:
 	// 1. Ensure errors in response to edits like this crash app and report telemetry.
@@ -133,19 +137,33 @@ export function schematizeView(
 	// out of schema handlers which update the schematized view of the tree instead of throwing.
 	tree.storedSchema.registerDependent(
 		new SimpleObservingDependent(() => {
-			const compatibility = viewSchema.checkCompatibility(tree.storedSchema);
-			if (compatibility.read !== Compatibility.Compatible) {
-				fail(
-					"Stored schema changed to one that permits data incompatible with the view schema",
-				);
-			}
+			// On schema change, setup a callback (deduplicated so its only run once) after a batch of changes.
+			// This avoids erroring about invalid schema in the middle of a batch of changes.
+			// TODO:
+			// Ideally this would run at the end of the batch containing the schema change, but currently schema changes don't trigger afterBatch.
+			// Fortunately this works out ok, since the tree can't actually become out of schema until its actually edited, which should trigger after batch.
+			// When batching properly handles schema edits, which documentation and related tests should be updated.
+			// TODO:
+			// This seems like the correct policy, but more clarity on how schematized views are updating during batches is needed.
+			afterBatchCheck ??= tree.events.on("afterBatch", () => {
+				assert(afterBatchCheck !== undefined, "unregistered event ran");
+				afterBatchCheck();
+				afterBatchCheck = undefined;
 
-			if (compatibility.write !== Compatibility.Compatible) {
-				// TODO: support readonly mode in this case.
-				fail(
-					"Stored schema changed to one that does not support all data allowed by view schema",
-				);
-			}
+				const compatibility = viewSchema.checkCompatibility(tree.storedSchema);
+				if (compatibility.read !== Compatibility.Compatible) {
+					fail(
+						"Stored schema changed to one that permits data incompatible with the view schema",
+					);
+				}
+
+				if (compatibility.write !== Compatibility.Compatible) {
+					// TODO: support readonly mode in this case.
+					fail(
+						"Stored schema changed to one that does not support all data allowed by view schema",
+					);
+				}
+			});
 		}),
 	);
 

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -3,15 +3,24 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
-import { SchemaBuilder, Any } from "../../feature-libraries";
-import { SharedTreeFactory } from "../../shared-tree";
-import { ValueSchema, AllowedUpdateType, storedEmptyFieldSchema } from "../../core";
+import {
+	MockFluidDataStoreRuntime,
+	validateAssertionError,
+} from "@fluidframework/test-runtime-utils";
+import { SchemaBuilder, Any, TypedSchemaCollection, FieldSchema } from "../../feature-libraries";
+import { ISharedTreeView, SharedTreeFactory } from "../../shared-tree";
+import {
+	ValueSchema,
+	AllowedUpdateType,
+	storedEmptyFieldSchema,
+	SimpleObservingDependent,
+} from "../../core";
 import { typeboxValidator } from "../../external-utilities";
+import { TestTreeProviderLite } from "../utils";
 
 const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
-const builder = new SchemaBuilder("Schematize Tree Tests");
 
+const builder = new SchemaBuilder("Schematize Tree Tests");
 const root = builder.leaf("root", ValueSchema.Number);
 const schema = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(Any));
 
@@ -19,25 +28,85 @@ const builderGeneralized = new SchemaBuilder("Schematize Tree Tests Generalized"
 const rootGeneralized = builderGeneralized.leaf("root", ValueSchema.Serializable);
 const schemaGeneralized = builderGeneralized.intoDocumentSchema(SchemaBuilder.fieldOptional(Any));
 
+const builderValue = new SchemaBuilder("Schematize Tree Tests");
+const root2 = builderValue.leaf("root", ValueSchema.Number);
+const schemaValueRoot = builderValue.intoDocumentSchema(SchemaBuilder.fieldValue(Any));
+
 describe("schematizeView", () => {
-	it("initialize tree schema", () => {
-		const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+	function testInitialize<TRoot extends FieldSchema>(
+		name: string,
+		documentSchema: TypedSchemaCollection<TRoot>,
+	): void {
+		describe(`Initialize with ${name} root`, () => {
+			function expectSchema(tree: ISharedTreeView): void {
+				assert.equal(
+					tree.storedSchema.rootFieldSchema.kind.identifier,
+					documentSchema.rootFieldSchema.kind.identifier,
+				);
+				assert.deepEqual(
+					tree.storedSchema.rootFieldSchema.types,
+					documentSchema.rootFieldSchema.types,
+				);
+				assert(tree.storedSchema.treeSchema.has(root.name));
+				assert.equal(tree.root, 10);
+			}
 
-		assert.equal(tree.storedSchema.rootFieldSchema, storedEmptyFieldSchema);
+			it("initialize tree schema", () => {
+				const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+				assert.equal(tree.storedSchema.rootFieldSchema, storedEmptyFieldSchema);
 
-		const schematized = tree.schematize({
-			allowedSchemaModifications: AllowedUpdateType.None,
-			initialTree: 10,
-			schema,
+				tree.schematize({
+					allowedSchemaModifications: AllowedUpdateType.None,
+					initialTree: 10 as any,
+					schema: documentSchema,
+				});
+				expectSchema(tree);
+			});
+
+			it("initialization works with collaboration", () => {
+				const provider = new TestTreeProviderLite(2, factory);
+				const tree = provider.trees[0];
+
+				tree.schematize({
+					allowedSchemaModifications: AllowedUpdateType.None,
+					initialTree: 10 as any,
+					schema: documentSchema,
+				});
+
+				expectSchema(tree);
+				provider.processMessages();
+				expectSchema(tree);
+				expectSchema(provider.trees[1]);
+			});
+
+			it("concurrent initialization", () => {
+				const provider = new TestTreeProviderLite(2, factory);
+				const tree = provider.trees[0];
+				const tree2 = provider.trees[1];
+
+				tree.schematize({
+					allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
+					initialTree: 10 as any,
+					schema: documentSchema,
+				});
+
+				tree2.schematize({
+					allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
+					initialTree: 10 as any,
+					schema: documentSchema,
+				});
+
+				expectSchema(tree);
+				expectSchema(tree2);
+				provider.processMessages();
+				expectSchema(tree);
+				expectSchema(tree2);
+			});
 		});
+	}
 
-		assert.deepEqual(
-			schematized.storedSchema.rootFieldSchema,
-			schemaGeneralized.rootFieldSchema,
-		);
-		assert(schematized.storedSchema.treeSchema.has(root.name));
-		assert.equal(schematized.root, 10);
-	});
+	testInitialize("optional", schema);
+	testInitialize("value", schemaValueRoot);
 
 	it("noop upgrade", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
@@ -87,5 +156,39 @@ describe("schematizeView", () => {
 		});
 		// Initial tree should not be applied
 		assert.equal(schematized.root, undefined);
+	});
+
+	it("errors if schema changes to not be compatible with view schema", () => {
+		const provider = new TestTreeProviderLite(2, factory);
+		const tree = provider.trees[0];
+		const tree2 = provider.trees[1];
+
+		const treeLog = [];
+		tree.events.on("afterBatch", () => treeLog.push("afterBatch"));
+		tree.storedSchema.registerDependent(
+			new SimpleObservingDependent(() => treeLog.push("schemaChange")),
+		);
+
+		const schematized = tree.schematize({
+			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
+			initialTree: "x",
+			schema: schemaGeneralized,
+		});
+
+		treeLog.push("schematized");
+		provider.processMessages();
+		treeLog.push("processed messages");
+
+		tree2.transaction.start();
+		tree2.storedSchema.update(schema);
+		tree2.transaction.commit();
+
+		// Error should occur here, but current limitation on schema editing defers the error until the following tree content edit.
+		provider.processMessages();
+
+		assert.throws(
+			() => tree.setContent(11),
+			(e: Error) => validateAssertionError(e, /schema changed/),
+		);
 	});
 });


### PR DESCRIPTION
## Description

Add some collab tests and test for errors for schematize.
Defer errors from schema changing to an incompatible one until afterBatch. This is enough to make the tests pass.

This addresses an issue found when refactoring some tests to use schematize to initialize the tree, which, if using a value field for the root, failed when running processMessages, even when not collaborating.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

