### PR TITLE
Fix grouped batch sequencing

### DIFF
--- a/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
@@ -129,7 +129,7 @@ describe("SharedString no reconnect fuzz testing", () => {
  * Disabled as all tests are failing due to eventual consistency issues.
  * ADO:5083 to deal with the failures.
  */
-describe.skip("SharedString fuzz testing with rebased batches", () => {
+describe("SharedString fuzz testing with rebased batches", () => {
 	const noReconnectWithRebaseModel = {
 		...baseModel,
 		workloadName: "SharedString with rebasing",


### PR DESCRIPTION
Take into account which client sent the last message and only progress the sequence number if the client changes to simulate grouped batching.