### PR TITLE
Fix grouped batching mocks + reenable tests.

### DIFF
--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -402,8 +402,6 @@ describe("SharedDirectory fuzz", () => {
 	createDDSFuzzSuite(
 		{ ...model, workloadName: "default directory 2 with rebasing" },
 		{
-			// ADO:5083, eventual consistency issue was detected
-			skip: [22],
 			validationStrategy: {
 				type: "fixedInterval",
 				interval: defaultOptions.validateInterval,

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -269,6 +269,8 @@ describe("IntervalCollection fuzz testing with rebased batches", () => {
 
 	createDDSFuzzSuite(noReconnectWithRebaseModel, {
 		...defaultFuzzOptions,
+		// ADO:5083, eventual consistency issue was detected
+		skip: [9, 12, 29],
 		reconnectProbability: 0.0,
 		numberOfClients: 3,
 		clientJoinOptions: {

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -261,11 +261,7 @@ describe("IntervalCollection no reconnect fuzz testing", () => {
 	});
 });
 
-/**
- * Disabled as all tests are failing due to eventual consistency issues.
- * ADO:5083 to deal with the failures.
- */
-describe.skip("IntervalCollection fuzz testing with rebased batches", () => {
+describe("IntervalCollection fuzz testing with rebased batches", () => {
 	const noReconnectWithRebaseModel = {
 		...baseModel,
 		workloadName: "interval collection with rebasing",

--- a/packages/dds/sequence/src/test/intervalRevertibles.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRevertibles.fuzz.spec.ts
@@ -207,11 +207,7 @@ describe("IntervalCollection fuzz testing", () => {
 	createDDSFuzzSuite(model, optionsWithEmitter);
 });
 
-/**
- * Disabled as all tests are failing due to eventual consistency issues.
- * ADO:5083 to deal with the failures.
- */
-describe.skip("IntervalCollection fuzz testing with rebasing", () => {
+describe("IntervalCollection fuzz testing with rebasing", () => {
 	const model: DDSFuzzModel<RevertibleFactory, RevertOperation, FuzzTestState> = {
 		workloadName: "interval collection with revertibles and rebasing",
 		generatorFactory: () =>

--- a/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
@@ -125,10 +125,6 @@ describe("SharedString no reconnect fuzz testing", () => {
 	});
 });
 
-/**
- * Disabled as all tests are failing due to eventual consistency issues.
- * ADO:5083 to deal with the failures.
- */
 describe("SharedString fuzz testing with rebased batches", () => {
 	const noReconnectWithRebaseModel = {
 		...baseModel,

--- a/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.fuzz.spec.ts
@@ -129,7 +129,7 @@ describe("SharedString no reconnect fuzz testing", () => {
  * Disabled as all tests are failing due to eventual consistency issues.
  * ADO:5083 to deal with the failures.
  */
-describe.skip("SharedString fuzz testing with rebased batches", () => {
+describe("SharedString fuzz testing with rebased batches", () => {
 	const noReconnectWithRebaseModel = {
 		...baseModel,
 		workloadName: "SharedString with rebasing",

--- a/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
@@ -261,8 +261,6 @@ describe("TaskManager fuzz testing with rebasing", () => {
 
 	createDDSFuzzSuite(model, {
 		validationStrategy: { type: "fixedInterval", interval: defaultOptions.validateInterval },
-		// ADO:5083, eventual consistency issue was detected
-		skip: [0, 2, 6],
 		rebaseProbability: 0.15,
 		containerRuntimeOptions: {
 			flushMode: FlushMode.TurnBased,

--- a/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
@@ -261,6 +261,8 @@ describe("TaskManager fuzz testing with rebasing", () => {
 
 	createDDSFuzzSuite(model, {
 		validationStrategy: { type: "fixedInterval", interval: defaultOptions.validateInterval },
+		// ADO:5083, eventual consistency issue was detected
+		skip: [0, 2, 6],
 		rebaseProbability: 0.15,
 		containerRuntimeOptions: {
 			flushMode: FlushMode.TurnBased,

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -396,7 +396,10 @@ export class MockContainerRuntimeFactory {
 		// TODO: Determine if this needs to be adapted for handling server-generated messages (which have null clientId and referenceSequenceNumber of -1).
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 		this.minSeq.set(message.clientId as string, message.referenceSequenceNumber);
-		if (this.lastProcessedMessage?.clientId !== message.clientId) {
+		if (
+			this.runtimeOptions.flushMode === FlushMode.Immediate ||
+			this.lastProcessedMessage?.clientId !== message.clientId
+		) {
 			this.sequenceNumber++;
 		}
 		message.sequenceNumber = this.sequenceNumber;


### PR DESCRIPTION
## Description
ADO: 5083

Original PR: https://github.com/microsoft/FluidFramework/pull/16783

Basically, when using `FlushMode.TurnBased` we need to advance the sequence number of the factory mock only when processing a foreign message.