### PR TITLE
Unsampled OpRoundtripTime perf investigation

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -31,7 +31,7 @@ export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
 export class ChildLogger extends TelemetryLogger {
     // (undocumented)
     protected readonly baseLogger: ITelemetryBaseLogger;
-    static create(baseLogger?: ITelemetryBaseLogger, namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    static create(baseLogger?: ITelemetryBaseLogger, namespace?: string, properties?: ITelemetryLoggerPropertyBags, sampling?: Map<string, number>): TelemetryLogger;
     send(event: ITelemetryBaseEvent): void;
 }
 
@@ -46,6 +46,7 @@ export function createChildLogger(props?: {
     logger?: ITelemetryBaseLogger;
     namespace?: string;
     properties?: ITelemetryLoggerPropertyBags;
+    samplingConfiguration?: Map<string, number>;
 }): ITelemetryLoggerExt;
 
 // @public (undocumented)

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -8,6 +8,7 @@ import {
 	AttachState,
 	IContainer,
 	IFluidModuleWithDetails,
+	LoaderHeader,
 } from "@fluidframework/container-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
@@ -108,7 +109,11 @@ export class TinyliciousClient {
 		services: TinyliciousContainerServices;
 	}> {
 		const loader = this.createLoader(containerSchema);
-		const container = await loader.resolve({ url: id });
+		const container = await loader.resolve({
+			url: id,
+			headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
+		});
+		container.connect();
 		const rootDataObject = await requestFluidObject<IRootDataObject>(container, "/");
 		const fluidContainer = new FluidContainer(container, rootDataObject);
 		const services = this.getContainerServices(container);

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -95,8 +95,8 @@ class OpPerfTelemetry {
 			"this.deltaManager.deltaManager.connectionManager: ",
 			JSON.stringify((this.deltaManager as unknown as any).deltaManager?.connectionManager),
 		);
-		// debugger;
-		this.logger = createChildLogger({ logger, namespace: "OpPerf" });
+		const samplingConfiguration = new Map<string, number>([["OpRoundtripTime", 5]]);
+		this.logger = createChildLogger({ logger, namespace: "OpPerf", samplingConfiguration });
 
 		this.deltaManager.on("pong", (latency) => this.recordPingTime(latency));
 		this.deltaManager.on("submitOp", (message) => this.beforeOpSubmit(message));

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -79,7 +79,7 @@ class OpPerfTelemetry {
 		private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
 		logger: ITelemetryLoggerExt,
 	) {
-		const samplingConfiguration = new Map<string, number>([["OpRoundtripTime", 5]]);
+		const samplingConfiguration = new Map<string, number>([["OpRoundtripTime", 500]]);
 		this.logger = createChildLogger({ logger, namespace: "OpPerf", samplingConfiguration });
 
 		this.deltaManager.on("pong", (latency) => this.recordPingTime(latency));

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/unsampledlogging.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/unsampledlogging.time.spec.ts
@@ -1,0 +1,126 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { benchmark } from "@fluid-tools/benchmark";
+import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import {
+	ITestObjectProvider,
+	ChannelFactoryRegistry,
+	ITestContainerConfig,
+	DataObjectFactoryType,
+	ITestFluidObject,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ISharedCounter, SharedCounter } from "@fluidframework/counter";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+
+class TestLogger implements ITelemetryBaseLogger {
+	public events: ITelemetryBaseEvent[] = [];
+	public send(event: ITelemetryBaseEvent): void {
+		this.events.push(event);
+	}
+
+	public clear(): void {
+		this.events = [];
+	}
+}
+
+const counterId = "counterKey";
+const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+	fluidDataObjectType: DataObjectFactoryType.Test,
+	registry,
+};
+
+const opCounts = [100, 500, 1_000, 2_000];
+
+describeNoCompat.only(
+	"Container - testing unsampled telemetry perf hit",
+	(getTestObjectProvider) => {
+		let provider: ITestObjectProvider;
+
+		before(async () => {
+			provider = getTestObjectProvider();
+		});
+
+		let sampledCounter: ISharedCounter;
+		let unsampledCounter: ISharedCounter;
+		const sampledLogger = new TestLogger();
+		const unsampledLogger = new TestLogger();
+
+		beforeEach(async () => {
+			// Create a Container for the loader without feature flag (does sampling).
+			const sampledLoader = provider.makeTestLoader({
+				...testContainerConfig,
+				loaderProps: { logger: sampledLogger },
+			});
+			const sampledContainer = await sampledLoader.createDetachedContainer(
+				provider.defaultCodeDetails,
+			);
+			const sampledDs = await requestFluidObject<ITestFluidObject>(
+				sampledContainer,
+				"default",
+			);
+			sampledCounter = await sampledDs.getSharedObject<SharedCounter>(counterId);
+
+			// Create a Container for the loader with feature flag (does NOT do sampling)
+			const configProvider: IConfigProviderBase = {
+				getRawConfig: (name: string): ConfigTypes =>
+					name === "Fluid.Telemetry.DisableSampling" ? true : undefined,
+			};
+			const unsampledLoader = provider.makeTestLoader({
+				...testContainerConfig,
+				loaderProps: { logger: unsampledLogger, configProvider },
+			});
+			const unsampledContainer = await unsampledLoader.createDetachedContainer(
+				provider.defaultCodeDetails,
+			);
+			const unsampledDs = await requestFluidObject<ITestFluidObject>(
+				unsampledContainer,
+				"default",
+			);
+			unsampledCounter = await unsampledDs.getSharedObject<SharedCounter>(counterId);
+			await sampledContainer.attach(provider.driver.createCreateNewRequest());
+			await unsampledContainer.attach(provider.driver.createCreateNewRequest());
+		});
+
+		for (const opCount of opCounts) {
+			benchmark({
+				title: `Generate ${opCount} ops without sampling`,
+				benchmarkFnAsync: async () => {
+					for (let i = 0; i < opCount; i++) {
+						unsampledCounter.increment(1);
+					}
+					await provider.ensureSynchronized(); // Wait for all ops to roundtrip so we generate OpRoundtripTime events.
+					assert(
+						unsampledLogger.events.filter((x) =>
+							x.eventName.endsWith("OpRoundtripTime"),
+						).length >= opCount,
+						`Too few events (${unsampledLogger.events.length}) seen in logger. Is sampling really disabled?`,
+					);
+					unsampledLogger.clear();
+				},
+			});
+
+			benchmark({
+				title: `Generate ${opCount} ops with sampling`,
+				benchmarkFnAsync: async () => {
+					for (let i = 0; i < opCount; i++) {
+						sampledCounter.increment(1);
+					}
+					await provider.ensureSynchronized(); // Wait for all ops to roundtrip so we generate OpRoundtripTime events.
+					assert(
+						sampledLogger.events.filter((x) => x.eventName.endsWith("OpRoundtripTime"))
+							.length <=
+							Math.ceil(opCount / 500) + 1, // Sampling rate is 500; bit of buffer to make tests not fail
+						`Too many events (${sampledLogger.events.length}) seen in logger. Is sampling really enabled?`,
+					);
+					sampledLogger.clear();
+				},
+			});
+		}
+	},
+);

--- a/packages/tools/devtools/devtools-example/src/App.tsx
+++ b/packages/tools/devtools/devtools-example/src/App.tsx
@@ -233,9 +233,9 @@ function useContainerInfo(
 	const [sharedContainerInfo, setSharedContainerInfo] = React.useState<
 		ContainerInfo | undefined
 	>();
-	const [privateContainerInfo, setPrivateContainerInfo] = React.useState<
-		ContainerInfo | undefined
-	>();
+	// const [privateContainerInfo, setPrivateContainerInfo] = React.useState<
+	// 	ContainerInfo | undefined
+	// >();
 
 	// Get the Fluid Data data on app startup and store in the state
 	React.useEffect(() => {
@@ -255,24 +255,24 @@ function useContainerInfo(
 			registerContainerWithDevtools(devtools, containerInfo.container, sharedContainerKey);
 		}, console.error);
 
-		async function getPrivateContainerData(): Promise<ContainerInfo> {
-			// Always create a new container for the private view.
-			// This isn't shared with other collaborators.
+		// async function getPrivateContainerData(): Promise<ContainerInfo> {
+		// 	// Always create a new container for the private view.
+		// 	// This isn't shared with other collaborators.
 
-			return createFluidContainer(containerSchema, logger, populateRootMap);
-		}
+		// 	return createFluidContainer(containerSchema, logger, populateRootMap);
+		// }
 
-		getPrivateContainerData().then((containerInfo) => {
-			setPrivateContainerInfo(containerInfo);
-			registerContainerWithDevtools(devtools, containerInfo.container, privateContainerKey);
-		}, console.error);
+		// getPrivateContainerData().then((containerInfo) => {
+		// 	setPrivateContainerInfo(containerInfo);
+		// 	registerContainerWithDevtools(devtools, containerInfo.container, privateContainerKey);
+		// }, console.error);
 
 		return (): void => {
 			devtools?.dispose();
 		};
 	}, [devtools, logger]);
 
-	return { sharedContainer: sharedContainerInfo, privateContainer: privateContainerInfo };
+	return { sharedContainer: sharedContainerInfo, privateContainer: undefined };
 }
 
 const appTheme: BrandVariants = {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -15,12 +15,7 @@ import {
 	TelemetryEventCategory,
 } from "@fluidframework/core-interfaces";
 import { IsomorphicPerformance, performance } from "@fluidframework/common-utils";
-import {
-	CachedConfigProvider,
-	loggerIsMonitoringContext,
-	loggerToMonitoringContext,
-	mixinMonitoringContext,
-} from "./config";
+import { CachedConfigProvider, loggerIsMonitoringContext, mixinMonitoringContext } from "./config";
 import {
 	isILoggingError,
 	extractLogSafeErrorProperties,
@@ -426,8 +421,7 @@ export class ChildLogger extends TelemetryLogger {
 			mixinMonitoringContext(this, new CachedConfigProvider(this, baseLogger.config));
 
 			// Read config flag only once, so we don't pay the price every time an event is logged.
-			const mc = loggerToMonitoringContext(this);
-			if (mc.config.getBoolean("Fluid.Telemetry.DisableSampling") === true) {
+			if (baseLogger.config.getBoolean("Fluid.Telemetry.DisableSampling") === true) {
 				this.isSamplingDisabled = true;
 			}
 		}


### PR DESCRIPTION
## Description

This implements the experimental idea for how to disable sampling, specifically for the OpRoundtripTime events. (Plus a few unrelated changes).

Impact is ~40% longer runtime when generating 500x the number of events, relatively constant across several datapoints with a different number of total ops being generated.

<img width="868" alt="image" src="https://github.com/microsoft/FluidFramework/assets/716334/abe923d3-2d4b-491b-a131-305b4c6456b1">

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

