### PR TITLE
matrix: fix TS 5.1 compilation error

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -63,6 +63,7 @@ interface ISetOpMetadata {
  * A matrix cell value may be undefined (indicating an empty cell) or any serializable type,
  * excluding null.  (However, nulls may be embedded inside objects and arrays.)
  */
+// eslint-disable-next-line @rushstack/no-new-null -- Using 'null' to disallow 'null'.
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
 /**

--- a/packages/dds/matrix/src/sparsearray2d.ts
+++ b/packages/dds/matrix/src/sparsearray2d.ts
@@ -44,6 +44,7 @@ type RecurArrayHelper<T> = RecurArray<T> | T;
 type RecurArray<T> = RecurArrayHelper<T>[];
 
 /** Undo JSON serialization's coercion of 'undefined' to null. */
+// eslint-disable-next-line @rushstack/no-new-null -- Private use of 'null' to preserve 'undefined'
 const nullToUndefined = <T>(array: RecurArray<T | null>): RecurArray<T | undefined> =>
 	array.map((value) => {
 		return value === null ? undefined : Array.isArray(value) ? nullToUndefined(value) : value;


### PR DESCRIPTION
TypeScript 5.1 performs less automatic coercion for numbers.

Also includes some minor opportunistic documentation/lint improvements.

```
@fluidframework/matrix: src/handletable.ts:38:3 - error TS2322: Type '0' is not assignable to type 'Handle | T'.
@fluidframework/matrix: 
@fluidframework/matrix: 38   this.handles[free] = 0;
@fluidframework/matrix:      ~~~~~~~~~~~~~~~~~~
@fluidframework/matrix: 
@fluidframework/matrix: 
@fluidframework/matrix: Found 1 error in src/handletable.ts:38
```