### PR TITLE
chore(merge-tree): remove mergeTreeUseNewLengthCalculations flag

### DIFF
--- a/.changeset/witty-fans-lose.md
+++ b/.changeset/witty-fans-lose.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/merge-tree": major
+"@fluidframework/sequence": major
+---
+
+remove the mergeTreeUseNewLengthCalculations flag
+
+removes the mergeTreeUseNewLengthCalculations flag, which was enabled by default in 6.0.0

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -18,7 +18,7 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 // @public (undocumented)
 export function addProperties(oldProps: PropertySet | undefined, newProps: PropertySet, op?: ICombiningOp, seq?: number): PropertySet;
 
-// @alpha
+// @alpha (undocumented)
 export function appendToMergeTreeDeltaRevertibles(deltaArgs: IMergeTreeDeltaCallbackArgs, revertibles: MergeTreeDeltaRevertible[]): void;
 
 // @alpha @sealed
@@ -269,7 +269,7 @@ export interface Dictionary<TKey, TData> {
     remove(key: TKey): void;
 }
 
-// @alpha
+// @alpha (undocumented)
 export function discardMergeTreeDeltaRevertible(revertibles: MergeTreeDeltaRevertible[]): void;
 
 // @public (undocumented)
@@ -504,7 +504,6 @@ export interface IMergeTreeOptions {
     catchUpBlobName?: string;
     // (undocumented)
     mergeTreeSnapshotChunkSize?: number;
-    mergeTreeUseNewLengthCalculations?: boolean;
     newMergeTreeSnapshotFormat?: boolean;
 }
 
@@ -754,7 +753,7 @@ export type MergeTreeDeltaOperationType = typeof MergeTreeDeltaType.ANNOTATE | t
 // @public (undocumented)
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 
-// @alpha
+// @alpha (undocumented)
 export type MergeTreeDeltaRevertible = {
     operation: typeof MergeTreeDeltaType.INSERT;
     trackingGroup: ITrackingGroup;
@@ -792,7 +791,7 @@ export const MergeTreeMaintenanceType: {
 // @public (undocumented)
 export type MergeTreeMaintenanceType = typeof MergeTreeMaintenanceType[keyof typeof MergeTreeMaintenanceType];
 
-// @alpha
+// @alpha (undocumented)
 export interface MergeTreeRevertibleDriver {
     // (undocumented)
     annotateRange(start: number, end: number, props: PropertySet): any;
@@ -1001,7 +1000,7 @@ export const reservedRangeLabelsKey = "referenceRangeLabels";
 // @public (undocumented)
 export const reservedTileLabelsKey = "referenceTileLabels";
 
-// @alpha
+// @alpha (undocumented)
 export function revertMergeTreeDeltaRevertibles(driver: MergeTreeRevertibleDriver, revertibles: MergeTreeDeltaRevertible[]): void;
 
 // @public (undocumented)

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -421,18 +421,6 @@ export interface ClientSeq {
 
 export interface IMergeTreeOptions {
 	catchUpBlobName?: string;
-	/**
-	 * Whether to enable the length calculations implemented in
-	 * https://github.com/microsoft/FluidFramework/pull/11678
-	 *
-	 * These calculations resolve bugginess that causes eventual consistency issues in certain conflicting
-	 * removal cases, but regress some index-based undo-redo implementations. The suggested path for
-	 * consumers is to switch to LocalReference-based undo-redo implementation (see
-	 * https://github.com/microsoft/FluidFramework/pull/11899) and enable this feature flag.
-	 *
-	 * default: false
-	 */
-	mergeTreeUseNewLengthCalculations?: boolean;
 	mergeTreeSnapshotChunkSize?: number;
 	/**
 	 * Whether to use the SnapshotV1 format over SnapshotLegacy.
@@ -722,16 +710,13 @@ export class MergeTree {
 		const removalInfo = toRemovalInfo(segment);
 		if (localSeq === undefined) {
 			if (removalInfo !== undefined) {
-				if (this.options?.mergeTreeUseNewLengthCalculations !== false) {
-					if (!seqLTE(removalInfo.removedSeq, this.collabWindow.minSeq)) {
-						return 0;
-					}
-					// this segment removed and outside the collab window which means it is zamboni eligible
-					// this also means the segment could not exist, so we should not consider it
-					// when making decisions about conflict resolutions
-					return undefined;
+				if (!seqLTE(removalInfo.removedSeq, this.collabWindow.minSeq)) {
+					return 0;
 				}
-				return 0;
+				// this segment removed and outside the collab window which means it is zamboni eligible
+				// this also means the segment could not exist, so we should not consider it
+				// when making decisions about conflict resolutions
+				return undefined;
 			} else {
 				return segment.cachedLength;
 			}
@@ -1120,59 +1105,21 @@ export class MergeTree {
 			} else {
 				const segment = node;
 				const removalInfo = toRemovalInfo(segment);
-				if (this.options?.mergeTreeUseNewLengthCalculations !== false) {
-					if (removalInfo !== undefined) {
-						if (seqLTE(removalInfo.removedSeq, this.collabWindow.minSeq)) {
-							return undefined;
-						}
-						if (
-							seqLTE(removalInfo.removedSeq, refSeq) ||
-							removalInfo.removedClientIds.includes(clientId)
-						) {
-							return 0;
-						}
-					}
-
-					return seqLTE(node.seq ?? 0, refSeq) || segment.clientId === clientId
-						? segment.cachedLength
-						: 0;
-				}
-
-				if (
-					removalInfo !== undefined &&
-					removalInfo.removedSeq !== UnassignedSequenceNumber &&
-					removalInfo.removedSeq <= refSeq
-				) {
-					// this segment is a tombstone eligible for zamboni
-					// so should never be considered, as it may not exist
-					// on other clients
-					return undefined;
-				}
-				if (
-					segment.clientId === clientId ||
-					(segment.seq !== UnassignedSequenceNumber && segment.seq! <= refSeq)
-				) {
-					// Segment happened by reference sequence number or segment from requesting client
-					if (removalInfo !== undefined) {
-						return removalInfo.removedClientIds.includes(clientId)
-							? 0
-							: segment.cachedLength;
-					} else {
-						return segment.cachedLength;
-					}
-				} else {
-					// the segment was inserted and removed before the
-					// this context, so it will never exist for this
-					// context
-					if (
-						removalInfo !== undefined &&
-						removalInfo.removedSeq !== UnassignedSequenceNumber
-					) {
+				if (removalInfo !== undefined) {
+					if (seqLTE(removalInfo.removedSeq, this.collabWindow.minSeq)) {
 						return undefined;
 					}
-					// Segment invisible to client at reference sequence number/branch id/client id of op
-					return 0;
+					if (
+						seqLTE(removalInfo.removedSeq, refSeq) ||
+						removalInfo.removedClientIds.includes(clientId)
+					) {
+						return 0;
+					}
 				}
+
+				return seqLTE(node.seq ?? 0, refSeq) || segment.clientId === clientId
+					? segment.cachedLength
+					: 0;
 			}
 		}
 	}

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -18,10 +18,6 @@ import { DetachedReferencePosition } from "./referencePositions";
 import { MergeTree, findRootMergeBlock } from "./mergeTree";
 
 /**
- * Revertibles are new and require the option
- * mergeTreeUseNewLengthCalculations to be set as true on the underlying merge tree
- * in order to function correctly.
- *
  * @alpha
  */
 export type MergeTreeDeltaRevertible =
@@ -64,10 +60,6 @@ interface RemoveSegmentRefProperties {
 }
 
 /**
- * Revertibles are new and require the option
- * mergeTreeUseNewLengthCalculations to be set as true on the underlying merge tree
- * in order to function correctly.
- *
  * @alpha
  */
 export interface MergeTreeRevertibleDriver {
@@ -198,9 +190,6 @@ function appendLocalAnnotateToRevertibles(
 }
 
 /**
- * Revertibles are new and require the option
- * mergeTreeUseNewLengthCalculations to be set as true on the underlying merge tree
- * in order to function correctly.
  * @alpha
  */
 export function appendToMergeTreeDeltaRevertibles(
@@ -229,9 +218,6 @@ export function appendToMergeTreeDeltaRevertibles(
 }
 
 /**
- * Revertibles are new and require the option
- * mergeTreeUseNewLengthCalculations to be set as true on the underlying merge tree
- * in order to function correctly.
  * @alpha
  */
 export function discardMergeTreeDeltaRevertible(revertibles: MergeTreeDeltaRevertible[]) {
@@ -394,9 +380,6 @@ function getPosition(mergeTreeWithRevert: MergeTreeWithRevert, segment: ISegment
 }
 
 /**
- * Revertibles are new and require the option
- * mergeTreeUseNewLengthCalculations to be set as true on the underlying merge tree
- * in order to function correctly.
  * @alpha
  */
 export function revertMergeTreeDeltaRevertibles(

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -27,9 +27,6 @@ import { ISequenceDeltaRange, SequenceDeltaEvent } from "./sequenceDeltaEvent";
 /**
  * Data for undoing edits on SharedStrings and Intervals.
  *
- * Revertibles are new and require the option mergeTreeUseNewLengthCalculations to
- * be set as true on the underlying merge tree in order to function correctly.
- *
  * @alpha
  */
 export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertible;
@@ -40,9 +37,6 @@ type IntervalOpType = typeof IntervalOpType[keyof typeof IntervalOpType];
 
 /**
  * Data for undoing edits affecting Intervals.
- *
- * Revertibles are new and require the option mergeTreeUseNewLengthCalculations to
- * be set as true on the underlying merge tree in order to function correctly.
  *
  * @alpha
  */
@@ -270,9 +264,6 @@ function addIfRevertibleRef(
 /**
  * Create revertibles for SharedStringDeltas, handling indirectly modified intervals
  * (e.g. reverting remove of a range that contains an interval will move the interval back)
- *
- * Revertibles are new and require the option mergeTreeUseNewLengthCalculations to
- * be set as true on the underlying merge tree in order to function correctly.
  *
  * @alpha
  */
@@ -596,9 +587,6 @@ function revertLocalSequenceRemove(
 
 /**
  * Invoke revertibles to reverse prior edits
- *
- * Revertibles are new and require the option mergeTreeUseNewLengthCalculations to
- * be set as true on the underlying merge tree in order to function correctly.
  *
  * @alpha
  */

--- a/packages/dds/sequence/src/test/intervalRevertibles.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRevertibles.fuzz.spec.ts
@@ -47,23 +47,18 @@ import {
 import { makeOperationGenerator } from "./intervalCollection.fuzz.spec";
 import { minimizeTestFromFailureFile } from "./intervalCollection.fuzzMinimization";
 
-// Since the clients are created by the fuzz harness, the factory object must be
-// modified in order to set the mergeTreeUseNewLengthCalculations option on the
-// underlying merge tree. This can be deleted after PR#15868 is in main.
 class RevertibleFactory extends SharedStringFactory {
-	options = { mergeTreeUseNewLengthCalculations: true };
+	options = {};
 	public async load(
 		runtime: IFluidDataStoreRuntime,
 		id: string,
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<SharedString> {
-		runtime.options.mergeTreeUseNewLengthCalculations = true;
 		return super.load(runtime, id, services, attributes);
 	}
 
 	public create(document: IFluidDataStoreRuntime, id: string): SharedString {
-		document.options.mergeTreeUseNewLengthCalculations = true;
 		return super.create(document, id);
 	}
 }


### PR DESCRIPTION
Removes the `mergeTreeUseNewLengthCalculations` flag, which was enabled by default in 6.0.0.