### PR TITLE
Give fluid-build knowledge of container-runtime's test index

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -147,6 +147,14 @@
 		"rimraf": "^4.4.0",
 		"typescript": "~4.5.5"
 	},
+	"fluidBuild": {
+		"tasks": {
+			"build:test": [
+				"...",
+				"@fluidframework/container-runtime#build:test"
+			]
+		}
+	},
 	"typeValidation": {
 		"disabled": true,
 		"broken": {}


### PR DESCRIPTION
## Description

#16536 added an import to the test index that container-runtime exports from the e2e tests. This can cause issues for build:fast if it tries to parallelize build of container-runtime's tests and the e2e tests. The fix here makes this task dependency known to fluid-build.

This case is similar to merge-tree and sequence: see sequence's `package.json`.