### PR TITLE
stop checkpoints when document is corrupt

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -408,6 +408,8 @@ export class ScribeLambda implements IPartitionLambda {
 									ex,
 								);
 							} else {
+								// Throwing error here leads to document being marked as corrupt in document partition
+								this.isDocumentCorrupt = true;
 								throw ex;
 							}
 						}
@@ -819,7 +821,10 @@ export class ScribeLambda implements IPartitionLambda {
 
 			// verify that the current scribe message matches the message that started this timer
 			// same implementation as in Deli
-			if (initialScribeCheckpointMessage === this.checkpointInfo.currentCheckpointMessage) {
+			if (
+				initialScribeCheckpointMessage === this.checkpointInfo.currentCheckpointMessage &&
+				!this.isDocumentCorrupt
+			) {
 				this.checkpoint(CheckpointReason.IdleTime);
 				if (initialScribeCheckpointMessage) {
 					this.checkpointCore(


### PR DESCRIPTION
Currently, some idleTime checkpoints have been occurring after the document is marked as corrupt on in the document partition due to errors being thrown from the scribe lambda. This leads to assertion errors as Kafka checkpoints when marking a document as corrupt, and the assertion that the offset to be checkpointed is between the last checkpointed offset and the largest offset processed by Kafka fails.

To avoid this, we need to stop idleTime checkpointing when we throw errors that lead to documents being marked as corrupt.