### PR TITLE
Removed console log from DocumentStorageServiceProxy

### DIFF
--- a/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
@@ -54,7 +54,6 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
 		summary: ISummaryTree,
 		context: ISummaryContext,
 	): Promise<string> {
-		console.log(`Summary uploaded:  ${JSON.stringify(summary).length} bytes`);
 		return this.internalStorageService.uploadSummaryWithContext(summary, context);
 	}
 


### PR DESCRIPTION
A console log was added accidentally by #15656 to `DocumentStorageServiceProxy`. This PR removes it.