### PR TITLE
build: Run prettier after tagging asserts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"lint:fix": "npm run prettier:root:fix && pnpm run -r --no-sort --stream lint:fix",
 		"policy-check": "flub check policy",
 		"policy-check-help": "echo Detect (and error on) policy-check violations, like package.json sorting, copyright headers etc. Excludes assert-short-code. Run the check or \"pnpm flub check policy --listHandlers\" for a full list.",
-		"policy-check:asserts": "flub check policy --handler assert-short-codes --fix",
+		"policy-check:asserts": "flub check policy --handler assert-short-codes --fix && pretty-quick",
 		"policy-check:fix": "flub check policy --excludeHandler assert-short-codes --fix",
 		"policy-check:fix-help": "echo Fix policy-check violations excludes assert-short-code/",
 		"prettier": "npm run prettier:root && pnpm run -r --no-sort --stream prettier",


### PR DESCRIPTION
Tagging asserts often requires reformatting the files that have been changed. This PR calls `pretty-quick` to format the changes files after they're tagged. 

Assert tagging also happens automatically in the build and release tools, but in those cases we call the root level npm script, so the build-tools will automatically benefit from this change.