### PR TITLE
refactor(container-utils): Deprecate DeltaManagerProxyBase

### DIFF
--- a/.changeset/moody-frogs-send.md
+++ b/.changeset/moody-frogs-send.md
@@ -2,6 +2,7 @@
 "@fluidframework/container-utils": minor
 ---
 
-Deprecate DeltaManagerProxyBase
+Deprecates DeltaManagerProxyBase
 
-Deprecates DeltaManagerProxyBase. No replacement API is intended.
+`DeltaManagerProxyBase`` is only used internally in FluidFramework code and will no longer be exported in a future release.
+No replacement API is intended for external consumers.

--- a/.changeset/moody-frogs-send.md
+++ b/.changeset/moody-frogs-send.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-utils": minor
+---
+
+Deprecate DeltaManagerProxyBase
+
+Deprecates DeltaManagerProxyBase. No replacement API is intended.

--- a/.changeset/moody-frogs-send.md
+++ b/.changeset/moody-frogs-send.md
@@ -4,5 +4,5 @@
 
 Deprecates DeltaManagerProxyBase
 
-`DeltaManagerProxyBase`` is only used internally in FluidFramework code and will no longer be exported in a future release.
+`DeltaManagerProxyBase` is only used internally in FluidFramework code and will no longer be exported in a future release.
 No replacement API is intended for external consumers.

--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -52,7 +52,7 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
     static wrapIfUnrecognized(originalError: any, dataProcessingCodepath: string, messageLike?: Partial<Pick<ISequencedDocumentMessage, "clientId" | "sequenceNumber" | "clientSequenceNumber" | "referenceSequenceNumber" | "minimumSequenceNumber" | "timestamp">>): IFluidErrorBase;
 }
 
-// @public
+// @public @deprecated
 export class DeltaManagerProxyBase extends EventForwarder<IDeltaManagerEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
     constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>);
     // (undocumented)

--- a/packages/loader/container-utils/src/deltaManagerProxyBase.ts
+++ b/packages/loader/container-utils/src/deltaManagerProxyBase.ts
@@ -23,7 +23,10 @@ import {
  * Base class for creating proxy to the real delta manager. It implements all required methods on IDeltaManager and
  * proxy implementations can override specific methods.
  *
- * @deprecated No replacement API is recommended.
+ * @deprecated
+ *
+ * This class is only used internally in FluidFramework code and will no longer be exported in a future release.
+ * No replacement API is intended for external consumers.
  */
 export class DeltaManagerProxyBase
 	extends EventForwarder<IDeltaManagerEvents>

--- a/packages/runtime/container-runtime/src/deltaManagerProxyBase.ts
+++ b/packages/runtime/container-runtime/src/deltaManagerProxyBase.ts
@@ -22,8 +22,6 @@ import {
 /**
  * Base class for creating proxy to the real delta manager. It implements all required methods on IDeltaManager and
  * proxy implementations can override specific methods.
- *
- * @deprecated No replacement API is recommended.
  */
 export class DeltaManagerProxyBase
 	extends EventForwarder<IDeltaManagerEvents>

--- a/packages/runtime/container-runtime/src/deltaManagerSummarizerProxy.ts
+++ b/packages/runtime/container-runtime/src/deltaManagerSummarizerProxy.ts
@@ -4,8 +4,9 @@
  */
 
 import { IDeltaManager, ReadOnlyInfo } from "@fluidframework/container-definitions";
-import { DeltaManagerProxyBase } from "@fluidframework/container-utils";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+
+import { DeltaManagerProxyBase } from "./deltaManagerProxyBase";
 import { summarizerClientType } from "./summary";
 
 /**


### PR DESCRIPTION
Deprecates DeltaManagerProxyBase. No replacement API is intended.