### PR TITLE
Adjusting some of the perf tests to improve reliability numbers

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
@@ -6,30 +6,33 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import * as crypto from "crypto";
 import { strict as assert } from "assert";
-import { v4 as uuid } from "uuid";
-import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	ChannelFactoryRegistry,
-	createSummarizer,
-	DataObjectFactoryType,
-	ITestContainerConfig,
-	ITestFluidObject,
+	createSummarizerFromFactory,
 	summarizeNow,
-	waitForContainerConnection,
 } from "@fluidframework/test-utils";
-import { IResolvedUrl } from "@fluidframework/driver-definitions";
-import { IRequest } from "@fluidframework/core-interfaces";
+import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
-import { CompressionAlgorithms, ISummarizer } from "@fluidframework/container-runtime";
+import {
+	CompressionAlgorithms,
+	ContainerRuntime,
+	IContainerRuntimeOptions,
+	ISummarizer,
+} from "@fluidframework/container-runtime";
 import { assertDocumentTypeInfo, isDocumentMapInfo } from "@fluid-internal/test-version-utils";
+import {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	DataObject,
+	DataObjectFactory,
+} from "@fluidframework/aqueduct";
 import {
 	IDocumentLoaderAndSummarizer,
 	IDocumentProps,
 	ISummarizeResult,
 } from "./DocumentCreator.js";
-
 const defaultDataStoreId = "default";
 const mapId = "mapId";
 const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
@@ -51,16 +54,58 @@ function validateMapKeys(map: SharedMap, count: number, expectedSize: number): v
 	}
 }
 
+class TestDataObject extends DataObject {
+	public get _root() {
+		return this.root;
+	}
+
+	public get _runtime() {
+		return this.runtime;
+	}
+
+	public get _context() {
+		return this.context;
+	}
+
+	private readonly mapKey = mapId;
+	public map!: SharedMap;
+
+	protected async initializingFirstTime() {
+		const sharedMap = SharedMap.create(this.runtime, this.mapKey);
+		this.root.set(this.mapKey, sharedMap.handle);
+	}
+
+	protected async hasInitialized() {
+		const mapHandle = this.root.get<IFluidHandle<SharedMap>>(this.mapKey);
+		assert(mapHandle !== undefined, "SharedMap not found");
+		this.map = await mapHandle.get();
+	}
+}
+
+const runtimeOptions: IContainerRuntimeOptions = {
+	summaryOptions: {
+		summaryConfigOverrides: {
+			state: "disabled",
+		},
+	},
+	compressionOptions: {
+		minimumBatchSizeInBytes: 1024 * 1024,
+		compressionAlgorithm: CompressionAlgorithms.lz4,
+	},
+	chunkSizeInBytes: 600 * 1024,
+};
+
 export class DocumentMap implements IDocumentLoaderAndSummarizer {
-	private testContainerConfig: ITestContainerConfig | undefined;
-	private loader: IHostLoader | undefined;
 	private readonly keysInMap: number;
 	private readonly sizeOfItemMb: number;
 	private _mainContainer: IContainer | undefined;
-	private dataObject1: ITestFluidObject | undefined;
-	private dataObject1map: SharedMap | undefined;
-	private fileName: string = "";
-	private containerUrl: IResolvedUrl | undefined;
+	private containerRuntime: ContainerRuntime | undefined;
+	private mainDataStore: TestDataObject | undefined;
+	private readonly _dataObjectFactory: DataObjectFactory<TestDataObject>;
+	public get dataObjectFactory() {
+		return this._dataObjectFactory;
+	}
+	private readonly runtimeFactory: ContainerRuntimeFactoryWithDefaultDataStore;
 	public get logger(): ITelemetryLoggerExt | undefined {
 		return this.props.logger;
 	}
@@ -78,6 +123,19 @@ export class DocumentMap implements IDocumentLoaderAndSummarizer {
 		// and info.documentType is either "DocumentMap" or "DocumentMultipleDataStores"
 		assert(isDocumentMapInfo(this.props.documentTypeInfo));
 
+		this._dataObjectFactory = new DataObjectFactory(
+			"TestDataObject",
+			TestDataObject,
+			[SharedMap.getFactory(), SharedMap.getFactory()],
+			[],
+		);
+		this.runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+			this.dataObjectFactory,
+			[[this.dataObjectFactory.type, Promise.resolve(this.dataObjectFactory)]],
+			undefined,
+			undefined,
+			runtimeOptions,
+		);
 		switch (this.props.documentType) {
 			case "DocumentMap":
 				this.keysInMap = this.props.documentTypeInfo.numberOfItems;
@@ -88,70 +146,80 @@ export class DocumentMap implements IDocumentLoaderAndSummarizer {
 		}
 	}
 
-	public async initializeDocument() {
-		this.testContainerConfig = {
-			fluidDataObjectType: DataObjectFactoryType.Test,
-			registry,
-			runtimeOptions: {
-				summaryOptions: {
-					initialSummarizerDelayMs: 0,
-					summaryConfigOverrides: {
-						state: "disabled",
-					},
-				},
-				compressionOptions: {
-					minimumBatchSizeInBytes: 1024 * 1024,
-					compressionAlgorithm: CompressionAlgorithms.lz4,
-				},
-				chunkSizeInBytes: 600 * 1024,
-			},
-			loaderProps: { logger: this.props.logger },
-		};
-
-		this.loader = this.props.provider.makeTestLoader(this.testContainerConfig);
-		this._mainContainer = await this.loader.createDetachedContainer(
-			this.props.provider.defaultCodeDetails,
+	private async populateMap() {
+		assert(
+			this._mainContainer !== undefined,
+			"Container should be initialized before creating data stores",
+		);
+		assert(
+			this.containerRuntime !== undefined,
+			"ContainerRuntime should be initialized before creating data stores",
+		);
+		assert(
+			this.mainDataStore !== undefined,
+			"mainDataStore should be initialized before creating data stores",
 		);
 
-		this.dataObject1 = await requestFluidObject<ITestFluidObject>(
-			this._mainContainer,
-			"default",
-		);
-		this.dataObject1map = await this.dataObject1.getSharedObject<SharedMap>(mapId);
+		const mapHandle = this.mainDataStore._root.get(mapId);
+		assert(mapHandle !== undefined, "map not found");
+		const map = await mapHandle.get();
 		const largeString = generateRandomStringOfSize(maxMessageSizeInBytes * this.sizeOfItemMb);
+		setMapKeys(map, this.keysInMap, largeString);
+		validateMapKeys(map, this.keysInMap, maxMessageSizeInBytes * this.sizeOfItemMb);
+	}
 
-		setMapKeys(this.dataObject1map, this.keysInMap, largeString);
-		this.fileName = uuid();
+	private async ensureContainerConnectedWriteMode(container: IContainer): Promise<void> {
+		const resolveIfActive = (res: () => void) => {
+			if (container.deltaManager.active) {
+				res();
+			}
+		};
+		const containerConnectedHandler = (_clientId: string): void => {};
 
-		await this._mainContainer.attach(
-			this.props.provider.driver.createCreateNewRequest(this.fileName),
-		);
-		assert(this._mainContainer.resolvedUrl, "Container URL should be resolved");
-		this.containerUrl = this._mainContainer.resolvedUrl;
-		await waitForContainerConnection(this._mainContainer, true);
+		if (!container.deltaManager.active) {
+			await new Promise<void>((resolve) =>
+				container.on("connected", () => resolveIfActive(resolve)),
+			);
+			container.off("connected", containerConnectedHandler);
+		}
+	}
+
+	public async initializeDocument() {
+		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory, {
+			logger: this.props.logger,
+		});
+		this.props.provider.updateDocumentId(this._mainContainer.resolvedUrl);
+		this.mainDataStore = await requestFluidObject<TestDataObject>(this._mainContainer, "/");
+		this.containerRuntime = this.mainDataStore._context.containerRuntime as ContainerRuntime;
+		this.mainDataStore._root.set("mode", "write");
+		await this.ensureContainerConnectedWriteMode(this._mainContainer);
+		await this.populateMap();
 	}
 
 	public async loadDocument(): Promise<IContainer> {
-		assert(this.loader !== undefined, "loader should be initialized when loading a document");
 		const requestUrl = await this.props.provider.driver.createContainerUrl(
-			this.fileName,
-			this.containerUrl,
+			this.props.provider.documentId,
+			this._mainContainer?.resolvedUrl,
 		);
-		const testRequest: IRequest = {
+		const request: IRequest = {
 			headers: {
 				[LoaderHeader.cache]: false,
 			},
 			url: requestUrl,
 		};
-
-		const container2 = await this.loader.resolve(testRequest);
-		const dataObject2 = await requestFluidObject<ITestFluidObject>(
-			container2,
-			defaultDataStoreId,
+		const loader = this.props.provider.createLoader(
+			[[this.props.provider.defaultCodeDetails, this.runtimeFactory]],
+			{ logger: this.props.logger },
 		);
-		const dataObject2map = await dataObject2.getSharedObject<SharedMap>(mapId);
-		validateMapKeys(dataObject2map, this.keysInMap, maxMessageSizeInBytes * this.sizeOfItemMb);
+		const container2 = await loader.resolve(request);
 
+		await this.props.provider.ensureSynchronized();
+		const dataStore = await requestFluidObject<TestDataObject>(container2, "/");
+
+		const mapHandle = dataStore._root.get(mapId);
+		assert(mapHandle !== undefined, "map not found");
+		const map = await mapHandle.get();
+		validateMapKeys(map, this.keysInMap, maxMessageSizeInBytes * this.sizeOfItemMb);
 		return container2;
 	}
 
@@ -163,29 +231,35 @@ export class DocumentMap implements IDocumentLoaderAndSummarizer {
 	}
 
 	public async summarize(
+		_container: IContainer,
 		summaryVersion?: string,
 		closeContainer: boolean = true,
 	): Promise<ISummarizeResult> {
-		assert(
-			this._mainContainer !== undefined,
-			"mainContainer needs to be initialized before summarization",
-		);
-		const { container: containerClient, summarizer: summarizerClient } = await createSummarizer(
-			this.props.provider,
-			this._mainContainer,
-			undefined,
-			summaryVersion,
-			this.logger,
-		);
-		const newSummaryVersion = await this.waitForSummary(summarizerClient);
-		assert(newSummaryVersion !== undefined, "summaryVersion needs to be valid.");
-		if (closeContainer) {
-			summarizerClient.close();
+		try {
+			assert(_container !== undefined, "Container should be initialized before summarize");
+			const { container: containerClient, summarizer: summarizerClient } =
+				await createSummarizerFromFactory(
+					this.props.provider,
+					_container,
+					this.dataObjectFactory,
+					summaryVersion,
+					undefined,
+					undefined,
+					this.logger,
+				);
+
+			const newSummaryVersion = await this.waitForSummary(summarizerClient);
+			assert(newSummaryVersion !== undefined, "summaryVersion needs to be valid.");
+			if (closeContainer) {
+				summarizerClient.close();
+			}
+			return {
+				container: containerClient,
+				summarizer: summarizerClient,
+				summaryVersion: newSummaryVersion,
+			};
+		} catch (_error: any) {
+			throw new Error(`Error Summarizing`);
 		}
-		return {
-			container: containerClient,
-			summarizer: summarizerClient,
-			summaryVersion: newSummaryVersion,
-		};
 	}
 }

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
@@ -193,7 +193,9 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 	}
 
 	public async initializeDocument(): Promise<void> {
-		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory);
+		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory, {
+			logger: this.props.logger,
+		});
 		this.props.provider.updateDocumentId(this._mainContainer.resolvedUrl);
 		this.mainDataStore = await requestFluidObject<TestDataObject>(this._mainContainer, "/");
 		this.containerRuntime = this.mainDataStore._context.containerRuntime as ContainerRuntime;
@@ -219,9 +221,10 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 			url: requestUrl,
 		};
 
-		const loader = this.props.provider.createLoader([
-			[this.props.provider.defaultCodeDetails, this.runtimeFactory],
-		]);
+		const loader = this.props.provider.createLoader(
+			[[this.props.provider.defaultCodeDetails, this.runtimeFactory]],
+			{ logger: this.props.logger },
+		);
 		const container2 = await loader.resolve(request);
 		return container2;
 	}
@@ -234,17 +237,15 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 	}
 
 	public async summarize(
+		_container: IContainer,
 		summaryVersion?: string,
 		closeContainer: boolean = true,
 	): Promise<ISummarizeResult> {
-		assert(
-			this._mainContainer !== undefined,
-			"Container should be initialized before summarize",
-		);
+		assert(_container !== undefined, "Container should be initialized before summarize");
 		const { container: containerClient, summarizer: summarizerClient } =
 			await createSummarizerFromFactory(
 				this.props.provider,
-				this._mainContainer,
+				_container,
 				this.dataObjectFactory,
 				summaryVersion,
 				undefined,

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
@@ -181,7 +181,9 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 	}
 
 	public async initializeDocument(): Promise<void> {
-		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory);
+		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory, {
+			logger: this.props.logger,
+		});
 		this.props.provider.updateDocumentId(this._mainContainer.resolvedUrl);
 		this.mainDataStore = await requestFluidObject<TestDataObject>(this._mainContainer, "/");
 		this.containerRuntime = this.mainDataStore._context.containerRuntime as ContainerRuntime;
@@ -207,9 +209,10 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 			url: requestUrl,
 		};
 
-		const loader = this.props.provider.createLoader([
-			[this.props.provider.defaultCodeDetails, this.runtimeFactory],
-		]);
+		const loader = this.props.provider.createLoader(
+			[[this.props.provider.defaultCodeDetails, this.runtimeFactory]],
+			{ logger: this.props.logger },
+		);
 		const container2 = await loader.resolve(request);
 		return container2;
 	}
@@ -222,17 +225,15 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 	}
 
 	public async summarize(
+		_container: IContainer,
 		summaryVersion?: string,
 		closeContainer: boolean = true,
 	): Promise<ISummarizeResult> {
-		assert(
-			this._mainContainer !== undefined,
-			"Container should be initialized before summarize",
-		);
+		assert(_container !== undefined, "Container should be initialized before summarize");
 		const { container: containerClient, summarizer: summarizerClient } =
 			await createSummarizerFromFactory(
 				this.props.provider,
-				this._mainContainer,
+				_container,
 				this.dataObjectFactory,
 				summaryVersion,
 				undefined,

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/LoadDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/LoadDocument.all.spec.ts
@@ -6,6 +6,7 @@ import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeE2EDocRun, getCurrentBenchmarkType } from "@fluid-internal/test-version-utils";
+import { delay } from "@fluidframework/common-utils";
 import {
 	benchmarkAll,
 	createDocument,
@@ -57,8 +58,9 @@ describeE2EDocRun("Load Document", (getTestObjectProvider, getDocumentInfo) => {
 				assert(this.container !== undefined, "container needs to be defined.");
 				this.container.close();
 			}
-			beforeIteration(): void {
+			async before(): Promise<void> {
 				this.container = undefined;
+				await delay(1000);
 			}
 		})(),
 	);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -54,9 +54,9 @@ describeNoCompat("PAS Test", () => {
 					}
 				}
 			}
-			before(): void {}
+			async before(): Promise<void> {}
 			beforeIteration(): void {}
-			after(): void {}
+			async after(): Promise<void> {}
 		})(),
 	);
 });

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/SimpleTest.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/SimpleTest.all.spec.ts
@@ -34,13 +34,13 @@ describeNoCompat("Simple Scenario Title", (getTestObjectProvider) => {
 				assert(this.iteration > 0, "testTitle needs to be defined");
 				console.log(`this will run for each iteration ${this.iteration}`);
 			}
-			before(): void {
+			async before(): Promise<void> {
 				console.log(`this will run before the measurements`);
 			}
 			beforeIteration(): void {
 				console.log(`this will run before each iteration ${this.iteration}`);
 			}
-			after(): void {
+			async after(): Promise<void> {
 				this.iteration = 0;
 			}
 		})(),
@@ -58,13 +58,13 @@ describeNoCompat("Simple Scenario Title", (getTestObjectProvider) => {
 				assert(this.iteration > 0, "testTitle needs to be defined");
 				console.log(`this will run for each iteration ${this.iteration}`);
 			}
-			before(): void {
+			async before(): Promise<void> {
 				console.log(`this will run before the measurements`);
 			}
 			beforeIteration(): void {
 				console.log(`this will run before each iteration ${this.iteration}`);
 			}
-			after(): void {
+			async after(): Promise<void> {
 				this.iteration = 0;
 			}
 		})(),

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
@@ -1,20 +1,20 @@
 {
 	"documents": [
 		{
-			"testTitle": "2Mb Map",
+			"testTitle": "1Mb Map",
 			"documentType": "DocumentMap",
 			"documentTypeInfo": {
-				"numberOfItems": "0.5",
-				"itemSizeMb": "4"
+				"numberOfItems": "1",
+				"itemSizeMb": "1"
 			},
 			"minSampleCount": "1"
 		},
 		{
-			"testTitle": "5Mb Map",
+			"testTitle": "2Mb Map",
 			"documentType": "DocumentMap",
 			"documentTypeInfo": {
 				"numberOfItems": "2",
-				"itemSizeMb": "2.5"
+				"itemSizeMb": "1"
 			},
 			"minSampleCount": "1"
 		},

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -14,7 +14,6 @@ import {
 	IDocumentLoaderAndSummarizer,
 	ISummarizeResult,
 } from "./DocumentCreator.js";
-const exceptionLogger = console.log;
 const scenarioTitle = "Summarize Document";
 describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 	let documentWrapper: IDocumentLoaderAndSummarizer;
@@ -83,7 +82,7 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 					summaryVersion = this.summarizerClient.summaryVersion;
 					this.summarizerClient.summarizer.close();
 				} catch (error) {
-					exceptionLogger(`Error summarizing: ${error}`);
+					throw new Error(`Error summarizing: ${error}`);
 				}
 				this.container.close();
 			}

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -4,6 +4,7 @@
  */
 import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
+import { delay } from "@fluidframework/common-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeE2EDocRun, getCurrentBenchmarkType } from "@fluid-internal/test-version-utils";
 import {
@@ -13,7 +14,7 @@ import {
 	IDocumentLoaderAndSummarizer,
 	ISummarizeResult,
 } from "./DocumentCreator.js";
-
+const exceptionLogger = console.log;
 const scenarioTitle = "Summarize Document";
 describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 	let documentWrapper: IDocumentLoaderAndSummarizer;
@@ -33,7 +34,11 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 		});
 		await documentWrapper.initializeDocument();
 		// Summarize the first time.
-		await documentWrapper.summarize();
+		const summarizerClient = await documentWrapper.summarize(
+			documentWrapper.mainContainer,
+			undefined,
+			/* close container */ true,
+		);
 	});
 
 	beforeEach(async function () {
@@ -64,16 +69,28 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 				assert(this.container !== undefined, "container needs to be defined.");
 				await provider.ensureSynchronized();
 				assert(this.container.closed !== true, "container needs to be open.");
-				this.summarizerClient = await documentWrapper.summarize(summaryVersion);
-				assert(
-					this.summarizerClient.summaryVersion !== undefined,
-					"summaryVersion needs to be defined.",
-				);
-				summaryVersion = this.summarizerClient.summaryVersion;
+				try {
+					this.summarizerClient = await documentWrapper.summarize(
+						this.container,
+						undefined,
+						/* close container */ false,
+					);
+
+					assert(
+						this.summarizerClient.summaryVersion !== undefined,
+						"summaryVersion needs to be defined.",
+					);
+					summaryVersion = this.summarizerClient.summaryVersion;
+					this.summarizerClient.summarizer.close();
+				} catch (error) {
+					exceptionLogger(`Error summarizing: ${error}`);
+				}
+				this.container.close();
 			}
-			beforeIteration(): void {
+			async before(): Promise<void> {
 				this.container = undefined;
 				this.summarizerClient = undefined;
+				await delay(2000);
 			}
 		})(),
 	);

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -66,7 +66,7 @@ async function createSummarizerCore(
 const defaultSummaryOptions: ISummaryRuntimeOptions = {
 	summaryConfigOverrides: {
 		state: "disableHeuristics",
-		maxAckWaitTime: 10000,
+		maxAckWaitTime: 20000, // Some of the AFR tests take a long time to ack.
 		maxOpsSinceLastSummary: 7000,
 		initialSummarizerDelayMs: 0,
 	},
@@ -142,7 +142,9 @@ export async function summarizeNow(summarizer: ISummarizer, reason: string = "en
 
 	const submitResult = await timeoutAwait(result.summarySubmitted);
 	if (!submitResult.success) {
-		submitResult.error.data = submitResult.data;
+		if (typeof submitResult.error !== "string") {
+			submitResult.error.data = submitResult.data;
+		}
 		throw submitResult.error;
 	}
 	assert(


### PR DESCRIPTION
## Description

The reliability of the AFR runs is impacting our comparative analysis against ODSP and the perf dashboard visualization over time. In order to improve it, we are adjusting some of the tests to decrease the load when running summaries, adding a little bit of delay between iterations and increasing the default acktimeout for the tests. Also, in case of exception, we want the summaries of other scenarios to run, so we are adding a simple try catch to deal with these cases where for some reason we time out.