### PR TITLE
Rename reason to summarizeReason so that it is not overwritten on summarize failure

### DIFF
--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -774,7 +774,7 @@ export class RunningSummarizer implements IDisposable {
 		}
 
 		const result = this.trySummarizeOnce(
-			{ summarizeReason: `onDemand/${reason}` },
+			{ summarizeReason: `onDemand;${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,
@@ -789,7 +789,7 @@ export class RunningSummarizer implements IDisposable {
 		override = false,
 		...options
 	}: IEnqueueSummarizeOptions): EnqueueSummarizeResult {
-		const onDemandReason = `enqueue;${reason}` as const;
+		const enqueueReason = `enqueue;${reason}` as const;
 		let overridden = false;
 		if (this.enqueuedSummary !== undefined) {
 			if (!override) {
@@ -804,7 +804,7 @@ export class RunningSummarizer implements IDisposable {
 			overridden = true;
 		}
 		this.enqueuedSummary = {
-			reason: onDemandReason,
+			reason: enqueueReason,
 			afterSequenceNumber,
 			options,
 			resultsBuilder: new SummarizeResultBuilder(),
@@ -837,7 +837,7 @@ export class RunningSummarizer implements IDisposable {
 		// Set to undefined first, so that subsequent enqueue attempt while summarize will occur later.
 		this.enqueuedSummary = undefined;
 		this.trySummarizeOnce(
-			{ summarizeReason: `enqueuedSummary/${reason}` },
+			{ summarizeReason: reason },
 			options,
 			this.cancellationToken,
 			resultsBuilder,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -198,7 +198,7 @@ export class RunningSummarizer implements IDisposable {
 			this.heuristicRunner = new SummarizeHeuristicRunner(
 				heuristicData,
 				this.configuration,
-				(reason) => this.trySummarize(reason),
+				(summarizeReason) => this.trySummarize(summarizeReason),
 				this.mc.logger,
 			);
 		}
@@ -454,7 +454,7 @@ export class RunningSummarizer implements IDisposable {
 			if (this.summarizingLock === undefined) {
 				this.trySummarizeOnce(
 					// summarizeProps
-					{ reason: "lastSummary" },
+					{ summarizeReason: "lastSummary" },
 					// ISummarizeOptions, using defaults: { refreshLatestAck: false, fullTree: false }
 					{},
 				);
@@ -581,7 +581,7 @@ export class RunningSummarizer implements IDisposable {
 
 	/** Heuristics summarize attempt. */
 	private trySummarize(
-		reason: SummarizeReason,
+		summarizeReason: SummarizeReason,
 		cancellationToken = this.cancellationToken,
 	): void {
 		if (this.summarizingLock !== undefined) {
@@ -597,8 +597,8 @@ export class RunningSummarizer implements IDisposable {
 			},
 			async () => {
 				await (this.mc.config.getBoolean("Fluid.Summarizer.TryDynamicRetries")
-					? this.trySummarizeWithRetries(reason, cancellationToken)
-					: this.trySummarizeWithStaticAttempts(reason, cancellationToken));
+					? this.trySummarizeWithRetries(summarizeReason, cancellationToken)
+					: this.trySummarizeWithStaticAttempts(summarizeReason, cancellationToken));
 				this.stopSummarizerCallback("failToSummarize");
 			},
 			() => {
@@ -614,7 +614,7 @@ export class RunningSummarizer implements IDisposable {
 	 * param, that attempt is tried once more.
 	 */
 	private async trySummarizeWithStaticAttempts(
-		reason: SummarizeReason,
+		summarizeReason: SummarizeReason,
 		cancellationToken: ISummaryCancellationToken,
 	) {
 		const attempts: ISummarizeOptions[] = [
@@ -630,7 +630,7 @@ export class RunningSummarizer implements IDisposable {
 			}
 
 			// We only want to attempt 1 summary when reason is "lastSummary"
-			if (++summaryAttempts > 1 && reason === "lastSummary") {
+			if (++summaryAttempts > 1 && summarizeReason === "lastSummary") {
 				return;
 			}
 
@@ -638,7 +638,7 @@ export class RunningSummarizer implements IDisposable {
 
 			const summarizeOptions = attempts[summaryAttemptPhase];
 			const summarizeProps: ISummarizeTelemetryProperties = {
-				reason,
+				summarizeReason,
 				summaryAttempts,
 				summaryAttemptsPerPhase,
 				summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
@@ -685,7 +685,7 @@ export class RunningSummarizer implements IDisposable {
 	 * For example, summarization may be retried for failures with "retryAfterSeconds" param.
 	 */
 	private async trySummarizeWithRetries(
-		reason: SummarizeReason,
+		summarizeReason: SummarizeReason,
 		cancellationToken: ISummaryCancellationToken,
 	) {
 		// The max number of attempts are based on the stage at which summarization failed. If it fails before it is
@@ -709,7 +709,7 @@ export class RunningSummarizer implements IDisposable {
 				fullTree: false,
 			};
 			const summarizeProps: ISummarizeTelemetryProperties = {
-				reason,
+				summarizeReason,
 				summaryAttempts: currentAttempt,
 				...summarizeOptions,
 			};
@@ -774,7 +774,7 @@ export class RunningSummarizer implements IDisposable {
 		}
 
 		const result = this.trySummarizeOnce(
-			{ reason: `onDemand/${reason}` },
+			{ summarizeReason: `onDemand/${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,
@@ -837,7 +837,7 @@ export class RunningSummarizer implements IDisposable {
 		// Set to undefined first, so that subsequent enqueue attempt while summarize will occur later.
 		this.enqueuedSummary = undefined;
 		this.trySummarizeOnce(
-			{ reason: `enqueuedSummary/${reason}` },
+			{ summarizeReason: `enqueuedSummary/${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,

--- a/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
@@ -102,19 +102,19 @@ export class SummarizeHeuristicRunner implements ISummarizeHeuristicRunner {
 	public constructor(
 		private readonly heuristicData: ISummarizeHeuristicData,
 		private readonly configuration: ISummaryConfigurationHeuristics,
-		trySummarize: (reason: SummarizeReason) => void,
+		trySummarize: (summarizeReason: SummarizeReason) => void,
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly summarizeStrategies: ISummaryHeuristicStrategy[] = getDefaultSummaryHeuristicStrategies(),
 	) {
 		this.idleTimer = new Timer(this.idleTime, () => this.runSummarize("idle"));
 
-		this.runSummarize = (reason: SummarizeReason) => {
+		this.runSummarize = (summarizeReason: SummarizeReason) => {
 			this.idleTimer?.clear();
 
 			// We shouldn't attempt a summary if there are no new processed ops
 			const opsSinceLastAck = this.opsSinceLastAck;
 			if (opsSinceLastAck > 0) {
-				trySummarize(reason);
+				trySummarize(summarizeReason);
 			}
 		};
 	}

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -442,7 +442,7 @@ export interface ISummarizeHeuristicRunner {
 
 type ISummarizeTelemetryRequiredProperties =
 	/** Reason code for attempting to summarize */
-	"reason";
+	"summarizeReason";
 
 type ISummarizeTelemetryOptionalProperties =
 	/** Number of attempts within the last time window, used for calculating the throttle delay. */

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -38,6 +38,7 @@ import {
 	SubmitSummaryResult,
 	RetriableSummaryError,
 	IGeneratedSummaryStats,
+	SummarizeReason,
 } from "../../summary";
 import {
 	defaultMaxAttempts,
@@ -1174,13 +1175,17 @@ describe("Runtime", () => {
 			});
 
 			describe("On-demand Summaries", () => {
+				const reason = "test";
+				// This is used to validate the summarizeReason property in telemetry.
+				const summarizeReason: SummarizeReason = `onDemand;${reason}`;
+
 				beforeEach(async () => {
 					await startRunningSummarizer();
 				});
 
 				it("Should create an on-demand summary", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason: "test" });
+					const result = summarizer.summarizeOnDemand(undefined, { reason });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1217,8 +1222,16 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
-							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
+							{
+								eventName: "Running:Summarize_generate",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
+							{
+								eventName: "Running:Summarize_Op",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
 						]),
 						"unexpected log sequence",
 					);
@@ -1247,7 +1260,7 @@ describe("Runtime", () => {
 
 					let resolved = false;
 					try {
-						summarizer.summarizeOnDemand(undefined, { reason: "test" });
+						summarizer.summarizeOnDemand(undefined, { reason });
 						resolved = true;
 					} catch {}
 
@@ -1257,7 +1270,7 @@ describe("Runtime", () => {
 
 				it("On-demand summary should fail on nack", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason: "test" });
+					const result = summarizer.summarizeOnDemand(undefined, { reason });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1294,8 +1307,16 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
-							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
+							{
+								eventName: "Running:Summarize_generate",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
+							{
+								eventName: "Running:Summarize_Op",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
 						]),
 						"unexpected log sequence",
 					);
@@ -1404,6 +1425,10 @@ describe("Runtime", () => {
 			});
 
 			describe("Enqueue Summaries", () => {
+				const reason = "test";
+				// This is used to validate the summarizeReason property in telemetry.
+				const summarizeReason: SummarizeReason = `enqueue;${reason}`;
+
 				beforeEach(async () => {
 					await startRunningSummarizer();
 				});
@@ -1412,7 +1437,7 @@ describe("Runtime", () => {
 					await emitNextOp(2); // set ref seq to 2
 					const afterSequenceNumber = 9;
 					const result = summarizer.enqueueSummarize({
-						reason: "test",
+						reason,
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1456,8 +1481,16 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
-							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
+							{
+								eventName: "Running:Summarize_generate",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
+							{
+								eventName: "Running:Summarize_Op",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
 						]),
 						"unexpected log sequence",
 					);
@@ -1487,7 +1520,7 @@ describe("Runtime", () => {
 					assertRunCounts(1, 0, 0);
 
 					const result = summarizer.enqueueSummarize({
-						reason: "test",
+						reason,
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1574,7 +1607,7 @@ describe("Runtime", () => {
 					await emitNextOp(2); // set ref seq to 2
 					const afterSequenceNumber = 9;
 					const result = summarizer.enqueueSummarize({
-						reason: "test",
+						reason,
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -1138,7 +1138,7 @@ describe("Runtime", () => {
 					);
 				});
 
-				it("Should not retry last summary", async () => {
+				it("should not retry last summary", async () => {
 					const stage: SummaryStage = "base";
 					const retryAfterSeconds = 10;
 					await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
@@ -1159,6 +1159,7 @@ describe("Runtime", () => {
 							retryAfterSeconds,
 							summarizeCount: 1,
 							stage,
+							summarizeReason: "lastSummary",
 						},
 					];
 					mockLogger.assertMatch(
@@ -1727,7 +1728,7 @@ describe("Runtime", () => {
 								eventName: "Running:Summarize_end",
 								summarizeCount: runCount,
 								summarizerSuccessfulAttempts: runCount,
-								reason: "maxOps",
+								summarizeReason: "maxOps",
 							},
 						]),
 						"unexpected log sequence 3",


### PR DESCRIPTION
The `reason` for summarization is overwritten by [this code](https://github.com/microsoft/FluidFramework/blob/277f5b8e89b4c0c3dcdac95fe4b5c7063cfdb870/packages/runtime/container-runtime/src/summary/summaryGenerator.ts#L293) if summarization fails. This means that the ``Summarizer_cancel` event will not have the reason for summarization. It would be helpful to know the reason for the summarization that fails.

This PR renames the summarize reason to `summarizeReason` instead of just `reason` which is generic and can be overwritten.