### PR TITLE
Clean up a couple undefined logger namespaces

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2852,7 +2852,6 @@ export class ContainerRuntime
 			const latestSnapshotInfo = await this.refreshLatestSummaryAckFromServer(
 				createChildLogger({
 					logger: summaryNumberLogger,
-					namespace: undefined,
 					properties: { all: { safeSummary: true } },
 				}),
 			);

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -248,7 +248,6 @@ export class SummaryGenerator {
 		const { refreshLatestAck, fullTree } = options;
 		const logger = createChildLogger({
 			logger: this.logger,
-			namespace: undefined,
 			properties: { all: summarizeProps },
 		});
 


### PR DESCRIPTION
Noticed a few places where we are explicitly setting namespace to undefined which is unnecessary as it is optional.