### PR TITLE
Startsession metric fix

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -291,7 +291,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		private readonly rawDeltasProducer: IProducer,
 		private readonly serviceConfiguration: IServiceConfiguration,
 		private sessionMetric: Lumber<LumberEventName.SessionResult> | undefined,
-		private sessionStartMetric: Lumber<LumberEventName.StartSessionResult> | undefined,
+		private readonly sessionStartMetric: Lumber<LumberEventName.StartSessionResult> | undefined,
 		private readonly checkpointService: ICheckpointService,
 		private readonly restartOnCheckpointFailure: boolean,
 		private readonly kafkaCheckpointOnReprocessingOp: boolean,

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -790,12 +790,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
 	private logSessionStartMetrics(failMetric: boolean = false) {
 		if (this.sessionStartMetric?.isCompleted()) {
-			this.sessionStartMetric = createSessionMetric(
-				this.tenantId,
-				this.documentId,
-				LumberEventName.StartSessionResult,
-				this.serviceConfiguration,
-			);
+			return;
 		}
 
 		if (failMetric) {


### PR DESCRIPTION
## Description

We are occasionally having cases where StartSession metric is getting logged twice for the same session. This is happening because we are recreating a start session metric during some race conditions instead of no-oping it.

This is an example case where this race condition is happening. Please not the duration for the last extra startsession at the very end. It is only around 0.022 ms

![image](https://github.com/microsoft/FluidFramework/assets/448106/69fba155-0e96-48a9-b2e3-2401d9334917)
