### PR TITLE
docs: Remove outdated docs from devtools-view README

### DIFF
--- a/packages/tools/devtools/devtools-view/README.md
+++ b/packages/tools/devtools/devtools-view/README.md
@@ -26,14 +26,6 @@ Next, to build the code, run `npm run build` from the root of the mono-repo, or 
 To run the tests, first ensure you have followed the [build](#build) steps above.
 Next, run `npm run test` from a terminal within this directory.
 
-### Test Sandbox App
-
-This package has a simple testing app that sets up a Container with some simple data for testing the debug view, as well as some interactive controls for testing live editing / collaboration scenarios.
-
-To run the app, navigate to the root of this package and run `npm run start:test-app`.
-
--   This will launch a local [Tinylicious](https://fluidframework.com/docs/testing/tinylicious/) service and serve the app at <http://localhost:8080/>.
-
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
## Description

Removes outdated docs from `devtools-view`. What used to be its simple testing app became `devtools-example`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
