### PR TITLE
Turn off socket timeout by default

### DIFF
--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -541,7 +541,7 @@ const DefaultMongoDbMonitoringEvents = [
 ];
 const DefaultHeartbeatFrequencyMS = 30000;
 const DefaultKeepAliveInitialDelay = 60000;
-const DefaultSocketTimeoutMS = 100000;
+const DefaultSocketTimeoutMS = 0;
 const DefaultConnectionTimeoutMS = 120000;
 const DefaultMinHeartbeatFrequencyMS = 10000;
 const DefaultApiCounterIntervalMS = 60000;


### PR DESCRIPTION
we found out the production connection poll socket is keep on close/reconnect with a very high rate. Looking at these, they were controlled by this `DefaultSocketTimeoutMS` setting. By tracking the source code, basically sdk will set the connection pool socket with this as a socket timeout, and the socket connection will goes to closed state with this setting. https://nodejs.org/api/net.html#socketsettimeouttimeout-callback

However, not sure if the sdk had an issue of that, looks like ALL connections are marking as error out state based on this setting on production. This setting was turned off by SDK as set to 0 by default. So just turn it off for now, we can inject customized settings.

We still have connection timeout and max idle timeout do the same thing.