### PR TITLE
fix: Add build:test script and fix issue from 6.0 breaking changes

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/e2e-tests/app/app.tsx
+++ b/packages/tools/devtools/devtools-browser-extension/e2e-tests/app/app.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-experimental/react-inputs";
 import { ContainerKey, DevtoolsLogger, initializeDevtools } from "@fluid-experimental/devtools";
-import { FluidContainer, IFluidContainer, RootDataObject } from "@fluidframework/fluid-static";
+import { FluidContainer, IFluidContainer, IRootDataObject } from "@fluidframework/fluid-static";
 import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
 
 import { CollaborativeTextContainerRuntimeFactory, ICollaborativeTextAppModel } from "./container";
@@ -72,9 +72,11 @@ async function createContainerAndRenderInElement(): Promise<IFluidContainer> {
 	window["fluidStarted"] = true;
 
 	const container = model.container;
+	// using unknown cast to unblock a build of the test project, since this file is changing significantly soon and
+	// won't use these APIs.
 	const rootDataObject = (await model.runtime.getRootDataStore(
 		"collaborative-text",
-	)) as RootDataObject;
+	)) as unknown as IRootDataObject;
 	const fluidContainer = new FluidContainer(container, rootDataObject);
 	return fluidContainer;
 }
@@ -89,6 +91,5 @@ function registerContainerWithDevtools(
 	devtools.registerContainerDevtools({
 		container,
 		containerKey,
-		dataVisualizers: undefined, // Use defaults
 	});
 }

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -15,6 +15,7 @@
 		"build": "fluid-build . --task build",
 		"build-and-test": "npm run build && npm run test",
 		"build:compile": "fluid-build . --task compile",
+		"build:test": "tsc --project ./e2e-tests/tsconfig.json",
 		"build:webpack": "npm run webpack",
 		"clean": "rimraf --glob \"coverage\" \"dist\" \"nyc\" \"*.tsbuildinfo\" \"*.build.log\" --glob",
 		"eslint": "eslint src",


### PR DESCRIPTION
## Description

Adds a missing `build:test` script for the test app in the to the devtools-browser-extension package. The test app wasn't building before with the repo build, and because of that we missed that it broke with the breaking changes in 6.0, which weren't addressed because they didn't cause a repo build failure.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
