### PR TITLE
docs: Changeset for the zombie TelemetryNullLogger

### DIFF
--- a/.changeset/bumpy-bump.md
+++ b/.changeset/bumpy-bump.md
@@ -2,6 +2,8 @@
 "@fluidframework/telemetry-utils": minor
 ---
 
+Removed `TelemetryNullLogger` class is again exported from @fluidframework/telemetry-utils
+
 The `TelemetryNullLogger` class has been brought back to ease the transition to `2.0.0-internal.6.x`
 *but is still deprecated* and will be removed in `2.0.0-internal.7.0.0`.
 

--- a/.changeset/bumpy-bump.md
+++ b/.changeset/bumpy-bump.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/telemetry-utils": minor
+---
+
+The `TelemetryNullLogger` class has been brought back to ease the transition to `2.0.0-internal.6.x`
+*but is still deprecated* and will be removed in `2.0.0-internal.7.0.0`.
+
+For internal use within the FluidFramework codebase, use `createChildLogger()` with no arguments instead.
+For external consumers we recommend writing a trivial implementation of `ITelemetryBaseLogger`
+(from the `@fluidframework/core-interfaces` package) where the `send()` method does nothing and using that.


### PR DESCRIPTION
## Description

Add a changeset about us temporarily bringing back `TelemetryNullLogger` to ease the transition to v2-int6.0.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).