### PR TITLE
[Data Migration] Integrate paused container into same-container demo

### DIFF
--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
@@ -28,7 +28,7 @@ export type SameContainerMigrationState =
 	| "collaborating"
 	| "proposingMigration"
 	| "stoppingCollaboration"
-	| "generatingV1Summary"
+	| "loadingV1PausedContainer"
 	| "uploadingV1Summary"
 	| "submittingV1Summary"
 	// TODO: "waitingForV2Proposal"?  Not a guarantee that we will issue a proposal here, if we see the proposal during catch up?

--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
@@ -5,6 +5,7 @@
 
 import type { IEvent, IEventProvider } from "@fluidframework/common-definitions";
 import type { IContainer } from "@fluidframework/container-definitions";
+import { ISameContainerMigratableModel } from "./sameContainerMigratableModel";
 
 /**
  * The collaboration session may be in one of these states:
@@ -92,4 +93,13 @@ export interface ISameContainerMigrationTool
 	 * @param container - the reference to the IContainer associated with this migration tool
 	 */
 	readonly setContainerRef: (container: IContainer) => void;
+
+	/**
+	 * Give a callback to IModelLoader.loadExistingPaused().  The migration tool must have this reference in order to
+	 * complete the migration flow.
+	 * @param fn - the callback function that calls IModelLoader.loadExistingPaused()
+	 */
+	readonly setLoadPausedContainerFn: (
+		fn: (sequenceNumber: number) => Promise<ISameContainerMigratableModel>,
+	) => void;
 }

--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
@@ -29,8 +29,6 @@ export type SameContainerMigrationState =
 	| "proposingMigration"
 	| "stoppingCollaboration"
 	| "loadingV1PausedContainer"
-	| "uploadingV1Summary"
-	| "submittingV1Summary"
 	// TODO: "waitingForV2Proposal"?  Not a guarantee that we will issue a proposal here, if we see the proposal during catch up?
 	| "proposingV2Code"
 	| "waitingForV2ProposalCompletion"
@@ -45,9 +43,6 @@ export interface ISameContainerMigrationToolEvents extends IEvent {
 		event:
 			| "proposingMigration"
 			| "stoppingCollaboration"
-			| "generatingV1Summary"
-			| "uploadingV1Summary"
-			| "submittingV1Summary"
 			| "proposingV2Code"
 			| "waitingForV2ProposalCompletion"
 			| "readyForMigration"

--- a/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/sameContainerMigrationTool.ts
@@ -5,7 +5,6 @@
 
 import type { IEvent, IEventProvider } from "@fluidframework/common-definitions";
 import type { IContainer } from "@fluidframework/container-definitions";
-import { ISameContainerMigratableModel } from "./sameContainerMigratableModel";
 
 /**
  * The collaboration session may be in one of these states:
@@ -28,7 +27,6 @@ export type SameContainerMigrationState =
 	| "collaborating"
 	| "proposingMigration"
 	| "stoppingCollaboration"
-	| "loadingV1PausedContainer"
 	// TODO: "waitingForV2Proposal"?  Not a guarantee that we will issue a proposal here, if we see the proposal during catch up?
 	| "proposingV2Code"
 	| "waitingForV2ProposalCompletion"
@@ -90,11 +88,8 @@ export interface ISameContainerMigrationTool
 	readonly setContainerRef: (container: IContainer) => void;
 
 	/**
-	 * Give a callback to IModelLoader.loadExistingPaused().  The migration tool must have this reference in order to
-	 * complete the migration flow.
-	 * @param fn - the callback function that calls IModelLoader.loadExistingPaused()
+	 * The sequence number that the proposal was accepted at. It will be defined once we reach the "proposingV2Code" migration state,
+	 * and undefined before reaching that state.
 	 */
-	readonly setLoadPausedContainerFn: (
-		fn: (sequenceNumber: number) => Promise<ISameContainerMigratableModel>,
-	) => void;
+	get acceptedSeqNum(): number | undefined;
 }

--- a/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
@@ -236,7 +236,7 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 	};
 
 	private readonly loadV1PausedContainer = async () => {
-		// TODO: issues if we summarize then connect a new client ? each client needs to do this?
+		// TODO: Error handling/retry logic
 		const loadPausedContainerFn = await this._loadPausedContainerFnP;
 		const pausedModel = await loadPausedContainerFn(this.acceptedSeqNum);
 		assert(

--- a/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
@@ -10,6 +10,7 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { MessageType } from "@fluidframework/protocol-definitions";
 
+import { assert } from "@fluidframework/common-utils";
 import type { ISameContainerMigrationTool } from "../migrationInterfaces";
 
 const pactMapKey = "pact-map";
@@ -371,7 +372,11 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 				// random ack.  Probably means storing the Quorum code accept sequence number and verifying the summary is based on that sequence number.
 				// Would be good if we can verify the contents somehow too.
 				// TODO: Not appropriate to be watching _seenV1SummaryAck here, I'm just doing this to simulate second ack after acceptance
-				if (this.acceptedSeqNum !== undefined && op.type === MessageType.SummaryAck) {
+				if (op.type === MessageType.SummaryAck) {
+					assert(
+						this.acceptedSeqNum !== undefined,
+						"this.acceptedSeqNum should be defined",
+					);
 					acksSeen++;
 					// TODO Is this also where I want to emit an internal state event of the ack coming in to help with abort flows?
 					// Or maybe set that up in ensureV1Summary().  Note as mentioned above, waiting for 2 acks here is a hack.

--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -29,7 +29,7 @@ export class SameContainerMigrator
 		if (this._pausedModel === undefined) {
 			throw new Error("_pausedModel has not been initialized");
 		}
-		return this._currentModel;
+		return this._pausedModel;
 	}
 
 	private _currentModelId: string;

--- a/examples/utils/example-utils/src/modelLoader/interfaces.ts
+++ b/examples/utils/example-utils/src/modelLoader/interfaces.ts
@@ -44,6 +44,13 @@ export interface IModelLoader<ModelType> {
 	 * @param id - the id of the container to load
 	 */
 	loadExisting(id: string): Promise<ModelType>;
+
+	/**
+	 * Load a model for the container with the given id.
+	 * @param id - the id of the container to load
+	 * @param sequenceNumber - the sequence number we want to load to and pause at
+	 */
+	loadExistingPaused(id: string, sequenceNumber: number): Promise<ModelType>;
 }
 
 /**

--- a/examples/utils/example-utils/src/modelLoader/modelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelLoader.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import type { IContainer, IHostLoader } from "@fluidframework/container-definitions";
+import {
+	LoaderHeader,
+	type IContainer,
+	type IHostLoader,
+} from "@fluidframework/container-definitions";
 import { ILoaderProps, Loader } from "@fluidframework/container-loader";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import type { IRequest, IResponse } from "@fluidframework/core-interfaces";
@@ -116,13 +120,28 @@ export class ModelLoader<ModelType> implements IModelLoader<ModelType> {
 		const container = await this.loader.resolve({
 			url: id,
 			headers: {
-				loadMode: {
+				[LoaderHeader.loadMode]: {
 					// Here we use "all" to ensure we are caught up before returning.  This is particularly important
 					// for direct-link scenarios, where the user might have a direct link to a data object that was
 					// just attached (i.e. the "attach" op and the "set" of the handle into some map is in the
 					// trailing ops).  If we don't fully process those ops, the expected object won't be found.
 					opsBeforeReturn: "all",
 				},
+			},
+		});
+		const model = await this.getModelFromContainer(container);
+		return model;
+	}
+
+	public async loadExistingPaused(id: string, sequenceNumber: number): Promise<ModelType> {
+		const container = await this.loader.resolve({
+			url: id,
+			headers: {
+				[LoaderHeader.loadMode]: {
+					opsBeforeReturn: "sequenceNumber",
+					pauseAfterLoad: true,
+				},
+				[LoaderHeader.sequenceNumber]: sequenceNumber,
 			},
 		});
 		const model = await this.getModelFromContainer(container);

--- a/examples/utils/example-utils/src/modelLoader/sessionStorageModelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/sessionStorageModelLoader.ts
@@ -58,4 +58,14 @@ export class SessionStorageModelLoader<ModelType> implements IModelLoader<ModelT
 		});
 		return modelLoader.loadExisting(`${window.location.origin}/${id}`);
 	}
+	public async loadExistingPaused(id: string, sequenceNumber: number): Promise<ModelType> {
+		const documentId = id;
+		const modelLoader = new ModelLoader<ModelType>({
+			urlResolver,
+			documentServiceFactory: getDocumentServiceFactory(documentId),
+			codeLoader: this.codeLoader,
+			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(documentId),
+		});
+		return modelLoader.loadExistingPaused(`${window.location.origin}/${id}`, sequenceNumber);
+	}
 }

--- a/examples/utils/example-utils/src/modelLoader/sessionStorageModelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/sessionStorageModelLoader.ts
@@ -59,12 +59,11 @@ export class SessionStorageModelLoader<ModelType> implements IModelLoader<ModelT
 		return modelLoader.loadExisting(`${window.location.origin}/${id}`);
 	}
 	public async loadExistingPaused(id: string, sequenceNumber: number): Promise<ModelType> {
-		const documentId = id;
 		const modelLoader = new ModelLoader<ModelType>({
 			urlResolver,
-			documentServiceFactory: getDocumentServiceFactory(documentId),
+			documentServiceFactory: getDocumentServiceFactory(id),
 			codeLoader: this.codeLoader,
-			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(documentId),
+			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(id),
 		});
 		return modelLoader.loadExistingPaused(`${window.location.origin}/${id}`, sequenceNumber);
 	}

--- a/examples/utils/example-utils/src/modelLoader/tinyliciousModelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/tinyliciousModelLoader.ts
@@ -46,4 +46,7 @@ export class TinyliciousModelLoader<ModelType> implements IModelLoader<ModelType
 	public async loadExisting(id: string) {
 		return this.modelLoader.loadExisting(id);
 	}
+	public async loadExistingPaused(id: string, sequenceNumber: number) {
+		return this.modelLoader.loadExistingPaused(id, sequenceNumber);
+	}
 }

--- a/examples/version-migration/same-container/src/view/appView.tsx
+++ b/examples/version-migration/same-container/src/view/appView.tsx
@@ -33,9 +33,6 @@ export const InventoryListAppView: React.FC<IInventoryListAppViewProps> = (
 		};
 		model.migrationTool.on("proposingMigration", migrationStateChangedHandler);
 		model.migrationTool.on("stoppingCollaboration", migrationStateChangedHandler);
-		model.migrationTool.on("generatingV1Summary", migrationStateChangedHandler);
-		model.migrationTool.on("uploadingV1Summary", migrationStateChangedHandler);
-		model.migrationTool.on("submittingV1Summary", migrationStateChangedHandler);
 		model.migrationTool.on("proposingV2Code", migrationStateChangedHandler);
 		model.migrationTool.on("waitingForV2ProposalCompletion", migrationStateChangedHandler);
 		model.migrationTool.on("readyForMigration", migrationStateChangedHandler);
@@ -46,9 +43,6 @@ export const InventoryListAppView: React.FC<IInventoryListAppViewProps> = (
 		return () => {
 			model.migrationTool.off("proposingMigration", migrationStateChangedHandler);
 			model.migrationTool.off("stoppingCollaboration", migrationStateChangedHandler);
-			model.migrationTool.off("generatingV1Summary", migrationStateChangedHandler);
-			model.migrationTool.off("uploadingV1Summary", migrationStateChangedHandler);
-			model.migrationTool.off("submittingV1Summary", migrationStateChangedHandler);
 			model.migrationTool.off("proposingV2Code", migrationStateChangedHandler);
 			model.migrationTool.off("waitingForV2ProposalCompletion", migrationStateChangedHandler);
 			model.migrationTool.off("readyForMigration", migrationStateChangedHandler);

--- a/examples/version-migration/same-container/src/view/debugView.tsx
+++ b/examples/version-migration/same-container/src/view/debugView.tsx
@@ -96,9 +96,7 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 				{migrationState === "collaborating" && " Normal collaboration"}
 				{migrationState === "proposingMigration" && " Proposing to migrate"}
 				{migrationState === "stoppingCollaboration" && " Stopping collaboration"}
-				{migrationState === "generatingV1Summary" && " Generating v1 summary"}
-				{migrationState === "uploadingV1Summary" && " Uploading v1 summary"}
-				{migrationState === "submittingV1Summary" && " Submitting v1 summary"}
+				{migrationState === "loadingV1PausedContainer" && " Generating v1 paused container"}
 				{migrationState === "proposingV2Code" && " Proposing v2 code"}
 				{migrationState === "waitingForV2ProposalCompletion" &&
 					" Waiting for v2 code proposal completion"}

--- a/examples/version-migration/same-container/src/view/debugView.tsx
+++ b/examples/version-migration/same-container/src/view/debugView.tsx
@@ -53,9 +53,6 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 		};
 		model.migrationTool.on("proposingMigration", migrationStateChangedHandler);
 		model.migrationTool.on("stoppingCollaboration", migrationStateChangedHandler);
-		model.migrationTool.on("generatingV1Summary", migrationStateChangedHandler);
-		model.migrationTool.on("uploadingV1Summary", migrationStateChangedHandler);
-		model.migrationTool.on("submittingV1Summary", migrationStateChangedHandler);
 		model.migrationTool.on("proposingV2Code", migrationStateChangedHandler);
 		model.migrationTool.on("waitingForV2ProposalCompletion", migrationStateChangedHandler);
 		model.migrationTool.on("readyForMigration", migrationStateChangedHandler);
@@ -66,9 +63,6 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 		return () => {
 			model.migrationTool.off("proposingMigration", migrationStateChangedHandler);
 			model.migrationTool.off("stoppingCollaboration", migrationStateChangedHandler);
-			model.migrationTool.off("generatingV1Summary", migrationStateChangedHandler);
-			model.migrationTool.off("uploadingV1Summary", migrationStateChangedHandler);
-			model.migrationTool.off("submittingV1Summary", migrationStateChangedHandler);
 			model.migrationTool.off("proposingV2Code", migrationStateChangedHandler);
 			model.migrationTool.off("waitingForV2ProposalCompletion", migrationStateChangedHandler);
 			model.migrationTool.off("readyForMigration", migrationStateChangedHandler);

--- a/examples/version-migration/same-container/src/view/debugView.tsx
+++ b/examples/version-migration/same-container/src/view/debugView.tsx
@@ -90,7 +90,6 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 				{migrationState === "collaborating" && " Normal collaboration"}
 				{migrationState === "proposingMigration" && " Proposing to migrate"}
 				{migrationState === "stoppingCollaboration" && " Stopping collaboration"}
-				{migrationState === "loadingV1PausedContainer" && " Generating v1 paused container"}
 				{migrationState === "proposingV2Code" && " Proposing v2 code"}
 				{migrationState === "waitingForV2ProposalCompletion" &&
 					" Waiting for v2 code proposal completion"}


### PR DESCRIPTION
## Description
This PR integrates the load paused container API (https://github.com/microsoft/FluidFramework/pull/16152) into the same container migration demo. The paused container will be used to export the container data when the migration was accepted. This PR also removes the v1 summary from the migration flow.

## Reviewer Guidance
1. Additional considerations for removing the v1 summary from the migration flow
1. Should the migration states be adjusted? All v1 summary states have been removed

## Misc
[AB#4527](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4527) / [AB#5198](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5198)