### PR TITLE
fix: Move output directory for e2e-tests app build in devtool-browser-extension

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/e2e-tests/tsconfig.json
+++ b/packages/tools/devtools/devtools-browser-extension/e2e-tests/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"compilerOptions": {
 		"module": "esnext",
-		"outDir": "dist/e2e-tests",
+		"outDir": "../dist/e2e-tests",
 		"composite": true,
 		"types": ["expect-puppeteer", "jest", "jest-environment-puppeteer", "puppeteer"],
 		"jsx": "react",


### PR DESCRIPTION
## Description

Move output directory for the TypeScript build of the e2e-tests app in devtools-browser-extension so that the output files aren't considered input during the next build.

If a local build had already produced a `packages/tools/devtools/devtools-browser-extension/e2e-tests/dist` folder, it can be safely deleted.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
