### PR TITLE
[main > 6.0] revert: Bring back TelemetryNullLogger for 6.x

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -12,7 +12,9 @@ import { ILoggingError } from '@fluidframework/core-interfaces';
 import { ITaggedTelemetryPropertyType } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
+import { ITelemetryErrorEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryGenericEvent } from '@fluidframework/core-interfaces';
+import { ITelemetryPerformanceEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryProperties } from '@fluidframework/core-interfaces';
 import { Lazy } from '@fluidframework/core-utils';
 import { TelemetryEventCategory } from '@fluidframework/core-interfaces';
@@ -336,6 +338,18 @@ export type TelemetryEventPropertyTypeExt = string | number | boolean | undefine
 
 // @public (undocumented)
 export type TelemetryEventPropertyTypes = TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
+
+// @public @deprecated
+export class TelemetryNullLogger implements ITelemetryLoggerExt {
+    // (undocumented)
+    send(event: ITelemetryBaseEvent): void;
+    // (undocumented)
+    sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
+    // (undocumented)
+    sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
+    // (undocumented)
+    sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any): void;
+}
 
 // @public
 export class ThresholdCounter {

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -55,6 +55,7 @@ export {
 	tagCodeArtifacts,
 	TelemetryDataTag,
 	TelemetryEventPropertyTypes,
+	TelemetryNullLogger,
 } from "./logger";
 export { MockLogger } from "./mockLogger";
 export { ThresholdCounter } from "./thresholdCounter";

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -629,6 +629,20 @@ export class PerformanceEvent {
 }
 
 /**
+ * Null logger that no-ops for all telemetry events passed to it.
+ * @deprecated - This will be removed in a future release.
+ * For internal use within the FluidFramework codebase, use {@link createChildLogger} with no arguments instead.
+ * For external consumers we recommend writing a trivial implementation of {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
+ * where the send() method does nothing and using that.
+ */
+export class TelemetryNullLogger implements ITelemetryLoggerExt {
+	public send(event: ITelemetryBaseEvent): void {}
+	public sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any): void {}
+	public sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void {}
+	public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {}
+}
+
+/**
  * Takes in an event object, and converts all of its values to a basePropertyType.
  * In the case of an invalid property type, the value will be converted to an error string.
  * @param event - Event with fields you want to stringify.


### PR DESCRIPTION
Cherry-pick of #16820 to the 6.0 release branch.