### PR TITLE
Move quorum validation back to ProtocolHandler so it can be overridden

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -59,7 +59,6 @@ import {
 	runWithRetry,
 	isCombinedAppAndProtocolSummary,
 	MessageType2,
-	canBeCoalescedByService,
 } from "@fluidframework/driver-utils";
 import { IQuorumSnapshot } from "@fluidframework/protocol-base";
 import {
@@ -761,7 +760,19 @@ export class Container
 		this.scope = scope;
 		this.detachedBlobStorage = detachedBlobStorage;
 		this.protocolHandlerBuilder =
-			protocolHandlerBuilder ?? ((...args) => new ProtocolHandler(...args, new Audience()));
+			protocolHandlerBuilder ??
+			((
+				attributes: IDocumentAttributes,
+				quorumSnapshot: IQuorumSnapshot,
+				sendProposal: (key: string, value: any) => number,
+			) =>
+				new ProtocolHandler(
+					attributes,
+					quorumSnapshot,
+					sendProposal,
+					new Audience(),
+					(clientId: string) => this.clientsWhoShouldHaveLeft.has(clientId),
+				));
 
 		// Note that we capture the createProps here so we can replicate the creation call when we want to clone.
 		this.clone = async (
@@ -2252,28 +2263,6 @@ export class Container
 			this.savedOps.push(message);
 		}
 		const local = this.clientId === message.clientId;
-
-		// Check and report if we're getting messages from a clientId that we previously
-		// flagged should have left, or from a client that's not in the quorum but should be
-		if (message.clientId != null) {
-			const client = this.protocolHandler.quorum.getMember(message.clientId);
-
-			if (client === undefined && message.type !== MessageType.ClientJoin) {
-				// pre-0.58 error message: messageClientIdMissingFromQuorum
-				throw new Error("Remote message's clientId is missing from the quorum");
-			}
-
-			// Here checking canBeCoalescedByService is used as an approximation of "is benign to process despite being unexpected".
-			// It's still not good to see these messages from unexpected clientIds, but since they don't harm the integrity of the
-			// document we don't need to blow up aggressively.
-			if (
-				this.clientsWhoShouldHaveLeft.has(message.clientId) &&
-				!canBeCoalescedByService(message)
-			) {
-				// pre-0.58 error message: messageClientIdShouldHaveLeft
-				throw new Error("Remote message's clientId already should have left");
-			}
-		}
 
 		// Allow the protocol handler to process the message
 		const result = this.protocolHandler.processMessage(message, local);

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -4,6 +4,7 @@
  */
 
 import { IAudienceOwner } from "@fluidframework/container-definitions";
+import { canBeCoalescedByService } from "@fluidframework/driver-utils";
 import {
 	IProtocolHandler as IBaseProtocolHandler,
 	IQuorumSnapshot,
@@ -11,8 +12,12 @@ import {
 } from "@fluidframework/protocol-base";
 import {
 	IDocumentAttributes,
+	IProcessMessageResult,
+	ISequencedClient,
+	ISequencedDocumentMessage,
 	ISignalClient,
 	ISignalMessage,
+	MessageType,
 } from "@fluidframework/protocol-definitions";
 
 // "term" was an experimental feature that is being removed.  The only safe value to use is 1.
@@ -44,7 +49,8 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
 		attributes: IDocumentAttributes,
 		quorumSnapshot: IQuorumSnapshot,
 		sendProposal: (key: string, value: any) => number,
-		readonly audience: IAudienceOwner,
+		public readonly audience: IAudienceOwner,
+		public readonly shouldClientHaveLeft: (clientId: string) => boolean,
 	) {
 		super(
 			attributes.minimumSequenceNumber,
@@ -63,6 +69,32 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
 		for (const [clientId, details] of this.quorum.getMembers()) {
 			this.audience.addMember(clientId, details.client);
 		}
+	}
+
+	public processMessage(
+		message: ISequencedDocumentMessage,
+		local: boolean,
+	): IProcessMessageResult {
+		const client: ISequencedClient | undefined = this.quorum.getMember(message.clientId);
+
+		// Check and report if we're getting messages from a clientId that we previously
+		// flagged as shouldHaveLeft, or from a client that's not in the quorum but should be
+		if (message.clientId != null) {
+			if (client === undefined && message.type !== MessageType.ClientJoin) {
+				// pre-0.58 error message: messageClientIdMissingFromQuorum
+				throw new Error("Remote message's clientId is missing from the quorum");
+			}
+
+			// Here checking canBeCoalescedByService is used as an approximation of "is benign to process despite being unexpected".
+			// It's still not good to see these messages from unexpected clientIds, but since they don't harm the integrity of the
+			// document we don't need to blow up aggressively.
+			if (this.shouldClientHaveLeft(message.clientId) && !canBeCoalescedByService(message)) {
+				// pre-0.58 error message: messageClientIdShouldHaveLeft
+				throw new Error("Remote message's clientId already should have left");
+			}
+		}
+
+		return super.processMessage(message, local);
 	}
 
 	public processSignal(message: ISignalMessage) {

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -50,7 +50,7 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
 		quorumSnapshot: IQuorumSnapshot,
 		sendProposal: (key: string, value: any) => number,
 		public readonly audience: IAudienceOwner,
-		public readonly shouldClientHaveLeft: (clientId: string) => boolean,
+		private readonly shouldClientHaveLeft: (clientId: string) => boolean,
 	) {
 		super(
 			attributes.minimumSequenceNumber,

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -138,6 +138,7 @@ describe("ConnectionStateHandler Tests", () => {
 			{ members: [], proposals: [], values: [] }, // quorumSnapshot
 			(key, value) => 0, // sendProposal
 			new Audience(),
+			(clientId: string) => false, // shouldClientHaveLeft
 		);
 		shouldClientJoinWrite = false;
 		handlerInputs = {


### PR DESCRIPTION
In #16016 I moved the logic to validate incoming messages were coming from valid clients to the Container.  However, this then means that customers who pass a protocolHandlerBuilder lose the opportunity to override this check in their custom protocol handler.  This presents a problem for customers who want to permit messages from clients not (yet) in the quorum.  In particular, Word uses a "joinless" protocol where clients are implicitly added to the quorum upon processing one of their messages, so it's never valid to reject a message due to the sender not being in the quorum.

This change moves the check back into the ProtocolHandler so it can be overridden in this case, but keeps the other characteristics of the prior change (avoid mutating the Quorum, consolidate tracking in the Container).  It then passes an explicit callback to the built-in ProtocolHandler to query whether a client should have left.  Longer-term we may consider other options for the protocolHandlerBuilder override and this check (I've been talking to @andre4i about some ideas), but this change is more targeted just to unblock partners.