### PR TITLE
tree2: Tidy op size tests

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -429,7 +429,7 @@ describe("Op Size", () => {
 		});
 		table.sort(["Avg. Op Size (Bytes)|des"]);
 
-		console.log("-- Op Size Benchmark Statistics Sorted by Avg. Op Size -- ");
+		console.log("-- Op Size Benchmark Statistics -- ");
 		console.log(table.toString());
 	});
 

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -2,14 +2,14 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { strict as assert } from "assert";
+import { strict as assert, fail } from "assert";
 import Table from "easy-table";
 import { isInPerformanceTestingMode } from "@fluid-tools/benchmark";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { SchemaBuilder, singleTextCursor } from "../../feature-libraries";
-import { ISharedTree, ISharedTreeView } from "../../shared-tree";
+import { ISharedTree, ISharedTreeView, SharedTreeFactory } from "../../shared-tree";
 import { JsonCompatibleReadOnly, brand, getOrAddEmptyToMap } from "../../util";
-import { TestTreeProviderLite } from "../utils";
 import {
 	AllowedUpdateType,
 	FieldKey,
@@ -20,6 +20,17 @@ import {
 	Value,
 	ValueSchema,
 } from "../../core";
+import { typeboxValidator } from "../../external-utilities";
+
+// Notes:
+// 1. Within this file "percentile" is commonly used, and seems to refer to a portion (0 to 1) or some maximum size.
+// While it would be useful and interesting to have some distribution of op sizes and measure some percentile from that distribution,
+// that does not appear to be what these tests are doing.
+// 2. Data from these tests are just printed: no other data collection is done. If a comparison is desire, manually run the tests before and after.
+// 3. Major changes in these sizes (regressions, optimizations or the tests not collecting what they should) do not make these tests fail.
+// 4. These tests are currently implemented as integration tests, meaning they use lots of dependencies and high level APIs.
+// They could be reimplemented targeted the lower level APIs if desired.
+// 5. "large" node just get a long repeated string value, not a complex tree, so tree encoding is not really covered here.
 
 const builder = new SchemaBuilder("opSize");
 
@@ -126,7 +137,6 @@ function createInitialTree(childNodes: number, childNodeByteSize: number): Jsona
 
 function insertNodesWithIndividualTransactions(
 	tree: ISharedTreeView,
-	provider: TestTreeProviderLite,
 	jsonNode: JsonableTree,
 	count: number,
 ): void {
@@ -142,12 +152,10 @@ function insertNodesWithIndividualTransactions(
 		field.insert(0, writeCursor);
 		tree.transaction.commit();
 	}
-	provider.processMessages();
 }
 
 function insertNodesWithSingleTransaction(
 	tree: ISharedTreeView,
-	provider: TestTreeProviderLite,
 	jsonNode: JsonableTree,
 	count: number,
 ): void {
@@ -162,12 +170,10 @@ function insertNodesWithSingleTransaction(
 		field.insert(0, singleTextCursor(jsonNode));
 	}
 	tree.transaction.commit();
-	provider.processMessages();
 }
 
 function deleteNodesWithIndividualTransactions(
 	tree: ISharedTree,
-	provider: TestTreeProviderLite,
 	numDeletes: number,
 	deletesPerTransaction: number,
 ): void {
@@ -181,15 +187,10 @@ function deleteNodesWithIndividualTransactions(
 		const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
 		field.delete(getChildrenLength(tree) - 1, deletesPerTransaction);
 		tree.transaction.commit();
-		provider.processMessages();
 	}
 }
 
-function deleteNodesWithSingleTransaction(
-	tree: ISharedTree,
-	provider: TestTreeProviderLite,
-	numDeletes: number,
-): void {
+function deleteNodesWithSingleTransaction(tree: ISharedTree, numDeletes: number): void {
 	tree.transaction.start();
 	const path = {
 		parent: undefined,
@@ -199,7 +200,6 @@ function deleteNodesWithSingleTransaction(
 	const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
 	field.delete(0, numDeletes);
 	tree.transaction.commit();
-	provider.processMessages();
 }
 
 function createStringFromLength(numberOfBytes: number): string {
@@ -208,7 +208,6 @@ function createStringFromLength(numberOfBytes: number): string {
 
 function editNodesWithIndividualTransactions(
 	tree: ISharedTree,
-	provider: TestTreeProviderLite,
 	numChildrenToEdit: number,
 	editPayload: Value,
 ): void {
@@ -232,13 +231,11 @@ function editNodesWithIndividualTransactions(
 			}),
 		);
 		tree.transaction.commit();
-		provider.processMessages();
 	}
 }
 
 function editNodesWithSingleTransaction(
 	tree: ISharedTree,
-	provider: TestTreeProviderLite,
 	numChildrenToEdit: number,
 	editPayload: Value,
 ): void {
@@ -263,7 +260,17 @@ function editNodesWithSingleTransaction(
 		);
 	}
 	tree.transaction.commit();
-	provider.processMessages();
+}
+
+enum Operation {
+	Insert = "Insert",
+	Delete = "Delete",
+	Edit = "Edit",
+}
+
+enum TransactionStyle {
+	Individual,
+	Single,
 }
 
 /**
@@ -276,38 +283,38 @@ function editNodesWithSingleTransaction(
  * Making the size in bytes of the children smaller.
  */
 const MAX_SUCCESSFUL_OP_BYTE_SIZES = {
-	INSERT: {
-		INDIVIDUAL: {
+	Insert: {
+		[TransactionStyle.Individual]: {
 			nodeCounts: {
 				"100": 8900,
 			},
 		},
-		SINGLE: {
+		[TransactionStyle.Single]: {
 			nodeCounts: {
 				"100": 9600,
 			},
 		},
 	},
-	DELETE: {
-		INDIVIDUAL: {
+	Delete: {
+		[TransactionStyle.Individual]: {
 			nodeCounts: {
 				"100": 9700,
 			},
 		},
-		SINGLE: {
+		[TransactionStyle.Single]: {
 			nodeCounts: {
 				"100": 9700,
 			},
 		},
 	},
-	EDIT: {
-		INDIVIDUAL: {
+	Edit: {
+		[TransactionStyle.Individual]: {
 			nodeCounts: {
 				// Edit benchmarks use 1/10 of the actual max sizes outside of perf mode because it takes so long to execute.
 				"100": isInPerformanceTestingMode ? 800000 : 80000,
 			},
 		},
-		SINGLE: {
+		[TransactionStyle.Single]: {
 			nodeCounts: {
 				"100": 8600,
 			},
@@ -316,8 +323,8 @@ const MAX_SUCCESSFUL_OP_BYTE_SIZES = {
 } as const;
 
 const getSuccessfulOpByteSize = (
-	operation: "INSERT" | "DELETE" | "EDIT",
-	transactionStyle: "INDIVIDUAL" | "SINGLE",
+	operation: Operation,
+	transactionStyle: TransactionStyle,
 	percentile: number,
 ) => {
 	return Math.floor(
@@ -327,67 +334,59 @@ const getSuccessfulOpByteSize = (
 
 const BENCHMARK_NODE_COUNT = 100;
 
-describe("SharedTree Op Size Benchmarks", () => {
+const sizes = [
+	{ percentile: 0.1, word: "small" },
+	{ percentile: 0.5, word: "medium" },
+	{ percentile: 1.0, word: "large" },
+];
+
+const styles = [
+	{
+		description: "Many Transactions",
+		style: TransactionStyle.Individual,
+		extraDescription: `${BENCHMARK_NODE_COUNT} transactions`,
+	},
+	{
+		description: "Single Transaction",
+		style: TransactionStyle.Single,
+		extraDescription: `1 transaction`,
+	},
+];
+
+const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
+
+describe("Op Size", () => {
 	const opsByBenchmarkName: Map<string, ISequencedDocumentMessage[]> = new Map();
 	let currentBenchmarkName = "";
 	const currentTestOps: ISequencedDocumentMessage[] = [];
 
-	const registerOpListener = (
-		provider: TestTreeProviderLite,
-		resultArray: ISequencedDocumentMessage[],
-	) => {
-		provider.trees[0].on("op", (message) => {
-			if (message?.type === "op") {
-				resultArray.push(message);
-			}
-		});
-	};
+	function registerOpListener(tree: ISharedTree, resultArray: ISequencedDocumentMessage[]): void {
+		// TODO: better way to hooke this up
+		const oldSubmitLocalMessage = (tree as any).submitLocalMessage.bind(tree);
+		function submitLocalMessage(content: any, localOpMetadata: unknown = undefined): void {
+			resultArray.push(content);
+			oldSubmitLocalMessage(content, localOpMetadata);
+		}
+		(tree as any).submitLocalMessage = submitLocalMessage;
+	}
 
 	const getOperationsStats = (operations: ISequencedDocumentMessage[]) => {
-		if (operations.length === 0) {
-			return {
-				"Avg. Op Size (Bytes)": 0,
-				"Max Op Size (Bytes)": 0,
-				"Min Op Size (Bytes)": 0,
-				"Total Ops:": 0,
-			};
-		}
-		let averageOpSizeBytes = 0;
-		operations.forEach((operation) => {
-			averageOpSizeBytes += new TextEncoder().encode(JSON.stringify(operation)).length;
-		});
-		averageOpSizeBytes = averageOpSizeBytes / operations.length;
-
-		let maxOpSizeBytes = new TextEncoder().encode(JSON.stringify(operations[0])).length;
-		operations.forEach(
-			(operation) =>
-				(maxOpSizeBytes = Math.max(
-					new TextEncoder().encode(JSON.stringify(operation)).length,
-					maxOpSizeBytes,
-				)),
+		const lengths = operations.map((operation) =>
+			utf8Length(operation as unknown as JsonCompatibleReadOnly),
 		);
-
-		let minOpSizeBytes = new TextEncoder().encode(JSON.stringify(operations[0])).length;
-		operations.forEach(
-			(operation) =>
-				(minOpSizeBytes = Math.min(
-					new TextEncoder().encode(JSON.stringify(operation)).length,
-					minOpSizeBytes,
-				)),
-		);
+		const totalOpBytes = lengths.reduce((a, b) => a + b, 0);
+		const maxOpSizeBytes = Math.max(...lengths);
 
 		return {
-			"Avg. Op Size (Bytes)": Number.parseFloat(averageOpSizeBytes.toFixed(2)),
+			"Total Op Size (Bytes)": totalOpBytes,
 			"Max Op Size (Bytes)": maxOpSizeBytes,
-			"Min Op Size (Bytes)": minOpSizeBytes,
 			"Total Ops:": operations.length,
 		};
 	};
 
-	const initializeOpDataCollection = (provider: TestTreeProviderLite, testName: string) => {
-		currentBenchmarkName = testName;
+	const initializeOpDataCollection = (tree: ISharedTree) => {
 		currentTestOps.length = 0;
-		registerOpListener(provider, currentTestOps);
+		registerOpListener(tree, currentTestOps);
 	};
 
 	const saveAndResetCurrentOps = () => {
@@ -401,7 +400,14 @@ describe("SharedTree Op Size Benchmarks", () => {
 		currentTestOps.length = 0;
 	};
 
+	beforeEach(function (): void {
+		currentBenchmarkName = this.currentTest?.fullTitle() ?? fail();
+		currentTestOps.length = 0;
+	});
+
 	afterEach(() => {
+		// Currently tests can pass when no data is collected, so throw here in that case to ensure tests don't break and start collecting no data.
+		assert(currentTestOps.length !== 0);
 		currentTestOps.forEach((op) =>
 			getOrAddEmptyToMap(opsByBenchmarkName, currentBenchmarkName).push(op),
 		);
@@ -427,291 +433,133 @@ describe("SharedTree Op Size Benchmarks", () => {
 		console.log(table.toString());
 	});
 
-	describe("1. Insert Nodes", () => {
-		describe("1a. With Individual transactions", () => {
-			function benchmarkInsertNodesWithIndividualTxs(
-				percentile: number,
-				testName: string,
-			): void {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
-				initializeTestTree(provider.trees[0]);
-				provider.processMessages();
-				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				const jsonNode = createTreeWithSize(
-					getSuccessfulOpByteSize("INSERT", "INDIVIDUAL", percentile),
-				);
-				insertNodesWithIndividualTransactions(
-					provider.trees[0],
-					provider,
-					jsonNode,
-					BENCHMARK_NODE_COUNT,
-				);
-				assertChildNodeCount(provider.trees[0], BENCHMARK_NODE_COUNT);
+	describe("Insert Nodes", () => {
+		function benchmarkOps(transactionStyle: TransactionStyle, percentile: number): void {
+			const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+			initializeOpDataCollection(tree);
+			initializeTestTree(tree);
+			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
+			const jsonNode = createTreeWithSize(
+				getSuccessfulOpByteSize(Operation.Insert, transactionStyle, percentile),
+			);
+			const apply =
+				transactionStyle === TransactionStyle.Individual
+					? insertNodesWithIndividualTransactions
+					: insertNodesWithSingleTransaction;
+			apply(tree, jsonNode, BENCHMARK_NODE_COUNT);
+			assertChildNodeCount(tree, BENCHMARK_NODE_COUNT);
+		}
+
+		for (const { description, style, extraDescription } of styles) {
+			describe(description, () => {
+				for (const { percentile, word } of sizes) {
+					it(`${BENCHMARK_NODE_COUNT} ${word} nodes in ${extraDescription}`, () => {
+						benchmarkOps(style, percentile);
+					});
+				}
+			});
+		}
+	});
+
+	describe("Delete Nodes", () => {
+		function benchmarkOps(transactionStyle: TransactionStyle, percentile: number): void {
+			const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+			initializeOpDataCollection(tree);
+			const childByteSize = getSuccessfulOpByteSize(
+				Operation.Delete,
+				transactionStyle,
+				percentile,
+			);
+			initializeTestTree(tree, createInitialTree(100, childByteSize));
+			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
+			if (transactionStyle === TransactionStyle.Individual) {
+				deleteNodesWithIndividualTransactions(tree, 100, 1);
+			} else {
+				deleteNodesWithSingleTransaction(tree, 100);
 			}
+			assertChildNodeCount(tree, 0);
+		}
 
-			it(`1a.a. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} transactions`, () => {
-				benchmarkInsertNodesWithIndividualTxs(
-					0.01,
-					`1a.a. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
-				);
+		for (const { description, style, extraDescription } of styles) {
+			describe(description, () => {
+				for (const { percentile, word } of sizes) {
+					it(`${BENCHMARK_NODE_COUNT} ${word} nodes in ${
+						style === TransactionStyle.Individual
+							? extraDescription
+							: `1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`
+					}`, () => {
+						benchmarkOps(style, percentile);
+					});
+				}
 			});
-
-			it(`1a.b. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
-				benchmarkInsertNodesWithIndividualTxs(
-					0.5,
-					`1a.b. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
-				);
-			});
-
-			it(`1a.c. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
-				benchmarkInsertNodesWithIndividualTxs(
-					1,
-					`1a.c. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
-				);
-			});
-		});
-
-		describe("1b. With Single transaction", () => {
-			const benchmarkInsertNodesWithSingleTx = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
-				initializeTestTree(provider.trees[0]);
-				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				const jsonNode = createTreeWithSize(
-					getSuccessfulOpByteSize("INSERT", "SINGLE", percentile),
-				);
-				insertNodesWithSingleTransaction(
-					provider.trees[0],
-					provider,
-					jsonNode,
-					BENCHMARK_NODE_COUNT,
-				);
-				assertChildNodeCount(provider.trees[0], BENCHMARK_NODE_COUNT);
-			};
-
-			it(`1b.a. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction`, () => {
-				benchmarkInsertNodesWithSingleTx(
-					0.01,
-					`1b.a. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction`,
-				);
-			});
-
-			it(`1b.b. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transaction`, () => {
-				benchmarkInsertNodesWithSingleTx(
-					0.5,
-					`1b.b. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transaction`,
-				);
-			});
-
-			it(`1b.c. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transaction`, () => {
-				benchmarkInsertNodesWithSingleTx(
-					1,
-					`1b.c. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transaction`,
-				);
-			});
-		});
+		}
 	});
 
-	describe("2. Delete Nodes", () => {
-		describe("2a. With Individual transactions", () => {
-			const benchmarkDeleteNodesWithIndividualTxs = (
-				percentile: number,
-				testName: string,
-			) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
-				const childByteSize = getSuccessfulOpByteSize("DELETE", "INDIVIDUAL", percentile);
-				initializeTestTree(provider.trees[0], createInitialTree(100, childByteSize));
-				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				deleteNodesWithIndividualTransactions(provider.trees[0], provider, 100, 1);
-				assertChildNodeCount(provider.trees[0], 0);
-			};
+	describe("Edit Nodes", () => {
+		function benchmarkOps(transactionStyle: TransactionStyle, percentile: number): void {
+			const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+			initializeOpDataCollection(tree);
+			// Note that the child node byte size for the initial tree here should be arbitrary
+			initializeTestTree(tree, createInitialTree(BENCHMARK_NODE_COUNT, 1000));
+			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
+			const editPayload = createStringFromLength(
+				getSuccessfulOpByteSize(Operation.Edit, transactionStyle, percentile),
+			);
+			if (transactionStyle === TransactionStyle.Individual) {
+				editNodesWithIndividualTransactions(tree, BENCHMARK_NODE_COUNT, editPayload);
+			} else {
+				editNodesWithSingleTransaction(tree, BENCHMARK_NODE_COUNT, editPayload);
+			}
+			expectChildrenValues(tree, editPayload, BENCHMARK_NODE_COUNT);
+		}
 
-			it(`2a.a. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
-				benchmarkDeleteNodesWithIndividualTxs(
-					0.01,
-					`2a.a. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
-				);
+		for (const { description, style, extraDescription } of styles) {
+			describe(description, () => {
+				for (const { percentile, word } of sizes) {
+					it(`${BENCHMARK_NODE_COUNT} ${word} changes in ${extraDescription} containing ${
+						style === TransactionStyle.Individual
+							? "1 edit"
+							: `${BENCHMARK_NODE_COUNT} edits`
+					}`, () => {
+						benchmarkOps(style, percentile);
+					});
+				}
 			});
-
-			it(`2a.b. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
-				benchmarkDeleteNodesWithIndividualTxs(
-					0.5,
-					`2a.b. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
-				);
-			});
-
-			it(`2a.c. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
-				benchmarkDeleteNodesWithIndividualTxs(
-					1,
-					`2a.c. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
-				);
-			});
-		});
-
-		describe("2b. With Single transaction", () => {
-			const benchmarkDeleteNodesWithSingleTx = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
-				const childByteSize = getSuccessfulOpByteSize("DELETE", "SINGLE", percentile);
-				initializeTestTree(provider.trees[0], createInitialTree(100, childByteSize));
-				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				deleteNodesWithSingleTransaction(provider.trees[0], provider, 100);
-				assertChildNodeCount(provider.trees[0], 0);
-			};
-
-			it(`2b.a. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, () => {
-				benchmarkDeleteNodesWithSingleTx(
-					0.01,
-					`2b.a. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`,
-				);
-			});
-
-			it(`2b.b. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, () => {
-				benchmarkDeleteNodesWithSingleTx(
-					0.5,
-					`2b.b. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`,
-				);
-			});
-
-			it(`2b.c. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, () => {
-				benchmarkDeleteNodesWithSingleTx(
-					1,
-					`2b.c. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`,
-				);
-			});
-		});
+		}
 	});
 
-	describe("3. Edit Nodes", () => {
-		describe("3a. With Individual transactions", () => {
-			const benchmarkEditNodesWithIndividualTxs = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
-				// Note that the child node byte size for the intial tree here should be arbitrary
-				initializeTestTree(
-					provider.trees[0],
-					createInitialTree(BENCHMARK_NODE_COUNT, 1000),
-				);
-				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				const editPayload = createStringFromLength(
-					getSuccessfulOpByteSize("EDIT", "INDIVIDUAL", percentile),
-				);
-				editNodesWithIndividualTransactions(
-					provider.trees[0],
-					provider,
-					BENCHMARK_NODE_COUNT,
-					editPayload,
-				);
-				expectChildrenValues(provider.trees[0], editPayload, BENCHMARK_NODE_COUNT);
-			};
-
-			it(`3a.a. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} small changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, () => {
-				benchmarkEditNodesWithIndividualTxs(
-					0.01,
-					`3a.a. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} small changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`,
-				);
-			});
-
-			it(`3a.b. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, () => {
-				benchmarkEditNodesWithIndividualTxs(
-					0.5,
-					`3a.b. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`,
-				);
-			});
-
-			it(`3a.c. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} large changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, () => {
-				benchmarkEditNodesWithIndividualTxs(
-					1,
-					`3a.c. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} large changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`,
-				);
-			});
-		});
-
-		describe("3b. With Single transaction", () => {
-			const benchmarkEditNodesWithSingleTx = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
-				// Note that the child node byte size for the intial tree here should be arbitrary
-				initializeTestTree(
-					provider.trees[0],
-					createInitialTree(BENCHMARK_NODE_COUNT, 1000),
-				);
-				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				const editPayload = createStringFromLength(
-					getSuccessfulOpByteSize("EDIT", "SINGLE", percentile),
-				);
-				editNodesWithSingleTransaction(
-					provider.trees[0],
-					provider,
-					BENCHMARK_NODE_COUNT,
-					editPayload,
-				);
-				expectChildrenValues(provider.trees[0], editPayload, BENCHMARK_NODE_COUNT);
-			};
-
-			it(`3b.a. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} small edits in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, () => {
-				benchmarkEditNodesWithSingleTx(
-					0.01,
-					`3b.a. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} small changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`,
-				);
-			});
-
-			it(`3b.b. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} medium changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, () => {
-				benchmarkEditNodesWithSingleTx(
-					0.5,
-					`3b.b. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} medium changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`,
-				);
-			});
-
-			it(`3b.c. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} large changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, () => {
-				benchmarkEditNodesWithSingleTx(
-					1,
-					`3b.c. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} large changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`,
-				);
-			});
-		});
-	});
-
-	describe("4. Insert, Delete & Edit Nodes", () => {
-		describe("4a. Insert, Delete & Edit Nodes in Individual Transactions", () => {
+	describe("Insert, Delete & Edit Nodes", () => {
+		describe("Individual Transactions", () => {
 			const benchmarkInsertDeleteEditNodesWithInvidiualTxs = (
 				percentile: number,
-				testName: string,
 				insertNodeCount: number,
 				deleteNodeCount: number,
 				editNodeCount: number,
 			) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
+				const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+				initializeOpDataCollection(tree);
 
 				// delete
-				const childByteSize = getSuccessfulOpByteSize("DELETE", "INDIVIDUAL", percentile);
-				initializeTestTree(
-					provider.trees[0],
-					createInitialTree(deleteNodeCount, childByteSize),
+				const childByteSize = getSuccessfulOpByteSize(
+					Operation.Delete,
+					TransactionStyle.Individual,
+					percentile,
 				);
+				initializeTestTree(tree, createInitialTree(deleteNodeCount, childByteSize));
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				deleteNodesWithIndividualTransactions(
-					provider.trees[0],
-					provider,
-					deleteNodeCount,
-					1,
-				);
-				assertChildNodeCount(provider.trees[0], 0);
+				deleteNodesWithIndividualTransactions(tree, deleteNodeCount, 1);
+				assertChildNodeCount(tree, 0);
 
 				// insert
 				const insertChildNode = createTreeWithSize(
-					getSuccessfulOpByteSize("INSERT", "INDIVIDUAL", percentile),
+					getSuccessfulOpByteSize(
+						Operation.Insert,
+						TransactionStyle.Individual,
+						percentile,
+					),
 				);
-				insertNodesWithIndividualTransactions(
-					provider.trees[0],
-					provider,
-					insertChildNode,
-					insertNodeCount,
-				);
-				assertChildNodeCount(provider.trees[0], insertNodeCount);
+				insertNodesWithIndividualTransactions(tree, insertChildNode, insertNodeCount);
+				assertChildNodeCount(tree, insertNodeCount);
 
 				// edit
 				// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
@@ -719,52 +567,47 @@ describe("SharedTree Op Size Benchmarks", () => {
 					const remainder = editNodeCount - insertNodeCount;
 					saveAndResetCurrentOps();
 					insertNodesWithIndividualTransactions(
-						provider.trees[0],
-						provider,
+						tree,
 						createTreeWithSize(childByteSize),
 						remainder,
 					);
 					deleteCurrentOps(); // We don't want to record the ops from re-initializing the tree.
 				}
 				const editPayload = createStringFromLength(
-					getSuccessfulOpByteSize("EDIT", "INDIVIDUAL", percentile),
+					getSuccessfulOpByteSize(
+						Operation.Edit,
+						TransactionStyle.Individual,
+						percentile,
+					),
 				);
-				editNodesWithIndividualTransactions(
-					provider.trees[0],
-					provider,
-					editNodeCount,
-					editPayload,
-				);
-				expectChildrenValues(provider.trees[0], editPayload, editNodeCount);
+				editNodesWithIndividualTransactions(tree, editNodeCount, editPayload);
+				expectChildrenValues(tree, editPayload, editNodeCount);
 			};
 
-			describe("4a.a. [Combination] [Individual Txs] With individual transactions and an equal distribution of operation type", () => {
+			describe("an equal distribution of operation type", () => {
 				const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
 
-				it(`4a.a.a. [Combination] [Individual Txs] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
+				it(`insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
-						`4a.a.a. [Combination] [Individual Txs] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 					);
 				});
 
-				it(`4a.a.b. [Combination] [Individual Txs] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
+				it(`insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
-						`4a.a.b. [Combination] [Individual Txs] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 					);
 				});
 
-				it(`4a.a.c. [Combination] [Individual Txs] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
+				it(`insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
-						`4a.a.c. [Combination] [Individual Txs] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
@@ -772,34 +615,31 @@ describe("SharedTree Op Size Benchmarks", () => {
 				});
 			});
 
-			describe("4a.b. [Combination] [Individual Txs] In individual transactions with 70% distribution of operations towards insert", () => {
+			describe("70% distribution of operations towards insert", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4a.b.a. [Combination] [Individual Txs] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+				it(`Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
-						`4a.b.a. [Combination] [Individual Txs] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						seventyPercentCount,
 						fifteenPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4a.b.b. [Combination] [Individual Txs] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+				it(`Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
-						`4a.b.b. [Combination] [Individual Txs] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						seventyPercentCount,
 						fifteenPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4a.b.c. [Combination] [Individual Txs] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+				it(`Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
-						`4a.b.c. [Combination] [Individual Txs] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`,
 						seventyPercentCount,
 						fifteenPercentCount,
 						fifteenPercentCount,
@@ -807,34 +647,31 @@ describe("SharedTree Op Size Benchmarks", () => {
 				});
 			});
 
-			describe("4a.c. [Combination] [Individual Txs] In individual transactions with 70% distribution of operations towards delete", () => {
+			describe("70% distribution of operations towards delete", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4a.c.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+				it(`Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
-						`4a.c.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
 						seventyPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+				it(`Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
-						`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
 						seventyPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
-						`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
 						seventyPercentCount,
 						fifteenPercentCount,
@@ -842,34 +679,31 @@ describe("SharedTree Op Size Benchmarks", () => {
 				});
 			});
 
-			describe("4a.d. [Combination] [Individual Txs] In individual transactions with 70% distribution of operations towards edit", () => {
+			describe("70% distribution of operations towards edit", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4a.d.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
+				it(`Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
-						`4a.d.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
 						fifteenPercentCount,
 						seventyPercentCount,
 					);
 				});
 
-				it(`4a.d.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
+				it(`Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
-						`4a.d.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
 						fifteenPercentCount,
 						seventyPercentCount,
 					);
 				});
 
-				it(`4a.d.c. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
+				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
-						`4a.d.c. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`,
 						fifteenPercentCount,
 						fifteenPercentCount,
 						seventyPercentCount,
@@ -878,91 +712,84 @@ describe("SharedTree Op Size Benchmarks", () => {
 			});
 		});
 
-		describe("4b. Insert, Delete & Edit Nodes in Single Transactions", () => {
+		// TODO:
+		// These tests don't actually do a single transaction (they do one per edit type).
+		// Therefor they are failing to test the size of transactions mixing inserts, deletes and edits.
+		// These tests also fail to clarify if the nodes being deleted are ones which were inserted or edited earlier,
+		// so it can't be used to test compaction of transient data within a transaction even if it was a single transaction.
+		// Instead correctness tests should cover that, and maybe this suite should simply be removed?
+		describe("Single Transactions", () => {
 			const benchmarkInsertDeleteEditNodesWithSingleTxs = (
 				percentile: number,
-				testName: string,
 				insertNodeCount: number,
 				deleteNodeCount: number,
 				editNodeCount: number,
 			) => {
-				const provider = new TestTreeProviderLite();
-				initializeOpDataCollection(provider, testName);
+				const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
+				initializeOpDataCollection(tree);
 
 				// delete
-				const childByteSize = getSuccessfulOpByteSize("DELETE", "SINGLE", percentile);
-				initializeTestTree(
-					provider.trees[0],
-					createInitialTree(deleteNodeCount, childByteSize),
+				const childByteSize = getSuccessfulOpByteSize(
+					Operation.Delete,
+					TransactionStyle.Single,
+					percentile,
 				);
+				initializeTestTree(tree, createInitialTree(deleteNodeCount, childByteSize));
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				deleteNodesWithSingleTransaction(provider.trees[0], provider, deleteNodeCount);
-				assertChildNodeCount(provider.trees[0], 0);
+				deleteNodesWithSingleTransaction(tree, deleteNodeCount);
+				assertChildNodeCount(tree, 0);
 
 				// insert
 				const insertChildNode = createTreeWithSize(
-					getSuccessfulOpByteSize("INSERT", "SINGLE", percentile),
+					getSuccessfulOpByteSize(Operation.Insert, TransactionStyle.Single, percentile),
 				);
-				insertNodesWithSingleTransaction(
-					provider.trees[0],
-					provider,
-					insertChildNode,
-					insertNodeCount,
-				);
-				assertChildNodeCount(provider.trees[0], insertNodeCount);
+				insertNodesWithSingleTransaction(tree, insertChildNode, insertNodeCount);
+				assertChildNodeCount(tree, insertNodeCount);
 
 				// edit
 				// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
+				// TODO: if actually making this do a single transaction like its supposed to, this would be an issue as it would get included in that transaction.
 				if (insertNodeCount < editNodeCount) {
 					const remainder = editNodeCount - insertNodeCount;
 					saveAndResetCurrentOps();
 					insertNodesWithIndividualTransactions(
-						provider.trees[0],
-						provider,
+						tree,
 						createTreeWithSize(childByteSize),
 						remainder,
 					);
 					deleteCurrentOps(); // We don't want to record the ops from re-initializing the tree.
 				}
 				const editPayload = createStringFromLength(
-					getSuccessfulOpByteSize("EDIT", "SINGLE", percentile),
+					getSuccessfulOpByteSize(Operation.Edit, TransactionStyle.Single, percentile),
 				);
-				editNodesWithSingleTransaction(
-					provider.trees[0],
-					provider,
-					editNodeCount,
-					editPayload,
-				);
-				expectChildrenValues(provider.trees[0], editPayload, editNodeCount);
+				editNodesWithSingleTransaction(tree, editNodeCount, editPayload);
+				expectChildrenValues(tree, editPayload, editNodeCount);
 			};
 
-			describe("4b.a. [Combination] [Single Tx] With single transactions and an equal distribution of operation type", () => {
+			describe("equal distribution of operation type", () => {
 				const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
 
-				it(`4b.a.a. [Combination] [Single Tx] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
+				it(`insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
-						`4b.a.a. [Combination] [Single Tx] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 					);
 				});
 
-				it(`4b.a.b. [Combination] [Single Tx] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
+				it(`insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
-						`4b.a.b. [Combination] [Single Tx] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 					);
 				});
 
-				it(`4b.a.c. [Combination] [Single Tx] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
+				it(`insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
-						`4b.a.c. [Combination] [Single Tx] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
 						oneThirdNodeCount,
@@ -970,34 +797,31 @@ describe("SharedTree Op Size Benchmarks", () => {
 				});
 			});
 
-			describe("4b.b. [Combination] [Single Tx] With single transactions with 70% distribution of operations towards insert", () => {
+			describe("70% distribution of operations towards insert", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4b.b.a. [Combination] [Single Tx] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+				it(`Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
-						`4b.b.a. [Combination] [Single Tx] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						seventyPercentCount,
 						fifteenPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4b.b.b. [Combination] [Single Tx] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+				it(`Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
-						`4b.b.b. [Combination] [Single Tx] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						seventyPercentCount,
 						fifteenPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4b.b.c. [Combination] [Single Tx] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+				it(`Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
-						`4b.b.c. [Combination] [Single Tx] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`,
 						seventyPercentCount,
 						fifteenPercentCount,
 						fifteenPercentCount,
@@ -1005,34 +829,31 @@ describe("SharedTree Op Size Benchmarks", () => {
 				});
 			});
 
-			describe("4b.c. [Combination] [Single Tx] With single transactions with 70% distribution of operations towards delete", () => {
+			describe("70% distribution of operations towards delete", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4b.c.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+				it(`Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
-						`4b.c.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
 						seventyPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+				it(`Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
-						`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
 						seventyPercentCount,
 						fifteenPercentCount,
 					);
 				});
 
-				it(`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
-						`4a.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
 						seventyPercentCount,
 						fifteenPercentCount,
@@ -1040,34 +861,31 @@ describe("SharedTree Op Size Benchmarks", () => {
 				});
 			});
 
-			describe("4b.d. [Combination] [Single Tx] In individual With single transactions with 70% distribution of operations towards edit", () => {
+			describe("70% distribution of operations towards edit", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4b.d.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
+				it(`Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
-						`4a.d.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
 						fifteenPercentCount,
 						seventyPercentCount,
 					);
 				});
 
-				it(`4b.d.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
+				it(`Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
-						`4b.d.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
 						fifteenPercentCount,
 						seventyPercentCount,
 					);
 				});
 
-				it(`4b.d.c. [Combination] Single Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
+				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
-						`4b.d.c. [Combination] [Single Tx] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`,
 						fifteenPercentCount,
 						fifteenPercentCount,
 						seventyPercentCount,

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -361,7 +361,7 @@ describe("Op Size", () => {
 	const currentTestOps: ISequencedDocumentMessage[] = [];
 
 	function registerOpListener(tree: ISharedTree, resultArray: ISequencedDocumentMessage[]): void {
-		// TODO: better way to hooke this up
+		// TODO: better way to hook this up. Needs to detect local ops exactly once.
 		const oldSubmitLocalMessage = (tree as any).submitLocalMessage.bind(tree);
 		function submitLocalMessage(content: any, localOpMetadata: unknown = undefined): void {
 			resultArray.push(content);

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -499,7 +499,7 @@ describe("Op Size", () => {
 		function benchmarkOps(transactionStyle: TransactionStyle, percentile: number): void {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
 			initializeOpDataCollection(tree);
-			// Note that the child node byte size for the initial tree here should be arbitrary
+			// Note that the child node byte size for the initial tree here should be arbitrary.
 			initializeTestTree(tree, createInitialTree(BENCHMARK_NODE_COUNT, 1000));
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 			const editPayload = createStringFromLength(


### PR DESCRIPTION
## Description

Initially this change attempted to keep the test results exactly the same. However after realizing that before this change there were extra ops getting counted that shouldn't exist, it was pivoted to cleaning up that as well. As a result the data has change at the same time as the test setup, which is not ideal, but given that these test's extra ops issue existed when they were new (#13356), and changed unnoticed to be worse sometime between then and now (up to 4 ops for tests that should have 1), I think it makes sense to just to all this as once.


Fixes several style issues with the op size tests:
- Redundant string formatting. Every test name (which is a lot of formatted text) occurred twice. Instead quert the info from the Mocha Context.
- Move some test setup into the beforeEach hook to simplify the tests (including the above).
- Avoid restating the whole hierarchy of each block in tests at every level. instead use fullTitle to include the parent describe blocks.
- Use Enums instead of string intersections where appropriate.
- Stop prefixing all the tests with letter.number.letter etc. Just use the descriptive parts of the names
- Share the utility to compute the size of each message instead of reimplementing it in multiple places
- Compute the size of each message once, instead of multiple times for each stat.
- Replace foreEach loops with .map,  and .reduce where appropriate.
- Use max(...numbers) to compute max instead of a forEach loop.
- Remove special case for no data (this case now would work without special cases and also is an error).
- Use table driven patterns to generate some of the tests to loops instead of hand written full cross products.

Functional changes:
- Make tests error if no data is collected
- Adjust test setup to avoid depending on mock services (works with purely local edits).
- No longer gets 4 ops for the single op cases (likely due to old version double counting all ops due to sequencing in processMessages, plus some other unknown issue)
- No longer reports average message or min size as they are not very useful. Instead add total size.
- Tests results are no longer sorted by average op size: this made comparing before and after results needless difficult and put everything in an order that made it hard to find things.


Also:
- Add documentation covering limitations of the tests

Not changed:
- What cases are tested and what edits are performed in them.
- Some of the tests weren't updated to the table driven pattern, mostly due to my lazyness and wondering if we even want to keep those.

This is a continuation of #16792 which cleaned up the helpers in this file.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Open questions:
- Is there a better way to subscript to local ops when not attached for tests like this?