### PR TITLE
Fix the seqnum issue when creating subdirectory with grouped batching - release 6.0

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -2248,7 +2248,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			if (op.type === "createSubDirectory") {
 				const dir = this._subdirectories.get(op.subdirName);
 				// Child sub directory create seq number can't be lower than the parent subdirectory.
-				if (this.sequenceNumber !== -1 && this.sequenceNumber < msg.sequenceNumber) {
+				// The sequence number for multiple ops can be the same when multiple createSubDirectory occurs with grouped batching enabled, thus <= and not just <.
+				if (this.sequenceNumber !== -1 && this.sequenceNumber <= msg.sequenceNumber) {
 					if (dir?.sequenceNumber === -1) {
 						// Only set the seq on the first message, could be more
 						dir.sequenceNumber = msg.sequenceNumber;


### PR DESCRIPTION
**Cherry-picking https://github.com/microsoft/FluidFramework/pull/16806 to the release branch. This is not intended to fix an ongoing bug, as the feature (op grouping) is disabled. However, if enabled via options, this bug will surface. Therefore, this PR is for prevention.**

## Description

[AB#5225](https://dev.azure.com/fluidframework/internal/_workitems/edit/5225)

The previous implementation lacks the capability to manage the case where multiple `createSubDirectory` messages with grouped batching enabled. For instance:

```typescript
directory.createSubDirectory("parent").createSubDirectory("child")
```

With grouped batching enabled, the message for creating the `/parent` directory carries the same sequence number as the message for creating `/parent/child`. However, the sequence number of `/parent/child` will be -1 by default and cannot be updated with the previous logic. This impacts the function `isMessageForCurrentInstanceOfSubDirectory` and may lead to the defect of the function `processSetMessage`, which subsequently causes the unexpected behavior when a remote client updates value for `/parent/child`

Also include the test of
https://github.com/microsoft/FluidFramework/pull/16731 in this PR

