### PR TITLE
Intercept upload completion when stashing

### DIFF
--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -64,8 +64,7 @@ describe("getPendingLocalState", () => {
 		assert.strictEqual(Object.keys(pendingBlobs).length, 1);
 		assert.strictEqual(Object.values<any>(pendingBlobs)[0].acked, false);
 		assert.strictEqual(Object.values<any>(pendingBlobs)[0].attached, true);
-		assert.ok(Object.values<any>(pendingBlobs)[0].uploadTime);
-
+		
 		const summaryData = validateSummary(runtime);
 		assert.strictEqual(summaryData.ids.length, 0);
 		assert.strictEqual(summaryData.redirectTable, undefined);


### PR DESCRIPTION
Once we start stashing blobs, there is no reason to allow them to upload and follow their code path in that container instance if we are about to close it. It could lead to unexpected behavior and changing some attributes in the stashed blobs. 