### PR TITLE
Revert summarizer change causing CI failures in t9s tests

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -420,7 +420,7 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
 }
 
 // @public (undocumented)
-export interface INackSummaryResult extends IRetriableFailureResult {
+export interface INackSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
@@ -438,12 +438,6 @@ export interface IRefreshSummaryAckOptions {
     readonly proposalHandle: string | undefined;
     readonly summaryLogger: ITelemetryLoggerExt;
     readonly summaryRefSeq: number;
-}
-
-// @public
-export interface IRetriableFailureResult {
-    // (undocumented)
-    readonly retryAfterSeconds?: number;
 }
 
 // @public @deprecated (undocumented)
@@ -658,7 +652,7 @@ export enum RuntimeMessage {
 }
 
 // @public
-export interface SubmitSummaryFailureData extends IRetriableFailureResult {
+export interface SubmitSummaryFailureData {
     // (undocumented)
     stage: SummaryStage;
 }
@@ -700,6 +694,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     data: TFailure | undefined;
     message: string;
     error: any;
+    retryAfterSeconds?: number;
 };
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -68,7 +68,6 @@ export {
 	ICancellableSummarizerController,
 	SubmitSummaryFailureData,
 	SummaryStage,
-	IRetriableFailureResult,
 } from "./summary";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle";
 export { generateStableId, isStableId, assertIsStableId } from "./id-compressor";

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -64,7 +64,6 @@ export {
 	SummarizeResultPart,
 	SubmitSummaryFailureData,
 	SummaryStage,
-	IRetriableFailureResult,
 } from "./summarizerTypes";
 export {
 	IAckedSummary,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -198,7 +198,7 @@ export class RunningSummarizer implements IDisposable {
 			this.heuristicRunner = new SummarizeHeuristicRunner(
 				heuristicData,
 				this.configuration,
-				(summarizeReason) => this.trySummarize(summarizeReason),
+				(reason) => this.trySummarize(reason),
 				this.mc.logger,
 			);
 		}
@@ -454,7 +454,7 @@ export class RunningSummarizer implements IDisposable {
 			if (this.summarizingLock === undefined) {
 				this.trySummarizeOnce(
 					// summarizeProps
-					{ summarizeReason: "lastSummary" },
+					{ reason: "lastSummary" },
 					// ISummarizeOptions, using defaults: { refreshLatestAck: false, fullTree: false }
 					{},
 				);
@@ -581,7 +581,7 @@ export class RunningSummarizer implements IDisposable {
 
 	/** Heuristics summarize attempt. */
 	private trySummarize(
-		summarizeReason: SummarizeReason,
+		reason: SummarizeReason,
 		cancellationToken = this.cancellationToken,
 	): void {
 		if (this.summarizingLock !== undefined) {
@@ -597,8 +597,8 @@ export class RunningSummarizer implements IDisposable {
 			},
 			async () => {
 				await (this.mc.config.getBoolean("Fluid.Summarizer.TryDynamicRetries")
-					? this.trySummarizeWithRetries(summarizeReason, cancellationToken)
-					: this.trySummarizeWithStaticAttempts(summarizeReason, cancellationToken));
+					? this.trySummarizeWithRetries(reason, cancellationToken)
+					: this.trySummarizeWithStaticAttempts(reason, cancellationToken));
 				this.stopSummarizerCallback("failToSummarize");
 			},
 			() => {
@@ -614,7 +614,7 @@ export class RunningSummarizer implements IDisposable {
 	 * param, that attempt is tried once more.
 	 */
 	private async trySummarizeWithStaticAttempts(
-		summarizeReason: SummarizeReason,
+		reason: SummarizeReason,
 		cancellationToken: ISummaryCancellationToken,
 	) {
 		const attempts: ISummarizeOptions[] = [
@@ -630,7 +630,7 @@ export class RunningSummarizer implements IDisposable {
 			}
 
 			// We only want to attempt 1 summary when reason is "lastSummary"
-			if (++summaryAttempts > 1 && summarizeReason === "lastSummary") {
+			if (++summaryAttempts > 1 && reason === "lastSummary") {
 				return;
 			}
 
@@ -638,7 +638,7 @@ export class RunningSummarizer implements IDisposable {
 
 			const summarizeOptions = attempts[summaryAttemptPhase];
 			const summarizeProps: ISummarizeTelemetryProperties = {
-				summarizeReason,
+				reason,
 				summaryAttempts,
 				summaryAttemptsPerPhase,
 				summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
@@ -685,7 +685,7 @@ export class RunningSummarizer implements IDisposable {
 	 * For example, summarization may be retried for failures with "retryAfterSeconds" param.
 	 */
 	private async trySummarizeWithRetries(
-		summarizeReason: SummarizeReason,
+		reason: SummarizeReason,
 		cancellationToken: ISummaryCancellationToken,
 	) {
 		// The max number of attempts are based on the stage at which summarization failed. If it fails before it is
@@ -709,7 +709,7 @@ export class RunningSummarizer implements IDisposable {
 				fullTree: false,
 			};
 			const summarizeProps: ISummarizeTelemetryProperties = {
-				summarizeReason,
+				reason,
 				summaryAttempts: currentAttempt,
 				...summarizeOptions,
 			};
@@ -774,7 +774,7 @@ export class RunningSummarizer implements IDisposable {
 		}
 
 		const result = this.trySummarizeOnce(
-			{ summarizeReason: `onDemand;${reason}` },
+			{ reason: `onDemand/${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,
@@ -789,7 +789,7 @@ export class RunningSummarizer implements IDisposable {
 		override = false,
 		...options
 	}: IEnqueueSummarizeOptions): EnqueueSummarizeResult {
-		const enqueueReason = `enqueue;${reason}` as const;
+		const onDemandReason = `enqueue;${reason}` as const;
 		let overridden = false;
 		if (this.enqueuedSummary !== undefined) {
 			if (!override) {
@@ -804,7 +804,7 @@ export class RunningSummarizer implements IDisposable {
 			overridden = true;
 		}
 		this.enqueuedSummary = {
-			reason: enqueueReason,
+			reason: onDemandReason,
 			afterSequenceNumber,
 			options,
 			resultsBuilder: new SummarizeResultBuilder(),
@@ -837,7 +837,7 @@ export class RunningSummarizer implements IDisposable {
 		// Set to undefined first, so that subsequent enqueue attempt while summarize will occur later.
 		this.enqueuedSummary = undefined;
 		this.trySummarizeOnce(
-			{ summarizeReason: reason },
+			{ reason: `enqueuedSummary/${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -45,17 +45,6 @@ import {
 const maxSummarizeAckWaitTime = 10 * 60 * 1000; // 10 minutes
 
 /**
- * The maximum number of summarization attempts that will be done by default in case of failures
- * that can be retried.
- */
-export const defaultMaxAttempts = 2;
-/**
- * The default value for maximum number of summarization attempts that will be done for summarization failures where
- * submit fails and the failure can be retried.
- */
-export const defaultMaxAttemptsForSubmitFailures = 5;
-
-/**
  * An instance of RunningSummarizer manages the heuristics for summarizing.
  * Until disposed, the instance of RunningSummarizer can assume that it is
  * in a state of running, meaning it is connected and initialized.  It keeps
@@ -158,9 +147,6 @@ export class RunningSummarizer implements IDisposable {
 
 	private readonly runtimeListener;
 
-	/** The maximum number of summary attempts to do when submit summary fails. */
-	private readonly maxAttemptsForSubmitFailures: number;
-
 	private constructor(
 		baseLogger: ITelemetryBaseLogger,
 		private readonly summaryWatcher: IClientSummaryWatcher,
@@ -254,17 +240,6 @@ export class RunningSummarizer implements IDisposable {
 			this.handleOp(op, runtimeMessage === true);
 		};
 		this.runtime.on("op", this.runtimeListener);
-
-		// The max attempts for submit failures can be overridden via a feature flag. This allows us to
-		// tweak this as per telemetry data until we arrive at a stable number.
-		// If its set to a number higher than `defaultMaxAttemptsForSubmitFailures`, it will be ignored.
-		const overrideMaxAttempts = this.mc.config.getNumber(
-			"Fluid.Summarizer.AttemptsForSubmitFailures",
-		);
-		this.maxAttemptsForSubmitFailures =
-			overrideMaxAttempts && overrideMaxAttempts < defaultMaxAttemptsForSubmitFailures
-				? overrideMaxAttempts
-				: defaultMaxAttemptsForSubmitFailures;
 	}
 
 	private async handleSummaryAck(): Promise<number> {
@@ -596,9 +571,67 @@ export class RunningSummarizer implements IDisposable {
 				this.beforeSummaryAction();
 			},
 			async () => {
-				await (this.mc.config.getBoolean("Fluid.Summarizer.TryDynamicRetries")
-					? this.trySummarizeWithRetries(reason, cancellationToken)
-					: this.trySummarizeWithStaticAttempts(reason, cancellationToken));
+				const attempts: ISummarizeOptions[] = [
+					{ refreshLatestAck: false, fullTree: false },
+					{ refreshLatestAck: true, fullTree: false },
+				];
+				let overrideDelaySeconds: number | undefined;
+				let summaryAttempts = 0;
+				let summaryAttemptsPerPhase = 0;
+				let summaryAttemptPhase = 0;
+				while (summaryAttemptPhase < attempts.length) {
+					if (this.cancellationToken.cancelled) {
+						return;
+					}
+
+					// We only want to attempt 1 summary when reason is "lastSummary"
+					if (++summaryAttempts > 1 && reason === "lastSummary") {
+						return;
+					}
+
+					summaryAttemptsPerPhase++;
+
+					const summarizeOptions = attempts[summaryAttemptPhase];
+					const summarizeProps: ISummarizeTelemetryProperties = {
+						reason,
+						summaryAttempts,
+						summaryAttemptsPerPhase,
+						summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
+						...summarizeOptions,
+					};
+
+					// Note: no need to account for cancellationToken.waitCancelled here, as
+					// this is accounted SummaryGenerator.summarizeCore that controls receivedSummaryAckOrNack.
+					const resultSummarize = this.generator.summarize(
+						summarizeProps,
+						summarizeOptions,
+						cancellationToken,
+					);
+					const result = await resultSummarize.receivedSummaryAckOrNack;
+
+					if (result.success) {
+						return;
+					}
+
+					// Check for retryDelay that can come from summaryNack or upload summary flow.
+					// Retry the same step only once per retryAfter response.
+					const delaySeconds = result.retryAfterSeconds;
+					if (delaySeconds === undefined || summaryAttemptsPerPhase > 1) {
+						summaryAttemptPhase++;
+						summaryAttemptsPerPhase = 0;
+					}
+
+					if (delaySeconds !== undefined) {
+						this.mc.logger.sendPerformanceEvent({
+							eventName: "SummarizeAttemptDelay",
+							duration: delaySeconds,
+							summaryNackDelay: overrideDelaySeconds !== undefined,
+							...summarizeProps,
+						});
+						await delay(delaySeconds * 1000);
+					}
+				}
+
 				this.stopSummarizerCallback("failToSummarize");
 			},
 			() => {
@@ -607,154 +640,6 @@ export class RunningSummarizer implements IDisposable {
 		).catch((error) => {
 			this.mc.logger.sendErrorEvent({ eventName: "UnexpectedSummarizeError" }, error);
 		});
-	}
-
-	/**
-	 * Tries to summarize 2 times with pre-defined summary options. If an attempt fails with "retryAfterSeconds"
-	 * param, that attempt is tried once more.
-	 */
-	private async trySummarizeWithStaticAttempts(
-		reason: SummarizeReason,
-		cancellationToken: ISummaryCancellationToken,
-	) {
-		const attempts: ISummarizeOptions[] = [
-			{ refreshLatestAck: false, fullTree: false },
-			{ refreshLatestAck: true, fullTree: false },
-		];
-		let summaryAttempts = 0;
-		let summaryAttemptsPerPhase = 0;
-		let summaryAttemptPhase = 0;
-		while (summaryAttemptPhase < attempts.length) {
-			if (cancellationToken.cancelled) {
-				return;
-			}
-
-			// We only want to attempt 1 summary when reason is "lastSummary"
-			if (++summaryAttempts > 1 && reason === "lastSummary") {
-				return;
-			}
-
-			summaryAttemptsPerPhase++;
-
-			const summarizeOptions = attempts[summaryAttemptPhase];
-			const summarizeProps: ISummarizeTelemetryProperties = {
-				reason,
-				summaryAttempts,
-				summaryAttemptsPerPhase,
-				summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
-				...summarizeOptions,
-			};
-
-			// Note: no need to account for cancellationToken.waitCancelled here, as
-			// this is accounted SummaryGenerator.summarizeCore that controls receivedSummaryAckOrNack.
-			const resultSummarize = this.generator.summarize(
-				summarizeProps,
-				summarizeOptions,
-				cancellationToken,
-			);
-			const ackNackResult = await resultSummarize.receivedSummaryAckOrNack;
-			if (ackNackResult.success) {
-				return;
-			}
-
-			// Check for retryDelay that can come from summaryNack, upload summary or submit summary flows.
-			// Retry the same step only once per retryAfter response.
-			const submitResult = await resultSummarize.summarySubmitted;
-			const delaySeconds = !submitResult.success
-				? submitResult.data?.retryAfterSeconds
-				: ackNackResult.data?.retryAfterSeconds;
-			if (delaySeconds === undefined || summaryAttemptsPerPhase > 1) {
-				summaryAttemptPhase++;
-				summaryAttemptsPerPhase = 0;
-			}
-
-			if (delaySeconds !== undefined) {
-				this.mc.logger.sendPerformanceEvent({
-					eventName: "SummarizeAttemptDelay",
-					duration: delaySeconds,
-					summaryNackDelay: ackNackResult.data?.retryAfterSeconds !== undefined,
-					...summarizeProps,
-				});
-				await delay(delaySeconds * 1000);
-			}
-		}
-	}
-
-	/**
-	 * Tries to summarize with retries where retry is based on the failure params.
-	 * For example, summarization may be retried for failures with "retryAfterSeconds" param.
-	 */
-	private async trySummarizeWithRetries(
-		reason: SummarizeReason,
-		cancellationToken: ISummaryCancellationToken,
-	) {
-		// The max number of attempts are based on the stage at which summarization failed. If it fails before it is
-		// submitted, a different value is used compared to if it fails after submission. Usually, in the former case,
-		// we would retry more often as its cheaper and retries are likely to succeed.
-		// This makes it harder to predict how many attempts would actually happen as that depends on how far an attempt
-		// made. To keep things simple, the max attempts is reset after every attempt based on where it failed. This may
-		// result in some failures not being retried depending on what happened before this attempt. That's fine because
-		// such scenarios are very unlikely and even if it happens, it would resolve when a new summarizer starts over.
-		let maxAttempts = defaultMaxAttempts;
-		let currentAttempt = 0;
-		const done = true;
-		do {
-			if (this.cancellationToken.cancelled) {
-				return;
-			}
-
-			currentAttempt++;
-			const summarizeOptions: ISummarizeOptions = {
-				refreshLatestAck: false,
-				fullTree: false,
-			};
-			const summarizeProps: ISummarizeTelemetryProperties = {
-				reason,
-				summaryAttempts: currentAttempt,
-				...summarizeOptions,
-			};
-			const summarizeResult = this.generator.summarize(
-				summarizeProps,
-				summarizeOptions,
-				cancellationToken,
-			);
-
-			// Ack / nack is the final step, so if it succeeds we're done.
-			const ackNackResult = await summarizeResult.receivedSummaryAckOrNack;
-			if (ackNackResult.success) {
-				return;
-			}
-
-			const submitSummaryResult = await summarizeResult.summarySubmitted;
-			let retryAfterSeconds: number | undefined;
-
-			// Update max attempts and retry params from the failure result.
-			// If submit summary failed, use the params from "summarySubmitted" result. Else, use the params
-			// from "receivedSummaryAckOrNack" result.
-			// Note: Check "summarySubmitted" result first because if it fails, ack nack would fail as well.
-			if (!submitSummaryResult.success) {
-				maxAttempts = this.maxAttemptsForSubmitFailures;
-				retryAfterSeconds = submitSummaryResult.data?.retryAfterSeconds;
-			} else {
-				maxAttempts = defaultMaxAttempts;
-				retryAfterSeconds = ackNackResult.data?.retryAfterSeconds;
-			}
-
-			// If the failure doesn't have "retryAfterSeconds" or the max number of attempts have been done, we're done.
-			if (retryAfterSeconds === undefined || currentAttempt >= maxAttempts) {
-				return;
-			}
-
-			this.mc.logger.sendPerformanceEvent({
-				eventName: "SummarizeAttemptDelay",
-				duration: retryAfterSeconds,
-				summaryNackDelay: ackNackResult.data?.retryAfterSeconds !== undefined,
-				stage: submitSummaryResult.data?.stage,
-				dynamicRetries: true, // To differentiate this telemetry from regular retry logic
-				...summarizeProps,
-			});
-			await delay(retryAfterSeconds * 1000);
-		} while (done);
 	}
 
 	/** {@inheritdoc (ISummarizer:interface).summarizeOnDemand} */

--- a/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
@@ -102,19 +102,19 @@ export class SummarizeHeuristicRunner implements ISummarizeHeuristicRunner {
 	public constructor(
 		private readonly heuristicData: ISummarizeHeuristicData,
 		private readonly configuration: ISummaryConfigurationHeuristics,
-		trySummarize: (summarizeReason: SummarizeReason) => void,
+		trySummarize: (reason: SummarizeReason) => void,
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly summarizeStrategies: ISummaryHeuristicStrategy[] = getDefaultSummaryHeuristicStrategies(),
 	) {
 		this.idleTimer = new Timer(this.idleTime, () => this.runSummarize("idle"));
 
-		this.runSummarize = (summarizeReason: SummarizeReason) => {
+		this.runSummarize = (reason: SummarizeReason) => {
 			this.idleTimer?.clear();
 
 			// We shouldn't attempt a summary if there are no new processed ops
 			const opsSinceLastAck = this.opsSinceLastAck;
 			if (opsSinceLastAck > 0) {
-				trySummarize(summarizeReason);
+				trySummarize(reason);
 			}
 		};
 	}

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -216,14 +216,8 @@ export type SubmitSummaryResult =
 
 /** The stages of Summarize, used to describe how far progress succeeded in case of a failure at a later stage. */
 export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
-
-/** Type for summarization failures that are retriable. */
-export interface IRetriableFailureResult {
-	readonly retryAfterSeconds?: number;
-}
-
 /** The data in summarizer result when submit summary stage fails. */
-export interface SubmitSummaryFailureData extends IRetriableFailureResult {
+export interface SubmitSummaryFailureData {
 	stage: SummaryStage;
 }
 
@@ -237,7 +231,7 @@ export interface IAckSummaryResult {
 	readonly ackNackDuration: number;
 }
 
-export interface INackSummaryResult extends IRetriableFailureResult {
+export interface INackSummaryResult {
 	readonly summaryNackOp: ISummaryNackMessage;
 	readonly ackNackDuration: number;
 }
@@ -252,6 +246,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> =
 			data: TFailure | undefined;
 			message: string;
 			error: any;
+			retryAfterSeconds?: number;
 	  };
 
 export interface ISummarizeResults {

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -442,7 +442,7 @@ export interface ISummarizeHeuristicRunner {
 
 type ISummarizeTelemetryRequiredProperties =
 	/** Reason code for attempting to summarize */
-	"summarizeReason";
+	"reason";
 
 type ISummarizeTelemetryOptionalProperties =
 	/** Number of attempts within the last time window, used for calculating the throttle delay. */

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -34,6 +34,7 @@ import {
 	ISummaryCancellationToken,
 	ISummarizeTelemetryProperties,
 	SummaryGeneratorTelemetry,
+	SummaryStage,
 	SubmitSummaryFailureData,
 } from "./summarizerTypes";
 import { IClientSummaryWatcher } from "./summaryCollection";
@@ -142,17 +143,12 @@ export class SummarizeResultBuilder {
 		SummarizeResultPart<IAckSummaryResult, INackSummaryResult>
 	>();
 
-	/**
-	 * Fails one or more of the three results as per the passed params.
-	 * If submit fails, all three results fail.
-	 * If op broadcast fails, only op broadcast result and ack nack result fails.
-	 * If ack nack fails, only ack nack result fails.
-	 */
 	public fail(
 		message: string,
 		error: any,
-		submitFailureResult?: SubmitSummaryFailureData,
+		stage: SummaryStage = "unknown",
 		nackSummaryResult?: INackSummaryResult,
+		retryAfterSeconds?: number,
 	) {
 		assert(
 			!this.receivedSummaryAckOrNack.isCompleted,
@@ -164,11 +160,9 @@ export class SummarizeResultBuilder {
 			message,
 			data: undefined,
 			error,
+			retryAfterSeconds,
 		} as const;
-
-		// Note that if any of these are already resolved, it will be a no-op. For example, if ack nack failed but
-		// submit summary and op broadcast has already been resolved as passed, only ack nack result will get modified.
-		this.summarySubmitted.resolve({ ...result, data: submitFailureResult });
+		this.summarySubmitted.resolve({ ...result, data: { stage } });
 		this.summaryOpBroadcasted.resolve(result);
 		this.receivedSummaryAckOrNack.resolve({ ...result, data: nackSummaryResult });
 	}
@@ -273,19 +267,16 @@ export class SummaryGenerator {
 		);
 
 		let summaryData: SubmitSummaryResult | undefined;
-
-		/**
-		 * Summarization can fail during submit, during op broadcast or during nack.
-		 * For submit failures, submitFailureResult should be provided. For nack failures, nackSummaryResult should
-		 * be provided. For op broadcast failures, only errors / properties should be provided.
-		 */
 		const fail = (
 			errorCode: keyof typeof summarizeErrors,
 			error?: any,
 			properties?: SummaryGeneratorTelemetry,
-			submitFailureResult?: SubmitSummaryFailureData,
 			nackSummaryResult?: INackSummaryResult,
 		) => {
+			// UploadSummary may fail with 429 and retryAfter - respect that
+			// Summary Nack also can have retryAfter, it's parsed below and comes as a property.
+			const retryAfterSeconds = getRetryDelaySecondsFromError(error);
+
 			// Report any failure as an error unless it was due to cancellation (like "disconnected" error)
 			// If failure happened on upload, we may not yet realized that socket disconnected, so check
 			// offlineError too.
@@ -300,14 +291,15 @@ export class SummaryGenerator {
 					...properties,
 					reason,
 					category,
-					retryAfterSeconds:
-						submitFailureResult?.retryAfterSeconds ??
-						nackSummaryResult?.retryAfterSeconds,
+					retryAfterSeconds,
 				},
 				error ?? reason,
 			); // disconnect & summaryAckTimeout do not have proper error.
 
-			resultsBuilder.fail(reason, error, submitFailureResult, nackSummaryResult);
+			// If summarize did not hit an unexpected error, summaryData would be available. Otherwise, the state is
+			// unknown.
+			const stage = summaryData?.stage ?? "unknown";
+			resultsBuilder.fail(reason, error, stage, nackSummaryResult, retryAfterSeconds);
 		};
 
 		// Wait to generate and send summary
@@ -341,10 +333,7 @@ export class SummaryGenerator {
 			);
 
 			if (summaryData.stage !== "submit") {
-				return fail("submitSummaryFailure", summaryData.error, summarizeTelemetryProps, {
-					stage: summaryData.stage,
-					retryAfterSeconds: getRetryDelaySecondsFromError(summaryData.error),
-				});
+				return fail("submitSummaryFailure", summaryData.error, summarizeTelemetryProps);
 			}
 
 			/**
@@ -377,10 +366,7 @@ export class SummaryGenerator {
 			summarizeEvent.reportEvent("generate", { ...summarizeTelemetryProps });
 			resultsBuilder.summarySubmitted.resolve({ success: true, data: summaryData });
 		} catch (error) {
-			return fail("submitSummaryFailure", error, undefined /* properties */, {
-				stage: "unknown",
-				retryAfterSeconds: getRetryDelaySecondsFromError(error),
-			});
+			return fail("submitSummaryFailure", error);
 		} finally {
 			if (summaryData === undefined) {
 				this.heuristicData.recordAttempt();
@@ -399,10 +385,10 @@ export class SummaryGenerator {
 				cancellationToken,
 			);
 			if (waitBroadcastResult.result === "cancelled") {
-				return fail("disconnect");
+				return fail("disconnect", summaryData.stage);
 			}
 			if (waitBroadcastResult.result !== "done") {
-				return fail("summaryOpWaitTimeout");
+				return fail("summaryOpWaitTimeout", summaryData.stage);
 			}
 			const summarizeOp = waitBroadcastResult.value;
 
@@ -482,8 +468,7 @@ export class SummaryGenerator {
 					"summaryNack",
 					error,
 					{ ...summarizeTelemetryProps, nackRetryAfter: retryAfterSeconds },
-					undefined /* submitFailureResult */,
-					{ summaryNackOp: ackNackOp, ackNackDuration, retryAfterSeconds },
+					{ summaryNackOp: ackNackOp, ackNackDuration },
 				);
 			}
 		} finally {

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -38,7 +38,6 @@ import {
 	SubmitSummaryResult,
 	RetriableSummaryError,
 	IGeneratedSummaryStats,
-	SummarizeReason,
 } from "../../summary";
 import {
 	defaultMaxAttempts,
@@ -1139,7 +1138,7 @@ describe("Runtime", () => {
 					);
 				});
 
-				it("should not retry last summary", async () => {
+				it("Should not retry last summary", async () => {
 					const stage: SummaryStage = "base";
 					const retryAfterSeconds = 10;
 					await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
@@ -1160,7 +1159,6 @@ describe("Runtime", () => {
 							retryAfterSeconds,
 							summarizeCount: 1,
 							stage,
-							summarizeReason: "lastSummary",
 						},
 					];
 					mockLogger.assertMatch(
@@ -1175,17 +1173,13 @@ describe("Runtime", () => {
 			});
 
 			describe("On-demand Summaries", () => {
-				const reason = "test";
-				// This is used to validate the summarizeReason property in telemetry.
-				const summarizeReason: SummarizeReason = `onDemand;${reason}`;
-
 				beforeEach(async () => {
 					await startRunningSummarizer();
 				});
 
 				it("Should create an on-demand summary", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason });
+					const result = summarizer.summarizeOnDemand(undefined, { reason: "test" });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1222,16 +1216,8 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{
-								eventName: "Running:Summarize_generate",
-								summarizeCount: runCount,
-								summarizeReason,
-							},
-							{
-								eventName: "Running:Summarize_Op",
-								summarizeCount: runCount,
-								summarizeReason,
-							},
+							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
+							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
 						]),
 						"unexpected log sequence",
 					);
@@ -1260,7 +1246,7 @@ describe("Runtime", () => {
 
 					let resolved = false;
 					try {
-						summarizer.summarizeOnDemand(undefined, { reason });
+						summarizer.summarizeOnDemand(undefined, { reason: "test" });
 						resolved = true;
 					} catch {}
 
@@ -1270,7 +1256,7 @@ describe("Runtime", () => {
 
 				it("On-demand summary should fail on nack", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason });
+					const result = summarizer.summarizeOnDemand(undefined, { reason: "test" });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1307,16 +1293,8 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{
-								eventName: "Running:Summarize_generate",
-								summarizeCount: runCount,
-								summarizeReason,
-							},
-							{
-								eventName: "Running:Summarize_Op",
-								summarizeCount: runCount,
-								summarizeReason,
-							},
+							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
+							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
 						]),
 						"unexpected log sequence",
 					);
@@ -1425,10 +1403,6 @@ describe("Runtime", () => {
 			});
 
 			describe("Enqueue Summaries", () => {
-				const reason = "test";
-				// This is used to validate the summarizeReason property in telemetry.
-				const summarizeReason: SummarizeReason = `enqueue;${reason}`;
-
 				beforeEach(async () => {
 					await startRunningSummarizer();
 				});
@@ -1437,7 +1411,7 @@ describe("Runtime", () => {
 					await emitNextOp(2); // set ref seq to 2
 					const afterSequenceNumber = 9;
 					const result = summarizer.enqueueSummarize({
-						reason,
+						reason: "test",
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1481,16 +1455,8 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{
-								eventName: "Running:Summarize_generate",
-								summarizeCount: runCount,
-								summarizeReason,
-							},
-							{
-								eventName: "Running:Summarize_Op",
-								summarizeCount: runCount,
-								summarizeReason,
-							},
+							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
+							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
 						]),
 						"unexpected log sequence",
 					);
@@ -1520,7 +1486,7 @@ describe("Runtime", () => {
 					assertRunCounts(1, 0, 0);
 
 					const result = summarizer.enqueueSummarize({
-						reason,
+						reason: "test",
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1607,7 +1573,7 @@ describe("Runtime", () => {
 					await emitNextOp(2); // set ref seq to 2
 					const afterSequenceNumber = 9;
 					const result = summarizer.enqueueSummarize({
-						reason,
+						reason: "test",
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1761,7 +1727,7 @@ describe("Runtime", () => {
 								eventName: "Running:Summarize_end",
 								summarizeCount: runCount,
 								summarizerSuccessfulAttempts: runCount,
-								summarizeReason: "maxOps",
+								reason: "maxOps",
 							},
 						]),
 						"unexpected log sequence 3",

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 import sinon from "sinon";
 import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
-import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import {
 	IDocumentMessage,
 	ISequencedDocumentMessage,
@@ -35,15 +34,7 @@ import {
 	SummarizeHeuristicData,
 	ISummarizerRuntime,
 	ISummarizeHeuristicData,
-	SubmitSummaryResult,
-	RetriableSummaryError,
-	IGeneratedSummaryStats,
 } from "../../summary";
-import {
-	defaultMaxAttempts,
-	defaultMaxAttemptsForSubmitFailures,
-	// eslint-disable-next-line import/no-internal-modules
-} from "../../summary/runningSummarizer";
 
 class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> {
 	disposed = false;
@@ -102,17 +93,6 @@ describe("Runtime", () => {
 			const summaryConfigDisableHeuristics: ISummaryConfiguration = {
 				state: "disableHeuristics",
 				...summaryCommon,
-			};
-
-			const emptySummaryStats: IGeneratedSummaryStats = {
-				treeNodeCount: 0,
-				blobNodeCount: 0,
-				handleNodeCount: 0,
-				totalBlobSize: 0,
-				dataStoreCount: 0,
-				summarizedDataStoreCount: 0,
-				unreferencedBlobSize: 0,
-				summaryNumber: 0,
 			};
 
 			let shouldDeferGenerateSummary: boolean = false;
@@ -236,37 +216,7 @@ describe("Runtime", () => {
 				);
 			}
 
-			async function successfulSubmitSummary(): Promise<SubmitSummaryResult> {
-				// emitBroadcast will increment this number
-				const lastRefSeqBefore = lastRefSeq;
-
-				// immediate broadcast
-				emitBroadcast();
-
-				if (shouldDeferGenerateSummary) {
-					deferGenerateSummary = new Deferred<void>();
-					await deferGenerateSummary.promise;
-					deferGenerateSummary = undefined;
-				}
-				return {
-					stage: "submit",
-					referenceSequenceNumber: lastRefSeqBefore,
-					minimumSequenceNumber: 0,
-					generateDuration: 0,
-					uploadDuration: 0,
-					submitOpDuration: 0,
-					summaryTree: { type: SummaryType.Tree, tree: {} },
-					summaryStats: emptySummaryStats,
-					handle: "test-handle",
-					clientSequenceNumber: lastClientSeq,
-					forcedFullTree: false,
-				} as const;
-			}
-
-			const startRunningSummarizer = async (
-				disableHeuristics?: boolean,
-				submitSummaryCallback: () => Promise<SubmitSummaryResult> = successfulSubmitSummary,
-			): Promise<void> => {
+			const startRunningSummarizer = async (disableHeuristics?: boolean): Promise<void> => {
 				heuristicData = new SummarizeHeuristicData(0, {
 					refSequenceNumber: 0,
 					summaryTime: Date.now(),
@@ -275,8 +225,10 @@ describe("Runtime", () => {
 					mockLogger,
 					summaryCollection.createWatcher(summarizerClientId),
 					disableHeuristics ? summaryConfigDisableHeuristics : summaryConfig,
+					// submitSummaryCallback
 					async (options) => {
 						runCount++;
+
 						heuristicData.recordAttempt(lastRefSeq);
 
 						const { fullTree = false, refreshLatestAck = false } = options;
@@ -286,7 +238,40 @@ describe("Runtime", () => {
 						if (refreshLatestAck) {
 							refreshLatestAckRunCount++;
 						}
-						return submitSummaryCallback();
+
+						// emitBroadcast will increment this number
+						const lastRefSeqBefore = lastRefSeq;
+
+						// immediate broadcast
+						emitBroadcast();
+
+						if (shouldDeferGenerateSummary) {
+							deferGenerateSummary = new Deferred<void>();
+							await deferGenerateSummary.promise;
+							deferGenerateSummary = undefined;
+						}
+						return {
+							stage: "submit",
+							referenceSequenceNumber: lastRefSeqBefore,
+							minimumSequenceNumber: 0,
+							generateDuration: 0,
+							uploadDuration: 0,
+							submitOpDuration: 0,
+							summaryTree: { type: SummaryType.Tree, tree: {} },
+							summaryStats: {
+								treeNodeCount: 0,
+								blobNodeCount: 0,
+								handleNodeCount: 0,
+								totalBlobSize: 0,
+								dataStoreCount: 0,
+								summarizedDataStoreCount: 0,
+								unreferencedBlobSize: 0,
+								summaryNumber: 0,
+							},
+							handle: "test-handle",
+							clientSequenceNumber: lastClientSeq,
+							forcedFullTree: false,
+						} as const;
 					},
 					async (options) => {},
 					heuristicData,
@@ -752,423 +737,6 @@ describe("Runtime", () => {
 						]),
 						"unexpected log sequence",
 					);
-				});
-			});
-
-			describe("Summarization attempts with retry", () => {
-				beforeEach(async () => {
-					settings["Fluid.Summarizer.TryDynamicRetries"] = true;
-					shouldDeferGenerateSummary = false;
-					deferGenerateSummary = undefined;
-				});
-
-				type SummaryStage = SubmitSummaryResult["stage"];
-
-				/**
-				 * Validate that a summary attempt fails as expected, correct events are received and summarization
-				 * stops (or doesn't) as per the given params.
-				 * @param attemptNumber - The current attempt number.
-				 * @param totalAttempts - The total number of attempts. After the last attempt, summarizer should close.
-				 * @param lastSuccessfulStage - The stage after which summarization failed.
-				 * @param retryAfterSeconds - The number of seconds after which the next attempt should be tried.
-				 */
-				const validateSummaryAttemptFails = async (
-					attemptNumber: number,
-					totalAttempts: number,
-					lastSuccessfulStage: SummaryStage,
-					retryAfterSeconds: number | undefined,
-				) => {
-					const finalAttempt = attemptNumber >= totalAttempts;
-					// Nack the summary with "retryAfterSeconds" specified.
-					await emitNack(retryAfterSeconds);
-
-					assertRunCounts(
-						attemptNumber,
-						0,
-						0,
-						`Total run count should be ${attemptNumber}`,
-					);
-
-					const retryProps1 = {
-						summarizeCount: 1,
-						summaryAttempts: attemptNumber,
-						stage: lastSuccessfulStage,
-					};
-					const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [
-						{
-							eventName: "Running:Summarize_cancel",
-							...retryProps1,
-							retryAfterSeconds,
-							reason: getFailMessage(
-								lastSuccessfulStage === "submit"
-									? "summaryNack" // if last stage is submit, summarization fails due to summary nack
-									: "submitSummaryFailure", // other stages fail because summary is not submitted
-							),
-						},
-					];
-
-					// After the final attempt, there shouldn't be any delay.
-					if (!finalAttempt) {
-						expectedEvents.push({
-							eventName: "Running:SummarizeAttemptDelay",
-							...retryProps1,
-							duration: retryAfterSeconds,
-							dynamicRetries: true,
-						});
-					}
-					mockLogger.assertMatch(
-						expectedEvents,
-						`Summarizer attempt ${attemptNumber} did not fail as expected`,
-					);
-
-					// After the final attempt, summarizer should stop.
-					assert.strictEqual(
-						stopCall,
-						finalAttempt ? 1 : 0,
-						`Summarizer should${
-							finalAttempt ? "" : "not"
-						} have stopped after ${totalAttempts} attempts`,
-					);
-				};
-
-				// Callback that fails the summary for all stages expect submit. For submit, the summarization
-				// will fail because of summary ack not received withing timeout.
-				const submitSummaryCallback = async (
-					stage: SummaryStage,
-					retryAfterSeconds: number | undefined,
-				): Promise<SubmitSummaryResult> => {
-					if (stage === "submit") {
-						return successfulSubmitSummary();
-					} else {
-						const error = new RetriableSummaryError(
-							`Fail summarization at ${stage}`,
-							retryAfterSeconds,
-						);
-						const failedResult: Partial<SubmitSummaryResult> = {
-							stage,
-							referenceSequenceNumber: lastRefSeq,
-							minimumSequenceNumber: 0,
-							error,
-						};
-						return failedResult as SubmitSummaryResult;
-					}
-				};
-
-				const failedStages: SummaryStage[] = ["base", "generate", "upload", "submit"];
-				for (const [stageIndex, stage] of failedStages.entries()) {
-					const maxAttempts =
-						stage === "submit"
-							? defaultMaxAttempts
-							: defaultMaxAttemptsForSubmitFailures;
-					const titleStage = stage === "submit" ? "nack" : stage;
-					it(`should attempt 1 time only on failure without retry specified at ${titleStage} stage`, async () => {
-						await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
-							submitSummaryCallback(stage, undefined /* retryAfterSeconds */),
-						);
-
-						await emitNextOp();
-						// This should run a summarization because max ops has reached.
-						await emitNextOp(summaryConfig.maxOps);
-						assertRunCounts(1, 0, 0, "Summarization should have run once");
-
-						await validateSummaryAttemptFails(
-							1 /* attemptNumber */,
-							1 /* totalAttempts */,
-							stage,
-							undefined /* retryAfterSeconds */,
-						);
-					});
-
-					it(`should attempt ${maxAttempts} times on failure with retryAfterSeconds at ${titleStage} stage`, async () => {
-						const retryAfterSeconds = 5;
-						await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
-							submitSummaryCallback(stage, retryAfterSeconds),
-						);
-
-						await emitNextOp();
-						// This should run a summarization because max ops has reached.
-						await emitNextOp(summaryConfig.maxOps);
-
-						for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-							await validateSummaryAttemptFails(
-								attempt,
-								maxAttempts,
-								stage,
-								retryAfterSeconds,
-							);
-							// Wait for "retryAfterSeconds". The next attempt should start after this.
-							await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-						}
-
-						// validate that summarization is not run again.
-						assertRunCounts(
-							maxAttempts,
-							0,
-							0,
-							`Summarization should not have been attempted more than ${maxAttempts} times`,
-						);
-					});
-
-					it(`should attempt ${maxAttempts} times on failure when stage changes from ${titleStage}`, async () => {
-						// Helper to get a different stage from the current one.
-						const getNewStage = () => {
-							let index = stageIndex + 1;
-							// If the new stage is "submit", get another stage instead. This is because the logic is
-							// different when failure happens after "submit" stage. This is validated in a separate test.
-							if (index > failedStages.length - 2) {
-								index = 0;
-							}
-							return failedStages[index];
-						};
-
-						const retryAfterSeconds = 5;
-						let currentStage: SummaryStage = stage;
-
-						await startRunningSummarizer(
-							undefined /* disableHeuristics */,
-							async () => {
-								if (currentStage === "submit") {
-									return successfulSubmitSummary();
-								} else {
-									const error = new RetriableSummaryError(
-										`Fail summarization at ${currentStage}`,
-										retryAfterSeconds,
-									);
-									const failedResult: Partial<SubmitSummaryResult> = {
-										stage: currentStage,
-										referenceSequenceNumber: lastRefSeq,
-										minimumSequenceNumber: 0,
-										error,
-									};
-									return failedResult as SubmitSummaryResult;
-								}
-							},
-						);
-
-						await emitNextOp();
-						// This should run a summarization because max ops has reached.
-						await emitNextOp(summaryConfig.maxOps);
-
-						for (let attemptNumber = 1; attemptNumber < maxAttempts; attemptNumber++) {
-							await validateSummaryAttemptFails(
-								attemptNumber,
-								maxAttempts,
-								currentStage,
-								retryAfterSeconds,
-							);
-
-							// Change the failure stage after 2 attempts.
-							if (attemptNumber === 2) {
-								currentStage = getNewStage();
-							}
-
-							// Wait for "retryAfterSeconds". The next attempt should start after this.
-							await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-						}
-
-						// Validate summarization is not run again.
-						assertRunCounts(
-							maxAttempts,
-							0,
-							0,
-							`Summarization should not have been attempted more than ${maxAttempts} times`,
-						);
-					});
-
-					it(`should update max attempts on failure at ${titleStage} stage as per AttemptsForSubmitFailures`, async () => {
-						const retryAfterSeconds = 5;
-						const maxAttemptsOverride =
-							stage === "submit"
-								? defaultMaxAttempts
-								: defaultMaxAttemptsForSubmitFailures - 1;
-						settings["Fluid.Summarizer.AttemptsForSubmitFailures"] =
-							maxAttemptsOverride;
-
-						await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
-							submitSummaryCallback(stage, retryAfterSeconds),
-						);
-
-						await emitNextOp();
-						// This should run a summarization because max ops has reached.
-						await emitNextOp(summaryConfig.maxOps);
-
-						for (let attempt = 1; attempt <= maxAttemptsOverride; attempt++) {
-							await validateSummaryAttemptFails(
-								attempt,
-								maxAttemptsOverride,
-								stage,
-								retryAfterSeconds,
-							);
-							// Wait for "retryAfterSeconds". The next attempt should start after this.
-							await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-						}
-
-						// validate that summarization is not run again.
-						assertRunCounts(
-							maxAttemptsOverride,
-							0,
-							0,
-							`Summarization should not have been attempted more than ${maxAttemptsOverride} times`,
-						);
-					});
-				}
-
-				it(`should attempt max ${defaultMaxAttempts} times on failure when stage changes to nack`, async () => {
-					const retryAfterSeconds = 5;
-					let currentStage: SummaryStage = "generate";
-
-					await startRunningSummarizer(undefined /* disableHeuristics */, async () => {
-						if (currentStage === "submit") {
-							return successfulSubmitSummary();
-						} else {
-							const error = new RetriableSummaryError(
-								`Fail summarization at ${currentStage}`,
-								retryAfterSeconds,
-							);
-							const failedResult: Partial<SubmitSummaryResult> = {
-								stage: currentStage,
-								referenceSequenceNumber: lastRefSeq,
-								minimumSequenceNumber: 0,
-								error,
-							};
-							return failedResult as SubmitSummaryResult;
-						}
-					});
-
-					await emitNextOp();
-					// This should run a summarization because max ops has reached.
-					await emitNextOp(summaryConfig.maxOps);
-
-					const maxAttempts = defaultMaxAttempts;
-					for (let attemptNumber = 1; attemptNumber < maxAttempts; attemptNumber++) {
-						await validateSummaryAttemptFails(
-							attemptNumber,
-							maxAttempts,
-							currentStage,
-							retryAfterSeconds,
-						);
-
-						// Change the failure stage to submit after 1 attempt. This should trigger a failure with nack
-						// which would be attempted once more.
-						if (attemptNumber === 1) {
-							currentStage = "submit";
-						}
-
-						// Wait for "retryAfterSeconds". The next attempt should start after this.
-						await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-					}
-
-					// Validate summarization is not run again.
-					assertRunCounts(
-						maxAttempts,
-						0,
-						0,
-						`Summarization should not have been attempted more than ${maxAttempts} times`,
-					);
-				});
-
-				it(`should change max attempts to ${defaultMaxAttempts} times on failure when stage changes to nack`, async () => {
-					const retryAfterSeconds = 5;
-					let currentStage: SummaryStage = "generate";
-
-					await startRunningSummarizer(undefined /* disableHeuristics */, async () => {
-						if (currentStage === "submit") {
-							return successfulSubmitSummary();
-						} else {
-							const error = new RetriableSummaryError(
-								`Fail summarization at ${currentStage}`,
-								retryAfterSeconds,
-							);
-							const failedResult: Partial<SubmitSummaryResult> = {
-								stage: currentStage,
-								referenceSequenceNumber: lastRefSeq,
-								minimumSequenceNumber: 0,
-								error,
-							};
-							return failedResult as SubmitSummaryResult;
-						}
-					});
-
-					// Fail at the "generate" stage 2 times.
-					await emitNextOp();
-					// This should run a summarization because max ops has reached.
-					await emitNextOp(summaryConfig.maxOps);
-					let maxAttempts = defaultMaxAttemptsForSubmitFailures;
-					let attemptNumber = 1;
-					await validateSummaryAttemptFails(
-						attemptNumber++,
-						maxAttempts,
-						currentStage,
-						retryAfterSeconds,
-					);
-
-					// Wait for "retryAfterSeconds". The next attempt should start after this.
-					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-					await validateSummaryAttemptFails(
-						attemptNumber++,
-						maxAttempts,
-						currentStage,
-						retryAfterSeconds,
-					);
-
-					// In the third attempt, fail at "submit" stage. This will trigger a nack failure. It should
-					// not retry attempts anymore because "defaultMaxAttempts" attempts have already been done.
-					currentStage = "submit";
-					maxAttempts = attemptNumber;
-
-					// Wait for "retryAfterSeconds". The next attempt should start after this.
-					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-
-					await validateSummaryAttemptFails(
-						attemptNumber,
-						maxAttempts,
-						currentStage,
-						retryAfterSeconds,
-					);
-
-					// Wait for "retryAfterSeconds". There shouldn't be any more attempts.
-					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-
-					// Validate summarization is not run again.
-					assertRunCounts(
-						maxAttempts,
-						0,
-						0,
-						`Summarization should not have been attempted more than ${maxAttempts} times`,
-					);
-				});
-
-				it("Should not retry last summary", async () => {
-					const stage: SummaryStage = "base";
-					const retryAfterSeconds = 10;
-					await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
-						submitSummaryCallback(stage, retryAfterSeconds),
-					);
-
-					// This should trigger last summary when summarizer stops.
-					await emitNextOp(summaryConfig.minOpsForLastSummaryAttempt);
-					const stopP = summarizer.waitStop(true /* allowLastSummary */);
-					await flushPromises();
-					await stopP;
-					summarizer.dispose();
-
-					assertRunCounts(1, 0, 0, "should perform lastSummary");
-					const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [
-						{
-							eventName: "Running:Summarize_cancel",
-							retryAfterSeconds,
-							summarizeCount: 1,
-							stage,
-						},
-					];
-					mockLogger.assertMatch(
-						expectedEvents,
-						`last summary attempt did not fail as expected`,
-					);
-
-					// Wait for "retryAfterSeconds". There shouldn't be any more attempts.
-					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
-					assertRunCounts(1, 0, 0, "should not retry lastSummary");
 				});
 			});
 

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -27,21 +27,18 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				}
 			},
@@ -71,8 +68,7 @@
 			"optionOverrides": {
 				"routerlicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
 					}
 				}
 			}


### PR DESCRIPTION
t9s e2e tests in our main CI pipeline start failing from PR #16694.
#16828 is a follow change in the same code so revert them together.

Revert both to get CI back to a good place.

```
cbfefc6d62 Rename reason to summarizeReason so that it is not overwritten on summarize failure (#16828)
7b0642a260 Update summarization retry logic to be based on failure params and error (#16694)
```