### PR TITLE
Change error Sanitization message

### DIFF
--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -25,7 +25,7 @@ import { MongoErrorRetryAnalyzer } from "./mongoExceptionRetryRules";
 const MaxFetchSize = 2000;
 const MaxRetryAttempts = 3;
 const InitialRetryIntervalInMs = 1000;
-const errorSanitizationMessage = "REDACTED";
+const errorSanitizationMessage = "FluidREDACTED";
 const errorResponseKeysAllowList = new Set([
 	"_id",
 	"code",


### PR DESCRIPTION
We are seeing these stuck mongo pods are having topology change event with `"REDACTED"` information. I didn't find any places in their source code would include this, this change is just to change the sanitization message scoped with `Fluid`, to rule out the possibility that things might from our side. Details: https://www.mongodb.com/community/forums/t/topologydescriptionchanged-ends-up-with-redacted-informations-and-in-a-bad-state/239748?u=xin_zhang