### PR TITLE
Fix getLoadedCodeDetails to return the details given to the container by the codeLoader

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2425,7 +2425,7 @@ export class Container
 		);
 		this._lifecycleEvents.emit("runtimeInstantiated");
 
-		this._loadedCodeDetails = codeDetails;
+		this._loadedCodeDetails = loadCodeResult.details;
 	}
 
 	private readonly updateDirtyContainerState = (dirty: boolean) => {


### PR DESCRIPTION
We (loop) have several different contexts where we would like to be able to access the version information of the code that actually loaded in a container at runtime. For example, to display debug information in a UI, to allow runtime memory leaks analysis tools to have quick access to this, and to be able to "stamp" the version on component iframes so it's easily visible in heap snapshots.

@leeviana indicated that she would expect the existing `container.getLoadedCodeDetails` to us exactly that. However, today, it will instead return details about the container that was _requested_ to be loaded, not the one that the codeLoader _actually_ loaded. These are different in our use case because logic in our codeLoader.

This PR updates the container to behave this way - hopefully that's right! (I'm open to feedback if you have other ideas about how to accomplish this goal).