### PR TITLE
Small optimizations to the Map and Matrix benchmark

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
@@ -124,10 +124,6 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 			"Container should be initialized before creating data stores",
 		);
 		assert(
-			this.containerRuntime !== undefined,
-			"ContainerRuntime should be initialized before creating data stores",
-		);
-		assert(
 			this.mainDataStore !== undefined,
 			"mainDataStore should be initialized before creating data stores",
 		);
@@ -146,7 +142,6 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 				sharedString.insertText(0, randomString);
 				matrix.setCell(i, j, sharedString.getText());
 			}
-			await this.waitForContainerSave(this._mainContainer);
 		}
 	}
 
@@ -193,15 +188,29 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 	}
 
 	public async initializeDocument(): Promise<void> {
-		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory, {
-			logger: this.props.logger,
-		});
+		const loader = this.props.provider.createLoader(
+			[[this.props.provider.defaultCodeDetails, this.runtimeFactory]],
+			{ logger: this.props.logger },
+		);
+		this._mainContainer = await loader.createDetachedContainer(
+			this.props.provider.defaultCodeDetails,
+		);
 		this.props.provider.updateDocumentId(this._mainContainer.resolvedUrl);
 		this.mainDataStore = await requestFluidObject<TestDataObject>(this._mainContainer, "/");
-		this.containerRuntime = this.mainDataStore._context.containerRuntime as ContainerRuntime;
 		this.mainDataStore._root.set("mode", "write");
-		await this.ensureContainerConnectedWriteMode(this._mainContainer);
+
 		await this.createDataStores();
+
+		await this._mainContainer.attach(
+			this.props.provider.driver.createCreateNewRequest(this.props.provider.documentId),
+		);
+
+		await this.waitForContainerSave(this._mainContainer);
+		this.containerRuntime = this.mainDataStore._context.containerRuntime as ContainerRuntime;
+
+		if (this._mainContainer.deltaManager.active) {
+			await this.ensureContainerConnectedWriteMode(this._mainContainer);
+		}
 	}
 
 	/**

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
@@ -4,57 +4,57 @@
 			"testTitle": "1Mb Map",
 			"documentType": "DocumentMap",
 			"documentTypeInfo": {
-				"numberOfItems": "1",
-				"itemSizeMb": "1"
+				"numberOfItems": 1,
+				"itemSizeMb": 1
 			},
-			"minSampleCount": "1"
+			"minSampleCount": 1
 		},
 		{
 			"testTitle": "2Mb Map",
 			"documentType": "DocumentMap",
 			"documentTypeInfo": {
-				"numberOfItems": "2",
-				"itemSizeMb": "1"
+				"numberOfItems": 2,
+				"itemSizeMb": 1
 			},
-			"minSampleCount": "1"
+			"minSampleCount": 1
 		},
 		{
 			"testTitle": "100 DataStores - 300 DDSs",
 			"documentType": "DocumentMultipleDataStores",
 			"documentTypeInfo": {
-				"numberDataStores": "100",
-				"numberDataStoresPerIteration": "50"
+				"numberDataStores": 100,
+				"numberDataStoresPerIteration": 50
 			},
-			"minSampleCount": "1"
+			"minSampleCount": 1
 		},
 		{
 			"testTitle": "150 DataStores - 450 DDSs",
 			"documentType": "DocumentMultipleDataStores",
 			"documentTypeInfo": {
-				"numberDataStores": "150",
-				"numberDataStoresPerIteration": "50"
+				"numberDataStores": 150,
+				"numberDataStoresPerIteration": 50
 			},
-			"minSampleCount": "1"
+			"minSampleCount": 1
 		},
 		{
 			"testTitle": "Matrix 10x10 with SharedStrings",
 			"documentType": "DocumentMatrix",
 			"documentTypeInfo": {
-				"rowSize": "10",
-				"columnSize": "10",
-				"stringSize": "100"
+				"rowSize": 10,
+				"columnSize": 10,
+				"stringSize": 100
 			},
-			"minSampleCount": "1"
+			"minSampleCount": 1
 		},
 		{
 			"testTitle": "Matrix 20x20 with SharedStrings",
 			"documentType": "DocumentMatrix",
 			"documentTypeInfo": {
-				"rowSize": "20",
-				"columnSize": "20",
-				"stringSize": "100"
+				"rowSize": 20,
+				"columnSize": 20,
+				"stringSize": 100
 			},
-			"minSampleCount": "1"
+			"minSampleCount": 1
 		}
 	]
 }

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -33,11 +33,12 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 		});
 		await documentWrapper.initializeDocument();
 		// Summarize the first time.
-		const summarizerClient = await documentWrapper.summarize(
+		const lastSummarizeClient = await documentWrapper.summarize(
 			documentWrapper.mainContainer,
 			undefined,
 			/* close container */ true,
 		);
+		summaryVersion = lastSummarizeClient.summaryVersion;
 	});
 
 	beforeEach(async function () {
@@ -71,7 +72,7 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 				try {
 					this.summarizerClient = await documentWrapper.summarize(
 						this.container,
-						undefined,
+						summaryVersion,
 						/* close container */ false,
 					);
 


### PR DESCRIPTION
## Description

Changing the Map and Matrix benchmark tests to initialize the container in detached mode and only attach when their controls have been populated.  Also, make sure the summarizer test always uses the latest summary version  when creating a new summarizer container. 