### PR TITLE
Update summarization retry logic to be based on failure params and error

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -432,7 +432,7 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
 }
 
 // @public (undocumented)
-export interface INackSummaryResult {
+export interface INackSummaryResult extends IRetriableFailureResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
@@ -450,6 +450,12 @@ export interface IRefreshSummaryAckOptions {
     readonly proposalHandle: string | undefined;
     readonly summaryLogger: ITelemetryLoggerExt;
     readonly summaryRefSeq: number;
+}
+
+// @public
+export interface IRetriableFailureResult {
+    // (undocumented)
+    readonly retryAfterSeconds?: number;
 }
 
 // @public @deprecated (undocumented)
@@ -664,7 +670,7 @@ export enum RuntimeMessage {
 }
 
 // @public
-export interface SubmitSummaryFailureData {
+export interface SubmitSummaryFailureData extends IRetriableFailureResult {
     // (undocumented)
     stage: SummaryStage;
 }
@@ -706,7 +712,6 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     data: TFailure | undefined;
     message: string;
     error: any;
-    retryAfterSeconds?: number;
 };
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -70,6 +70,7 @@ export {
 	ICancellableSummarizerController,
 	SubmitSummaryFailureData,
 	SummaryStage,
+	IRetriableFailureResult,
 } from "./summary";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle";
 export { generateStableId, isStableId, assertIsStableId } from "./id-compressor";

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -64,6 +64,7 @@ export {
 	SummarizeResultPart,
 	SubmitSummaryFailureData,
 	SummaryStage,
+	IRetriableFailureResult,
 } from "./summarizerTypes";
 export {
 	IAckedSummary,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -45,6 +45,17 @@ import {
 const maxSummarizeAckWaitTime = 10 * 60 * 1000; // 10 minutes
 
 /**
+ * The maximum number of summarization attempts that will be done by default in case of failures
+ * that can be retried.
+ */
+export const defaultMaxAttempts = 2;
+/**
+ * The default value for maximum number of summarization attempts that will be done for summarization failures where
+ * submit fails and the failure can be retried.
+ */
+export const defaultMaxAttemptsForSubmitFailures = 5;
+
+/**
  * An instance of RunningSummarizer manages the heuristics for summarizing.
  * Until disposed, the instance of RunningSummarizer can assume that it is
  * in a state of running, meaning it is connected and initialized.  It keeps
@@ -147,6 +158,9 @@ export class RunningSummarizer implements IDisposable {
 
 	private readonly runtimeListener;
 
+	/** The maximum number of summary attempts to do when submit summary fails. */
+	private readonly maxAttemptsForSubmitFailures: number;
+
 	private constructor(
 		baseLogger: ITelemetryBaseLogger,
 		private readonly summaryWatcher: IClientSummaryWatcher,
@@ -240,6 +254,17 @@ export class RunningSummarizer implements IDisposable {
 			this.handleOp(op, runtimeMessage === true);
 		};
 		this.runtime.on("op", this.runtimeListener);
+
+		// The max attempts for submit failures can be overridden via a feature flag. This allows us to
+		// tweak this as per telemetry data until we arrive at a stable number.
+		// If its set to a number higher than `defaultMaxAttemptsForSubmitFailures`, it will be ignored.
+		const overrideMaxAttempts = this.mc.config.getNumber(
+			"Fluid.Summarizer.AttemptsForSubmitFailures",
+		);
+		this.maxAttemptsForSubmitFailures =
+			overrideMaxAttempts && overrideMaxAttempts < defaultMaxAttemptsForSubmitFailures
+				? overrideMaxAttempts
+				: defaultMaxAttemptsForSubmitFailures;
 	}
 
 	private async handleSummaryAck(): Promise<number> {
@@ -571,68 +596,9 @@ export class RunningSummarizer implements IDisposable {
 				this.beforeSummaryAction();
 			},
 			async () => {
-				const attempts: ISummarizeOptions[] = [
-					{ refreshLatestAck: false, fullTree: false },
-					{ refreshLatestAck: true, fullTree: false },
-				];
-				let overrideDelaySeconds: number | undefined;
-				let summaryAttempts = 0;
-				let summaryAttemptsPerPhase = 0;
-				let summaryAttemptPhase = 0;
-				while (summaryAttemptPhase < attempts.length) {
-					if (this.cancellationToken.cancelled) {
-						return;
-					}
-
-					// We only want to attempt 1 summary when reason is "lastSummary"
-					if (++summaryAttempts > 1 && reason === "lastSummary") {
-						return;
-					}
-
-					summaryAttemptsPerPhase++;
-
-					const summarizeOptions = attempts[summaryAttemptPhase];
-					const summarizeProps: ISummarizeTelemetryProperties = {
-						reason,
-						summaryAttempts,
-						summaryAttemptsPerPhase,
-						summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
-						...summarizeOptions,
-					};
-
-					// Note: no need to account for cancellationToken.waitCancelled here, as
-					// this is accounted SummaryGenerator.summarizeCore that controls receivedSummaryAckOrNack.
-					const resultSummarize = this.generator.summarize(
-						summarizeProps,
-						summarizeOptions,
-						cancellationToken,
-					);
-					const result = await resultSummarize.receivedSummaryAckOrNack;
-
-					if (result.success) {
-						return;
-					}
-
-					// Check for retryDelay that can come from summaryNack or upload summary flow.
-					// Retry the same step only once per retryAfter response.
-					const delaySeconds = result.retryAfterSeconds;
-					if (delaySeconds === undefined || summaryAttemptsPerPhase > 1) {
-						summaryAttemptPhase++;
-						summaryAttemptsPerPhase = 0;
-					}
-
-					if (delaySeconds !== undefined) {
-						this.mc.logger.sendPerformanceEvent({
-							eventName: "SummarizeAttemptDelay",
-							duration: delaySeconds,
-							summaryNackDelay: overrideDelaySeconds !== undefined,
-							...summarizeProps,
-						});
-						await delay(delaySeconds * 1000);
-					}
-				}
-
-				this.stopSummarizerCallback("failToSummarize");
+				return this.mc.config.getBoolean("Fluid.Summarizer.TryDynamicRetries")
+					? this.trySummarizeWithRetries(reason, cancellationToken)
+					: this.trySummarizeWithStaticAttempts(reason, cancellationToken);
 			},
 			() => {
 				this.afterSummaryAction();
@@ -640,6 +606,167 @@ export class RunningSummarizer implements IDisposable {
 		).catch((error) => {
 			this.mc.logger.sendErrorEvent({ eventName: "UnexpectedSummarizeError" }, error);
 		});
+	}
+
+	/**
+	 * Tries to summarize 2 times with pre-defined summary options. If an attempt fails with "retryAfterSeconds"
+	 * param, that attempt is tried once more.
+	 */
+	private async trySummarizeWithStaticAttempts(
+		reason: SummarizeReason,
+		cancellationToken: ISummaryCancellationToken,
+	) {
+		const attempts: ISummarizeOptions[] = [
+			{ refreshLatestAck: false, fullTree: false },
+			{ refreshLatestAck: true, fullTree: false },
+		];
+		let summaryAttempts = 0;
+		let summaryAttemptsPerPhase = 0;
+		let summaryAttemptPhase = 0;
+		while (summaryAttemptPhase < attempts.length) {
+			if (cancellationToken.cancelled) {
+				return;
+			}
+
+			// We only want to attempt 1 summary when reason is "lastSummary"
+			if (++summaryAttempts > 1 && reason === "lastSummary") {
+				return;
+			}
+
+			summaryAttemptsPerPhase++;
+
+			const summarizeOptions = attempts[summaryAttemptPhase];
+			const summarizeProps: ISummarizeTelemetryProperties = {
+				reason,
+				summaryAttempts,
+				summaryAttemptsPerPhase,
+				summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
+				...summarizeOptions,
+			};
+
+			// Note: no need to account for cancellationToken.waitCancelled here, as
+			// this is accounted SummaryGenerator.summarizeCore that controls receivedSummaryAckOrNack.
+			const resultSummarize = this.generator.summarize(
+				summarizeProps,
+				summarizeOptions,
+				cancellationToken,
+			);
+			const ackNackResult = await resultSummarize.receivedSummaryAckOrNack;
+			if (ackNackResult.success) {
+				return;
+			}
+
+			// Check for retryDelay that can come from summaryNack, upload summary or submit summary flows.
+			// Retry the same step only once per retryAfter response.
+			const submitResult = await resultSummarize.summarySubmitted;
+			const delaySeconds = !submitResult.success
+				? submitResult.data?.retryAfterSeconds
+				: ackNackResult.data?.retryAfterSeconds;
+			if (delaySeconds === undefined || summaryAttemptsPerPhase > 1) {
+				summaryAttemptPhase++;
+				summaryAttemptsPerPhase = 0;
+			}
+
+			if (delaySeconds !== undefined) {
+				this.mc.logger.sendPerformanceEvent({
+					eventName: "SummarizeAttemptDelay",
+					duration: delaySeconds,
+					summaryNackDelay: ackNackResult.data?.retryAfterSeconds !== undefined,
+					...summarizeProps,
+				});
+				await delay(delaySeconds * 1000);
+			}
+		}
+		this.stopSummarizerCallback("failToSummarize");
+	}
+
+	/**
+	 * Tries to summarize with retries where retry is based on the failure params.
+	 * For example, summarization may be retried for failures with "retryAfterSeconds" param.
+	 */
+	private async trySummarizeWithRetries(
+		reason: SummarizeReason,
+		cancellationToken: ISummaryCancellationToken,
+	) {
+		// The max number of attempts are based on the stage at which summarization failed. If it fails before it is
+		// submitted, a different value is used compared to if it fails after submission. Usually, in the former case,
+		// we would retry more often as its cheaper and retries are likely to succeed.
+		// This makes it harder to predict how many attempts would actually happen as that depends on how far an attempt
+		// made. To keep things simple, the max attempts is reset after every attempt based on where it failed. This may
+		// result in some failures not being retried depending on what happened before this attempt. That's fine because
+		// such scenarios are very unlikely and even if it happens, it would resolve when a new summarizer starts over.
+		let maxAttempts = defaultMaxAttempts;
+		let currentAttempt = 0;
+		let success = false;
+		let done = false;
+		do {
+			if (this.cancellationToken.cancelled) {
+				success = true;
+				done = true;
+				break;
+			}
+
+			currentAttempt++;
+			const summarizeOptions: ISummarizeOptions = {
+				refreshLatestAck: false,
+				fullTree: false,
+			};
+			const summarizeProps: ISummarizeTelemetryProperties = {
+				reason,
+				summaryAttempts: currentAttempt,
+				...summarizeOptions,
+			};
+			const summarizeResult = this.generator.summarize(
+				summarizeProps,
+				summarizeOptions,
+				cancellationToken,
+			);
+
+			// Ack / nack is the final step, so if it succeeds we're done.
+			const ackNackResult = await summarizeResult.receivedSummaryAckOrNack;
+			if (ackNackResult.success) {
+				success = true;
+				done = true;
+				break;
+			}
+
+			const submitSummaryResult = await summarizeResult.summarySubmitted;
+			let retryAfterSeconds: number | undefined;
+
+			// Update max attempts and retry params from the failure result.
+			// If submit summary failed, use the params from "summarySubmitted" result. Else, use the params
+			// from "receivedSummaryAckOrNack" result.
+			// Note: Check "summarySubmitted" result first because if it fails, ack nack would fail as well.
+			if (!submitSummaryResult.success) {
+				maxAttempts = this.maxAttemptsForSubmitFailures;
+				retryAfterSeconds = submitSummaryResult.data?.retryAfterSeconds;
+			} else {
+				maxAttempts = defaultMaxAttempts;
+				retryAfterSeconds = ackNackResult.data?.retryAfterSeconds;
+			}
+
+			// If the failure doesn't have "retryAfterSeconds" or the max number of attempts have been done, we're done.
+			if (retryAfterSeconds === undefined || currentAttempt >= maxAttempts) {
+				success = false;
+				done = true;
+				break;
+			}
+
+			this.mc.logger.sendPerformanceEvent({
+				eventName: "SummarizeAttemptDelay",
+				duration: retryAfterSeconds,
+				summaryNackDelay: ackNackResult.data?.retryAfterSeconds !== undefined,
+				stage: submitSummaryResult.data?.stage,
+				dynamicRetries: true, // To differentiate this telemetry from regular retry logic
+				...summarizeProps,
+			});
+			await delay(retryAfterSeconds * 1000);
+		} while (!done);
+
+		// If summarization isn't successful, stop the summarizer.
+		if (!success) {
+			this.stopSummarizerCallback("failToSummarize");
+		}
 	}
 
 	/** {@inheritdoc (ISummarizer:interface).summarizeOnDemand} */

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -216,8 +216,14 @@ export type SubmitSummaryResult =
 
 /** The stages of Summarize, used to describe how far progress succeeded in case of a failure at a later stage. */
 export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
+
+/** Type for summarization failures that are retriable. */
+export interface IRetriableFailureResult {
+	readonly retryAfterSeconds?: number;
+}
+
 /** The data in summarizer result when submit summary stage fails. */
-export interface SubmitSummaryFailureData {
+export interface SubmitSummaryFailureData extends IRetriableFailureResult {
 	stage: SummaryStage;
 }
 
@@ -231,7 +237,7 @@ export interface IAckSummaryResult {
 	readonly ackNackDuration: number;
 }
 
-export interface INackSummaryResult {
+export interface INackSummaryResult extends IRetriableFailureResult {
 	readonly summaryNackOp: ISummaryNackMessage;
 	readonly ackNackDuration: number;
 }
@@ -246,7 +252,6 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> =
 			data: TFailure | undefined;
 			message: string;
 			error: any;
-			retryAfterSeconds?: number;
 	  };
 
 export interface ISummarizeResults {

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -34,7 +34,6 @@ import {
 	ISummaryCancellationToken,
 	ISummarizeTelemetryProperties,
 	SummaryGeneratorTelemetry,
-	SummaryStage,
 	SubmitSummaryFailureData,
 } from "./summarizerTypes";
 import { IClientSummaryWatcher } from "./summaryCollection";
@@ -143,12 +142,17 @@ export class SummarizeResultBuilder {
 		SummarizeResultPart<IAckSummaryResult, INackSummaryResult>
 	>();
 
+	/**
+	 * Fails one or more of the three results as per the passed params.
+	 * If submit fails, all three results fail.
+	 * If op broadcast fails, only op broadcast result and ack nack result fails.
+	 * If ack nack fails, only ack nack result fails.
+	 */
 	public fail(
 		message: string,
 		error: any,
-		stage: SummaryStage = "unknown",
+		submitFailureResult?: SubmitSummaryFailureData,
 		nackSummaryResult?: INackSummaryResult,
-		retryAfterSeconds?: number,
 	) {
 		assert(
 			!this.receivedSummaryAckOrNack.isCompleted,
@@ -160,9 +164,11 @@ export class SummarizeResultBuilder {
 			message,
 			data: undefined,
 			error,
-			retryAfterSeconds,
 		} as const;
-		this.summarySubmitted.resolve({ ...result, data: { stage } });
+
+		// Note that if any of these are already resolved, it will be a no-op. For example, if ack nack failed but
+		// submit summary and op broadcast has already been resolved as passed, only ack nack result will get modified.
+		this.summarySubmitted.resolve({ ...result, data: submitFailureResult });
 		this.summaryOpBroadcasted.resolve(result);
 		this.receivedSummaryAckOrNack.resolve({ ...result, data: nackSummaryResult });
 	}
@@ -267,16 +273,19 @@ export class SummaryGenerator {
 		);
 
 		let summaryData: SubmitSummaryResult | undefined;
+
+		/**
+		 * Summarization can fail during submit, during op broadcast or during nack.
+		 * For submit failures, submitFailureResult should be provided. For nack failures, nackSummaryResult should
+		 * be provided. For op broadcast failures, only errors / properties should be provided.
+		 */
 		const fail = (
 			errorCode: keyof typeof summarizeErrors,
 			error?: any,
 			properties?: SummaryGeneratorTelemetry,
+			submitFailureResult?: SubmitSummaryFailureData,
 			nackSummaryResult?: INackSummaryResult,
 		) => {
-			// UploadSummary may fail with 429 and retryAfter - respect that
-			// Summary Nack also can have retryAfter, it's parsed below and comes as a property.
-			const retryAfterSeconds = getRetryDelaySecondsFromError(error);
-
 			// Report any failure as an error unless it was due to cancellation (like "disconnected" error)
 			// If failure happened on upload, we may not yet realized that socket disconnected, so check
 			// offlineError too.
@@ -291,15 +300,14 @@ export class SummaryGenerator {
 					...properties,
 					reason,
 					category,
-					retryAfterSeconds,
+					retryAfterSeconds:
+						submitFailureResult?.retryAfterSeconds ??
+						nackSummaryResult?.retryAfterSeconds,
 				},
 				error ?? reason,
 			); // disconnect & summaryAckTimeout do not have proper error.
 
-			// If summarize did not hit an unexpected error, summaryData would be available. Otherwise, the state is
-			// unknown.
-			const stage = summaryData?.stage ?? "unknown";
-			resultsBuilder.fail(reason, error, stage, nackSummaryResult, retryAfterSeconds);
+			resultsBuilder.fail(reason, error, submitFailureResult, nackSummaryResult);
 		};
 
 		// Wait to generate and send summary
@@ -333,7 +341,10 @@ export class SummaryGenerator {
 			);
 
 			if (summaryData.stage !== "submit") {
-				return fail("submitSummaryFailure", summaryData.error, summarizeTelemetryProps);
+				return fail("submitSummaryFailure", summaryData.error, summarizeTelemetryProps, {
+					stage: summaryData.stage,
+					retryAfterSeconds: getRetryDelaySecondsFromError(summaryData.error),
+				});
 			}
 
 			/**
@@ -366,7 +377,10 @@ export class SummaryGenerator {
 			summarizeEvent.reportEvent("generate", { ...summarizeTelemetryProps });
 			resultsBuilder.summarySubmitted.resolve({ success: true, data: summaryData });
 		} catch (error) {
-			return fail("submitSummaryFailure", error);
+			return fail("submitSummaryFailure", error, undefined /* properties */, {
+				stage: "unknown",
+				retryAfterSeconds: getRetryDelaySecondsFromError(error),
+			});
 		} finally {
 			if (summaryData === undefined) {
 				this.heuristicData.recordAttempt();
@@ -385,10 +399,10 @@ export class SummaryGenerator {
 				cancellationToken,
 			);
 			if (waitBroadcastResult.result === "cancelled") {
-				return fail("disconnect", summaryData.stage);
+				return fail("disconnect");
 			}
 			if (waitBroadcastResult.result !== "done") {
-				return fail("summaryOpWaitTimeout", summaryData.stage);
+				return fail("summaryOpWaitTimeout");
 			}
 			const summarizeOp = waitBroadcastResult.value;
 
@@ -468,7 +482,8 @@ export class SummaryGenerator {
 					"summaryNack",
 					error,
 					{ ...summarizeTelemetryProps, nackRetryAfter: retryAfterSeconds },
-					{ summaryNackOp: ackNackOp, ackNackDuration },
+					undefined /* submitFailureResult */,
+					{ summaryNackOp: ackNackOp, ackNackDuration, retryAfterSeconds },
 				);
 			}
 		} finally {

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import sinon from "sinon";
 import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
+import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import {
 	IDocumentMessage,
 	ISequencedDocumentMessage,
@@ -34,7 +35,15 @@ import {
 	SummarizeHeuristicData,
 	ISummarizerRuntime,
 	ISummarizeHeuristicData,
+	SubmitSummaryResult,
+	RetriableSummaryError,
+	IGeneratedSummaryStats,
 } from "../../summary";
+import {
+	defaultMaxAttempts,
+	defaultMaxAttemptsForSubmitFailures,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../summary/runningSummarizer";
 
 class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> {
 	disposed = false;
@@ -93,6 +102,17 @@ describe("Runtime", () => {
 			const summaryConfigDisableHeuristics: ISummaryConfiguration = {
 				state: "disableHeuristics",
 				...summaryCommon,
+			};
+
+			const emptySummaryStats: IGeneratedSummaryStats = {
+				treeNodeCount: 0,
+				blobNodeCount: 0,
+				handleNodeCount: 0,
+				totalBlobSize: 0,
+				dataStoreCount: 0,
+				summarizedDataStoreCount: 0,
+				unreferencedBlobSize: 0,
+				summaryNumber: 0,
 			};
 
 			let shouldDeferGenerateSummary: boolean = false;
@@ -197,6 +217,7 @@ describe("Runtime", () => {
 				expectedFullTreeRunCount: number,
 				expectedRefreshLatestAckRunCount: number,
 				errorMessage?: string,
+				expectedStopCount = 0,
 			) {
 				const errorPrefix = errorMessage ? `${errorMessage}: ` : "";
 				assert.strictEqual(
@@ -214,9 +235,46 @@ describe("Runtime", () => {
 					expectedRefreshLatestAckRunCount,
 					`${errorPrefix}unexpected refreshLatestAck count`,
 				);
+				assert.strictEqual(
+					stopCall,
+					expectedStopCount,
+					`${errorPrefix}summarizer should ${
+						expectedStopCount === 1 ? "" : "not"
+					} have stopped`,
+				);
 			}
 
-			const startRunningSummarizer = async (disableHeuristics?: boolean): Promise<void> => {
+			async function successfulSubmitSummary(): Promise<SubmitSummaryResult> {
+				// emitBroadcast will increment this number
+				const lastRefSeqBefore = lastRefSeq;
+
+				// immediate broadcast
+				emitBroadcast();
+
+				if (shouldDeferGenerateSummary) {
+					deferGenerateSummary = new Deferred<void>();
+					await deferGenerateSummary.promise;
+					deferGenerateSummary = undefined;
+				}
+				return {
+					stage: "submit",
+					referenceSequenceNumber: lastRefSeqBefore,
+					minimumSequenceNumber: 0,
+					generateDuration: 0,
+					uploadDuration: 0,
+					submitOpDuration: 0,
+					summaryTree: { type: SummaryType.Tree, tree: {} },
+					summaryStats: emptySummaryStats,
+					handle: "test-handle",
+					clientSequenceNumber: lastClientSeq,
+					forcedFullTree: false,
+				} as const;
+			}
+
+			const startRunningSummarizer = async (
+				disableHeuristics?: boolean,
+				submitSummaryCallback: () => Promise<SubmitSummaryResult> = successfulSubmitSummary,
+			): Promise<void> => {
 				heuristicData = new SummarizeHeuristicData(0, {
 					refSequenceNumber: 0,
 					summaryTime: Date.now(),
@@ -225,10 +283,8 @@ describe("Runtime", () => {
 					mockLogger,
 					summaryCollection.createWatcher(summarizerClientId),
 					disableHeuristics ? summaryConfigDisableHeuristics : summaryConfig,
-					// submitSummaryCallback
 					async (options) => {
 						runCount++;
-
 						heuristicData.recordAttempt(lastRefSeq);
 
 						const { fullTree = false, refreshLatestAck = false } = options;
@@ -238,40 +294,7 @@ describe("Runtime", () => {
 						if (refreshLatestAck) {
 							refreshLatestAckRunCount++;
 						}
-
-						// emitBroadcast will increment this number
-						const lastRefSeqBefore = lastRefSeq;
-
-						// immediate broadcast
-						emitBroadcast();
-
-						if (shouldDeferGenerateSummary) {
-							deferGenerateSummary = new Deferred<void>();
-							await deferGenerateSummary.promise;
-							deferGenerateSummary = undefined;
-						}
-						return {
-							stage: "submit",
-							referenceSequenceNumber: lastRefSeqBefore,
-							minimumSequenceNumber: 0,
-							generateDuration: 0,
-							uploadDuration: 0,
-							submitOpDuration: 0,
-							summaryTree: { type: SummaryType.Tree, tree: {} },
-							summaryStats: {
-								treeNodeCount: 0,
-								blobNodeCount: 0,
-								handleNodeCount: 0,
-								totalBlobSize: 0,
-								dataStoreCount: 0,
-								summarizedDataStoreCount: 0,
-								unreferencedBlobSize: 0,
-								summaryNumber: 0,
-							},
-							handle: "test-handle",
-							clientSequenceNumber: lastClientSeq,
-							forcedFullTree: false,
-						} as const;
+						return submitSummaryCallback();
 					},
 					async (options) => {},
 					heuristicData,
@@ -737,6 +760,447 @@ describe("Runtime", () => {
 						]),
 						"unexpected log sequence",
 					);
+				});
+			});
+
+			describe("Summarization attempts with retry", () => {
+				beforeEach(async () => {
+					settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+					shouldDeferGenerateSummary = false;
+					deferGenerateSummary = undefined;
+				});
+
+				type SummaryStage = SubmitSummaryResult["stage"];
+
+				/**
+				 * Validate that a summary attempt fails as expected, correct events are received and summarization
+				 * stops (or doesn't) as per the given params.
+				 * @param attemptNumber - The current attempt number.
+				 * @param totalAttempts - The total number of attempts. After the last attempt, summarizer should close.
+				 * @param lastSuccessfulStage - The stage after which summarization failed.
+				 * @param retryAfterSeconds - The number of seconds after which the next attempt should be tried.
+				 */
+				const validateSummaryAttemptFails = async (
+					attemptNumber: number,
+					totalAttempts: number,
+					lastSuccessfulStage: SummaryStage,
+					retryAfterSeconds: number | undefined,
+				) => {
+					const finalAttempt = attemptNumber >= totalAttempts;
+					// Nack the summary with "retryAfterSeconds" specified.
+					await emitNack(retryAfterSeconds);
+
+					assertRunCounts(
+						attemptNumber,
+						0,
+						0,
+						`Total run count should be ${attemptNumber}`,
+						finalAttempt ? 1 : 0 /* expectedStopCount */,
+					);
+
+					const retryProps1 = {
+						summarizeCount: 1,
+						summaryAttempts: attemptNumber,
+						stage: lastSuccessfulStage,
+					};
+					const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [
+						{
+							eventName: "Running:Summarize_cancel",
+							...retryProps1,
+							retryAfterSeconds,
+							reason: getFailMessage(
+								lastSuccessfulStage === "submit"
+									? "summaryNack" // if last stage is submit, summarization fails due to summary nack
+									: "submitSummaryFailure", // other stages fail because summary is not submitted
+							),
+						},
+					];
+
+					// After the final attempt, there shouldn't be any delay.
+					if (!finalAttempt) {
+						expectedEvents.push({
+							eventName: "Running:SummarizeAttemptDelay",
+							...retryProps1,
+							duration: retryAfterSeconds,
+							dynamicRetries: true,
+						});
+					}
+					mockLogger.assertMatch(
+						expectedEvents,
+						`Summarizer attempt ${attemptNumber} did not fail as expected`,
+					);
+
+					// After the final attempt, summarizer should stop.
+					assert.strictEqual(
+						stopCall,
+						finalAttempt ? 1 : 0,
+						`Summarizer should ${
+							finalAttempt ? "" : "not"
+						} have stopped after ${totalAttempts} attempts`,
+					);
+				};
+
+				// Callback that fails the summary for all stages expect submit. For submit, the summarization
+				// will fail because of summary ack not received withing timeout.
+				const submitSummaryCallback = async (
+					stage: SummaryStage,
+					retryAfterSeconds: number | undefined,
+				): Promise<SubmitSummaryResult> => {
+					if (stage === "submit") {
+						return successfulSubmitSummary();
+					} else {
+						const error = new RetriableSummaryError(
+							`Fail summarization at ${stage}`,
+							retryAfterSeconds,
+						);
+						const failedResult: Partial<SubmitSummaryResult> = {
+							stage,
+							referenceSequenceNumber: lastRefSeq,
+							minimumSequenceNumber: 0,
+							error,
+						};
+						return failedResult as SubmitSummaryResult;
+					}
+				};
+
+				it(`should not retry when summary attempt succeeds`, async () => {
+					await startRunningSummarizer();
+
+					await emitNextOp();
+					// This should run a summarization because max ops has reached.
+					await emitNextOp(summaryConfig.maxOps);
+					assertRunCounts(1, 0, 0, `Total run count should be 1`);
+
+					await emitAck();
+					assertRunCounts(1, 0, 0, `The run count should still be 1`);
+					assert.strictEqual(stopCall, 0, "Summarizer should not have stopped");
+				});
+
+				const failedStages: SummaryStage[] = ["base", "generate", "upload", "submit"];
+				for (const [stageIndex, stage] of failedStages.entries()) {
+					// When stage is "submit", the submit stage was successful and default max attempts is used
+					// for any other failures.
+					const maxAttempts =
+						stage === "submit"
+							? defaultMaxAttempts
+							: defaultMaxAttemptsForSubmitFailures;
+					const titleStage = stage === "submit" ? "nack" : stage;
+
+					it(`should attempt 1 time only on failure without retry specified at ${titleStage} stage`, async () => {
+						await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
+							submitSummaryCallback(stage, undefined /* retryAfterSeconds */),
+						);
+
+						await emitNextOp();
+						// This should run a summarization because max ops has reached.
+						await emitNextOp(summaryConfig.maxOps);
+						await validateSummaryAttemptFails(
+							1 /* attemptNumber */,
+							1 /* totalAttempts */,
+							stage,
+							undefined /* retryAfterSeconds */,
+						);
+					});
+
+					it(`should attempt ${maxAttempts} times on failure with retryAfterSeconds at ${titleStage} stage`, async () => {
+						const retryAfterSeconds = 5;
+						await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
+							submitSummaryCallback(stage, retryAfterSeconds),
+						);
+
+						await emitNextOp();
+						// This should run a summarization because max ops has reached.
+						await emitNextOp(summaryConfig.maxOps);
+
+						for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber++) {
+							await validateSummaryAttemptFails(
+								attemptNumber,
+								maxAttempts,
+								stage,
+								retryAfterSeconds,
+							);
+							// Wait for "retryAfterSeconds". The next attempt should start after this.
+							await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+						}
+
+						// validate that summarization is not run again.
+						assertRunCounts(
+							maxAttempts,
+							0,
+							0,
+							`Summarization should not have been attempted more than ${maxAttempts} times`,
+							1 /** expectedStopCount */,
+						);
+					});
+
+					it(`should attempt ${maxAttempts} times on failure when stage changes from ${titleStage}`, async () => {
+						// Helper to get a different stage from the current one.
+						const getNewStage = () => {
+							let index = stageIndex + 1;
+							// If the new stage is "submit", get another stage instead. This is because the logic is
+							// different when failure happens after "submit" stage. This is validated in a separate test.
+							if (index > failedStages.length - 2) {
+								index = 0;
+							}
+							return failedStages[index];
+						};
+
+						const retryAfterSeconds = 5;
+						let currentStage: SummaryStage = stage;
+
+						await startRunningSummarizer(
+							undefined /* disableHeuristics */,
+							async () => {
+								if (currentStage === "submit") {
+									return successfulSubmitSummary();
+								} else {
+									const error = new RetriableSummaryError(
+										`Fail summarization at ${currentStage}`,
+										retryAfterSeconds,
+									);
+									const failedResult: Partial<SubmitSummaryResult> = {
+										stage: currentStage,
+										referenceSequenceNumber: lastRefSeq,
+										minimumSequenceNumber: 0,
+										error,
+									};
+									return failedResult as SubmitSummaryResult;
+								}
+							},
+						);
+
+						await emitNextOp();
+						// This should run a summarization because max ops has reached.
+						await emitNextOp(summaryConfig.maxOps);
+
+						for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber++) {
+							await validateSummaryAttemptFails(
+								attemptNumber,
+								maxAttempts,
+								currentStage,
+								retryAfterSeconds,
+							);
+
+							// Change the failure stage after 2 attempts.
+							if (attemptNumber === 2) {
+								currentStage = getNewStage();
+							}
+
+							// Wait for "retryAfterSeconds". The next attempt should start after this.
+							await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+						}
+
+						// Validate summarization is not run again.
+						assertRunCounts(
+							maxAttempts,
+							0,
+							0,
+							`Summarization should not have been attempted more than ${maxAttempts} times`,
+							1 /** expectedStopCount */,
+						);
+					});
+
+					it(`should update max attempts on failure at ${titleStage} stage as per AttemptsForSubmitFailures`, async () => {
+						const retryAfterSeconds = 5;
+						const maxAttemptsOverride =
+							stage === "submit"
+								? defaultMaxAttempts
+								: defaultMaxAttemptsForSubmitFailures - 1;
+						settings["Fluid.Summarizer.AttemptsForSubmitFailures"] =
+							maxAttemptsOverride;
+
+						await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
+							submitSummaryCallback(stage, retryAfterSeconds),
+						);
+
+						await emitNextOp();
+						// This should run a summarization because max ops has reached.
+						await emitNextOp(summaryConfig.maxOps);
+
+						for (
+							let attemptNumber = 1;
+							attemptNumber <= maxAttemptsOverride;
+							attemptNumber++
+						) {
+							await validateSummaryAttemptFails(
+								attemptNumber,
+								maxAttemptsOverride,
+								stage,
+								retryAfterSeconds,
+							);
+							// Wait for "retryAfterSeconds". The next attempt should start after this.
+							await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+						}
+
+						// validate that summarization is not run again.
+						assertRunCounts(
+							maxAttemptsOverride,
+							0,
+							0,
+							`Summarization should not have been attempted more than ${maxAttemptsOverride} times`,
+							1 /** expectedStopCount */,
+						);
+					});
+				}
+
+				it(`should attempt max ${defaultMaxAttempts} times on failure when stage changes to nack`, async () => {
+					const retryAfterSeconds = 5;
+					let currentStage: SummaryStage = "generate";
+
+					await startRunningSummarizer(undefined /* disableHeuristics */, async () => {
+						if (currentStage === "submit") {
+							return successfulSubmitSummary();
+						} else {
+							const error = new RetriableSummaryError(
+								`Fail summarization at ${currentStage}`,
+								retryAfterSeconds,
+							);
+							const failedResult: Partial<SubmitSummaryResult> = {
+								stage: currentStage,
+								referenceSequenceNumber: lastRefSeq,
+								minimumSequenceNumber: 0,
+								error,
+							};
+							return failedResult as SubmitSummaryResult;
+						}
+					});
+
+					await emitNextOp();
+					// This should run a summarization because max ops has reached.
+					await emitNextOp(summaryConfig.maxOps);
+
+					const maxAttempts = defaultMaxAttempts;
+					for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber++) {
+						await validateSummaryAttemptFails(
+							attemptNumber,
+							maxAttempts,
+							currentStage,
+							retryAfterSeconds,
+						);
+
+						// Change the failure stage to submit after 1 attempt. This should trigger a failure with nack
+						// which would be attempted once more.
+						if (attemptNumber === 1) {
+							currentStage = "submit";
+						}
+
+						// Wait for "retryAfterSeconds". The next attempt should start after this.
+						await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+					}
+
+					// Validate summarization is not run again.
+					assertRunCounts(
+						maxAttempts,
+						0,
+						0,
+						`Summarization should not have been attempted more than ${maxAttempts} times`,
+						1 /** expectedStopCount */,
+					);
+				});
+
+				it(`should change max attempts to ${defaultMaxAttempts} times on failure when stage changes to nack`, async () => {
+					const retryAfterSeconds = 5;
+					let currentStage: SummaryStage = "generate";
+
+					await startRunningSummarizer(undefined /* disableHeuristics */, async () => {
+						if (currentStage === "submit") {
+							return successfulSubmitSummary();
+						} else {
+							const error = new RetriableSummaryError(
+								`Fail summarization at ${currentStage}`,
+								retryAfterSeconds,
+							);
+							const failedResult: Partial<SubmitSummaryResult> = {
+								stage: currentStage,
+								referenceSequenceNumber: lastRefSeq,
+								minimumSequenceNumber: 0,
+								error,
+							};
+							return failedResult as SubmitSummaryResult;
+						}
+					});
+
+					// Fail at the "generate" stage 2 times.
+					await emitNextOp();
+					// This should run a summarization because max ops has reached.
+					await emitNextOp(summaryConfig.maxOps);
+					let maxAttempts = defaultMaxAttemptsForSubmitFailures;
+					let attemptNumber = 1;
+					await validateSummaryAttemptFails(
+						attemptNumber++,
+						maxAttempts,
+						currentStage,
+						retryAfterSeconds,
+					);
+
+					// Wait for "retryAfterSeconds". The next attempt should start after this.
+					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+					await validateSummaryAttemptFails(
+						attemptNumber++,
+						maxAttempts,
+						currentStage,
+						retryAfterSeconds,
+					);
+
+					// In the third attempt, fail at "submit" stage. This will trigger a nack failure. It should
+					// not retry attempts anymore because "defaultMaxAttempts" attempts have already been done.
+					currentStage = "submit";
+					maxAttempts = attemptNumber;
+
+					// Wait for "retryAfterSeconds". The next attempt should start after this.
+					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+
+					await validateSummaryAttemptFails(
+						attemptNumber,
+						maxAttempts,
+						currentStage,
+						retryAfterSeconds,
+					);
+
+					// Wait for "retryAfterSeconds". There shouldn't be any more attempts.
+					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+
+					// Validate summarization is not run again.
+					assertRunCounts(
+						maxAttempts,
+						0,
+						0,
+						`Summarization should not have been attempted more than ${maxAttempts} times`,
+						1 /** expectedStopCount */,
+					);
+				});
+
+				it("Should not retry last summary", async () => {
+					const stage: SummaryStage = "base";
+					const retryAfterSeconds = 10;
+					await startRunningSummarizer(undefined /* disableHeuristics */, async () =>
+						submitSummaryCallback(stage, retryAfterSeconds),
+					);
+
+					// This should trigger last summary when summarizer stops.
+					await emitNextOp(summaryConfig.minOpsForLastSummaryAttempt);
+					const stopP = summarizer.waitStop(true /* allowLastSummary */);
+					await flushPromises();
+					await stopP;
+					summarizer.dispose();
+
+					assertRunCounts(1, 0, 0, "should perform lastSummary");
+					const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [
+						{
+							eventName: "Running:Summarize_cancel",
+							retryAfterSeconds,
+							summarizeCount: 1,
+							stage,
+						},
+					];
+					mockLogger.assertMatch(
+						expectedEvents,
+						`last summary attempt did not fail as expected`,
+					);
+
+					// Wait for "retryAfterSeconds". There shouldn't be any more attempts.
+					await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+					assertRunCounts(1, 0, 0, "should not retry lastSummary");
 				});
 			});
 

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -47,7 +47,6 @@
 		"test:realsvc:run": "mocha dist/test --config src/test/.mocharc.cjs --exclude dist/test/benchmark/**/* --verbose",
 		"test:realsvc:t9s": "start-server-and-test start:tinylicious:test 7070 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious": "npm run test:realsvc:t9s",
-		"test:realsvc:tinylicious:full": "cross-env FLUID_TEST_VERBOSE=1 fluid__test__backCompat=FULL npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report:full": "cross-env FLUID_TEST_MULTIREPORT=1 fluid__test__backCompat=FULL npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s --timeout=5s",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -47,6 +47,7 @@
 		"test:realsvc:run": "mocha dist/test --config src/test/.mocharc.cjs --exclude dist/test/benchmark/**/* --verbose",
 		"test:realsvc:t9s": "start-server-and-test start:tinylicious:test 7070 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious": "npm run test:realsvc:t9s",
+		"test:realsvc:tinylicious:full": "cross-env FLUID_TEST_VERBOSE=1 fluid__test__backCompat=FULL npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report:full": "cross-env FLUID_TEST_MULTIREPORT=1 fluid__test__backCompat=FULL npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s --timeout=5s",

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -197,7 +197,7 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 	});
 
 	itExpects(
-		"with ValidateSummaryBeforeUpload true, summary should fail before generate stage when data store is created during summarize",
+		"ValidateSummaryBeforeUpload = true. Summary should fail before generate stage when data store is created during summarize",
 		[
 			{
 				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
@@ -231,7 +231,7 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 	);
 
 	itExpects(
-		"with ValidateSummaryBeforeUpload false, summary should fail after upload when data store is created during summarize",
+		"ValidateSummaryBeforeUpload = false. Summary should fail after upload when data store is created during summarize",
 		[
 			{
 				eventName: "fluid:telemetry:SummarizerNode:NodeDidNotRunGC",
@@ -271,89 +271,99 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 		},
 	);
 
-	/**
-	 * This test results in gcUnknownOutboundReferences error - A data store is created in summarizer and its handle
-	 * is stored in the root data store's DDS. This results in a reference to the new data store but it is not
-	 * explicitly notified to GC. The notification to GC happens when op containing handle is processed and the
-	 * handle is parsed in remote clients. Local clients do not parse handle as its not serialized in it.
-	 */
-	itExpects(
-		"with ValidateSummaryBeforeUpload true, heuristic based summaries should pass on retry when NodeDidNotRunGC is hit",
-		[
-			{
-				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-				clientType: "noninteractive/summarizer",
-				error: "NodeDidNotRunGC",
-			},
-			{
-				eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences",
-				clientType: "noninteractive/summarizer",
-			},
-		],
-		async () => {
-			settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
-			const logger = new MockLogger();
-			const mainContainer = await createContainer(
-				provider,
-				false /* disableSummary */,
-				logger,
-			);
-			const rootDataObject = await requestFluidObject<RootTestDataObject>(mainContainer, "/");
-			const dataObject = await dataStoreFactory1.createInstance(
-				rootDataObject.containerRuntime,
-			);
-			rootDataObject._root.set("store", dataObject.handle);
-			await waitForContainerConnection(mainContainer);
-
-			const summarySucceeded = await timeoutAwait(waitForSummaryOp(mainContainer), {
-				errorMsg: "Timeout on waiting for summary op",
-			});
-			assert(summarySucceeded === true, "Summary should have been successful");
-
-			// The sequence of events that should happen:
-			// 1. First summarize attempt starts for the first phase, i.e., summarizeAttemptPerPhase = 1.
-			// 2. Data store is created in summarizer.
-			// 3. Summarize cancels with NodeDidNotRunGC error.
-			// 4. Second summarize attempts starts for the first phase, i.e., summarizeAttemptPerPhase = 2.
-			// 5. Summary is successfully generated.
-			const clientType = "noninteractive/summarizer";
-			const expectedEventsInSequence: Omit<ITelemetryBaseEvent, "category">[] = [
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_start",
-					clientType,
-					summaryAttemptPhase: 1,
-					summaryAttempts: 1,
-					summaryAttemptsPerPhase: 1,
-				},
-				{
-					eventName: "fluid:telemetry:FluidDataStoreContext:DataStoreCreatedInSummarizer",
-					clientType,
-				},
+	const dynamicSummarizationRetries = [true, false];
+	for (const tryDynamicRetry of dynamicSummarizationRetries) {
+		/**
+		 * This test results in gcUnknownOutboundReferences error - A data store is created in summarizer and its handle
+		 * is stored in the root data store's DDS. This results in a reference to the new data store but it is not
+		 * explicitly notified to GC. The notification to GC happens when op containing handle is processed and the
+		 * handle is parsed in remote clients. Local clients do not parse handle as its not serialized in it.
+		 */
+		itExpects(
+			`ValidateSummaryBeforeUpload = true. TryDynamicRetires = ${tryDynamicRetry}. ` +
+				`Heuristic based summaries should pass on retry when NodeDidNotRunGC is hit`,
+			[
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-					clientType,
+					clientType: "noninteractive/summarizer",
 					error: "NodeDidNotRunGC",
-					summaryAttemptPhase: 1,
-					summaryAttempts: 1,
-					summaryAttemptsPerPhase: 1,
 				},
 				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_start",
-					clientType,
-					summaryAttemptPhase: 1,
-					summaryAttempts: 2,
-					summaryAttemptsPerPhase: 2,
+					eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences",
+					clientType: "noninteractive/summarizer",
 				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_generate",
-					clientType,
-					summaryAttemptPhase: 1,
-					summaryAttempts: 2,
-					summaryAttemptsPerPhase: 2,
-				},
-			];
+			],
+			async () => {
+				settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
+				settings["Fluid.Summarizer.TryDynamicRetries"] = tryDynamicRetry;
+				const logger = new MockLogger();
+				const mainContainer = await createContainer(
+					provider,
+					false /* disableSummary */,
+					logger,
+				);
+				const rootDataObject = await requestFluidObject<RootTestDataObject>(
+					mainContainer,
+					"/",
+				);
+				const dataObject = await dataStoreFactory1.createInstance(
+					rootDataObject.containerRuntime,
+				);
+				rootDataObject._root.set("store", dataObject.handle);
+				await waitForContainerConnection(mainContainer);
 
-			logger.assertMatch(expectedEventsInSequence, "Unexpected sequence of events");
-		},
-	);
+				const summarySucceeded = await timeoutAwait(waitForSummaryOp(mainContainer), {
+					errorMsg: "Timeout on waiting for summary op",
+				});
+				assert(summarySucceeded === true, "Summary should have been successful");
+
+				// The sequence of events that should happen:
+				// 1. First summarize attempt starts, i.e., summaryAttempts = 1.
+				// 2. Data store is created in summarizer.
+				// 3. Summarize cancels with NodeDidNotRunGC error.
+				// 4. Second summarize attempts starts, i.e., summaryAttempts = 2.
+				// 5. Summary is successfully generated.
+				const clientType = "noninteractive/summarizer";
+				// Note: summaryAttemptPhase and summaryAttemptsPerPhase are not logged with dynamic retries.
+				const expectedEventsInSequence: Omit<ITelemetryBaseEvent, "category">[] = [
+					{
+						eventName: "fluid:telemetry:Summarizer:Running:Summarize_start",
+						clientType,
+						summaryAttempts: 1,
+						summaryAttemptPhase: tryDynamicRetry ? undefined : 1,
+						summaryAttemptsPerPhase: tryDynamicRetry ? undefined : 1,
+					},
+					{
+						eventName:
+							"fluid:telemetry:FluidDataStoreContext:DataStoreCreatedInSummarizer",
+						clientType,
+					},
+					{
+						eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+						clientType,
+						error: "NodeDidNotRunGC",
+						summaryAttempts: 1,
+						summaryAttemptPhase: tryDynamicRetry ? undefined : 1,
+						summaryAttemptsPerPhase: tryDynamicRetry ? undefined : 1,
+					},
+					{
+						eventName: "fluid:telemetry:Summarizer:Running:Summarize_start",
+						clientType,
+						summaryAttempts: 2,
+						summaryAttemptPhase: tryDynamicRetry ? undefined : 1,
+						summaryAttemptsPerPhase: tryDynamicRetry ? undefined : 2,
+					},
+					{
+						eventName: "fluid:telemetry:Summarizer:Running:Summarize_generate",
+						clientType,
+						summaryAttempts: 2,
+						summaryAttemptPhase: tryDynamicRetry ? undefined : 1,
+						summaryAttemptsPerPhase: tryDynamicRetry ? undefined : 2,
+					},
+				];
+
+				logger.assertMatch(expectedEventsInSequence, "Unexpected sequence of events");
+			},
+		);
+	}
 });

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -27,18 +27,21 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					}
 				}
 			},
@@ -68,7 +71,8 @@
 			"optionOverrides": {
 				"routerlicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					}
 				}
 			}


### PR DESCRIPTION
## Reviewer Guidance
This change was merged before via #16694 but it introduced a regression and was backed out. This change fixed the bug and updated tests to ensure that the bug does not happen again.
The regressions was that after attempting summarization in `RunningSummarize::trySummarize`, it always called `this.stopSummarizerCallback` instead of only doing it for failures.

The CI pipeline passes with this - https://dev.azure.com/fluidframework/internal/_build/results?buildId=183045&view=results

## Current retry logic
Currently, summarization retries are done statically:
- Two attempts are done with different params.
- In the second attempt, refreshFromLatest option is true meaning that the latest snapshot is downloaded, summary state updated from it before attempting summarization .
- In addition, if there is a server error with retryAfterSeconds param set, that particular attempt is tried again once.
- So, in total summarization can be tried max 4 times - two attempts with a retry possible in each attempt.

Note: The second attempt will always fail because of the recent changes where if refreshFromLatest option is set, container runtime closes the summarizer instead.

## New retry logic
This PR adds new retry logic which is based on the failure params received from a summarization attempt. The retry logic is in RunningSummarizer. Here is how it works:

- Summarization attempts will only be retried if the failure params has retryAfterSeconds set.
- If summarization fails before it is submitted, summarization will be retried 4 times (5 total attempts).
    - The total attempts can be overridden via a feature flag. The idea is to look at telemetry and tweak it until we can determine a stable value.
- If summarization fails after it is submitted, summarization will be retried 1 time (2 total attempts). This only happens today when summary is nacked by server with retryAfterSeconds set.

The idea behind this approach is that some kind of failures are intermittent and can go away after retries. The failure site is the best place to know which failures can be retried and how many times before giving up. For example, when summarizer node validation fails because GC did not run on a given node, this failure is transient and a retry will most likely fix it and so, it sets retryAfterSeconds. Other failues such as registry not found for a package won't be fixed on retry so these properties are not set on the error.

[AB#4708](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4708)
[AB#5199](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5199)