### PR TITLE
Rename reason to summarizeReason so that it is not overwritten on summarize failure

### DIFF
--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -454,7 +454,7 @@ export class RunningSummarizer implements IDisposable {
 			if (this.summarizingLock === undefined) {
 				this.trySummarizeOnce(
 					// summarizeProps
-					{ reason: "lastSummary" },
+					{ summarizeReason: "lastSummary" },
 					// ISummarizeOptions, using defaults: { refreshLatestAck: false, fullTree: false }
 					{},
 				);
@@ -637,7 +637,7 @@ export class RunningSummarizer implements IDisposable {
 
 			const summarizeOptions = attempts[summaryAttemptPhase];
 			const summarizeProps: ISummarizeTelemetryProperties = {
-				reason,
+				summarizeReason: reason,
 				summaryAttempts,
 				summaryAttemptsPerPhase,
 				summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
@@ -712,7 +712,7 @@ export class RunningSummarizer implements IDisposable {
 				fullTree: false,
 			};
 			const summarizeProps: ISummarizeTelemetryProperties = {
-				reason,
+				summarizeReason: reason,
 				summaryAttempts: currentAttempt,
 				...summarizeOptions,
 			};
@@ -786,7 +786,7 @@ export class RunningSummarizer implements IDisposable {
 		}
 
 		const result = this.trySummarizeOnce(
-			{ reason: `onDemand/${reason}` },
+			{ summarizeReason: `onDemand/${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,
@@ -849,7 +849,7 @@ export class RunningSummarizer implements IDisposable {
 		// Set to undefined first, so that subsequent enqueue attempt while summarize will occur later.
 		this.enqueuedSummary = undefined;
 		this.trySummarizeOnce(
-			{ reason: `enqueuedSummary/${reason}` },
+			{ summarizeReason: `enqueuedSummary/${reason}` },
 			options,
 			this.cancellationToken,
 			resultsBuilder,

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -442,7 +442,7 @@ export interface ISummarizeHeuristicRunner {
 
 type ISummarizeTelemetryRequiredProperties =
 	/** Reason code for attempting to summarize */
-	"reason";
+	"summarizeReason";
 
 type ISummarizeTelemetryOptionalProperties =
 	/** Number of attempts within the last time window, used for calculating the throttle delay. */

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -1205,13 +1205,17 @@ describe("Runtime", () => {
 			});
 
 			describe("On-demand Summaries", () => {
+				const reason = "test";
+				// This is used to validate the summarizeReason property in telemetry.
+				const summarizeReason = `onDemand/${reason}`;
+
 				beforeEach(async () => {
 					await startRunningSummarizer();
 				});
 
 				it("Should create an on-demand summary", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason: "test" });
+					const result = summarizer.summarizeOnDemand(undefined, { reason });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1248,8 +1252,16 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
-							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
+							{
+								eventName: "Running:Summarize_generate",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
+							{
+								eventName: "Running:Summarize_Op",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
 						]),
 						"unexpected log sequence",
 					);
@@ -1278,7 +1290,7 @@ describe("Runtime", () => {
 
 					let resolved = false;
 					try {
-						summarizer.summarizeOnDemand(undefined, { reason: "test" });
+						summarizer.summarizeOnDemand(undefined, { reason });
 						resolved = true;
 					} catch {}
 
@@ -1288,7 +1300,7 @@ describe("Runtime", () => {
 
 				it("On-demand summary should fail on nack", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason: "test" });
+					const result = summarizer.summarizeOnDemand(undefined, { reason });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1325,8 +1337,16 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
-							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
+							{
+								eventName: "Running:Summarize_generate",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
+							{
+								eventName: "Running:Summarize_Op",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
 						]),
 						"unexpected log sequence",
 					);
@@ -1435,6 +1455,10 @@ describe("Runtime", () => {
 			});
 
 			describe("Enqueue Summaries", () => {
+				const reason = "test";
+				// This is used to validate the summarizeReason property in telemetry.
+				const summarizeReason = `enqueuedSummary/enqueue;${reason}`;
+
 				beforeEach(async () => {
 					await startRunningSummarizer();
 				});
@@ -1443,7 +1467,7 @@ describe("Runtime", () => {
 					await emitNextOp(2); // set ref seq to 2
 					const afterSequenceNumber = 9;
 					const result = summarizer.enqueueSummarize({
-						reason: "test",
+						reason,
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1487,8 +1511,16 @@ describe("Runtime", () => {
 
 					assert(
 						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", summarizeCount: runCount },
-							{ eventName: "Running:Summarize_Op", summarizeCount: runCount },
+							{
+								eventName: "Running:Summarize_generate",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
+							{
+								eventName: "Running:Summarize_Op",
+								summarizeCount: runCount,
+								summarizeReason,
+							},
 						]),
 						"unexpected log sequence",
 					);
@@ -1518,7 +1550,7 @@ describe("Runtime", () => {
 					assertRunCounts(1, 0, 0);
 
 					const result = summarizer.enqueueSummarize({
-						reason: "test",
+						reason,
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1605,7 +1637,7 @@ describe("Runtime", () => {
 					await emitNextOp(2); // set ref seq to 2
 					const afterSequenceNumber = 9;
 					const result = summarizer.enqueueSummarize({
-						reason: "test",
+						reason,
 						afterSequenceNumber,
 					});
 					assert(result.alreadyEnqueued === undefined, "should not be already enqueued");
@@ -1759,7 +1791,7 @@ describe("Runtime", () => {
 								eventName: "Running:Summarize_end",
 								summarizeCount: runCount,
 								summarizerSuccessfulAttempts: runCount,
-								reason: "maxOps",
+								summarizeReason: "maxOps",
 							},
 						]),
 						"unexpected log sequence 3",


### PR DESCRIPTION
## Reviewer guidance
This change was merged before via #16828 but tinylicious tests were timing out. The reason it is failing is because that change updated the summarize reason in `RunningSummarizer::summarizeOnDemand` from `onDemand/${reason}` to `onDemand;${reason}`. This PR reverses the changes to the reason strings but keeps the rename from `reason` to `summarizeReason`.
The CI pipeline passes with this - https://dev.azure.com/fluidframework/internal/_build/results?buildId=183062&view=results

## Description
The `reason` for summarization is overwritten by [this code](https://github.com/microsoft/FluidFramework/blob/277f5b8e89b4c0c3dcdac95fe4b5c7063cfdb870/packages/runtime/container-runtime/src/summary/summaryGenerator.ts#L293) if summarization fails. This means that the `Summarizer_cancel` event will not have the reason for summarization. It would be helpful to know the reason for the summarization that fails.

This PR renames the summarize reason to `summarizeReason` instead of just `reason` which is generic and can be overwritten.