### PR TITLE
Move ChangesetLocalId and ChangeAtomId

### DIFF
--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -137,6 +137,8 @@ export {
 	isRevisionTag,
 	RevisionTag,
 	RevisionTagSchema,
+	ChangesetLocalId,
+	ChangeAtomId,
 	TaggedChange,
 	makeAnonChange,
 	tagChange,

--- a/experimental/dds/tree2/src/core/rebase/index.ts
+++ b/experimental/dds/tree2/src/core/rebase/index.ts
@@ -11,6 +11,8 @@ export {
 	GraphCommit,
 	RevisionTag,
 	RevisionTagSchema,
+	ChangesetLocalId,
+	ChangeAtomId,
 	SessionId,
 	SessionIdSchema,
 } from "./types";

--- a/experimental/dds/tree2/src/core/rebase/types.ts
+++ b/experimental/dds/tree2/src/core/rebase/types.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { isStableId } from "@fluidframework/container-runtime";
 import { StableId } from "@fluidframework/runtime-definitions";
-import { brandedStringType, generateStableId } from "../../util";
+import { Brand, brandedStringType, generateStableId } from "../../util";
 import { ReadonlyRepairDataStore } from "../repair";
 
 /**
@@ -23,6 +23,33 @@ export const SessionIdSchema = brandedStringType<SessionId>();
 // TODO: These can be compressed by an `IdCompressor` in the future
 export type RevisionTag = StableId;
 export const RevisionTagSchema = brandedStringType<StableId>();
+
+/**
+ * An ID which is unique within a revision of a `ModularChangeset`.
+ * A `ModularChangeset` which is a composition of multiple revisions may contain duplicate `ChangesetLocalId`s,
+ * but they are unique when qualified by the revision of the change they are used in.
+ * @alpha
+ */
+export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
+
+/**
+ * A globally unique ID for an atom of change, or a node associated with the atom of change.
+ * @alpha
+ *
+ * @privateRemarks
+ * TODO: Rename this to be more general.
+ */
+export interface ChangeAtomId {
+	/**
+	 * Uniquely identifies the changeset within which the change was made.
+	 * Only undefined when referring to an anonymous changesets.
+	 */
+	readonly revision?: RevisionTag;
+	/**
+	 * Uniquely identifies, in the scope of the changeset, the change made to the field.
+	 */
+	readonly localId: ChangesetLocalId;
+}
 
 /**
  * @returns a `RevisionTag` from the given string, or fails if the string is not a valid `RevisionTag`

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldChangeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldChangeTypes.ts
@@ -3,8 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { ITreeCursorSynchronous, JsonableTree, RevisionTag } from "../../core";
-import { ChangeAtomId, ChangesetLocalId, NodeChangeset } from "../modular-schema";
+import {
+	ChangeAtomId,
+	ChangesetLocalId,
+	ITreeCursorSynchronous,
+	JsonableTree,
+	RevisionTag,
+} from "../../core";
+import { NodeChangeset } from "../modular-schema";
 
 export type NodeUpdate =
 	| {

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldKinds.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldKinds.ts
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKindIdentifier, Delta, ITreeCursor, forbiddenFieldKindIdentifier } from "../../core";
+import {
+	FieldKindIdentifier,
+	Delta,
+	ITreeCursor,
+	forbiddenFieldKindIdentifier,
+	ChangesetLocalId,
+} from "../../core";
 import { fail } from "../../util";
 import {
 	FieldKind,
@@ -13,7 +19,6 @@ import {
 	FieldChangeHandler,
 	FieldEditor,
 	referenceFreeFieldChangeRebaser,
-	ChangesetLocalId,
 	BrandedFieldKind,
 	brandedFieldKind,
 } from "../modular-schema";

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
@@ -4,7 +4,14 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { Delta, ITreeCursor, TaggedChange, ITreeCursorSynchronous, tagChange } from "../../core";
+import {
+	Delta,
+	ITreeCursor,
+	TaggedChange,
+	ITreeCursorSynchronous,
+	tagChange,
+	ChangesetLocalId,
+} from "../../core";
 import { fail, Mutable } from "../../util";
 import { singleTextCursor, jsonableTreeFromCursor } from "../treeTextCursor";
 import {
@@ -21,7 +28,6 @@ import {
 	RevisionMetadataSource,
 	getIntention,
 	NodeExistenceState,
-	ChangesetLocalId,
 	FieldChangeHandler,
 } from "../modular-schema";
 import { populateChildModifications } from "../deltaUtils";

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -97,7 +97,6 @@ import * as SequenceField from "./sequence-field";
 export { SequenceField };
 
 export {
-	ChangesetLocalId,
 	idAllocatorFromMaxId,
 	isNeverField,
 	ModularEditBuilder,
@@ -137,7 +136,6 @@ export {
 	NodeExistsConstraint,
 	NodeExistenceState,
 	BrandedFieldKind,
-	ChangeAtomId,
 } from "./modular-schema";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/crossFieldQueries.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/crossFieldQueries.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { RevisionTag } from "../../core";
+import { ChangesetLocalId, RevisionTag } from "../../core";
 import {
 	RangeEntry,
 	RangeMap,
@@ -14,7 +14,6 @@ import {
 	setInRangeMap,
 } from "../../util";
 import { IdAllocator } from "./fieldChangeHandler";
-import { ChangesetLocalId } from "./modularChangeTypes";
 
 export type CrossFieldMap<T> = Map<RevisionTag | undefined, RangeMap<T>>;
 export type CrossFieldQuerySet = CrossFieldMap<boolean>;

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { Delta, TaggedChange, RevisionTag } from "../../core";
+import { Delta, TaggedChange, RevisionTag, ChangesetLocalId } from "../../core";
 import { fail, Invariant } from "../../util";
 import { ICodecFamily, IJsonCodec } from "../../codec";
 import { CrossFieldManager } from "./crossFieldQueries";
-import { ChangesetLocalId, NodeChangeset, RevisionInfo } from "./modularChangeTypes";
+import { NodeChangeset, RevisionInfo } from "./modularChangeTypes";
 
 /**
  * Functionality provided by a field kind which will be composed with other `FieldChangeHandler`s to

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/index.ts
@@ -20,7 +20,6 @@ export {
 	idAllocatorFromMaxId,
 	setInCrossFieldMap,
 } from "./crossFieldQueries";
-export { ChangesetLocalId, ChangeAtomId } from "./modularChangeTypes";
 export { ChangesetLocalIdSchema, EncodedChangeAtomId } from "./modularChangeFormat";
 export {
 	FieldKind,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -21,6 +21,7 @@ import {
 	makeAnonChange,
 	ChangeFamilyEditor,
 	FieldUpPath,
+	ChangesetLocalId,
 } from "../../core";
 import { brand, getOrAddEmptyToMap, Mutable } from "../../util";
 import { dummyRepairDataStore } from "../fakeRepairDataStore";
@@ -47,7 +48,6 @@ import { convertGenericChange, genericFieldKind, newGenericChangeset } from "./g
 import { GenericChangeset } from "./genericFieldKindTypes";
 import { makeModularChangeCodecFamily } from "./modularChangeCodecs";
 import {
-	ChangesetLocalId,
 	FieldChange,
 	FieldChangeMap,
 	FieldChangeset,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFormat.ts
@@ -4,13 +4,17 @@
  */
 
 import { ObjectOptions, Static, Type } from "@sinclair/typebox";
-import { FieldKindIdentifierSchema, FieldKeySchema, RevisionTagSchema } from "../../core";
+import {
+	FieldKindIdentifierSchema,
+	FieldKeySchema,
+	RevisionTagSchema,
+	ChangesetLocalId,
+} from "../../core";
 import {
 	brandedNumberType,
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnlySchema,
 } from "../../util";
-import { ChangesetLocalId } from "./modularChangeTypes";
 
 const noAdditionalProps: ObjectOptions = { additionalProperties: false };
 

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeTypes.ts
@@ -3,32 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKey, FieldKindIdentifier, RevisionTag } from "../../core";
+import { ChangesetLocalId, FieldKey, FieldKindIdentifier, RevisionTag } from "../../core";
 import { Brand } from "../../util";
-
-/**
- * An ID which is unique within a revision of a `ModularChangeset`.
- * A `ModularChangeset` which is a composition of multiple revisions may contain duplicate `ChangesetLocalId`s,
- * but they are unique when qualified by the revision of the change they are used in.
- * @alpha
- */
-export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
-
-/**
- * A globally unique ID for an atom of change, or a node associated with the atom of change.
- * @alpha
- */
-export interface ChangeAtomId {
-	/**
-	 * Uniquely identifies the changeset within which the change was made.
-	 * Only undefined when referring to an anonymous changesets.
-	 */
-	readonly revision?: RevisionTag;
-	/**
-	 * Uniquely identifies, in the scope of the changeset, the change made to the field.
-	 */
-	readonly localId: ChangesetLocalId;
-}
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -4,10 +4,9 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { makeAnonChange, RevisionTag, tagChange, TaggedChange } from "../../core";
+import { ChangeAtomId, makeAnonChange, RevisionTag, tagChange, TaggedChange } from "../../core";
 import { asMutable, brand, fail } from "../../util";
 import {
-	ChangeAtomId,
 	CrossFieldManager,
 	CrossFieldTarget,
 	getIntention,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -4,14 +4,15 @@
  */
 
 import { ObjectOptions, TSchema, Type } from "@sinclair/typebox";
-import { ITreeCursorSynchronous, JsonableTree, RevisionTag, RevisionTagSchema } from "../../core";
 import {
 	ChangeAtomId,
 	ChangesetLocalId,
-	ChangesetLocalIdSchema,
-	EncodedChangeAtomId,
-	NodeChangeset,
-} from "../modular-schema";
+	ITreeCursorSynchronous,
+	JsonableTree,
+	RevisionTag,
+	RevisionTagSchema,
+} from "../../core";
+import { ChangesetLocalIdSchema, EncodedChangeAtomId, NodeChangeset } from "../modular-schema";
 
 // TODO:AB#4259 Decouple types used for sequence-field's in-memory representation from their encoded variants.
 // Currently, types in this file are largely used for both.

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -4,15 +4,9 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { RevisionTag, TaggedChange } from "../../core";
+import { ChangeAtomId, RevisionTag, TaggedChange } from "../../core";
 import { fail } from "../../util";
-import {
-	ChangeAtomId,
-	CrossFieldManager,
-	CrossFieldTarget,
-	IdAllocator,
-	NodeReviver,
-} from "../modular-schema";
+import { CrossFieldManager, CrossFieldTarget, IdAllocator, NodeReviver } from "../modular-schema";
 import { Changeset, Mark, MarkList, ReturnFrom, NoopMarkType, MoveOut, NoopMark } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -6,9 +6,8 @@
 import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { StableId } from "@fluidframework/runtime-definitions";
 import { fail } from "../../util";
-import { RevisionTag, TaggedChange } from "../../core";
+import { ChangesetLocalId, RevisionTag, TaggedChange } from "../../core";
 import {
-	ChangesetLocalId,
 	CrossFieldManager,
 	CrossFieldTarget,
 	IdAllocator,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -5,8 +5,8 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { jsonableTreeFromCursor } from "../treeTextCursor";
-import { ITreeCursor } from "../../core";
-import { ChangesetLocalId, FieldEditor, NodeReviver } from "../modular-schema";
+import { ChangesetLocalId, ITreeCursor } from "../../core";
+import { FieldEditor, NodeReviver } from "../modular-schema";
 import { brand } from "../../util";
 import {
 	CellId,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -4,12 +4,10 @@
  */
 
 import { assert, unreachableCase } from "@fluidframework/common-utils";
-import { RevisionTag, TaggedChange } from "../../core";
+import { ChangeAtomId, ChangesetLocalId, RevisionTag, TaggedChange } from "../../core";
 import { brand, fail, getFirstFromRangeMap, getOrAddEmptyToMap, RangeMap } from "../../util";
 import {
 	addCrossFieldQuery,
-	ChangeAtomId,
-	ChangesetLocalId,
 	CrossFieldManager,
 	CrossFieldQuerySet,
 	CrossFieldTarget,

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -57,6 +57,7 @@ export {
 	SchemaData,
 	FieldAnchor,
 	RevisionTag,
+	ChangesetLocalId,
 	TaggedChange,
 	RepairDataStore,
 	ReadonlyRepairDataStore,
@@ -124,7 +125,6 @@ export {
 
 export {
 	buildForest,
-	ChangesetLocalId,
 	IdAllocator,
 	ModularChangeset,
 	EditDescription,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -11,13 +11,13 @@ import {
 	TreeSchemaIdentifier,
 	mintRevisionTag,
 	tagRollbackInverse,
+	ChangesetLocalId,
+	ChangeAtomId,
 } from "../../../core";
-import { ChangesetLocalId, RevisionInfo, SequenceField as SF } from "../../../feature-libraries";
+import { RevisionInfo, SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { TestChange } from "../../testChange";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
-// eslint-disable-next-line import/no-internal-modules
-import { ChangeAtomId } from "../../../feature-libraries/modular-schema";
 import { cases, ChangeMaker as Change, MarkMaker as Mark } from "./testEdits";
 import { compose, composeNoVerify, shallowCompose } from "./utils";
 

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -4,11 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-import { mintRevisionTag, RevisionTag, tagChange } from "../../../core";
+import { ChangesetLocalId, mintRevisionTag, RevisionTag, tagChange } from "../../../core";
 import { TestChange } from "../../testChange";
 import { deepFreeze, fakeRepair } from "../../utils";
 import { brand } from "../../../util";
-import { ChangesetLocalId } from "../../../feature-libraries";
 import { composeAnonChanges, invert as invertChange } from "./utils";
 import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits";
 

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -4,8 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import { mintRevisionTag, RevisionTag, TreeSchemaIdentifier } from "../../../core";
-import { ChangesetLocalId, SequenceField as SF } from "../../../feature-libraries";
+import {
+	ChangesetLocalId,
+	mintRevisionTag,
+	RevisionTag,
+	TreeSchemaIdentifier,
+} from "../../../core";
+import { SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
 import { MarkMaker as Mark } from "./testEdits";

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -4,12 +4,9 @@
  */
 
 import { strict as assert } from "assert";
+import { SequenceField as SF, singleTextCursor } from "../../../feature-libraries";
 import {
 	ChangesetLocalId,
-	SequenceField as SF,
-	singleTextCursor,
-} from "../../../feature-libraries";
-import {
 	mintRevisionTag,
 	RevisionTag,
 	tagChange,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
@@ -5,11 +5,8 @@
 
 import { strict as assert } from "assert";
 import { jsonString } from "../../../domains";
-import {
-	ChangesetLocalId,
-	SequenceField as SF,
-	singleTextCursor,
-} from "../../../feature-libraries";
+import { ChangesetLocalId } from "../../../core";
+import { SequenceField as SF, singleTextCursor } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { deepFreeze } from "../../utils";
 import { TestChange } from "../../testChange";

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -11,9 +11,9 @@ import {
 	ITreeCursorSynchronous,
 	TreeSchemaIdentifier,
 	mintRevisionTag,
+	ChangesetLocalId,
 } from "../../../core";
 import {
-	ChangesetLocalId,
 	FieldChange,
 	FieldKinds,
 	NodeChangeset,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -3,14 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import {
-	ChangesetLocalId,
-	SequenceField as SF,
-	singleTextCursor,
-} from "../../../feature-libraries";
+import { SequenceField as SF, singleTextCursor } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
 import {
+	ChangeAtomId,
+	ChangesetLocalId,
 	ITreeCursorSynchronous,
 	JsonableTree,
 	mintRevisionTag,
@@ -18,8 +16,6 @@ import {
 	TreeSchemaIdentifier,
 } from "../../../core";
 import { TestChange } from "../../testChange";
-// eslint-disable-next-line import/no-internal-modules
-import { ChangeAtomId } from "../../../feature-libraries/modular-schema";
 import { composeAnonChanges, composeAnonChangesShallow } from "./utils";
 
 const type: TreeSchemaIdentifier = brand("Node");

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
@@ -5,14 +5,13 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-	ChangesetLocalId,
 	IdAllocator,
 	idAllocatorFromMaxId,
 	RevisionInfo,
 	revisionMetadataSourceFromInfo,
 	SequenceField as SF,
 } from "../../../feature-libraries";
-import { Delta, TaggedChange, makeAnonChange, tagChange } from "../../../core";
+import { ChangesetLocalId, Delta, TaggedChange, makeAnonChange, tagChange } from "../../../core";
 import { TestChange } from "../../testChange";
 import {
 	assertMarkListEqual,


### PR DESCRIPTION
## Description

Moves `ChangesetLocalId` and `ChangeAtomId` to the core package to be used for repair data.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).