### PR TITLE
Pass relevant override options for Container's detached/attach flow

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -6,6 +6,7 @@
 
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IAudienceOwner } from '@fluidframework/container-definitions';
+import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
 import { IContainer } from '@fluidframework/container-definitions';
 import { IDocumentAttributes } from '@fluidframework/protocol-definitions';
@@ -101,11 +102,17 @@ export interface IProtocolHandler extends IProtocolHandler_2 {
 export class Loader implements IHostLoader {
     constructor(loaderProps: ILoaderProps);
     // (undocumented)
-    createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer>;
+    createDetachedContainer(codeDetails: IFluidCodeDetails, createDetachedProps?: {
+        canReconnect?: boolean;
+        clientDetailsOverride?: IClientDetails;
+    }): Promise<IContainer>;
     // @deprecated (undocumented)
     get IFluidRouter(): IFluidRouter;
     // (undocumented)
-    rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
+    rehydrateDetachedContainerFromSnapshot(snapshot: string, createDetachedProps?: {
+        canReconnect?: boolean;
+        clientDetailsOverride?: IClientDetails;
+    }): Promise<IContainer>;
     // @deprecated (undocumented)
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -217,6 +217,10 @@ export interface IContainerCreateProps {
 	 */
 	readonly detachedBlobStorage?: IDetachedBlobStorage;
 
+	/**
+	 * Optional property for allowing the container to use a custom
+	 * protocol implementation for handling the quorum and/or the audience.
+	 */
 	readonly protocolHandlerBuilder?: ProtocolHandlerBuilder;
 }
 
@@ -1640,13 +1644,12 @@ export class Container
 				);
 				break;
 			case "sequenceNumber":
-				opsBeforeReturnP = this.attachDeltaManagerOpHandler(dmAttributes, "sequenceNumber");
-				break;
 			case "cached":
-				opsBeforeReturnP = this.attachDeltaManagerOpHandler(dmAttributes, "cached");
-				break;
 			case "all":
-				opsBeforeReturnP = this.attachDeltaManagerOpHandler(dmAttributes, "all");
+				opsBeforeReturnP = this.attachDeltaManagerOpHandler(
+					dmAttributes,
+					loadMode.opsBeforeReturn,
+				);
 				break;
 			default:
 				unreachableCase(loadMode.opsBeforeReturn);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1155,7 +1155,10 @@ export class Container
 		return JSON.stringify(combinedSummary);
 	}
 
-	public async attach(request: IRequest): Promise<void> {
+	public async attach(
+		request: IRequest,
+		attachProps?: { deltaConnection?: "none" | "delayed" },
+	): Promise<void> {
 		await PerformanceEvent.timedExecAsync(
 			this.mc.logger,
 			{ eventName: "Attach" },
@@ -1281,10 +1284,13 @@ export class Container
 					this.emit("attached");
 
 					if (!this.closed) {
-						this.resumeInternal({
-							fetchOpsFromStorage: false,
-							reason: { text: "createDetached" },
-						});
+						this.handleDeltaConnectionArg(
+							{
+								fetchOpsFromStorage: false,
+								reason: { text: "createDetached" },
+							},
+							attachProps?.deltaConnection,
+						);
 					}
 				} catch (error) {
 					// add resolved URL on error object so that host has the ability to find this document and delete it
@@ -1705,27 +1711,11 @@ export class Container
 				this._deltaManager.inbound.pause();
 			}
 
-			switch (loadMode.deltaConnection) {
-				case undefined:
-					if (pendingLocalState) {
-						// connect to delta stream now since we did not before
-						this.connectToDeltaStream(connectionArgs);
-					}
-				// intentional fallthrough
-				case "delayed":
-					assert(
-						this.inboundQueuePausedFromInit,
-						0x346 /* inboundQueuePausedFromInit should be true */,
-					);
-					this.inboundQueuePausedFromInit = false;
-					this._deltaManager.inbound.resume();
-					this._deltaManager.inboundSignal.resume();
-					break;
-				case "none":
-					break;
-				default:
-					unreachableCase(loadMode.deltaConnection);
-			}
+			this.handleDeltaConnectionArg(
+				connectionArgs,
+				loadMode.deltaConnection,
+				pendingLocalState !== undefined,
+			);
 		}
 
 		// If we have not yet reached `loadToSequenceNumber`, we will wait for ops to arrive until we reach it
@@ -2454,6 +2444,34 @@ export class Container
 			 * See https://dev.azure.com/fluidframework/internal/_workitems/edit/1246
 			 */
 			this.runtime.setConnectionState(state && !readonly, this.clientId);
+		}
+	}
+
+	private handleDeltaConnectionArg(
+		connectionArgs: IConnectionArgs,
+		deltaConnectionArg?: "none" | "delayed",
+		canConnect: boolean = true,
+	) {
+		switch (deltaConnectionArg) {
+			case undefined:
+				if (canConnect) {
+					// connect to delta stream now since we did not before
+					this.connectToDeltaStream(connectionArgs);
+				}
+			// intentional fallthrough
+			case "delayed":
+				assert(
+					this.inboundQueuePausedFromInit,
+					0x346 /* inboundQueuePausedFromInit should be true */,
+				);
+				this.inboundQueuePausedFromInit = false;
+				this._deltaManager.inbound.resume();
+				this._deltaManager.inboundSignal.resume();
+				break;
+			case "none":
+				break;
+			default:
+				unreachableCase(deltaConnectionArg);
 		}
 	}
 }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -357,8 +357,19 @@ export class Loader implements IHostLoader {
 		return this;
 	}
 
-	public async createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer> {
-		const container = await Container.createDetached(this.services, codeDetails);
+	public async createDetachedContainer(
+		codeDetails: IFluidCodeDetails,
+		containerCreateHeaders?: IRequestHeader,
+	): Promise<IContainer> {
+		// "this.services" doesn't contain property for clientDetailsOverride
+		const container = await Container.createDetached(
+			{
+				canReconnect: containerCreateHeaders?.[LoaderHeader.reconnect],
+				clientDetailsOverride: containerCreateHeaders?.[LoaderHeader.clientDetails],
+				...this.services,
+			},
+			codeDetails,
+		);
 
 		if (this.cachingEnabled) {
 			container.once("attached", () => {
@@ -373,8 +384,18 @@ export class Loader implements IHostLoader {
 		return container;
 	}
 
-	public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer> {
-		return Container.rehydrateDetachedFromSnapshot(this.services, snapshot);
+	public async rehydrateDetachedContainerFromSnapshot(
+		snapshot: string,
+		containerCreateHeaders?: IRequestHeader,
+	): Promise<IContainer> {
+		return Container.rehydrateDetachedFromSnapshot(
+			{
+				canReconnect: containerCreateHeaders?.[LoaderHeader.reconnect],
+				clientDetailsOverride: containerCreateHeaders?.[LoaderHeader.clientDetails],
+				...this.services,
+			},
+			snapshot,
+		);
 	}
 
 	public async resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer> {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -38,6 +38,7 @@ import {
 	IUrlResolver,
 } from "@fluidframework/driver-definitions";
 import { UsageError } from "@fluidframework/container-utils";
+import { IClientDetails } from "@fluidframework/protocol-definitions";
 import { Container, IPendingContainerState } from "./container";
 import { IParsedUrl, parseUrl } from "./utils";
 import { pkgVersion } from "./packageVersion";
@@ -359,13 +360,14 @@ export class Loader implements IHostLoader {
 
 	public async createDetachedContainer(
 		codeDetails: IFluidCodeDetails,
-		containerCreateHeaders?: IRequestHeader,
+		createDetachedProps?: {
+			canReconnect?: boolean;
+			clientDetailsOverride?: IClientDetails;
+		},
 	): Promise<IContainer> {
-		// "this.services" doesn't contain property for clientDetailsOverride
 		const container = await Container.createDetached(
 			{
-				canReconnect: containerCreateHeaders?.[LoaderHeader.reconnect],
-				clientDetailsOverride: containerCreateHeaders?.[LoaderHeader.clientDetails],
+				...createDetachedProps,
 				...this.services,
 			},
 			codeDetails,
@@ -386,12 +388,14 @@ export class Loader implements IHostLoader {
 
 	public async rehydrateDetachedContainerFromSnapshot(
 		snapshot: string,
-		containerCreateHeaders?: IRequestHeader,
+		createDetachedProps?: {
+			canReconnect?: boolean;
+			clientDetailsOverride?: IClientDetails;
+		},
 	): Promise<IContainer> {
 		return Container.rehydrateDetachedFromSnapshot(
 			{
-				canReconnect: containerCreateHeaders?.[LoaderHeader.reconnect],
-				clientDetailsOverride: containerCreateHeaders?.[LoaderHeader.clientDetails],
+				...createDetachedProps,
 				...this.services,
 			},
 			snapshot,


### PR DESCRIPTION
## Description

There is currently a gap in functionality when using the `load` flow vs the `createDetached` flow on the Container. For the `createDetached` flow, there was no way to provide override values for things like `canReconnect` and `clientDetailsOverride` on the `IContainerCreateProps` interface.

Now, the Loader's `createDetachedContainer(...)` and `rehydrateDetachedContainerFromSnapshot(...)` methods contain an optional props argument to pass in these values.

Also, for the `attach` method there was no way to configure connecting to the deltaConnect (normally done through the `LoaderHeader.loadMode` header in the `load` flow). Now, the Container's `attach(...)` method contains an optional props argument to pass in this values.

[AB#4958](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4958)