### PR TITLE
tree2: Assert lazyCursor is not freed

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/ProxyTarget.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/ProxyTarget.ts
@@ -56,7 +56,11 @@ export abstract class ProxyTarget<T extends Anchor | FieldAnchor> {
 	}
 
 	public get cursor(): ITreeSubscriptionCursor {
-		if (this.lazyCursor.state === ITreeSubscriptionCursorState.Cleared) {
+		if (this.lazyCursor.state !== ITreeSubscriptionCursorState.Current) {
+			assert(
+				this.lazyCursor.state === ITreeSubscriptionCursorState.Cleared,
+				"Unset cursor should be in cleared state",
+			);
 			assert(
 				this.anchor !== undefined,
 				0x3c3 /* EditableTree should have an anchor if it does not have a cursor */,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.binder.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.binder.spec.ts
@@ -37,7 +37,6 @@ import {
 	BindTree,
 	InvalidationBindingContext,
 	setField,
-	isEditableField,
 	isEditableTree,
 } from "../../../feature-libraries";
 import { brand } from "../../../util";

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.binder.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.binder.spec.ts
@@ -37,6 +37,8 @@ import {
 	BindTree,
 	InvalidationBindingContext,
 	setField,
+	isEditableField,
+	isEditableTree,
 } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { ISharedTreeView, SharedTreeFactory, ViewEvents } from "../../../shared-tree";
@@ -1189,7 +1191,7 @@ describe("editable-tree: data binder", () => {
 			assert.deepEqual(log, []);
 		});
 		it("registers to root, enables autoFlush, matches paths with subtree policy and any index. Triggers step === undefined in getListeners.accumulateMatching", () => {
-			const { tree, root, address } = retrieveNodes();
+			const { tree, root } = retrieveNodes();
 			const options: BinderOptions = createBinderOptions({
 				matchPolicy: "subtree",
 			});
@@ -1218,6 +1220,8 @@ describe("editable-tree: data binder", () => {
 				},
 			);
 			root[setField](fieldAddress, { zip: "33428", phones: ["12345"] });
+			const address = root.address;
+			assert(isEditableTree(address));
 			address[setField](fieldPhones, [111, 112]);
 			address.zip = "66566";
 			assert.deepEqual(addrLog, [


### PR DESCRIPTION
## Description

Detects some use after free bugs got EditableTree, including one test which needed an update.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

