### PR TITLE
feat: Telemetry logger for Fluid Devtools using public packages

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -68,7 +68,10 @@
 		"@fluentui/react": "^8.109.4",
 		"@fluid-experimental/devtools-core": "workspace:~",
 		"@fluid-experimental/devtools-view": "workspace:~",
+		"@fluidframework/common-definitions": "^0.20.1",
 		"@fluidframework/common-utils": "^1.1.1",
+		"@microsoft/oteljs": "^4.13.14",
+		"@microsoft/oteljs-1ds": "^4.13.14",
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1"
 	},

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -68,7 +68,6 @@
 		"@fluentui/react": "^8.109.4",
 		"@fluid-experimental/devtools-core": "workspace:~",
 		"@fluid-experimental/devtools-view": "workspace:~",
-		"@fluidframework/common-definitions": "^0.20.1",
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@microsoft/1ds-core-js": "^3.2.13",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -70,10 +70,12 @@
 		"@fluid-experimental/devtools-view": "workspace:~",
 		"@fluidframework/common-definitions": "^0.20.1",
 		"@fluidframework/common-utils": "^1.1.1",
-		"@microsoft/oteljs": "^4.13.14",
-		"@microsoft/oteljs-1ds": "^4.13.14",
+		"@fluidframework/core-interfaces": "workspace:~",
+		"@microsoft/1ds-core-js": "^3.2.13",
+		"@microsoft/1ds-post-js": "^3.2.13",
 		"react": "^17.0.1",
-		"react-dom": "^17.0.1"
+		"react-dom": "^17.0.1",
+		"tslib": "^1.10.0"
 	},
 	"devDependencies": {
 		"@fluid-example/example-utils": "workspace:~",
@@ -84,7 +86,6 @@
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",
-		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
@@ -10,6 +10,7 @@ import { DevtoolsPanel } from "@fluid-experimental/devtools-view";
 
 import { BackgroundConnection } from "./BackgroundConnection";
 import { formatDevtoolsScriptMessageForLogging } from "./Logging";
+import { DevtoolsOtelLogger } from "./TelemetryLogging";
 
 /**
  * Renders the Fluid Devtools view into the provided target element.
@@ -19,8 +20,15 @@ import { formatDevtoolsScriptMessageForLogging } from "./Logging";
 export async function initializeDevtoolsView(target: HTMLElement): Promise<void> {
 	const connection = await BackgroundConnection.Initialize();
 
+	const logger = new DevtoolsOtelLogger();
 	ReactDOM.render(
-		React.createElement(DevtoolsPanel, { messageRelay: connection }),
+		React.createElement(DevtoolsPanel, {
+			messageRelay: connection,
+			usageTelemetryLogger: logger,
+			unloadCallback: () => {
+				logger.shutdown(); // This also flushes outstanding events in the queue, if any
+			},
+		}),
 		target,
 		() => {
 			console.log(

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
@@ -10,7 +10,7 @@ import { DevtoolsPanel } from "@fluid-experimental/devtools-view";
 
 import { BackgroundConnection } from "./BackgroundConnection";
 import { formatDevtoolsScriptMessageForLogging } from "./Logging";
-import { DevtoolsOtelLogger } from "./TelemetryLogging";
+import { OneDSLogger } from "./TelemetryLogging";
 
 /**
  * Renders the Fluid Devtools view into the provided target element.
@@ -20,13 +20,13 @@ import { DevtoolsOtelLogger } from "./TelemetryLogging";
 export async function initializeDevtoolsView(target: HTMLElement): Promise<void> {
 	const connection = await BackgroundConnection.Initialize();
 
-	const logger = new DevtoolsOtelLogger();
+	const logger = new OneDSLogger();
 	ReactDOM.render(
 		React.createElement(DevtoolsPanel, {
 			messageRelay: connection,
 			usageTelemetryLogger: logger,
 			unloadCallback: () => {
-				logger.shutdown(); // This also flushes outstanding events in the queue, if any
+				logger.flush(); // This also flushes outstanding events in the queue, if any
 			},
 		}),
 		target,

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -1,0 +1,119 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as UTel from "@microsoft/oteljs";
+import { EventThrottler, OneDSEndpoint, OneDSSink } from "@microsoft/oteljs-1ds";
+import { ITelemetryBaseLogger, ITelemetryBaseEvent } from "@fluid-experimental/devtools-view";
+import type {
+	TelemetryEventPropertyType,
+	ITaggedTelemetryPropertyType,
+} from "@fluidframework/common-definitions";
+
+// These probably can be lowered
+const singleEventThrottleLimit = 100;
+const totalEventThrottleLimit = 1000;
+
+/**
+ * Logger that sends logs to the OneDS collection endpoint.
+ */
+export class DevtoolsOtelLogger implements ITelemetryBaseLogger {
+	private readonly telemetryLogger: UTel.ISimpleTelemetryLogger;
+	private readonly oneDsSink: OneDSSink;
+
+	public constructor() {
+		const config: UTel.ITelemetryConfig = { enableQueue: true };
+		this.telemetryLogger = new UTel.TelemetryLogger(undefined, undefined, config);
+
+		// Copied from office-bohemia; this is for the Office Fluid Test tenant in Aria
+		this.telemetryLogger.setTenantToken("<nampespace-prefix>", "<token>", UTel.SuppressNexus);
+		this.registerOtelErrorsListener();
+
+		this.oneDsSink = new OneDSSink([], { endpointUrl: OneDSEndpoint.PUBLIC });
+
+		this.oneDsSink.setFullEventsEnabled(true);
+
+		// We throttle on the client as a safety net in case a bug causes us to log a vast amount of events in a tight loop.
+		const eventThrottler = new EventThrottler("_", this.oneDsSink);
+		// Not more than 100 events of any one type per second.
+		eventThrottler.setSingleEventThrottle(singleEventThrottleLimit);
+		// Not more than 1000 events per second.
+		eventThrottler.setTotalEventThrottle(totalEventThrottleLimit);
+		this.oneDsSink.addPreprocessor(eventThrottler);
+
+		// Add sink to underlying logger
+		this.telemetryLogger.addSink(this.oneDsSink);
+		this.telemetryLogger.flushQueue();
+	}
+
+	public send(event: ITelemetryBaseEvent): void {
+		const telemetryEvent = this.getBasicOtelEvent(event);
+		telemetryEvent.eventFlags.dataCategories =
+			UTel.EnumObjects.DataCategories.ProductServiceUsage;
+		telemetryEvent.dataFields = this.getDataFieldsFromProps(event);
+		this.telemetryLogger.sendTelemetryEvent(telemetryEvent);
+	}
+
+	/**
+	 * Shut down the underlying sink, which includes flushing any pending events in the queue.
+	 */
+	public shutdown(): void {
+		this.oneDsSink.shutdown();
+	}
+	private getBasicOtelEvent(event: ITelemetryBaseEvent): UTel.TelemetryEvent {
+		// // Otel APIs will fail if the last part of the eventName is not uppercase
+		// let eventType = event.category && `${event.category.charAt(0).toUpperCase()}${event.category.substring(1)}`;
+
+		return {
+			eventName: "<fully-namespaced-event-name>",
+			eventFlags: {},
+		};
+	}
+
+	private getDataFieldsFromProps(props: ITelemetryBaseEvent): UTel.DataField[] {
+		const dataFields: UTel.DataField[] = [];
+		for (const key of Object.keys(props)) {
+			const dataField: UTel.DataField | undefined = getOtelDataField(props[key], key);
+			if (!dataField) {
+				break;
+			}
+			dataFields.push(dataField);
+		}
+		return dataFields;
+	}
+
+	private registerOtelErrorsListener(): void {
+		UTel.onNotification().addListener((event) => {
+			if (event.category === 0 && event.level === 0) {
+				console.error(event.message());
+			}
+		});
+	}
+}
+
+/**
+ * Helper method that returns Data fields in the form that Otel expects
+ * @param value - Value for the field
+ * @param key - Key for the field
+ * @returns A field that the OTel library can handle
+ */
+const getOtelDataField = (
+	value: TelemetryEventPropertyType | ITaggedTelemetryPropertyType,
+	key: string,
+): UTel.DataField | undefined => {
+	if (value === undefined) {
+		return undefined;
+	}
+	if ((value as ITaggedTelemetryPropertyType).value !== undefined) {
+		// In Fluid Devtools we don't currently plan to log tagged properties because we don't intend to capture any
+		// user-identifiable or user-generated information. If we do later, we'll need to add support for this.
+		throw new Error(`Tagged properties not supported`);
+	}
+	if (typeof value === "string") return UTel.makeStringDataField(key, value);
+	if (typeof value === "number") return UTel.makeDoubleDataField(key, value);
+	if (typeof value === "boolean") return UTel.makeBooleanDataField(key, value);
+
+	// This shouldn't happen, we were exhaustive above, but the compiler was not letting me skip the last if
+	throw new Error(`Unknown data type for key ${key}`);
+};

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -21,20 +21,9 @@ const fetchHttpXHROverride: IXHROverride = {
 			method: "POST",
 			headers: payload.headers,
 			credentials: "include",
-			// 'Content-Length': Buffer.byteLength(requestData).toString()
 		};
-		console.log("RequestUrl:\n", payload.urlString);
-		console.log("RequestHeaders:\n", requestInit.headers);
-		console.log("RequestBody:\n", requestInit.body);
 		fetch(payload.urlString, requestInit)
 			.then((response) => {
-				// console.log(
-				// 	"Response:",
-				// 	response.status,
-				// 	response.statusText,
-				// 	"\n",
-				// 	response.headers,
-				// );
 				const headerMap: { [key: string]: string } = {};
 				// response.headers is not a run-of-the-mill array, it satisfies a particular interface that
 				// only has forEach, not a general iterator.
@@ -47,11 +36,9 @@ const fetchHttpXHROverride: IXHROverride = {
 					response
 						.text()
 						.then((text) => {
-							// console.log("Response data:", text);
 							oncomplete(response.status, headerMap, text);
 						})
 						.catch((error) => {
-							// console.error("Error parsing response body:", error);
 							// Something wrong with the response body? Play it safe by passing the response status; don't try to
 							// explicitly re-send the telemetry events by specifying status 0.
 							oncomplete(response.status, headerMap, "");
@@ -78,7 +65,6 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 		const channelConfig: IChannelConfiguration = {
 			alwaysUseXhrOverride: true,
 			httpXHROverride: fetchHttpXHROverride,
-			eventsLimitInMem: 5000,
 		};
 
 		// Configure App insights core to send to collector
@@ -99,9 +85,6 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	}
 
 	public send(event: ITelemetryBaseEvent): void {
-		// console.log(event);
-		// return;
-
 		// Note: some APIs might fail if the last part of the eventName is not uppercase
 		const category = event.category ? `${event.category.charAt(0).toUpperCase()}${event.category.substring(1)}` : "Generic";
 		const eventType = `Office.Fluid.Devtools.${category}`

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -116,7 +116,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 		const telemetryEvent = {
 			name: eventType, // Dictates which table the event goes to
 			data: {
-				["Event.Time"]: new Date().toISOString(),
+				["Event.Time"]: new Date(),
 				["Event.Name"]: eventType, // Same as 'name' but is an actual column in Kusto; useful for cross-table queries
 			},
 		};

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -101,15 +101,16 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	public send(event: ITelemetryBaseEvent): void {
 		// console.log(event);
 		// return;
+
+		// Note: some APIs might fail if the last part of the eventName is not uppercase
+		const category = event.category ? `${event.category.charAt(0).toUpperCase()}${event.category.substring(1)}` : "Generic";
+		const eventType = `Office.Fluid.Ffautomation.${category}`
+
 		const telemetryEvent = {
-			name: "Office.Fluid.Ffautomation.Generic", // Dictates which table the event goes to
+			name: eventType, // Dictates which table the event goes to
 			data: {
 				["Event.Time"]: new Date().toISOString(),
-				["Event.Name"]: "Office.Fluid.Ffautomation.Generic", // Kind of redundant with 'name' but is an actual column in Kusto
-				// ["Data.eventName"]: "MyCustomEvent",
-				// ["Data.details"]: `{"myCustomProp":"myCustomValue", "uuid":"${uuid()}"}`,
-				// ["Data.devtoolsVersion"]: "2.0.0-internal.6.1.0",
-				// ['Data.category']: "generic",
+				["Event.Name"]: eventType, // Kind of redundant with 'name' but is an actual column in Kusto
 			},
 		};
 

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -3,117 +3,140 @@
  * Licensed under the MIT License.
  */
 
-import * as UTel from "@microsoft/oteljs";
-import { EventThrottler, OneDSEndpoint, OneDSSink } from "@microsoft/oteljs-1ds";
+import { AppInsightsCore, IExtendedConfiguration } from "@microsoft/1ds-core-js";
+import { PostChannel, IChannelConfiguration, IXHROverride } from "@microsoft/1ds-post-js";
 import { ITelemetryBaseLogger, ITelemetryBaseEvent } from "@fluid-experimental/devtools-view";
-import type {
-	TelemetryEventPropertyType,
-	ITaggedTelemetryPropertyType,
-} from "@fluidframework/common-definitions";
+import { ITaggedTelemetryPropertyType } from "@fluidframework/core-interfaces";
 
-// These probably can be lowered
-const singleEventThrottleLimit = 100;
-const totalEventThrottleLimit = 1000;
+const fetchHttpXHROverride: IXHROverride = {
+	sendPOST: (payload, oncomplete, sync) => {
+		console.log("Original payload data:\n", payload.data);
+		const telemetryRequestData =
+			typeof payload.data === "string"
+				? payload.data
+				: new TextDecoder().decode(payload.data);
 
+		const requestInit: RequestInit = {
+			body: telemetryRequestData,
+			method: "POST",
+			headers: payload.headers,
+			credentials: "include",
+			// 'Content-Length': Buffer.byteLength(requestData).toString()
+		};
+		console.log("RequestUrl:\n", payload.urlString);
+		console.log("RequestHeaders:\n", requestInit.headers);
+		console.log("RequestBody:\n", requestInit.body);
+		fetch(payload.urlString, requestInit)
+			.then((response) => {
+				// console.log(
+				// 	"Response:",
+				// 	response.status,
+				// 	response.statusText,
+				// 	"\n",
+				// 	response.headers,
+				// );
+				const headerMap: { [key: string]: string } = {};
+				// response.headers is not a run-of-the-mill array, it satisfies a particular interface that
+				// only has forEach, not a general iterator.
+				// eslint-disable-next-line unicorn/no-array-for-each
+				response.headers.forEach((value: string, name: string) => {
+					headerMap[name] = value;
+				});
+
+				if (response.body) {
+					response
+						.text()
+						.then((text) => {
+							// console.log("Response data:", text);
+							oncomplete(response.status, headerMap, text);
+						})
+						.catch((error) => {
+							// console.error("Error parsing response body:", error);
+							// Something wrong with the response body? Play it safe by passing the response status; don't try to
+							// explicitly re-send the telemetry events by specifying status 0.
+							oncomplete(response.status, headerMap, "");
+						});
+				} else {
+					oncomplete(response.status, headerMap, "");
+				}
+			})
+			.catch((error) => {
+				console.error("Error issuing telemetry request:", error);
+				// Error sending the request. Set the status to 0 so that the events can be retried.
+				oncomplete(0, {});
+			});
+	},
+};
 /**
  * Logger that sends logs to the OneDS collection endpoint.
  */
-export class DevtoolsOtelLogger implements ITelemetryBaseLogger {
-	private readonly telemetryLogger: UTel.ISimpleTelemetryLogger;
-	private readonly oneDsSink: OneDSSink;
+export class OneDSLogger implements ITelemetryBaseLogger {
+	private readonly appInsightsCore = new AppInsightsCore();
+	private readonly postChannel: PostChannel = new PostChannel();
 
 	public constructor() {
-		const config: UTel.ITelemetryConfig = { enableQueue: true };
-		this.telemetryLogger = new UTel.TelemetryLogger(undefined, undefined, config);
+		const channelConfig: IChannelConfiguration = {
+			alwaysUseXhrOverride: true,
+			httpXHROverride: fetchHttpXHROverride,
+			eventsLimitInMem: 5000,
+		};
 
-		// Copied from office-bohemia; this is for the Office Fluid Test tenant in Aria
-		this.telemetryLogger.setTenantToken("<nampespace-prefix>", "<token>", UTel.SuppressNexus);
-		this.registerOtelErrorsListener();
+		// Configure App insights core to send to collector
+		const coreConfig: IExtendedConfiguration = {
+			instrumentationKey: "<KEY-GOES-HERE>",
+			endpointUrl: "https://mobile.events.data.microsoft.com/OneCollector/1.0",
+			loggingLevelConsole: 0, // Do not log to console
+			disableDbgExt: true, // Small perf optimization
+			extensions: [
+				this.postChannel, // Removing this as part of telemetry opt-in would be ideal
+			],
+			extensionConfig: {
+				[this.postChannel.identifier]: channelConfig,
+			},
+		};
 
-		this.oneDsSink = new OneDSSink([], { endpointUrl: OneDSEndpoint.PUBLIC });
-
-		this.oneDsSink.setFullEventsEnabled(true);
-
-		// We throttle on the client as a safety net in case a bug causes us to log a vast amount of events in a tight loop.
-		const eventThrottler = new EventThrottler("_", this.oneDsSink);
-		// Not more than 100 events of any one type per second.
-		eventThrottler.setSingleEventThrottle(singleEventThrottleLimit);
-		// Not more than 1000 events per second.
-		eventThrottler.setTotalEventThrottle(totalEventThrottleLimit);
-		this.oneDsSink.addPreprocessor(eventThrottler);
-
-		// Add sink to underlying logger
-		this.telemetryLogger.addSink(this.oneDsSink);
-		this.telemetryLogger.flushQueue();
+		this.appInsightsCore.initialize(coreConfig, []);
 	}
 
 	public send(event: ITelemetryBaseEvent): void {
-		const telemetryEvent = this.getBasicOtelEvent(event);
-		telemetryEvent.eventFlags.dataCategories =
-			UTel.EnumObjects.DataCategories.ProductServiceUsage;
-		telemetryEvent.dataFields = this.getDataFieldsFromProps(event);
-		this.telemetryLogger.sendTelemetryEvent(telemetryEvent);
+		// console.log(event);
+		// return;
+		const telemetryEvent = {
+			name: "Office.Fluid.Ffautomation.Generic", // Dictates which table the event goes to
+			data: {
+				["Event.Time"]: new Date().toISOString(),
+				["Event.Name"]: "Office.Fluid.Ffautomation.Generic", // Kind of redundant with 'name' but is an actual column in Kusto
+				// ["Data.eventName"]: "MyCustomEvent",
+				// ["Data.details"]: `{"myCustomProp":"myCustomValue", "uuid":"${uuid()}"}`,
+				// ["Data.devtoolsVersion"]: "2.0.0-internal.6.1.0",
+				// ['Data.category']: "generic",
+			},
+		};
+
+		// Add properties from the passed-in event with the appropriate keys in the final event to be sent to the server
+		for (const key of Object.keys(event)) {
+			const value = event[key];
+			if (value === undefined) {
+				continue;
+			}
+			if ((value as ITaggedTelemetryPropertyType).value !== undefined) {
+				// In Fluid Devtools we don't currently plan to log tagged properties because we don't intend to capture any
+				// user-identifiable or user-generated information. If we do later, we'll need to add support for this.
+				throw new Error(`Tagged properties not supported by telemetry logger`);
+			}
+			if (!["string", "number", "boolean"].includes(typeof value)) {
+				throw new Error(`Unknown data type for key ${key}`);
+			}
+			telemetryEvent.data[`Data.${key}`] = value;
+		}
+
+		this.appInsightsCore.track(telemetryEvent);
 	}
 
 	/**
 	 * Shut down the underlying sink, which includes flushing any pending events in the queue.
 	 */
-	public shutdown(): void {
-		this.oneDsSink.shutdown();
-	}
-	private getBasicOtelEvent(event: ITelemetryBaseEvent): UTel.TelemetryEvent {
-		// // Otel APIs will fail if the last part of the eventName is not uppercase
-		// let eventType = event.category && `${event.category.charAt(0).toUpperCase()}${event.category.substring(1)}`;
-
-		return {
-			eventName: "<fully-namespaced-event-name>",
-			eventFlags: {},
-		};
-	}
-
-	private getDataFieldsFromProps(props: ITelemetryBaseEvent): UTel.DataField[] {
-		const dataFields: UTel.DataField[] = [];
-		for (const key of Object.keys(props)) {
-			const dataField: UTel.DataField | undefined = getOtelDataField(props[key], key);
-			if (!dataField) {
-				break;
-			}
-			dataFields.push(dataField);
-		}
-		return dataFields;
-	}
-
-	private registerOtelErrorsListener(): void {
-		UTel.onNotification().addListener((event) => {
-			if (event.category === 0 && event.level === 0) {
-				console.error(event.message());
-			}
-		});
+	public flush(): void {
+		this.appInsightsCore.flush();
 	}
 }
-
-/**
- * Helper method that returns Data fields in the form that Otel expects
- * @param value - Value for the field
- * @param key - Key for the field
- * @returns A field that the OTel library can handle
- */
-const getOtelDataField = (
-	value: TelemetryEventPropertyType | ITaggedTelemetryPropertyType,
-	key: string,
-): UTel.DataField | undefined => {
-	if (value === undefined) {
-		return undefined;
-	}
-	if ((value as ITaggedTelemetryPropertyType).value !== undefined) {
-		// In Fluid Devtools we don't currently plan to log tagged properties because we don't intend to capture any
-		// user-identifiable or user-generated information. If we do later, we'll need to add support for this.
-		throw new Error(`Tagged properties not supported`);
-	}
-	if (typeof value === "string") return UTel.makeStringDataField(key, value);
-	if (typeof value === "number") return UTel.makeDoubleDataField(key, value);
-	if (typeof value === "boolean") return UTel.makeBooleanDataField(key, value);
-
-	// This shouldn't happen, we were exhaustive above, but the compiler was not letting me skip the last if
-	throw new Error(`Unknown data type for key ${key}`);
-};

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -78,7 +78,6 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 			// A non-empty instrumentation key needs to provided for the logger to do anything.
 			// AB#5167 tracks how to inject one at build time to keep it out of source control.
 			instrumentationKey: "",
-			endpointUrl: "https://mobile.events.data.microsoft.com/OneCollector/1.0",
 			loggingLevelConsole: 0, // Do not log to console
 			disableDbgExt: true, // Small perf optimization
 			extensions: [

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -104,7 +104,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 
 		// Note: some APIs might fail if the last part of the eventName is not uppercase
 		const category = event.category ? `${event.category.charAt(0).toUpperCase()}${event.category.substring(1)}` : "Generic";
-		const eventType = `Office.Fluid.Ffautomation.${category}`
+		const eventType = `Office.Fluid.Devtools.${category}`
 
 		const telemetryEvent = {
 			name: eventType, // Dictates which table the event goes to

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -10,7 +10,6 @@ import { ITaggedTelemetryPropertyType } from "@fluidframework/core-interfaces";
 
 const fetchHttpXHROverride: IXHROverride = {
 	sendPOST: (payload, oncomplete, sync) => {
-		console.log("Original payload data:\n", payload.data);
 		const telemetryRequestData =
 			typeof payload.data === "string"
 				? payload.data

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -142,7 +142,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	}
 
 	/**
-	 * Shut down the underlying sink, which includes flushing any pending events in the queue.
+	 * Flush the underlying sink, forcing any events that haven't been sent to the remote endpoint to be sent immediately.
 	 */
 	public flush(): void {
 		if (this.enabled) {

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -110,7 +110,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 			name: eventType, // Dictates which table the event goes to
 			data: {
 				["Event.Time"]: new Date().toISOString(),
-				["Event.Name"]: eventType, // Kind of redundant with 'name' but is an actual column in Kusto
+				["Event.Name"]: eventType, // Same as 'name' but is an actual column in Kusto; useful for cross-table queries
 			},
 		};
 

--- a/packages/tools/devtools/devtools-view/api-report/devtools-view.api.md
+++ b/packages/tools/devtools/devtools-view/api-report/devtools-view.api.md
@@ -18,6 +18,7 @@ export function DevtoolsPanel(props: DevtoolsPanelProps): React_2.ReactElement;
 // @public
 export interface DevtoolsPanelProps {
     messageRelay: IMessageRelay;
+    unloadCallback?: () => void;
     usageTelemetryLogger?: ITelemetryBaseLogger;
 }
 

--- a/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
@@ -30,6 +30,11 @@ export interface DevtoolsPanelProps {
 	 * inline with the app, it should *not* be used in those cases.
 	 */
 	usageTelemetryLogger?: ITelemetryBaseLogger;
+
+	/**
+	 * Optional function that will be invoked when the React component for the Devtools panel is unloaded.
+	 */
+	unloadCallback?: () => void;
 }
 
 /**
@@ -40,7 +45,14 @@ export interface DevtoolsPanelProps {
  * Initializes the message relay context required by internal components.
  */
 export function DevtoolsPanel(props: DevtoolsPanelProps): React.ReactElement {
-	const { usageTelemetryLogger, messageRelay } = props;
+	const { usageTelemetryLogger, messageRelay, unloadCallback } = props;
+
+	React.useEffect(() => {
+		// Called when the React component for the Devtools panel is unloaded.
+		return (): void => {
+			unloadCallback?.();
+		};
+	}, [unloadCallback]);
 
 	return (
 		<MessageRelayContext.Provider value={messageRelay}>

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -49,7 +49,6 @@ import {
 	useLogger,
 } from "./TelemetryUtils";
 import { getFluentUIThemeToUse, ThemeContext } from "./ThemeHelper";
-import { useLogger } from "./TelemetryUtils";
 
 const loggingContext = "INLINE(DevtoolsView)";
 
@@ -487,10 +486,8 @@ function Menu(props: MenuProps): React.ReactElement {
 	const usageLogger = useLogger();
 
 	const styles = useMenuStyles();
-	const logger = useLogger();
 
 	function onContainerClicked(containerKey: ContainerKey): void {
-		logger?.sendTelemetryEvent({ eventName: "containerClicked", containerKey });
 		setSelection({ type: "containerMenuSelection", containerKey });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",
@@ -499,7 +496,6 @@ function Menu(props: MenuProps): React.ReactElement {
 	}
 
 	function onTelemetryClicked(): void {
-		logger?.sendTelemetryEvent({ eventName: "telemetryClicked" });
 		setSelection({ type: "telemetryMenuSelection" });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",
@@ -508,7 +504,6 @@ function Menu(props: MenuProps): React.ReactElement {
 	}
 
 	function onSettingsClicked(): void {
-		logger?.sendTelemetryEvent({ eventName: "settingsClicked" });
 		setSelection({ type: "settingsMenuSelection" });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",
@@ -517,7 +512,6 @@ function Menu(props: MenuProps): React.ReactElement {
 	}
 
 	function onHomeClicked(): void {
-		logger?.sendTelemetryEvent({ eventName: "homeClicked" });
 		setSelection({ type: "homeMenuSelection" });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -49,6 +49,7 @@ import {
 	useLogger,
 } from "./TelemetryUtils";
 import { getFluentUIThemeToUse, ThemeContext } from "./ThemeHelper";
+import { useLogger } from "./TelemetryUtils";
 
 const loggingContext = "INLINE(DevtoolsView)";
 
@@ -486,8 +487,10 @@ function Menu(props: MenuProps): React.ReactElement {
 	const usageLogger = useLogger();
 
 	const styles = useMenuStyles();
+	const logger = useLogger();
 
 	function onContainerClicked(containerKey: ContainerKey): void {
+		logger?.sendTelemetryEvent({ eventName: "containerClicked", containerKey });
 		setSelection({ type: "containerMenuSelection", containerKey });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",
@@ -496,6 +499,7 @@ function Menu(props: MenuProps): React.ReactElement {
 	}
 
 	function onTelemetryClicked(): void {
+		logger?.sendTelemetryEvent({ eventName: "telemetryClicked" });
 		setSelection({ type: "telemetryMenuSelection" });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",
@@ -504,6 +508,7 @@ function Menu(props: MenuProps): React.ReactElement {
 	}
 
 	function onSettingsClicked(): void {
+		logger?.sendTelemetryEvent({ eventName: "settingsClicked" });
 		setSelection({ type: "settingsMenuSelection" });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",
@@ -512,6 +517,7 @@ function Menu(props: MenuProps): React.ReactElement {
 	}
 
 	function onHomeClicked(): void {
+		logger?.sendTelemetryEvent({ eventName: "homeClicked" });
 		setSelection({ type: "homeMenuSelection" });
 		usageLogger?.sendTelemetryEvent({
 			eventName: "Navigation",

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -211,7 +211,7 @@ export function DevtoolsView(props: DevtoolsViewProps): React.ReactElement {
 				});
 
 				newTopLevelLogger.sendTelemetryEvent({
-					eventName: "Connection established with Devtools in the application.",
+					eventName: "DevtoolsConnected",
 				});
 
 				setTopLevelLogger(newTopLevelLogger);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10663,9 +10663,9 @@ importers:
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-utils': workspace:~
+      '@microsoft/1ds-core-js': ^3.2.13
+      '@microsoft/1ds-post-js': ^3.2.13
       '@microsoft/api-extractor': ^7.34.4
-      '@microsoft/oteljs': ^4.13.14
-      '@microsoft/oteljs-1ds': ^4.13.14
       '@types/chai': ^4.0.0
       '@types/chrome': 0.0.232
       '@types/expect-puppeteer': 2.2.1
@@ -10711,6 +10711,7 @@ importers:
       start-server-and-test: ^1.11.7
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
+      tslib: ^1.10.0
       typescript: ~4.5.5
       webpack: ^5.82.0
       webpack-cli: ^4.9.2
@@ -10720,10 +10721,12 @@ importers:
       '@fluid-experimental/devtools-view': link:../devtools-view
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@microsoft/oteljs': 4.14.0
-      '@microsoft/oteljs-1ds': 4.14.0
+      '@fluidframework/core-interfaces': link:../../../common/core-interfaces
+      '@microsoft/1ds-core-js': 3.2.13_tslib@1.14.1
+      '@microsoft/1ds-post-js': 3.2.13_tslib@1.14.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      tslib: 1.14.1
     devDependencies:
       '@fluid-example/example-utils': link:../../../../examples/utils/example-utils
       '@fluid-experimental/react-inputs': link:../../../../experimental/framework/react-inputs
@@ -10733,7 +10736,6 @@ importers:
       '@fluidframework/container-definitions': link:../../../common/container-definitions
       '@fluidframework/container-loader': link:../../../loader/container-loader
       '@fluidframework/container-runtime-definitions': link:../../../runtime/container-runtime-definitions
-      '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../../runtime/runtime-utils
@@ -16000,7 +16002,7 @@ packages:
       '@types/react-dom': 17.0.18
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/set-version/8.2.11:
@@ -19115,20 +19117,20 @@ packages:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: true
 
-  /@microsoft/1ds-core-js/3.2.12_tslib@1.14.1:
-    resolution: {integrity: sha1-gJ0hoS1IXwuzYdQGZUGxv2S8HXA=}
+  /@microsoft/1ds-core-js/3.2.13_tslib@1.14.1:
+    resolution: {integrity: sha512-CluYTRWcEk0ObG5EWFNWhs87e2qchJUn0p2D21ZUa3PWojPZfPSBs4//WIE0MYV8Qg1Hdif2ZTwlM7TbYUjfAg==}
     dependencies:
-      '@microsoft/applicationinsights-core-js': 2.8.14_tslib@1.14.1
+      '@microsoft/applicationinsights-core-js': 2.8.15_tslib@1.14.1
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.9
     transitivePeerDependencies:
       - tslib
     dev: false
 
-  /@microsoft/1ds-post-js/3.2.12_tslib@1.14.1:
-    resolution: {integrity: sha1-t1SJfh+82+m13OxU1v9qdho5DoM=}
+  /@microsoft/1ds-post-js/3.2.13_tslib@1.14.1:
+    resolution: {integrity: sha512-HgS574fdD19Bo2vPguyznL4eDw7Pcm1cVNpvbvBLWiW3x4e1FCQ3VMXChWnAxCae8Hb0XqlA2sz332ZobBavTA==}
     dependencies:
-      '@microsoft/1ds-core-js': 3.2.12_tslib@1.14.1
+      '@microsoft/1ds-core-js': 3.2.13_tslib@1.14.1
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.9
     transitivePeerDependencies:
@@ -19285,8 +19287,8 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@microsoft/applicationinsights-core-js/2.8.14_tslib@1.14.1:
-    resolution: {integrity: sha1-gOPZ1CEC50FJRybXiskjCYutcTI=}
+  /@microsoft/applicationinsights-core-js/2.8.15_tslib@1.14.1:
+    resolution: {integrity: sha512-yYAs9MyjGr2YijQdUSN9mVgT1ijI1FPMgcffpaPmYbHAVbQmF7bXudrBWHxmLzJlwl5rfep+Zgjli2e67lwUqQ==}
     peerDependencies:
       tslib: '*'
     dependencies:
@@ -19320,7 +19322,7 @@ packages:
     dev: false
 
   /@microsoft/applicationinsights-shims/2.0.2:
-    resolution: {integrity: sha1-krNqCTdeLZyytCAzg7BXcr6DcIU=}
+    resolution: {integrity: sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg==}
     dev: false
 
   /@microsoft/applicationinsights-web-snippet/1.0.1:
@@ -19344,26 +19346,11 @@ packages:
     dev: false
 
   /@microsoft/dynamicproto-js/1.1.9:
-    resolution: {integrity: sha1-dDfbeqBhFi7pTkExtppiuNrV3qY=}
+    resolution: {integrity: sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ==}
     dev: false
 
   /@microsoft/load-themed-styles/1.10.295:
     resolution: {integrity: sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==}
-    dev: false
-
-  /@microsoft/oteljs-1ds/4.14.0:
-    resolution: {integrity: sha1-y75Tex1hxxEyDJ61v5HhFSo7cVk=}
-    dependencies:
-      '@microsoft/1ds-core-js': 3.2.12_tslib@1.14.1
-      '@microsoft/1ds-post-js': 3.2.12_tslib@1.14.1
-      '@microsoft/oteljs': 4.14.0
-      tslib: 1.14.1
-    dev: false
-
-  /@microsoft/oteljs/4.14.0:
-    resolution: {integrity: sha1-NCNgxtfIUpBc0U4xRmc2kw1kuJk=}
-    dependencies:
-      tslib: 1.14.1
     dev: false
 
   /@microsoft/tsdoc-config/0.16.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10652,6 +10652,7 @@ importers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
+      '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10663,6 +10664,8 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
+      '@microsoft/oteljs': ^4.13.14
+      '@microsoft/oteljs-1ds': ^4.13.14
       '@types/chai': ^4.0.0
       '@types/chrome': 0.0.232
       '@types/expect-puppeteer': 2.2.1
@@ -10715,7 +10718,10 @@ importers:
       '@fluentui/react': 8.109.4_74b3ggvk3akyhuq4eydyx3fqim
       '@fluid-experimental/devtools-core': link:../devtools-core
       '@fluid-experimental/devtools-view': link:../devtools-view
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
+      '@microsoft/oteljs': 4.14.0
+      '@microsoft/oteljs-1ds': 4.14.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -19109,6 +19115,26 @@ packages:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: true
 
+  /@microsoft/1ds-core-js/3.2.12_tslib@1.14.1:
+    resolution: {integrity: sha1-gJ0hoS1IXwuzYdQGZUGxv2S8HXA=}
+    dependencies:
+      '@microsoft/applicationinsights-core-js': 2.8.14_tslib@1.14.1
+      '@microsoft/applicationinsights-shims': 2.0.2
+      '@microsoft/dynamicproto-js': 1.1.9
+    transitivePeerDependencies:
+      - tslib
+    dev: false
+
+  /@microsoft/1ds-post-js/3.2.12_tslib@1.14.1:
+    resolution: {integrity: sha1-t1SJfh+82+m13OxU1v9qdho5DoM=}
+    dependencies:
+      '@microsoft/1ds-core-js': 3.2.12_tslib@1.14.1
+      '@microsoft/applicationinsights-shims': 2.0.2
+      '@microsoft/dynamicproto-js': 1.1.9
+    transitivePeerDependencies:
+      - tslib
+    dev: false
+
   /@microsoft/api-documenter/7.22.5:
     resolution: {integrity: sha512-umZ2Xn/q8CXi31pQ3+6aQdjmNULej41VSuKm5AFf8QT/75bqJmjstiwb4t1M9I4ZBIrfnGcn217h9XKp0Xkf9w==}
     hasBin: true
@@ -19259,6 +19285,16 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@microsoft/applicationinsights-core-js/2.8.14_tslib@1.14.1:
+    resolution: {integrity: sha1-gOPZ1CEC50FJRybXiskjCYutcTI=}
+    peerDependencies:
+      tslib: '*'
+    dependencies:
+      '@microsoft/applicationinsights-shims': 2.0.2
+      '@microsoft/dynamicproto-js': 1.1.9
+      tslib: 1.14.1
+    dev: false
+
   /@microsoft/applicationinsights-dependencies-js/2.8.13_tslib@1.14.1:
     resolution: {integrity: sha512-Ix4ej+Brohj0iUlWRMuFr7uK902C7R20zAvvzEwDiKFp4DTxue3kLr+ClxxLedMmMoI2M+N4UoA0081jJqUfmg==}
     peerDependencies:
@@ -19284,7 +19320,7 @@ packages:
     dev: false
 
   /@microsoft/applicationinsights-shims/2.0.2:
-    resolution: {integrity: sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg==}
+    resolution: {integrity: sha1-krNqCTdeLZyytCAzg7BXcr6DcIU=}
     dev: false
 
   /@microsoft/applicationinsights-web-snippet/1.0.1:
@@ -19308,11 +19344,26 @@ packages:
     dev: false
 
   /@microsoft/dynamicproto-js/1.1.9:
-    resolution: {integrity: sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ==}
+    resolution: {integrity: sha1-dDfbeqBhFi7pTkExtppiuNrV3qY=}
     dev: false
 
   /@microsoft/load-themed-styles/1.10.295:
     resolution: {integrity: sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==}
+    dev: false
+
+  /@microsoft/oteljs-1ds/4.14.0:
+    resolution: {integrity: sha1-y75Tex1hxxEyDJ61v5HhFSo7cVk=}
+    dependencies:
+      '@microsoft/1ds-core-js': 3.2.12_tslib@1.14.1
+      '@microsoft/1ds-post-js': 3.2.12_tslib@1.14.1
+      '@microsoft/oteljs': 4.14.0
+      tslib: 1.14.1
+    dev: false
+
+  /@microsoft/oteljs/4.14.0:
+    resolution: {integrity: sha1-NCNgxtfIUpBc0U4xRmc2kw1kuJk=}
+    dependencies:
+      tslib: 1.14.1
     dev: false
 
   /@microsoft/tsdoc-config/0.16.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10652,7 +10652,6 @@ importers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10719,7 +10718,6 @@ importers:
       '@fluentui/react': 8.109.4_74b3ggvk3akyhuq4eydyx3fqim
       '@fluid-experimental/devtools-core': link:../devtools-core
       '@fluid-experimental/devtools-view': link:../devtools-view
-      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@microsoft/1ds-core-js': 3.2.13_tslib@1.14.1


### PR DESCRIPTION
## Description

Supersedes https://github.com/microsoft/FluidFramework/pull/16351, as an implementation of a logger to send usage telemetry for Fluid Devtools that only requires public npm packages.

As-is, this PR does not send telemetry; a valid instrumentationKey is necessary. We're still exploring options on how to inject that value during the build so it's not in source control.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#5228](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5228)