### PR TITLE
Deprecated refreshLatestAck summarize option

### DIFF
--- a/.changeset/tiny-hands-send.md
+++ b/.changeset/tiny-hands-send.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-runtime": minor
+---
+
+Deprecated `refreshLatestAck` in `ISummarizeOptions`, `IOnDemandSummarizeOptions` and `IEnqueueSummarizeOptions`
+
+Passing `refreshLatestAck` as true in `ISummarizeOptions` will result in closing the summarizer. It is not supported anymore and will be removed in a future release. It should not be passed in to `summarizeOnDemand` and `enqueueSummarize` APIs anymore.

--- a/.changeset/tiny-hands-send.md
+++ b/.changeset/tiny-hands-send.md
@@ -4,4 +4,4 @@
 
 Deprecated `refreshLatestAck` in `ISummarizeOptions`, `IOnDemandSummarizeOptions` and `IEnqueueSummarizeOptions`
 
-Passing `refreshLatestAck` as true in `ISummarizeOptions` will result in closing the summarizer. It is not supported anymore and will be removed in a future release. It should not be passed in to `summarizeOnDemand` and `enqueueSummarize` APIs anymore.
+Passing `refreshLatestAck` as true will result in closing the summarizer. It is not supported anymore and will be removed in a future release. It should not be passed in to `summarizeOnDemand` and `enqueueSummarize` APIs anymore.

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -137,7 +137,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     readonly disposeFn: (error?: ICriticalContainerError) => void;
     // (undocumented)
-    readonly enqueueSummarize: ISummarizer["enqueueSummarize"];
+    enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult;
     ensureNoDataModelChanges<T>(callback: () => T): T;
     // (undocumented)
     get flushMode(): FlushMode;
@@ -228,7 +228,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         runSweep?: boolean;
     }): Promise<ISummaryTreeWithStats>;
     // (undocumented)
-    readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
+    summarizeOnDemand(options: IOnDemandSummarizeOptions): ISummarizeResults;
     get summarizerClientId(): string | undefined;
     updateStateBeforeGC(): Promise<void>;
     updateTombstonedRoutes(tombstonedRoutes: string[]): void;
@@ -481,6 +481,7 @@ export interface ISubmitSummaryOptions extends ISummarizeOptions {
 // @public
 export interface ISummarizeOptions {
     readonly fullTree?: boolean;
+    // @deprecated
     readonly refreshLatestAck?: boolean;
 }
 
@@ -688,7 +689,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     static create(loader: ILoader, url: string): Promise<ISummarizer>;
     dispose(): void;
     // (undocumented)
-    readonly enqueueSummarize: ISummarizer["enqueueSummarize"];
+    enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult;
     // (undocumented)
     get ISummarizer(): this;
     // (undocumented)
@@ -698,7 +699,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     stop(reason: SummarizerStopReason): void;
     static stopReasonCanRunLastSummary(stopReason: SummarizerStopReason): boolean;
     // (undocumented)
-    readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
+    summarizeOnDemand(options: IOnDemandSummarizeOptions): ISummarizeResults;
     // (undocumented)
     readonly summaryCollection: SummaryCollection;
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -151,6 +151,10 @@ import {
 	RunWhileConnectedCoordinator,
 	IGenerateSummaryTreeResult,
 	RetriableSummaryError,
+	IOnDemandSummarizeOptions,
+	ISummarizeResults,
+	IEnqueueSummarizeOptions,
+	EnqueueSummarizeResult,
 } from "./summary";
 import { formExponentialFn, Throttler } from "./throttler";
 import {
@@ -3836,31 +3840,31 @@ export class ContainerRuntime
 		};
 	}
 
-	public readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"] = (...args) => {
+	public summarizeOnDemand(options: IOnDemandSummarizeOptions): ISummarizeResults {
 		if (this.isSummarizerClient) {
-			return this.summarizer.summarizeOnDemand(...args);
+			return this.summarizer.summarizeOnDemand(options);
 		} else if (this.summaryManager !== undefined) {
-			return this.summaryManager.summarizeOnDemand(...args);
+			return this.summaryManager.summarizeOnDemand(options);
 		} else {
 			// If we're not the summarizer, and we don't have a summaryManager, we expect that
 			// disableSummaries is turned on. We are throwing instead of returning a failure here,
 			// because it is a misuse of the API rather than an expected failure.
 			throw new UsageError(`Can't summarize, disableSummaries: ${this.summariesDisabled}`);
 		}
-	};
+	}
 
-	public readonly enqueueSummarize: ISummarizer["enqueueSummarize"] = (...args) => {
+	public enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult {
 		if (this.isSummarizerClient) {
-			return this.summarizer.enqueueSummarize(...args);
+			return this.summarizer.enqueueSummarize(options);
 		} else if (this.summaryManager !== undefined) {
-			return this.summaryManager.enqueueSummarize(...args);
+			return this.summaryManager.enqueueSummarize(options);
 		} else {
 			// If we're not the summarizer, and we don't have a summaryManager, we expect that
 			// generateSummaries is turned off. We are throwing instead of returning a failure here,
 			// because it is a misuse of the API rather than an expected failure.
 			throw new UsageError(`Can't summarize, disableSummaries: ${this.summariesDisabled}`);
 		}
-	};
+	}
 
 	/**
 	 * * Forms a function that will request a Summarizer.

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -148,7 +148,7 @@ export class RunningSummarizer implements IDisposable {
 		| {
 				reason: SummarizeReason;
 				afterSequenceNumber: number;
-				options: ISummarizeOptions;
+				summarizeOptions: ISummarizeOptions;
 				readonly resultsBuilder: SummarizeResultBuilder;
 		  }
 		| undefined;
@@ -549,7 +549,6 @@ export class RunningSummarizer implements IDisposable {
 	private trySummarizeOnce(
 		summarizeProps: ISummarizeTelemetryProperties,
 		options: ISummarizeOptions,
-		cancellationToken = this.cancellationToken,
 		resultsBuilder = new SummarizeResultBuilder(),
 	): ISummarizeResults {
 		this.lockedSummaryAction(
@@ -560,7 +559,7 @@ export class RunningSummarizer implements IDisposable {
 				const summarizeResult = this.generator.summarize(
 					summarizeProps,
 					options,
-					cancellationToken,
+					this.cancellationToken,
 					resultsBuilder,
 				);
 				// ensure we wait till the end of the process
@@ -580,10 +579,7 @@ export class RunningSummarizer implements IDisposable {
 	}
 
 	/** Heuristics summarize attempt. */
-	private trySummarize(
-		reason: SummarizeReason,
-		cancellationToken = this.cancellationToken,
-	): void {
+	private trySummarize(reason: SummarizeReason): void {
 		if (this.summarizingLock !== undefined) {
 			// lockedSummaryAction() will retry heuristic-based summary at the end of current attempt
 			// if it's still needed
@@ -597,8 +593,8 @@ export class RunningSummarizer implements IDisposable {
 			},
 			async () => {
 				return this.mc.config.getBoolean("Fluid.Summarizer.TryDynamicRetries")
-					? this.trySummarizeWithRetries(reason, cancellationToken)
-					: this.trySummarizeWithStaticAttempts(reason, cancellationToken);
+					? this.trySummarizeWithRetries(reason)
+					: this.trySummarizeWithStaticAttempts(reason);
 			},
 			() => {
 				this.afterSummaryAction();
@@ -612,19 +608,16 @@ export class RunningSummarizer implements IDisposable {
 	 * Tries to summarize 2 times with pre-defined summary options. If an attempt fails with "retryAfterSeconds"
 	 * param, that attempt is tried once more.
 	 */
-	private async trySummarizeWithStaticAttempts(
-		reason: SummarizeReason,
-		cancellationToken: ISummaryCancellationToken,
-	) {
-		const attempts: ISummarizeOptions[] = [
+	private async trySummarizeWithStaticAttempts(reason: SummarizeReason) {
+		const attemptOptions: ISummarizeOptions[] = [
 			{ refreshLatestAck: false, fullTree: false },
 			{ refreshLatestAck: true, fullTree: false },
 		];
 		let summaryAttempts = 0;
 		let summaryAttemptsPerPhase = 0;
 		let summaryAttemptPhase = 0;
-		while (summaryAttemptPhase < attempts.length) {
-			if (cancellationToken.cancelled) {
+		while (summaryAttemptPhase < attemptOptions.length) {
+			if (this.cancellationToken.cancelled) {
 				return;
 			}
 
@@ -635,7 +628,7 @@ export class RunningSummarizer implements IDisposable {
 
 			summaryAttemptsPerPhase++;
 
-			const summarizeOptions = attempts[summaryAttemptPhase];
+			const summarizeOptions = attemptOptions[summaryAttemptPhase];
 			const summarizeProps: ISummarizeTelemetryProperties = {
 				summarizeReason: reason,
 				summaryAttempts,
@@ -649,7 +642,7 @@ export class RunningSummarizer implements IDisposable {
 			const resultSummarize = this.generator.summarize(
 				summarizeProps,
 				summarizeOptions,
-				cancellationToken,
+				this.cancellationToken,
 			);
 			const ackNackResult = await resultSummarize.receivedSummaryAckOrNack;
 			if (ackNackResult.success) {
@@ -684,10 +677,7 @@ export class RunningSummarizer implements IDisposable {
 	 * Tries to summarize with retries where retry is based on the failure params.
 	 * For example, summarization may be retried for failures with "retryAfterSeconds" param.
 	 */
-	private async trySummarizeWithRetries(
-		reason: SummarizeReason,
-		cancellationToken: ISummaryCancellationToken,
-	) {
+	private async trySummarizeWithRetries(reason: SummarizeReason) {
 		// The max number of attempts are based on the stage at which summarization failed. If it fails before it is
 		// submitted, a different value is used compared to if it fails after submission. Usually, in the former case,
 		// we would retry more often as its cheaper and retries are likely to succeed.
@@ -719,7 +709,7 @@ export class RunningSummarizer implements IDisposable {
 			const summarizeResult = this.generator.summarize(
 				summarizeProps,
 				summarizeOptions,
-				cancellationToken,
+				this.cancellationToken,
 			);
 
 			// Ack / nack is the final step, so if it succeeds we're done.
@@ -771,8 +761,8 @@ export class RunningSummarizer implements IDisposable {
 
 	/** {@inheritdoc (ISummarizer:interface).summarizeOnDemand} */
 	public summarizeOnDemand(
+		options: IOnDemandSummarizeOptions,
 		resultsBuilder: SummarizeResultBuilder = new SummarizeResultBuilder(),
-		{ reason, ...options }: IOnDemandSummarizeOptions,
 	): ISummarizeResults {
 		if (this.stopping) {
 			resultsBuilder.fail("RunningSummarizer stopped or disposed", undefined);
@@ -785,23 +775,18 @@ export class RunningSummarizer implements IDisposable {
 			throw new UsageError("Attempted to run an already-running summarizer on demand");
 		}
 
+		const { reason, ...summarizeOptions } = options;
 		const result = this.trySummarizeOnce(
 			{ summarizeReason: `onDemand/${reason}` },
-			options,
-			this.cancellationToken,
+			summarizeOptions,
 			resultsBuilder,
 		);
 		return result;
 	}
 
 	/** {@inheritdoc (ISummarizer:interface).enqueueSummarize} */
-	public enqueueSummarize({
-		reason,
-		afterSequenceNumber = 0,
-		override = false,
-		...options
-	}: IEnqueueSummarizeOptions): EnqueueSummarizeResult {
-		const onDemandReason = `enqueue;${reason}` as const;
+	public enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult {
+		const { reason, afterSequenceNumber = 0, override = false, ...summarizeOptions } = options;
 		let overridden = false;
 		if (this.enqueuedSummary !== undefined) {
 			if (!override) {
@@ -815,10 +800,11 @@ export class RunningSummarizer implements IDisposable {
 			this.enqueuedSummary = undefined;
 			overridden = true;
 		}
+
 		this.enqueuedSummary = {
-			reason: onDemandReason,
+			reason: `enqueue;${reason}`,
 			afterSequenceNumber,
-			options,
+			summarizeOptions,
 			resultsBuilder: new SummarizeResultBuilder(),
 		};
 		const results = this.enqueuedSummary.resultsBuilder.build();
@@ -845,13 +831,12 @@ export class RunningSummarizer implements IDisposable {
 			// If no enqueued summary is ready or a summary is already in progress, take no action.
 			return false;
 		}
-		const { reason, resultsBuilder, options } = this.enqueuedSummary;
+		const { reason, resultsBuilder, summarizeOptions } = this.enqueuedSummary;
 		// Set to undefined first, so that subsequent enqueue attempt while summarize will occur later.
 		this.enqueuedSummary = undefined;
 		this.trySummarizeOnce(
 			{ summarizeReason: `enqueuedSummary/${reason}` },
-			options,
-			this.cancellationToken,
+			summarizeOptions,
 			resultsBuilder,
 		);
 		return true;

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -34,6 +34,20 @@ export interface ICancellationToken<T> {
 /* Similar to AbortSignal, but using promise instead of events */
 export type ISummaryCancellationToken = ICancellationToken<SummarizerStopReason>;
 
+/**
+ * Data required to update internal tracking state after receiving a Summary Ack.
+ */
+export interface IRefreshSummaryAckOptions {
+	/** Handle from the ack's summary op. */
+	readonly proposalHandle: string | undefined;
+	/** Handle from the summary ack just received */
+	readonly ackHandle: string;
+	/** Reference sequence number from the ack's summary op */
+	readonly summaryRefSeq: number;
+	/** Telemetry logger to which telemetry events will be forwarded. */
+	readonly summaryLogger: ITelemetryLoggerExt;
+}
+
 export interface ISummarizerInternalsProvider {
 	/** Encapsulates the work to walk the internals of the running container to generate a summary */
 	submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
@@ -88,22 +102,12 @@ export interface ISummarizerRuntime extends IConnectableRuntime {
 export interface ISummarizeOptions {
 	/** True to generate the full tree with no handle reuse optimizations; defaults to false */
 	readonly fullTree?: boolean;
-	/** True to ask the server what the latest summary is first; defaults to false */
+	/**
+	 * True to ask the server what the latest summary is first; defaults to false
+	 *
+	 * @deprecated - Summarize will not refresh latest snapshot state anymore.
+	 */
 	readonly refreshLatestAck?: boolean;
-}
-
-/**
- * Data required to update internal tracking state after receiving a Summary Ack.
- */
-export interface IRefreshSummaryAckOptions {
-	/** Handle from the ack's summary op. */
-	readonly proposalHandle: string | undefined;
-	/** Handle from the summary ack just received */
-	readonly ackHandle: string;
-	/** Reference sequence number from the ack's summary op */
-	readonly summaryRefSeq: number;
-	/** Telemetry logger to which telemetry events will be forwarded. */
-	readonly summaryLogger: ITelemetryLoggerExt;
 }
 
 export interface ISubmitSummaryOptions extends ISummarizeOptions {

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -14,7 +14,14 @@ import {
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { IThrottler } from "../throttler";
 import { ISummarizerClientElection } from "./summarizerClientElection";
-import { ISummarizer, SummarizerStopReason } from "./summarizerTypes";
+import {
+	EnqueueSummarizeResult,
+	IEnqueueSummarizeOptions,
+	IOnDemandSummarizeOptions,
+	ISummarizeResults,
+	ISummarizer,
+	SummarizerStopReason,
+} from "./summarizerTypes";
 import { SummaryCollection } from "./summaryCollection";
 import { Summarizer } from "./summarizer";
 
@@ -404,21 +411,21 @@ export class SummaryManager implements IDisposable {
 		return startWithInitialDelay;
 	}
 
-	public readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"] = (...args) => {
+	public summarizeOnDemand(options: IOnDemandSummarizeOptions): ISummarizeResults {
 		if (this.summarizer === undefined) {
 			throw Error("No running summarizer client");
 			// TODO: could spawn a summarizer client temporarily.
 		}
-		return this.summarizer.summarizeOnDemand(...args);
-	};
+		return this.summarizer.summarizeOnDemand(options);
+	}
 
-	public readonly enqueueSummarize: ISummarizer["enqueueSummarize"] = (...args) => {
+	public enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult {
 		if (this.summarizer === undefined) {
 			throw Error("No running summarizer client");
 			// TODO: could spawn a summarizer client temporarily.
 		}
-		return this.summarizer.enqueueSummarize(...args);
-	};
+		return this.summarizer.enqueueSummarize(options);
+	}
 
 	public dispose() {
 		this.clientElection.off("electedSummarizerChanged", this.refreshSummarizer);

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -1215,7 +1215,7 @@ describe("Runtime", () => {
 
 				it("Should create an on-demand summary", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason });
+					const result = summarizer.summarizeOnDemand({ reason });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1290,7 +1290,7 @@ describe("Runtime", () => {
 
 					let resolved = false;
 					try {
-						summarizer.summarizeOnDemand(undefined, { reason });
+						summarizer.summarizeOnDemand({ reason });
 						resolved = true;
 					} catch {}
 
@@ -1300,7 +1300,7 @@ describe("Runtime", () => {
 
 				it("On-demand summary should fail on nack", async () => {
 					await emitNextOp(2); // set ref seq to 2
-					const result = summarizer.summarizeOnDemand(undefined, { reason });
+					const result = summarizer.summarizeOnDemand({ reason });
 
 					const submitResult = await result.summarySubmitted;
 					assertRunCounts(1, 0, 0, "on-demand should run");
@@ -1372,16 +1372,16 @@ describe("Runtime", () => {
 				it("Should fail an on-demand summary if stopping", async () => {
 					summarizer.waitStop(true).catch(() => {});
 					const [refreshLatestAck, fullTree] = [true, true];
-					const result1 = summarizer.summarizeOnDemand(undefined, { reason: "test1" });
-					const result2 = summarizer.summarizeOnDemand(undefined, {
+					const result1 = summarizer.summarizeOnDemand({ reason: "test1" });
+					const result2 = summarizer.summarizeOnDemand({
 						reason: "test2",
 						refreshLatestAck,
 					});
-					const result3 = summarizer.summarizeOnDemand(undefined, {
+					const result3 = summarizer.summarizeOnDemand({
 						reason: "test3",
 						fullTree,
 					});
-					const result4 = summarizer.summarizeOnDemand(undefined, {
+					const result4 = summarizer.summarizeOnDemand({
 						reason: "test4",
 						refreshLatestAck,
 						fullTree,
@@ -1414,16 +1414,16 @@ describe("Runtime", () => {
 				it("Should fail an on-demand summary if disposed", async () => {
 					summarizer.dispose();
 					const [refreshLatestAck, fullTree] = [true, true];
-					const result1 = summarizer.summarizeOnDemand(undefined, { reason: "test1" });
-					const result2 = summarizer.summarizeOnDemand(undefined, {
+					const result1 = summarizer.summarizeOnDemand({ reason: "test1" });
+					const result2 = summarizer.summarizeOnDemand({
 						reason: "test2",
 						refreshLatestAck,
 					});
-					const result3 = summarizer.summarizeOnDemand(undefined, {
+					const result3 = summarizer.summarizeOnDemand({
 						reason: "test3",
 						fullTree,
 					});
-					const result4 = summarizer.summarizeOnDemand(undefined, {
+					const result4 = summarizer.summarizeOnDemand({
 						reason: "test4",
 						refreshLatestAck,
 						fullTree,


### PR DESCRIPTION
The `refreshLatestAck` summarize option has been deprecated. This does not work as expected because the container shuts down when summarization is invoked with this option (See #15009 for details).
This will be removed from the summarize options in a later release.

This PR also does a couple other small refactors:
1. In `RunningSummarizer`, removed the `cancelationToken` params from `trySummarize` methods. No one passes in this paramter; they use `this.cancelationToken`.
2. Changed the style of `summarizeOnDemand` / `enqueuSummarize` params and return types to make them easier to understand.