### PR TITLE
Fix edge case in createWeightedGenerator

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -241,7 +241,7 @@ export const makeTransactionEditGenerator = (
 	]);
 
 	return (state) => {
-		const contents = transactionBoundaryType(state)
+		const contents = transactionBoundaryType(state);
 
 		return contents === done
 			? done
@@ -287,34 +287,26 @@ export function makeOpGenerator(
 		...opWeights,
 	};
 	const generatorWeights: Weights<Operation, FuzzTestState> = [];
-	if(sumWeights([passedOpWeights.delete, passedOpWeights.insert]) > 0){
-		generatorWeights.push(
-			[
-				makeEditGenerator(passedOpWeights),
-				sumWeights([passedOpWeights.delete, passedOpWeights.insert]),
-			]
-		)
+	if (sumWeights([passedOpWeights.delete, passedOpWeights.insert]) > 0) {
+		generatorWeights.push([
+			makeEditGenerator(passedOpWeights),
+			sumWeights([passedOpWeights.delete, passedOpWeights.insert]),
+		]);
 	}
-	if(sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]) > 0){
-		generatorWeights.push(
-			[
-				makeTransactionEditGenerator(passedOpWeights),
-				sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]),
-			]
-		)
+	if (sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]) > 0) {
+		generatorWeights.push([
+			makeTransactionEditGenerator(passedOpWeights),
+			sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]),
+		]);
 	}
-	if(sumWeights([passedOpWeights.undo, passedOpWeights.redo]) > 0){
-		generatorWeights.push(
-			[
-				makeUndoRedoEditGenerator(passedOpWeights),
-				sumWeights([passedOpWeights.undo, passedOpWeights.redo]),
-			]
-		)
+	if (sumWeights([passedOpWeights.undo, passedOpWeights.redo]) > 0) {
+		generatorWeights.push([
+			makeUndoRedoEditGenerator(passedOpWeights),
+			sumWeights([passedOpWeights.undo, passedOpWeights.redo]),
+		]);
 	}
-	if(passedOpWeights.synchronizeTrees > 0){
-		generatorWeights.push(
-			[{ type: "synchronizeTrees" }, passedOpWeights.synchronizeTrees],
-		)
+	if (passedOpWeights.synchronizeTrees > 0) {
+		generatorWeights.push([{ type: "synchronizeTrees" }, passedOpWeights.synchronizeTrees]);
 	}
 	const generatorAssumingTreeIsSelected = createWeightedGenerator<Operation, FuzzTestState>(
 		generatorWeights,

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -241,7 +241,7 @@ export const makeTransactionEditGenerator = (
 	]);
 
 	return (state) => {
-		const contents = transactionBoundaryType(state);
+		const contents = transactionBoundaryType(state)
 
 		return contents === done
 			? done
@@ -286,22 +286,36 @@ export function makeOpGenerator(
 		...defaultEditGeneratorOpWeights,
 		...opWeights,
 	};
-	const generatorWeights: Weights<Operation, FuzzTestState> = [
-		[
-			makeEditGenerator(passedOpWeights),
-			sumWeights([passedOpWeights.delete, passedOpWeights.insert]),
-		],
-		[
-			makeTransactionEditGenerator(passedOpWeights),
-			sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]),
-		],
-		[
-			makeUndoRedoEditGenerator(passedOpWeights),
-			sumWeights([passedOpWeights.undo, passedOpWeights.redo]),
-		],
-		[{ type: "synchronizeTrees" }, passedOpWeights.synchronizeTrees],
-	];
-
+	const generatorWeights: Weights<Operation, FuzzTestState> = [];
+	if(sumWeights([passedOpWeights.delete, passedOpWeights.insert]) > 0){
+		generatorWeights.push(
+			[
+				makeEditGenerator(passedOpWeights),
+				sumWeights([passedOpWeights.delete, passedOpWeights.insert]),
+			]
+		)
+	}
+	if(sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]) > 0){
+		generatorWeights.push(
+			[
+				makeTransactionEditGenerator(passedOpWeights),
+				sumWeights([passedOpWeights.abort, passedOpWeights.commit, passedOpWeights.start]),
+			]
+		)
+	}
+	if(sumWeights([passedOpWeights.undo, passedOpWeights.redo]) > 0){
+		generatorWeights.push(
+			[
+				makeUndoRedoEditGenerator(passedOpWeights),
+				sumWeights([passedOpWeights.undo, passedOpWeights.redo]),
+			]
+		)
+	}
+	if(passedOpWeights.synchronizeTrees > 0){
+		generatorWeights.push(
+			[{ type: "synchronizeTrees" }, passedOpWeights.synchronizeTrees],
+		)
+	}
 	const generatorAssumingTreeIsSelected = createWeightedGenerator<Operation, FuzzTestState>(
 		generatorWeights,
 	);

--- a/packages/test/stochastic-test-utils/src/generators.ts
+++ b/packages/test/stochastic-test-utils/src/generators.ts
@@ -45,8 +45,13 @@ export function createWeightedGenerator<T, TState extends BaseFuzzTestState>(
 	let totalWeight = 0;
 	for (const [tOrGenerator, weight, shouldAccept] of weights) {
 		const cumulativeWeight = totalWeight + weight;
-		cumulativeSums.push([tOrGenerator, cumulativeWeight, shouldAccept]);
+		if (weight > 0) {
+			cumulativeSums.push([tOrGenerator, cumulativeWeight, shouldAccept]);
+		}
 		totalWeight = cumulativeWeight;
+	}
+	if (totalWeight === 0) {
+		throw new Error("createWeightedGenerator must have some positive weight");
 	}
 
 	// Note: if this is a perf bottleneck in usage, the cumulative weights array could be
@@ -282,8 +287,13 @@ export function createWeightedAsyncGenerator<T, TState extends BaseFuzzTestState
 	let totalWeight = 0;
 	for (const [tOrGenerator, weight, shouldAccept] of weights) {
 		const cumulativeWeight = totalWeight + weight;
-		cumulativeSums.push([tOrGenerator, cumulativeWeight, shouldAccept]);
+		if (weight > 0) {
+			cumulativeSums.push([tOrGenerator, cumulativeWeight, shouldAccept]);
+		}
 		totalWeight = cumulativeWeight;
+	}
+	if (totalWeight === 0) {
+		throw new Error("createWeightedAsyncGenerator must have some positive weight");
 	}
 
 	// Note: if this is a perf bottleneck in usage, the cumulative weights array could be


### PR DESCRIPTION
## Description

@daesun-park was seeing some odd behavior in SharedTree fuzz tests: insert ops were getting generated despite setting their weight to 0.

I noticed that the implementation of `createWeightedGenerator` and `createWeightedAsyncGenerator` technically does allow this to be possible, since `random.real` is inclusive on its lower bound. It should be excessively rare assuming statistical guarantees of the randomness are valid, but this removes that as a potential issue by explicitly not including 0-weight entries in the `cumulativeSums` array we sample from.

It also throws an explicit error when used with all 0 weights, instead of infinite looping.