### PR TITLE
tree2: Add isEmpty to Forest

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -228,9 +228,6 @@ abstract class BrandedType<ValueType, Name extends string> {
 // @alpha
 export function brandOpaque<T extends BrandedType<any, string>>(value: isAny<ValueFromBranded<T>> extends true ? never : ValueFromBranded<T>): BrandedType<ValueFromBranded<T>, NameFromBranded<T>>;
 
-// @alpha (undocumented)
-export function buildForest(schema: StoredSchemaRepository, anchors?: AnchorSet): IEditableForest;
-
 // @alpha
 export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
 
@@ -865,6 +862,7 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
     allocateCursor(): ITreeSubscriptionCursor;
     clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
+    readonly isEmpty: boolean;
     readonly schema: StoredSchemaRepository;
     tryMoveCursorToField(destination: FieldAnchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
     tryMoveCursorToNode(destination: Anchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;

--- a/experimental/dds/tree2/src/core/forest/editableForest.ts
+++ b/experimental/dds/tree2/src/core/forest/editableForest.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { FieldKey } from "../schema-stored";
 import {
 	AnchorSet,
@@ -36,8 +37,18 @@ export interface IEditableForest extends IForestSubscription {
 	applyDelta(delta: Delta.Root): void;
 }
 
-export function initializeForest(forest: IEditableForest, content: ITreeCursorSynchronous[]): void {
-	// TODO: maybe assert forest is empty?
+/**
+ * Sets the contents of the forest via delta.
+ * Requires the fores starts empty.
+ *
+ * @remarks
+ * This does not perform an edit: it updates the forest content as if there was an edit that did that.
+ */
+export function initializeForest(
+	forest: IEditableForest,
+	content: readonly ITreeCursorSynchronous[],
+): void {
+	assert(forest.isEmpty, "forest must be empty");
 	const insert: Delta.Insert = { type: Delta.MarkType.Insert, content };
 	forest.applyDelta(new Map([[rootFieldKey, [insert]]]));
 }

--- a/experimental/dds/tree2/src/core/forest/forest.ts
+++ b/experimental/dds/tree2/src/core/forest/forest.ts
@@ -95,6 +95,11 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 		destination: FieldAnchor,
 		cursorToMove: ITreeSubscriptionCursor,
 	): TreeNavigationResult;
+
+	/**
+	 * True if there are no nodes in the forest at all.
+	 */
+	readonly isEmpty: boolean;
 }
 
 /**

--- a/experimental/dds/tree2/src/core/forest/forest.ts
+++ b/experimental/dds/tree2/src/core/forest/forest.ts
@@ -98,6 +98,9 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 
 	/**
 	 * True if there are no nodes in the forest at all.
+	 *
+	 * @remarks
+	 * This means no nodes under any detached field, not just the special document root one.
 	 */
 	readonly isEmpty: boolean;
 }

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -68,6 +68,10 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		recordDependency(this.dependent, this.schema);
 	}
 
+	public get isEmpty(): boolean {
+		return this.roots.fields.size === 0;
+	}
+
 	public on<K extends keyof ForestEvents>(eventName: K, listener: ForestEvents[K]): () => void {
 		return this.events.on(eventName, listener);
 	}

--- a/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
@@ -69,6 +69,10 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		recordDependency(this.dependent, this.schema);
 	}
 
+	public get isEmpty(): boolean {
+		return this.roots.fields.size === 0;
+	}
+
 	public on<K extends keyof ForestEvents>(eventName: K, listener: ForestEvents[K]): () => void {
 		return this.events.on(eventName, listener);
 	}
@@ -445,12 +449,11 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 	}
 }
 
-// This function is the only package level export for objectForest, and hides all the implementation types.
+// This function is the folder level export for objectForest, and hides all the implementation types.
 // When other forest implementations are created (ex: optimized ones),
 // this function should likely be moved and updated to (at least conditionally) use them.
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
- * @alpha
  */
 export function buildForest(schema: StoredSchemaRepository, anchors?: AnchorSet): IEditableForest {
 	return new ObjectForest(schema, anchors);

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -124,7 +124,6 @@ export {
 } from "./domains";
 
 export {
-	buildForest,
 	IdAllocator,
 	ModularChangeset,
 	EditDescription,

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -152,6 +152,15 @@ export function testForest(config: ForestTestConfiguration): void {
 			reader2.free();
 		});
 
+		it("isEmpty", () => {
+			const forest = factory(
+				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
+			);
+			assert(forest.isEmpty);
+			initializeForest(forest, [singleJsonCursor([])]);
+			assert(!forest.isEmpty);
+		});
+
 		it("moving a cursor to the root of an empty forest fails", () => {
 			const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
 			const cursor = forest.allocateCursor();

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -172,7 +172,6 @@ export function testForest(config: ForestTestConfiguration): void {
 				content: [singleJsonCursor([])],
 			};
 			forest.applyDelta(new Map([[brand("different root"), [insert]]]));
-			initializeForest(forest, [singleJsonCursor([])]);
 			assert(!forest.isEmpty);
 		});
 

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -152,11 +152,26 @@ export function testForest(config: ForestTestConfiguration): void {
 			reader2.free();
 		});
 
-		it("isEmpty", () => {
+		it("isEmpty: rootFieldKey", () => {
 			const forest = factory(
 				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
 			);
 			assert(forest.isEmpty);
+			initializeForest(forest, [singleJsonCursor([])]);
+			assert(!forest.isEmpty);
+		});
+
+		it("isEmpty: other root", () => {
+			const forest = factory(
+				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
+			);
+			assert(forest.isEmpty);
+
+			const insert: Delta.Insert = {
+				type: Delta.MarkType.Insert,
+				content: [singleJsonCursor([])],
+			};
+			forest.applyDelta(new Map([[brand("different root"), [insert]]]));
 			initializeForest(forest, [singleJsonCursor([])]);
 			assert(!forest.isEmpty);
 		});


### PR DESCRIPTION
## Description

Its annoying to check a forest for emptiness, so add an API for it.

The use case is mainly sanity checking asserts that a forest which should not have been populated yet is empty.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

