### PR TITLE
Fixed inconsistent usage of pending messages in container runtime

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1530,8 +1530,7 @@ export class ContainerRuntime
 		this.summaryCollection = new SummaryCollection(this.deltaManager, this.logger);
 
 		this.dirtyContainer =
-			this.attachState !== AttachState.Attached ||
-			this.pendingStateManager.hasPendingMessages();
+			this.attachState !== AttachState.Attached || this.hasPendingMessages();
 		context.updateDirtyContainerState(this.dirtyContainer);
 
 		if (this.summariesDisabled) {
@@ -1930,7 +1929,7 @@ export class ContainerRuntime
 			this.mc.logger.sendTelemetryEvent({
 				eventName: "ReconnectsWithNoProgress",
 				attempts: this.consecutiveReconnects,
-				pendingMessages: this.pendingStateManager.pendingMessagesCount,
+				pendingMessages: this.pendingMessagesCount,
 			});
 		}
 
@@ -2133,7 +2132,7 @@ export class ContainerRuntime
 						{
 							dataLoss: 1,
 							attempts: this.consecutiveReconnects,
-							pendingMessages: this.pendingStateManager.pendingMessagesCount,
+							pendingMessages: this.pendingMessagesCount,
 						},
 					),
 				);
@@ -3208,8 +3207,12 @@ export class ContainerRuntime
 		}
 	}
 
+	private get pendingMessagesCount(): number {
+		return this.pendingStateManager.pendingMessagesCount + this.outbox.messageCount;
+	}
+
 	private hasPendingMessages() {
-		return this.pendingStateManager.hasPendingMessages() || !this.outbox.isEmpty;
+		return this.pendingMessagesCount !== 0;
 	}
 
 	private updateDocumentDirtyState(dirty: boolean) {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -111,12 +111,12 @@ export class Outbox {
 		this.blobAttachBatch = new BatchManager({ hardLimit });
 	}
 
+	public get messageCount(): number {
+		return this.attachFlowBatch.length + this.mainBatch.length + this.blobAttachBatch.length;
+	}
+
 	public get isEmpty(): boolean {
-		return (
-			this.attachFlowBatch.length === 0 &&
-			this.mainBatch.length === 0 &&
-			this.blobAttachBatch.length === 0
-		);
+		return this.messageCount === 0;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -86,10 +86,6 @@ export class PendingStateManager implements IDisposable {
 		this.pendingMessages.clear();
 	});
 
-	public get pendingMessagesCount(): number {
-		return this.pendingMessages.length;
-	}
-
 	// Indicates whether we are processing a batch.
 	private isProcessingBatch: boolean = false;
 
@@ -100,11 +96,19 @@ export class PendingStateManager implements IDisposable {
 	private clientId: string | undefined;
 
 	/**
+	 * The pending messages count. Includes `pendingMessages` and `initialMessages` to keep in sync with
+	 * 'hasPendingMessages'.
+	 */
+	public get pendingMessagesCount(): number {
+		return this.pendingMessages.length + this.initialMessages.length;
+	}
+
+	/**
 	 * Called to check if there are any pending messages in the pending message queue.
 	 * @returns A boolean indicating whether there are messages or not.
 	 */
 	public hasPendingMessages(): boolean {
-		return !this.pendingMessages.isEmpty() || !this.initialMessages.isEmpty();
+		return this.pendingMessagesCount !== 0;
 	}
 
 	public getLocalState(): IPendingLocalState | undefined {

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -440,4 +440,103 @@ describe("Pending State Manager", () => {
 			]);
 		});
 	});
+
+	describe("Pending messages state", () => {
+		const messages = [
+			{ type: "message", content: '{"type":"component"}' },
+			{
+				type: "message",
+				content: '{"type": "component", "contents": {"prop1": "value"}}',
+			},
+		];
+
+		function createPendingStateManager(pendingStates): PendingStateManager_WithPrivates {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return new PendingStateManager(
+				{
+					applyStashedOp: async () => undefined,
+					clientId: () => undefined,
+					close: () => {},
+					connected: () => true,
+					reSubmit: () => {},
+					reSubmitBatch: () => {},
+					isActiveConnection: () => false,
+				},
+				{ pendingStates },
+				undefined /* logger */,
+			) as any;
+		}
+
+		it("no pending or initial messages", () => {
+			const pendingStateManager = createPendingStateManager(undefined);
+			assert.strictEqual(
+				pendingStateManager.hasPendingMessages(),
+				false,
+				"There shouldn't be pending messages",
+			);
+			assert.strictEqual(
+				pendingStateManager.pendingMessagesCount,
+				0,
+				"Pending messages count should be 0",
+			);
+		});
+
+		it("has pending messages but no initial messages", () => {
+			const pendingStateManager = createPendingStateManager(undefined);
+			for (const message of messages) {
+				pendingStateManager.onSubmitMessage(
+					JSON.stringify(message.content),
+					0,
+					undefined /* localOpMetadata */,
+					undefined /* opMetadata */,
+				);
+			}
+			assert.strictEqual(
+				pendingStateManager.hasPendingMessages(),
+				true,
+				"There should be pending messages",
+			);
+			assert.strictEqual(
+				pendingStateManager.pendingMessagesCount,
+				messages.length,
+				"Pending messages count should be same as pending messages",
+			);
+		});
+
+		it("has initial messages but no pending messages", () => {
+			const pendingStateManager = createPendingStateManager(messages);
+			assert.strictEqual(
+				pendingStateManager.hasPendingMessages(),
+				true,
+				"There should be initial messages",
+			);
+			assert.strictEqual(
+				pendingStateManager.pendingMessagesCount,
+				messages.length,
+				"Pending messages count should be same as initial messages",
+			);
+		});
+
+		it("has both pending messages and initial messages", () => {
+			const pendingStateManager = createPendingStateManager(messages);
+			for (const message of messages) {
+				pendingStateManager.onSubmitMessage(
+					JSON.stringify(message.content),
+					0,
+					undefined /* localOpMetadata */,
+					undefined /* opMetadata */,
+				);
+			}
+			assert.strictEqual(
+				pendingStateManager.hasPendingMessages(),
+				true,
+				"There should be pending messages",
+			);
+			assert.strictEqual(
+				pendingStateManager.pendingMessagesCount,
+				messages.length * 2,
+				"Pending messages count should be same as pending + initial messages",
+			);
+		});
+	});
 });


### PR DESCRIPTION
## Description
ContainerRuntime checks for pending messages and logs the number of pending messages. However, these are not consistent:
- PendingStateManager's `hasPendingMessages` checks for pendingMessages and initialMessages. However, `pendingMessagesCount` only checks for pendingMessages.
- ContainerRuntime's `hasPendingMessages` checks for pending messages in PendingStateManager and Outbox. However, the pending messages count logged in telemetry only includes peding state manager.

This PR fixes the issues described above:
- Made `hasPendingMessages` and `pendingMessageCount` consistent in `PendingStateManager` and `ContainerRuntime`.
- Added `messageCount` to `Outbobx`.
- Updated all usages in container runtime to use its `hasPendingMessages` and `pendingMessageCount` instead of pending state manager's.

[AB#5330](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5330)