### PR TITLE
Update type tests to use 6.1

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -58,7 +58,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.6.0.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.6.1.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.6.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -74,7 +74,7 @@
 		"path-browserify": "^1.0.1"
 	},
 	"devDependencies": {
-		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.0.0-internal.6.0.0",
+		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.0.0-internal.6.1.0",
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/events": "^3.0.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.6.0.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^16.18.38",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.6.0.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.6.0.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.6.0.0",
+		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.6.0.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.6.0.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.6.0.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.6.0.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.6.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.6.0.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.6.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources": "^1.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.6.0.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.6.1.0",
 		"@fluidframework/server-services-client": "^1.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.6.0.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.6.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.6.0.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.6.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.6.0.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.6.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.6.0.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -72,7 +72,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.6.0.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.6.0.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -44,7 +44,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.6.0.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^16.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.6.0.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.6.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.6.0.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.6.1.0",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.6.0.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.6.0.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.6.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.6.0.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.6.0.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -50,7 +50,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.6.0.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.6.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",
 		"@types/node": "^16.18.38",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-tools": "^0.2.158186",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.6.0.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.6.1.0",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.6.0.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.6.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.6.0.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.6.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -77,7 +77,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.6.0.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -71,7 +71,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.6.0.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.6.0.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.6.1.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
@@ -98,15 +98,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedClassDeclaration_RootDataObject": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_RootDataObjectProps": {
-				"backCompat": false,
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.6.0.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.6.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.6.0.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -62,7 +62,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.6.0.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.6.0.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.6.0.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.6.0.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -83,7 +83,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.6.0.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",
@@ -108,10 +108,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_IContainerContext": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -71,7 +71,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -77,7 +77,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -70,7 +70,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -87,7 +87,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.6.0.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -81,7 +81,7 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.6.0.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.6.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -65,7 +65,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.6.0.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.6.0.0",
+		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"concurrently": "^7.6.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.6.0.0",
+		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.6.1.0",
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
@@ -117,78 +117,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"EnumDeclaration_ContainerDevtoolsFeature": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"EnumDeclaration_DevtoolsFeature": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"EnumDeclaration_EditType": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_FluidHandleNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_FluidObjectNodeBase": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_FluidObjectTreeNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_FluidObjectValueNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_FluidUnknownObjectNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_TreeNodeBase": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_UnknownObjectNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ValueNodeBase": {
-				"backCompat": false
-			},
-			"TypeAliasDeclaration_VisualChildNode": {
-				"backCompat": false
-			},
-			"TypeAliasDeclaration_VisualNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_VisualNodeBase": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_VisualTreeNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_VisualValueNode": {
-				"backCompat": false
-			},
-			"RemovedEnumDeclaration_DevtoolsFeature": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedEnumDeclaration_EditType": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedEnumDeclaration_ContainerDevtoolsFeature": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"TypeAliasDeclaration_FluidObjectNode": {
-				"backCompat": false
-			},
-			"TypeAliasDeclaration_RootHandleNode": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_Edit": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -376,38 +376,26 @@ use_old_InterfaceDeclaration_ConnectionStateChangeLogEntry(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_ContainerDevtoolsFeature": {"forwardCompat": false}
+* "InterfaceDeclaration_ContainerDevtoolsFeatureFlags": {"forwardCompat": false}
 */
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_ContainerDevtoolsFeature": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_ContainerDevtoolsFeatureFlags": {"forwardCompat": false}
-*/
-declare function get_old_TypeAliasDeclaration_ContainerDevtoolsFeatureFlags():
+declare function get_old_InterfaceDeclaration_ContainerDevtoolsFeatureFlags():
     TypeOnly<old.ContainerDevtoolsFeatureFlags>;
-declare function use_current_RemovedTypeAliasDeclaration_ContainerDevtoolsFeatureFlags(
+declare function use_current_InterfaceDeclaration_ContainerDevtoolsFeatureFlags(
     use: TypeOnly<current.ContainerDevtoolsFeatureFlags>);
-use_current_RemovedTypeAliasDeclaration_ContainerDevtoolsFeatureFlags(
-    get_old_TypeAliasDeclaration_ContainerDevtoolsFeatureFlags());
+use_current_InterfaceDeclaration_ContainerDevtoolsFeatureFlags(
+    get_old_InterfaceDeclaration_ContainerDevtoolsFeatureFlags());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_ContainerDevtoolsFeatureFlags": {"backCompat": false}
+* "InterfaceDeclaration_ContainerDevtoolsFeatureFlags": {"backCompat": false}
 */
-declare function get_current_RemovedTypeAliasDeclaration_ContainerDevtoolsFeatureFlags():
+declare function get_current_InterfaceDeclaration_ContainerDevtoolsFeatureFlags():
     TypeOnly<current.ContainerDevtoolsFeatureFlags>;
-declare function use_old_TypeAliasDeclaration_ContainerDevtoolsFeatureFlags(
+declare function use_old_InterfaceDeclaration_ContainerDevtoolsFeatureFlags(
     use: TypeOnly<old.ContainerDevtoolsFeatureFlags>);
-use_old_TypeAliasDeclaration_ContainerDevtoolsFeatureFlags(
-    get_current_RemovedTypeAliasDeclaration_ContainerDevtoolsFeatureFlags());
+use_old_InterfaceDeclaration_ContainerDevtoolsFeatureFlags(
+    get_current_InterfaceDeclaration_ContainerDevtoolsFeatureFlags());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1156,38 +1144,26 @@ use_old_FunctionDeclaration_DevtoolsDisposed_createMessage(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_DevtoolsFeature": {"forwardCompat": false}
+* "InterfaceDeclaration_DevtoolsFeatureFlags": {"forwardCompat": false}
 */
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_DevtoolsFeature": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_DevtoolsFeatureFlags": {"forwardCompat": false}
-*/
-declare function get_old_TypeAliasDeclaration_DevtoolsFeatureFlags():
+declare function get_old_InterfaceDeclaration_DevtoolsFeatureFlags():
     TypeOnly<old.DevtoolsFeatureFlags>;
-declare function use_current_RemovedTypeAliasDeclaration_DevtoolsFeatureFlags(
+declare function use_current_InterfaceDeclaration_DevtoolsFeatureFlags(
     use: TypeOnly<current.DevtoolsFeatureFlags>);
-use_current_RemovedTypeAliasDeclaration_DevtoolsFeatureFlags(
-    get_old_TypeAliasDeclaration_DevtoolsFeatureFlags());
+use_current_InterfaceDeclaration_DevtoolsFeatureFlags(
+    get_old_InterfaceDeclaration_DevtoolsFeatureFlags());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_DevtoolsFeatureFlags": {"backCompat": false}
+* "InterfaceDeclaration_DevtoolsFeatureFlags": {"backCompat": false}
 */
-declare function get_current_RemovedTypeAliasDeclaration_DevtoolsFeatureFlags():
+declare function get_current_InterfaceDeclaration_DevtoolsFeatureFlags():
     TypeOnly<current.DevtoolsFeatureFlags>;
-declare function use_old_TypeAliasDeclaration_DevtoolsFeatureFlags(
+declare function use_old_InterfaceDeclaration_DevtoolsFeatureFlags(
     use: TypeOnly<old.DevtoolsFeatureFlags>);
-use_old_TypeAliasDeclaration_DevtoolsFeatureFlags(
-    get_current_RemovedTypeAliasDeclaration_DevtoolsFeatureFlags());
+use_old_InterfaceDeclaration_DevtoolsFeatureFlags(
+    get_current_InterfaceDeclaration_DevtoolsFeatureFlags());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1427,8 +1403,31 @@ declare function get_current_InterfaceDeclaration_Edit():
 declare function use_old_InterfaceDeclaration_Edit(
     use: TypeOnly<old.Edit>);
 use_old_InterfaceDeclaration_Edit(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_Edit());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_EditData": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_EditData():
+    TypeOnly<old.EditData>;
+declare function use_current_TypeAliasDeclaration_EditData(
+    use: TypeOnly<current.EditData>);
+use_current_TypeAliasDeclaration_EditData(
+    get_old_TypeAliasDeclaration_EditData());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_EditData": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_EditData():
+    TypeOnly<current.EditData>;
+declare function use_old_TypeAliasDeclaration_EditData(
+    use: TypeOnly<old.EditData>);
+use_old_TypeAliasDeclaration_EditData(
+    get_current_TypeAliasDeclaration_EditData());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1457,14 +1456,50 @@ use_old_TypeAliasDeclaration_EditSharedObject(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_EditType": {"forwardCompat": false}
+* "VariableDeclaration_EditType": {"forwardCompat": false}
 */
+declare function get_old_VariableDeclaration_EditType():
+    TypeOnly<typeof old.EditType>;
+declare function use_current_VariableDeclaration_EditType(
+    use: TypeOnly<typeof current.EditType>);
+use_current_VariableDeclaration_EditType(
+    get_old_VariableDeclaration_EditType());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_EditType": {"backCompat": false}
+* "VariableDeclaration_EditType": {"backCompat": false}
 */
+declare function get_current_VariableDeclaration_EditType():
+    TypeOnly<typeof current.EditType>;
+declare function use_old_VariableDeclaration_EditType(
+    use: TypeOnly<typeof old.EditType>);
+use_old_VariableDeclaration_EditType(
+    get_current_VariableDeclaration_EditType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_EditType": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_EditType():
+    TypeOnly<old.EditType>;
+declare function use_current_TypeAliasDeclaration_EditType(
+    use: TypeOnly<current.EditType>);
+use_current_TypeAliasDeclaration_EditType(
+    get_old_TypeAliasDeclaration_EditType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_EditType": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_EditType():
+    TypeOnly<current.EditType>;
+declare function use_old_TypeAliasDeclaration_EditType(
+    use: TypeOnly<old.EditType>);
+use_old_TypeAliasDeclaration_EditType(
+    get_current_TypeAliasDeclaration_EditType());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1512,7 +1547,6 @@ declare function get_current_InterfaceDeclaration_FluidHandleNode():
 declare function use_old_InterfaceDeclaration_FluidHandleNode(
     use: TypeOnly<old.FluidHandleNode>);
 use_old_InterfaceDeclaration_FluidHandleNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_FluidHandleNode());
 
 /*
@@ -1561,7 +1595,6 @@ declare function get_current_TypeAliasDeclaration_FluidObjectNode():
 declare function use_old_TypeAliasDeclaration_FluidObjectNode(
     use: TypeOnly<old.FluidObjectNode>);
 use_old_TypeAliasDeclaration_FluidObjectNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_FluidObjectNode());
 
 /*
@@ -1586,7 +1619,6 @@ declare function get_current_InterfaceDeclaration_FluidObjectNodeBase():
 declare function use_old_InterfaceDeclaration_FluidObjectNodeBase(
     use: TypeOnly<old.FluidObjectNodeBase>);
 use_old_InterfaceDeclaration_FluidObjectNodeBase(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_FluidObjectNodeBase());
 
 /*
@@ -1611,7 +1643,6 @@ declare function get_current_InterfaceDeclaration_FluidObjectTreeNode():
 declare function use_old_InterfaceDeclaration_FluidObjectTreeNode(
     use: TypeOnly<old.FluidObjectTreeNode>);
 use_old_InterfaceDeclaration_FluidObjectTreeNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_FluidObjectTreeNode());
 
 /*
@@ -1636,7 +1667,6 @@ declare function get_current_InterfaceDeclaration_FluidObjectValueNode():
 declare function use_old_InterfaceDeclaration_FluidObjectValueNode(
     use: TypeOnly<old.FluidObjectValueNode>);
 use_old_InterfaceDeclaration_FluidObjectValueNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_FluidObjectValueNode());
 
 /*
@@ -1661,7 +1691,6 @@ declare function get_current_InterfaceDeclaration_FluidUnknownObjectNode():
 declare function use_old_InterfaceDeclaration_FluidUnknownObjectNode(
     use: TypeOnly<old.FluidUnknownObjectNode>);
 use_old_InterfaceDeclaration_FluidUnknownObjectNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_FluidUnknownObjectNode());
 
 /*
@@ -2790,7 +2819,6 @@ declare function get_current_TypeAliasDeclaration_RootHandleNode():
 declare function use_old_TypeAliasDeclaration_RootHandleNode(
     use: TypeOnly<old.RootHandleNode>);
 use_old_TypeAliasDeclaration_RootHandleNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_RootHandleNode());
 
 /*
@@ -3055,7 +3083,6 @@ declare function get_current_InterfaceDeclaration_TreeNodeBase():
 declare function use_old_InterfaceDeclaration_TreeNodeBase(
     use: TypeOnly<old.TreeNodeBase>);
 use_old_InterfaceDeclaration_TreeNodeBase(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_TreeNodeBase());
 
 /*
@@ -3080,7 +3107,6 @@ declare function get_current_InterfaceDeclaration_UnknownObjectNode():
 declare function use_old_InterfaceDeclaration_UnknownObjectNode(
     use: TypeOnly<old.UnknownObjectNode>);
 use_old_InterfaceDeclaration_UnknownObjectNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_UnknownObjectNode());
 
 /*
@@ -3105,7 +3131,6 @@ declare function get_current_InterfaceDeclaration_ValueNodeBase():
 declare function use_old_InterfaceDeclaration_ValueNodeBase(
     use: TypeOnly<old.ValueNodeBase>);
 use_old_InterfaceDeclaration_ValueNodeBase(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ValueNodeBase());
 
 /*
@@ -3130,7 +3155,6 @@ declare function get_current_TypeAliasDeclaration_VisualChildNode():
 declare function use_old_TypeAliasDeclaration_VisualChildNode(
     use: TypeOnly<old.VisualChildNode>);
 use_old_TypeAliasDeclaration_VisualChildNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_VisualChildNode());
 
 /*
@@ -3155,7 +3179,6 @@ declare function get_current_TypeAliasDeclaration_VisualNode():
 declare function use_old_TypeAliasDeclaration_VisualNode(
     use: TypeOnly<old.VisualNode>);
 use_old_TypeAliasDeclaration_VisualNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_VisualNode());
 
 /*
@@ -3180,7 +3203,6 @@ declare function get_current_InterfaceDeclaration_VisualNodeBase():
 declare function use_old_InterfaceDeclaration_VisualNodeBase(
     use: TypeOnly<old.VisualNodeBase>);
 use_old_InterfaceDeclaration_VisualNodeBase(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_VisualNodeBase());
 
 /*
@@ -3229,7 +3251,6 @@ declare function get_current_InterfaceDeclaration_VisualTreeNode():
 declare function use_old_InterfaceDeclaration_VisualTreeNode(
     use: TypeOnly<old.VisualTreeNode>);
 use_old_InterfaceDeclaration_VisualTreeNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_VisualTreeNode());
 
 /*
@@ -3254,7 +3275,6 @@ declare function get_current_InterfaceDeclaration_VisualValueNode():
 declare function use_old_InterfaceDeclaration_VisualValueNode(
     use: TypeOnly<old.VisualValueNode>);
 use_old_InterfaceDeclaration_VisualValueNode(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_VisualValueNode());
 
 /*

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/fluid-static": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.6.0.0",
+		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.6.1.0",
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.6.0.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.6.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.6.0.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.6.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -93,7 +93,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.6.0.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.6.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.6.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",
 		"@types/node-fetch": "^2.5.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -640,6 +640,30 @@ use_old_TypeAliasDeclaration_TelemetryEventPropertyTypes(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TelemetryNullLogger": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_TelemetryNullLogger():
+    TypeOnly<old.TelemetryNullLogger>;
+declare function use_current_ClassDeclaration_TelemetryNullLogger(
+    use: TypeOnly<current.TelemetryNullLogger>);
+use_current_ClassDeclaration_TelemetryNullLogger(
+    get_old_ClassDeclaration_TelemetryNullLogger());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TelemetryNullLogger": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_TelemetryNullLogger():
+    TypeOnly<current.TelemetryNullLogger>;
+declare function use_old_ClassDeclaration_TelemetryNullLogger(
+    use: TypeOnly<old.TelemetryNullLogger>);
+use_old_ClassDeclaration_TelemetryNullLogger(
+    get_current_ClassDeclaration_TelemetryNullLogger());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_ThresholdCounter": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_ThresholdCounter():

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.6.0.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.6.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/jwt-decode": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.6.0.0
+      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.6.1.0
       '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
@@ -128,7 +128,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
-      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.6.0.0
+      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.6.1.0
       '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
@@ -189,7 +189,7 @@ importers:
   azure/packages/azure-service-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.6.0.0
+      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -212,7 +212,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0
-      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.6.0.0
+      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -5293,7 +5293,7 @@ importers:
 
   experimental/dds/attributable-map:
     specifiers:
-      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.6.0.0
+      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.6.1.0
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
@@ -5341,7 +5341,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
       path-browserify: 1.0.1
     devDependencies:
-      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.6.0.0
+      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.6.1.0
       '@fluid-internal/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
@@ -6037,7 +6037,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.6.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6061,7 +6061,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       '@types/events': 3.0.0
@@ -6078,7 +6078,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/node': ^16.18.38
@@ -6092,7 +6092,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/node': 16.18.38
@@ -6163,7 +6163,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
@@ -6180,7 +6180,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -6196,7 +6196,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.6.0.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.6.1.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6235,7 +6235,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.6.0.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6262,7 +6262,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.6.0.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.6.1.0
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6298,7 +6298,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.6.0.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6328,7 +6328,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.6.0.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6363,7 +6363,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.6.0.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9
@@ -6395,7 +6395,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.6.0.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6438,7 +6438,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.6.0.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6470,7 +6470,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.6.0.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.6.1.0
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6524,7 +6524,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.6.0.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6563,7 +6563,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.6.0.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6608,7 +6608,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.6.0.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6641,7 +6641,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.6.0.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
@@ -6679,7 +6679,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.6.0.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -6777,7 +6777,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.6.0.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.6.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -6811,7 +6811,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.6.0.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -6848,7 +6848,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.6.0.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': ^1.0.0
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -6895,7 +6895,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.6.0.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': 1.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6935,7 +6935,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.6.0.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.6.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -6976,7 +6976,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.6.0.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/benchmark': 2.1.2
@@ -7011,7 +7011,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.6.0.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/benchmark': ^2.1.0
@@ -7044,7 +7044,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.6.0.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/benchmark': 2.1.2
@@ -7082,7 +7082,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.6.0.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7120,7 +7120,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.6.0.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -7200,7 +7200,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.6.0.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.6.1.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7228,7 +7228,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.6.0.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -7248,7 +7248,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.6.0.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.6.1.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7282,7 +7282,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.6.0.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -7309,7 +7309,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.6.0.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -7335,7 +7335,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.6.0.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/jest': 29.5.3
@@ -7359,7 +7359,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.6.0.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -7382,7 +7382,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.6.0.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/node': 16.18.38
       concurrently: 7.6.0
@@ -7395,7 +7395,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.6.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -7425,7 +7425,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -7454,7 +7454,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.6.0.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^1.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7508,7 +7508,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.6.0.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/jsrsasign': 8.0.13
@@ -7544,7 +7544,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': ^1.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': workspace:~
@@ -7592,7 +7592,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -7620,7 +7620,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
@@ -7637,7 +7637,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -7659,7 +7659,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.6.1.0
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
       concurrently: ^7.6.0
@@ -7683,7 +7683,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.6.1.0
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
       concurrently: 7.6.0
@@ -7708,7 +7708,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.6.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7734,7 +7734,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7763,7 +7763,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^1.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': ^1.0.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -7815,7 +7815,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7850,7 +7850,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.6.1.0
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
       '@types/node': ^16.18.38
@@ -7880,7 +7880,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.1.0
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
       '@types/node': 16.18.38
@@ -7910,7 +7910,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/server-services-client': ^1.0.0
       '@fluidframework/test-tools': ^0.2.158186
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.6.1.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
@@ -7940,7 +7940,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 0.2.158186
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.6.1.0
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -7956,7 +7956,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.6.0.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -7996,7 +7996,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.6.0.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -8013,7 +8013,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -8065,7 +8065,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -8226,7 +8226,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.6.0.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.6.1.0
       '@fluidframework/datastore': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -8262,7 +8262,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.6.0.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -8282,7 +8282,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.6.0.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
       '@fluidframework/merge-tree': workspace:~
@@ -8319,7 +8319,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.6.0.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8401,7 +8401,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.6.0.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.6.1.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -8441,7 +8441,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.6.0.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.6.1.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -8522,7 +8522,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.6.0.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.6.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -8557,7 +8557,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.6.0.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/diff': 3.5.5
@@ -8590,7 +8590,7 @@ importers:
       '@fluidframework/datastore': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.6.0.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
@@ -8617,7 +8617,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.6.0.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -8655,7 +8655,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.6.1.0
       '@fluidframework/tinylicious-driver': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8693,7 +8693,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -8719,7 +8719,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.6.0.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -8754,7 +8754,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.6.0.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/diff': 3.5.5
       '@types/events': 3.0.0
@@ -8783,7 +8783,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.6.0.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.6.1.0
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': 17.0.52
@@ -8806,7 +8806,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.6.0.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8824,7 +8824,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.6.0.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8841,7 +8841,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.6.0.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8860,7 +8860,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.6.0.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.6.1.0
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -8917,7 +8917,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.6.0.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -8948,7 +8948,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.6.0.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.6.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8980,7 +8980,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.6.0.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -9008,7 +9008,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.6.0.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^1.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -9052,7 +9052,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.6.0.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -9081,7 +9081,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.6.0.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -9109,7 +9109,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.6.0.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -9171,7 +9171,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.6.1.0
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -9234,7 +9234,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9264,7 +9264,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.6.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -9287,7 +9287,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -9308,7 +9308,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.6.0.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.6.1.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -9357,7 +9357,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.6.0.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9386,7 +9386,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -9407,7 +9407,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -9428,7 +9428,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
@@ -9448,7 +9448,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
       copyfiles: 2.4.1
@@ -9473,7 +9473,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.6.0.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.6.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -9508,7 +9508,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.6.0.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -9545,7 +9545,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.6.0.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -9589,7 +9589,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.6.0.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -9806,7 +9806,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.6.0.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.6.1.0
       '@fluidframework/test-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -9828,7 +9828,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.6.0.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -10028,7 +10028,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       concurrently: ^7.6.0
@@ -10050,7 +10050,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       '@types/mocha': 9.1.1
       concurrently: 7.6.0
@@ -10438,7 +10438,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-driver-definitions': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.6.0.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -10494,7 +10494,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.6.0.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/debug': 4.1.7
       '@types/diff': 3.5.5
@@ -10641,7 +10641,7 @@ importers:
   packages/tools/devtools/devtools:
     specifiers:
       '@fluid-experimental/devtools-core': workspace:~
-      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.6.1.0
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
@@ -10677,7 +10677,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
-      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.6.1.0
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
@@ -10844,7 +10844,7 @@ importers:
 
   packages/tools/devtools/devtools-core:
     specifiers:
-      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.6.1.0
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
@@ -10903,7 +10903,7 @@ importers:
       '@fluidframework/sequence': link:../../../dds/sequence
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
     devDependencies:
-      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.6.1.0
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
@@ -11164,7 +11164,7 @@ importers:
   packages/tools/fetch-tool:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.6.0.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.6.1.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
@@ -11207,7 +11207,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.6.0.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -11229,7 +11229,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.6.0.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
@@ -11266,7 +11266,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.6.0.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -11375,7 +11375,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.6.0.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -11457,7 +11457,7 @@ importers:
       webpack-dev-server: 4.6.0_nwcuyijzf6l5chuh7xhtrzgjly
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.0.0_nwcuyijzf6l5chuh7xhtrzgjly
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.1.0_nwcuyijzf6l5chuh7xhtrzgjly
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -11494,7 +11494,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.6.1.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@types/mocha': ^9.1.1
@@ -11526,7 +11526,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.1.0
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
       '@types/node-fetch': 2.6.4
@@ -11552,7 +11552,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -11588,7 +11588,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/debug': 4.1.7
       '@types/events': 3.0.0
@@ -11620,7 +11620,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.6.0.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
@@ -11657,7 +11657,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.6.0.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/debug': 4.1.7
       '@types/jwt-decode': 2.2.1
@@ -11755,7 +11755,7 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@azure/core-auth/1.4.0:
@@ -11763,7 +11763,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@azure/core-rest-pipeline/1.10.1:
@@ -11778,7 +11778,7 @@ packages:
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      tslib: 2.6.0
+      tslib: 2.6.1
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -11788,7 +11788,7 @@ packages:
     resolution: {integrity: sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@azure/core-util/1.2.0:
@@ -11796,14 +11796,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@azure/logger/1.0.4:
     resolution: {integrity: sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@azure/opentelemetry-instrumentation-azure-sdk/1.0.0-beta.3:
@@ -11815,7 +11815,7 @@ packages:
       '@opentelemetry/api': 1.4.1
       '@opentelemetry/core': 1.13.0_@opentelemetry+api@1.4.1
       '@opentelemetry/instrumentation': 0.35.1_@opentelemetry+api@1.4.1
-      tslib: 2.6.0
+      tslib: 2.6.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -13870,7 +13870,7 @@ packages:
       lodash.get: 4.4.2
       make-error: 1.3.6
       ts-node: 9.1.1_typescript@4.5.5
-      tslib: 2.6.0
+      tslib: 2.6.1
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -13969,7 +13969,7 @@ packages:
     resolution: {integrity: sha512-q3zaKmH79+gO5t0EwR2ghSVbJqP3nnNNXx3o/rp+v6LKVZaxRZYMWgw2ESR2gF8rI7TWSeKkGVfBime2mVbDoQ==}
     dependencies:
       '@fluentui/set-version': 8.2.9
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/dom-utilities/1.1.2:
@@ -13983,7 +13983,7 @@ packages:
     resolution: {integrity: sha512-rdqMelLb+d+GjB33j1D2IH+zEO9ofUDP3Yeb7GUCm9byDiUW1aVY2mL7hSZ3t2CearYtEfodbUQaLijWScxO0A==}
     dependencies:
       '@fluentui/set-version': 8.2.9
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/font-icons-mdl2/8.5.17_q5o373oqrklnndq2vhekyuzhxi:
@@ -13992,7 +13992,7 @@ packages:
       '@fluentui/set-version': 8.2.9
       '@fluentui/style-utilities': 8.9.10_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.13_q5o373oqrklnndq2vhekyuzhxi
-      tslib: 2.6.0
+      tslib: 2.6.1
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -14010,7 +14010,7 @@ packages:
       '@fluentui/utilities': 8.13.13_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/keyboard-key/0.2.17:
@@ -14022,7 +14022,7 @@ packages:
   /@fluentui/keyboard-key/0.4.9:
     resolution: {integrity: sha512-TttoZOrkzVR6Lg9wUTR0xGZwwJnpTTCKK0/CnA0feZoMNAgYR/FZTt7yNIe2Ty2622Q1JesWiEwPT027VdGxkA==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/keyboard-keys/9.0.3:
@@ -14035,7 +14035,7 @@ packages:
     resolution: {integrity: sha512-vIiFv7WtXTPz0Sx6h1NpzqrwDN7yef7aQwqFl46yov72BodiAQMTazBl2A/z76IanBPklJmaTquFT9Uydlp/Dg==}
     dependencies:
       '@fluentui/set-version': 8.2.9
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/priority-overflow/9.0.3:
@@ -14444,7 +14444,7 @@ packages:
       '@fluentui/utilities': 8.13.13_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/react-hooks/8.6.24_q5o373oqrklnndq2vhekyuzhxi:
@@ -15244,7 +15244,7 @@ packages:
       '@fluentui/set-version': 8.2.9
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/react/8.109.4_74b3ggvk3akyhuq4eydyx3fqim:
@@ -15278,7 +15278,7 @@ packages:
   /@fluentui/set-version/8.2.9:
     resolution: {integrity: sha512-fpWo4DLt8K4spNip2YhNZlGnSKIa5F9hL/wQBE0EPei6+HEeRO2slXfHohOO5v1lIkfLPcpAh/Lzs2iuxzw/lw==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/style-utilities/8.9.10_q5o373oqrklnndq2vhekyuzhxi:
@@ -15289,7 +15289,7 @@ packages:
       '@fluentui/theme': 2.6.29_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.13_q5o373oqrklnndq2vhekyuzhxi
       '@microsoft/load-themed-styles': 1.10.295
-      tslib: 2.6.0
+      tslib: 2.6.1
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -15324,7 +15324,7 @@ packages:
       '@fluentui/utilities': 8.13.13_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@fluentui/tokens/1.0.0-alpha.5:
@@ -15344,78 +15344,78 @@ packages:
       '@fluentui/set-version': 8.2.9
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
-  /@fluid-experimental/attributable-map/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-GaNbohuj/a+xXMisZqavVVERshatzn45OjvdLJxxN9d/He6BCk+ZKe2uPo6GIftWCRL4weYmX3RpnjdzXyr35g==}
+  /@fluid-experimental/attributable-map/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-ssXcSqkCQygprdOeXE5yu5yzsvtfTs5Ksq2PIuueszvqZ/ii6WHr/LzJBbt/Th1EiZ7BaDXM01gzrJ4oLmBzHw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Mk1UTKqZmeHvqpYQkgoTL1czv8BVnZWvHWFIAEiE7tejTWAHWCj+HBTAP4F7pjqy8Jf3jypO5TZCooRBliRS4g==}
+  /@fluid-experimental/devtools-core/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-FBNncOzBerYI1j1pC+4uLLxXX8aDPUxZD1JhUe/zEgkHNfBF8XjA0OhIlDQABJ29kHlRihfLyBRe+Dt4vvQhJw==}
     dependencies:
-      '@fluid-experimental/tree2': 2.0.0-internal.6.0.0
-      '@fluidframework/cell': 2.0.0-internal.6.0.0
+      '@fluid-experimental/tree2': 2.0.0-internal.6.1.1
+      '@fluidframework/cell': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/counter': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/matrix': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/counter': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/matrix': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/sequence': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/sequence': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-aOBFPjOMMpC6p92qG7QEMRNjbsVYmndRSOrYe8uFohjOdI4EBy8Aos4JvneIpZIB/3LlUjlbVzg+tXk29oQBYw==}
+  /@fluid-experimental/devtools/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-wrcTA9GMi6Wq/gI5HRcuI2o7ZyveaVKEdIVPS32PEOxUz9W1X4lx6aG9HIR9X9JIMUCttEGEF1Aqagzwp1H6Nw==}
     dependencies:
-      '@fluid-experimental/devtools-core': 2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-core': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/fluid-static': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/fluid-static': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/tree2/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-3EJqFGBcaK0Qmpb4g+pKVOM0DccSM7GnKUD38xPIMH5ohi1yJ2O9qCu34/aORyuXK7cAMkQSXFGJRJXGe+zFsQ==}
+  /@fluid-experimental/tree2/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-g5CUiuI65rOOqeNqVhky/haHkYYWXJTHEzMsYsW0MJ6pTbreVs421cGwcBXBz2iRATEwKJ0EzJJXYcuSl6OW+Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.1
       '@sinclair/typebox': 0.29.4
       '@ungap/structured-clone': 0.3.4
       sorted-btree: 1.8.1
@@ -15617,25 +15617,25 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-TkGgy4x2lmcK9fqvoMZ0RUaRrbKsULQbz8HP58j/Y7RZP3GOXFpqIXMETBV8qXdFymOG+SPjUXi9HqIdm84Bag==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-NBC+OsY/UDIuPDwU5d2zG4RO7Hn9Yf0tj79foH1B+s8lIAuJBGjWDDwl14hxb88OR9nDCbLM6uavni8ezG7x9w==}
     hasBin: true
     dependencies:
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.6.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.6.1.0
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/tool-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/tool-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15644,14 +15644,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-NVaOMZIGCwuUa5wDHIxS1rzNH8G4tDGzq9zkfl7B86ppAAsIjn2D4sy24k9JB9IOW/Y2zjaqbZ1ACmXCLhIFDw==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-UE/QrQUxSmevQwPCh+sftsBRbHtavOEN3dYg4buHzXapWoXXAX+A43RpE9pOWuJ5mg8vEeuKm40ARtrYZs7qBA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15677,28 +15677,28 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.0.0_nwcuyijzf6l5chuh7xhtrzgjly:
-    resolution: {integrity: sha512-GZFc21H85R/wes7xN03SOydCouMabHs2uudF1gWOC7hzcgxMYX9qbFFUIQvUXj+otYBxWckInBSqZvRgAYIM0w==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.1.0_nwcuyijzf6l5chuh7xhtrzgjly:
+    resolution: {integrity: sha512-gYMgx4oKqSJaQ9QWzdGd6PsK6uxz9WEE+AI3RDOYP8uWqvR102lygCdKtuluhIg8ePLQHgtgZZrDrLzuFzZBOw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/local-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/local-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
       '@fluidframework/server-local-server': 1.0.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/tool-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/tool-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -15718,89 +15718,89 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-aOifrcU6kBG2Zc8v2sy/3MFfH7yWPns/PDRuA3PWhqmwIXWmcGuMKIPbkemdIWlkm8+1SYVn8ldDWi6Xjd6b9Q==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-2d1pDVihPdT53TmOMRlrktSDSC2FX+qEALF0DP4+z2MvSf/9xq2tU9s4Ss8vwtXky6EeM/7COLt9amIH6QifTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/register-collection': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/register-collection': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-K7O7G8lqh8Zxh9Efam6EfA0yLKhWqo8Un77zre8igt8//eZ+bT+B9wxYEa91ULpnp9r2/aK/Y+fyFE23WgLCew==}
+  /@fluidframework/aqueduct/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-Lr6zboBJoiFJN6LCPiAAvIPmy4qzWKcZULNUt/Uldu22SDcbBZQobsjr3zM0MhU+YNjdqnAH0zHpqmwlSHZoKQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/synthesize': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/synthesize': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-K7O7G8lqh8Zxh9Efam6EfA0yLKhWqo8Un77zre8igt8//eZ+bT+B9wxYEa91ULpnp9r2/aK/Y+fyFE23WgLCew==}
+  /@fluidframework/aqueduct/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-Lr6zboBJoiFJN6LCPiAAvIPmy4qzWKcZULNUt/Uldu22SDcbBZQobsjr3zM0MhU+YNjdqnAH0zHpqmwlSHZoKQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/synthesize': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/synthesize': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/azure-client/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-8kzEXgONC0F2s+V7iaeEeXjx+7L9O46qogbg999/+aqY8OZLaLEmdUugSycaLYLabwX2WgMM8gt3ZTdt7zst1Q==}
+  /@fluidframework/azure-client/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-TzeApcamwrVRbtLjON3ypbUwo3HQ+TRRTxRDJnyEo6TxQWXVyVimFltoCBrm7n01fzP5wAPQFDCrC3hZaK3vIg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/fluid-static': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/fluid-static': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1
     transitivePeerDependencies:
       - bufferutil
@@ -15810,8 +15810,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/azure-service-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-y2WrLUPcRMnDu7de+7RvjvMGvCnK8BxOVdAUaz6Hl0Uj2FcClg3ACO+vc/gfIiBWKmWQpp9db5EXO9Bpk+c4jA==}
+  /@fluidframework/azure-service-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-S1eF9MvBMe1OVwyNbcCgarWstiyF6e2x/ygq762uYO0SXUz3yQpe4XZg1OfMC0zdvPTzDMNQMsQ0vaAWykWDCg==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.2.0
       jsrsasign: 10.8.6
@@ -16039,16 +16039,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Rh5sRFMO5QSV0Q81upD1ZiRWgv58Qla0kEj6aBhRolLQ8+0758OIMf91FqMnjnB2NzvlojeFHXjGhROzi9pblA==}
+  /@fluidframework/cell/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-NPbdwCsnckSqghcXrU+FVJmctkQ+5rfZT4NyqhvePqPoFOg4VyVHPs9fRTnovtLPGPNniBkc01TDoZG+hVwt3w==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16068,29 +16068,39 @@ packages:
       lodash: 4.17.21
       sha.js: 2.4.11
 
-  /@fluidframework/container-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-AxEs6UDSLjr7TIAvI9ArAwK5kZS2y3AF7+OTbf4flEDsicWC6RHy6a0er5lHu2EIAZWgdPlMvI1h7P/cvj1/vg==}
+  /@fluidframework/container-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-U1wUbUJNhlGo08eJmCZ75Ipyl+A7/jwL52SZYiZmipRFbtx0kTIq0H9sIOrbOzQJ/VyWE23LRvxVZAsFs/Gu5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-5HUFpNaDriWfvDK83pq4EVg0aonRHKTtTjLQyMV36cWs6nZ8HIr6FCkRIBHrBoYexg5aTuJmyGHJoPfUNZpO6A==}
+  /@fluidframework/container-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-KYSWEKGZztRfUypsfQS3t/b/5278R4AT05tGSLkMluCMBBCsD9BR6mRKEIqhInQrZLWBEehLu6cz8OnN2sVk9A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      events: 3.3.0
+    dev: true
+
+  /@fluidframework/container-loader/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-q0Bip2nLWK/1sfEc2XMDP2+L3N0w4LFYWXXnHYPNsinANOZb98RrctzEnJ/1InOojg36iRIYl4rze5LXLy3zdw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -16101,34 +16111,45 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-yWTIsKlLZGI97cZjA/FkybEhkTdD5AzBWRkIHIsQWIBvxRvoDx+dNDLLmeDuXPG0+huyeaH/bRnxTbomZpycag==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-tXx9y0qVJNlaamaYB+oX/ZWVci5j2GH4EcoL1llwk1NC62FYwGEBkj5WsQH7+a5irwDOOa1u8wpyYL0Mms8Auw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-j4VPYvVGhvXrQZ6+hUvhY50hXvV6oSPtyOM2R01GMJuSaRMEpLD5cuoC6DlLJInJGyY1YSzc4FnurUsB9DfBfw==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-SF8l6RyFqwSHxfUv3TN/oi/dtawkr0yOnLssqNraP0IbUb0fF/C0rsXgEtgDeOuH9GKUDRlpdjucjbARNVYuQQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+    dev: true
+
+  /@fluidframework/container-runtime/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-x7Jn393bSJR3bQr0rs20nX/15sSPV5Nx9/BkFqpXL29WLvHntFqFdlCS+OqtBe8q7HorkUSYyKGWreRfvSk1cw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -16139,23 +16160,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-j4VPYvVGhvXrQZ6+hUvhY50hXvV6oSPtyOM2R01GMJuSaRMEpLD5cuoC6DlLJInJGyY1YSzc4FnurUsB9DfBfw==}
+  /@fluidframework/container-runtime/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-x7Jn393bSJR3bQr0rs20nX/15sSPV5Nx9/BkFqpXL29WLvHntFqFdlCS+OqtBe8q7HorkUSYyKGWreRfvSk1cw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -16166,90 +16187,144 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-l2TWZMmyXFL2J1Djy/c+j9nENDUWsGR3vWa7jU2LHiSWpPxGmtVwMcOuw7gk75aszRT0pZgQjmjKimpolZzgBQ==}
+  /@fluidframework/container-runtime/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-/VBvs5dF8un/8jCsn+/fzApmf+5QsORpn1aIw/FRifFz1sujwgqLNL81Xj0Sx2gVE6LKndaTwFeGlk4p3FmvLA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/core-interfaces/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-dsga6zZWuIphC5suGR8HhMUd5uFmZ3SrOexbEAN2AFc2Up0u2ok1XvvlIt1dMU+6W5+4918J44HMW7rLUK18rQ==}
-    dev: true
-
-  /@fluidframework/core-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-8D/inRzBBy1htw6zy5lBhBcBbR0wg22TZ43AoghM22ZziJrDEfCz/tl4/a1c8pVq4MY+t/n0AuqPIb9DdTQdbQ==}
-    dev: true
-
-  /@fluidframework/counter/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-7ALUFvHgT3NzwT8KLeYnJEVzTiH8cQmg9AMDTrNIhrVRQqU2J7EFidGdWffYzmxvh153zEJcfaFywAKslQ8tgA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      sorted-btree: 1.8.1
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-snTZATxsaDKmcBIAmI84AsqIjVTlxdBEQBsT66pDp+GGxhfOIO2VltCEF/S/aO+VNXF6Z8EgoQDcMw3MGUha6Q==}
+  /@fluidframework/container-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-yx49kKTSY3LpgXSDnTMTqRiot1PpOYEgb6ee4Eg+G2cgXTTqh11r3r4ws4pZ34NI+j7w7hj9FlhNByDZ/8h5Hg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/container-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-pUdhirgJd6Ofp4888aOXcc5/Sa8lJCgzmqhC+yRoK57cUD7zG6HvJQ3GeW+/jtQumrDsMr1lojanCuySrS7mCg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/core-interfaces/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-QcBqjl9P1ZXxwOHdfPyQD68BJ7iUVQyFCEy3rslyt8xSkzTJi90/5PBbIHSIviPUBDEoNtYErVCDooGIEjasVQ==}
+    dev: true
+
+  /@fluidframework/core-interfaces/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-xvHhlxodN64LNVO432uCzIqpiNVeduIGd2WytJHe4BSKuWjKIVp3lPHNDVdOUlEWzHZreZwh8l/QmmXUZRf2Vg==}
+    dev: true
+
+  /@fluidframework/core-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-q2ITM0x0VQLZxVCkN2PxbJHbG7Hy4akvGa5QUaadJ5uVoUs83QvV3W5rVregHfd3dvG591L3pyUCnq0jX4+65w==}
+    dev: true
+
+  /@fluidframework/counter/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-sEKxpJupXXwwGgpwXjsFGtwsnIJUUZ/YWFyeIuH07cXxWW1ekGE6Dq9p5/P3PdD9MDVmfsD2VzEs7uqtTckn4g==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-2BHlkQIgBV9VjMBTPUM6XOtWil+CCfAlBFSZNvjhV1Rot+Ep5HANktHC1hVinGWcBQ8N62Wf/C8bV/JIe5zLnQ==}
+  /@fluidframework/data-object-base/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-5hTmqWwjwKaEQToF95KGpq+sF8owdnRTaBm49W9kRMgBobnyJql0rm72m8SdsMnP3TmlNTma1ZQ1cYlrU87LCQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-vA5dV5UjRPfeNKSfTwm5alFbUTXOUvoY3Av1xBx/Z09oYhxd911+iZX8cKhcZMNbuy3jvUsbK7eg4AbhPPouOg==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-vTELaK8CJHSG+t5edAFOSpUWnLFq4xu3gjVQMgqdbzsEfSNXEkIv/cfMlIDvO/Q2V7ED0BIma2d7fazag8/Bcg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+    dev: true
+
+  /@fluidframework/datastore-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-yDNUsvoD36oyLS2Hsm1lxHCNm7wMhgDk0jYHelWyFmSDj0Plpvi6ZK4N8Pomx7I888acSYTWe2vDoM/r9H6g/A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+    dev: true
+
+  /@fluidframework/datastore/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-xTqbNVgoscod1/caUcxLhCNI6CYh1VVchnN3mxJb89o0lQO1boQi8D6YXyJYk8TPW2t0TWtg+g0k26Ke8lpZTw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16257,23 +16332,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-vA5dV5UjRPfeNKSfTwm5alFbUTXOUvoY3Av1xBx/Z09oYhxd911+iZX8cKhcZMNbuy3jvUsbK7eg4AbhPPouOg==}
+  /@fluidframework/datastore/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-xTqbNVgoscod1/caUcxLhCNI6CYh1VVchnN3mxJb89o0lQO1boQi8D6YXyJYk8TPW2t0TWtg+g0k26Ke8lpZTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16281,79 +16356,111 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-we0ds0n+KoDidE7z/abh5CWE+IglC+Q7Oakr3qOGtp6MK1kCMZQsPnU02cp65LewnCI5OOmzK987PD6fHhfwxw==}
+  /@fluidframework/datastore/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-wb2H8Mtbx/jCMxAsAJ+1/72r7f01wG7qtA8ACOGoaKxmJCPyIbNY7r02EO/JzkMk/tOooj8sf2foHjK97sgB4A==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/sequence': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-base': 1.0.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      lodash: 4.17.21
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-CLQBfUFCUG910Ihft1oU0eA/7EXnvBQPQqAIZm1qc2xjxpqOU79zi52LDtq7ARet/vyytQrQrwTJYM9Y2VCSxw==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-AleEm2MsgDEquFFII8/8LnPiGKPGaGwGEdrNQNzKyf7N0bxTf84xTVR5FLn/36AgeJLWKxyUHbIXehyjQi5U8Q==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/sequence': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/debugger/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-NN2nB6l//I0NqiHFqD9YKkTF9CZSK2FjaKR4gHJvKrU3l1W2dBhe3hNWOilE0vziekKAI0l63vC3L3EepSNP8Q==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/replay-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver': 2.0.0-internal.6.1.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-vf1sxzreJAhNGpv25EKWy34aHZ466Ks5/k62U/R53fQt1s9uvnDt7BLB1irFqHN/vOQuKWza7WGMndUnT2wHdA==}
+  /@fluidframework/driver-base/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-HAWzoYX9cgjvomVNOR5OJw4ouHtn601jzsQE/CNmy4/oFane+AIvc+yDnaINAJIBhB5Uon+UDHRk1z/8FZvAmg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-vf1sxzreJAhNGpv25EKWy34aHZ466Ks5/k62U/R53fQt1s9uvnDt7BLB1irFqHN/vOQuKWza7WGMndUnT2wHdA==}
+  /@fluidframework/driver-base/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-HAWzoYX9cgjvomVNOR5OJw4ouHtn601jzsQE/CNmy4/oFane+AIvc+yDnaINAJIBhB5Uon+UDHRk1z/8FZvAmg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-gL0zIisH+O2YRdo0g5EYS2TNdORHVmNa7E3WDOs8YTrPKUXrxJzlT6fZgYcpuJrKaB15QR+r6LWx4rjQTbvbdA==}
+  /@fluidframework/driver-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-T4iBg5g5kIxiCZ3UtuPQ5jQX7lo+uu0tSUlI6CdmWmt9UbEH38hxWYp68juSdu5Z4a98alZForbhsXLS/c95Wg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-PD4h8O/XEBqlizZYONy3M8pdpqd33vvKNZ8dj1iMloCXPLKpfOyEe1nmlmXZBOjsNc6deBB7WZX0WWbY6UMEPQ==}
+  /@fluidframework/driver-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-DzlvnOJPd2XsPtW0r0KrDGPug8waoaU4foKYni0ssd21x4GknQ7QWlWJ0DcsMGt6R7lflIijbc6nZ/4MWI3XXQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+    dev: true
+
+  /@fluidframework/driver-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-3ni6XUm/zvtRVGLyLZGVVghzwTQ05GCbz24MMcnahiUOpyvvlytGus/rvPy4RytzSqy4VDw2exOYXYrPakUQNg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1
       lz4js: 0.2.0
       url: 0.11.1
@@ -16363,16 +16470,16 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-PD4h8O/XEBqlizZYONy3M8pdpqd33vvKNZ8dj1iMloCXPLKpfOyEe1nmlmXZBOjsNc6deBB7WZX0WWbY6UMEPQ==}
+  /@fluidframework/driver-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-3ni6XUm/zvtRVGLyLZGVVghzwTQ05GCbz24MMcnahiUOpyvvlytGus/rvPy4RytzSqy4VDw2exOYXYrPakUQNg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
       url: 0.11.1
@@ -16382,13 +16489,32 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-OQi7X9aCm9CPGY4o6BsxP8gLPU3xWixaFUAuZmQ2c9giAdibTNtmJEcK+4qr+b7hr34gokAcNEQ/WNeo0Wpftw==}
+  /@fluidframework/driver-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-dQaK5RldJTs+NsUCA/Et16AzyYElFnmNbClIdxxy/EiynqhXPc2qJBxJUaXYWZ55Pdrs/FmLWt0/hC/4uy131Q==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/gitresources': 1.0.0
+      '@fluidframework/protocol-base': 1.0.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      axios: 0.26.1
+      lz4js: 0.2.0
+      url: 0.11.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-web-cache/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-6r8V3T7Z274eMoI9F9TAvESJVfGxxfHo2WfGd0vey/XI9YztpBBGkizt7yajN4HvMgqamEvOhqNkCGqfweZKWg==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -16446,33 +16572,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-zXjKpEgN9rhuozfZ62q62Hq1aVZMU5qLzsN+kBEAy4uTz88PbBpdknuWVqPS0e1cljUODGMjROOWfii0rCZjKw==}
+  /@fluidframework/file-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-siGv4HxIucqna3a2bsXMrdqoMUSs3i9RazRH+u4l9MjdB10R/wUC8ngGwUik5hSyJlqBbQa53nkWJJQy6vSFmQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/replay-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-FpTKuH+zLFDOfXjeb7tBl4F6aWJXZqf1xrydhZMhbSXX2TTcGF64Hh3BEMRNp+F7F6+VuzD/QdioS0+dGgqPuQ==}
+  /@fluidframework/fluid-runner/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-sUDfw06gk/lJ4U6ujq9u6LAUAxGjawoZ+ETVoBogKF5YZ9qawPnZ1owRyIE3vdEkY7MJpzRAd9Pyu4f2juJjMA==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -16483,21 +16609,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-TIy4nZQzHcxqkn0/8vT9YQfoVGNTrAlG1Qm6yoq4dsODIP6ZQfMQWmV5vqIFqFyVrC/O/yQ/utUQwY7iLo1/ww==}
+  /@fluidframework/fluid-static/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-YcMQrXPgUw2hAQ1kwCzWi/NZPWYBxnbZPvmY/tTQpY5/SxL5jQEqjN+StbLnQH2L4Z4sU6CUcx2JTtVMAIMCFg==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16506,66 +16632,38 @@ packages:
   /@fluidframework/gitresources/1.0.0:
     resolution: {integrity: sha512-j4yu9JM5kU3y+5XfPOu19Ak1vJZai+6tiqCAYeJeXaczfGRlWVdqWgl4Cc8LUdJ+JDPEKo9a54FaJG+Gpa/kwQ==}
 
-  /@fluidframework/ink/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-egl/1+CIIlIMa4p7ZgUTanu0K0vCt1lUjWe/9/j9wl6TNYpKXNn/M3PZSqnAtCX2s0sdLPLyKHNsJMvJmyg5fg==}
+  /@fluidframework/ink/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-5xVHh3d65WEEHPPF8FOjLTcMROhxBJrizNMza7cg4g6nkF1TIDt0kG3HWk+hpsiwgB3G/+vaSNlTQy/gXIMfJA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Tj7J7lZkOY/nyNA8Q/FsJH3mvbJibnvDPltx33idXmBGt5aYMDkaobRJ1Q4WaKWR6A/uUh1rTLToon04rjHtUQ==}
+  /@fluidframework/local-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-KoTV0oRWUAwzDOyVP6MwsmAZPFtsB8xSRAjgu76O/N0xZsjddPh5IJ4XqDvsouDftKcEFpZ5pYRLIE+Zwoulkw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
       '@fluidframework/server-local-server': 1.0.0
       '@fluidframework/server-services-client': 1.0.0
       '@fluidframework/server-services-core': 1.0.0
       '@fluidframework/server-test-utils': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      events: 3.3.0
-      jsrsasign: 10.8.6
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/local-driver/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-Tj7J7lZkOY/nyNA8Q/FsJH3mvbJibnvDPltx33idXmBGt5aYMDkaobRJ1Q4WaKWR6A/uUh1rTLToon04rjHtUQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/protocol-base': 1.0.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/server-local-server': 1.0.0
-      '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/server-services-core': 1.0.0
-      '@fluidframework/server-test-utils': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.1
@@ -16578,68 +16676,96 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/location-redirection-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-aNZmZrQydaOnH0/T0d21pEBNhfc/9YTI18GtIXDAQSARLxthbKG5Q2Xxb3AjCKMusm9KoMmHbdkHRvIRqolEHw==}
+  /@fluidframework/local-driver/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-KoTV0oRWUAwzDOyVP6MwsmAZPFtsB8xSRAjgu76O/N0xZsjddPh5IJ4XqDvsouDftKcEFpZ5pYRLIE+Zwoulkw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/protocol-base': 1.0.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/server-local-server': 1.0.0
+      '@fluidframework/server-services-client': 1.0.0
+      '@fluidframework/server-services-core': 1.0.0
+      '@fluidframework/server-test-utils': 1.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      events: 3.3.0
+      jsrsasign: 10.8.6
+      url: 0.11.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@fluidframework/location-redirection-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-OuGIXLYsv2pkBytAgOWy6D0L2nBfQTzu8VpFmvCgHqfH8v3zJvs8cVcCo6Z/kLcfS7ssuIiBbkJqmpnlNAFsxg==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-vS1+5vCgEOOKD5a9WsU3VcnDW4drbhUjrFiseH7gzulmZ2Tvl5TOmM9hJCvBGnTQh0i0auTXgGXWcxXEWvTmeA==}
+  /@fluidframework/map/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-O1bREZJYe5PdlAdWROzbz3u+GBDBAh2gQWKfJuQbJXLvEiwb2XpEXu5LJddOcqJkS7xYCzkXrcWu0BEKW0506g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-vS1+5vCgEOOKD5a9WsU3VcnDW4drbhUjrFiseH7gzulmZ2Tvl5TOmM9hJCvBGnTQh0i0auTXgGXWcxXEWvTmeA==}
+  /@fluidframework/map/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-O1bREZJYe5PdlAdWROzbz3u+GBDBAh2gQWKfJuQbJXLvEiwb2XpEXu5LJddOcqJkS7xYCzkXrcWu0BEKW0506g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0_debug@4.3.4
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-1KeelT0oGiMpxrDDCs9LfVDw/pI/MzQK7cQTR8ZDSD3L7wRWsQwKM8d5oib9H2++bNv4nSo92sGZx+3vqNJcmg==}
+  /@fluidframework/matrix/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-a8hxtOa6y21clNF7biR1muqFB+5iKFhLblCrJywSrBVO88Rm/QgyuRzcFs36J56VokHFVuarrcVeVrp0JmaRXA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -16648,89 +16774,89 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-TJ5PN4WLgR7//5sHQ5RC3ds0xl/UdmRrE7sFOGdz+9M2Y0brx0w+w93tzg5VQaWYR7fhkWOqpYRpa2uT8dhHnw==}
+  /@fluidframework/merge-tree/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-7RxKnZ5Q9r6YgRTK46wWKTTphfX4ERV/zgtbSim7rBHehEjh+uD8x1naQa24jNF4xQpV3SuSgDNs/0Hz99tKEA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-nf5pAJUQKqBeKgUyqFHnkXFwy9E1lnFCoZsP4L/mvzwPO68i6TegCGHJrXtFiobYifeAuEqWpGIdpRi5qXZnZg==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-LuKctxNjiOmVlAKoJzDtLn+HfGGfAgMOgqIEhU+HJZV+qWOjx5j6wX5Lqw4Ob2qVYtO4RVRHIhjSXjdcoIRY6Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.1.0
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-tHxAK6Aqk+zN/EteM9PsMBIHetnh+qMG94WeuU0XlcpZA8LT9wFHTDkhgAnEDAWlmqR3BRpN1w7jOy9SLnHCMA==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-RYiiCJKavNqynbV20Xqpjc5RUIDgJEe3kxAGs9dAwVX0bBN90fnE4QSEbxRsUBRiVe9UskEiqzAkKizJFpWkuA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      node-fetch: 2.6.11
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - debug
       - encoding
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-tHxAK6Aqk+zN/EteM9PsMBIHetnh+qMG94WeuU0XlcpZA8LT9wFHTDkhgAnEDAWlmqR3BRpN1w7jOy9SLnHCMA==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-RYiiCJKavNqynbV20Xqpjc5RUIDgJEe3kxAGs9dAwVX0bBN90fnE4QSEbxRsUBRiVe9UskEiqzAkKizJFpWkuA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      node-fetch: 2.6.11
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - debug
       - encoding
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-W55ZJ8DW1Bbvq2iaIFYwPDnwJAbvwrce1UciVkF0cUqtMF1hEDM3HkMlOu4zs4kJfwvb9cSh3f0bjcvs/dzztA==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-AEhoVp+CTK8fduel9MRpa5ynBwu8AB2V32OrlC7LhhrccJ9NvHLcC+suj9Nri64Xf+5tjj9yzz3OL91eOVzarg==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-XNzT7J0Iy2hcrdOH5K/bFpUMxo13U2IxeuR6vM5PgmOcWKBbfetauo/ZZfSqJ+6CL9UtiGHyYGwqxEEaQn/HGg==}
+  /@fluidframework/odsp-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-I/B0TKY1BIicx5v5CxrHY49L72ki63O4EPpIdl3b16U6b8Xmvee+jES7gEXIko3gf1ZD0W4U/X17tJ/03Zb7YA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      node-fetch: 2.6.11
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      node-fetch: 2.6.12
       socket.io-client: 4.6.1
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16741,13 +16867,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-r4GQBhgA/pAMp9r4af3ZXODrqjsqSEcSVxbwtIqUjyZkQeVGxOF4pB8cLGeM2+h1zgeCiD7Xm7nsJSoeh666MQ==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-Dj4JKrpvpmmS2W1uLs//NtzhGe6q6SzBovjsERsZE+87URk6PemomchoMPYpSI09W0QhCj/jgR73jGc/rBfwMg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16756,16 +16882,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-f2+zCdD5UT9KWq7fZR1JrBOKtkdSVpaeGNFkqjMcjPbhXwypb88YrJjS0fSIU6ULEoMvxrCUdK5MTBropKccgg==}
+  /@fluidframework/ordered-collection/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-j0PSMf39zvV8Q/vcjDLdwQj47ALTf5HiAYfVwZ7KJlLHjTtMDbER2m3R3BRKX4LrGhgmFnclNuBTl4OTp2uCrA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -16785,76 +16911,76 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-5FpPd6tyXoizANMD2RL5QdIishc3hfavHFo3DRsPEdC9G/isyVPI9kqz+hYWPDpnfAuM7Qbxy/KeYH8OXmlS8Q==}
+  /@fluidframework/register-collection/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-XLdmwbhdMtu5iaRJ9PXcS+FQ9NshZxWYpNqt489ah/YU/k4AFRoSxi9Ze76CuVKKX9eUQd0us8JynZLF4NBDyw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-h+SpPyYb40BJhZp2zsppxQk/047yi7qL+feUGHhGciA38HwstoddFkZdIi98uDxRJvI5zEEe9ZXwxx0pR+4/yw==}
+  /@fluidframework/replay-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-AakxDAfzLzPrfO4DWAMnOgiAFo8iIArGfTiCzEY13vkule6/NNVZTlLBm/9NdubqENmNdohvxSDLBETkRluZdg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-EHoVGfwcF4EQkzHfT6yPXR6h/HTKxOJzIbPY6F1POrsL/FYC//P41lukaQS00pOq33QTeg7C7ZWQQpXu/jzsxg==}
+  /@fluidframework/request-handler/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-7JEDHR6MMmOL9OjFSi9id/7knUJN9Nb2sNyB7jwSwGfQrybSwpSvpZTkdwv7hkNrkloc2eaBOmzX8IZapjQkaA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-EHoVGfwcF4EQkzHfT6yPXR6h/HTKxOJzIbPY6F1POrsL/FYC//P41lukaQS00pOq33QTeg7C7ZWQQpXu/jzsxg==}
+  /@fluidframework/request-handler/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-7JEDHR6MMmOL9OjFSi9id/7knUJN9Nb2sNyB7jwSwGfQrybSwpSvpZTkdwv7hkNrkloc2eaBOmzX8IZapjQkaA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-kFTTcSvZDzh22dhiOO1Ea0/vfN4qFlxM0d5Ntq91wfpXAiVH6vATp20Tx35QfwilAV+mmInOdbYJb0c+Joe3TA==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-Hn3JCCt6bF7Vkb/+cBaE3pp4bAxW253lZMDeHr0Hp+RLn4LzQ2CyIVEyHlZ9NoRsJf4Gd1ip+PlNDzY4ssmZ5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
@@ -16868,20 +16994,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-kFTTcSvZDzh22dhiOO1Ea0/vfN4qFlxM0d5Ntq91wfpXAiVH6vATp20Tx35QfwilAV+mmInOdbYJb0c+Joe3TA==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-Hn3JCCt6bF7Vkb/+cBaE3pp4bAxW253lZMDeHr0Hp+RLn4LzQ2CyIVEyHlZ9NoRsJf4Gd1ip+PlNDzY4ssmZ5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
@@ -16895,76 +17021,104 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-ZJCKdue+pNHTTujgmlez3Jlcoo+VBZLhJ9DLOaj77KFopOq+gIGXsJMfWePb53xoika96tj0LBlSJPBm7m28Rw==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-QBtGPEIhdp8kp6CruaLd3BiPWw19KmwoyTH3UZwtHh4enOVtVT74nE0cxaH5jK+T/WS7zRiJUIUlr//xnlHinw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       nconf: 0.12.0
-      url: 0.11.0
+      url: 0.11.1
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-lELlnssXUlKknDqzKmL65PEV9k9x30N3Rn/x2oUDfO+rSwkbGdbldaRxnTI0m/vOFwkW2b+SMNDmRjoc8/EyzQ==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-ucNnpxjPL1GtHOsbeBi9fxZHJbPp4+0JYJ36mlrLm6Efugg8UFdBZB7XJdrDUxQSSBbdkMcFnR9V9Np3mn/Fhg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-GTzvWSvUO1l6pchLvkfU1P1Ck/HeA69BWzHuJQzEUvLIcHr3AUJiwzeuhjuJCm9kqPF1/zvBRcsKO/nD+JgXbQ==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-NMdo1VTLiVG3/AdNywe9pITyYpxMyCsXOUt44TTI4RD4em6/RVOLjA6ebHAbIU83Zlk+F9op3esTN4b7NgRfzg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+    dev: true
+
+  /@fluidframework/runtime-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-liLYqA+kMwd8evCrFERTEIX2LMEB2PPzSMhi1Wrg7XSttpimCl1XQpqCxUDM5wegDGO6YrljUUDt/4zbYBrNJA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-GTzvWSvUO1l6pchLvkfU1P1Ck/HeA69BWzHuJQzEUvLIcHr3AUJiwzeuhjuJCm9kqPF1/zvBRcsKO/nD+JgXbQ==}
+  /@fluidframework/runtime-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-liLYqA+kMwd8evCrFERTEIX2LMEB2PPzSMhi1Wrg7XSttpimCl1XQpqCxUDM5wegDGO6YrljUUDt/4zbYBrNJA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-1jVLzy/Dgtfnz6nrvo2NP94n+Ak7EQm6ZQstNDYrc0ZaCYXc+twPh+TusNKYAKTxLA97B0PWr02RF2L5ipgBXw==}
+  /@fluidframework/runtime-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-V23b3CkAIbmzAIt38ZqFymc12+tCf4Mz05S1hMUW8sdEYrLxxNuCBb1GP5tOmf65XOL0+QUa5WWEl1QztqbyuA==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/sequence/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-u1j+6cfKrsCAbigIMjg4lMvi2inwGzMpe6BioUIWHd9Q2nYbcksEX0CSzFrl/FiD6N/1Jf0djVxuQH7pkSMM4A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -17209,96 +17363,117 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/shared-object-base/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-DMePxQDeFNTo/WJL1NgrtrYiV3tZjHLQKGWkB7Hqotq1B/f9g7czwLD+aeS1gucNz8myBrhJZX/xC/cFNdZPCQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-dfPgJ4bPBHBECxHdqt3EZxLLQDBwHA/DsRSGypNmTD4PBB8D5KKBQiFD+DaKb37BokPZhs8sIrTL7tu1KFPCZg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-DMePxQDeFNTo/WJL1NgrtrYiV3tZjHLQKGWkB7Hqotq1B/f9g7czwLD+aeS1gucNz8myBrhJZX/xC/cFNdZPCQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-dfPgJ4bPBHBECxHdqt3EZxLLQDBwHA/DsRSGypNmTD4PBB8D5KKBQiFD+DaKb37BokPZhs8sIrTL7tu1KFPCZg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-cNX9rT3aXqTOHzt0v1Da/nyM+68E46XXYpRxyqDt9tjU5ap7D/ACDitU6oTHdSAP4M4Iu4rB62CqU71jVQI7kQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-bAXmR8iucvOaOhP2gWIX4V5khvUpU0YcYoh4q4dfH2Kay0XWynomooW4IIXtA0zj9PfC4XM3UvDQTO5bnM9zQQ==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-qa8Zq4tghoWX934h3JCL08MnJjxmrqv9f2IiSwbSI1F7gYm1WSOd++8uc9wqCm10w5ISe8BDDgEung/e+DB/fg==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-rNhJ2QpOS0pDweBI6M9Z+qYhGu8F/2rB/RE50YLV65Z+uDosLAhKGnL9WP9MVpRs8CRYMg1yobVhfwdmY3eP3g==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Pgdj06xaHIsu/vQov3A7DjYHMmrdzQbgpoMrVDcz8xEMLCPhBHU8ba+/G+f0TqROpXss97Df6jUpPiopB4iSvw==}
+  /@fluidframework/synthesize/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-d3nal6W8nnptpyzvzGsDJG9Wcfrv8AIMP/v8WnKPmJN8/6JB5NQMLXJwFRh+ON6yNgenULdqemkT6m7SLJZmrA==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+    dev: true
+
+  /@fluidframework/task-manager/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-3WKrlg460Kq7jKidQdA5f8JsiKycaS+luaR0fnCAq194O6FnSfm+GjPdfO5wXFYy/xA+6b8GUAd5TXr2qXd6Iw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-pnw57Vv/uYJWLf12DgTg+cXLb0aulYM7xkHwTByC3FhvMB5+wmwCWFONQBdbcZ0LRLdMgswXIAwwxoThrmQwPA==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-rKPlyPKkXa+yWhEvCfoiJfWduooM0FpI2E22E8WAQrR/E9ZKAJmiDy8CkfPfnRyPXVceS7F5Wb6URtXXk1zXQw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
       debug: 4.3.4
       events: 3.3.0
       uuid: 8.3.2
@@ -17306,30 +17481,44 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-9cwPAluxjBzeNvnEZW7fjilY2jWVbJbI0MvRaX4ormv2316GrK6h/Bs9pg5q5yzUCFevJ/hyvm/6EmdbltMWdQ==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-orXhV5K6FVMJj6jInTAt2uNG8zgZ20VMM5nNXtxGM5p9xwE+g/xpuLUij1jmQzmst3i57ZP/d/MmUxIgQTGCxw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      debug: 4.3.4
+      events: 3.3.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/test-driver-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-aahTs38FqFWSSUgxmMc8eDQMHt+6FhuAzAiiFprT9wPht9sZmcTInqQ58BF6jl/gV0hb0sUwciJ5YP4rC3LLIQ==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-+8KOLeabu/sPSbFailtj6EeBGX+k0zSYjGsXYsvsQgKnaKJxXegbsqLXywy66KtxMEC1xtEKwZU08/dW9hmy1g==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-ui4U8aBnwni1pd1XfbutMiq51AnDLZl8lTzQqRwvkG4YKdNayy0B6YjwyoxeKyNU8/wJpwzN/KGCZfiBuLTecg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17342,21 +17531,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-+8KOLeabu/sPSbFailtj6EeBGX+k0zSYjGsXYsvsQgKnaKJxXegbsqLXywy66KtxMEC1xtEKwZU08/dW9hmy1g==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-ui4U8aBnwni1pd1XfbutMiq51AnDLZl8lTzQqRwvkG4YKdNayy0B6YjwyoxeKyNU8/wJpwzN/KGCZfiBuLTecg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17374,30 +17563,30 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-ELpsYMMl1ETn1TSjAkAGwj5uDROf3xC++9Oy+KVe8ZWfKB3zxp5bj0lfJBCCnihrcLjvBqWkKl2BDdy0kDcQng==}
+  /@fluidframework/test-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-QVHQ7rAwPrM+Ws3TvLaWL1I5ba6DiLH/daSG9O/t15YMukKDA2f9cDDbTU0Xi9lbxFE/WDz/Q25+uZOKsba3YA==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
@@ -17408,21 +17597,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-+tKCH45zmGUFbQ32D9CBegRVui1JXmuxMpcckJHEEaN4YXMZmZYQSPSiRlzrt8/3TH72XMZ+Pt3JDA2CuNUSkQ==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-GIKuweVy9RqQFMZjjKM2fBiOWknZFCCNECNHeozzkt7y/4Mg4GpGJIhE+j9T1gLcxSE/AQYXufv07VMYQfOoTA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/fluid-static': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/fluid-static': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -17432,14 +17621,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-WzQYpNmbV2PADRuy1K0pAE1hIoZWQSUtgz8ZkOTStqvoRqa/MqQE6pf4NCbaQCG/QwPkiT/ERR18twG4cp6RkA==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-YMKZZkT2dRFTbpheCVE4vqiBmum0t1Z3Bln7mnZcxsJkI+JUhFYL7ypmeOL0ZJGgBZ0nOgZFXZEgolUlBPxymA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': 1.0.0
       jsrsasign: 10.8.6
       uuid: 8.3.2
@@ -17451,12 +17640,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-N5ahotYoDD6WzlGLa1ReRIrGRxTvvwmLAuhSV58s0bfstqhUNHqRsIF5Ct89QCVY+x5O7/BDTfsR97FmrmdvgA==}
+  /@fluidframework/tool-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-IkzLQpd62G5wdD94KybkFBzzAwe2H9Ho7M3vL9cFdOyC6DKoT5pbq5sBAZxxz0Zy+GJvc4ZKgozvf+NvCTVZIg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
       async-mutex: 0.3.2
       debug: 4.3.4
@@ -17467,32 +17656,32 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-PNVzemvRecbPTAP5GGc+qx5IiP30PMhQ4FGYh31SZdjUsJuaLRNwu9wfTy/uBFe4D1h/6LYi1H6jOWVEkT4ZWQ==}
+  /@fluidframework/undo-redo/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-+CvBh1H0Z31HchlvgxSc58r9RgoCeyk9AvB7TlMe1q057ZQDb0rSe67iiXqYnDk+ZCCQKajiNyJfHSJoEhbgGg==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/matrix': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
-      '@fluidframework/sequence': 2.0.0-internal.6.0.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/matrix': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
+      '@fluidframework/sequence': 2.0.0-internal.6.1.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Q+T5TSbByZwoN++xdKtu8Z2yvauwk1a/HQphdT8IoHdJPG1SExwcSC1tGamCnNqDGDVUvWwGa7JzSjE9lsVGOw==}
+  /@fluidframework/view-adapters/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-mP92In2qQJZGncNf2/pwYjRhKnBGhd7FVn6laRheSssiknhq5YF1AOnb/28Guf1NBU/SEOKEURJIFdQZFn6Rdw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-gXDTRWzua28by6lZtlMGmFbIf/lnFfz9osLpxPMLgMDagTQ5LdMAk2hoRNpFq8VfB0yQocDMLh8WaDxXYwOJ1g==}
+  /@fluidframework/view-interfaces/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-mjr2ql2vHfDjtn5w5RmtkCpeL3TV1P6BSaxQfWDJ7k/Nf/zfBnc5Dxl4c/yCOXzG8bg3VKc/95lJ1DUuufCQlw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
     dev: true
 
   /@gar/promisify/1.1.3:
@@ -17739,7 +17928,7 @@ packages:
       '@graphql-tools/utils': 9.2.1_graphql@15.8.0
       graphql: 15.8.0
       resolve-from: 5.0.0
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /@graphql-tools/json-file-loader/6.2.6_graphql@15.8.0:
     resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
@@ -17778,7 +17967,7 @@ packages:
     dependencies:
       globby: 11.1.0
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
       unixify: 1.0.0
     dev: false
 
@@ -17826,7 +18015,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 8.9.0_graphql@15.8.0
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /@graphql-tools/mock/7.0.0_graphql@15.8.0:
     resolution: {integrity: sha512-ShO8D9HudgnhqoWeKb3iejGtPV8elFqSO1U0O70g3FH3W/CBW2abXfuyodBUevXVGIjyqzfkNzVtpIE0qiOVVQ==}
@@ -17864,7 +18053,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /@graphql-tools/prisma-loader/6.3.0_graphql@15.8.0:
     resolution: {integrity: sha512-9V3W/kzsFBmUQqOsd96V4a4k7Didz66yh/IK89B1/rrvy9rYj+ULjEqR73x9BYZ+ww9FV8yP8LasWAJwWaqqJQ==}
@@ -17909,7 +18098,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0_graphql@15.8.0
       '@graphql-tools/utils': 9.2.1_graphql@15.8.0
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -17923,7 +18112,7 @@ packages:
       graphql: 15.8.0
       lodash: 4.17.21
       micromatch: 4.0.5
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@graphql-tools/schema/7.1.5_graphql@15.8.0:
@@ -17944,7 +18133,7 @@ packages:
       '@graphql-tools/merge': 8.3.1_graphql@15.8.0
       '@graphql-tools/utils': 8.9.0_graphql@15.8.0
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
       value-or-promise: 1.0.11
 
   /@graphql-tools/stitch/7.5.3_graphql@15.8.0:
@@ -18028,7 +18217,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /@graphql-tools/utils/9.2.1_graphql@15.8.0:
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
@@ -18037,7 +18226,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0_graphql@15.8.0
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /@graphql-tools/wrap/7.0.8_graphql@15.8.0:
     resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
@@ -18065,7 +18254,7 @@ packages:
       csstype: 3.1.2
       rtl-css-js: 1.16.1
       stylis: 4.2.0
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@griffel/react/1.5.7_react@17.0.2:
@@ -18075,7 +18264,7 @@ packages:
     dependencies:
       '@griffel/core': 1.11.0
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@hapi/address/2.1.4:
@@ -21026,7 +21215,7 @@ packages:
       globby: 11.1.0
       ip: 2.0.0
       lodash: 4.17.21
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
       open: 8.4.2
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
@@ -21173,7 +21362,7 @@ packages:
       find-up: 5.0.0
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
       pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -21330,7 +21519,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2_typescript@4.5.5
-      tslib: 2.6.0
+      tslib: 2.6.1
       typescript: 4.5.5
       webpack: 5.87.0_webpack-cli@4.10.0
     transitivePeerDependencies:
@@ -21566,7 +21755,7 @@ packages:
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@szmarczak/http-timer/1.1.2:
@@ -23217,7 +23406,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_webpack@5.83.0
+      webpack-cli: 4.10.0_qsn6o3u33rjjm6wv75wpbgo5ga
     dev: true
 
   /@wojtekmaj/enzyme-adapter-react-17/0.6.7_7ltvq4e2railvf5uya4ffxpe2a:
@@ -23254,28 +23443,28 @@ packages:
     resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@wry/context/0.7.3:
     resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@wry/equality/0.5.6:
     resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@wry/trie/0.3.2:
     resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@xtuc/ieee754/1.2.0:
@@ -23968,7 +24157,7 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: true
 
   /astral-regex/2.0.0:
@@ -25407,7 +25596,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
       upper-case-first: 2.0.2
 
   /capture-exit/2.0.0:
@@ -25548,7 +25737,7 @@ packages:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /changesets-format-with-issue-links/0.3.0_@changesets+cli@2.26.1:
     resolution: {integrity: sha512-+GmelydJ+bYPVQyapFIELe/bM2+98cBIG7gb9raBxzx5MiBY0cDZnj4ii7xkrgpQLx96PWH3O9VA7Mhag0gs3w==}
@@ -26333,7 +26522,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
       upper-case: 2.0.2
 
   /constants-browserify/1.0.0:
@@ -26645,14 +26834,14 @@ packages:
   /cross-fetch/3.0.6:
     resolution: {integrity: sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==}
     dependencies:
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
 
   /cross-fetch/3.1.2:
     resolution: {integrity: sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==}
     dependencies:
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -26660,7 +26849,7 @@ packages:
   /cross-fetch/3.1.4:
     resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
     dependencies:
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
 
@@ -30499,7 +30688,7 @@ packages:
     engines: {node: '>= 10.x'}
     dependencies:
       debug: 4.3.4
-      tslib: 2.6.0
+      tslib: 2.6.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -30882,7 +31071,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /graphql-tools/7.0.5_graphql@15.8.0:
     resolution: {integrity: sha512-pJ/ZVfuPEZfGO2Jlk/4mZnqa6blSiUDejTAX+q/ndAbZNUH9Xxdq+6XZy4GDjC1MivC6OnAtLbICWZ6GAvuUhQ==}
@@ -31199,7 +31388,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /highlight.js/9.18.5:
     resolution: {integrity: sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==}
@@ -32369,7 +32558,7 @@ packages:
   /is-lower-case/2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /is-map/2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
@@ -32598,7 +32787,7 @@ packages:
   /is-upper-case/2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /is-utf8/0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
@@ -32730,7 +32919,7 @@ packages:
   /isomorphic-unfetch/3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
     dependencies:
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
       unfetch: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -34984,7 +35173,7 @@ packages:
   /lower-case-first/2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -36355,7 +36544,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
@@ -36437,7 +36625,7 @@ packages:
       string_decoder: 1.3.0
       timers-browserify: 2.0.12
       tty-browserify: 0.0.0
-      url: 0.11.0
+      url: 0.11.1
       util: 0.11.1
       vm-browserify: 1.1.2
     dev: true
@@ -37712,7 +37900,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /path-dirname/1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -40447,7 +40635,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
       upper-case-first: 2.0.2
 
   /serialize-error/8.1.0:
@@ -40783,7 +40971,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /snapdragon-node/2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -41131,7 +41319,7 @@ packages:
   /sponge-case/1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -41821,7 +42009,7 @@ packages:
   /swap-case/2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /symbol-observable/1.2.0:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
@@ -41851,7 +42039,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       buffer: 5.7.1
-      node-fetch: 2.6.11
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
 
@@ -41904,7 +42092,7 @@ packages:
     resolution: {integrity: sha512-Am5XszZz/5PnWVWveQubi4jfE6aJzTAEJ+c9Bc6R0tTEl1XYaPZpFrJUFb/SCq0BPE6ncFxLyPPpy6CwrIhnVg==}
     dependencies:
       keyborg: 2.0.0
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /taffydb/2.6.2:
@@ -42100,7 +42288,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.17.4
-      webpack: 5.88.1_webpack-cli@4.10.0
+      webpack: 5.88.1
     dev: true
 
   /terser/4.8.1:
@@ -42265,7 +42453,7 @@ packages:
   /title-case/3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /titleize/3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
@@ -42453,7 +42641,7 @@ packages:
     resolution: {integrity: sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /ts-jest/29.1.1_dph2mes4elc76oozpus7ywlloi:
@@ -43226,12 +43414,12 @@ packages:
   /upper-case-first/2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /upper-case/2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.6.0.0
+      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.6.1.0
       '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
@@ -128,7 +128,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
-      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.6.0.0
+      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.6.1.0
       '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
@@ -189,7 +189,7 @@ importers:
   azure/packages/azure-service-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.6.0.0
+      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -212,7 +212,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0
-      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.6.0.0
+      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -5293,7 +5293,7 @@ importers:
 
   experimental/dds/attributable-map:
     specifiers:
-      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.6.0.0
+      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.6.1.0
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
@@ -5341,7 +5341,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
       path-browserify: 1.0.1
     devDependencies:
-      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.6.0.0
+      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.6.1.0
       '@fluid-internal/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
@@ -5974,7 +5974,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.6.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5998,7 +5998,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       '@types/events': 3.0.0
@@ -6015,7 +6015,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/node': ^16.18.38
@@ -6029,7 +6029,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/node': 16.18.38
@@ -6100,7 +6100,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
@@ -6117,7 +6117,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -6133,7 +6133,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.6.0.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.6.1.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6172,7 +6172,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.6.0.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6199,7 +6199,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.6.0.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.6.1.0
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6235,7 +6235,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.6.0.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6265,7 +6265,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.6.0.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6300,7 +6300,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.6.0.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9
@@ -6332,7 +6332,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.6.0.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6375,7 +6375,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.6.0.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6407,7 +6407,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.6.0.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.6.1.0
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6461,7 +6461,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.6.0.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6500,7 +6500,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.6.0.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6545,7 +6545,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.6.0.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6578,7 +6578,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.6.0.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
@@ -6616,7 +6616,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.6.0.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -6714,7 +6714,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.6.0.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.6.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -6748,7 +6748,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.6.0.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -6785,7 +6785,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.6.0.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': ^1.0.0
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -6832,7 +6832,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.6.0.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': 1.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -6872,7 +6872,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.6.0.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.6.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -6913,7 +6913,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.6.0.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/benchmark': 2.1.2
@@ -6948,7 +6948,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.6.0.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/benchmark': ^2.1.0
@@ -6981,7 +6981,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.6.0.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/benchmark': 2.1.2
@@ -7019,7 +7019,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.6.0.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7057,7 +7057,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.6.0.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -7137,7 +7137,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.6.0.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.6.1.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7165,7 +7165,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.6.0.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -7185,7 +7185,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.6.0.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.6.1.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7219,7 +7219,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.6.0.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -7246,7 +7246,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.6.0.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -7272,7 +7272,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.6.0.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/jest': 29.5.3
@@ -7296,7 +7296,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.6.0.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -7319,7 +7319,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.6.0.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/node': 16.18.38
       concurrently: 7.6.0
@@ -7332,7 +7332,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.6.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -7362,7 +7362,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -7391,7 +7391,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.6.0.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^1.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7445,7 +7445,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.6.0.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/jsrsasign': 8.0.13
@@ -7481,7 +7481,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': ^1.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': workspace:~
@@ -7529,7 +7529,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -7557,7 +7557,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
@@ -7574,7 +7574,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -7596,7 +7596,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.6.1.0
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
       concurrently: ^7.6.0
@@ -7620,7 +7620,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.6.1.0
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
       concurrently: 7.6.0
@@ -7645,7 +7645,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.6.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7671,7 +7671,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7700,7 +7700,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^1.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': ^1.0.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
@@ -7752,7 +7752,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7787,7 +7787,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.6.1.0
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
       '@types/node': ^16.18.38
@@ -7817,7 +7817,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.1.0
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
       '@types/node': 16.18.38
@@ -7847,7 +7847,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/server-services-client': ^1.0.0
       '@fluidframework/test-tools': ^0.2.158186
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.6.1.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
@@ -7877,7 +7877,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 0.2.158186
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.6.1.0
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -7893,7 +7893,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.6.0.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -7933,7 +7933,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.6.0.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -7950,7 +7950,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -8002,7 +8002,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -8163,7 +8163,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.6.0.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.6.1.0
       '@fluidframework/datastore': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -8199,7 +8199,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.6.0.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
@@ -8219,7 +8219,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.6.0.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
       '@fluidframework/merge-tree': workspace:~
@@ -8256,7 +8256,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.6.0.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8338,7 +8338,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.6.0.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.6.1.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -8378,7 +8378,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.6.0.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.6.1.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -8459,7 +8459,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.6.0.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.6.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -8494,7 +8494,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.6.0.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.6.1.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/diff': 3.5.5
@@ -8527,7 +8527,7 @@ importers:
       '@fluidframework/datastore': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.6.0.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
@@ -8554,7 +8554,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.6.0.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -8592,7 +8592,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.6.1.0
       '@fluidframework/tinylicious-driver': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8630,7 +8630,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.6.0.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -8656,7 +8656,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.6.0.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -8691,7 +8691,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.6.0.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/diff': 3.5.5
       '@types/events': 3.0.0
@@ -8720,7 +8720,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.6.0.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.6.1.0
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': 17.0.52
@@ -8743,7 +8743,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.6.0.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8761,7 +8761,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.6.0.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8778,7 +8778,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.6.0.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -8797,7 +8797,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.6.0.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.6.1.0
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -8854,7 +8854,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.6.0.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -8885,7 +8885,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.6.0.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.6.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8917,7 +8917,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.6.0.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8945,7 +8945,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.6.0.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^1.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8989,7 +8989,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.6.0.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -9018,7 +9018,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.6.0.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -9046,7 +9046,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.6.0.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
@@ -9108,7 +9108,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.6.1.0
       '@fluidframework/container-utils': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -9171,7 +9171,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9201,7 +9201,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.6.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -9224,7 +9224,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -9245,7 +9245,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.6.0.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.6.1.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -9294,7 +9294,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.6.0.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9323,7 +9323,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -9344,7 +9344,7 @@ importers:
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.6.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
@@ -9365,7 +9365,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
@@ -9385,7 +9385,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       concurrently: 7.6.0
       copyfiles: 2.4.1
@@ -9410,7 +9410,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': workspace:~
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.6.0.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.6.1.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -9445,7 +9445,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.6.0.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -9482,7 +9482,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.6.0.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -9526,7 +9526,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.6.0.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -9743,7 +9743,7 @@ importers:
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.6.0.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.6.1.0
       '@fluidframework/test-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -9765,7 +9765,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.6.0.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -9965,7 +9965,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.6.0.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       concurrently: ^7.6.0
@@ -9987,7 +9987,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.6.0.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9
       '@types/mocha': 9.1.1
       concurrently: 7.6.0
@@ -10375,7 +10375,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-driver-definitions': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.6.0.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -10431,7 +10431,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.6.0.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/debug': 4.1.7
       '@types/diff': 3.5.5
@@ -10578,7 +10578,7 @@ importers:
   packages/tools/devtools/devtools:
     specifiers:
       '@fluid-experimental/devtools-core': workspace:~
-      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.6.1.0
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
@@ -10614,7 +10614,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
-      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.6.1.0
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
@@ -10781,7 +10781,7 @@ importers:
 
   packages/tools/devtools/devtools-core:
     specifiers:
-      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.6.1.0
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
@@ -10840,7 +10840,7 @@ importers:
       '@fluidframework/sequence': link:../../../dds/sequence
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
     devDependencies:
-      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.6.1.0
       '@fluid-tools/build-cli': 0.22.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0
@@ -11101,7 +11101,7 @@ importers:
   packages/tools/fetch-tool:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.6.0.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.6.1.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
@@ -11144,7 +11144,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.6.0.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.6.1.0
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -11166,7 +11166,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.6.0.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
@@ -11203,7 +11203,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.6.0.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.6.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
@@ -11312,7 +11312,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.22.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.6.0.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.6.1.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/common-utils': ^1.1.1
@@ -11394,7 +11394,7 @@ importers:
       webpack-dev-server: 4.6.0_nwcuyijzf6l5chuh7xhtrzgjly
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.0.0_nwcuyijzf6l5chuh7xhtrzgjly
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.1.0_nwcuyijzf6l5chuh7xhtrzgjly
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -11431,7 +11431,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.6.0.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.6.1.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@types/mocha': ^9.1.1
@@ -11463,7 +11463,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.0.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.1.0
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
       '@types/node-fetch': 2.6.4
@@ -11489,7 +11489,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -11525,7 +11525,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/debug': 4.1.7
       '@types/events': 3.0.0
@@ -11557,7 +11557,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.6.0.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.6.1.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
@@ -11594,7 +11594,7 @@ importers:
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.6.0.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.6.1.0
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.38
       '@types/debug': 4.1.7
       '@types/jwt-decode': 2.2.1
@@ -13745,6 +13745,21 @@ packages:
     resolution: {integrity: sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==}
     dev: false
 
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_vmzpgoyysqpn2i7zjvyqsntvhy:
+    resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      cosmiconfig: '>=6'
+    dependencies:
+      cosmiconfig: 7.0.0
+      lodash.get: 4.4.2
+      make-error: 1.3.6
+      ts-node: 9.1.1_typescript@4.5.5
+      tslib: 2.6.1
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
   /@es-joy/jsdoccomment/0.33.4:
     resolution: {integrity: sha512-02XyYuvR/Gn+3BT6idHVNQ4SSQlA1X1FeEfeKm2ypv8ANB6Lt9KRFZ2S7y5xjwR+EPQ/Rzb0XFaD+xKyqe4ALw==}
     engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
@@ -15217,75 +15232,75 @@ packages:
       tslib: 2.6.1
     dev: false
 
-  /@fluid-experimental/attributable-map/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-GaNbohuj/a+xXMisZqavVVERshatzn45OjvdLJxxN9d/He6BCk+ZKe2uPo6GIftWCRL4weYmX3RpnjdzXyr35g==}
+  /@fluid-experimental/attributable-map/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-ssXcSqkCQygprdOeXE5yu5yzsvtfTs5Ksq2PIuueszvqZ/ii6WHr/LzJBbt/Th1EiZ7BaDXM01gzrJ4oLmBzHw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Mk1UTKqZmeHvqpYQkgoTL1czv8BVnZWvHWFIAEiE7tejTWAHWCj+HBTAP4F7pjqy8Jf3jypO5TZCooRBliRS4g==}
+  /@fluid-experimental/devtools-core/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-FBNncOzBerYI1j1pC+4uLLxXX8aDPUxZD1JhUe/zEgkHNfBF8XjA0OhIlDQABJ29kHlRihfLyBRe+Dt4vvQhJw==}
     dependencies:
-      '@fluid-experimental/tree2': 2.0.0-internal.6.0.0
-      '@fluidframework/cell': 2.0.0-internal.6.0.0
+      '@fluid-experimental/tree2': 2.0.0-internal.6.1.1
+      '@fluidframework/cell': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/counter': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/matrix': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/counter': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/matrix': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/sequence': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/sequence': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-aOBFPjOMMpC6p92qG7QEMRNjbsVYmndRSOrYe8uFohjOdI4EBy8Aos4JvneIpZIB/3LlUjlbVzg+tXk29oQBYw==}
+  /@fluid-experimental/devtools/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-wrcTA9GMi6Wq/gI5HRcuI2o7ZyveaVKEdIVPS32PEOxUz9W1X4lx6aG9HIR9X9JIMUCttEGEF1Aqagzwp1H6Nw==}
     dependencies:
-      '@fluid-experimental/devtools-core': 2.0.0-internal.6.0.0
+      '@fluid-experimental/devtools-core': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/fluid-static': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/fluid-static': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/tree2/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-3EJqFGBcaK0Qmpb4g+pKVOM0DccSM7GnKUD38xPIMH5ohi1yJ2O9qCu34/aORyuXK7cAMkQSXFGJRJXGe+zFsQ==}
+  /@fluid-experimental/tree2/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-g5CUiuI65rOOqeNqVhky/haHkYYWXJTHEzMsYsW0MJ6pTbreVs421cGwcBXBz2iRATEwKJ0EzJJXYcuSl6OW+Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.1
       '@sinclair/typebox': 0.29.4
       '@ungap/structured-clone': 0.3.4
       sorted-btree: 1.8.1
@@ -15487,25 +15502,25 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-TkGgy4x2lmcK9fqvoMZ0RUaRrbKsULQbz8HP58j/Y7RZP3GOXFpqIXMETBV8qXdFymOG+SPjUXi9HqIdm84Bag==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-NBC+OsY/UDIuPDwU5d2zG4RO7Hn9Yf0tj79foH1B+s8lIAuJBGjWDDwl14hxb88OR9nDCbLM6uavni8ezG7x9w==}
     hasBin: true
     dependencies:
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.6.0.0
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.6.1.0
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/tool-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/tool-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15514,14 +15529,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-NVaOMZIGCwuUa5wDHIxS1rzNH8G4tDGzq9zkfl7B86ppAAsIjn2D4sy24k9JB9IOW/Y2zjaqbZ1ACmXCLhIFDw==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-UE/QrQUxSmevQwPCh+sftsBRbHtavOEN3dYg4buHzXapWoXXAX+A43RpE9pOWuJ5mg8vEeuKm40ARtrYZs7qBA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15547,28 +15562,28 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.0.0_nwcuyijzf6l5chuh7xhtrzgjly:
-    resolution: {integrity: sha512-GZFc21H85R/wes7xN03SOydCouMabHs2uudF1gWOC7hzcgxMYX9qbFFUIQvUXj+otYBxWckInBSqZvRgAYIM0w==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.1.0_nwcuyijzf6l5chuh7xhtrzgjly:
+    resolution: {integrity: sha512-gYMgx4oKqSJaQ9QWzdGd6PsK6uxz9WEE+AI3RDOYP8uWqvR102lygCdKtuluhIg8ePLQHgtgZZrDrLzuFzZBOw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/local-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/local-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
       '@fluidframework/server-local-server': 1.0.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/tool-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/tool-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -15588,89 +15603,89 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-aOifrcU6kBG2Zc8v2sy/3MFfH7yWPns/PDRuA3PWhqmwIXWmcGuMKIPbkemdIWlkm8+1SYVn8ldDWi6Xjd6b9Q==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-2d1pDVihPdT53TmOMRlrktSDSC2FX+qEALF0DP4+z2MvSf/9xq2tU9s4Ss8vwtXky6EeM/7COLt9amIH6QifTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/register-collection': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/register-collection': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-K7O7G8lqh8Zxh9Efam6EfA0yLKhWqo8Un77zre8igt8//eZ+bT+B9wxYEa91ULpnp9r2/aK/Y+fyFE23WgLCew==}
+  /@fluidframework/aqueduct/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-Lr6zboBJoiFJN6LCPiAAvIPmy4qzWKcZULNUt/Uldu22SDcbBZQobsjr3zM0MhU+YNjdqnAH0zHpqmwlSHZoKQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/synthesize': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/synthesize': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-K7O7G8lqh8Zxh9Efam6EfA0yLKhWqo8Un77zre8igt8//eZ+bT+B9wxYEa91ULpnp9r2/aK/Y+fyFE23WgLCew==}
+  /@fluidframework/aqueduct/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-Lr6zboBJoiFJN6LCPiAAvIPmy4qzWKcZULNUt/Uldu22SDcbBZQobsjr3zM0MhU+YNjdqnAH0zHpqmwlSHZoKQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/synthesize': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/synthesize': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/azure-client/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-8kzEXgONC0F2s+V7iaeEeXjx+7L9O46qogbg999/+aqY8OZLaLEmdUugSycaLYLabwX2WgMM8gt3ZTdt7zst1Q==}
+  /@fluidframework/azure-client/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-TzeApcamwrVRbtLjON3ypbUwo3HQ+TRRTxRDJnyEo6TxQWXVyVimFltoCBrm7n01fzP5wAPQFDCrC3hZaK3vIg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/fluid-static': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/fluid-static': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1
     transitivePeerDependencies:
       - bufferutil
@@ -15680,8 +15695,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/azure-service-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-y2WrLUPcRMnDu7de+7RvjvMGvCnK8BxOVdAUaz6Hl0Uj2FcClg3ACO+vc/gfIiBWKmWQpp9db5EXO9Bpk+c4jA==}
+  /@fluidframework/azure-service-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-S1eF9MvBMe1OVwyNbcCgarWstiyF6e2x/ygq762uYO0SXUz3yQpe4XZg1OfMC0zdvPTzDMNQMsQ0vaAWykWDCg==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.2.0
       jsrsasign: 10.8.6
@@ -15909,16 +15924,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Rh5sRFMO5QSV0Q81upD1ZiRWgv58Qla0kEj6aBhRolLQ8+0758OIMf91FqMnjnB2NzvlojeFHXjGhROzi9pblA==}
+  /@fluidframework/cell/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-NPbdwCsnckSqghcXrU+FVJmctkQ+5rfZT4NyqhvePqPoFOg4VyVHPs9fRTnovtLPGPNniBkc01TDoZG+hVwt3w==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -15938,29 +15953,39 @@ packages:
       lodash: 4.17.21
       sha.js: 2.4.11
 
-  /@fluidframework/container-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-AxEs6UDSLjr7TIAvI9ArAwK5kZS2y3AF7+OTbf4flEDsicWC6RHy6a0er5lHu2EIAZWgdPlMvI1h7P/cvj1/vg==}
+  /@fluidframework/container-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-U1wUbUJNhlGo08eJmCZ75Ipyl+A7/jwL52SZYiZmipRFbtx0kTIq0H9sIOrbOzQJ/VyWE23LRvxVZAsFs/Gu5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-5HUFpNaDriWfvDK83pq4EVg0aonRHKTtTjLQyMV36cWs6nZ8HIr6FCkRIBHrBoYexg5aTuJmyGHJoPfUNZpO6A==}
+  /@fluidframework/container-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-KYSWEKGZztRfUypsfQS3t/b/5278R4AT05tGSLkMluCMBBCsD9BR6mRKEIqhInQrZLWBEehLu6cz8OnN2sVk9A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      events: 3.3.0
+    dev: true
+
+  /@fluidframework/container-loader/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-q0Bip2nLWK/1sfEc2XMDP2+L3N0w4LFYWXXnHYPNsinANOZb98RrctzEnJ/1InOojg36iRIYl4rze5LXLy3zdw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -15971,34 +15996,45 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-yWTIsKlLZGI97cZjA/FkybEhkTdD5AzBWRkIHIsQWIBvxRvoDx+dNDLLmeDuXPG0+huyeaH/bRnxTbomZpycag==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-tXx9y0qVJNlaamaYB+oX/ZWVci5j2GH4EcoL1llwk1NC62FYwGEBkj5WsQH7+a5irwDOOa1u8wpyYL0Mms8Auw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-j4VPYvVGhvXrQZ6+hUvhY50hXvV6oSPtyOM2R01GMJuSaRMEpLD5cuoC6DlLJInJGyY1YSzc4FnurUsB9DfBfw==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-SF8l6RyFqwSHxfUv3TN/oi/dtawkr0yOnLssqNraP0IbUb0fF/C0rsXgEtgDeOuH9GKUDRlpdjucjbARNVYuQQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+    dev: true
+
+  /@fluidframework/container-runtime/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-x7Jn393bSJR3bQr0rs20nX/15sSPV5Nx9/BkFqpXL29WLvHntFqFdlCS+OqtBe8q7HorkUSYyKGWreRfvSk1cw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -16009,23 +16045,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-j4VPYvVGhvXrQZ6+hUvhY50hXvV6oSPtyOM2R01GMJuSaRMEpLD5cuoC6DlLJInJGyY1YSzc4FnurUsB9DfBfw==}
+  /@fluidframework/container-runtime/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-x7Jn393bSJR3bQr0rs20nX/15sSPV5Nx9/BkFqpXL29WLvHntFqFdlCS+OqtBe8q7HorkUSYyKGWreRfvSk1cw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -16036,90 +16072,144 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-l2TWZMmyXFL2J1Djy/c+j9nENDUWsGR3vWa7jU2LHiSWpPxGmtVwMcOuw7gk75aszRT0pZgQjmjKimpolZzgBQ==}
+  /@fluidframework/container-runtime/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-/VBvs5dF8un/8jCsn+/fzApmf+5QsORpn1aIw/FRifFz1sujwgqLNL81Xj0Sx2gVE6LKndaTwFeGlk4p3FmvLA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/core-interfaces/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-dsga6zZWuIphC5suGR8HhMUd5uFmZ3SrOexbEAN2AFc2Up0u2ok1XvvlIt1dMU+6W5+4918J44HMW7rLUK18rQ==}
-    dev: true
-
-  /@fluidframework/core-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-8D/inRzBBy1htw6zy5lBhBcBbR0wg22TZ43AoghM22ZziJrDEfCz/tl4/a1c8pVq4MY+t/n0AuqPIb9DdTQdbQ==}
-    dev: true
-
-  /@fluidframework/counter/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-7ALUFvHgT3NzwT8KLeYnJEVzTiH8cQmg9AMDTrNIhrVRQqU2J7EFidGdWffYzmxvh153zEJcfaFywAKslQ8tgA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      sorted-btree: 1.8.1
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-snTZATxsaDKmcBIAmI84AsqIjVTlxdBEQBsT66pDp+GGxhfOIO2VltCEF/S/aO+VNXF6Z8EgoQDcMw3MGUha6Q==}
+  /@fluidframework/container-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-yx49kKTSY3LpgXSDnTMTqRiot1PpOYEgb6ee4Eg+G2cgXTTqh11r3r4ws4pZ34NI+j7w7hj9FlhNByDZ/8h5Hg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/container-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-pUdhirgJd6Ofp4888aOXcc5/Sa8lJCgzmqhC+yRoK57cUD7zG6HvJQ3GeW+/jtQumrDsMr1lojanCuySrS7mCg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/core-interfaces/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-QcBqjl9P1ZXxwOHdfPyQD68BJ7iUVQyFCEy3rslyt8xSkzTJi90/5PBbIHSIviPUBDEoNtYErVCDooGIEjasVQ==}
+    dev: true
+
+  /@fluidframework/core-interfaces/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-xvHhlxodN64LNVO432uCzIqpiNVeduIGd2WytJHe4BSKuWjKIVp3lPHNDVdOUlEWzHZreZwh8l/QmmXUZRf2Vg==}
+    dev: true
+
+  /@fluidframework/core-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-q2ITM0x0VQLZxVCkN2PxbJHbG7Hy4akvGa5QUaadJ5uVoUs83QvV3W5rVregHfd3dvG591L3pyUCnq0jX4+65w==}
+    dev: true
+
+  /@fluidframework/counter/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-sEKxpJupXXwwGgpwXjsFGtwsnIJUUZ/YWFyeIuH07cXxWW1ekGE6Dq9p5/P3PdD9MDVmfsD2VzEs7uqtTckn4g==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-2BHlkQIgBV9VjMBTPUM6XOtWil+CCfAlBFSZNvjhV1Rot+Ep5HANktHC1hVinGWcBQ8N62Wf/C8bV/JIe5zLnQ==}
+  /@fluidframework/data-object-base/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-5hTmqWwjwKaEQToF95KGpq+sF8owdnRTaBm49W9kRMgBobnyJql0rm72m8SdsMnP3TmlNTma1ZQ1cYlrU87LCQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-vA5dV5UjRPfeNKSfTwm5alFbUTXOUvoY3Av1xBx/Z09oYhxd911+iZX8cKhcZMNbuy3jvUsbK7eg4AbhPPouOg==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-vTELaK8CJHSG+t5edAFOSpUWnLFq4xu3gjVQMgqdbzsEfSNXEkIv/cfMlIDvO/Q2V7ED0BIma2d7fazag8/Bcg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+    dev: true
+
+  /@fluidframework/datastore-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-yDNUsvoD36oyLS2Hsm1lxHCNm7wMhgDk0jYHelWyFmSDj0Plpvi6ZK4N8Pomx7I888acSYTWe2vDoM/r9H6g/A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+    dev: true
+
+  /@fluidframework/datastore/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-xTqbNVgoscod1/caUcxLhCNI6CYh1VVchnN3mxJb89o0lQO1boQi8D6YXyJYk8TPW2t0TWtg+g0k26Ke8lpZTw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16127,23 +16217,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-vA5dV5UjRPfeNKSfTwm5alFbUTXOUvoY3Av1xBx/Z09oYhxd911+iZX8cKhcZMNbuy3jvUsbK7eg4AbhPPouOg==}
+  /@fluidframework/datastore/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-xTqbNVgoscod1/caUcxLhCNI6CYh1VVchnN3mxJb89o0lQO1boQi8D6YXyJYk8TPW2t0TWtg+g0k26Ke8lpZTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16151,79 +16241,111 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-we0ds0n+KoDidE7z/abh5CWE+IglC+Q7Oakr3qOGtp6MK1kCMZQsPnU02cp65LewnCI5OOmzK987PD6fHhfwxw==}
+  /@fluidframework/datastore/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-wb2H8Mtbx/jCMxAsAJ+1/72r7f01wG7qtA8ACOGoaKxmJCPyIbNY7r02EO/JzkMk/tOooj8sf2foHjK97sgB4A==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/sequence': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-base': 1.0.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      lodash: 4.17.21
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-CLQBfUFCUG910Ihft1oU0eA/7EXnvBQPQqAIZm1qc2xjxpqOU79zi52LDtq7ARet/vyytQrQrwTJYM9Y2VCSxw==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-AleEm2MsgDEquFFII8/8LnPiGKPGaGwGEdrNQNzKyf7N0bxTf84xTVR5FLn/36AgeJLWKxyUHbIXehyjQi5U8Q==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/sequence': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/debugger/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-NN2nB6l//I0NqiHFqD9YKkTF9CZSK2FjaKR4gHJvKrU3l1W2dBhe3hNWOilE0vziekKAI0l63vC3L3EepSNP8Q==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/replay-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver': 2.0.0-internal.6.1.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-vf1sxzreJAhNGpv25EKWy34aHZ466Ks5/k62U/R53fQt1s9uvnDt7BLB1irFqHN/vOQuKWza7WGMndUnT2wHdA==}
+  /@fluidframework/driver-base/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-HAWzoYX9cgjvomVNOR5OJw4ouHtn601jzsQE/CNmy4/oFane+AIvc+yDnaINAJIBhB5Uon+UDHRk1z/8FZvAmg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-vf1sxzreJAhNGpv25EKWy34aHZ466Ks5/k62U/R53fQt1s9uvnDt7BLB1irFqHN/vOQuKWza7WGMndUnT2wHdA==}
+  /@fluidframework/driver-base/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-HAWzoYX9cgjvomVNOR5OJw4ouHtn601jzsQE/CNmy4/oFane+AIvc+yDnaINAJIBhB5Uon+UDHRk1z/8FZvAmg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-gL0zIisH+O2YRdo0g5EYS2TNdORHVmNa7E3WDOs8YTrPKUXrxJzlT6fZgYcpuJrKaB15QR+r6LWx4rjQTbvbdA==}
+  /@fluidframework/driver-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-T4iBg5g5kIxiCZ3UtuPQ5jQX7lo+uu0tSUlI6CdmWmt9UbEH38hxWYp68juSdu5Z4a98alZForbhsXLS/c95Wg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-PD4h8O/XEBqlizZYONy3M8pdpqd33vvKNZ8dj1iMloCXPLKpfOyEe1nmlmXZBOjsNc6deBB7WZX0WWbY6UMEPQ==}
+  /@fluidframework/driver-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-DzlvnOJPd2XsPtW0r0KrDGPug8waoaU4foKYni0ssd21x4GknQ7QWlWJ0DcsMGt6R7lflIijbc6nZ/4MWI3XXQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+    dev: true
+
+  /@fluidframework/driver-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-3ni6XUm/zvtRVGLyLZGVVghzwTQ05GCbz24MMcnahiUOpyvvlytGus/rvPy4RytzSqy4VDw2exOYXYrPakUQNg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1
       lz4js: 0.2.0
       url: 0.11.1
@@ -16233,16 +16355,16 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-PD4h8O/XEBqlizZYONy3M8pdpqd33vvKNZ8dj1iMloCXPLKpfOyEe1nmlmXZBOjsNc6deBB7WZX0WWbY6UMEPQ==}
+  /@fluidframework/driver-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-3ni6XUm/zvtRVGLyLZGVVghzwTQ05GCbz24MMcnahiUOpyvvlytGus/rvPy4RytzSqy4VDw2exOYXYrPakUQNg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
       url: 0.11.1
@@ -16252,13 +16374,32 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-OQi7X9aCm9CPGY4o6BsxP8gLPU3xWixaFUAuZmQ2c9giAdibTNtmJEcK+4qr+b7hr34gokAcNEQ/WNeo0Wpftw==}
+  /@fluidframework/driver-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-dQaK5RldJTs+NsUCA/Et16AzyYElFnmNbClIdxxy/EiynqhXPc2qJBxJUaXYWZ55Pdrs/FmLWt0/hC/4uy131Q==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/gitresources': 1.0.0
+      '@fluidframework/protocol-base': 1.0.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      axios: 0.26.1
+      lz4js: 0.2.0
+      url: 0.11.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-web-cache/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-6r8V3T7Z274eMoI9F9TAvESJVfGxxfHo2WfGd0vey/XI9YztpBBGkizt7yajN4HvMgqamEvOhqNkCGqfweZKWg==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -16316,33 +16457,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-zXjKpEgN9rhuozfZ62q62Hq1aVZMU5qLzsN+kBEAy4uTz88PbBpdknuWVqPS0e1cljUODGMjROOWfii0rCZjKw==}
+  /@fluidframework/file-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-siGv4HxIucqna3a2bsXMrdqoMUSs3i9RazRH+u4l9MjdB10R/wUC8ngGwUik5hSyJlqBbQa53nkWJJQy6vSFmQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/replay-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/replay-driver': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-FpTKuH+zLFDOfXjeb7tBl4F6aWJXZqf1xrydhZMhbSXX2TTcGF64Hh3BEMRNp+F7F6+VuzD/QdioS0+dGgqPuQ==}
+  /@fluidframework/fluid-runner/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-sUDfw06gk/lJ4U6ujq9u6LAUAxGjawoZ+ETVoBogKF5YZ9qawPnZ1owRyIE3vdEkY7MJpzRAd9Pyu4f2juJjMA==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -16353,21 +16494,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-TIy4nZQzHcxqkn0/8vT9YQfoVGNTrAlG1Qm6yoq4dsODIP6ZQfMQWmV5vqIFqFyVrC/O/yQ/utUQwY7iLo1/ww==}
+  /@fluidframework/fluid-static/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-YcMQrXPgUw2hAQ1kwCzWi/NZPWYBxnbZPvmY/tTQpY5/SxL5jQEqjN+StbLnQH2L4Z4sU6CUcx2JTtVMAIMCFg==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.6.0.0
+      '@fluidframework/aqueduct': 2.0.0-internal.6.1.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16376,38 +16517,38 @@ packages:
   /@fluidframework/gitresources/1.0.0:
     resolution: {integrity: sha512-j4yu9JM5kU3y+5XfPOu19Ak1vJZai+6tiqCAYeJeXaczfGRlWVdqWgl4Cc8LUdJ+JDPEKo9a54FaJG+Gpa/kwQ==}
 
-  /@fluidframework/ink/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-egl/1+CIIlIMa4p7ZgUTanu0K0vCt1lUjWe/9/j9wl6TNYpKXNn/M3PZSqnAtCX2s0sdLPLyKHNsJMvJmyg5fg==}
+  /@fluidframework/ink/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-5xVHh3d65WEEHPPF8FOjLTcMROhxBJrizNMza7cg4g6nkF1TIDt0kG3HWk+hpsiwgB3G/+vaSNlTQy/gXIMfJA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Tj7J7lZkOY/nyNA8Q/FsJH3mvbJibnvDPltx33idXmBGt5aYMDkaobRJ1Q4WaKWR6A/uUh1rTLToon04rjHtUQ==}
+  /@fluidframework/local-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-KoTV0oRWUAwzDOyVP6MwsmAZPFtsB8xSRAjgu76O/N0xZsjddPh5IJ4XqDvsouDftKcEFpZ5pYRLIE+Zwoulkw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
       '@fluidframework/server-local-server': 1.0.0
       '@fluidframework/server-services-client': 1.0.0
       '@fluidframework/server-services-core': 1.0.0
       '@fluidframework/server-test-utils': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.1
@@ -16420,22 +16561,22 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-Tj7J7lZkOY/nyNA8Q/FsJH3mvbJibnvDPltx33idXmBGt5aYMDkaobRJ1Q4WaKWR6A/uUh1rTLToon04rjHtUQ==}
+  /@fluidframework/local-driver/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-KoTV0oRWUAwzDOyVP6MwsmAZPFtsB8xSRAjgu76O/N0xZsjddPh5IJ4XqDvsouDftKcEFpZ5pYRLIE+Zwoulkw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/server-local-server': 1.0.0
       '@fluidframework/server-services-client': 1.0.0
       '@fluidframework/server-services-core': 1.0.0
       '@fluidframework/server-test-utils': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.1
@@ -16448,68 +16589,68 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/location-redirection-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-aNZmZrQydaOnH0/T0d21pEBNhfc/9YTI18GtIXDAQSARLxthbKG5Q2Xxb3AjCKMusm9KoMmHbdkHRvIRqolEHw==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-OuGIXLYsv2pkBytAgOWy6D0L2nBfQTzu8VpFmvCgHqfH8v3zJvs8cVcCo6Z/kLcfS7ssuIiBbkJqmpnlNAFsxg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-vS1+5vCgEOOKD5a9WsU3VcnDW4drbhUjrFiseH7gzulmZ2Tvl5TOmM9hJCvBGnTQh0i0auTXgGXWcxXEWvTmeA==}
+  /@fluidframework/map/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-O1bREZJYe5PdlAdWROzbz3u+GBDBAh2gQWKfJuQbJXLvEiwb2XpEXu5LJddOcqJkS7xYCzkXrcWu0BEKW0506g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-vS1+5vCgEOOKD5a9WsU3VcnDW4drbhUjrFiseH7gzulmZ2Tvl5TOmM9hJCvBGnTQh0i0auTXgGXWcxXEWvTmeA==}
+  /@fluidframework/map/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-O1bREZJYe5PdlAdWROzbz3u+GBDBAh2gQWKfJuQbJXLvEiwb2XpEXu5LJddOcqJkS7xYCzkXrcWu0BEKW0506g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0_debug@4.3.4
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-1KeelT0oGiMpxrDDCs9LfVDw/pI/MzQK7cQTR8ZDSD3L7wRWsQwKM8d5oib9H2++bNv4nSo92sGZx+3vqNJcmg==}
+  /@fluidframework/matrix/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-a8hxtOa6y21clNF7biR1muqFB+5iKFhLblCrJywSrBVO88Rm/QgyuRzcFs36J56VokHFVuarrcVeVrp0JmaRXA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -16518,43 +16659,43 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-TJ5PN4WLgR7//5sHQ5RC3ds0xl/UdmRrE7sFOGdz+9M2Y0brx0w+w93tzg5VQaWYR7fhkWOqpYRpa2uT8dhHnw==}
+  /@fluidframework/merge-tree/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-7RxKnZ5Q9r6YgRTK46wWKTTphfX4ERV/zgtbSim7rBHehEjh+uD8x1naQa24jNF4xQpV3SuSgDNs/0Hz99tKEA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-nf5pAJUQKqBeKgUyqFHnkXFwy9E1lnFCoZsP4L/mvzwPO68i6TegCGHJrXtFiobYifeAuEqWpGIdpRi5qXZnZg==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-LuKctxNjiOmVlAKoJzDtLn+HfGGfAgMOgqIEhU+HJZV+qWOjx5j6wX5Lqw4Ob2qVYtO4RVRHIhjSXjdcoIRY6Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.1.0
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-tHxAK6Aqk+zN/EteM9PsMBIHetnh+qMG94WeuU0XlcpZA8LT9wFHTDkhgAnEDAWlmqR3BRpN1w7jOy9SLnHCMA==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-RYiiCJKavNqynbV20Xqpjc5RUIDgJEe3kxAGs9dAwVX0bBN90fnE4QSEbxRsUBRiVe9UskEiqzAkKizJFpWkuA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       node-fetch: 2.6.12
     transitivePeerDependencies:
       - debug
@@ -16562,15 +16703,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-tHxAK6Aqk+zN/EteM9PsMBIHetnh+qMG94WeuU0XlcpZA8LT9wFHTDkhgAnEDAWlmqR3BRpN1w7jOy9SLnHCMA==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-RYiiCJKavNqynbV20Xqpjc5RUIDgJEe3kxAGs9dAwVX0bBN90fnE4QSEbxRsUBRiVe9UskEiqzAkKizJFpWkuA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       node-fetch: 2.6.12
     transitivePeerDependencies:
       - debug
@@ -16578,28 +16719,28 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-W55ZJ8DW1Bbvq2iaIFYwPDnwJAbvwrce1UciVkF0cUqtMF1hEDM3HkMlOu4zs4kJfwvb9cSh3f0bjcvs/dzztA==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-AEhoVp+CTK8fduel9MRpa5ynBwu8AB2V32OrlC7LhhrccJ9NvHLcC+suj9Nri64Xf+5tjj9yzz3OL91eOVzarg==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-XNzT7J0Iy2hcrdOH5K/bFpUMxo13U2IxeuR6vM5PgmOcWKBbfetauo/ZZfSqJ+6CL9UtiGHyYGwqxEEaQn/HGg==}
+  /@fluidframework/odsp-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-I/B0TKY1BIicx5v5CxrHY49L72ki63O4EPpIdl3b16U6b8Xmvee+jES7gEXIko3gf1ZD0W4U/X17tJ/03Zb7YA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       node-fetch: 2.6.12
       socket.io-client: 4.6.1
       uuid: 8.3.2
@@ -16611,13 +16752,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-r4GQBhgA/pAMp9r4af3ZXODrqjsqSEcSVxbwtIqUjyZkQeVGxOF4pB8cLGeM2+h1zgeCiD7Xm7nsJSoeh666MQ==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-Dj4JKrpvpmmS2W1uLs//NtzhGe6q6SzBovjsERsZE+87URk6PemomchoMPYpSI09W0QhCj/jgR73jGc/rBfwMg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16626,16 +16767,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-f2+zCdD5UT9KWq7fZR1JrBOKtkdSVpaeGNFkqjMcjPbhXwypb88YrJjS0fSIU6ULEoMvxrCUdK5MTBropKccgg==}
+  /@fluidframework/ordered-collection/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-j0PSMf39zvV8Q/vcjDLdwQj47ALTf5HiAYfVwZ7KJlLHjTtMDbER2m3R3BRKX4LrGhgmFnclNuBTl4OTp2uCrA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -16655,76 +16796,76 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-5FpPd6tyXoizANMD2RL5QdIishc3hfavHFo3DRsPEdC9G/isyVPI9kqz+hYWPDpnfAuM7Qbxy/KeYH8OXmlS8Q==}
+  /@fluidframework/register-collection/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-XLdmwbhdMtu5iaRJ9PXcS+FQ9NshZxWYpNqt489ah/YU/k4AFRoSxi9Ze76CuVKKX9eUQd0us8JynZLF4NBDyw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-h+SpPyYb40BJhZp2zsppxQk/047yi7qL+feUGHhGciA38HwstoddFkZdIi98uDxRJvI5zEEe9ZXwxx0pR+4/yw==}
+  /@fluidframework/replay-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-AakxDAfzLzPrfO4DWAMnOgiAFo8iIArGfTiCzEY13vkule6/NNVZTlLBm/9NdubqENmNdohvxSDLBETkRluZdg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-EHoVGfwcF4EQkzHfT6yPXR6h/HTKxOJzIbPY6F1POrsL/FYC//P41lukaQS00pOq33QTeg7C7ZWQQpXu/jzsxg==}
+  /@fluidframework/request-handler/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-7JEDHR6MMmOL9OjFSi9id/7knUJN9Nb2sNyB7jwSwGfQrybSwpSvpZTkdwv7hkNrkloc2eaBOmzX8IZapjQkaA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-EHoVGfwcF4EQkzHfT6yPXR6h/HTKxOJzIbPY6F1POrsL/FYC//P41lukaQS00pOq33QTeg7C7ZWQQpXu/jzsxg==}
+  /@fluidframework/request-handler/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-7JEDHR6MMmOL9OjFSi9id/7knUJN9Nb2sNyB7jwSwGfQrybSwpSvpZTkdwv7hkNrkloc2eaBOmzX8IZapjQkaA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-kFTTcSvZDzh22dhiOO1Ea0/vfN4qFlxM0d5Ntq91wfpXAiVH6vATp20Tx35QfwilAV+mmInOdbYJb0c+Joe3TA==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-Hn3JCCt6bF7Vkb/+cBaE3pp4bAxW253lZMDeHr0Hp+RLn4LzQ2CyIVEyHlZ9NoRsJf4Gd1ip+PlNDzY4ssmZ5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
@@ -16738,20 +16879,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-kFTTcSvZDzh22dhiOO1Ea0/vfN4qFlxM0d5Ntq91wfpXAiVH6vATp20Tx35QfwilAV+mmInOdbYJb0c+Joe3TA==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-Hn3JCCt6bF7Vkb/+cBaE3pp4bAxW253lZMDeHr0Hp+RLn4LzQ2CyIVEyHlZ9NoRsJf4Gd1ip+PlNDzY4ssmZ5Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/gitresources': 1.0.0
       '@fluidframework/protocol-base': 1.0.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
@@ -16765,76 +16906,104 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-ZJCKdue+pNHTTujgmlez3Jlcoo+VBZLhJ9DLOaj77KFopOq+gIGXsJMfWePb53xoika96tj0LBlSJPBm7m28Rw==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-QBtGPEIhdp8kp6CruaLd3BiPWw19KmwoyTH3UZwtHh4enOVtVT74nE0cxaH5jK+T/WS7zRiJUIUlr//xnlHinw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       nconf: 0.12.0
       url: 0.11.1
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-lELlnssXUlKknDqzKmL65PEV9k9x30N3Rn/x2oUDfO+rSwkbGdbldaRxnTI0m/vOFwkW2b+SMNDmRjoc8/EyzQ==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-ucNnpxjPL1GtHOsbeBi9fxZHJbPp4+0JYJ36mlrLm6Efugg8UFdBZB7XJdrDUxQSSBbdkMcFnR9V9Np3mn/Fhg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-GTzvWSvUO1l6pchLvkfU1P1Ck/HeA69BWzHuJQzEUvLIcHr3AUJiwzeuhjuJCm9kqPF1/zvBRcsKO/nD+JgXbQ==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-NMdo1VTLiVG3/AdNywe9pITyYpxMyCsXOUt44TTI4RD4em6/RVOLjA6ebHAbIU83Zlk+F9op3esTN4b7NgRfzg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+    dev: true
+
+  /@fluidframework/runtime-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-liLYqA+kMwd8evCrFERTEIX2LMEB2PPzSMhi1Wrg7XSttpimCl1XQpqCxUDM5wegDGO6YrljUUDt/4zbYBrNJA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-GTzvWSvUO1l6pchLvkfU1P1Ck/HeA69BWzHuJQzEUvLIcHr3AUJiwzeuhjuJCm9kqPF1/zvBRcsKO/nD+JgXbQ==}
+  /@fluidframework/runtime-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-liLYqA+kMwd8evCrFERTEIX2LMEB2PPzSMhi1Wrg7XSttpimCl1XQpqCxUDM5wegDGO6YrljUUDt/4zbYBrNJA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-1jVLzy/Dgtfnz6nrvo2NP94n+Ak7EQm6ZQstNDYrc0ZaCYXc+twPh+TusNKYAKTxLA97B0PWr02RF2L5ipgBXw==}
+  /@fluidframework/runtime-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-V23b3CkAIbmzAIt38ZqFymc12+tCf4Mz05S1hMUW8sdEYrLxxNuCBb1GP5tOmf65XOL0+QUa5WWEl1QztqbyuA==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/sequence/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-u1j+6cfKrsCAbigIMjg4lMvi2inwGzMpe6BioUIWHd9Q2nYbcksEX0CSzFrl/FiD6N/1Jf0djVxuQH7pkSMM4A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -17079,96 +17248,117 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/shared-object-base/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-DMePxQDeFNTo/WJL1NgrtrYiV3tZjHLQKGWkB7Hqotq1B/f9g7czwLD+aeS1gucNz8myBrhJZX/xC/cFNdZPCQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-dfPgJ4bPBHBECxHdqt3EZxLLQDBwHA/DsRSGypNmTD4PBB8D5KKBQiFD+DaKb37BokPZhs8sIrTL7tu1KFPCZg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-DMePxQDeFNTo/WJL1NgrtrYiV3tZjHLQKGWkB7Hqotq1B/f9g7czwLD+aeS1gucNz8myBrhJZX/xC/cFNdZPCQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-dfPgJ4bPBHBECxHdqt3EZxLLQDBwHA/DsRSGypNmTD4PBB8D5KKBQiFD+DaKb37BokPZhs8sIrTL7tu1KFPCZg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-cNX9rT3aXqTOHzt0v1Da/nyM+68E46XXYpRxyqDt9tjU5ap7D/ACDitU6oTHdSAP4M4Iu4rB62CqU71jVQI7kQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-bAXmR8iucvOaOhP2gWIX4V5khvUpU0YcYoh4q4dfH2Kay0XWynomooW4IIXtA0zj9PfC4XM3UvDQTO5bnM9zQQ==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore': 2.0.0-internal.6.1.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.1
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-qa8Zq4tghoWX934h3JCL08MnJjxmrqv9f2IiSwbSI1F7gYm1WSOd++8uc9wqCm10w5ISe8BDDgEung/e+DB/fg==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-rNhJ2QpOS0pDweBI6M9Z+qYhGu8F/2rB/RE50YLV65Z+uDosLAhKGnL9WP9MVpRs8CRYMg1yobVhfwdmY3eP3g==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Pgdj06xaHIsu/vQov3A7DjYHMmrdzQbgpoMrVDcz8xEMLCPhBHU8ba+/G+f0TqROpXss97Df6jUpPiopB4iSvw==}
+  /@fluidframework/synthesize/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-d3nal6W8nnptpyzvzGsDJG9Wcfrv8AIMP/v8WnKPmJN8/6JB5NQMLXJwFRh+ON6yNgenULdqemkT6m7SLJZmrA==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+    dev: true
+
+  /@fluidframework/task-manager/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-3WKrlg460Kq7jKidQdA5f8JsiKycaS+luaR0fnCAq194O6FnSfm+GjPdfO5wXFYy/xA+6b8GUAd5TXr2qXd6Iw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.1.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-pnw57Vv/uYJWLf12DgTg+cXLb0aulYM7xkHwTByC3FhvMB5+wmwCWFONQBdbcZ0LRLdMgswXIAwwxoThrmQwPA==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-rKPlyPKkXa+yWhEvCfoiJfWduooM0FpI2E22E8WAQrR/E9ZKAJmiDy8CkfPfnRyPXVceS7F5Wb6URtXXk1zXQw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
       debug: 4.3.4
       events: 3.3.0
       uuid: 8.3.2
@@ -17176,30 +17366,44 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-9cwPAluxjBzeNvnEZW7fjilY2jWVbJbI0MvRaX4ormv2316GrK6h/Bs9pg5q5yzUCFevJ/hyvm/6EmdbltMWdQ==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.6.1.1:
+    resolution: {integrity: sha512-orXhV5K6FVMJj6jInTAt2uNG8zgZ20VMM5nNXtxGM5p9xwE+g/xpuLUij1jmQzmst3i57ZP/d/MmUxIgQTGCxw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.1.1
+      debug: 4.3.4
+      events: 3.3.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/test-driver-definitions/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-aahTs38FqFWSSUgxmMc8eDQMHt+6FhuAzAiiFprT9wPht9sZmcTInqQ58BF6jl/gV0hb0sUwciJ5YP4rC3LLIQ==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-+8KOLeabu/sPSbFailtj6EeBGX+k0zSYjGsXYsvsQgKnaKJxXegbsqLXywy66KtxMEC1xtEKwZU08/dW9hmy1g==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-ui4U8aBnwni1pd1XfbutMiq51AnDLZl8lTzQqRwvkG4YKdNayy0B6YjwyoxeKyNU8/wJpwzN/KGCZfiBuLTecg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17212,21 +17416,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.6.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-+8KOLeabu/sPSbFailtj6EeBGX+k0zSYjGsXYsvsQgKnaKJxXegbsqLXywy66KtxMEC1xtEKwZU08/dW9hmy1g==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.6.1.0_debug@4.3.4:
+    resolution: {integrity: sha512-ui4U8aBnwni1pd1XfbutMiq51AnDLZl8lTzQqRwvkG4YKdNayy0B6YjwyoxeKyNU8/wJpwzN/KGCZfiBuLTecg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17244,30 +17448,30 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-ELpsYMMl1ETn1TSjAkAGwj5uDROf3xC++9Oy+KVe8ZWfKB3zxp5bj0lfJBCCnihrcLjvBqWkKl2BDdy0kDcQng==}
+  /@fluidframework/test-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-QVHQ7rAwPrM+Ws3TvLaWL1I5ba6DiLH/daSG9O/t15YMukKDA2f9cDDbTU0Xi9lbxFE/WDz/Q25+uZOKsba3YA==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/datastore': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/datastore': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
@@ -17278,21 +17482,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-+tKCH45zmGUFbQ32D9CBegRVui1JXmuxMpcckJHEEaN4YXMZmZYQSPSiRlzrt8/3TH72XMZ+Pt3JDA2CuNUSkQ==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-GIKuweVy9RqQFMZjjKM2fBiOWknZFCCNECNHeozzkt7y/4Mg4GpGJIhE+j9T1gLcxSE/AQYXufv07VMYQfOoTA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/container-loader': 2.0.0-internal.6.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/fluid-static': 2.0.0-internal.6.0.0
-      '@fluidframework/map': 2.0.0-internal.6.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.6.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/fluid-static': 2.0.0-internal.6.1.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.0.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.1.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.6.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -17302,14 +17506,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-WzQYpNmbV2PADRuy1K0pAE1hIoZWQSUtgz8ZkOTStqvoRqa/MqQE6pf4NCbaQCG/QwPkiT/ERR18twG4cp6RkA==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-YMKZZkT2dRFTbpheCVE4vqiBmum0t1Z3Bln7mnZcxsJkI+JUhFYL7ypmeOL0ZJGgBZ0nOgZFXZEgolUlBPxymA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.0.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.1.0
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.6.1.0
       '@fluidframework/server-services-client': 1.0.0
       jsrsasign: 10.8.6
       uuid: 8.3.2
@@ -17321,12 +17525,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-N5ahotYoDD6WzlGLa1ReRIrGRxTvvwmLAuhSV58s0bfstqhUNHqRsIF5Ct89QCVY+x5O7/BDTfsR97FmrmdvgA==}
+  /@fluidframework/tool-utils/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-IkzLQpd62G5wdD94KybkFBzzAwe2H9Ho7M3vL9cFdOyC6DKoT5pbq5sBAZxxz0Zy+GJvc4ZKgozvf+NvCTVZIg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-utils': 2.0.0-internal.6.0.0_debug@4.3.4
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.0.0_debug@4.3.4
+      '@fluidframework/driver-utils': 2.0.0-internal.6.1.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.1.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
       async-mutex: 0.3.2
       debug: 4.3.4
@@ -17337,37 +17541,596 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-PNVzemvRecbPTAP5GGc+qx5IiP30PMhQ4FGYh31SZdjUsJuaLRNwu9wfTy/uBFe4D1h/6LYi1H6jOWVEkT4ZWQ==}
+  /@fluidframework/undo-redo/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-+CvBh1H0Z31HchlvgxSc58r9RgoCeyk9AvB7TlMe1q057ZQDb0rSe67iiXqYnDk+ZCCQKajiNyJfHSJoEhbgGg==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.6.0.0
-      '@fluidframework/matrix': 2.0.0-internal.6.0.0
-      '@fluidframework/merge-tree': 2.0.0-internal.6.0.0
-      '@fluidframework/sequence': 2.0.0-internal.6.0.0
+      '@fluidframework/map': 2.0.0-internal.6.1.0
+      '@fluidframework/matrix': 2.0.0-internal.6.1.0
+      '@fluidframework/merge-tree': 2.0.0-internal.6.1.0
+      '@fluidframework/sequence': 2.0.0-internal.6.1.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-Q+T5TSbByZwoN++xdKtu8Z2yvauwk1a/HQphdT8IoHdJPG1SExwcSC1tGamCnNqDGDVUvWwGa7JzSjE9lsVGOw==}
+  /@fluidframework/view-adapters/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-mP92In2qQJZGncNf2/pwYjRhKnBGhd7FVn6laRheSssiknhq5YF1AOnb/28Guf1NBU/SEOKEURJIFdQZFn6Rdw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.6.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.6.0.0:
-    resolution: {integrity: sha512-gXDTRWzua28by6lZtlMGmFbIf/lnFfz9osLpxPMLgMDagTQ5LdMAk2hoRNpFq8VfB0yQocDMLh8WaDxXYwOJ1g==}
+  /@fluidframework/view-interfaces/2.0.0-internal.6.1.0:
+    resolution: {integrity: sha512-mjr2ql2vHfDjtn5w5RmtkCpeL3TV1P6BSaxQfWDJ7k/Nf/zfBnc5Dxl4c/yCOXzG8bg3VKc/95lJ1DUuufCQlw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.1.0
     dev: true
 
   /@gar/promisify/1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
+
+  /@graphql-codegen/cli/1.20.1_zb5anfqjd4osidq6scqzr4gy3i:
+    resolution: {integrity: sha512-jT5aMxIniER/gg0/sfx+BPmvI2ZAncQ6ZT/xkiFvXcYMiL9tDiAcVYJTmXcRdMTEIZnlzw3rhE4VPYiw1KqruQ==}
+    hasBin: true
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/core': 1.17.9_graphql@15.8.0
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-tools/apollo-engine-loader': 6.2.5_graphql@15.8.0
+      '@graphql-tools/code-file-loader': 6.3.1_graphql@15.8.0
+      '@graphql-tools/git-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/github-loader': 6.2.5_graphql@15.8.0
+      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/load': 6.2.8_graphql@15.8.0
+      '@graphql-tools/prisma-loader': 6.3.0_graphql@15.8.0
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      ansi-escapes: 4.3.2
+      camel-case: 4.1.2
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      common-tags: 1.8.2
+      constant-case: 3.0.4
+      cosmiconfig: 7.1.0
+      debounce: 1.2.1
+      dependency-graph: 0.10.0
+      detect-indent: 6.1.0
+      glob: 7.2.3
+      graphql: 15.8.0
+      graphql-config: 3.4.1_zb5anfqjd4osidq6scqzr4gy3i
+      indent-string: 4.0.0
+      inquirer: 7.3.3
+      is-glob: 4.0.3
+      json-to-pretty-yaml: 1.2.2
+      latest-version: 5.1.0
+      listr: 0.14.3
+      listr-update-renderer: 0.5.0_listr@0.14.3
+      log-symbols: 4.1.0
+      lower-case: 2.0.2
+      minimatch: 3.1.2
+      mkdirp: 1.0.4
+      pascal-case: 3.1.2
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.5
+      tslib: 2.1.0
+      upper-case: 2.0.2
+      valid-url: 1.0.9
+      wrap-ansi: 7.0.0
+      yaml: 1.10.2
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zen-observable
+      - zenObservable
+    dev: true
+
+  /@graphql-codegen/core/1.17.9_graphql@15.8.0:
+    resolution: {integrity: sha512-7nwy+bMWqb0iYJ2DKxA9UiE16meeJ2Ch2XWS/N/ZnA0snTR+GZ20USI8z6YqP1Fuist7LvGO1MbitO2qBT8raA==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/utils': 6.2.4_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: true
+
+  /@graphql-codegen/plugin-helpers/1.18.8_graphql@15.8.0:
+    resolution: {integrity: sha512-mb4I9j9lMGqvGggYuZ0CV+Hme08nar68xkpPbAVotg/ZBmlhZIok/HqW2BcMQi7Rj+Il5HQMeQ1wQ1M7sv/TlQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      common-tags: 1.8.0
+      graphql: 15.8.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.3.1
+
+  /@graphql-codegen/typescript/1.20.2_graphql@15.8.0:
+    resolution: {integrity: sha512-D/DMUz4O2UEoFucUVu2K2xoaMPAn68BwYGnCAKnSDqtFKsOEqmTjHFwcgyEnpucQ5xFeG0pKGMb1SlS2Go9J8Q==}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-codegen/visitor-plugin-common': 1.22.0_graphql@15.8.0
+      auto-bind: 4.0.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-codegen/visitor-plugin-common/1.22.0_graphql@15.8.0:
+    resolution: {integrity: sha512-2afJGb6d8iuZl9KizYsexPwraEKO1lAvt5eVHNM5Xew4vwz/AUHeqDR2uOeQgVV+27EzjjzSDd47IEdH0dLC2w==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-tools/optimize': 1.4.0_graphql@15.8.0
+      '@graphql-tools/relay-operation-optimizer': 6.5.18_graphql@15.8.0
+      array.prototype.flatmap: 1.3.1
+      auto-bind: 4.0.0
+      change-case-all: 1.0.14
+      dependency-graph: 0.11.0
+      graphql: 15.8.0
+      graphql-tag: 2.12.6_graphql@15.8.0
+      parse-filepath: 1.0.2
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@graphql-tools/apollo-engine-loader/6.2.5_graphql@15.8.0:
+    resolution: {integrity: sha512-CE4uef6PyxtSG+7OnLklIr2BZZDgjO89ZXK47EKdY7jQy/BQD/9o+8SxPsgiBc+2NsDJH2I6P/nqoaJMOEat6g==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      cross-fetch: 3.0.6
+      graphql: 15.8.0
+      tslib: 2.0.3
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /@graphql-tools/batch-delegate/7.0.2_graphql@15.8.0:
+    resolution: {integrity: sha512-Dn1LKcbZfgttfxW1V7E3JYrLGCWOhtPC+HkxBRrvzxkesxqDbgaOH8X4rsx3Po8AQD49J0eLdg9KXa0yF20VCA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      dataloader: 2.0.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    dev: false
+
+  /@graphql-tools/batch-execute/7.1.2_graphql@15.8.0:
+    resolution: {integrity: sha512-IuR2SB2MnC2ztA/XeTMTfWcA0Wy7ZH5u+nDkDNLAdX+AaSyDnsQS35sCmHqG0VOGTl7rzoyBWLCKGwSJplgtwg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      dataloader: 2.0.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-tools/code-file-loader/6.3.1_graphql@15.8.0:
+    resolution: {integrity: sha512-ZJimcm2ig+avgsEOWWVvAaxZrXXhiiSZyYYOJi0hk9wh5BxZcLUNKkTp6EFnZE/jmGUwuos3pIjUD3Hwi3Bwhg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@graphql-tools/delegate/7.1.5_graphql@15.8.0:
+    resolution: {integrity: sha512-bQu+hDd37e+FZ0CQGEEczmRSfQRnnXeUxI/0miDV+NV/zCbEdIJj5tYFNrKT03W6wgdqx8U06d8L23LxvGri/g==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      '@graphql-tools/batch-execute': 7.1.2_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      dataloader: 2.0.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-tools/git-loader/6.2.6_graphql@15.8.0:
+    resolution: {integrity: sha512-ooQTt2CaG47vEYPP3CPD+nbA0F+FYQXfzrB1Y1ABN9K3d3O2RK3g8qwslzZaI8VJQthvKwt0A95ZeE4XxteYfw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@graphql-tools/github-loader/6.2.5_graphql@15.8.0:
+    resolution: {integrity: sha512-DLuQmYeNNdPo8oWus8EePxWCfCAyUXPZ/p1PWqjrX/NGPyH2ZObdqtDAfRHztljt0F/qkBHbGHCEk2TKbRZTRw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      cross-fetch: 3.0.6
+      graphql: 15.8.0
+      tslib: 2.0.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@graphql-tools/graphql-file-loader/6.2.7_graphql@15.8.0:
+    resolution: {integrity: sha512-5k2SNz0W87tDcymhEMZMkd6/vs6QawDyjQXWtqkuLTBF3vxjxPD1I4dwHoxgWPIjjANhXybvulD7E+St/7s9TQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/import': 6.7.18_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+
+  /@graphql-tools/graphql-tag-pluck/6.5.1_graphql@15.8.0:
+    resolution: {integrity: sha512-7qkm82iFmcpb8M6/yRgzjShtW6Qu2OlCSZp8uatA3J0eMl87TxyJoUmL3M3UMMOSundAK8GmoyNVFUrueueV5Q==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@babel/parser': 7.12.16
+      '@babel/traverse': 7.12.13
+      '@babel/types': 7.12.13
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@graphql-tools/import/6.7.18_graphql@15.8.0:
+    resolution: {integrity: sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
+      graphql: 15.8.0
+      resolve-from: 5.0.0
+      tslib: 2.6.1
+
+  /@graphql-tools/json-file-loader/6.2.6_graphql@15.8.0:
+    resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.0.3
+
+  /@graphql-tools/links/7.1.0_gijvqbksvnpa37pw7emzt4tx2u:
+    resolution: {integrity: sha512-8cJLs3ko0Zq0agJiFiHuAZ27OXbfgRF5JtVtIx8q2RfjVN0sss9QeetrTBjc2XfTj5HYZr6BHqqlyMMA4OXp7A==}
+    peerDependencies:
+      '@apollo/client': ~3.2.5 || ~3.3.0
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@apollo/client': 3.3.21_graphql@15.8.0
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      apollo-upload-client: 14.1.3_graphql@15.8.0
+      cross-fetch: 3.1.2
+      form-data: 4.0.0
+      graphql: 15.8.0
+      is-promise: 4.0.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - encoding
+      - react
+      - subscriptions-transport-ws
+    dev: false
+
+  /@graphql-tools/load-files/6.6.1_graphql@15.8.0:
+    resolution: {integrity: sha512-nd4GOjdD68bdJkHfRepILb0gGwF63mJI7uD4oJuuf2Kzeq8LorKa6WfyxUhdMuLmZhnx10zdAlWPfwv1NOAL4Q==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      globby: 11.1.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+      unixify: 1.0.0
+    dev: false
+
+  /@graphql-tools/load/6.2.8_graphql@15.8.0:
+    resolution: {integrity: sha512-JpbyXOXd8fJXdBh2ta0Q4w8ia6uK5FHzrTNmcvYBvflFuWly2LDTk2abbSl81zKkzswQMEd2UIYghXELRg8eTA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      globby: 11.0.3
+      graphql: 15.8.0
+      import-from: 3.0.0
+      is-glob: 4.0.1
+      p-limit: 3.1.0
+      tslib: 2.2.0
+      unixify: 1.0.0
+      valid-url: 1.0.9
+
+  /@graphql-tools/merge/6.2.14_graphql@15.8.0:
+    resolution: {integrity: sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+    dev: true
+
+  /@graphql-tools/merge/6.2.17_graphql@15.8.0:
+    resolution: {integrity: sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/schema': 8.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 8.0.2_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.3.1
+
+  /@graphql-tools/merge/8.3.1_graphql@15.8.0:
+    resolution: {integrity: sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 8.9.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/mock/7.0.0_graphql@15.8.0:
+    resolution: {integrity: sha512-ShO8D9HudgnhqoWeKb3iejGtPV8elFqSO1U0O70g3FH3W/CBW2abXfuyodBUevXVGIjyqzfkNzVtpIE0qiOVVQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: false
+
+  /@graphql-tools/module-loader/6.2.7_graphql@15.8.0:
+    resolution: {integrity: sha512-ItAAbHvwfznY9h1H9FwHYDstTcm22Dr5R9GZtrWlpwqj0jaJGcBxsMB9jnK9kFqkbtFYEe4E/NsSnxsS4/vViQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    dev: false
+
+  /@graphql-tools/optimize/1.0.1_graphql@15.8.0:
+    resolution: {integrity: sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: false
+
+  /@graphql-tools/optimize/1.4.0_graphql@15.8.0:
+    resolution: {integrity: sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/prisma-loader/6.3.0_graphql@15.8.0:
+    resolution: {integrity: sha512-9V3W/kzsFBmUQqOsd96V4a4k7Didz66yh/IK89B1/rrvy9rYj+ULjEqR73x9BYZ+ww9FV8yP8LasWAJwWaqqJQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@types/http-proxy-agent': 2.0.2
+      '@types/js-yaml': 4.0.5
+      '@types/json-stable-stringify': 1.0.34
+      '@types/jsonwebtoken': 8.5.9
+      chalk: 4.1.2
+      debug: 4.3.4
+      dotenv: 8.6.0
+      graphql: 15.8.0
+      graphql-request: 3.7.0_graphql@15.8.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      isomorphic-fetch: 3.0.0
+      js-yaml: 4.1.0
+      json-stable-stringify: 1.0.2
+      jsonwebtoken: 8.5.1
+      lodash: 4.17.21
+      replaceall: 0.1.6
+      scuid: 1.1.0
+      tslib: 2.1.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@graphql-tools/relay-operation-optimizer/6.5.18_graphql@15.8.0:
+    resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/relay-compiler': 12.0.0_graphql@15.8.0
+      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@graphql-tools/resolvers-composition/6.5.18_graphql@15.8.0:
+    resolution: {integrity: sha512-RhKDkq58wVCmL8roC/XndCKurKG65/8VoXBiJ3rgehuIXbuZusMwk7sUfO2b7OoaDmK3ARmpBO0NAkeo6Aaj0A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
+      graphql: 15.8.0
+      lodash: 4.17.21
+      micromatch: 4.0.5
+      tslib: 2.6.1
+    dev: false
+
+  /@graphql-tools/schema/7.1.5_graphql@15.8.0:
+    resolution: {integrity: sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-tools/schema/8.5.1_graphql@15.8.0:
+    resolution: {integrity: sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/merge': 8.3.1_graphql@15.8.0
+      '@graphql-tools/utils': 8.9.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+      value-or-promise: 1.0.11
+
+  /@graphql-tools/stitch/7.5.3_graphql@15.8.0:
+    resolution: {integrity: sha512-0oBdNFkviWRs0OkQiGow6THjRtDbiSOljCxCtkwF+C+bB/yLEPCNatTMo3ZR51twWBRPFgMwHZbSVbhRlK51kw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/batch-delegate': 7.0.2_graphql@15.8.0
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+    dev: false
+
+  /@graphql-tools/url-loader/6.10.1_graphql@15.8.0:
+    resolution: {integrity: sha512-DSDrbhQIv7fheQ60pfDpGD256ixUQIR6Hhf9Z5bRjVkXOCvO5XrkwoWLiU7iHL81GB1r0Ba31bf+sl+D4nyyfw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
+      '@microsoft/fetch-event-source': 2.0.1
+      '@types/websocket': 1.0.2
+      abort-controller: 3.0.0
+      cross-fetch: 3.1.4
+      extract-files: 9.0.0
+      form-data: 4.0.0
+      graphql: 15.8.0
+      graphql-ws: 4.9.0_graphql@15.8.0
+      is-promise: 4.0.0
+      isomorphic-ws: 4.0.1_ws@7.4.5
+      lodash: 4.17.21
+      meros: 1.1.4
+      subscriptions-transport-ws: 0.9.19_graphql@15.8.0
+      sync-fetch: 0.3.0
+      tslib: 2.2.0
+      valid-url: 1.0.9
+      ws: 7.4.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  /@graphql-tools/utils/6.2.4_graphql@15.8.0:
+    resolution: {integrity: sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      camel-case: 4.1.1
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: true
+
+  /@graphql-tools/utils/7.10.0_graphql@15.8.0:
+    resolution: {integrity: sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      camel-case: 4.1.2
+      graphql: 15.8.0
+      tslib: 2.2.0
+
+  /@graphql-tools/utils/8.0.2_graphql@15.8.0:
+    resolution: {integrity: sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.3.1
+
+  /@graphql-tools/utils/8.9.0_graphql@15.8.0:
+    resolution: {integrity: sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/utils/9.2.1_graphql@15.8.0:
+    resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/wrap/7.0.8_graphql@15.8.0:
+    resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-typed-document-node/core/3.2.0_graphql@15.8.0:
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
 
   /@griffel/core/1.11.0:
     resolution: {integrity: sha512-3jlrsJVbNC0avRMfNGWmbklptmtH5s63Gt/xa0zY6+Oa3kU/StNAu+d0LqLChb5egwXrisQIeC+tzzJ+YozGjg==}
@@ -22503,6 +23266,34 @@ packages:
       react: 17.0.2
     dev: true
 
+  /@wry/context/0.6.1:
+    resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /@wry/context/0.7.3:
+    resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /@wry/equality/0.5.6:
+    resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /@wry/trie/0.3.2:
+    resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -24539,6 +25330,13 @@ packages:
     resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
     dev: true
 
+  /capital-case/1.0.4:
+    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+      upper-case-first: 2.0.2
+
   /capture-exit/2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -24648,6 +25446,36 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
+
+  /change-case-all/1.0.14:
+    resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
+    dependencies:
+      change-case: 4.1.2
+      is-lower-case: 2.0.2
+      is-upper-case: 2.0.2
+      lower-case: 2.0.2
+      lower-case-first: 2.0.2
+      sponge-case: 1.0.1
+      swap-case: 2.0.2
+      title-case: 3.0.3
+      upper-case: 2.0.2
+      upper-case-first: 2.0.2
+
+  /change-case/4.1.2:
+    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+      tslib: 2.6.1
 
   /changesets-format-with-issue-links/0.3.0_@changesets+cli@2.26.1:
     resolution: {integrity: sha512-+GmelydJ+bYPVQyapFIELe/bM2+98cBIG7gb9raBxzx5MiBY0cDZnj4ii7xkrgpQLx96PWH3O9VA7Mhag0gs3w==}
@@ -25412,6 +26240,13 @@ packages:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
 
+  /constant-case/3.0.4:
+    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+      upper-case: 2.0.2
+
   /constants-browserify/1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
     dev: true
@@ -25696,6 +26531,28 @@ packages:
     hasBin: true
     dependencies:
       cross-spawn: 7.0.3
+
+  /cross-fetch/3.0.6:
+    resolution: {integrity: sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
+
+  /cross-fetch/3.1.2:
+    resolution: {integrity: sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /cross-fetch/3.1.4:
+    resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
 
   /cross-fetch/3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
@@ -29784,6 +30641,110 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
+  /graphql-config/3.4.1_zb5anfqjd4osidq6scqzr4gy3i:
+    resolution: {integrity: sha512-g9WyK4JZl1Ko++FSyE5Ir2g66njfxGzrDDhBOwnkoWf/t3TnnZG6BBkWP+pkqVJ5pqMJGPKHNrbew8jRxStjhw==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_vmzpgoyysqpn2i7zjvyqsntvhy
+      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/load': 6.2.8_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.14_graphql@15.8.0
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      cosmiconfig: 7.0.0
+      cosmiconfig-toml-loader: 1.0.0
+      graphql: 15.8.0
+      minimatch: 3.0.4
+      string-env-interpolation: 1.0.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /graphql-request/3.7.0_graphql@15.8.0:
+    resolution: {integrity: sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==}
+    peerDependencies:
+      graphql: 14 - 16
+    dependencies:
+      cross-fetch: 3.1.6
+      extract-files: 9.0.0
+      form-data: 3.0.1
+      graphql: 15.8.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /graphql-tag/2.12.6_graphql@15.8.0:
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /graphql-tools/7.0.5_graphql@15.8.0:
+    resolution: {integrity: sha512-pJ/ZVfuPEZfGO2Jlk/4mZnqa6blSiUDejTAX+q/ndAbZNUH9Xxdq+6XZy4GDjC1MivC6OnAtLbICWZ6GAvuUhQ==}
+    deprecated: This package has been deprecated and now it only exports makeExecutableSchema.\nAnd it will no longer receive updates.\nWe recommend you to migrate to scoped packages such as @graphql-tools/schema, @graphql-tools/utils and etc.\nCheck out https://www.graphql-tools.com to learn what package you should use instead
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/batch-delegate': 7.0.2_graphql@15.8.0
+      '@graphql-tools/batch-execute': 7.1.2_graphql@15.8.0
+      '@graphql-tools/code-file-loader': 6.3.1_graphql@15.8.0
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/git-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/github-loader': 6.2.5_graphql@15.8.0
+      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/import': 6.7.18_graphql@15.8.0
+      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/links': 7.1.0_gijvqbksvnpa37pw7emzt4tx2u
+      '@graphql-tools/load': 6.2.8_graphql@15.8.0
+      '@graphql-tools/load-files': 6.6.1_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/mock': 7.0.0_graphql@15.8.0
+      '@graphql-tools/module-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/optimize': 1.0.1_graphql@15.8.0
+      '@graphql-tools/relay-operation-optimizer': 6.5.18_graphql@15.8.0
+      '@graphql-tools/resolvers-composition': 6.5.18_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/stitch': 7.5.3_graphql@15.8.0
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+    optionalDependencies:
+      '@apollo/client': 3.3.21_graphql@15.8.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - react
+      - subscriptions-transport-ws
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /graphql-ws/4.9.0_graphql@15.8.0:
+    resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=15'
+    dependencies:
+      graphql: 15.8.0
+
+  /graphql/15.8.0:
+    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
+    engines: {node: '>= 10.x'}
+
   /gray-matter/4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -30039,6 +31000,12 @@ packages:
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  /header-case/2.0.4:
+    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.6.1
 
   /highlight.js/9.18.5:
     resolution: {integrity: sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==}
@@ -31159,6 +32126,11 @@ packages:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     dev: true
 
+  /is-lower-case/2.0.2:
+    resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
+    dependencies:
+      tslib: 2.6.1
+
   /is-map/2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: true
@@ -31365,6 +32337,11 @@ packages:
   /is-unicode-supported/0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  /is-upper-case/2.0.2:
+    resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
+    dependencies:
+      tslib: 2.6.1
 
   /is-utf8/0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
@@ -33651,6 +34628,11 @@ packages:
     dependencies:
       get-func-name: 2.0.0
 
+  /lower-case-first/2.0.2:
+    resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
+    dependencies:
+      tslib: 2.6.1
+
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -35009,7 +35991,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
@@ -36328,6 +37309,12 @@ packages:
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  /path-case/3.0.4:
+    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.1
 
   /path-dirname/1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -38996,6 +39983,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /sentence-case/3.0.4:
+    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+      upper-case-first: 2.0.2
+
   /serialize-error/8.1.0:
     resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
     engines: {node: '>=10'}
@@ -39317,6 +40311,12 @@ packages:
       wcwidth: 1.0.1
       yargs: 15.4.1
     dev: true
+
+  /snake-case/3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.1
 
   /snapdragon-node/2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -39660,6 +40660,11 @@ packages:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
     dependencies:
       through: 2.3.8
+
+  /sponge-case/1.0.1:
+    resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
+    dependencies:
+      tslib: 2.6.1
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -40329,6 +41334,20 @@ packages:
       util.promisify: 1.0.1
     dev: true
 
+  /swap-case/2.0.2:
+    resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
+    dependencies:
+      tslib: 2.6.1
+
+  /symbol-observable/1.2.0:
+    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
+    engines: {node: '>=0.10.0'}
+
+  /symbol-observable/4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
@@ -40342,6 +41361,15 @@ packages:
       has-symbols: 1.0.3
       object.getownpropertydescriptors: 2.1.6
     dev: true
+
+  /sync-fetch/0.3.0:
+    resolution: {integrity: sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==}
+    engines: {node: '>=8'}
+    dependencies:
+      buffer: 5.7.1
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
 
   /synchronous-promise/2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
@@ -40750,6 +41778,11 @@ packages:
       - supports-color
       - utf-8-validate
 
+  /title-case/3.0.3:
+    resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
+    dependencies:
+      tslib: 2.6.1
+
   /titleize/3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -40926,6 +41959,13 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
+
+  /ts-invariant/0.8.2:
+    resolution: {integrity: sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
 
   /ts-jest/29.1.1_dph2mes4elc76oozpus7ywlloi:
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -41651,6 +42691,16 @@ packages:
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
+
+  /upper-case-first/2.0.2:
+    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
+    dependencies:
+      tslib: 2.6.1
+
+  /upper-case/2.0.2:
+    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
+    dependencies:
+      tslib: 2.6.1
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13745,21 +13745,6 @@ packages:
     resolution: {integrity: sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==}
     dev: false
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_vmzpgoyysqpn2i7zjvyqsntvhy:
-    resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      cosmiconfig: '>=6'
-    dependencies:
-      cosmiconfig: 7.0.0
-      lodash.get: 4.4.2
-      make-error: 1.3.6
-      ts-node: 9.1.1_typescript@4.5.5
-      tslib: 2.6.1
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
   /@es-joy/jsdoccomment/0.33.4:
     resolution: {integrity: sha512-02XyYuvR/Gn+3BT6idHVNQ4SSQlA1X1FeEfeKm2ypv8ANB6Lt9KRFZ2S7y5xjwR+EPQ/Rzb0XFaD+xKyqe4ALw==}
     engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
@@ -17572,565 +17557,6 @@ packages:
   /@gar/promisify/1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
-
-  /@graphql-codegen/cli/1.20.1_zb5anfqjd4osidq6scqzr4gy3i:
-    resolution: {integrity: sha512-jT5aMxIniER/gg0/sfx+BPmvI2ZAncQ6ZT/xkiFvXcYMiL9tDiAcVYJTmXcRdMTEIZnlzw3rhE4VPYiw1KqruQ==}
-    hasBin: true
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-codegen/core': 1.17.9_graphql@15.8.0
-      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
-      '@graphql-tools/apollo-engine-loader': 6.2.5_graphql@15.8.0
-      '@graphql-tools/code-file-loader': 6.3.1_graphql@15.8.0
-      '@graphql-tools/git-loader': 6.2.6_graphql@15.8.0
-      '@graphql-tools/github-loader': 6.2.5_graphql@15.8.0
-      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
-      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
-      '@graphql-tools/load': 6.2.8_graphql@15.8.0
-      '@graphql-tools/prisma-loader': 6.3.0_graphql@15.8.0
-      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      ansi-escapes: 4.3.2
-      camel-case: 4.1.2
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      common-tags: 1.8.2
-      constant-case: 3.0.4
-      cosmiconfig: 7.1.0
-      debounce: 1.2.1
-      dependency-graph: 0.10.0
-      detect-indent: 6.1.0
-      glob: 7.2.3
-      graphql: 15.8.0
-      graphql-config: 3.4.1_zb5anfqjd4osidq6scqzr4gy3i
-      indent-string: 4.0.0
-      inquirer: 7.3.3
-      is-glob: 4.0.3
-      json-to-pretty-yaml: 1.2.2
-      latest-version: 5.1.0
-      listr: 0.14.3
-      listr-update-renderer: 0.5.0_listr@0.14.3
-      log-symbols: 4.1.0
-      lower-case: 2.0.2
-      minimatch: 3.1.2
-      mkdirp: 1.0.4
-      pascal-case: 3.1.2
-      string-env-interpolation: 1.0.1
-      ts-log: 2.2.5
-      tslib: 2.1.0
-      upper-case: 2.0.2
-      valid-url: 1.0.9
-      wrap-ansi: 7.0.0
-      yaml: 1.10.2
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zen-observable
-      - zenObservable
-    dev: true
-
-  /@graphql-codegen/core/1.17.9_graphql@15.8.0:
-    resolution: {integrity: sha512-7nwy+bMWqb0iYJ2DKxA9UiE16meeJ2Ch2XWS/N/ZnA0snTR+GZ20USI8z6YqP1Fuist7LvGO1MbitO2qBT8raA==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
-      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
-      '@graphql-tools/utils': 6.2.4_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.0.3
-    dev: true
-
-  /@graphql-codegen/plugin-helpers/1.18.8_graphql@15.8.0:
-    resolution: {integrity: sha512-mb4I9j9lMGqvGggYuZ0CV+Hme08nar68xkpPbAVotg/ZBmlhZIok/HqW2BcMQi7Rj+Il5HQMeQ1wQ1M7sv/TlQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      common-tags: 1.8.0
-      graphql: 15.8.0
-      import-from: 4.0.0
-      lodash: 4.17.21
-      tslib: 2.3.1
-
-  /@graphql-codegen/typescript/1.20.2_graphql@15.8.0:
-    resolution: {integrity: sha512-D/DMUz4O2UEoFucUVu2K2xoaMPAn68BwYGnCAKnSDqtFKsOEqmTjHFwcgyEnpucQ5xFeG0pKGMb1SlS2Go9J8Q==}
-    peerDependencies:
-      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
-      '@graphql-codegen/visitor-plugin-common': 1.22.0_graphql@15.8.0
-      auto-bind: 4.0.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
-  /@graphql-codegen/visitor-plugin-common/1.22.0_graphql@15.8.0:
-    resolution: {integrity: sha512-2afJGb6d8iuZl9KizYsexPwraEKO1lAvt5eVHNM5Xew4vwz/AUHeqDR2uOeQgVV+27EzjjzSDd47IEdH0dLC2w==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
-      '@graphql-tools/optimize': 1.4.0_graphql@15.8.0
-      '@graphql-tools/relay-operation-optimizer': 6.5.18_graphql@15.8.0
-      array.prototype.flatmap: 1.3.1
-      auto-bind: 4.0.0
-      change-case-all: 1.0.14
-      dependency-graph: 0.11.0
-      graphql: 15.8.0
-      graphql-tag: 2.12.6_graphql@15.8.0
-      parse-filepath: 1.0.2
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  /@graphql-tools/apollo-engine-loader/6.2.5_graphql@15.8.0:
-    resolution: {integrity: sha512-CE4uef6PyxtSG+7OnLklIr2BZZDgjO89ZXK47EKdY7jQy/BQD/9o+8SxPsgiBc+2NsDJH2I6P/nqoaJMOEat6g==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      cross-fetch: 3.0.6
-      graphql: 15.8.0
-      tslib: 2.0.3
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
-  /@graphql-tools/batch-delegate/7.0.2_graphql@15.8.0:
-    resolution: {integrity: sha512-Dn1LKcbZfgttfxW1V7E3JYrLGCWOhtPC+HkxBRrvzxkesxqDbgaOH8X4rsx3Po8AQD49J0eLdg9KXa0yF20VCA==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
-      dataloader: 2.0.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-    dev: false
-
-  /@graphql-tools/batch-execute/7.1.2_graphql@15.8.0:
-    resolution: {integrity: sha512-IuR2SB2MnC2ztA/XeTMTfWcA0Wy7ZH5u+nDkDNLAdX+AaSyDnsQS35sCmHqG0VOGTl7rzoyBWLCKGwSJplgtwg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      dataloader: 2.0.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-      value-or-promise: 1.0.6
-
-  /@graphql-tools/code-file-loader/6.3.1_graphql@15.8.0:
-    resolution: {integrity: sha512-ZJimcm2ig+avgsEOWWVvAaxZrXXhiiSZyYYOJi0hk9wh5BxZcLUNKkTp6EFnZE/jmGUwuos3pIjUD3Hwi3Bwhg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@graphql-tools/delegate/7.1.5_graphql@15.8.0:
-    resolution: {integrity: sha512-bQu+hDd37e+FZ0CQGEEczmRSfQRnnXeUxI/0miDV+NV/zCbEdIJj5tYFNrKT03W6wgdqx8U06d8L23LxvGri/g==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@ardatan/aggregate-error': 0.0.6
-      '@graphql-tools/batch-execute': 7.1.2_graphql@15.8.0
-      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      dataloader: 2.0.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-      value-or-promise: 1.0.6
-
-  /@graphql-tools/git-loader/6.2.6_graphql@15.8.0:
-    resolution: {integrity: sha512-ooQTt2CaG47vEYPP3CPD+nbA0F+FYQXfzrB1Y1ABN9K3d3O2RK3g8qwslzZaI8VJQthvKwt0A95ZeE4XxteYfw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@graphql-tools/github-loader/6.2.5_graphql@15.8.0:
-    resolution: {integrity: sha512-DLuQmYeNNdPo8oWus8EePxWCfCAyUXPZ/p1PWqjrX/NGPyH2ZObdqtDAfRHztljt0F/qkBHbGHCEk2TKbRZTRw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      cross-fetch: 3.0.6
-      graphql: 15.8.0
-      tslib: 2.0.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  /@graphql-tools/graphql-file-loader/6.2.7_graphql@15.8.0:
-    resolution: {integrity: sha512-5k2SNz0W87tDcymhEMZMkd6/vs6QawDyjQXWtqkuLTBF3vxjxPD1I4dwHoxgWPIjjANhXybvulD7E+St/7s9TQ==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/import': 6.7.18_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-
-  /@graphql-tools/graphql-tag-pluck/6.5.1_graphql@15.8.0:
-    resolution: {integrity: sha512-7qkm82iFmcpb8M6/yRgzjShtW6Qu2OlCSZp8uatA3J0eMl87TxyJoUmL3M3UMMOSundAK8GmoyNVFUrueueV5Q==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@babel/parser': 7.12.16
-      '@babel/traverse': 7.12.13
-      '@babel/types': 7.12.13
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@graphql-tools/import/6.7.18_graphql@15.8.0:
-    resolution: {integrity: sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
-      graphql: 15.8.0
-      resolve-from: 5.0.0
-      tslib: 2.6.1
-
-  /@graphql-tools/json-file-loader/6.2.6_graphql@15.8.0:
-    resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.0.3
-
-  /@graphql-tools/links/7.1.0_gijvqbksvnpa37pw7emzt4tx2u:
-    resolution: {integrity: sha512-8cJLs3ko0Zq0agJiFiHuAZ27OXbfgRF5JtVtIx8q2RfjVN0sss9QeetrTBjc2XfTj5HYZr6BHqqlyMMA4OXp7A==}
-    peerDependencies:
-      '@apollo/client': ~3.2.5 || ~3.3.0
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@apollo/client': 3.3.21_graphql@15.8.0
-      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      apollo-upload-client: 14.1.3_graphql@15.8.0
-      cross-fetch: 3.1.2
-      form-data: 4.0.0
-      graphql: 15.8.0
-      is-promise: 4.0.0
-      tslib: 2.1.0
-    transitivePeerDependencies:
-      - encoding
-      - react
-      - subscriptions-transport-ws
-    dev: false
-
-  /@graphql-tools/load-files/6.6.1_graphql@15.8.0:
-    resolution: {integrity: sha512-nd4GOjdD68bdJkHfRepILb0gGwF63mJI7uD4oJuuf2Kzeq8LorKa6WfyxUhdMuLmZhnx10zdAlWPfwv1NOAL4Q==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      globby: 11.1.0
-      graphql: 15.8.0
-      tslib: 2.6.1
-      unixify: 1.0.0
-    dev: false
-
-  /@graphql-tools/load/6.2.8_graphql@15.8.0:
-    resolution: {integrity: sha512-JpbyXOXd8fJXdBh2ta0Q4w8ia6uK5FHzrTNmcvYBvflFuWly2LDTk2abbSl81zKkzswQMEd2UIYghXELRg8eTA==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      globby: 11.0.3
-      graphql: 15.8.0
-      import-from: 3.0.0
-      is-glob: 4.0.1
-      p-limit: 3.1.0
-      tslib: 2.2.0
-      unixify: 1.0.0
-      valid-url: 1.0.9
-
-  /@graphql-tools/merge/6.2.14_graphql@15.8.0:
-    resolution: {integrity: sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-    dev: true
-
-  /@graphql-tools/merge/6.2.17_graphql@15.8.0:
-    resolution: {integrity: sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/schema': 8.5.1_graphql@15.8.0
-      '@graphql-tools/utils': 8.0.2_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.3.1
-
-  /@graphql-tools/merge/8.3.1_graphql@15.8.0:
-    resolution: {integrity: sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/utils': 8.9.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.6.1
-
-  /@graphql-tools/mock/7.0.0_graphql@15.8.0:
-    resolution: {integrity: sha512-ShO8D9HudgnhqoWeKb3iejGtPV8elFqSO1U0O70g3FH3W/CBW2abXfuyodBUevXVGIjyqzfkNzVtpIE0qiOVVQ==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.0.3
-    dev: false
-
-  /@graphql-tools/module-loader/6.2.7_graphql@15.8.0:
-    resolution: {integrity: sha512-ItAAbHvwfznY9h1H9FwHYDstTcm22Dr5R9GZtrWlpwqj0jaJGcBxsMB9jnK9kFqkbtFYEe4E/NsSnxsS4/vViQ==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.1.0
-    dev: false
-
-  /@graphql-tools/optimize/1.0.1_graphql@15.8.0:
-    resolution: {integrity: sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      graphql: 15.8.0
-      tslib: 2.0.3
-    dev: false
-
-  /@graphql-tools/optimize/1.4.0_graphql@15.8.0:
-    resolution: {integrity: sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 15.8.0
-      tslib: 2.6.1
-
-  /@graphql-tools/prisma-loader/6.3.0_graphql@15.8.0:
-    resolution: {integrity: sha512-9V3W/kzsFBmUQqOsd96V4a4k7Didz66yh/IK89B1/rrvy9rYj+ULjEqR73x9BYZ+ww9FV8yP8LasWAJwWaqqJQ==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      '@types/http-proxy-agent': 2.0.2
-      '@types/js-yaml': 4.0.5
-      '@types/json-stable-stringify': 1.0.34
-      '@types/jsonwebtoken': 8.5.9
-      chalk: 4.1.2
-      debug: 4.3.4
-      dotenv: 8.6.0
-      graphql: 15.8.0
-      graphql-request: 3.7.0_graphql@15.8.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      isomorphic-fetch: 3.0.0
-      js-yaml: 4.1.0
-      json-stable-stringify: 1.0.2
-      jsonwebtoken: 8.5.1
-      lodash: 4.17.21
-      replaceall: 0.1.6
-      scuid: 1.1.0
-      tslib: 2.1.0
-      yaml-ast-parser: 0.0.43
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@graphql-tools/relay-operation-optimizer/6.5.18_graphql@15.8.0:
-    resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/relay-compiler': 12.0.0_graphql@15.8.0
-      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.6.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  /@graphql-tools/resolvers-composition/6.5.18_graphql@15.8.0:
-    resolution: {integrity: sha512-RhKDkq58wVCmL8roC/XndCKurKG65/8VoXBiJ3rgehuIXbuZusMwk7sUfO2b7OoaDmK3ARmpBO0NAkeo6Aaj0A==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
-      graphql: 15.8.0
-      lodash: 4.17.21
-      micromatch: 4.0.5
-      tslib: 2.6.1
-    dev: false
-
-  /@graphql-tools/schema/7.1.5_graphql@15.8.0:
-    resolution: {integrity: sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-      value-or-promise: 1.0.6
-
-  /@graphql-tools/schema/8.5.1_graphql@15.8.0:
-    resolution: {integrity: sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/merge': 8.3.1_graphql@15.8.0
-      '@graphql-tools/utils': 8.9.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.6.1
-      value-or-promise: 1.0.11
-
-  /@graphql-tools/stitch/7.5.3_graphql@15.8.0:
-    resolution: {integrity: sha512-0oBdNFkviWRs0OkQiGow6THjRtDbiSOljCxCtkwF+C+bB/yLEPCNatTMo3ZR51twWBRPFgMwHZbSVbhRlK51kw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/batch-delegate': 7.0.2_graphql@15.8.0
-      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
-      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
-      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-    dev: false
-
-  /@graphql-tools/url-loader/6.10.1_graphql@15.8.0:
-    resolution: {integrity: sha512-DSDrbhQIv7fheQ60pfDpGD256ixUQIR6Hhf9Z5bRjVkXOCvO5XrkwoWLiU7iHL81GB1r0Ba31bf+sl+D4nyyfw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
-      '@microsoft/fetch-event-source': 2.0.1
-      '@types/websocket': 1.0.2
-      abort-controller: 3.0.0
-      cross-fetch: 3.1.4
-      extract-files: 9.0.0
-      form-data: 4.0.0
-      graphql: 15.8.0
-      graphql-ws: 4.9.0_graphql@15.8.0
-      is-promise: 4.0.0
-      isomorphic-ws: 4.0.1_ws@7.4.5
-      lodash: 4.17.21
-      meros: 1.1.4
-      subscriptions-transport-ws: 0.9.19_graphql@15.8.0
-      sync-fetch: 0.3.0
-      tslib: 2.2.0
-      valid-url: 1.0.9
-      ws: 7.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-
-  /@graphql-tools/utils/6.2.4_graphql@15.8.0:
-    resolution: {integrity: sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@ardatan/aggregate-error': 0.0.6
-      camel-case: 4.1.1
-      graphql: 15.8.0
-      tslib: 2.0.3
-    dev: true
-
-  /@graphql-tools/utils/7.10.0_graphql@15.8.0:
-    resolution: {integrity: sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@ardatan/aggregate-error': 0.0.6
-      camel-case: 4.1.2
-      graphql: 15.8.0
-      tslib: 2.2.0
-
-  /@graphql-tools/utils/8.0.2_graphql@15.8.0:
-    resolution: {integrity: sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      graphql: 15.8.0
-      tslib: 2.3.1
-
-  /@graphql-tools/utils/8.9.0_graphql@15.8.0:
-    resolution: {integrity: sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 15.8.0
-      tslib: 2.6.1
-
-  /@graphql-tools/utils/9.2.1_graphql@15.8.0:
-    resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.6.1
-
-  /@graphql-tools/wrap/7.0.8_graphql@15.8.0:
-    resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
-      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-      value-or-promise: 1.0.6
-
-  /@graphql-typed-document-node/core/3.2.0_graphql@15.8.0:
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 15.8.0
 
   /@griffel/core/1.11.0:
     resolution: {integrity: sha512-3jlrsJVbNC0avRMfNGWmbklptmtH5s63Gt/xa0zY6+Oa3kU/StNAu+d0LqLChb5egwXrisQIeC+tzzJ+YozGjg==}
@@ -23266,34 +22692,6 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@wry/context/0.6.1:
-    resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
-
-  /@wry/context/0.7.3:
-    resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
-
-  /@wry/equality/0.5.6:
-    resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
-
-  /@wry/trie/0.3.2:
-    resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
-
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -25330,13 +24728,6 @@ packages:
     resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
     dev: true
 
-  /capital-case/1.0.4:
-    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.1
-      upper-case-first: 2.0.2
-
   /capture-exit/2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -25446,36 +24837,6 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
-
-  /change-case-all/1.0.14:
-    resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
-    dependencies:
-      change-case: 4.1.2
-      is-lower-case: 2.0.2
-      is-upper-case: 2.0.2
-      lower-case: 2.0.2
-      lower-case-first: 2.0.2
-      sponge-case: 1.0.1
-      swap-case: 2.0.2
-      title-case: 3.0.3
-      upper-case: 2.0.2
-      upper-case-first: 2.0.2
-
-  /change-case/4.1.2:
-    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
-    dependencies:
-      camel-case: 4.1.2
-      capital-case: 1.0.4
-      constant-case: 3.0.4
-      dot-case: 3.0.4
-      header-case: 2.0.4
-      no-case: 3.0.4
-      param-case: 3.0.4
-      pascal-case: 3.1.2
-      path-case: 3.0.4
-      sentence-case: 3.0.4
-      snake-case: 3.0.4
-      tslib: 2.6.1
 
   /changesets-format-with-issue-links/0.3.0_@changesets+cli@2.26.1:
     resolution: {integrity: sha512-+GmelydJ+bYPVQyapFIELe/bM2+98cBIG7gb9raBxzx5MiBY0cDZnj4ii7xkrgpQLx96PWH3O9VA7Mhag0gs3w==}
@@ -26240,13 +25601,6 @@ packages:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
 
-  /constant-case/3.0.4:
-    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.1
-      upper-case: 2.0.2
-
   /constants-browserify/1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
     dev: true
@@ -26531,28 +25885,6 @@ packages:
     hasBin: true
     dependencies:
       cross-spawn: 7.0.3
-
-  /cross-fetch/3.0.6:
-    resolution: {integrity: sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==}
-    dependencies:
-      node-fetch: 2.6.12
-    transitivePeerDependencies:
-      - encoding
-
-  /cross-fetch/3.1.2:
-    resolution: {integrity: sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==}
-    dependencies:
-      node-fetch: 2.6.12
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /cross-fetch/3.1.4:
-    resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
-    dependencies:
-      node-fetch: 2.6.12
-    transitivePeerDependencies:
-      - encoding
 
   /cross-fetch/3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
@@ -30641,110 +29973,6 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /graphql-config/3.4.1_zb5anfqjd4osidq6scqzr4gy3i:
-    resolution: {integrity: sha512-g9WyK4JZl1Ko++FSyE5Ir2g66njfxGzrDDhBOwnkoWf/t3TnnZG6BBkWP+pkqVJ5pqMJGPKHNrbew8jRxStjhw==}
-    engines: {node: '>= 10.0.0'}
-    peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-    dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_vmzpgoyysqpn2i7zjvyqsntvhy
-      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
-      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
-      '@graphql-tools/load': 6.2.8_graphql@15.8.0
-      '@graphql-tools/merge': 6.2.14_graphql@15.8.0
-      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      cosmiconfig: 7.0.0
-      cosmiconfig-toml-loader: 1.0.0
-      graphql: 15.8.0
-      minimatch: 3.0.4
-      string-env-interpolation: 1.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-    dev: true
-
-  /graphql-request/3.7.0_graphql@15.8.0:
-    resolution: {integrity: sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==}
-    peerDependencies:
-      graphql: 14 - 16
-    dependencies:
-      cross-fetch: 3.1.6
-      extract-files: 9.0.0
-      form-data: 3.0.1
-      graphql: 15.8.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
-  /graphql-tag/2.12.6_graphql@15.8.0:
-    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 15.8.0
-      tslib: 2.6.1
-
-  /graphql-tools/7.0.5_graphql@15.8.0:
-    resolution: {integrity: sha512-pJ/ZVfuPEZfGO2Jlk/4mZnqa6blSiUDejTAX+q/ndAbZNUH9Xxdq+6XZy4GDjC1MivC6OnAtLbICWZ6GAvuUhQ==}
-    deprecated: This package has been deprecated and now it only exports makeExecutableSchema.\nAnd it will no longer receive updates.\nWe recommend you to migrate to scoped packages such as @graphql-tools/schema, @graphql-tools/utils and etc.\nCheck out https://www.graphql-tools.com to learn what package you should use instead
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0
-    dependencies:
-      '@graphql-tools/batch-delegate': 7.0.2_graphql@15.8.0
-      '@graphql-tools/batch-execute': 7.1.2_graphql@15.8.0
-      '@graphql-tools/code-file-loader': 6.3.1_graphql@15.8.0
-      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
-      '@graphql-tools/git-loader': 6.2.6_graphql@15.8.0
-      '@graphql-tools/github-loader': 6.2.5_graphql@15.8.0
-      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
-      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
-      '@graphql-tools/import': 6.7.18_graphql@15.8.0
-      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
-      '@graphql-tools/links': 7.1.0_gijvqbksvnpa37pw7emzt4tx2u
-      '@graphql-tools/load': 6.2.8_graphql@15.8.0
-      '@graphql-tools/load-files': 6.6.1_graphql@15.8.0
-      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
-      '@graphql-tools/mock': 7.0.0_graphql@15.8.0
-      '@graphql-tools/module-loader': 6.2.7_graphql@15.8.0
-      '@graphql-tools/optimize': 1.0.1_graphql@15.8.0
-      '@graphql-tools/relay-operation-optimizer': 6.5.18_graphql@15.8.0
-      '@graphql-tools/resolvers-composition': 6.5.18_graphql@15.8.0
-      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
-      '@graphql-tools/stitch': 7.5.3_graphql@15.8.0
-      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
-      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
-      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.2.0
-    optionalDependencies:
-      '@apollo/client': 3.3.21_graphql@15.8.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - react
-      - subscriptions-transport-ws
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /graphql-ws/4.9.0_graphql@15.8.0:
-    resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: '>=0.11 <=15'
-    dependencies:
-      graphql: 15.8.0
-
-  /graphql/15.8.0:
-    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
-    engines: {node: '>= 10.x'}
-
   /gray-matter/4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -31000,12 +30228,6 @@ packages:
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
-
-  /header-case/2.0.4:
-    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
-    dependencies:
-      capital-case: 1.0.4
-      tslib: 2.6.1
 
   /highlight.js/9.18.5:
     resolution: {integrity: sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==}
@@ -32126,11 +31348,6 @@ packages:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     dev: true
 
-  /is-lower-case/2.0.2:
-    resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
-    dependencies:
-      tslib: 2.6.1
-
   /is-map/2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: true
@@ -32337,11 +31554,6 @@ packages:
   /is-unicode-supported/0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  /is-upper-case/2.0.2:
-    resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
-    dependencies:
-      tslib: 2.6.1
 
   /is-utf8/0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
@@ -34628,11 +33840,6 @@ packages:
     dependencies:
       get-func-name: 2.0.0
 
-  /lower-case-first/2.0.2:
-    resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
-    dependencies:
-      tslib: 2.6.1
-
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -35991,6 +35198,7 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
 
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
@@ -37309,12 +36517,6 @@ packages:
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
-
-  /path-case/3.0.4:
-    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.1
 
   /path-dirname/1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -39983,13 +39185,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /sentence-case/3.0.4:
-    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.1
-      upper-case-first: 2.0.2
-
   /serialize-error/8.1.0:
     resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
     engines: {node: '>=10'}
@@ -40311,12 +39506,6 @@ packages:
       wcwidth: 1.0.1
       yargs: 15.4.1
     dev: true
-
-  /snake-case/3.0.4:
-    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.1
 
   /snapdragon-node/2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -40660,11 +39849,6 @@ packages:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
     dependencies:
       through: 2.3.8
-
-  /sponge-case/1.0.1:
-    resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
-    dependencies:
-      tslib: 2.6.1
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -41334,20 +40518,6 @@ packages:
       util.promisify: 1.0.1
     dev: true
 
-  /swap-case/2.0.2:
-    resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
-    dependencies:
-      tslib: 2.6.1
-
-  /symbol-observable/1.2.0:
-    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
-    engines: {node: '>=0.10.0'}
-
-  /symbol-observable/4.0.0:
-    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
-    engines: {node: '>=0.10'}
-    dev: false
-
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
@@ -41361,15 +40531,6 @@ packages:
       has-symbols: 1.0.3
       object.getownpropertydescriptors: 2.1.6
     dev: true
-
-  /sync-fetch/0.3.0:
-    resolution: {integrity: sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==}
-    engines: {node: '>=8'}
-    dependencies:
-      buffer: 5.7.1
-      node-fetch: 2.6.12
-    transitivePeerDependencies:
-      - encoding
 
   /synchronous-promise/2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
@@ -41778,11 +40939,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /title-case/3.0.3:
-    resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
-    dependencies:
-      tslib: 2.6.1
-
   /titleize/3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -41959,13 +41115,6 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
-
-  /ts-invariant/0.8.2:
-    resolution: {integrity: sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
 
   /ts-jest/29.1.1_dph2mes4elc76oozpus7ywlloi:
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -42691,16 +41840,6 @@ packages:
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
-
-  /upper-case-first/2.0.2:
-    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
-    dependencies:
-      tslib: 2.6.1
-
-  /upper-case/2.0.2:
-    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
-    dependencies:
-      tslib: 2.6.1
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13745,6 +13745,21 @@ packages:
     resolution: {integrity: sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==}
     dev: false
 
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_vmzpgoyysqpn2i7zjvyqsntvhy:
+    resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      cosmiconfig: '>=6'
+    dependencies:
+      cosmiconfig: 7.0.0
+      lodash.get: 4.4.2
+      make-error: 1.3.6
+      ts-node: 9.1.1_typescript@4.5.5
+      tslib: 2.6.1
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
   /@es-joy/jsdoccomment/0.33.4:
     resolution: {integrity: sha512-02XyYuvR/Gn+3BT6idHVNQ4SSQlA1X1FeEfeKm2ypv8ANB6Lt9KRFZ2S7y5xjwR+EPQ/Rzb0XFaD+xKyqe4ALw==}
     engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
@@ -17557,6 +17572,565 @@ packages:
   /@gar/promisify/1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
+
+  /@graphql-codegen/cli/1.20.1_zb5anfqjd4osidq6scqzr4gy3i:
+    resolution: {integrity: sha512-jT5aMxIniER/gg0/sfx+BPmvI2ZAncQ6ZT/xkiFvXcYMiL9tDiAcVYJTmXcRdMTEIZnlzw3rhE4VPYiw1KqruQ==}
+    hasBin: true
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/core': 1.17.9_graphql@15.8.0
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-tools/apollo-engine-loader': 6.2.5_graphql@15.8.0
+      '@graphql-tools/code-file-loader': 6.3.1_graphql@15.8.0
+      '@graphql-tools/git-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/github-loader': 6.2.5_graphql@15.8.0
+      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/load': 6.2.8_graphql@15.8.0
+      '@graphql-tools/prisma-loader': 6.3.0_graphql@15.8.0
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      ansi-escapes: 4.3.2
+      camel-case: 4.1.2
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      common-tags: 1.8.2
+      constant-case: 3.0.4
+      cosmiconfig: 7.1.0
+      debounce: 1.2.1
+      dependency-graph: 0.10.0
+      detect-indent: 6.1.0
+      glob: 7.2.3
+      graphql: 15.8.0
+      graphql-config: 3.4.1_zb5anfqjd4osidq6scqzr4gy3i
+      indent-string: 4.0.0
+      inquirer: 7.3.3
+      is-glob: 4.0.3
+      json-to-pretty-yaml: 1.2.2
+      latest-version: 5.1.0
+      listr: 0.14.3
+      listr-update-renderer: 0.5.0_listr@0.14.3
+      log-symbols: 4.1.0
+      lower-case: 2.0.2
+      minimatch: 3.1.2
+      mkdirp: 1.0.4
+      pascal-case: 3.1.2
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.5
+      tslib: 2.1.0
+      upper-case: 2.0.2
+      valid-url: 1.0.9
+      wrap-ansi: 7.0.0
+      yaml: 1.10.2
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zen-observable
+      - zenObservable
+    dev: true
+
+  /@graphql-codegen/core/1.17.9_graphql@15.8.0:
+    resolution: {integrity: sha512-7nwy+bMWqb0iYJ2DKxA9UiE16meeJ2Ch2XWS/N/ZnA0snTR+GZ20USI8z6YqP1Fuist7LvGO1MbitO2qBT8raA==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/utils': 6.2.4_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: true
+
+  /@graphql-codegen/plugin-helpers/1.18.8_graphql@15.8.0:
+    resolution: {integrity: sha512-mb4I9j9lMGqvGggYuZ0CV+Hme08nar68xkpPbAVotg/ZBmlhZIok/HqW2BcMQi7Rj+Il5HQMeQ1wQ1M7sv/TlQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      common-tags: 1.8.0
+      graphql: 15.8.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.3.1
+
+  /@graphql-codegen/typescript/1.20.2_graphql@15.8.0:
+    resolution: {integrity: sha512-D/DMUz4O2UEoFucUVu2K2xoaMPAn68BwYGnCAKnSDqtFKsOEqmTjHFwcgyEnpucQ5xFeG0pKGMb1SlS2Go9J8Q==}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-codegen/visitor-plugin-common': 1.22.0_graphql@15.8.0
+      auto-bind: 4.0.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-codegen/visitor-plugin-common/1.22.0_graphql@15.8.0:
+    resolution: {integrity: sha512-2afJGb6d8iuZl9KizYsexPwraEKO1lAvt5eVHNM5Xew4vwz/AUHeqDR2uOeQgVV+27EzjjzSDd47IEdH0dLC2w==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 1.18.8_graphql@15.8.0
+      '@graphql-tools/optimize': 1.4.0_graphql@15.8.0
+      '@graphql-tools/relay-operation-optimizer': 6.5.18_graphql@15.8.0
+      array.prototype.flatmap: 1.3.1
+      auto-bind: 4.0.0
+      change-case-all: 1.0.14
+      dependency-graph: 0.11.0
+      graphql: 15.8.0
+      graphql-tag: 2.12.6_graphql@15.8.0
+      parse-filepath: 1.0.2
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@graphql-tools/apollo-engine-loader/6.2.5_graphql@15.8.0:
+    resolution: {integrity: sha512-CE4uef6PyxtSG+7OnLklIr2BZZDgjO89ZXK47EKdY7jQy/BQD/9o+8SxPsgiBc+2NsDJH2I6P/nqoaJMOEat6g==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      cross-fetch: 3.0.6
+      graphql: 15.8.0
+      tslib: 2.0.3
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /@graphql-tools/batch-delegate/7.0.2_graphql@15.8.0:
+    resolution: {integrity: sha512-Dn1LKcbZfgttfxW1V7E3JYrLGCWOhtPC+HkxBRrvzxkesxqDbgaOH8X4rsx3Po8AQD49J0eLdg9KXa0yF20VCA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      dataloader: 2.0.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    dev: false
+
+  /@graphql-tools/batch-execute/7.1.2_graphql@15.8.0:
+    resolution: {integrity: sha512-IuR2SB2MnC2ztA/XeTMTfWcA0Wy7ZH5u+nDkDNLAdX+AaSyDnsQS35sCmHqG0VOGTl7rzoyBWLCKGwSJplgtwg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      dataloader: 2.0.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-tools/code-file-loader/6.3.1_graphql@15.8.0:
+    resolution: {integrity: sha512-ZJimcm2ig+avgsEOWWVvAaxZrXXhiiSZyYYOJi0hk9wh5BxZcLUNKkTp6EFnZE/jmGUwuos3pIjUD3Hwi3Bwhg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@graphql-tools/delegate/7.1.5_graphql@15.8.0:
+    resolution: {integrity: sha512-bQu+hDd37e+FZ0CQGEEczmRSfQRnnXeUxI/0miDV+NV/zCbEdIJj5tYFNrKT03W6wgdqx8U06d8L23LxvGri/g==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      '@graphql-tools/batch-execute': 7.1.2_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      dataloader: 2.0.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-tools/git-loader/6.2.6_graphql@15.8.0:
+    resolution: {integrity: sha512-ooQTt2CaG47vEYPP3CPD+nbA0F+FYQXfzrB1Y1ABN9K3d3O2RK3g8qwslzZaI8VJQthvKwt0A95ZeE4XxteYfw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@graphql-tools/github-loader/6.2.5_graphql@15.8.0:
+    resolution: {integrity: sha512-DLuQmYeNNdPo8oWus8EePxWCfCAyUXPZ/p1PWqjrX/NGPyH2ZObdqtDAfRHztljt0F/qkBHbGHCEk2TKbRZTRw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      cross-fetch: 3.0.6
+      graphql: 15.8.0
+      tslib: 2.0.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@graphql-tools/graphql-file-loader/6.2.7_graphql@15.8.0:
+    resolution: {integrity: sha512-5k2SNz0W87tDcymhEMZMkd6/vs6QawDyjQXWtqkuLTBF3vxjxPD1I4dwHoxgWPIjjANhXybvulD7E+St/7s9TQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/import': 6.7.18_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+
+  /@graphql-tools/graphql-tag-pluck/6.5.1_graphql@15.8.0:
+    resolution: {integrity: sha512-7qkm82iFmcpb8M6/yRgzjShtW6Qu2OlCSZp8uatA3J0eMl87TxyJoUmL3M3UMMOSundAK8GmoyNVFUrueueV5Q==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@babel/parser': 7.12.16
+      '@babel/traverse': 7.12.13
+      '@babel/types': 7.12.13
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@graphql-tools/import/6.7.18_graphql@15.8.0:
+    resolution: {integrity: sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
+      graphql: 15.8.0
+      resolve-from: 5.0.0
+      tslib: 2.6.1
+
+  /@graphql-tools/json-file-loader/6.2.6_graphql@15.8.0:
+    resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.0.3
+
+  /@graphql-tools/links/7.1.0_gijvqbksvnpa37pw7emzt4tx2u:
+    resolution: {integrity: sha512-8cJLs3ko0Zq0agJiFiHuAZ27OXbfgRF5JtVtIx8q2RfjVN0sss9QeetrTBjc2XfTj5HYZr6BHqqlyMMA4OXp7A==}
+    peerDependencies:
+      '@apollo/client': ~3.2.5 || ~3.3.0
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@apollo/client': 3.3.21_graphql@15.8.0
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      apollo-upload-client: 14.1.3_graphql@15.8.0
+      cross-fetch: 3.1.2
+      form-data: 4.0.0
+      graphql: 15.8.0
+      is-promise: 4.0.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - encoding
+      - react
+      - subscriptions-transport-ws
+    dev: false
+
+  /@graphql-tools/load-files/6.6.1_graphql@15.8.0:
+    resolution: {integrity: sha512-nd4GOjdD68bdJkHfRepILb0gGwF63mJI7uD4oJuuf2Kzeq8LorKa6WfyxUhdMuLmZhnx10zdAlWPfwv1NOAL4Q==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      globby: 11.1.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+      unixify: 1.0.0
+    dev: false
+
+  /@graphql-tools/load/6.2.8_graphql@15.8.0:
+    resolution: {integrity: sha512-JpbyXOXd8fJXdBh2ta0Q4w8ia6uK5FHzrTNmcvYBvflFuWly2LDTk2abbSl81zKkzswQMEd2UIYghXELRg8eTA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      globby: 11.0.3
+      graphql: 15.8.0
+      import-from: 3.0.0
+      is-glob: 4.0.1
+      p-limit: 3.1.0
+      tslib: 2.2.0
+      unixify: 1.0.0
+      valid-url: 1.0.9
+
+  /@graphql-tools/merge/6.2.14_graphql@15.8.0:
+    resolution: {integrity: sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+    dev: true
+
+  /@graphql-tools/merge/6.2.17_graphql@15.8.0:
+    resolution: {integrity: sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/schema': 8.5.1_graphql@15.8.0
+      '@graphql-tools/utils': 8.0.2_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.3.1
+
+  /@graphql-tools/merge/8.3.1_graphql@15.8.0:
+    resolution: {integrity: sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 8.9.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/mock/7.0.0_graphql@15.8.0:
+    resolution: {integrity: sha512-ShO8D9HudgnhqoWeKb3iejGtPV8elFqSO1U0O70g3FH3W/CBW2abXfuyodBUevXVGIjyqzfkNzVtpIE0qiOVVQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: false
+
+  /@graphql-tools/module-loader/6.2.7_graphql@15.8.0:
+    resolution: {integrity: sha512-ItAAbHvwfznY9h1H9FwHYDstTcm22Dr5R9GZtrWlpwqj0jaJGcBxsMB9jnK9kFqkbtFYEe4E/NsSnxsS4/vViQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.1.0
+    dev: false
+
+  /@graphql-tools/optimize/1.0.1_graphql@15.8.0:
+    resolution: {integrity: sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: false
+
+  /@graphql-tools/optimize/1.4.0_graphql@15.8.0:
+    resolution: {integrity: sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/prisma-loader/6.3.0_graphql@15.8.0:
+    resolution: {integrity: sha512-9V3W/kzsFBmUQqOsd96V4a4k7Didz66yh/IK89B1/rrvy9rYj+ULjEqR73x9BYZ+ww9FV8yP8LasWAJwWaqqJQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@types/http-proxy-agent': 2.0.2
+      '@types/js-yaml': 4.0.5
+      '@types/json-stable-stringify': 1.0.34
+      '@types/jsonwebtoken': 8.5.9
+      chalk: 4.1.2
+      debug: 4.3.4
+      dotenv: 8.6.0
+      graphql: 15.8.0
+      graphql-request: 3.7.0_graphql@15.8.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      isomorphic-fetch: 3.0.0
+      js-yaml: 4.1.0
+      json-stable-stringify: 1.0.2
+      jsonwebtoken: 8.5.1
+      lodash: 4.17.21
+      replaceall: 0.1.6
+      scuid: 1.1.0
+      tslib: 2.1.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@graphql-tools/relay-operation-optimizer/6.5.18_graphql@15.8.0:
+    resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/relay-compiler': 12.0.0_graphql@15.8.0
+      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@graphql-tools/resolvers-composition/6.5.18_graphql@15.8.0:
+    resolution: {integrity: sha512-RhKDkq58wVCmL8roC/XndCKurKG65/8VoXBiJ3rgehuIXbuZusMwk7sUfO2b7OoaDmK3ARmpBO0NAkeo6Aaj0A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1_graphql@15.8.0
+      graphql: 15.8.0
+      lodash: 4.17.21
+      micromatch: 4.0.5
+      tslib: 2.6.1
+    dev: false
+
+  /@graphql-tools/schema/7.1.5_graphql@15.8.0:
+    resolution: {integrity: sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-tools/schema/8.5.1_graphql@15.8.0:
+    resolution: {integrity: sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/merge': 8.3.1_graphql@15.8.0
+      '@graphql-tools/utils': 8.9.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+      value-or-promise: 1.0.11
+
+  /@graphql-tools/stitch/7.5.3_graphql@15.8.0:
+    resolution: {integrity: sha512-0oBdNFkviWRs0OkQiGow6THjRtDbiSOljCxCtkwF+C+bB/yLEPCNatTMo3ZR51twWBRPFgMwHZbSVbhRlK51kw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/batch-delegate': 7.0.2_graphql@15.8.0
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+    dev: false
+
+  /@graphql-tools/url-loader/6.10.1_graphql@15.8.0:
+    resolution: {integrity: sha512-DSDrbhQIv7fheQ60pfDpGD256ixUQIR6Hhf9Z5bRjVkXOCvO5XrkwoWLiU7iHL81GB1r0Ba31bf+sl+D4nyyfw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
+      '@microsoft/fetch-event-source': 2.0.1
+      '@types/websocket': 1.0.2
+      abort-controller: 3.0.0
+      cross-fetch: 3.1.4
+      extract-files: 9.0.0
+      form-data: 4.0.0
+      graphql: 15.8.0
+      graphql-ws: 4.9.0_graphql@15.8.0
+      is-promise: 4.0.0
+      isomorphic-ws: 4.0.1_ws@7.4.5
+      lodash: 4.17.21
+      meros: 1.1.4
+      subscriptions-transport-ws: 0.9.19_graphql@15.8.0
+      sync-fetch: 0.3.0
+      tslib: 2.2.0
+      valid-url: 1.0.9
+      ws: 7.4.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  /@graphql-tools/utils/6.2.4_graphql@15.8.0:
+    resolution: {integrity: sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      camel-case: 4.1.1
+      graphql: 15.8.0
+      tslib: 2.0.3
+    dev: true
+
+  /@graphql-tools/utils/7.10.0_graphql@15.8.0:
+    resolution: {integrity: sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      camel-case: 4.1.2
+      graphql: 15.8.0
+      tslib: 2.2.0
+
+  /@graphql-tools/utils/8.0.2_graphql@15.8.0:
+    resolution: {integrity: sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.3.1
+
+  /@graphql-tools/utils/8.9.0_graphql@15.8.0:
+    resolution: {integrity: sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/utils/9.2.1_graphql@15.8.0:
+    resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /@graphql-tools/wrap/7.0.8_graphql@15.8.0:
+    resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+      value-or-promise: 1.0.6
+
+  /@graphql-typed-document-node/core/3.2.0_graphql@15.8.0:
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
 
   /@griffel/core/1.11.0:
     resolution: {integrity: sha512-3jlrsJVbNC0avRMfNGWmbklptmtH5s63Gt/xa0zY6+Oa3kU/StNAu+d0LqLChb5egwXrisQIeC+tzzJ+YozGjg==}
@@ -22692,6 +23266,34 @@ packages:
       react: 17.0.2
     dev: true
 
+  /@wry/context/0.6.1:
+    resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /@wry/context/0.7.3:
+    resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /@wry/equality/0.5.6:
+    resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
+  /@wry/trie/0.3.2:
+    resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
+
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -24728,6 +25330,13 @@ packages:
     resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
     dev: true
 
+  /capital-case/1.0.4:
+    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+      upper-case-first: 2.0.2
+
   /capture-exit/2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -24837,6 +25446,36 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
+
+  /change-case-all/1.0.14:
+    resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
+    dependencies:
+      change-case: 4.1.2
+      is-lower-case: 2.0.2
+      is-upper-case: 2.0.2
+      lower-case: 2.0.2
+      lower-case-first: 2.0.2
+      sponge-case: 1.0.1
+      swap-case: 2.0.2
+      title-case: 3.0.3
+      upper-case: 2.0.2
+      upper-case-first: 2.0.2
+
+  /change-case/4.1.2:
+    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+      tslib: 2.6.1
 
   /changesets-format-with-issue-links/0.3.0_@changesets+cli@2.26.1:
     resolution: {integrity: sha512-+GmelydJ+bYPVQyapFIELe/bM2+98cBIG7gb9raBxzx5MiBY0cDZnj4ii7xkrgpQLx96PWH3O9VA7Mhag0gs3w==}
@@ -25601,6 +26240,13 @@ packages:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
 
+  /constant-case/3.0.4:
+    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+      upper-case: 2.0.2
+
   /constants-browserify/1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
     dev: true
@@ -25885,6 +26531,28 @@ packages:
     hasBin: true
     dependencies:
       cross-spawn: 7.0.3
+
+  /cross-fetch/3.0.6:
+    resolution: {integrity: sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
+
+  /cross-fetch/3.1.2:
+    resolution: {integrity: sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /cross-fetch/3.1.4:
+    resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
 
   /cross-fetch/3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
@@ -29973,6 +30641,110 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
+  /graphql-config/3.4.1_zb5anfqjd4osidq6scqzr4gy3i:
+    resolution: {integrity: sha512-g9WyK4JZl1Ko++FSyE5Ir2g66njfxGzrDDhBOwnkoWf/t3TnnZG6BBkWP+pkqVJ5pqMJGPKHNrbew8jRxStjhw==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    dependencies:
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_vmzpgoyysqpn2i7zjvyqsntvhy
+      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/load': 6.2.8_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.14_graphql@15.8.0
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      cosmiconfig: 7.0.0
+      cosmiconfig-toml-loader: 1.0.0
+      graphql: 15.8.0
+      minimatch: 3.0.4
+      string-env-interpolation: 1.0.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /graphql-request/3.7.0_graphql@15.8.0:
+    resolution: {integrity: sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==}
+    peerDependencies:
+      graphql: 14 - 16
+    dependencies:
+      cross-fetch: 3.1.6
+      extract-files: 9.0.0
+      form-data: 3.0.1
+      graphql: 15.8.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /graphql-tag/2.12.6_graphql@15.8.0:
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.1
+
+  /graphql-tools/7.0.5_graphql@15.8.0:
+    resolution: {integrity: sha512-pJ/ZVfuPEZfGO2Jlk/4mZnqa6blSiUDejTAX+q/ndAbZNUH9Xxdq+6XZy4GDjC1MivC6OnAtLbICWZ6GAvuUhQ==}
+    deprecated: This package has been deprecated and now it only exports makeExecutableSchema.\nAnd it will no longer receive updates.\nWe recommend you to migrate to scoped packages such as @graphql-tools/schema, @graphql-tools/utils and etc.\nCheck out https://www.graphql-tools.com to learn what package you should use instead
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    dependencies:
+      '@graphql-tools/batch-delegate': 7.0.2_graphql@15.8.0
+      '@graphql-tools/batch-execute': 7.1.2_graphql@15.8.0
+      '@graphql-tools/code-file-loader': 6.3.1_graphql@15.8.0
+      '@graphql-tools/delegate': 7.1.5_graphql@15.8.0
+      '@graphql-tools/git-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/github-loader': 6.2.5_graphql@15.8.0
+      '@graphql-tools/graphql-file-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/graphql-tag-pluck': 6.5.1_graphql@15.8.0
+      '@graphql-tools/import': 6.7.18_graphql@15.8.0
+      '@graphql-tools/json-file-loader': 6.2.6_graphql@15.8.0
+      '@graphql-tools/links': 7.1.0_gijvqbksvnpa37pw7emzt4tx2u
+      '@graphql-tools/load': 6.2.8_graphql@15.8.0
+      '@graphql-tools/load-files': 6.6.1_graphql@15.8.0
+      '@graphql-tools/merge': 6.2.17_graphql@15.8.0
+      '@graphql-tools/mock': 7.0.0_graphql@15.8.0
+      '@graphql-tools/module-loader': 6.2.7_graphql@15.8.0
+      '@graphql-tools/optimize': 1.0.1_graphql@15.8.0
+      '@graphql-tools/relay-operation-optimizer': 6.5.18_graphql@15.8.0
+      '@graphql-tools/resolvers-composition': 6.5.18_graphql@15.8.0
+      '@graphql-tools/schema': 7.1.5_graphql@15.8.0
+      '@graphql-tools/stitch': 7.5.3_graphql@15.8.0
+      '@graphql-tools/url-loader': 6.10.1_graphql@15.8.0
+      '@graphql-tools/utils': 7.10.0_graphql@15.8.0
+      '@graphql-tools/wrap': 7.0.8_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.2.0
+    optionalDependencies:
+      '@apollo/client': 3.3.21_graphql@15.8.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - react
+      - subscriptions-transport-ws
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /graphql-ws/4.9.0_graphql@15.8.0:
+    resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=15'
+    dependencies:
+      graphql: 15.8.0
+
+  /graphql/15.8.0:
+    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
+    engines: {node: '>= 10.x'}
+
   /gray-matter/4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -30228,6 +31000,12 @@ packages:
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  /header-case/2.0.4:
+    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.6.1
 
   /highlight.js/9.18.5:
     resolution: {integrity: sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==}
@@ -31348,6 +32126,11 @@ packages:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     dev: true
 
+  /is-lower-case/2.0.2:
+    resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
+    dependencies:
+      tslib: 2.6.1
+
   /is-map/2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: true
@@ -31554,6 +32337,11 @@ packages:
   /is-unicode-supported/0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  /is-upper-case/2.0.2:
+    resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
+    dependencies:
+      tslib: 2.6.1
 
   /is-utf8/0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
@@ -33840,6 +34628,11 @@ packages:
     dependencies:
       get-func-name: 2.0.0
 
+  /lower-case-first/2.0.2:
+    resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
+    dependencies:
+      tslib: 2.6.1
+
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -35198,7 +35991,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
@@ -36517,6 +37309,12 @@ packages:
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  /path-case/3.0.4:
+    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.1
 
   /path-dirname/1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -39185,6 +39983,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /sentence-case/3.0.4:
+    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+      upper-case-first: 2.0.2
+
   /serialize-error/8.1.0:
     resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
     engines: {node: '>=10'}
@@ -39506,6 +40311,12 @@ packages:
       wcwidth: 1.0.1
       yargs: 15.4.1
     dev: true
+
+  /snake-case/3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.1
 
   /snapdragon-node/2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -39849,6 +40660,11 @@ packages:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
     dependencies:
       through: 2.3.8
+
+  /sponge-case/1.0.1:
+    resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
+    dependencies:
+      tslib: 2.6.1
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -40518,6 +41334,20 @@ packages:
       util.promisify: 1.0.1
     dev: true
 
+  /swap-case/2.0.2:
+    resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
+    dependencies:
+      tslib: 2.6.1
+
+  /symbol-observable/1.2.0:
+    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
+    engines: {node: '>=0.10.0'}
+
+  /symbol-observable/4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
@@ -40531,6 +41361,15 @@ packages:
       has-symbols: 1.0.3
       object.getownpropertydescriptors: 2.1.6
     dev: true
+
+  /sync-fetch/0.3.0:
+    resolution: {integrity: sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==}
+    engines: {node: '>=8'}
+    dependencies:
+      buffer: 5.7.1
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
 
   /synchronous-promise/2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
@@ -40939,6 +41778,11 @@ packages:
       - supports-color
       - utf-8-validate
 
+  /title-case/3.0.3:
+    resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
+    dependencies:
+      tslib: 2.6.1
+
   /titleize/3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -41115,6 +41959,13 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
+
+  /ts-invariant/0.8.2:
+    resolution: {integrity: sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
 
   /ts-jest/29.1.1_dph2mes4elc76oozpus7ywlloi:
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -41840,6 +42691,16 @@ packages:
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
+
+  /upper-case-first/2.0.2:
+    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
+    dependencies:
+      tslib: 2.6.1
+
+  /upper-case/2.0.2:
+    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
+    dependencies:
+      tslib: 2.6.1
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}


### PR DESCRIPTION
## Description

Update type tests for 2.0.0-internal.6.1.0 client release.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
