### PR TITLE
Refactor summarize options in SummaryGenerator and remove extra refresh from server method

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -381,7 +381,7 @@
 			"env": {
 				// "fluid__test__driver": "odsp" //values: local, tinylicious, routerlicious, odsp,
 				// "fluid__test__backCompat": "FULL" //values: FULL This tests loader-driver compatibility for describeFullCompat tests
-				// "FLUID_TEST_VERBOSE": "1"
+				"FLUID_TEST_VERBOSE": "1",
 			},
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
 			"stopOnEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -381,7 +381,7 @@
 			"env": {
 				// "fluid__test__driver": "odsp" //values: local, tinylicious, routerlicious, odsp,
 				// "fluid__test__backCompat": "FULL" //values: FULL This tests loader-driver compatibility for describeFullCompat tests
-				// "FLUID_TEST_VERBOSE": "1",
+				// "FLUID_TEST_VERBOSE": "1"
 			},
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
 			"stopOnEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -381,7 +381,7 @@
 			"env": {
 				// "fluid__test__driver": "odsp" //values: local, tinylicious, routerlicious, odsp,
 				// "fluid__test__backCompat": "FULL" //values: FULL This tests loader-driver compatibility for describeFullCompat tests
-				"FLUID_TEST_VERBOSE": "1",
+				// "FLUID_TEST_VERBOSE": "1",
 			},
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
 			"stopOnEntry": false,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3608,7 +3608,7 @@ export class ContainerRuntime
 		// It should only be done by the summarizerNode, if required.
 		// When fetching from storage we will always get the latest version and do not use the ackHandle.
 		const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
-			let fetchResult = await this.fetchLatestSnapshotFromStorage(
+			let fetchResult = await this.fetchSnapshotFromStorageAndMaybeClose(
 				summaryLogger,
 				{
 					eventName: "RefreshLatestSummaryAckFetch",
@@ -3616,6 +3616,7 @@ export class ContainerRuntime
 					targetSequenceNumber: summaryRefSeq,
 				},
 				readAndParseBlob,
+				null,
 			);
 
 			/**
@@ -3625,7 +3626,7 @@ export class ContainerRuntime
 			 * change that started fetching latest snapshot always.
 			 */
 			if (fetchResult.latestSnapshotRefSeq < summaryRefSeq) {
-				fetchResult = await this.fetchSnapshotFromStorageAndClose(
+				fetchResult = await this.fetchSnapshotFromStorageAndMaybeClose(
 					summaryLogger,
 					{
 						eventName: "RefreshLatestSummaryAckFetchBackCompat",
@@ -3698,12 +3699,13 @@ export class ContainerRuntime
 	): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined }> {
 		const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
 		const { snapshotTree, versionId, latestSnapshotRefSeq } =
-			await this.fetchLatestSnapshotFromStorage(
+			await this.fetchSnapshotFromStorageAndMaybeClose(
 				summaryLogger,
 				{
 					eventName: "RefreshLatestSummaryFromServerFetch",
 				},
 				readAndParseBlob,
+				null,
 			);
 		const fetchLatestSnapshot: IFetchSnapshotResult = {
 			snapshotTree,
@@ -3727,20 +3729,12 @@ export class ContainerRuntime
 		return { latestSnapshotRefSeq, latestSnapshotVersionId: versionId };
 	}
 
-	private async fetchLatestSnapshotFromStorage(
-		logger: ITelemetryLoggerExt,
-		event: ITelemetryGenericEvent,
-		readAndParseBlob: ReadAndParseBlob,
-	): Promise<{ snapshotTree: ISnapshotTree; versionId: string; latestSnapshotRefSeq: number }> {
-		return this.fetchSnapshotFromStorageAndClose(
-			logger,
-			event,
-			readAndParseBlob,
-			null /* latest */,
-		);
-	}
-
-	private async fetchSnapshotFromStorageAndClose(
+	/**
+	 * Downloads snapshot from storage with the given versionId or latest if versionId is null.
+	 * By default, it also closes the container after downloading the snapshot. However, this may be
+	 * overridden via options.
+	 */
+	private async fetchSnapshotFromStorageAndMaybeClose(
 		logger: ITelemetryLoggerExt,
 		event: ITelemetryGenericEvent,
 		readAndParseBlob: ReadAndParseBlob,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -556,12 +556,16 @@ export class RunningSummarizer implements IDisposable {
 				this.beforeSummaryAction();
 			},
 			async () => {
-				const summarizeResult = this.generator.summarize(
-					summarizeProps,
-					options,
-					this.cancellationToken,
-					resultsBuilder,
-				);
+				const summaryLogger = createChildLogger({
+					logger: this.mc.logger,
+					properties: { all: summarizeProps },
+				});
+				const summaryOptions: ISubmitSummaryOptions = {
+					...options,
+					summaryLogger,
+					cancellationToken: this.cancellationToken,
+				};
+				const summarizeResult = this.generator.summarize(summaryOptions, resultsBuilder);
 				// ensure we wait till the end of the process
 				return summarizeResult.receivedSummaryAckOrNack;
 			},
@@ -636,14 +640,19 @@ export class RunningSummarizer implements IDisposable {
 				summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
 				...summarizeOptions,
 			};
+			const summaryLogger = createChildLogger({
+				logger: this.mc.logger,
+				properties: { all: summarizeProps },
+			});
+			const summaryOptions: ISubmitSummaryOptions = {
+				...summarizeOptions,
+				summaryLogger,
+				cancellationToken: this.cancellationToken,
+			};
 
 			// Note: no need to account for cancellationToken.waitCancelled here, as
 			// this is accounted SummaryGenerator.summarizeCore that controls receivedSummaryAckOrNack.
-			const resultSummarize = this.generator.summarize(
-				summarizeProps,
-				summarizeOptions,
-				this.cancellationToken,
-			);
+			const resultSummarize = this.generator.summarize(summaryOptions);
 			const ackNackResult = await resultSummarize.receivedSummaryAckOrNack;
 			if (ackNackResult.success) {
 				return;
@@ -706,11 +715,16 @@ export class RunningSummarizer implements IDisposable {
 				summaryAttempts: currentAttempt,
 				...summarizeOptions,
 			};
-			const summarizeResult = this.generator.summarize(
-				summarizeProps,
-				summarizeOptions,
-				this.cancellationToken,
-			);
+			const summaryLogger = createChildLogger({
+				logger: this.mc.logger,
+				properties: { all: summarizeProps },
+			});
+			const summaryOptions: ISubmitSummaryOptions = {
+				...summarizeOptions,
+				summaryLogger,
+				cancellationToken: this.cancellationToken,
+			};
+			const summarizeResult = this.generator.summarize(summaryOptions);
 
 			// Ack / nack is the final step, so if it succeeds we're done.
 			const ackNackResult = await summarizeResult.receivedSummaryAckOrNack;

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -7,7 +7,6 @@ import {
 	ITelemetryLoggerExt,
 	PerformanceEvent,
 	LoggingError,
-	createChildLogger,
 } from "@fluidframework/telemetry-utils";
 import { ITelemetryProperties } from "@fluidframework/core-interfaces";
 
@@ -24,7 +23,6 @@ import { DriverErrorType } from "@fluidframework/driver-definitions";
 import {
 	IAckSummaryResult,
 	INackSummaryResult,
-	ISummarizeOptions,
 	IBroadcastSummaryResult,
 	ISummarizeResults,
 	ISummarizeHeuristicData,
@@ -32,7 +30,6 @@ import {
 	SubmitSummaryResult,
 	SummarizeResultPart,
 	ISummaryCancellationToken,
-	ISummarizeTelemetryProperties,
 	SummaryGeneratorTelemetry,
 	SubmitSummaryFailureData,
 } from "./summarizerTypes";
@@ -223,32 +220,23 @@ export class SummaryGenerator {
 	 * fullTree to generate tree without any summary handles even if unchanged
 	 */
 	public summarize(
-		summarizeProps: ISummarizeTelemetryProperties,
-		options: ISummarizeOptions,
-		cancellationToken: ISummaryCancellationToken,
+		summaryOptions: ISubmitSummaryOptions,
 		resultsBuilder = new SummarizeResultBuilder(),
 	): ISummarizeResults {
-		this.summarizeCore(summarizeProps, options, resultsBuilder, cancellationToken).catch(
-			(error) => {
-				const message = "UnexpectedSummarizeError";
-				this.logger.sendErrorEvent({ eventName: message, ...summarizeProps }, error);
-				resultsBuilder.fail(message, error);
-			},
-		);
+		this.summarizeCore(summaryOptions, resultsBuilder).catch((error) => {
+			const message = "UnexpectedSummarizeError";
+			summaryOptions.summaryLogger.sendErrorEvent({ eventName: message }, error);
+			resultsBuilder.fail(message, error);
+		});
 
 		return resultsBuilder.build();
 	}
 
 	private async summarizeCore(
-		summarizeProps: ISummarizeTelemetryProperties,
-		summarizeOptions: ISummarizeOptions,
+		submitSummaryOptions: ISubmitSummaryOptions,
 		resultsBuilder: SummarizeResultBuilder,
-		cancellationToken: ISummaryCancellationToken,
 	): Promise<void> {
-		const logger = createChildLogger({
-			logger: this.logger,
-			properties: { all: summarizeProps },
-		});
+		const { summaryLogger, cancellationToken, ...summarizeOptions } = submitSummaryOptions;
 
 		// Note: timeSinceLastAttempt and timeSinceLastSummary for the
 		// first summary are basically the time since the summarizer was loaded.
@@ -263,7 +251,7 @@ export class SummaryGenerator {
 		};
 
 		const summarizeEvent = PerformanceEvent.start(
-			logger,
+			summaryLogger,
 			{
 				eventName: "Summarize",
 				...summarizeTelemetryProps,
@@ -315,11 +303,7 @@ export class SummaryGenerator {
 			// Need to save refSeqNum before we record new attempt (happens as part of submitSummaryCallback)
 			const lastAttemptRefSeqNum = this.heuristicData.lastAttempt.refSequenceNumber;
 
-			summaryData = await this.submitSummaryCallback({
-				...summarizeOptions,
-				summaryLogger: logger,
-				cancellationToken,
-			});
+			summaryData = await this.submitSummaryCallback(submitSummaryOptions);
 
 			// Cumulatively add telemetry properties based on how far generateSummary went.
 			const referenceSequenceNumber = summaryData.referenceSequenceNumber;
@@ -355,14 +339,14 @@ export class SummaryGenerator {
 			 * state change of multiple data stores. So, the total number of data stores that are summarized should not
 			 * exceed the number of ops since last summary + number of data store whose reference state changed.
 			 */
-			if (!summarizeOptions.fullTree && !summaryData.forcedFullTree) {
+			if (!submitSummaryOptions.fullTree && !summaryData.forcedFullTree) {
 				const { summarizedDataStoreCount, gcStateUpdatedDataStoreCount = 0 } =
 					summaryData.summaryStats;
 				if (
 					summarizedDataStoreCount >
 					gcStateUpdatedDataStoreCount + this.heuristicData.opsSinceLastSummary
 				) {
-					logger.sendErrorEvent({
+					summaryLogger.sendErrorEvent({
 						eventName: "IncrementalSummaryViolation",
 						summarizedDataStoreCount,
 						gcStateUpdatedDataStoreCount,
@@ -411,7 +395,7 @@ export class SummaryGenerator {
 			});
 
 			this.heuristicData.lastAttempt.summarySequenceNumber = summarizeOp.sequenceNumber;
-			logger.sendTelemetryEvent({
+			summaryLogger.sendTelemetryEvent({
 				eventName: "Summarize_Op",
 				duration: broadcastDuration,
 				referenceSequenceNumber: summarizeOp.referenceSequenceNumber,


### PR DESCRIPTION
## Description
This PR does a couple of small refactors without any change in functionality:
1. It moved the creation of correlated summary logger from `SummaryGenerator` to `RunningSummarizer`.  This helps reduce the parameters sent to `SummaryGenerator` and keeps more control in `RunningSummarizer`.
2. It removed `fetchLatestSnapshotFromStorage` method from container runtime which was just a pass through.

These changes will help clean up the summarizer code bit by bit and makes future changes easier by not needing to plumb every change though multiple layers.