### PR TITLE
[bump] common-definitions: 1.0.0 => 1.1.0 (minor)

### DIFF
--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/common-definitions",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Fluid common definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped common-definitions from 1.0.0 to 1.1.0 in preparation to release 1.0.0.
