### PR TITLE
[bump] eslint-config-fluid: 2.1.0 => 2.2.0 (minor)

### DIFF
--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped eslint-config-fluid from 2.1.0 to 2.2.0 in preparation to release 2.1.0.