### PR TITLE
fix(bump:deps): Add undefined check

### DIFF
--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -749,9 +749,9 @@ export async function npmCheckUpdatesHomegrown(
 	updatedPackages: PackageWithKind[];
 	updatedDependencies: PackageVersionMap;
 }> {
-	if (releaseGroup === releaseGroupFilter) {
+	if (releaseGroupFilter !== undefined && releaseGroup === releaseGroupFilter) {
 		throw new Error(
-			`releaseGroup and releaseGroupFilter are the same. They must be different values.`,
+			`releaseGroup and releaseGroupFilter are the same (${releaseGroup}). They must be different values.`,
 		);
 	}
 	log?.info(`Calculating dependency updates...`);


### PR DESCRIPTION
The npmCheckUpdatesHomegrown function accepts undefined for both the releaseGroup and filterReleaseGroup properties. Both being undefined is a supported combo, but the code was failing. I updated the check to allow the undefined case.