### PR TITLE
tree2: Add ISharedTreeBranchView

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1026,21 +1026,26 @@ export interface ISharedTree extends ISharedObject, ISharedTreeView {
 }
 
 // @alpha
+export interface ISharedTreeBranchView extends ISharedTreeView {
+    rebaseOnto(view: ISharedTreeView): void;
+}
+
+// @alpha
 export interface ISharedTreeView extends AnchorLocator {
     readonly context: EditableTreeContext;
     readonly editor: IDefaultEditBuilder;
     readonly events: ISubscribable<ViewEvents>;
     readonly forest: IForestSubscription;
-    fork(): SharedTreeView;
-    merge(view: SharedTreeView): void;
-    merge(view: SharedTreeView, disposeView: boolean): void;
+    fork(): ISharedTreeBranchView;
+    merge(view: ISharedTreeBranchView): void;
+    merge(view: ISharedTreeBranchView, disposeView: boolean): void;
     readonly nodeKey: {
         generate(): LocalNodeKey;
         stabilize(key: LocalNodeKey): StableNodeKey;
         localize(key: StableNodeKey): LocalNodeKey;
         map: ReadonlyMap<LocalNodeKey, EditableTree>;
     };
-    rebase(view: SharedTreeView): void;
+    rebase(view: ISharedTreeBranchView): void;
     redo(): void;
     get root(): UnwrappedEditableField;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
@@ -1063,6 +1068,14 @@ export function isPrimitiveValue(nodeValue: Value): nodeValue is PrimitiveValue;
 // @alpha
 export interface ISubscribable<E extends Events<E>> {
     on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
+}
+
+// @alpha
+export interface ITransaction {
+    abort(): TransactionResult.Abort;
+    commit(): TransactionResult.Commit;
+    inProgress(): boolean;
+    start(): void;
 }
 
 // @alpha
@@ -1337,7 +1350,7 @@ export type NameFromBranded<T extends BrandedType<any, string>> = T extends Bran
 export type NestedMap<Key1, Key2, Value> = Map<Key1, Map<Key2, Value>>;
 
 // @alpha
-export type NewFieldContent = ITreeCursor | readonly ITreeCursor[] | ContextuallyTypedFieldData;
+export type NewFieldContent = ITreeCursorSynchronous | readonly ITreeCursorSynchronous[] | ContextuallyTypedFieldData;
 
 // @alpha (undocumented)
 export type NodeChangeComposer = (changes: TaggedChange<NodeChangeset>[]) => NodeChangeset;
@@ -1685,7 +1698,7 @@ export interface SchemaLintConfiguration {
 // @alpha
 export interface SchematizeConfiguration<TRoot extends FieldSchema = FieldSchema> {
     readonly allowedSchemaModifications: AllowedUpdateType;
-    readonly initialTree: SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple> | readonly ITreeCursor[];
+    readonly initialTree: SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple> | readonly ITreeCursorSynchronous[];
     readonly schema: TypedSchemaCollection<TRoot>;
 }
 
@@ -1721,50 +1734,6 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha (undocumented)
 export interface SharedTreeOptions extends Partial<ICodecOptions> {
-}
-
-// @alpha
-export class SharedTreeView implements ISharedTreeBranchView {
-    constructor(transaction: ITransaction, branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>, changeFamily: DefaultChangeFamily, _storedSchema: InMemoryStoredSchemaRepository, _forest: IEditableForest, context: EditableTreeContext, _nodeKeyManager: NodeKeyManager, _nodeKeyIndex: NodeKeyIndex, _events: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>);
-    // (undocumented)
-    readonly context: EditableTreeContext;
-    dispose(): void;
-    // (undocumented)
-    get editor(): IDefaultEditBuilder;
-    // (undocumented)
-    get events(): ISubscribable<ViewEvents>;
-    // (undocumented)
-    get forest(): IForestSubscription;
-    // (undocumented)
-    fork(): SharedTreeView;
-    // (undocumented)
-    locate(anchor: Anchor): AnchorNode | undefined;
-    // (undocumented)
-    merge(view: SharedTreeView): void;
-    // (undocumented)
-    merge(view: SharedTreeView, disposeView: boolean): void;
-    // (undocumented)
-    readonly nodeKey: ISharedTreeView["nodeKey"];
-    // (undocumented)
-    rebase(view: SharedTreeView): void;
-    // (undocumented)
-    rebaseOnto(view: ISharedTreeView): void;
-    // (undocumented)
-    redo(): void;
-    // (undocumented)
-    get root(): UnwrappedEditableField;
-    // (undocumented)
-    get rootEvents(): ISubscribable<AnchorSetRootEvents>;
-    // (undocumented)
-    schematize<TRoot extends FieldSchema>(config: SchematizeConfiguration<TRoot>): ISharedTreeView;
-    // (undocumented)
-    setContent(data: NewFieldContent): void;
-    // (undocumented)
-    get storedSchema(): StoredSchemaRepository;
-    // (undocumented)
-    readonly transaction: ITransaction;
-    // (undocumented)
-    undo(): void;
 }
 
 // @alpha

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1026,33 +1026,33 @@ export interface ISharedTree extends ISharedObject, ISharedTreeView {
 }
 
 // @alpha
+export interface ISharedTreeBranchView extends ISharedTreeView {
+    rebaseOnto(view: ISharedTreeView): void;
+}
+
+// @alpha
 export interface ISharedTreeView extends AnchorLocator {
     readonly context: EditableTreeContext;
     readonly editor: IDefaultEditBuilder;
     readonly events: ISubscribable<ViewEvents>;
     readonly forest: IForestSubscription;
-    fork(): SharedTreeView;
-    merge(view: SharedTreeView): void;
-    merge(view: SharedTreeView, disposeView: boolean): void;
+    fork(): ISharedTreeBranchView;
+    merge(view: ISharedTreeBranchView): void;
+    merge(view: ISharedTreeBranchView, disposeView: boolean): void;
     readonly nodeKey: {
         generate(): LocalNodeKey;
         stabilize(key: LocalNodeKey): StableNodeKey;
         localize(key: StableNodeKey): LocalNodeKey;
         map: ReadonlyMap<LocalNodeKey, EditableTree>;
     };
-    rebase(view: SharedTreeView): void;
+    rebase(view: ISharedTreeBranchView): void;
     redo(): void;
     get root(): UnwrappedEditableField;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
     schematize<TRoot extends FieldSchema>(config: SchematizeConfiguration<TRoot>): ISharedTreeView;
     setContent(data: NewFieldContent): void;
     readonly storedSchema: StoredSchemaRepository;
-    readonly transaction: {
-        start(): void;
-        commit(): TransactionResult.Commit;
-        abort(): TransactionResult.Abort;
-        inProgress(): boolean;
-    };
+    readonly transaction: ITransaction;
     undo(): void;
 }
 
@@ -1068,6 +1068,14 @@ export function isPrimitiveValue(nodeValue: Value): nodeValue is PrimitiveValue;
 // @alpha
 export interface ISubscribable<E extends Events<E>> {
     on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
+}
+
+// @alpha
+export interface ITransaction {
+    abort(): TransactionResult.Abort;
+    commit(): TransactionResult.Commit;
+    inProgress(): boolean;
+    start(): void;
 }
 
 // @alpha
@@ -1342,7 +1350,7 @@ export type NameFromBranded<T extends BrandedType<any, string>> = T extends Bran
 export type NestedMap<Key1, Key2, Value> = Map<Key1, Map<Key2, Value>>;
 
 // @alpha
-export type NewFieldContent = ITreeCursor | readonly ITreeCursor[] | ContextuallyTypedFieldData;
+export type NewFieldContent = ITreeCursorSynchronous | readonly ITreeCursorSynchronous[] | ContextuallyTypedFieldData;
 
 // @alpha (undocumented)
 export type NodeChangeComposer = (changes: TaggedChange<NodeChangeset>[]) => NodeChangeset;
@@ -1690,7 +1698,7 @@ export interface SchemaLintConfiguration {
 // @alpha
 export interface SchematizeConfiguration<TRoot extends FieldSchema = FieldSchema> {
     readonly allowedSchemaModifications: AllowedUpdateType;
-    readonly initialTree: SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple> | readonly ITreeCursor[];
+    readonly initialTree: SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple> | readonly ITreeCursorSynchronous[];
     readonly schema: TypedSchemaCollection<TRoot>;
 }
 
@@ -1726,48 +1734,6 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha (undocumented)
 export interface SharedTreeOptions extends Partial<ICodecOptions> {
-}
-
-// @alpha
-export class SharedTreeView implements ISharedTreeView {
-    // (undocumented)
-    readonly context: EditableTreeContext;
-    dispose(): void;
-    // (undocumented)
-    get editor(): IDefaultEditBuilder;
-    // (undocumented)
-    get events(): ISubscribable<ViewEvents>;
-    // (undocumented)
-    get forest(): IForestSubscription;
-    // (undocumented)
-    fork(): SharedTreeView;
-    // (undocumented)
-    locate(anchor: Anchor): AnchorNode | undefined;
-    // (undocumented)
-    merge(view: SharedTreeView): void;
-    // (undocumented)
-    merge(view: SharedTreeView, disposeView: boolean): void;
-    // (undocumented)
-    readonly nodeKey: ISharedTreeView["nodeKey"];
-    // (undocumented)
-    rebase(view: SharedTreeView): void;
-    rebaseOnto(view: ISharedTreeView): void;
-    // (undocumented)
-    redo(): void;
-    // (undocumented)
-    get root(): UnwrappedEditableField;
-    // (undocumented)
-    get rootEvents(): ISubscribable<AnchorSetRootEvents>;
-    // (undocumented)
-    schematize<TRoot extends FieldSchema>(config: SchematizeConfiguration<TRoot>): ISharedTreeView;
-    // (undocumented)
-    setContent(data: NewFieldContent): void;
-    // (undocumented)
-    get storedSchema(): StoredSchemaRepository;
-    // (undocumented)
-    readonly transaction: ISharedTreeView["transaction"];
-    // (undocumented)
-    undo(): void;
 }
 
 // @alpha

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1026,26 +1026,21 @@ export interface ISharedTree extends ISharedObject, ISharedTreeView {
 }
 
 // @alpha
-export interface ISharedTreeBranchView extends ISharedTreeView {
-    rebaseOnto(view: ISharedTreeView): void;
-}
-
-// @alpha
 export interface ISharedTreeView extends AnchorLocator {
     readonly context: EditableTreeContext;
     readonly editor: IDefaultEditBuilder;
     readonly events: ISubscribable<ViewEvents>;
     readonly forest: IForestSubscription;
-    fork(): ISharedTreeBranchView;
-    merge(view: ISharedTreeBranchView): void;
-    merge(view: ISharedTreeBranchView, disposeView: boolean): void;
+    fork(): SharedTreeView;
+    merge(view: SharedTreeView): void;
+    merge(view: SharedTreeView, disposeView: boolean): void;
     readonly nodeKey: {
         generate(): LocalNodeKey;
         stabilize(key: LocalNodeKey): StableNodeKey;
         localize(key: StableNodeKey): LocalNodeKey;
         map: ReadonlyMap<LocalNodeKey, EditableTree>;
     };
-    rebase(view: ISharedTreeBranchView): void;
+    rebase(view: SharedTreeView): void;
     redo(): void;
     get root(): UnwrappedEditableField;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
@@ -1068,14 +1063,6 @@ export function isPrimitiveValue(nodeValue: Value): nodeValue is PrimitiveValue;
 // @alpha
 export interface ISubscribable<E extends Events<E>> {
     on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
-}
-
-// @alpha
-export interface ITransaction {
-    abort(): TransactionResult.Abort;
-    commit(): TransactionResult.Commit;
-    inProgress(): boolean;
-    start(): void;
 }
 
 // @alpha
@@ -1350,7 +1337,7 @@ export type NameFromBranded<T extends BrandedType<any, string>> = T extends Bran
 export type NestedMap<Key1, Key2, Value> = Map<Key1, Map<Key2, Value>>;
 
 // @alpha
-export type NewFieldContent = ITreeCursorSynchronous | readonly ITreeCursorSynchronous[] | ContextuallyTypedFieldData;
+export type NewFieldContent = ITreeCursor | readonly ITreeCursor[] | ContextuallyTypedFieldData;
 
 // @alpha (undocumented)
 export type NodeChangeComposer = (changes: TaggedChange<NodeChangeset>[]) => NodeChangeset;
@@ -1698,7 +1685,7 @@ export interface SchemaLintConfiguration {
 // @alpha
 export interface SchematizeConfiguration<TRoot extends FieldSchema = FieldSchema> {
     readonly allowedSchemaModifications: AllowedUpdateType;
-    readonly initialTree: SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple> | readonly ITreeCursorSynchronous[];
+    readonly initialTree: SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple> | readonly ITreeCursor[];
     readonly schema: TypedSchemaCollection<TRoot>;
 }
 
@@ -1734,6 +1721,50 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha (undocumented)
 export interface SharedTreeOptions extends Partial<ICodecOptions> {
+}
+
+// @alpha
+export class SharedTreeView implements ISharedTreeBranchView {
+    constructor(transaction: ITransaction, branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>, changeFamily: DefaultChangeFamily, _storedSchema: InMemoryStoredSchemaRepository, _forest: IEditableForest, context: EditableTreeContext, _nodeKeyManager: NodeKeyManager, _nodeKeyIndex: NodeKeyIndex, _events: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>);
+    // (undocumented)
+    readonly context: EditableTreeContext;
+    dispose(): void;
+    // (undocumented)
+    get editor(): IDefaultEditBuilder;
+    // (undocumented)
+    get events(): ISubscribable<ViewEvents>;
+    // (undocumented)
+    get forest(): IForestSubscription;
+    // (undocumented)
+    fork(): SharedTreeView;
+    // (undocumented)
+    locate(anchor: Anchor): AnchorNode | undefined;
+    // (undocumented)
+    merge(view: SharedTreeView): void;
+    // (undocumented)
+    merge(view: SharedTreeView, disposeView: boolean): void;
+    // (undocumented)
+    readonly nodeKey: ISharedTreeView["nodeKey"];
+    // (undocumented)
+    rebase(view: SharedTreeView): void;
+    // (undocumented)
+    rebaseOnto(view: ISharedTreeView): void;
+    // (undocumented)
+    redo(): void;
+    // (undocumented)
+    get root(): UnwrappedEditableField;
+    // (undocumented)
+    get rootEvents(): ISubscribable<AnchorSetRootEvents>;
+    // (undocumented)
+    schematize<TRoot extends FieldSchema>(config: SchematizeConfiguration<TRoot>): ISharedTreeView;
+    // (undocumented)
+    setContent(data: NewFieldContent): void;
+    // (undocumented)
+    get storedSchema(): StoredSchemaRepository;
+    // (undocumented)
+    readonly transaction: ITransaction;
+    // (undocumented)
+    undo(): void;
 }
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
@@ -11,9 +11,9 @@ import {
 	TreeSchemaIdentifier,
 	ValueSchema,
 } from "../../../core";
-import { FullSchemaPolicy, Multiplicity } from "../../modular-schema";
+import { FieldKind, FullSchemaPolicy, Multiplicity } from "../../modular-schema";
 import { fail } from "../../../util";
-import { getFieldKind } from "../../contextuallyTyped";
+import { fieldKinds } from "../../default-field-kinds";
 import { EncodedChunk, EncodedValueShape } from "./format";
 import {
 	EncoderCache,
@@ -48,6 +48,13 @@ export function buildCache(schema: SchemaData, policy: FullSchemaPolicy): Encode
 			fieldShaper(treeHandler, field, cache),
 	);
 	return cache;
+}
+
+export function getFieldKind(fieldSchema: FieldStoredSchema): FieldKind {
+	// TODO:
+	// This module currently is assuming use of defaultFieldKinds.
+	// The field kinds should instead come from a view schema registry thats provided somewhere.
+	return fieldKinds.get(fieldSchema.kind.identifier) ?? fail("missing field kind");
 }
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -27,7 +27,8 @@ import {
 	ContextuallyTypedNodeData,
 	arrayLikeMarkerSymbol,
 	cursorFromContextualData,
-	cursorsFromContextualData,
+	NewFieldContent,
+	normalizeNewFieldContent,
 } from "../contextuallyTyped";
 import {
 	FieldKinds,
@@ -35,7 +36,7 @@ import {
 	SequenceFieldEditBuilder,
 	ValueFieldEditBuilder,
 } from "../default-field-kinds";
-import { assertValidIndex, fail, isReadonlyArray, assertNonNegativeSafeInteger } from "../../util";
+import { assertValidIndex, fail, assertNonNegativeSafeInteger } from "../../util";
 import {
 	AdaptingProxyHandler,
 	adaptWithProxy,
@@ -47,10 +48,8 @@ import { ProxyContext } from "./editableTreeContext";
 import {
 	EditableField,
 	EditableTree,
-	NewFieldContent,
 	UnwrappedEditableField,
 	UnwrappedEditableTree,
-	areCursors,
 	proxyTargetSymbol,
 } from "./editableTreeTypes";
 import { makeTree } from "./editableTree";
@@ -124,23 +123,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 	}
 
 	public normalizeNewContent(content: NewFieldContent): readonly ITreeCursor[] {
-		if (areCursors(content)) {
-			if (this.kind.multiplicity === Multiplicity.Sequence) {
-				assert(isReadonlyArray(content), 0x6b7 /* sequence fields require array content */);
-				return content;
-			} else {
-				if (isReadonlyArray(content)) {
-					assert(
-						content.length === 1,
-						0x6b8 /* non-sequence fields can not be provided content that is multiple cursors */,
-					);
-					return content;
-				}
-				return [content];
-			}
-		}
-
-		return cursorsFromContextualData(this.context, this.fieldSchema, content);
+		return normalizeNewFieldContent(this.context, this.fieldSchema, content);
 	}
 
 	public get [proxyTargetSymbol](): FieldProxyTarget {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -23,7 +23,13 @@ import {
 } from "../../core";
 import { brand, fail } from "../../util";
 import { FieldKind } from "../modular-schema";
-import { getFieldKind, getFieldSchema, typeNameSymbol, valueSymbol } from "../contextuallyTyped";
+import {
+	getFieldKind,
+	NewFieldContent,
+	getFieldSchema,
+	typeNameSymbol,
+	valueSymbol,
+} from "../contextuallyTyped";
 import { LocalNodeKey } from "../node-key";
 import { FieldKinds } from "../default-field-kinds";
 import {
@@ -41,7 +47,6 @@ import {
 	EditableTree,
 	UnwrappedEditableField,
 	proxyTargetSymbol,
-	NewFieldContent,
 	localNodeKeySymbol,
 	setField,
 } from "./editableTreeTypes";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -17,8 +17,8 @@ import {
 import { ISubscribable } from "../../events";
 import { DefaultEditBuilder } from "../default-field-kinds";
 import { NodeKeyManager } from "../node-key";
-import { FieldGenerator } from "../contextuallyTyped";
-import { EditableField, NewFieldContent, UnwrappedEditableField } from "./editableTreeTypes";
+import { FieldGenerator, NewFieldContent } from "../contextuallyTyped";
+import { EditableField, UnwrappedEditableField } from "./editableTreeTypes";
 import { makeField, unwrappedField } from "./editableField";
 import { ProxyTarget } from "./ProxyTarget";
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeTypes.ts
@@ -3,13 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { Value, TreeSchemaIdentifier, ITreeCursor, isCursor, FieldKey } from "../../core";
 import {
-	PrimitiveValue,
-	typeNameSymbol,
-	valueSymbol,
-	ContextuallyTypedFieldData,
-} from "../contextuallyTyped";
+	Value,
+	TreeSchemaIdentifier,
+	isCursor,
+	FieldKey,
+	ITreeCursorSynchronous,
+} from "../../core";
+import { PrimitiveValue, typeNameSymbol, valueSymbol, NewFieldContent } from "../contextuallyTyped";
 import { LocalNodeKey } from "../node-key";
 import { UntypedField, UntypedTreeCore, parentField } from "../untypedTree";
 import { EditableTreeContext } from "./editableTreeContext";
@@ -120,26 +121,13 @@ export interface EditableTree
 }
 
 /**
- * Content to use for a field.
- *
- * When used, this content will be deeply copied into the tree, and must comply with the schema.
- *
- * The content must follow the {@link Multiplicity} of the {@link FieldKind}:
- * - use a single cursor for an `optional` or `value` field;
- * - use array of cursors for a `sequence` field;
- *
- * TODO: this should allow a field cursor instead of an array of cursors.
- * TODO: Make this generic so a variant of this type that allows placeholders for detached sequences to consume.
- * @alpha
- */
-export type NewFieldContent = ITreeCursor | readonly ITreeCursor[] | ContextuallyTypedFieldData;
-
-/**
  * Check if NewFieldContent is made of {@link ITreeCursor}s.
  *
  * Useful when APIs want to take in tree data in multiple formats, including cursors.
  */
-export function areCursors(data: NewFieldContent): data is ITreeCursor | readonly ITreeCursor[] {
+export function areCursors(
+	data: NewFieldContent,
+): data is ITreeCursorSynchronous | readonly ITreeCursorSynchronous[] {
 	if (isCursor(data)) {
 		return true;
 	}

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/index.ts
@@ -10,7 +10,6 @@ export {
 	proxyTargetSymbol,
 	UnwrappedEditableTree,
 	UnwrappedEditableField,
-	NewFieldContent,
 	areCursors,
 	localNodeKeySymbol,
 	setField,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -15,7 +15,6 @@ export {
 	proxyTargetSymbol,
 	UnwrappedEditableField,
 	UnwrappedEditableTree,
-	NewFieldContent,
 	localNodeKeySymbol,
 	createDataBinderBuffering,
 	createDataBinderDirect,
@@ -75,6 +74,8 @@ export {
 	cursorsForTypedFieldData,
 	FieldGenerator,
 	TreeDataContext,
+	normalizeNewFieldContent,
+	NewFieldContent,
 } from "./contextuallyTyped";
 
 export { ForestSummarizer } from "./forestSummarizer";

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/partlyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/partlyTyped.ts
@@ -4,9 +4,8 @@
  */
 
 import { FieldStoredSchema, ITreeCursor } from "../../core";
-import { ContextuallyTypedNodeData } from "../contextuallyTyped";
+import { ContextuallyTypedNodeData, NewFieldContent } from "../contextuallyTyped";
 import { Optional, Sequence, ValueFieldKind } from "../default-field-kinds";
-import { NewFieldContent } from "../editable-tree";
 import {
 	UntypedField,
 	UntypedTree,

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -265,10 +265,11 @@ export {
 export {
 	ISharedTree,
 	ISharedTreeView,
+	ITransaction,
 	runSynchronous,
 	SharedTreeFactory,
 	SharedTreeOptions,
-	SharedTreeView,
+	ISharedTreeBranchView,
 	ViewEvents,
 	SchematizeConfiguration,
 } from "./shared-tree";

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -9,7 +9,6 @@ export {
 	createSharedTreeView,
 	ISharedTreeView,
 	runSynchronous,
-	SharedTreeView,
 	ViewEvents,
 	ITransaction,
 	ISharedTreeBranchView,

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -11,6 +11,8 @@ export {
 	runSynchronous,
 	SharedTreeView,
 	ViewEvents,
+	ITransaction,
+	ISharedTreeBranchView,
 } from "./sharedTreeView";
 
 export { SchematizeConfiguration } from "./schematizedTree";

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -10,7 +10,7 @@ import {
 	Compatibility,
 	SimpleObservingDependent,
 	SchemaData,
-	ITreeCursor,
+	ITreeCursorSynchronous,
 } from "../core";
 import {
 	ViewSchema,
@@ -191,5 +191,5 @@ export interface SchematizeConfiguration<TRoot extends FieldSchema = FieldSchema
 	 */
 	readonly initialTree:
 		| SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Simple>
-		| readonly ITreeCursor[];
+		| readonly ITreeCursorSynchronous[];
 }

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -44,9 +44,11 @@ import {
 } from "../feature-libraries";
 import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
 import { JsonCompatibleReadOnly, brand } from "../util";
-import { SchematizeConfiguration, schematizeView } from "./schematizedTree";
+import { SchematizeConfiguration } from "./schematizedTree";
 import {
+	ISharedTreeBranchView,
 	ISharedTreeView,
+	ITransaction,
 	SharedTreeView,
 	ViewEvents,
 	createSharedTreeView,
@@ -155,10 +157,10 @@ export class SharedTree
 	public schematize<TRoot extends FieldSchema>(
 		config: SchematizeConfiguration<TRoot>,
 	): ISharedTreeView {
-		return schematizeView(this, config);
+		return this.view.schematize(config);
 	}
 
-	public get transaction(): SharedTreeView["transaction"] {
+	public get transaction(): ITransaction {
 		return this.view.transaction;
 	}
 
@@ -166,17 +168,17 @@ export class SharedTree
 		return this.view.nodeKey;
 	}
 
-	public fork(): SharedTreeView {
+	public fork(): ISharedTreeBranchView {
 		return this.view.fork();
 	}
 
-	public merge(view: SharedTreeView): void;
-	public merge(view: SharedTreeView, disposeView: boolean): void;
-	public merge(view: SharedTreeView, disposeView = true): void {
+	public merge(view: ISharedTreeBranchView): void;
+	public merge(view: ISharedTreeBranchView, disposeView: boolean): void;
+	public merge(view: ISharedTreeBranchView, disposeView = true): void {
 		this.view.merge(view, disposeView);
 	}
 
-	public rebase(fork: SharedTreeView): void {
+	public rebase(fork: ISharedTreeBranchView): void {
 		fork.rebaseOnto(this.view);
 	}
 

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -44,12 +44,11 @@ import {
 } from "../feature-libraries";
 import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
 import { JsonCompatibleReadOnly, brand } from "../util";
-import { SchematizeConfiguration } from "./schematizedTree";
+import { SchematizeConfiguration, schematizeView } from "./schematizedTree";
 import {
 	ISharedTreeBranchView,
 	ISharedTreeView,
 	ITransaction,
-	SharedTreeView,
 	ViewEvents,
 	createSharedTreeView,
 } from "./sharedTreeView";
@@ -113,6 +112,9 @@ export class SharedTree
 		this._events = createEmitter<ViewEvents>();
 		this.view = createSharedTreeView({
 			branch: this.getLocalBranch(),
+			// TODO:
+			// This passes in a version of schema thats not wrapped with the editor.
+			// This allows editing schema on the vide without sending ops, which is incorrect behavior.
 			schema,
 			forest,
 			repairProvider,
@@ -131,6 +133,11 @@ export class SharedTree
 	}
 
 	public get storedSchema(): StoredSchemaRepository {
+		// TODO:
+		// Schema editing on the view should be the same as editing it here.
+		// However, currently editing schema on views doesn't send ops because schema editing is a hack and not properly implemented.
+		// When this is fixes, this assert should start passing:
+		// assert(this.schema === this.view.storedSchema, "mismatched schema");
 		return this.schema;
 	}
 
@@ -157,14 +164,18 @@ export class SharedTree
 	public schematize<TRoot extends FieldSchema>(
 		config: SchematizeConfiguration<TRoot>,
 	): ISharedTreeView {
-		return this.view.schematize(config);
+		// TODO:
+		// This should work, but schema editing on views doesn't send ops.
+		// return this.view.schematize(config);
+		// For now, use this as a workaround:
+		return schematizeView(this, config);
 	}
 
 	public get transaction(): ITransaction {
 		return this.view.transaction;
 	}
 
-	public get nodeKey(): SharedTreeView["nodeKey"] {
+	public get nodeKey(): ISharedTreeView["nodeKey"] {
 		return this.view.nodeKey;
 	}
 

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -114,7 +114,7 @@ export class SharedTree
 			branch: this.getLocalBranch(),
 			// TODO:
 			// This passes in a version of schema thats not wrapped with the editor.
-			// This allows editing schema on the vide without sending ops, which is incorrect behavior.
+			// This allows editing schema on the view without sending ops, which is incorrect behavior.
 			schema,
 			forest,
 			repairProvider,
@@ -136,7 +136,7 @@ export class SharedTree
 		// TODO:
 		// Schema editing on the view should be the same as editing it here.
 		// However, currently editing schema on views doesn't send ops because schema editing is a hack and not properly implemented.
-		// When this is fixes, this assert should start passing:
+		// When this is fixed, this assert should start passing:
 		// assert(this.schema === this.view.storedSchema, "mismatched schema");
 		return this.schema;
 	}

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -170,41 +170,14 @@ export interface ISharedTreeView extends AnchorLocator {
 
 	/**
 	 * A collection of functions for managing transactions.
-	 * Transactions allow edits to be batched into atomic units.
-	 * Edits made during a transaction will update the local state of the tree immediately, but will be squashed into a single edit when the transaction is committed.
-	 * If the transaction is aborted, the local state will be reset to what it was before the transaction began.
-	 * Transactions may nest, meaning that a transaction may be started while a transaction is already ongoing.
-	 *
-	 * To avoid updating observers of the view state with intermediate results during a transaction,
-	 * use {@link ISharedTreeView#fork} and {@link ISharedTreeFork#merge}.
 	 */
-	readonly transaction: {
-		/**
-		 * Start a new transaction.
-		 * If a transaction is already in progress when this new transaction starts, then this transaction will be "nested" inside of it,
-		 * i.e. the outer transaction will still be in progress after this new transaction is committed or aborted.
-		 */
-		start(): void;
-		/**
-		 * Close this transaction by squashing its edits and committing them as a single edit.
-		 * If this is the root view and there are no ongoing transactions remaining, the squashed edit will be submitted to Fluid.
-		 */
-		commit(): TransactionResult.Commit;
-		/**
-		 * Close this transaction and revert the state of the tree to what it was before this transaction began.
-		 */
-		abort(): TransactionResult.Abort;
-		/**
-		 * True if there is at least one transaction currently in progress on this view, otherwise false.
-		 */
-		inProgress(): boolean;
-	};
+	readonly transaction: ITransaction;
 
 	/**
 	 * Spawn a new view which is based off of the current state of this view.
 	 * Any mutations of the new view will not apply to this view until the new view is merged back into this view via `merge()`.
 	 */
-	fork(): SharedTreeView;
+	fork(): ISharedTreeBranchView;
 
 	/**
 	 * Apply all the new changes on the given view to this view.
@@ -212,7 +185,7 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * It is automatically disposed after the merge completes.
 	 * @remarks All ongoing transactions (if any) in `view` will be committed before the merge.
 	 */
-	merge(view: SharedTreeView): void;
+	merge(view: ISharedTreeBranchView): void;
 
 	/**
 	 * Apply all the new changes on the given view to this view.
@@ -220,13 +193,13 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * @param disposeView - whether or not to dispose `view` after the merge completes.
 	 * @remarks All ongoing transactions (if any) in `view` will be committed before the merge.
 	 */
-	merge(view: SharedTreeView, disposeView: boolean): void;
+	merge(view: ISharedTreeBranchView, disposeView: boolean): void;
 
 	/**
 	 * Rebase the given view onto this view.
 	 * @param view - a view which was created by a call to `fork()`. It is modified by this operation.
 	 */
-	rebase(view: SharedTreeView): void;
+	rebase(view: ISharedTreeBranchView): void;
 
 	/**
 	 * Events about this view.
@@ -295,11 +268,6 @@ export interface ISharedTreeView extends AnchorLocator {
 }
 
 /**
- * Used as a static property to access the creation function for a {@link SharedTreeView}.
- */
-export const create = Symbol("Create SharedTreeView");
-
-/**
  * Creates a {@link SharedTreeView}.
  * @param args - an object containing optional components that will be used to build the view.
  * Any components not provided will be created by default.
@@ -347,7 +315,11 @@ export function createSharedTreeView(args?: {
 	);
 	const nodeKeyIndex = args?.nodeKeyIndex ?? new NodeKeyIndex(brand(nodeKeyFieldKey));
 	const events = args?.events ?? createEmitter();
-	return SharedTreeView[create](
+
+	const transaction = new Transaction(branch, changeFamily, forest);
+
+	return new SharedTreeView(
+		transaction,
 		branch,
 		changeFamily,
 		schema,
@@ -360,11 +332,86 @@ export function createSharedTreeView(args?: {
 }
 
 /**
- * An implementation of {@link ISharedTreeView}.
+ * A collection of functions for managing transactions.
+ * Transactions allow edits to be batched into atomic units.
+ * Edits made during a transaction will update the local state of the tree immediately, but will be squashed into a single edit when the transaction is committed.
+ * If the transaction is aborted, the local state will be reset to what it was before the transaction began.
+ * Transactions may nest, meaning that a transaction may be started while a transaction is already ongoing.
+ *
+ * To avoid updating observers of the view state with intermediate results during a transaction,
+ * use {@link ISharedTreeView#fork} and {@link ISharedTreeFork#merge}.
  * @alpha
  */
-export class SharedTreeView implements ISharedTreeView {
-	private constructor(
+export interface ITransaction {
+	/**
+	 * Start a new transaction.
+	 * If a transaction is already in progress when this new transaction starts, then this transaction will be "nested" inside of it,
+	 * i.e. the outer transaction will still be in progress after this new transaction is committed or aborted.
+	 */
+	start(): void;
+	/**
+	 * Close this transaction by squashing its edits and committing them as a single edit.
+	 * If this is the root view and there are no ongoing transactions remaining, the squashed edit will be submitted to Fluid.
+	 */
+	commit(): TransactionResult.Commit;
+	/**
+	 * Close this transaction and revert the state of the tree to what it was before this transaction began.
+	 */
+	abort(): TransactionResult.Abort;
+	/**
+	 * True if there is at least one transaction currently in progress on this view, otherwise false.
+	 */
+	inProgress(): boolean;
+}
+
+class Transaction implements ITransaction {
+	public constructor(
+		private readonly branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>,
+		private readonly changeFamily: DefaultChangeFamily,
+		private readonly forest: IEditableForest,
+	) {}
+
+	public start(): void {
+		this.branch.startTransaction(
+			new ForestRepairDataStore(this.forest, (change) => this.changeFamily.intoDelta(change)),
+		);
+		this.branch.editor.enterTransaction();
+	}
+	public commit(): TransactionResult.Commit {
+		this.branch.commitTransaction();
+		this.branch.editor.exitTransaction();
+		return TransactionResult.Commit;
+	}
+	public abort(): TransactionResult.Abort {
+		this.branch.abortTransaction();
+		this.branch.editor.exitTransaction();
+		return TransactionResult.Abort;
+	}
+	public inProgress(): boolean {
+		return this.branch.isTransacting();
+	}
+}
+
+/**
+ * Branch (like in a version control system) of SharedTree.
+ *
+ * {@link ISharedTreeView} that has forked off of the main trunk/branch.
+ * @alpha
+ */
+export interface ISharedTreeBranchView extends ISharedTreeView {
+	/**
+	 * Rebase the changes that have been applied to this view over all the new changes in the given view.
+	 * @param view - Either the root view or a view that was created by a call to `fork()`. It is not modified by this operation.
+	 */
+	rebaseOnto(view: ISharedTreeView): void;
+}
+
+/**
+ * An implementation of {@link ISharedTreeView}.
+ */
+export class SharedTreeView implements ISharedTreeBranchView {
+	public constructor(
+		public readonly transaction: ITransaction,
 		private readonly branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>,
 		private readonly changeFamily: DefaultChangeFamily,
 		private readonly _storedSchema: InMemoryStoredSchemaRepository,
@@ -376,40 +423,22 @@ export class SharedTreeView implements ISharedTreeView {
 			IEmitter<ViewEvents> &
 			HasListeners<ViewEvents>,
 	) {
+		// Keep _nodeKeyIndex up to date with forest content.
+		// Note that just running this in the "change" code-path below is insufficient for handling summary load.
+		this.forest.on("afterDelta", () => {
+			this._nodeKeyIndex.scanKeys(this.context);
+		});
+
 		branch.on("change", ({ change }) => {
 			if (change !== undefined) {
 				const delta = this.changeFamily.intoDelta(change);
 				this._forest.applyDelta(delta);
-				this._nodeKeyIndex.scanKeys(this.context);
 				this._events.emit("afterBatch");
 			}
 		});
 		branch.on("revertible", (type) => {
 			this._events.emit("revertible", type);
 		});
-	}
-
-	// SharedTreeView is a public type, but its instantiation is internal
-	private static [create](
-		branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>,
-		changeFamily: DefaultChangeFamily,
-		storedSchema: InMemoryStoredSchemaRepository,
-		forest: IEditableForest,
-		context: EditableTreeContext,
-		_nodeKeyManager: NodeKeyManager,
-		nodeKeyIndex: NodeKeyIndex,
-		events: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>,
-	): SharedTreeView {
-		return new SharedTreeView(
-			branch,
-			changeFamily,
-			storedSchema,
-			forest,
-			context,
-			_nodeKeyManager,
-			nodeKeyIndex,
-			events,
-		);
 	}
 
 	public get events(): ISubscribable<ViewEvents> {
@@ -431,28 +460,6 @@ export class SharedTreeView implements ISharedTreeView {
 	public get editor(): IDefaultEditBuilder {
 		return this.branch.editor;
 	}
-
-	public readonly transaction: ISharedTreeView["transaction"] = {
-		start: () => {
-			this.branch.startTransaction(
-				new ForestRepairDataStore(this.forest, (change) =>
-					this.changeFamily.intoDelta(change),
-				),
-			);
-			this.branch.editor.enterTransaction();
-		},
-		commit: () => {
-			this.branch.commitTransaction();
-			this.branch.editor.exitTransaction();
-			return TransactionResult.Commit;
-		},
-		abort: () => {
-			this.branch.abortTransaction();
-			this.branch.editor.exitTransaction();
-			return TransactionResult.Abort;
-		},
-		inProgress: () => this.branch.isTransacting(),
-	};
 
 	public readonly nodeKey: ISharedTreeView["nodeKey"] = {
 		generate: () => this._nodeKeyManager.generateLocalNodeKey(),
@@ -495,7 +502,9 @@ export class SharedTreeView implements ISharedTreeView {
 			this._nodeKeyManager,
 			this._nodeKeyIndex.fieldKey,
 		);
+		const transaction = new Transaction(branch, this.changeFamily, forest);
 		return new SharedTreeView(
+			transaction,
 			branch,
 			this.changeFamily,
 			storedSchema,
@@ -511,10 +520,6 @@ export class SharedTreeView implements ISharedTreeView {
 		view.branch.rebaseOnto(this.branch);
 	}
 
-	/**
-	 * Rebase the changes that have been applied to this view over all the new changes in the given view.
-	 * @param view - Either the root view or a view that was created by a call to `fork()`. It is not modified by this operation.
-	 */
 	public rebaseOnto(view: ISharedTreeView): void {
 		view.rebase(this);
 	}

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -423,16 +423,11 @@ export class SharedTreeView implements ISharedTreeBranchView {
 			IEmitter<ViewEvents> &
 			HasListeners<ViewEvents>,
 	) {
-		// Keep _nodeKeyIndex up to date with forest content.
-		// Note that just running this in the "change" code-path below is insufficient for handling summary load.
-		this.forest.on("afterDelta", () => {
-			this._nodeKeyIndex.scanKeys(this.context);
-		});
-
 		branch.on("change", ({ change }) => {
 			if (change !== undefined) {
 				const delta = this.changeFamily.intoDelta(change);
 				this._forest.applyDelta(delta);
+				this._nodeKeyIndex.scanKeys(this.context);
 				this._events.emit("afterBatch");
 			}
 		});

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -407,7 +407,7 @@ export interface ISharedTreeBranchView extends ISharedTreeView {
 }
 
 /**
- * An implementation of {@link ISharedTreeView}.
+ * An implementation of {@link ISharedTreeBranchView}.
  */
 export class SharedTreeView implements ISharedTreeBranchView {
 	public constructor(

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -9,7 +9,7 @@ import { jsonObject, jsonString, singleJsonCursor } from "../../domains";
 import { rootFieldKey, UpPath, moveToDetachedField, FieldUpPath } from "../../core";
 import { JsonCompatible, brand, makeArray } from "../../util";
 import { makeTreeFromJson, remove, insert, expectJsonTree } from "../utils";
-import { SharedTreeView } from "../../shared-tree";
+import { ISharedTreeView } from "../../shared-tree";
 import { singleTextCursor } from "../../feature-libraries";
 
 describe("Editing", () => {
@@ -1537,10 +1537,10 @@ describe("Editing", () => {
 				return buildScenariosWithPrefix();
 			}
 
-			const delAction = (peer: SharedTreeView, idx: number) => remove(peer, idx, 1);
+			const delAction = (peer: ISharedTreeView, idx: number) => remove(peer, idx, 1);
 			const srcField: FieldUpPath = { parent: undefined, field: rootFieldKey };
 			const dstField: FieldUpPath = { parent: undefined, field: brand("dst") };
-			const moveAction = (peer: SharedTreeView, idx: number) =>
+			const moveAction = (peer: ISharedTreeView, idx: number) =>
 				peer.editor.move(srcField, idx, 1, dstField, 0);
 
 			/**

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "@fluid-internal/test-dds-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { SharedTreeTestFactory, toJsonableTree, validateTree } from "../../utils";
-import { SharedTreeView } from "../../../shared-tree";
+import { ISharedTreeBranchView } from "../../../shared-tree";
 import { makeOpGenerator, EditGeneratorOpWeights, FuzzTestState } from "./fuzzEditGenerators";
 import {
 	applyFieldEdit,
@@ -31,7 +31,7 @@ import { Operation } from "./operationTypes";
  * This interface is meant to be used for tests that require you to store a branch of a tree
  */
 interface BranchedTreeFuzzTestState extends FuzzTestState {
-	branch?: SharedTreeView;
+	branch?: ISharedTreeBranchView;
 }
 
 const fuzzComposedVsIndividualReducer = combineReducersAsync<Operation, BranchedTreeFuzzTestState>({


### PR DESCRIPTION
## Description

Misc API cleanup and refactors.

Mainly remove SharedTreeView from package API. 

SharedTreeView vs ISharedTreeView was a strange undocumented distinction. It has been replaced by ISharedTreeBranchView and ISharedTreeView, which are more clearly semantically different.

## Breaking Changes

Users of SharedTreeView should migrates to ISharedTreeBranchView .

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

