### PR TITLE
feat(api-markdown-documenter) Allow consumers to specify document front matter as a string

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
@@ -142,7 +142,7 @@ export const defaultConsoleLogger: Logger;
 export namespace DefaultDocumentationSuiteOptions {
     const defaultDocumentBoundaries: ApiMemberKind[];
     const defaultHierarchyBoundaries: ApiMemberKind[];
-    export function defaultGenerateFrontMatter(): undefined;
+    export function defaultFrontMatter(): undefined;
     export function defaultGetFileNameForItem(apiItem: ApiItem): string;
     export function defaultGetHeadingTextForItem(apiItem: ApiItem): string;
     export function defaultGetLinkTextForItem(apiItem: ApiItem): string;
@@ -202,7 +202,7 @@ export abstract class DocumentationParentNodeBase<TDocumentationNode extends Doc
 // @public
 export interface DocumentationSuiteOptions {
     documentBoundaries?: DocumentBoundaries;
-    generateFrontMatter?: (documentItem: ApiItem) => string | undefined;
+    frontMatter?: string | ((documentItem: ApiItem) => string | undefined);
     getFileNameForItem?: (apiItem: ApiItem) => string;
     getHeadingTextForItem?: (apiItem: ApiItem) => string;
     getLinkTextForItem?: (apiItem: ApiItem) => string;

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -28,10 +28,20 @@ export function createDocument(
 		contents = [wrapInSection(sections, { title: config.getHeadingTextForItem(documentItem) })];
 	}
 
-	const frontMatter =
-		config.generateFrontMatter === undefined
-			? undefined
-			: config.generateFrontMatter(documentItem);
+	// Generate front-matter (if specified in configuration)
+	let frontMatter: string | undefined;
+	if (config.frontMatter !== undefined) {
+		if (typeof config.frontMatter === "string") {
+			frontMatter = config.frontMatter;
+		} else {
+			if (typeof config.frontMatter !== "function") {
+				throw new TypeError(
+					"Invalid `frontMatter` configuration provided. Must be either a string or a function.",
+				);
+			}
+			frontMatter = config.frontMatter(documentItem);
+		}
+	}
 
 	return new DocumentNode({
 		children: contents,

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
@@ -198,7 +198,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue No front matter is generated.
 	 */
-	generateFrontMatter?: (documentItem: ApiItem) => string | undefined;
+	frontMatter?: string | ((documentItem: ApiItem) => string | undefined);
 }
 
 /**
@@ -315,11 +315,11 @@ export namespace DefaultDocumentationSuiteOptions {
 	}
 
 	/**
-	 * Default {@link DocumentationSuiteOptions.generateFrontMatter}.
+	 * Default {@link DocumentationSuiteOptions.frontMatter}.
 	 *
 	 * Unconditionally returns `undefined` (i.e. no front-matter will be generated).
 	 */
-	export function defaultGenerateFrontMatter(): undefined {
+	export function defaultFrontMatter(): undefined {
 		return undefined;
 	}
 }
@@ -337,7 +337,7 @@ const defaultDocumentationSuiteOptions: Required<DocumentationSuiteOptions> = {
 	getHeadingTextForItem: DefaultDocumentationSuiteOptions.defaultGetHeadingTextForItem,
 	getLinkTextForItem: DefaultDocumentationSuiteOptions.defaultGetLinkTextForItem,
 	skipPackage: DefaultDocumentationSuiteOptions.defaultSkipPackage,
-	generateFrontMatter: DefaultDocumentationSuiteOptions.defaultGenerateFrontMatter,
+	frontMatter: DefaultDocumentationSuiteOptions.defaultFrontMatter,
 };
 
 /**

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -79,5 +79,5 @@ export {
 	verboseConsoleLogger,
 } from "./Logging";
 
-// Conveinence re-exports of API model types
+// Convenience re-exports of API model types
 export type { ApiItem, ApiItemKind, ApiModel, ApiPackage } from "@microsoft/api-extractor-model";

--- a/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
@@ -178,6 +178,7 @@ describe("api-markdown-documenter full-suite tests", () => {
 			configName: "default-config",
 			transformConfigLessApiModel: {
 				uriRoot: ".",
+				frontMatter: "<!-- Front Matter! -->",
 			},
 			renderConfig: {
 				newlineKind: NewlineKind.Lf,
@@ -195,7 +196,7 @@ describe("api-markdown-documenter full-suite tests", () => {
 				includeTopLevelDocumentHeading: false,
 				documentBoundaries: [], // Render everything to package documents
 				hierarchyBoundaries: [], // No additional hierarchy beyond the package level
-				generateFrontMatter: (documentItem): string =>
+				frontMatter: (documentItem): string =>
 					`<!--- This is sample front-matter for API item "${documentItem.displayName}" -->`,
 			},
 			renderConfig: {

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/index.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # API Overview
 
 ## Packages

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # simple-suite-test
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testabstractclass-class.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestAbstractClass
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestAbstractClass](./simple-suite-test/testabstractclass-class)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testclass-class.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestClass
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestClass](./simple-suite-test/testclass-class)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testemptyinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testemptyinterface-interface.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestEmptyInterface
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestEmptyInterface](./simple-suite-test/testemptyinterface-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestInterface
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterface](./simple-suite-test/testinterface-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfaceextendingotherinterfaces-interface.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestInterfaceExtendingOtherInterfaces
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceExtendingOtherInterfaces](./simple-suite-test/testinterfaceextendingotherinterfaces-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithindexsignature-interface.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestInterfaceWithIndexSignature
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceWithIndexSignature](./simple-suite-test/testinterfacewithindexsignature-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithtypeparameter-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithtypeparameter-interface.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestInterfaceWithTypeParameter
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceWithTypeParameter](./simple-suite-test/testinterfacewithtypeparameter-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testmodule-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testmodule-namespace.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestModule
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestModule](./simple-suite-test/testmodule-namespace)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace-namespace.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestNamespace
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testclass-class.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestClass
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestClass](./simple-suite-test/testnamespace/testclass-class)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testinterface-interface.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestInterface
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestInterface](./simple-suite-test/testnamespace/testinterface-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testsubnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testsubnamespace-namespace.md
@@ -1,3 +1,5 @@
+<!-- Front Matter! -->
+
 # TestSubNamespace
 
 [Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestSubNamespace](./simple-suite-test/testnamespace/testsubnamespace-namespace)


### PR DESCRIPTION
Previously, configurations only accepted a callback for generating front-matter. This change allows specifying a constant string value in place of the callback when desired. 

### Breaking Change

This changes the config parameter name from "generateFrontMatter" to "frontMatter".