### PR TITLE
Remove old code path in token validation flow

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -6,13 +6,9 @@
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import { IClient, IClientJoin, ScopeType } from "@fluidframework/protocol-definitions";
-import {
-	BasicRestWrapper,
-	validateTokenClaimsExpiration,
-} from "@fluidframework/server-services-client";
+import { BasicRestWrapper } from "@fluidframework/server-services-client";
 import * as core from "@fluidframework/server-services-core";
 import {
-	validateTokenClaims,
 	throttle,
 	IThrottleMiddlewareOptions,
 	getParam,
@@ -248,37 +244,18 @@ async function verifyTokenWrapper(
 	if (!documentId) {
 		throw new Error("Missing documentId in request.");
 	}
-	const claims = validateTokenClaims(token, documentId, tenantId);
-	if (isTokenExpiryEnabled) {
-		validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
-	}
 
-	if (!tokenCacheEnabled && revokedTokenChecker && claims.jti) {
-		const tokenRevoked = await revokedTokenChecker.isTokenRevoked(
-			tenantId,
-			documentId,
-			claims.jti,
-		);
-		if (tokenRevoked) {
-			throw new Error("Permission denied. Token is revoked.");
-		}
-	}
-
-	if (tokenCacheEnabled && tokenCache) {
-		const options = {
-			requireDocumentId: true,
-			requireTokenExpiryCheck: isTokenExpiryEnabled,
-			maxTokenLifetimeSec,
-			ensureSingleUseToken: false,
-			singleUseTokenCache: undefined,
-			enableTokenCache: tokenCacheEnabled,
-			tokenCache,
-			revokedTokenChecker,
-		};
-		return verifyToken(tenantId, documentId, token, tenantManager, options);
-	}
-
-	return tenantManager.verifyToken(claims.tenantId, token);
+	const options = {
+		requireDocumentId: true,
+		requireTokenExpiryCheck: isTokenExpiryEnabled,
+		maxTokenLifetimeSec,
+		ensureSingleUseToken: false,
+		singleUseTokenCache: undefined,
+		enableTokenCache: tokenCacheEnabled,
+		tokenCache,
+		revokedTokenChecker,
+	};
+	return verifyToken(tenantId, documentId, token, tenantManager, options);
 }
 
 async function checkDocumentExistence(


### PR DESCRIPTION
Previously in the PR: https://github.com/microsoft/FluidFramework/pull/15612/files
I refactored the token validation flow to group the logic in one function: verifyToken
For safety reason, it is guarded by this flag: enableTokenCache. this flag enableTokenCache not only controls whether we use token cache or not, but also controls whether we use the new validation function (refactored function: verifyToken).

Token cache change has been deployed and validated in FRS. Now we don't need to keep the old token validation flow anymore.

This PR just removes the old code path in token validation while keep the logic same as before. The removed logic should already be covered in verifyToken function, regardless of the enableTokenCache flag.

Within the enableTokenCache, it has all the logics to validate a token:
- valid claims
- token expired or not
- token revoked or not
- single token check if enabled
- use cached token if enabled
- send request to riddler for token validation if cache is not enabled or token not found in cache.
