### PR TITLE
Remove deprecated members from PureDataObject (re-applies breaking change reverted for 6.x)

### DIFF
--- a/.changeset/sad-pants-sort.md
+++ b/.changeset/sad-pants-sort.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/aqueduct": major
+---
+
+EventForwarder and IDisposable members removed from PureDataObject
+
+The `EventForwarder` and `IDisposable` members of `PureDataObject` were deprecated in 2.0.0-internal.5.2.0 and have now been removed.
+
+If your code was overriding any methods/properties from `EventForwarder` and or `IDisposable` on a class that inherits
+(directly or transitively) from `PureDataObject`, you'll have to remove the `override` keyword.

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -6,8 +6,6 @@
 
 import { AsyncFluidObjectProvider } from '@fluidframework/synthesize';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
-import type { EventEmitter } from 'events';
-import { EventForwarder } from '@fluidframework/common-utils';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { FluidObjectSymbolProvider } from '@fluidframework/synthesize';
@@ -18,7 +16,6 @@ import { IContainerRuntime } from '@fluidframework/container-runtime-definitions
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
 import { IContainerRuntimeOptions } from '@fluidframework/container-runtime';
 import { IEvent } from '@fluidframework/core-interfaces';
-import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IFluidDataStoreContext } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreContextDetached } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
@@ -39,6 +36,7 @@ import { NamedFluidDataStoreRegistryEntry } from '@fluidframework/runtime-defini
 import { RequestParser } from '@fluidframework/runtime-utils';
 import { RuntimeFactoryHelper } from '@fluidframework/runtime-utils';
 import { RuntimeRequestHandler } from '@fluidframework/request-handler';
+import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
 export class BaseContainerRuntimeFactory extends RuntimeFactoryHelper implements IProvideFluidDataStoreRegistry {
@@ -121,16 +119,10 @@ export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
 export const mountableViewRequestHandler: (MountableViewClass: IFluidMountableViewClass, handlers: RuntimeRequestHandler[]) => (request: RequestParser, runtime: IContainerRuntime) => Promise<IResponse>;
 
 // @public
-export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends EventForwarder<I["Events"] & IEvent> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle {
+export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends TypedEventEmitter<I["Events"] & IEvent> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle {
     constructor(props: IDataObjectProps<I>);
     protected readonly context: IFluidDataStoreContext;
-    // @deprecated
-    dispose(): void;
-    // @deprecated (undocumented)
-    get disposed(): boolean;
     finishInitialization(existing: boolean): Promise<void>;
-    // @deprecated (undocumented)
-    protected forwardEvent(source: EventEmitter | IEventProvider<I["Events"] & IEvent>, ...events: string[]): void;
     // (undocumented)
     static getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject<DataObjectTypes>>;
     get handle(): IFluidHandle<this>;
@@ -150,14 +142,10 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     protected initializingFromExisting(): Promise<void>;
     // (undocumented)
     protected initProps?: I["InitialState"];
-    // @deprecated (undocumented)
-    protected static isEmitterEvent(event: string): boolean;
     protected preInitialize(): Promise<void>;
     protected readonly providers: AsyncFluidObjectProvider<I["OptionalProviders"]>;
     request(req: IRequest): Promise<IResponse>;
     protected readonly runtime: IFluidDataStoreRuntime;
-    // @deprecated (undocumented)
-    protected unforwardEvent(source: EventEmitter | IEventProvider<I["Events"] & IEvent>, ...events: string[]): void;
 }
 
 // @public

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -106,6 +106,13 @@
 	},
 	"module:es5": "es5/index.js",
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_DataObject": {
+				"backCompat": false
+			},
+			"ClassDeclaration_PureDataObject": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -3,11 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type { EventEmitter } from "events";
-import { assert, EventForwarder } from "@fluidframework/common-utils";
+import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
 	IEvent,
-	IEventProvider,
 	IFluidHandle,
 	IFluidLoadable,
 	IFluidRouter,
@@ -29,11 +27,9 @@ import { DataObjectTypes, IDataObjectProps } from "./types";
  * @typeParam I - The optional input types used to strongly type the data object
  */
 export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes>
-	extends EventForwarder<I["Events"] & IEvent>
+	extends TypedEventEmitter<I["Events"] & IEvent>
 	implements IFluidLoadable, IFluidRouter, IProvideFluidHandle
 {
-	private _disposed = false;
-
 	/**
 	 * This is your FluidDataStoreRuntime object
 	 */
@@ -56,14 +52,6 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 	protected initProps?: I["InitialState"];
 
 	protected initializeP: Promise<void> | undefined;
-
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - PureDataObject does not provide a functioning built-in disposed flow.
-	 * This member will be removed in an upcoming release.
-	 */
-	public get disposed() {
-		return this._disposed;
-	}
 
 	public get id() {
 		return this.runtime.id;
@@ -107,12 +95,6 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 			0x0bd /* "Object runtime already has DataObject!" */,
 		);
 		(this.runtime as any)._dataObject = this;
-
-		// Container event handlers
-		this.runtime.once("dispose", () => {
-			this._disposed = true;
-			this.dispose();
-		});
 	}
 
 	// #region IFluidRouter
@@ -193,42 +175,4 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 	 * Called every time the data store is initialized after create or existing.
 	 */
 	protected async hasInitialized(): Promise<void> {}
-
-	/**
-	 * Called when the host container closes and disposes itself
-	 * @deprecated 2.0.0-internal.5.2.0 - Dispose does nothing and will be removed in an upcoming release.
-	 */
-	public dispose(): void {
-		super.dispose();
-	}
-
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - PureDataObject does not actually set up to forward events, and will not be an EventForwarder
-	 * in a future release.
-	 */
-	protected static isEmitterEvent(event: string): boolean {
-		return super.isEmitterEvent(event);
-	}
-
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - PureDataObject does not actually set up to forward events, and will not be an EventForwarder
-	 * in a future release.
-	 */
-	protected forwardEvent(
-		source: EventEmitter | IEventProvider<I["Events"] & IEvent>,
-		...events: string[]
-	): void {
-		super.forwardEvent(source, ...events);
-	}
-
-	/**
-	 * @deprecated 2.0.0-internal.5.2.0 - PureDataObject does not actually set up to forward events, and will not be an EventForwarder
-	 * in a future release.
-	 */
-	protected unforwardEvent(
-		source: EventEmitter | IEventProvider<I["Events"] & IEvent>,
-		...events: string[]
-	): void {
-		super.unforwardEvent(source, ...events);
-	}
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -83,6 +83,7 @@ declare function get_current_ClassDeclaration_DataObject():
 declare function use_old_ClassDeclaration_DataObject(
     use: TypeOnly<old.DataObject>);
 use_old_ClassDeclaration_DataObject(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DataObject());
 
 /*
@@ -203,6 +204,7 @@ declare function get_current_ClassDeclaration_PureDataObject():
 declare function use_old_ClassDeclaration_PureDataObject(
     use: TypeOnly<old.PureDataObject>);
 use_old_ClassDeclaration_PureDataObject(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_PureDataObject());
 
 /*


### PR DESCRIPTION
## Description

Re-applies some breaking change bits from https://github.com/microsoft/FluidFramework/pull/16283 that we reverted in 6.x to ease the transition into it.

## Breaking Changes

Members of `EventForwarder` and `IDisposable` previously implemented by `PureDataObject`/`DataObject` are now removed. Consumers that extended from either of these classes and overrode members from these interfaces will need to remove the `override` keyword on those members when taking this change.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

