### PR TITLE
update makeField()  to free cursors on delete

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/ProxyTarget.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/ProxyTarget.ts
@@ -22,30 +22,21 @@ export abstract class ProxyTarget<T extends Anchor | FieldAnchor> {
 	public constructor(
 		public readonly context: ProxyContext,
 		cursor: ITreeSubscriptionCursor,
-		private anchor?: T,
+		private readonly anchor: T,
 	) {
 		this.lazyCursor = cursor.fork();
 		context.withCursors.add(this);
-		if (anchor !== undefined) {
-			this.context.withAnchors.add(this);
-		}
+		this.context.withAnchors.add(this);
 	}
 
 	public free(): void {
 		this.lazyCursor.free();
 		this.context.withCursors.delete(this);
-		if (this.anchor !== undefined) {
-			this.forgetAnchor(this.anchor);
-			this.context.withAnchors.delete(this);
-			this.anchor = undefined;
-		}
+		this.forgetAnchor(this.anchor);
+		this.context.withAnchors.delete(this);
 	}
 
 	public getAnchor(): T {
-		if (this.anchor === undefined) {
-			this.anchor = this.buildAnchor();
-			this.context.withAnchors.add(this);
-		}
 		return this.anchor;
 	}
 
@@ -74,8 +65,6 @@ export abstract class ProxyTarget<T extends Anchor | FieldAnchor> {
 		}
 		return this.lazyCursor;
 	}
-
-	protected abstract buildAnchor(): T;
 
 	protected abstract tryMoveCursorToAnchor(
 		anchor: T,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -70,7 +70,7 @@ export function makeField(
 	if (fieldAnchor.parent !== undefined) {
 		const anchorNode =
 			context.forest.anchors.locate(fieldAnchor.parent) ??
-			fail("cursor should point to a node that is not the root of the AnchorSet");
+			fail("parent anchor node should always exist since field is under a node");
 		anchorNode.on("afterDelete", () => {
 			targetSequence.free();
 		});

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -173,10 +173,6 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		return output;
 	}
 
-	protected buildAnchor(): FieldAnchor {
-		return this.cursor.buildFieldAnchor();
-	}
-
 	protected tryMoveCursorToAnchor(
 		anchor: FieldAnchor,
 		cursor: ITreeSubscriptionCursor,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -65,6 +65,8 @@ export function makeField(
 
 	const targetSequence = new FieldProxyTarget(context, fieldSchema, cursor, fieldAnchor);
 	const output = adaptWithProxy(targetSequence, fieldProxyHandler);
+	// Fields currently live as long as their parent does.
+	// For root fields, this means forever, but other cases can be cleaned up when their parent anchor is deleted.
 	if (fieldAnchor.parent !== undefined) {
 		const anchorNode =
 			context.forest.anchors.locate(fieldAnchor.parent) ??

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -103,10 +103,6 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		);
 	}
 
-	protected buildAnchor(): Anchor {
-		return this.context.forest.anchors.track(this.anchorNode);
-	}
-
 	protected tryMoveCursorToAnchor(
 		anchor: Anchor,
 		cursor: ITreeSubscriptionCursor,


### PR DESCRIPTION
## Description

This PR updates the `makeField()` function in `EditableTree.ts` to free cursors and forget delete/forget the anchor when the `"afterDelete"`  `AnchorEvent` is called.