### PR TITLE
refactor: Change chrome port names

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/background/BackgroundScript.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/background/BackgroundScript.ts
@@ -87,7 +87,9 @@ browser.runtime.onConnect.addListener((devtoolsPort: Port): void => {
 						);
 					}
 
-					tabConnection = browser.tabs.connect(tabId, { name: "Background-Content-Port" });
+					tabConnection = browser.tabs.connect(tabId, {
+						name: "Background-Content-Port",
+					});
 
 					console.log(
 						formatBackgroundScriptMessageForLogging(`Connected to tab: ${tabId}.`),

--- a/packages/tools/devtools/devtools-browser-extension/src/background/BackgroundScript.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/background/BackgroundScript.ts
@@ -87,7 +87,7 @@ browser.runtime.onConnect.addListener((devtoolsPort: Port): void => {
 						);
 					}
 
-					tabConnection = browser.tabs.connect(tabId, { name: "Content Script" });
+					tabConnection = browser.tabs.connect(tabId, { name: "Background-Content-Port" });
 
 					console.log(
 						formatBackgroundScriptMessageForLogging(`Connected to tab: ${tabId}.`),

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/BackgroundConnection.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/BackgroundConnection.ts
@@ -162,7 +162,7 @@ export class BackgroundConnection
 
 		// Create a connection to the background page
 		this.backgroundServiceConnection = browser.runtime.connect({
-			name: "Background Script",
+			name: "Devtools-Background-Port",
 		});
 
 		// Relay the tab ID to the background service worker.


### PR DESCRIPTION
## Description

Minor thing for clarity, since the port name is used on both ends in our log messages. I keep getting confused when I see the background script posting something to the "Background Script" port when I know it's not talking to itself :).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).