### PR TITLE
refactor: Move ClientSessionExpiredError from `container-utils` to `container-runtime`

### DIFF
--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -25,7 +25,7 @@ import { LoggingError } from '@fluidframework/telemetry-utils';
 import { ReadOnlyInfo } from '@fluidframework/container-definitions';
 import { UsageError } from '@fluidframework/telemetry-utils';
 
-// @public
+// @public @deprecated
 export class ClientSessionExpiredError extends LoggingError implements IFluidErrorBase {
     constructor(message: string, expiryMs: number);
     // (undocumented)
@@ -113,7 +113,5 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
 }
 
 export { UsageError }
-
-// (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -56,6 +56,11 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
 
 /**
  * Error indicating that a client's session has reached its time limit and is closed.
+ *
+ * @deprecated
+ *
+ * This type is not intended for external use and is being removed from library exports.
+ * No replacement API is intended.
  */
 export class ClientSessionExpiredError extends LoggingError implements IFluidErrorBase {
 	readonly errorType = ContainerErrorTypes.clientSessionExpiredError;

--- a/packages/loader/container-utils/src/index.ts
+++ b/packages/loader/container-utils/src/index.ts
@@ -3,6 +3,16 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @deprecated
+ *
+ * Note: this package is scheduled for deletion.
+ * Remaining exports are here for backwards compatibility and to notify consumers where to look for replacement APIs.
+ * Please do not add any new code or exports to this package.
+ *
+ * @packageDocumentation
+ */
+
 export { DeltaManagerProxyBase } from "./deltaManagerProxyBase";
 export {
 	ClientSessionExpiredError,

--- a/packages/runtime/container-runtime/src/error.ts
+++ b/packages/runtime/container-runtime/src/error.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ContainerErrorTypes } from "@fluidframework/container-definitions";
+import { IFluidErrorBase, LoggingError } from "@fluidframework/telemetry-utils";
+
+/**
+ * Error indicating that a client's session has reached its time limit and is closed.
+ */
+export class ClientSessionExpiredError extends LoggingError implements IFluidErrorBase {
+	readonly errorType = ContainerErrorTypes.clientSessionExpiredError;
+
+	constructor(message: string, readonly expiryMs: number) {
+		super(message, { timeoutMs: expiryMs });
+	}
+}

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -5,7 +5,7 @@
 
 import { Timer } from "@fluidframework/common-utils";
 import { LazyPromise } from "@fluidframework/core-utils";
-import { ClientSessionExpiredError, DataProcessingError } from "@fluidframework/container-utils";
+import { DataProcessingError } from "@fluidframework/container-utils";
 import { IRequest, IRequestHeader } from "@fluidframework/core-interfaces";
 import {
 	gcTreeKey,
@@ -32,6 +32,7 @@ import {
 	InactiveResponseHeaderKey,
 	RuntimeHeaders,
 } from "../containerRuntime";
+import { ClientSessionExpiredError } from "../error";
 import { RefreshSummaryResult } from "../summary";
 import { generateGCConfigs } from "./gcConfigs";
 import {


### PR DESCRIPTION
ClientSessionExpiredError is exclusively used by `container-runtime`. This PR moves a copy of the type from `container-utils` (which is scheduled for removal) to `container-runtime`, where it is no longer exported. The existing copy in `container-utils` has been marked as deprecated.

Also adds a `@packageDocumentation` comment to `container-utils` to notify consumers that the package itself is considered deprecated.