### PR TITLE
Tree: Add test demonstrating sequence rebasing bug

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -865,6 +865,8 @@ function compareCellPositions(
 		0x6a1 /* Lineage should determine order of marks unless one is a new attach */,
 	);
 
+	// BUG 5351: The following assumption is incorrect as `newMark` may be targeting cells which were created on its branch,
+	// which will come after `baseMark` in the final sequence order.
 	// `newMark` points to cells which were emptied before `baseMark` was created.
 	// We use `baseMark`'s tiebreak policy as if `newMark`'s cells were created concurrently and before `baseMark`.
 	// TODO: Use specified tiebreak instead of always tiebreaking left.

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -277,6 +277,18 @@ describe("SequenceField - Sandwich Rebasing", () => {
 		assert.deepEqual(insertB3.change, insertB.change);
 	});
 
+	// This test fails due to the rebaser incorrectly interpreting the order of the cell created by `insertT` and the cell targeted by `deleteB`.
+	// See BUG 5351
+	it.skip("(Insert, delete) ↷ adjacent insert", () => {
+		const insertT = tagChange(Change.insert(0, 1), tag1);
+		const insertA = tagChange(Change.insert(0, 1), tag2);
+		const deleteB = tagChange(Change.delete(0, 1), tag3);
+		const insertA2 = rebaseTagged(insertA, insertT);
+		const inverseA = tagRollbackInverse(invert(insertA), tag4, insertA.revision);
+		const deleteB2 = rebaseTagged(deleteB, inverseA, insertT, insertA2);
+		assert.deepEqual(deleteB2.change, deleteB.change);
+	});
+
 	it("Nested inserts composition", () => {
 		const insertA = tagChange(Change.insert(0, 2), tag1);
 		const insertB = tagChange(Change.insert(1, 1), tag2);


### PR DESCRIPTION
## Description

Currently when rebasing a sequence mark targeting empty cells over a new insert we assume that the new insert's cells are newer than the empty cells, but this is not true if the empty cells were created on the branch we're rebasing. This could be fixed by providing the rebaser the relative order of the cell revisions, or by avoiding sandwich rebasing altogether. This PR adds a comment in the relevant code and a test demonstrating the issue.