### PR TITLE
Perf Benchmark: Add initial set of Plain Matrix tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -24,6 +24,7 @@ import { ISummarizer } from "@fluidframework/container-runtime";
 import { DocumentMap } from "./DocumentMap.js";
 import { DocumentMultipleDds } from "./DocumentMultipleDataStores.js";
 import { DocumentMatrix } from "./DocumentMatrix.js";
+import { DocumentMatrixPlain } from "./DocumentMatrixPlain.js";
 export interface IDocumentCreatorProps {
 	testName: string;
 	provider: ITestObjectProvider;
@@ -83,6 +84,8 @@ export function createDocument(props: IDocumentCreatorProps): IDocumentLoaderAnd
 			return new DocumentMultipleDds(documentProps);
 		case "DocumentMatrix":
 			return new DocumentMatrix(documentProps);
+		case "DocumentMatrixPlain":
+			return new DocumentMatrixPlain(documentProps);
 		default:
 			throw new Error("Invalid document type");
 	}

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
@@ -23,12 +23,24 @@ import {
 	assertDocumentTypeInfo,
 	isDocumentMultipleDataStoresInfo,
 } from "@fluid-internal/test-version-utils";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	ITelemetryLoggerExt,
+} from "@fluidframework/telemetry-utils";
 import {
 	IDocumentLoaderAndSummarizer,
 	IDocumentProps,
 	ISummarizeResult,
 } from "./DocumentCreator.js";
+
+const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+	getRawConfig: (name: string): ConfigTypes => settings[name],
+});
+
+const featureGates = {
+	"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": true,
+};
 
 // Tests usually make use of the default data object provided by the test object provider.
 // However, it only creates a single DDS and in these tests we create multiple (3) DDSes per data store.
@@ -183,6 +195,7 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 	public async initializeDocument(): Promise<void> {
 		this._mainContainer = await this.props.provider.createContainer(this.runtimeFactory, {
 			logger: this.props.logger,
+			configProvider: configProvider(featureGates),
 		});
 		this.props.provider.updateDocumentId(this._mainContainer.resolvedUrl);
 		this.mainDataStore = await requestFluidObject<TestDataObject>(this._mainContainer, "/");
@@ -211,7 +224,7 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 
 		const loader = this.props.provider.createLoader(
 			[[this.props.provider.defaultCodeDetails, this.runtimeFactory]],
-			{ logger: this.props.logger },
+			{ logger: this.props.logger, configProvider: configProvider(featureGates) },
 		);
 		const container2 = await loader.resolve(request);
 		return container2;
@@ -239,6 +252,7 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 				undefined,
 				undefined,
 				this.logger,
+				configProvider(featureGates),
 			);
 
 		const newSummaryVersion = await this.waitForSummary(summarizerClient);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
@@ -1,6 +1,66 @@
 {
 	"documents": [
 		{
+			"testTitle": "Matrix 20k cells (100 x 200 - 100 bytes each)",
+			"documentType": "DocumentMatrixPlain",
+			"documentTypeInfo": {
+				"rowSize": 100,
+				"columnSize": 200,
+				"beginRow": 0,
+				"endRow": 99,
+				"beginColumn": 0,
+				"endColumn": 199,
+				"stringSize": 100
+			},
+			"minSampleCount": 1,
+			"supportedEndpoints": ["local", "odsp"]
+		},
+		{
+			"testTitle": "Matrix 20k cells (1000 x 20 - 100 bytes each)",
+			"documentType": "DocumentMatrixPlain",
+			"documentTypeInfo": {
+				"rowSize": 1000,
+				"columnSize": 20,
+				"beginRow": 0,
+				"endRow": 999,
+				"beginColumn": 0,
+				"endColumn": 19,
+				"stringSize": 100
+			},
+			"minSampleCount": 1,
+			"supportedEndpoints": ["local", "odsp"]
+		},
+		{
+			"testTitle": "Matrix 20k cells (2000 x 10 - 100 bytes each)",
+			"documentType": "DocumentMatrixPlain",
+			"documentTypeInfo": {
+				"rowSize": 2000,
+				"columnSize": 10,
+				"beginRow": 0,
+				"endRow": 1999,
+				"beginColumn": 0,
+				"endColumn": 9,
+				"stringSize": 100
+			},
+			"minSampleCount": 1,
+			"supportedEndpoints": ["local", "odsp"]
+		},
+		{
+			"testTitle": "Matrix 1M x 16k cells (20k with 100 bytes each)",
+			"documentType": "DocumentMatrixPlain",
+			"documentTypeInfo": {
+				"rowSize": 1048576,
+				"columnSize": 16384,
+				"beginRow": 1048476,
+				"endRow": 1048575,
+				"beginColumn": 16184,
+				"endColumn": 16383,
+				"stringSize": 100
+			},
+			"minSampleCount": 1,
+			"supportedEndpoints": ["local", "odsp"]
+		},
+		{
 			"testTitle": "1Mb Map",
 			"documentType": "DocumentMap",
 			"documentTypeInfo": {

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -26,7 +26,9 @@ export type DocumentType =
 	/** Document with Multiple DataStores */
 	| "DocumentMultipleDataStores"
 	/** Document with a SharedMatrix */
-	| "DocumentMatrix";
+	| "DocumentMatrix"
+	/** Document with a SharedMatrix and plain objects */
+	| "DocumentMatrixPlain";
 
 export interface DocumentMapInfo {
 	numberOfItems: number;
@@ -44,10 +46,24 @@ export interface DocumentMatrixInfo {
 	stringSize: number;
 }
 
+export interface DocumentMatrixPlainInfo {
+	// Actual matrix size.
+	rowSize: number;
+	columnSize: number;
+	// Definition of the matrix area to be populated.
+	beginRow: number;
+	endRow: number;
+	beginColumn: number;
+	endColumn: number;
+	// String size in each cell.
+	stringSize: number;
+}
+
 export type DocumentTypeInfo =
 	| DocumentMapInfo
 	| DocumentMultipleDataStoresInfo
-	| DocumentMatrixInfo;
+	| DocumentMatrixInfo
+	| DocumentMatrixPlainInfo;
 
 export interface IE2EDocsConfig {
 	documents: DescribeE2EDocInfo[];
@@ -104,7 +120,7 @@ const E2EDefaultDocumentTypes: DescribeE2EDocInfo[] = [
 	},
 	{
 		testTitle: "Matrix 100x100 with SharedStrings",
-		documentType: "DocumentMatrix",
+		documentType: "DocumentMatrixPlain",
 		documentTypeInfo: {
 			rowSize: 100,
 			columnSize: 100,
@@ -141,6 +157,9 @@ export function isDocumentMultipleDataStoresInfo(
 export function isDocumentMatrixInfo(info: DocumentTypeInfo): info is DocumentMatrixInfo {
 	return (info as DocumentMatrixInfo).rowSize !== undefined;
 }
+export function isDocumentMatrixPlainInfo(info: DocumentTypeInfo): info is DocumentMatrixPlainInfo {
+	return (info as DocumentMatrixPlainInfo).rowSize !== undefined;
+}
 
 export function assertDocumentTypeInfo(
 	info: DocumentTypeInfo,
@@ -162,6 +181,11 @@ export function assertDocumentTypeInfo(
 		case "DocumentMatrix":
 			if (!isDocumentMatrixInfo(info)) {
 				throw new Error(`Expected DocumentMatrixInfo but got ${JSON.stringify(info)}`);
+			}
+			break;
+		case "DocumentMatrixPlain":
+			if (!isDocumentMatrixPlainInfo(info)) {
+				throw new Error(`Expected DocumentMatrixPlainInfo but got ${JSON.stringify(info)}`);
 			}
 			break;
 		default:

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -33,10 +33,12 @@ export {
 	DocumentMapInfo,
 	DocumentMultipleDataStoresInfo,
 	DocumentMatrixInfo,
+	DocumentMatrixPlainInfo,
 	assertDocumentTypeInfo,
 	isDocumentMapInfo,
 	isDocumentMultipleDataStoresInfo,
 	isDocumentMatrixInfo,
+	isDocumentMatrixPlainInfo,
 } from "./describeE2eDocs.js";
 export { ExpectedEvents, ExpectsTest, itExpects } from "./itExpects.js";
 export {


### PR DESCRIPTION


## Description

Adding Shared Matrix test that makes use of plain strings (75% random and 25% repeated) - for now we are only enabling on ODSP.  

Also, we are adjusting the existing tests to avoid using cache when downloading the snapshots. 