### PR TITLE
feat: Extension version in usage telemetry

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -8,6 +8,8 @@ import { PostChannel, IChannelConfiguration, IXHROverride } from "@microsoft/1ds
 import { ITelemetryBaseLogger, ITelemetryBaseEvent } from "@fluid-experimental/devtools-view";
 import { ITaggedTelemetryPropertyType } from "@fluidframework/core-interfaces";
 
+const extensionVersion = chrome.runtime.getManifest().version;
+
 const fetchHttpXHROverride: IXHROverride = {
 	sendPOST: (payload, oncomplete, sync) => {
 		const telemetryRequestData =
@@ -117,6 +119,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 			data: {
 				["Event.Time"]: new Date(),
 				["Event.Name"]: eventType, // Same as 'name' but is an actual column in Kusto; useful for cross-table queries
+				["Data.extensionVersion"]: extensionVersion,
 			},
 		};
 

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -43,7 +43,7 @@ export class ConsoleVerboseLogger implements ITelemetryBaseLogger {
 
 	public send(event: ITelemetryBaseEvent): void {
 		// Deliberately using console.debug() instead of console.log() so the events are only shown when the console's
-		// verobsity level is set to "Verbose".
+		// verbosity level is set to "Verbose".
 		console.debug(`USAGE_TELEMETRY: ${JSON.stringify(event)}`);
 		this.baseLogger?.send(event);
 	}


### PR DESCRIPTION
## Description

Adds the version of the browser extension to all telemetry logs sent to the remote collection endpoint.

Confirmed that the field shows up in the telemetry logs:

![image](https://github.com/microsoft/FluidFramework/assets/716334/23c1da5a-b101-49a3-8109-4c118e34e3cc)

Supersedes https://github.com/microsoft/FluidFramework/pull/16779.

Also fixes a typo in a comment.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#4995](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4995)