### PR TITLE
feat: Add pm2 stop script

### DIFF
--- a/packages/tools/devtools/devtools-example/README.md
+++ b/packages/tools/devtools/devtools-example/README.md
@@ -23,12 +23,18 @@ You can run this example using the following steps:
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
-This package uses pm2 to setup a cross-package hot reloading solution. When you run `pnpm run start` it will start multiple processes with pm2. pm2 is configured using the [pm2 ecosystem file](./pm2.ecosystem.config.js) and [pm2's offical documentation](https://pm2.keymetrics.io/docs/usage/quick-start/). Here are a few helpful commands:
+This package uses pm2 to setup a cross-package hot reloading solution.
+When you run `pnpm run start` it will start multiple processes with pm2.
+pm2 is configured using the [pm2 ecosystem file](./pm2.ecosystem.config.js) and [pm2's offical documentation](https://pm2.keymetrics.io/docs/usage/quick-start/).
+Here are a few helpful commands:
 
 -   `pm2 list <name of app in pm2.ecosystem.config.js>` Shows all currently running processes managed by pm2 and the status they are in.
 -   `pm2 log <name of app in pm2.ecosystem.config.js>` Shows the typical logs for a given process, what you'd expect to see if you started the app without pm2.
 -   `pm2 delete <name of app in pm2.ecosystem.config.js>` Deletes a specific process managed by pm2
 -   `pm2 delete all` Deletes all the processes managed by pm2
+
+`pnpm run stop` will stop all the processes managed by pm2.
+Use it when you're done testing this application so no processes are left in the background re-compiling the projects on every change.
 
 ### Test
 

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -28,6 +28,7 @@
 		"rebuild": "npm run clean && npm run build",
 		"start": "pm2 start pm2.ecosystem.config.js",
 		"start:client": "webpack serve --config webpack.config.js",
+		"stop": "pm2 stop pm2.ecosystem.config.js",
 		"test": "npm run test:jest",
 		"test:coverage": "npm run test:jest:coverage",
 		"test:jest": "jest --detectOpenHandles",


### PR DESCRIPTION
## Description

Add `stop` script for pm2 usage to avoid long-running background processes. I would have preferred `npm run start` to stay in the foreground and stop all processes on `Ctrl-c` but pm2 doesn't seem to support that.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
