### PR TITLE
fix: Replace instanceof check in test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat, itExpects } from "@fluid-internal/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IErrorBase } from "@fluidframework/core-interfaces";
+import { FluidErrorTypes, IErrorBase } from "@fluidframework/core-interfaces";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import { CompressionAlgorithms, ContainerMessageType } from "@fluidframework/container-runtime";
 import {
@@ -133,11 +133,11 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 			} catch {}
 
 			const error = await errorEvent;
-			assert.ok(error instanceof GenericError);
-			assert.ok(error.getTelemetryProperties().opSize ?? 0 > maxMessageSizeInBytes);
+			assert.equal(error?.errorType, FluidErrorTypes.genericError);
+			assert.ok(error.getTelemetryProperties?.().opSize ?? 0 > maxMessageSizeInBytes);
 
 			// Limit has to be around 1Mb, but we should not assume here precise number.
-			const limit = error.getTelemetryProperties().limit as number;
+			const limit = error.getTelemetryProperties?.().limit as number;
 			assert(limit > maxMessageSizeInBytes / 2);
 			assert(limit < maxMessageSizeInBytes * 2);
 		},


### PR DESCRIPTION
## Description

Replace an `instanceof` check in end-to-end tests with a more type-safe alternative. This is failing in CI but not locally. It started when we moved some error types (`GenericError` included) from container-utils to telemetry-utils, so probably this is ending up with types coming from different packages but I can't quite explain exactly how or why only in CI.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
