### PR TITLE
Cleaning up summary and doc metadata for ephemeral containers

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -220,13 +220,14 @@ async function deleteSummary(
 	if (!repoPerDocEnabled) {
 		throw new NetworkError(501, "Not Implemented");
 	}
-	const lumberjackProperties = {
+	const lumberjackProperties: Record<string, any> = {
 		...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
 		[BaseGitRestTelemetryProperties.repoPerDocEnabled]: repoPerDocEnabled,
 		[BaseGitRestTelemetryProperties.softDelete]: softDelete,
 	};
 	// In repo-per-doc model, the repoManager's path represents the directory that contains summary data.
 	const summaryFolderPath = repoManager.path;
+	lumberjackProperties.summaryFolderPath = summaryFolderPath;
 	Lumberjack.info(`Deleting summary`, lumberjackProperties);
 
 	try {

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -30,6 +30,7 @@ export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
 		lumberjackBaseProperties: Record<string, any>,
 		enableRepositoryManagerMetrics: boolean = false,
 		apiMetricsSamplingPeriod?: number,
+		private readonly isEphemeralContainer?: boolean,
 	) {
 		super(
 			directory,
@@ -77,7 +78,7 @@ export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
 				};
 				return result;
 			});
-		} catch (err) {
+		} catch (err: any) {
 			Lumberjack.error(
 				"getCommits error",
 				{
@@ -88,6 +89,9 @@ export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
 				},
 				err,
 			);
+			if (this.isEphemeralContainer && err?.code === "NotFoundError") {
+				throw new NetworkError(404, "Unable to get commits for ephemeral container.");
+			}
 			throw new NetworkError(500, "Unable to get commits.");
 		}
 	}
@@ -422,6 +426,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 		lumberjackBaseProperties: Record<string, any>,
 		enableRepositoryManagerMetrics: boolean,
 		apiMetricsSamplingPeriod?: number,
+		isEphemeralContainer?: boolean,
 	): IRepositoryManager {
 		return new IsomorphicGitRepositoryManager(
 			fileSystemManager,
@@ -431,6 +436,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 			lumberjackBaseProperties,
 			enableRepositoryManagerMetrics,
 			apiMetricsSamplingPeriod,
+			isEphemeralContainer,
 		);
 	}
 

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
@@ -51,8 +51,9 @@ export class Redis {
 		}
 	}
 
-	public async delete(key: string): Promise<boolean> {
-		const result = await this.client.del(key);
+	public async delete(key: string, appendPrefixToKey = true): Promise<boolean> {
+		const keyToDelete = appendPrefixToKey ? this.getKey(key) : key;
+		const result = await this.client.del(keyToDelete);
 		// The DEL API in Redis returns the number of keys that were removed.
 		// We always call Redis DEL with one key only, so we expect a result equal to 1
 		// to indicate that the key was removed. 0 would indicate that the key does not exist.

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
@@ -52,7 +52,7 @@ export class Redis {
 	}
 
 	public async delete(key: string): Promise<boolean> {
-		const result = await this.client.del(this.getKey(key));
+		const result = await this.client.del(key);
 		// The DEL API in Redis returns the number of keys that were removed.
 		// We always call Redis DEL with one key only, so we expect a result equal to 1
 		// to indicate that the key was removed. 0 would indicate that the key does not exist.

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
@@ -52,6 +52,10 @@ export class Redis {
 	}
 
 	public async delete(key: string, appendPrefixToKey = true): Promise<boolean> {
+		// If 'appendPrefixToKey' is true, we prepend a prefix to the 'key' parameter.
+		// This is useful in scenarios where we want to consistently manage keys with a common prefix,
+		// If 'appendPrefixToKey' is false, we assume that the 'key' parameter with prefix is already passed in by the caller,
+		// and no additional prefix needs to be added.
 		const keyToDelete = appendPrefixToKey ? this.getKey(key) : key;
 		const result = await this.client.del(keyToDelete);
 		// The DEL API in Redis returns the number of keys that were removed.

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
@@ -295,7 +295,7 @@ export class RedisFs implements IFileSystemPromises {
 				this.redisFsConfig.enableRedisFsMetrics,
 				this.redisFsConfig.redisApiMetricsSamplingPeriod,
 				{
-					folderpathString,
+					key,
 				},
 			);
 		});
@@ -363,6 +363,10 @@ export class RedisFs implements IFileSystemPromises {
 	 */
 	public async rm(filepath: PathLike, options?: RmOptions): Promise<void> {
 		const filepathString = filepath.toString();
+		if (options?.recursive) {
+			return this.rmdir(filepath);
+		}
+
 		await executeRedisFsApi(
 			async () => this.redisFsClient.delete(filepathString),
 			RedisFsApis.Removefile,

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
@@ -289,7 +289,7 @@ export class RedisFs implements IFileSystemPromises {
 
 		const deleteP = keysToRemove.map(async (key) => {
 			return executeRedisFsApi(
-				async () => this.redisFsClient.delete(key),
+				async () => this.redisFsClient.delete(key, false),
 				RedisFsApis.Rmdir,
 				RedisFSConstants.RedisFsApi,
 				this.redisFsConfig.enableRedisFsMetrics,

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -54,6 +54,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 		lumberjackBaseProperties: Record<string, any>,
 		enableRepositoryManagerMetrics: boolean,
 		apiMetricsSamplingPeriod?: number,
+		isEphemeralContainer?: boolean,
 	): IRepositoryManager;
 
 	constructor(
@@ -264,6 +265,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 				lumberjackBaseProperties,
 				this.enableRepositoryManagerMetrics,
 				this.apiMetricsSamplingPeriod,
+				params.isEphemeralContainer,
 			);
 		};
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -251,13 +251,8 @@ export class DeliLambdaFactory
 					const message = `Marked session alive and active as false for closeType:
                         ${JSON.stringify(closeType)}`;
 
-					const lumberjackProperties: Record<string, any> = getLumberBaseProperties(
-						documentId,
-						tenantId,
-					);
-					lumberjackProperties.isEphemeralContainer = document?.isEphemeralContainer;
 					context.log?.info(message, { messageMetaData });
-					Lumberjack.info(message, lumberjackProperties);
+					Lumberjack.info(message, getLumberBaseProperties(documentId, tenantId));
 				}
 			};
 			handler().catch((e) => {

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -96,6 +96,12 @@
 			},
 			"InterfaceDeclaration_ISequencedOperationMessage": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IDocumentRepository": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_MongoDocumentRepository": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -58,6 +58,11 @@ export interface IDocumentRepository {
 	updateOne(filter: any, update: any, options?: any): Promise<void>;
 
 	/**
+	 * Delete one document in the database
+	 */
+	deleteOne(filter: any): Promise<any>;
+
+	/**
 	 * Find and create a document in the database by following option behavior
 	 */
 	findOneOrCreate(

--- a/server/routerlicious/packages/services-core/src/mongoDocumentRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoDocumentRepository.ts
@@ -20,6 +20,10 @@ export class MongoDocumentRepository implements IDocumentRepository {
 			: this.collection.update(filter, update, addToSet, options));
 	}
 
+	async deleteOne(filter: any): Promise<any> {
+		return this.collection.deleteOne(filter);
+	}
+
 	async findOneOrCreate(
 		filter: any,
 		value: any,

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -841,6 +841,7 @@ declare function get_old_InterfaceDeclaration_IDocumentRepository():
 declare function use_current_InterfaceDeclaration_IDocumentRepository(
     use: TypeOnly<current.IDocumentRepository>);
 use_current_InterfaceDeclaration_IDocumentRepository(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDocumentRepository());
 
 /*
@@ -2744,6 +2745,7 @@ declare function get_old_ClassDeclaration_MongoDocumentRepository():
 declare function use_current_ClassDeclaration_MongoDocumentRepository(
     use: TypeOnly<current.MongoDocumentRepository>);
 use_current_ClassDeclaration_MongoDocumentRepository(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MongoDocumentRepository());
 
 /*

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -86,6 +86,10 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_TestNotImplementedDocumentRepository": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -407,6 +407,7 @@ declare function get_old_ClassDeclaration_TestNotImplementedDocumentRepository()
 declare function use_current_ClassDeclaration_TestNotImplementedDocumentRepository(
     use: TypeOnly<current.TestNotImplementedDocumentRepository>);
 use_current_ClassDeclaration_TestNotImplementedDocumentRepository(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestNotImplementedDocumentRepository());
 
 /*

--- a/server/routerlicious/packages/test-utils/src/testNotImplementedDocumentRepository.ts
+++ b/server/routerlicious/packages/test-utils/src/testNotImplementedDocumentRepository.ts
@@ -19,6 +19,10 @@ export class TestNotImplementedDocumentRepository implements IDocumentRepository
 		throw new Error(defaultErrorMsg);
 	}
 
+	async deleteOne(filter: any): Promise<any> {
+		throw new Error(defaultErrorMsg);
+	}
+
 	async findOneOrCreate(
 		filter: any,
 		value: any,


### PR DESCRIPTION
## Description

- This PR deletes the summary related artifacts and the document metadata for ephemeral containers at the end of the session.
- Added recursive rm support
- Also, made a change to throw a 404 instead of 500 when commits are not found for ephemeral containers
- A few telemetry improvements
