### PR TITLE
fix(fluid-build): fix incremental builds for TS 5.1

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -84,7 +84,7 @@
 		"rimraf": "^4.4.1",
 		"run-script-os": "^1.1.6",
 		"syncpack": "^9.8.6",
-		"typescript": "~4.5.5"
+		"typescript": "~5.1.6"
 	},
 	"packageManager": "pnpm@7.33.5+sha512.4e499f22fffe5845aa8f9463e1386b2d72c3134e0ebef9409360ad844fef0290e82b479b32eb2ec0f30e56607e1820c22167829fd62656d41a8fd0cc4a0f4267",
 	"engines": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -145,7 +145,7 @@
 		"rimraf": "^4.4.1",
 		"ts-node": "^10.9.1",
 		"tslib": "^2.6.0",
-		"typescript": "~4.5.5"
+		"typescript": "~5.1.6"
 	},
 	"engines": {
 		"node": ">=14.17.0"

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -66,6 +66,7 @@
 		"sort-package-json": "1.57.0",
 		"ts-morph": "^17.0.1",
 		"type-fest": "^2.19.0",
+		"typescript": "~5.1.6",
 		"yaml": "^2.3.1"
 	},
 	"devDependencies": {
@@ -86,8 +87,7 @@
 		"concurrently": "^7.6.0",
 		"eslint": "~8.6.0",
 		"mocha": "^10.2.0",
-		"prettier": "~2.6.2",
-		"typescript": "~4.5.5"
+		"prettier": "~2.6.2"
 	},
 	"engines": {
 		"node": ">=14.17.0"

--- a/build-tools/packages/build-tools/src/common/fileHashCache.ts
+++ b/build-tools/packages/build-tools/src/common/fileHashCache.ts
@@ -2,22 +2,20 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import crypto from "crypto";
 
+import { sha256 } from "./hash";
 import { readFileAsync } from "./utils";
 
 export class FileHashCache {
 	private fileHashCache = new Map<string, Promise<string>>();
-	private async calcFileHash(path: string) {
-		const content = await readFileAsync(path);
-		return crypto.createHash("sha256").update(content).digest("hex");
-	}
-	public async getFileHash(path: string) {
+
+	public async getFileHash(path: string, hash: (buffer: Buffer) => string = sha256) {
 		const cachedHashP = this.fileHashCache.get(path);
 		if (cachedHashP) {
 			return cachedHashP;
 		}
-		const newHashP = this.calcFileHash(path);
+
+		const newHashP = readFileAsync(path).then(hash);
 		this.fileHashCache.set(path, newHashP);
 		return newHashP;
 	}

--- a/build-tools/packages/build-tools/src/common/hash.ts
+++ b/build-tools/packages/build-tools/src/common/hash.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import crypto from "crypto";
+
+export const sha256 = (buffer: Buffer) => {
+	return crypto.createHash("sha256").update(buffer).digest("hex");
+};

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -87,7 +87,10 @@ export class TscTask extends LeafTask {
 				if (this._projectReference) {
 					fullPath = this._projectReference.remapSrcDeclFile(fullPath, config);
 				}
-				const hash = await this.node.buildContext.fileHashCache.getFileHash(fullPath);
+				const hash = await this.node.buildContext.fileHashCache.getFileHash(
+					fullPath,
+					TscUtils.getSourceFileVersion,
+				);
 				const version = typeof fileInfo === "string" ? fileInfo : fileInfo.version;
 				if (hash !== version) {
 					this.traceTrigger(`version mismatch for ${fileName}, ${hash}, ${version}`);

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -35,7 +35,7 @@
 		"jszip": "^3.10.1",
 		"msgpack-lite": "^0.1.26",
 		"pako": "^2.1.0",
-		"typescript": "~4.5.5",
+		"typescript": "~5.1.6",
 		"webpack": "^5.88.1"
 	},
 	"devDependencies": {

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -73,7 +73,7 @@
 		"rimraf": "^4.4.1",
 		"ts-node": "^10.9.1",
 		"tslib": "^2.6.0",
-		"typescript": "~4.5.5"
+		"typescript": "~5.1.6"
 	},
 	"engines": {
 		"node": ">=14.17.0"

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -105,7 +105,7 @@
 		"rimraf": "^4.4.1",
 		"ts-node": "^10.9.1",
 		"tslib": "^2.6.0",
-		"typescript": "~4.5.5"
+		"typescript": "~5.1.6"
 	},
 	"engines": {
 		"node": ">=14.17.0"

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -335,18 +335,18 @@ importers:
       pako: ^2.1.0
       prettier: ~2.6.2
       rimraf: ^4.4.1
-      typescript: ~4.5.5
+      typescript: ~5.1.6
       webpack: ^5.88.1
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
       msgpack-lite: 0.1.26
       pako: 2.1.0
-      typescript: 4.5.5
+      typescript: 5.1.6
       webpack: 5.88.1
     devDependencies:
       '@fluidframework/build-common': 2.0.0
-      '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 2.0.0_qvtltsyn3reahc7lgycismcfiq
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
       '@types/msgpack-lite': 0.1.8
       '@types/node': 14.18.53
@@ -393,17 +393,17 @@ importers:
       semver: ^7.5.4
       ts-node: ^10.9.1
       tslib: ^2.6.0
-      typescript: ~4.5.5
+      typescript: ~5.1.6
     dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-help': 5.2.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-plugins': 3.1.6_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/test': 2.3.27_xwahr3c6nnleznukhncjhj6fk4
-      oclif: 3.9.1_xwahr3c6nnleznukhncjhj6fk4
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-help': 5.2.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-plugins': 3.1.6_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/test': 2.3.27_vliugzio5c6rxk3co27b7rq74a
+      oclif: 3.9.1_vliugzio5c6rxk3co27b7rq74a
       semver: 7.5.4
     devDependencies:
       '@fluidframework/build-common': 2.0.0
-      '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 2.0.0_qvtltsyn3reahc7lgycismcfiq
       '@types/chai': 4.3.5
       '@types/chai-arrays': 2.0.0
       '@types/mocha': 9.1.1
@@ -416,7 +416,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.6.0
       eslint-config-oclif: 4.0.0_eslint@8.6.0
-      eslint-config-oclif-typescript: 1.0.3_kufnqfq7tb5rpdawkdb6g5smma
+      eslint-config-oclif-typescript: 1.0.3_qvtltsyn3reahc7lgycismcfiq
       eslint-config-prettier: 8.5.0_eslint@8.6.0
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
@@ -425,9 +425,9 @@ importers:
       nyc: 15.1.0
       prettier: 2.6.2
       rimraf: 4.4.1
-      ts-node: 10.9.1_xwahr3c6nnleznukhncjhj6fk4
+      ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
       tslib: 2.6.0
-      typescript: 4.5.5
+      typescript: 5.1.6
 
   packages/version-tools:
     specifiers:
@@ -467,23 +467,23 @@ importers:
       table: ^6.8.1
       ts-node: ^10.9.1
       tslib: ^2.6.0
-      typescript: ~4.5.5
+      typescript: ~5.1.6
     dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-autocomplete': 2.3.1_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-commands': 2.2.17_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-help': 5.2.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-not-found': 2.3.27_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-plugins': 3.1.6_xwahr3c6nnleznukhncjhj6fk4
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-autocomplete': 2.3.1_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-commands': 2.2.17_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-help': 5.2.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-not-found': 2.3.27_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-plugins': 3.1.6_vliugzio5c6rxk3co27b7rq74a
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
     devDependencies:
       '@fluid-internal/readme-command': link:../readme-command
       '@fluidframework/build-common': 2.0.0
-      '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 2.0.0_qvtltsyn3reahc7lgycismcfiq
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
-      '@oclif/test': 2.3.27_xwahr3c6nnleznukhncjhj6fk4
+      '@oclif/test': 2.3.27_vliugzio5c6rxk3co27b7rq74a
       '@types/chai': 4.3.5
       '@types/mocha': 9.1.1
       '@types/node': 14.18.53
@@ -494,19 +494,19 @@ importers:
       cross-env: 7.0.3
       eslint: 8.6.0
       eslint-config-oclif: 4.0.0_eslint@8.6.0
-      eslint-config-oclif-typescript: 1.0.3_kufnqfq7tb5rpdawkdb6g5smma
+      eslint-config-oclif-typescript: 1.0.3_qvtltsyn3reahc7lgycismcfiq
       eslint-config-prettier: 8.5.0_eslint@8.6.0
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
       nyc: 15.1.0
-      oclif: 3.9.1_xwahr3c6nnleznukhncjhj6fk4
+      oclif: 3.9.1_vliugzio5c6rxk3co27b7rq74a
       prettier: 2.6.2
       rimraf: 4.4.1
-      ts-node: 10.9.1_xwahr3c6nnleznukhncjhj6fk4
+      ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
       tslib: 2.6.0
-      typescript: 4.5.5
+      typescript: 5.1.6
 
 packages:
 
@@ -1159,32 +1159,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/eslint-config-fluid/2.0.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==}
-    dependencies:
-      '@rushstack/eslint-patch': 1.1.4
-      '@rushstack/eslint-plugin': 0.8.6_kufnqfq7tb5rpdawkdb6g5smma
-      '@rushstack/eslint-plugin-security': 0.2.6_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/eslint-plugin': 5.9.1_i37r4pxnuonvhfobrnldva5ppi
-      '@typescript-eslint/parser': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
-      eslint-config-prettier: 8.5.0_eslint@8.6.0
-      eslint-plugin-editorconfig: 3.2.0_4x3vxi7gdq53yv6dpzqqqrxppq
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
-      eslint-plugin-import: 2.25.4_gyqcce5u2ijhn2hqkipmk56rmu
-      eslint-plugin-jsdoc: 39.3.6_eslint@8.6.0
-      eslint-plugin-promise: 6.0.1_eslint@8.6.0
-      eslint-plugin-react: 7.28.0_eslint@8.6.0
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-unicorn: 40.0.0_eslint@8.6.0
-      eslint-plugin-unused-imports: 2.0.0_fhnxgfsp6r3qynjxjvskmntitm
-    transitivePeerDependencies:
-      - eslint
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-      - typescript
-    dev: true
-
   /@fluidframework/eslint-config-fluid/2.0.0_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==}
     dependencies:
@@ -1762,46 +1736,6 @@ packages:
       - '@swc/wasm'
       - '@types/node'
       - typescript
-    dev: false
-
-  /@oclif/core/2.8.11_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-9wYW6KRSWfB/D+tqeyl/jxmEz/xPXkFJGVWfKaptqHz6FPWNJREjAM945MuJL2Y8NRhMe+ScRlZ3WpdToX5aVQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@types/cli-progress': 3.11.0
-      ansi-escapes: 4.3.2
-      ansi-styles: 4.3.0
-      cardinal: 2.1.1
-      chalk: 4.1.2
-      clean-stack: 3.0.1
-      cli-progress: 3.12.0
-      debug: 4.3.4_supports-color@8.1.1
-      ejs: 3.1.8
-      fs-extra: 9.1.0
-      get-package-type: 0.1.0
-      globby: 11.1.0
-      hyperlinker: 1.0.0
-      indent-string: 4.0.0
-      is-wsl: 2.2.0
-      js-yaml: 3.14.1
-      natural-orderby: 2.0.3
-      object-treeify: 1.1.33
-      password-prompt: 1.1.2
-      semver: 7.5.4
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      supports-color: 8.1.1
-      supports-hyperlinks: 2.3.0
-      ts-node: 10.9.1_xwahr3c6nnleznukhncjhj6fk4
-      tslib: 2.6.0
-      widest-line: 3.1.0
-      wordwrap: 1.0.0
-      wrap-ansi: 7.0.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
 
   /@oclif/plugin-autocomplete/2.3.1_typescript@5.1.6:
     resolution: {integrity: sha512-UGkw6UObfkDdM/cwr16iEJW8OKLb4X8ZLG5Lc596Dl6WgW0GnzZjVQIu126koNt1T3jp9Oo9rrT26LbxtdryoQ==}
@@ -1824,22 +1758,6 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
-      chalk: 4.1.2
-      debug: 4.3.4
-      fs-extra: 9.1.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - supports-color
-      - typescript
-    dev: false
-
-  /@oclif/plugin-autocomplete/2.3.1_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-UGkw6UObfkDdM/cwr16iEJW8OKLb4X8ZLG5Lc596Dl6WgW0GnzZjVQIu126koNt1T3jp9Oo9rrT26LbxtdryoQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
       chalk: 4.1.2
       debug: 4.3.4
       fs-extra: 9.1.0
@@ -1877,19 +1795,6 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-commands/2.2.17_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-shjVZCopCIbTN8I/i/DR7NwqFRMFau++n3+x2ON7JSNRo+zr/lXQUejxv50D64etQ4dP5wyIyvs+t9iN7j//gg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
-    dev: false
-
   /@oclif/plugin-help/5.2.11_typescript@5.1.6:
     resolution: {integrity: sha512-B2cGOyRskorr8NiGrmIBYxEK0c4laJo+W16VeEblLVDW8w6BvnSwC6K4Vd6rkKmPHRsgqoYrA5BCfPTwvUdSCg==}
     engines: {node: '>=12.0.0'}
@@ -1907,18 +1812,6 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
-    dev: false
-
-  /@oclif/plugin-help/5.2.11_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-B2cGOyRskorr8NiGrmIBYxEK0c4laJo+W16VeEblLVDW8w6BvnSwC6K4Vd6rkKmPHRsgqoYrA5BCfPTwvUdSCg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -1945,20 +1838,6 @@ packages:
     dependencies:
       '@oclif/color': 1.0.7
       '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
-      fast-levenshtein: 3.0.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
-    dev: false
-
-  /@oclif/plugin-not-found/2.3.27_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-L4AEoq73z3Zz+NhhxlA/xPK2LCuEPPS4X5d0Z6r/FCZIvy/cBRNjqbeNs5zhc985YHo1hpzwuVZt0G6WH0fBUQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/color': 1.0.7
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -2018,32 +1897,6 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-plugins/3.1.6_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-bri3GHqUs2d9mMoqm0/CIef+u+nJrNDzno5xpnB0cg7x3mAhXM/miuzdNz7D8opupuJeiJMv+A/WSMG2nY2IEw==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@oclif/color': 1.0.6
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      chalk: 4.1.2
-      debug: 4.3.4
-      fs-extra: 9.1.0
-      http-call: 5.3.0
-      load-json-file: 5.3.0
-      npm: 9.8.0
-      npm-run-path: 4.0.1
-      semver: 7.5.4
-      shelljs: 0.8.5
-      tslib: 2.6.0
-      validate-npm-package-name: 5.0.0
-      yarn: 1.22.19
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - supports-color
-      - typescript
-    dev: false
-
   /@oclif/plugin-warn-if-update-available/2.0.27_typescript@5.1.6:
     resolution: {integrity: sha512-be6dnM3bhf7r6Jy1rzPjOt5qV5MZtqda4p1krbH9a5Ww6jAsYh6CIeKbIP2zPUFthoejG9wt7UFQt3J110DdMQ==}
     engines: {node: '>=12.0.0'}
@@ -2080,25 +1933,6 @@ packages:
       - '@types/node'
       - supports-color
       - typescript
-    dev: false
-
-  /@oclif/plugin-warn-if-update-available/2.0.27_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-be6dnM3bhf7r6Jy1rzPjOt5qV5MZtqda4p1krbH9a5Ww6jAsYh6CIeKbIP2zPUFthoejG9wt7UFQt3J110DdMQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      chalk: 4.1.2
-      debug: 4.3.4
-      fs-extra: 9.1.0
-      http-call: 5.3.0
-      lodash: 4.17.21
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - supports-color
-      - typescript
 
   /@oclif/test/2.3.27_typescript@5.1.6:
     resolution: {integrity: sha512-qDzV2w5SIBFPPgBCg8/417A4O+fNhKYWZQIZ8gA8qoix51HRVFx9aj5ao32SN9NFTuqOl75pcH7GxKGU3oXlQA==}
@@ -2119,20 +1953,6 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
-      fancy-test: 2.0.28
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - supports-color
-      - typescript
-    dev: false
-
-  /@oclif/test/2.3.27_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-qDzV2w5SIBFPPgBCg8/417A4O+fNhKYWZQIZ8gA8qoix51HRVFx9aj5ao32SN9NFTuqOl75pcH7GxKGU3oXlQA==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
       fancy-test: 2.0.28
     transitivePeerDependencies:
       - '@swc/core'
@@ -2384,19 +2204,6 @@ packages:
     resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
     dev: true
 
-  /@rushstack/eslint-plugin-security/0.2.6_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.3
-      '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
-      eslint: 8.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@rushstack/eslint-plugin-security/0.2.6_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
     peerDependencies:
@@ -2404,19 +2211,6 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.2.3
       '@typescript-eslint/experimental-utils': 5.6.0_qvtltsyn3reahc7lgycismcfiq
-      eslint: 8.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin/0.8.6_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.3
-      '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
       eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
@@ -2790,32 +2584,6 @@ packages:
       '@types/expect': 1.20.4
       '@types/node': 14.18.53
 
-  /@typescript-eslint/eslint-plugin/4.33.0_4m7ogdpa3eknlttnvur5iofgmi:
-    resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.6.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/parser': 4.33.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.3.4
-      eslint: 8.6.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.4
-      regexpp: 3.2.0
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/4.33.0_y4cidrydn2syizi742yjrazmia:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2869,51 +2637,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.9.1_i37r4pxnuonvhfobrnldva5ppi:
-    resolution: {integrity: sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/parser': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/scope-manager': 5.9.1
-      '@typescript-eslint/type-utils': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
-      debug: 4.3.4
-      eslint: 8.6.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.4
-      regexpp: 3.2.0
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/experimental-utils/4.33.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 4.33.0
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.5
-      eslint: 8.6.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/experimental-utils/4.33.0_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2924,24 +2647,6 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0_typescript@5.1.6
-      eslint: 8.6.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/experimental-utils/5.6.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.6.0
-      '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.5
       eslint: 8.6.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.6.0
@@ -2968,24 +2673,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.9.1_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.9.1
-      '@typescript-eslint/types': 5.9.1
-      '@typescript-eslint/typescript-estree': 5.9.1_typescript@4.5.5
-      eslint: 8.6.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/experimental-utils/5.9.1_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3004,26 +2691,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.6.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.33.0
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.5
-      debug: 4.3.4
-      eslint: 8.6.0
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/4.33.0_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3040,26 +2707,6 @@ packages:
       debug: 4.3.4
       eslint: 8.6.0
       typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser/5.9.1_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.9.1
-      '@typescript-eslint/types': 5.9.1
-      '@typescript-eslint/typescript-estree': 5.9.1_typescript@4.5.5
-      debug: 4.3.4
-      eslint: 8.6.0
-      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3108,25 +2755,6 @@ packages:
       '@typescript-eslint/visitor-keys': 5.9.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.9.1_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
-      debug: 4.3.4
-      eslint: 8.6.0
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/type-utils/5.9.1_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3161,27 +2789,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/4.33.0_typescript@4.5.5:
-    resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/4.33.0_typescript@5.1.6:
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3203,27 +2810,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.5:
-    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/visitor-keys': 5.6.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.6.0_typescript@5.1.6:
     resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3241,27 +2827,6 @@ packages:
       semver: 7.5.4
       tsutils: 3.21.0_typescript@5.1.6
       typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree/5.9.1_typescript@4.5.5:
-    resolution: {integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.9.1
-      '@typescript-eslint/visitor-keys': 5.9.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5267,21 +4832,6 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-oclif-typescript/1.0.3_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-TeJKXWBQ3uKMtzgz++UFNWpe1WCx8mfqRuzZy1LirREgRlVv656SkVG4gNZat5rRNIQgfDmTS+YebxK02kfylA==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0_4m7ogdpa3eknlttnvur5iofgmi
-      '@typescript-eslint/parser': 4.33.0_kufnqfq7tb5rpdawkdb6g5smma
-      eslint-config-xo-space: 0.29.0_eslint@8.6.0
-      eslint-plugin-mocha: 9.0.0_eslint@8.6.0
-      eslint-plugin-node: 11.1.0_eslint@8.6.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - typescript
-    dev: true
-
   /eslint-config-oclif-typescript/1.0.3_qvtltsyn3reahc7lgycismcfiq:
     resolution: {integrity: sha512-TeJKXWBQ3uKMtzgz++UFNWpe1WCx8mfqRuzZy1LirREgRlVv656SkVG4gNZat5rRNIQgfDmTS+YebxK02kfylA==}
     engines: {node: '>=12.0.0'}
@@ -5423,19 +4973,6 @@ packages:
       eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /eslint-plugin-editorconfig/3.2.0_4x3vxi7gdq53yv6dpzqqqrxppq:
-    resolution: {integrity: sha512-XiUg69+qgv6BekkPCjP8+2DMODzPqtLV5i0Q9FO1v40P62pfodG1vjIihVbw/338hS5W26S+8MTtXaAlrg37QQ==}
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.9.1_i37r4pxnuonvhfobrnldva5ppi
-      editorconfig: 0.15.3
-      eslint: 8.6.0
-      klona: 2.0.5
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - supports-color
-      - typescript
     dev: true
 
   /eslint-plugin-editorconfig/3.2.0_wmfc36oedcysqoz7alxdqaji5e:
@@ -8975,41 +8512,6 @@ packages:
       - mem-fs
       - supports-color
       - typescript
-    dev: false
-
-  /oclif/3.9.1_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-gJ8gJrohFY8qEeVBOw7wgAFdwPt2CTTkEFXDTkfUeXap6URIy6ngP7g/E1A2zFt2I0wH/qQHwcfuTpfBbj1+Uw==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    dependencies:
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-help': 5.2.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-not-found': 2.3.27_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-warn-if-update-available': 2.0.27_xwahr3c6nnleznukhncjhj6fk4
-      aws-sdk: 2.1313.0
-      concurrently: 7.6.0
-      debug: 4.3.4
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 8.1.0
-      github-slugger: 1.5.0
-      got: 11.8.6
-      lodash: 4.17.21
-      normalize-package-data: 3.0.3
-      semver: 7.5.4
-      shelljs: 0.8.5
-      tslib: 2.6.0
-      yeoman-environment: 3.19.3
-      yeoman-generator: 5.9.0_yeoman-environment@3.19.3
-      yosay: 2.0.2
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bluebird
-      - encoding
-      - mem-fs
-      - supports-color
-      - typescript
 
   /octokit-pagination-methods/1.1.0:
     resolution: {integrity: sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==}
@@ -10925,36 +10427,6 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /ts-node/10.9.1_xwahr3c6nnleznukhncjhj6fk4:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.53
-      acorn: 8.8.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.5.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -10970,16 +10442,6 @@ packages:
 
   /tslib/2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
-
-  /tsutils/3.21.0_typescript@4.5.5:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.5.5
-    dev: true
 
   /tsutils/3.21.0_typescript@5.1.6:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -11079,6 +10541,7 @@ packages:
     resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /typescript/5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
       rimraf: ^4.4.1
       run-script-os: ^1.1.6
       syncpack: ^9.8.6
-      typescript: ~4.5.5
+      typescript: ~5.1.6
     devDependencies:
       '@commitlint/cli': 17.6.6
       '@commitlint/config-conventional': 17.6.6
       '@commitlint/cz-commitlint': 17.5.0_i4x6owxztfhigiiqlxwntt4k24
-      '@fluid-tools/build-cli': 0.22.0_typescript@4.5.5
+      '@fluid-tools/build-cli': 0.22.0_typescript@5.1.6
       '@fluidframework/build-common': 2.0.0
-      '@fluidframework/build-tools': 0.22.0_typescript@4.5.5
+      '@fluidframework/build-tools': 0.22.0_typescript@5.1.6
       '@microsoft/api-documenter': 7.22.24
       '@microsoft/api-extractor': 7.36.1
       c8: 7.14.0
@@ -53,7 +53,7 @@ importers:
       rimraf: 4.4.1
       run-script-os: 1.1.6
       syncpack: 9.8.6
-      typescript: 4.5.5
+      typescript: 5.1.6
 
   packages/build-cli:
     specifiers:
@@ -131,18 +131,18 @@ importers:
       ts-node: ^10.9.1
       tslib: ^2.6.0
       type-fest: ^2.19.0
-      typescript: ~4.5.5
+      typescript: ~5.1.6
     dependencies:
       '@fluid-tools/version-tools': link:../version-tools
       '@fluidframework/build-tools': link:../build-tools
       '@fluidframework/bundle-size-tools': link:../bundle-size-tools
-      '@oclif/core': 2.8.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-autocomplete': 2.3.1_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-commands': 2.2.17_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-help': 5.2.11_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-not-found': 2.3.27_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/plugin-plugins': 3.1.6_xwahr3c6nnleznukhncjhj6fk4
-      '@oclif/test': 2.3.27_xwahr3c6nnleznukhncjhj6fk4
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-autocomplete': 2.3.1_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-commands': 2.2.17_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-help': 5.2.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-not-found': 2.3.27_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-plugins': 3.1.6_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/test': 2.3.27_vliugzio5c6rxk3co27b7rq74a
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.59.5_@types+node@14.18.53
       async: 3.2.4
@@ -161,7 +161,7 @@ importers:
       minimatch: 7.4.6
       node-fetch: 2.6.9
       npm-check-updates: 16.10.15
-      oclif: 3.9.1_xwahr3c6nnleznukhncjhj6fk4
+      oclif: 3.9.1_vliugzio5c6rxk3co27b7rq74a
       prettier: 2.6.2
       prompts: 2.4.2
       read-pkg-up: 7.0.1
@@ -176,7 +176,7 @@ importers:
     devDependencies:
       '@fluid-internal/readme-command': link:../readme-command
       '@fluidframework/build-common': 2.0.0
-      '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 2.0.0_qvtltsyn3reahc7lgycismcfiq
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
       '@types/async': 3.2.20
       '@types/chai': 4.3.5
@@ -198,7 +198,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.6.0
       eslint-config-oclif: 4.0.0_eslint@8.6.0
-      eslint-config-oclif-typescript: 1.0.3_kufnqfq7tb5rpdawkdb6g5smma
+      eslint-config-oclif-typescript: 1.0.3_qvtltsyn3reahc7lgycismcfiq
       eslint-config-prettier: 8.5.0_eslint@8.6.0
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
@@ -206,9 +206,9 @@ importers:
       moment: 2.29.4
       nyc: 15.1.0
       rimraf: 4.4.1
-      ts-node: 10.9.1_xwahr3c6nnleznukhncjhj6fk4
+      ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
       tslib: 2.6.0
-      typescript: 4.5.5
+      typescript: 5.1.6
 
   packages/build-tools:
     specifiers:
@@ -260,7 +260,7 @@ importers:
       sort-package-json: 1.57.0
       ts-morph: ^17.0.1
       type-fest: ^2.19.0
-      typescript: ~4.5.5
+      typescript: ~5.1.6
       yaml: ^2.3.1
     dependencies:
       '@fluid-tools/version-tools': link:../version-tools
@@ -293,10 +293,11 @@ importers:
       sort-package-json: 1.57.0
       ts-morph: 17.0.1
       type-fest: 2.19.0
+      typescript: 5.1.6
       yaml: 2.3.1
     devDependencies:
       '@fluidframework/build-common': 2.0.0
-      '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 2.0.0_qvtltsyn3reahc7lgycismcfiq
       '@types/async': 3.2.20
       '@types/fs-extra': 8.1.2
       '@types/glob': 7.2.0
@@ -313,7 +314,6 @@ importers:
       eslint: 8.6.0
       mocha: 10.2.0
       prettier: 2.6.2
-      typescript: 4.5.5
 
   packages/bundle-size-tools:
     specifiers:
@@ -780,6 +780,15 @@ packages:
       ajv: 8.12.0
     dev: true
 
+  /@commitlint/config-validator/17.6.7:
+    resolution: {integrity: sha512-vJSncmnzwMvpr3lIcm0I8YVVDJTzyjy7NZAeXbTXy+MPUdAr9pKyyg7Tx/ebOQ9kqzE6O9WT6jg2164br5UdsQ==}
+    engines: {node: '>=v14'}
+    dependencies:
+      '@commitlint/types': 17.4.4
+      ajv: 8.12.0
+    dev: true
+    optional: true
+
   /@commitlint/cz-commitlint/17.5.0_i4x6owxztfhigiiqlxwntt4k24:
     resolution: {integrity: sha512-zW68IvFPuejgbwvWG5SZFkf6g/cniiCsvcphp1WCoA9fn65nnl6kE3VvwbyNRTFpO1Pczpa4OTsaWigQ1jdk7A==}
     engines: {node: '>=v14'}
@@ -854,17 +863,42 @@ packages:
       '@types/node': 14.18.53
       chalk: 4.1.2
       cosmiconfig: 8.2.0
-      cosmiconfig-typescript-loader: 4.2.0_z7gweahxmyulahylrfuwfdwu7u
+      cosmiconfig-typescript-loader: 4.2.0_tazpyvwgkvxwqi6wvc5xpgbgni
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1_ozyin5stzrwwpdpivjxanfahiu
-      typescript: 5.0.4
+      ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
     dev: true
+
+  /@commitlint/load/17.7.1:
+    resolution: {integrity: sha512-S/QSOjE1ztdogYj61p6n3UbkUvweR17FQ0zDbNtoTLc+Hz7vvfS7ehoTMQ27hPSjVBpp7SzEcOQu081RLjKHJQ==}
+    engines: {node: '>=v14'}
+    requiresBuild: true
+    dependencies:
+      '@commitlint/config-validator': 17.6.7
+      '@commitlint/execute-rule': 17.4.0
+      '@commitlint/resolve-extends': 17.6.7
+      '@commitlint/types': 17.4.4
+      '@types/node': 20.4.7
+      chalk: 4.1.2
+      cosmiconfig: 8.2.0
+      cosmiconfig-typescript-loader: 4.2.0_mrt2wnih5zjrgf7emf6zukdxaq
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      lodash.uniq: 4.5.0
+      resolve-from: 5.0.0
+      ts-node: 10.9.1_dvq55o6ihfzbtkatyu52wpt2ee
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+    dev: true
+    optional: true
 
   /@commitlint/message/17.4.2:
     resolution: {integrity: sha512-3XMNbzB+3bhKA1hSAWPCQA3lNxR4zaeQAQcHj0Hx5sVdO6ryXtgUBGGv+1ZCLMgAPRixuc6en+iNAzZ4NzAa8Q==}
@@ -902,6 +936,19 @@ packages:
       resolve-from: 5.0.0
       resolve-global: 1.0.0
     dev: true
+
+  /@commitlint/resolve-extends/17.6.7:
+    resolution: {integrity: sha512-PfeoAwLHtbOaC9bGn/FADN156CqkFz6ZKiVDMjuC2N5N0740Ke56rKU7Wxdwya8R8xzLK9vZzHgNbuGhaOVKIg==}
+    engines: {node: '>=v14'}
+    dependencies:
+      '@commitlint/config-validator': 17.6.7
+      '@commitlint/types': 17.4.4
+      import-fresh: 3.3.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+      resolve-global: 1.0.0
+    dev: true
+    optional: true
 
   /@commitlint/rules/17.6.5:
     resolution: {integrity: sha512-uTB3zSmnPyW2qQQH+Dbq2rekjlWRtyrjDo4aLFe63uteandgkI+cc0NhhbBAzcXShzVk0qqp8SlkQMu0mgHg/A==}
@@ -964,21 +1011,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/build-cli/0.22.0_typescript@4.5.5:
+  /@fluid-tools/build-cli/0.22.0_typescript@5.1.6:
     resolution: {integrity: sha512-WK7EXIHl4/VVsrdGAUZL5DCK5BSin2PqzA/W5ehDD2JKW4jX+Ys1jxT+8/6g/ptwNws83B3orDU2oUb8VWfu2g==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.22.0_typescript@4.5.5
-      '@fluidframework/build-tools': 0.22.0_typescript@4.5.5
+      '@fluid-tools/version-tools': 0.22.0_typescript@5.1.6
+      '@fluidframework/build-tools': 0.22.0_typescript@5.1.6
       '@fluidframework/bundle-size-tools': 0.22.0
-      '@oclif/core': 2.8.11_typescript@4.5.5
-      '@oclif/plugin-autocomplete': 2.3.1_typescript@4.5.5
-      '@oclif/plugin-commands': 2.2.17_typescript@4.5.5
-      '@oclif/plugin-help': 5.2.11_typescript@4.5.5
-      '@oclif/plugin-not-found': 2.3.27_typescript@4.5.5
-      '@oclif/plugin-plugins': 3.1.6_typescript@4.5.5
-      '@oclif/test': 2.3.27_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
+      '@oclif/plugin-autocomplete': 2.3.1_typescript@5.1.6
+      '@oclif/plugin-commands': 2.2.17_typescript@5.1.6
+      '@oclif/plugin-help': 5.2.11_typescript@5.1.6
+      '@oclif/plugin-not-found': 2.3.27_typescript@5.1.6
+      '@oclif/plugin-plugins': 3.1.6_typescript@5.1.6
+      '@oclif/test': 2.3.27_typescript@5.1.6
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.59.5
       async: 3.2.4
@@ -995,7 +1042,7 @@ packages:
       jssm-viz-cli: 5.89.2
       minimatch: 7.4.6
       npm-check-updates: 16.10.15
-      oclif: 3.9.1_typescript@4.5.5
+      oclif: 3.9.1_typescript@5.1.6
       prettier: 2.6.2
       prompts: 2.4.2
       read-pkg-up: 7.0.1
@@ -1021,17 +1068,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.22.0_typescript@4.5.5:
+  /@fluid-tools/version-tools/0.22.0_typescript@5.1.6:
     resolution: {integrity: sha512-XA8OC0OQ06EUiYoP12XmuP2u/7xVx6R2dQq0TRUK3XUhv9q1AY6vcvPZzdG8U4wS9tHiCO/ThDf8dTICJf2NOw==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
-      '@oclif/plugin-autocomplete': 2.3.1_typescript@4.5.5
-      '@oclif/plugin-commands': 2.2.17_typescript@4.5.5
-      '@oclif/plugin-help': 5.2.11_typescript@4.5.5
-      '@oclif/plugin-not-found': 2.3.27_typescript@4.5.5
-      '@oclif/plugin-plugins': 3.1.6_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
+      '@oclif/plugin-autocomplete': 2.3.1_typescript@5.1.6
+      '@oclif/plugin-commands': 2.2.17_typescript@5.1.6
+      '@oclif/plugin-help': 5.2.11_typescript@5.1.6
+      '@oclif/plugin-not-found': 2.3.27_typescript@5.1.6
+      '@oclif/plugin-plugins': 3.1.6_typescript@5.1.6
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -1048,12 +1095,12 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.22.0_typescript@4.5.5:
+  /@fluidframework/build-tools/0.22.0_typescript@5.1.6:
     resolution: {integrity: sha512-KqQ6v0ut8dEPpA9x9jGD/MjOzMx9JtMtrLf08vxUQCcQNZqQVELOVeM2wjf1n2NV9Oj8ejlcsL8pkT24oWIETA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.22.0_typescript@4.5.5
+      '@fluid-tools/version-tools': 0.22.0_typescript@5.1.6
       '@fluidframework/bundle-size-tools': 0.22.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
@@ -1122,6 +1169,32 @@ packages:
       '@typescript-eslint/parser': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
       eslint-config-prettier: 8.5.0_eslint@8.6.0
       eslint-plugin-editorconfig: 3.2.0_4x3vxi7gdq53yv6dpzqqqrxppq
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
+      eslint-plugin-import: 2.25.4_gyqcce5u2ijhn2hqkipmk56rmu
+      eslint-plugin-jsdoc: 39.3.6_eslint@8.6.0
+      eslint-plugin-promise: 6.0.1_eslint@8.6.0
+      eslint-plugin-react: 7.28.0_eslint@8.6.0
+      eslint-plugin-tsdoc: 0.2.17
+      eslint-plugin-unicorn: 40.0.0_eslint@8.6.0
+      eslint-plugin-unused-imports: 2.0.0_fhnxgfsp6r3qynjxjvskmntitm
+    transitivePeerDependencies:
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
+    dev: true
+
+  /@fluidframework/eslint-config-fluid/2.0.0_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==}
+    dependencies:
+      '@rushstack/eslint-patch': 1.1.4
+      '@rushstack/eslint-plugin': 0.8.6_qvtltsyn3reahc7lgycismcfiq
+      '@rushstack/eslint-plugin-security': 0.2.6_qvtltsyn3reahc7lgycismcfiq
+      '@typescript-eslint/eslint-plugin': 5.9.1_emxmh7nqtmkkxg3e3bawst6t3i
+      '@typescript-eslint/parser': 5.9.1_qvtltsyn3reahc7lgycismcfiq
+      eslint-config-prettier: 8.5.0_eslint@8.6.0
+      eslint-plugin-editorconfig: 3.2.0_wmfc36oedcysqoz7alxdqaji5e
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
       eslint-plugin-import: 2.25.4_gyqcce5u2ijhn2hqkipmk56rmu
       eslint-plugin-jsdoc: 39.3.6_eslint@8.6.0
@@ -1611,7 +1684,7 @@ packages:
       supports-color: 8.1.1
       tslib: 2.6.0
 
-  /@oclif/core/2.8.11_typescript@4.5.5:
+  /@oclif/core/2.8.11_typescript@5.1.6:
     resolution: {integrity: sha512-9wYW6KRSWfB/D+tqeyl/jxmEz/xPXkFJGVWfKaptqHz6FPWNJREjAM945MuJL2Y8NRhMe+ScRlZ3WpdToX5aVQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
@@ -1639,7 +1712,7 @@ packages:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.1_typescript@4.5.5
+      ts-node: 10.9.1_typescript@5.1.6
       tslib: 2.6.0
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -1650,6 +1723,46 @@ packages:
       - '@types/node'
       - typescript
     dev: true
+
+  /@oclif/core/2.8.11_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-9wYW6KRSWfB/D+tqeyl/jxmEz/xPXkFJGVWfKaptqHz6FPWNJREjAM945MuJL2Y8NRhMe+ScRlZ3WpdToX5aVQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@types/cli-progress': 3.11.0
+      ansi-escapes: 4.3.2
+      ansi-styles: 4.3.0
+      cardinal: 2.1.1
+      chalk: 4.1.2
+      clean-stack: 3.0.1
+      cli-progress: 3.12.0
+      debug: 4.3.4_supports-color@8.1.1
+      ejs: 3.1.8
+      fs-extra: 9.1.0
+      get-package-type: 0.1.0
+      globby: 11.1.0
+      hyperlinker: 1.0.0
+      indent-string: 4.0.0
+      is-wsl: 2.2.0
+      js-yaml: 3.14.1
+      natural-orderby: 2.0.3
+      object-treeify: 1.1.33
+      password-prompt: 1.1.2
+      semver: 7.5.4
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      supports-color: 8.1.1
+      supports-hyperlinks: 2.3.0
+      ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
+      tslib: 2.6.0
+      widest-line: 3.1.0
+      wordwrap: 1.0.0
+      wrap-ansi: 7.0.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+    dev: false
 
   /@oclif/core/2.8.11_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-9wYW6KRSWfB/D+tqeyl/jxmEz/xPXkFJGVWfKaptqHz6FPWNJREjAM945MuJL2Y8NRhMe+ScRlZ3WpdToX5aVQ==}
@@ -1690,11 +1803,11 @@ packages:
       - '@types/node'
       - typescript
 
-  /@oclif/plugin-autocomplete/2.3.1_typescript@4.5.5:
+  /@oclif/plugin-autocomplete/2.3.1_typescript@5.1.6:
     resolution: {integrity: sha512-UGkw6UObfkDdM/cwr16iEJW8OKLb4X8ZLG5Lc596Dl6WgW0GnzZjVQIu126koNt1T3jp9Oo9rrT26LbxtdryoQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
       chalk: 4.1.2
       debug: 4.3.4
       fs-extra: 9.1.0
@@ -1705,6 +1818,22 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@oclif/plugin-autocomplete/2.3.1_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-UGkw6UObfkDdM/cwr16iEJW8OKLb4X8ZLG5Lc596Dl6WgW0GnzZjVQIu126koNt1T3jp9Oo9rrT26LbxtdryoQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      chalk: 4.1.2
+      debug: 4.3.4
+      fs-extra: 9.1.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+    dev: false
 
   /@oclif/plugin-autocomplete/2.3.1_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-UGkw6UObfkDdM/cwr16iEJW8OKLb4X8ZLG5Lc596Dl6WgW0GnzZjVQIu126koNt1T3jp9Oo9rrT26LbxtdryoQ==}
@@ -1722,11 +1851,11 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-commands/2.2.17_typescript@4.5.5:
+  /@oclif/plugin-commands/2.2.17_typescript@5.1.6:
     resolution: {integrity: sha512-shjVZCopCIbTN8I/i/DR7NwqFRMFau++n3+x2ON7JSNRo+zr/lXQUejxv50D64etQ4dP5wyIyvs+t9iN7j//gg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@swc/core'
@@ -1734,6 +1863,19 @@ packages:
       - '@types/node'
       - typescript
     dev: true
+
+  /@oclif/plugin-commands/2.2.17_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-shjVZCopCIbTN8I/i/DR7NwqFRMFau++n3+x2ON7JSNRo+zr/lXQUejxv50D64etQ4dP5wyIyvs+t9iN7j//gg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+    dev: false
 
   /@oclif/plugin-commands/2.2.17_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-shjVZCopCIbTN8I/i/DR7NwqFRMFau++n3+x2ON7JSNRo+zr/lXQUejxv50D64etQ4dP5wyIyvs+t9iN7j//gg==}
@@ -1748,17 +1890,29 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-help/5.2.11_typescript@4.5.5:
+  /@oclif/plugin-help/5.2.11_typescript@5.1.6:
     resolution: {integrity: sha512-B2cGOyRskorr8NiGrmIBYxEK0c4laJo+W16VeEblLVDW8w6BvnSwC6K4Vd6rkKmPHRsgqoYrA5BCfPTwvUdSCg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
     dev: true
+
+  /@oclif/plugin-help/5.2.11_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-B2cGOyRskorr8NiGrmIBYxEK0c4laJo+W16VeEblLVDW8w6BvnSwC6K4Vd6rkKmPHRsgqoYrA5BCfPTwvUdSCg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+    dev: false
 
   /@oclif/plugin-help/5.2.11_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-B2cGOyRskorr8NiGrmIBYxEK0c4laJo+W16VeEblLVDW8w6BvnSwC6K4Vd6rkKmPHRsgqoYrA5BCfPTwvUdSCg==}
@@ -1771,12 +1925,12 @@ packages:
       - '@types/node'
       - typescript
 
-  /@oclif/plugin-not-found/2.3.27_typescript@4.5.5:
+  /@oclif/plugin-not-found/2.3.27_typescript@5.1.6:
     resolution: {integrity: sha512-L4AEoq73z3Zz+NhhxlA/xPK2LCuEPPS4X5d0Z6r/FCZIvy/cBRNjqbeNs5zhc985YHo1hpzwuVZt0G6WH0fBUQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/color': 1.0.7
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -1784,6 +1938,20 @@ packages:
       - '@types/node'
       - typescript
     dev: true
+
+  /@oclif/plugin-not-found/2.3.27_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-L4AEoq73z3Zz+NhhxlA/xPK2LCuEPPS4X5d0Z6r/FCZIvy/cBRNjqbeNs5zhc985YHo1hpzwuVZt0G6WH0fBUQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@oclif/color': 1.0.7
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      fast-levenshtein: 3.0.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+    dev: false
 
   /@oclif/plugin-not-found/2.3.27_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-L4AEoq73z3Zz+NhhxlA/xPK2LCuEPPS4X5d0Z6r/FCZIvy/cBRNjqbeNs5zhc985YHo1hpzwuVZt0G6WH0fBUQ==}
@@ -1798,12 +1966,12 @@ packages:
       - '@types/node'
       - typescript
 
-  /@oclif/plugin-plugins/3.1.6_typescript@4.5.5:
+  /@oclif/plugin-plugins/3.1.6_typescript@5.1.6:
     resolution: {integrity: sha512-bri3GHqUs2d9mMoqm0/CIef+u+nJrNDzno5xpnB0cg7x3mAhXM/miuzdNz7D8opupuJeiJMv+A/WSMG2nY2IEw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/color': 1.0.6
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
       chalk: 4.1.2
       debug: 4.3.4
       fs-extra: 9.1.0
@@ -1823,6 +1991,32 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@oclif/plugin-plugins/3.1.6_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-bri3GHqUs2d9mMoqm0/CIef+u+nJrNDzno5xpnB0cg7x3mAhXM/miuzdNz7D8opupuJeiJMv+A/WSMG2nY2IEw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@oclif/color': 1.0.6
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      chalk: 4.1.2
+      debug: 4.3.4
+      fs-extra: 9.1.0
+      http-call: 5.3.0
+      load-json-file: 5.3.0
+      npm: 9.8.0
+      npm-run-path: 4.0.1
+      semver: 7.5.4
+      shelljs: 0.8.5
+      tslib: 2.6.0
+      validate-npm-package-name: 5.0.0
+      yarn: 1.22.19
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+    dev: false
 
   /@oclif/plugin-plugins/3.1.6_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-bri3GHqUs2d9mMoqm0/CIef+u+nJrNDzno5xpnB0cg7x3mAhXM/miuzdNz7D8opupuJeiJMv+A/WSMG2nY2IEw==}
@@ -1850,11 +2044,11 @@ packages:
       - typescript
     dev: false
 
-  /@oclif/plugin-warn-if-update-available/2.0.27_typescript@4.5.5:
+  /@oclif/plugin-warn-if-update-available/2.0.27_typescript@5.1.6:
     resolution: {integrity: sha512-be6dnM3bhf7r6Jy1rzPjOt5qV5MZtqda4p1krbH9a5Ww6jAsYh6CIeKbIP2zPUFthoejG9wt7UFQt3J110DdMQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
       chalk: 4.1.2
       debug: 4.3.4
       fs-extra: 9.1.0
@@ -1868,6 +2062,25 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@oclif/plugin-warn-if-update-available/2.0.27_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-be6dnM3bhf7r6Jy1rzPjOt5qV5MZtqda4p1krbH9a5Ww6jAsYh6CIeKbIP2zPUFthoejG9wt7UFQt3J110DdMQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      chalk: 4.1.2
+      debug: 4.3.4
+      fs-extra: 9.1.0
+      http-call: 5.3.0
+      lodash: 4.17.21
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+    dev: false
 
   /@oclif/plugin-warn-if-update-available/2.0.27_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-be6dnM3bhf7r6Jy1rzPjOt5qV5MZtqda4p1krbH9a5Ww6jAsYh6CIeKbIP2zPUFthoejG9wt7UFQt3J110DdMQ==}
@@ -1887,11 +2100,11 @@ packages:
       - supports-color
       - typescript
 
-  /@oclif/test/2.3.27_typescript@4.5.5:
+  /@oclif/test/2.3.27_typescript@5.1.6:
     resolution: {integrity: sha512-qDzV2w5SIBFPPgBCg8/417A4O+fNhKYWZQIZ8gA8qoix51HRVFx9aj5ao32SN9NFTuqOl75pcH7GxKGU3oXlQA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
       fancy-test: 2.0.28
     transitivePeerDependencies:
       - '@swc/core'
@@ -1900,6 +2113,20 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@oclif/test/2.3.27_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-qDzV2w5SIBFPPgBCg8/417A4O+fNhKYWZQIZ8gA8qoix51HRVFx9aj5ao32SN9NFTuqOl75pcH7GxKGU3oXlQA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      fancy-test: 2.0.28
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+    dev: false
 
   /@oclif/test/2.3.27_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-qDzV2w5SIBFPPgBCg8/417A4O+fNhKYWZQIZ8gA8qoix51HRVFx9aj5ao32SN9NFTuqOl75pcH7GxKGU3oXlQA==}
@@ -2170,6 +2397,19 @@ packages:
       - typescript
     dev: true
 
+  /@rushstack/eslint-plugin-security/0.2.6_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.3
+      '@typescript-eslint/experimental-utils': 5.6.0_qvtltsyn3reahc7lgycismcfiq
+      eslint: 8.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@rushstack/eslint-plugin/0.8.6_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
     peerDependencies:
@@ -2177,6 +2417,19 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.2.3
       '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
+      eslint: 8.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin/0.8.6_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.3
+      '@typescript-eslint/experimental-utils': 5.6.0_qvtltsyn3reahc7lgycismcfiq
       eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
@@ -2463,6 +2716,11 @@ packages:
   /@types/node/15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
 
+  /@types/node/20.4.7:
+    resolution: {integrity: sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==}
+    dev: true
+    optional: true
+
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
 
@@ -2558,6 +2816,59 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin/4.33.0_y4cidrydn2syizi742yjrazmia:
+    resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^4.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.6.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 4.33.0_qvtltsyn3reahc7lgycismcfiq
+      '@typescript-eslint/parser': 4.33.0_qvtltsyn3reahc7lgycismcfiq
+      '@typescript-eslint/scope-manager': 4.33.0
+      debug: 4.3.4
+      eslint: 8.6.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.4
+      regexpp: 3.2.0
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@5.1.6
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.9.1_emxmh7nqtmkkxg3e3bawst6t3i:
+    resolution: {integrity: sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.9.1_qvtltsyn3reahc7lgycismcfiq
+      '@typescript-eslint/parser': 5.9.1_qvtltsyn3reahc7lgycismcfiq
+      '@typescript-eslint/scope-manager': 5.9.1
+      '@typescript-eslint/type-utils': 5.9.1_qvtltsyn3reahc7lgycismcfiq
+      debug: 4.3.4
+      eslint: 8.6.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.4
+      regexpp: 3.2.0
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@5.1.6
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin/5.9.1_i37r4pxnuonvhfobrnldva5ppi:
     resolution: {integrity: sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2603,6 +2914,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/4.33.0_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 4.33.0
+      '@typescript-eslint/types': 4.33.0
+      '@typescript-eslint/typescript-estree': 4.33.0_typescript@5.1.6
+      eslint: 8.6.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/experimental-utils/5.6.0_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2621,6 +2950,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.6.0_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.6.0
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@5.1.6
+      eslint: 8.6.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/experimental-utils/5.9.1_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2631,6 +2978,24 @@ packages:
       '@typescript-eslint/scope-manager': 5.9.1
       '@typescript-eslint/types': 5.9.1
       '@typescript-eslint/typescript-estree': 5.9.1_typescript@4.5.5
+      eslint: 8.6.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/experimental-utils/5.9.1_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.9.1
+      '@typescript-eslint/types': 5.9.1
+      '@typescript-eslint/typescript-estree': 5.9.1_typescript@5.1.6
       eslint: 8.6.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.6.0
@@ -2659,6 +3024,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/4.33.0_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.6.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 4.33.0
+      '@typescript-eslint/types': 4.33.0
+      '@typescript-eslint/typescript-estree': 4.33.0_typescript@5.1.6
+      debug: 4.3.4
+      eslint: 8.6.0
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser/5.9.1_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2675,6 +3060,26 @@ packages:
       debug: 4.3.4
       eslint: 8.6.0
       typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser/5.9.1_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.9.1
+      '@typescript-eslint/types': 5.9.1
+      '@typescript-eslint/typescript-estree': 5.9.1_typescript@5.1.6
+      debug: 4.3.4
+      eslint: 8.6.0
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2722,6 +3127,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils/5.9.1_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.9.1_qvtltsyn3reahc7lgycismcfiq
+      debug: 4.3.4
+      eslint: 8.6.0
+      tsutils: 3.21.0_typescript@5.1.6
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types/4.33.0:
     resolution: {integrity: sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -2758,6 +3182,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/4.33.0_typescript@5.1.6:
+    resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 4.33.0
+      '@typescript-eslint/visitor-keys': 4.33.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@5.1.6
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.5:
     resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2779,6 +3224,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.6.0_typescript@5.1.6:
+    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/visitor-keys': 5.6.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@5.1.6
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/5.9.1_typescript@4.5.5:
     resolution: {integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2796,6 +3262,27 @@ packages:
       semver: 7.5.4
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.9.1_typescript@5.1.6:
+    resolution: {integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.9.1
+      '@typescript-eslint/visitor-keys': 5.9.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@5.1.6
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3650,7 +4137,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr/1.1.4:
@@ -4182,7 +4669,23 @@ packages:
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader/4.2.0_z7gweahxmyulahylrfuwfdwu7u:
+  /cosmiconfig-typescript-loader/4.2.0_mrt2wnih5zjrgf7emf6zukdxaq:
+    resolution: {integrity: sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=7'
+      ts-node: '>=10'
+      typescript: '>=3'
+    dependencies:
+      '@types/node': 20.4.7
+      cosmiconfig: 8.2.0
+      ts-node: 10.9.1_dvq55o6ihfzbtkatyu52wpt2ee
+      typescript: 5.1.6
+    dev: true
+    optional: true
+
+  /cosmiconfig-typescript-loader/4.2.0_tazpyvwgkvxwqi6wvc5xpgbgni:
     resolution: {integrity: sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -4193,8 +4696,8 @@ packages:
     dependencies:
       '@types/node': 14.18.53
       cosmiconfig: 8.2.0
-      ts-node: 10.9.1_ozyin5stzrwwpdpivjxanfahiu
-      typescript: 5.0.4
+      ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
+      typescript: 5.1.6
     dev: true
 
   /cosmiconfig/8.1.3:
@@ -4262,7 +4765,7 @@ packages:
       longest: 2.0.1
       word-wrap: 1.2.3
     optionalDependencies:
-      '@commitlint/load': 17.5.0
+      '@commitlint/load': 17.7.1
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4779,6 +5282,21 @@ packages:
       - typescript
     dev: true
 
+  /eslint-config-oclif-typescript/1.0.3_qvtltsyn3reahc7lgycismcfiq:
+    resolution: {integrity: sha512-TeJKXWBQ3uKMtzgz++UFNWpe1WCx8mfqRuzZy1LirREgRlVv656SkVG4gNZat5rRNIQgfDmTS+YebxK02kfylA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 4.33.0_y4cidrydn2syizi742yjrazmia
+      '@typescript-eslint/parser': 4.33.0_qvtltsyn3reahc7lgycismcfiq
+      eslint-config-xo-space: 0.29.0_eslint@8.6.0
+      eslint-plugin-mocha: 9.0.0_eslint@8.6.0
+      eslint-plugin-node: 11.1.0_eslint@8.6.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+    dev: true
+
   /eslint-config-oclif/4.0.0_eslint@8.6.0:
     resolution: {integrity: sha512-5tkUQeC33rHAhJxaGeBGYIflDLumeV2qD/4XLBdXhB/6F/+Jnwdce9wYHSvkx0JUqUQShpQv8JEVkBp/zzD7hg==}
     engines: {node: '>=12.0.0'}
@@ -4899,7 +5417,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
+      '@typescript-eslint/parser': 5.9.1_qvtltsyn3reahc7lgycismcfiq
       debug: 3.2.7
       eslint: 8.6.0
       eslint-import-resolver-node: 0.3.6
@@ -4911,6 +5429,19 @@ packages:
     resolution: {integrity: sha512-XiUg69+qgv6BekkPCjP8+2DMODzPqtLV5i0Q9FO1v40P62pfodG1vjIihVbw/338hS5W26S+8MTtXaAlrg37QQ==}
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.9.1_i37r4pxnuonvhfobrnldva5ppi
+      editorconfig: 0.15.3
+      eslint: 8.6.0
+      klona: 2.0.5
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - supports-color
+      - typescript
+    dev: true
+
+  /eslint-plugin-editorconfig/3.2.0_wmfc36oedcysqoz7alxdqaji5e:
+    resolution: {integrity: sha512-XiUg69+qgv6BekkPCjP8+2DMODzPqtLV5i0Q9FO1v40P62pfodG1vjIihVbw/338hS5W26S+8MTtXaAlrg37QQ==}
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.9.1_emxmh7nqtmkkxg3e3bawst6t3i
       editorconfig: 0.15.3
       eslint: 8.6.0
       klona: 2.0.5
@@ -4982,7 +5513,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.9.1_kufnqfq7tb5rpdawkdb6g5smma
+      '@typescript-eslint/parser': 5.9.1_qvtltsyn3reahc7lgycismcfiq
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -5156,7 +5687,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.9.1_i37r4pxnuonvhfobrnldva5ppi
+      '@typescript-eslint/eslint-plugin': 5.9.1_emxmh7nqtmkkxg3e3bawst6t3i
       eslint: 8.6.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -5734,8 +6265,8 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -8376,15 +8907,15 @@ packages:
       es-abstract: 1.20.1
     dev: true
 
-  /oclif/3.9.1_typescript@4.5.5:
+  /oclif/3.9.1_typescript@5.1.6:
     resolution: {integrity: sha512-gJ8gJrohFY8qEeVBOw7wgAFdwPt2CTTkEFXDTkfUeXap6URIy6ngP7g/E1A2zFt2I0wH/qQHwcfuTpfBbj1+Uw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 2.8.11_typescript@4.5.5
-      '@oclif/plugin-help': 5.2.11_typescript@4.5.5
-      '@oclif/plugin-not-found': 2.3.27_typescript@4.5.5
-      '@oclif/plugin-warn-if-update-available': 2.0.27_typescript@4.5.5
+      '@oclif/core': 2.8.11_typescript@5.1.6
+      '@oclif/plugin-help': 5.2.11_typescript@5.1.6
+      '@oclif/plugin-not-found': 2.3.27_typescript@5.1.6
+      '@oclif/plugin-warn-if-update-available': 2.0.27_typescript@5.1.6
       aws-sdk: 2.1313.0
       concurrently: 7.6.0
       debug: 4.3.4
@@ -8410,6 +8941,41 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /oclif/3.9.1_vliugzio5c6rxk3co27b7rq74a:
+    resolution: {integrity: sha512-gJ8gJrohFY8qEeVBOw7wgAFdwPt2CTTkEFXDTkfUeXap6URIy6ngP7g/E1A2zFt2I0wH/qQHwcfuTpfBbj1+Uw==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      '@oclif/core': 2.8.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-help': 5.2.11_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-not-found': 2.3.27_vliugzio5c6rxk3co27b7rq74a
+      '@oclif/plugin-warn-if-update-available': 2.0.27_vliugzio5c6rxk3co27b7rq74a
+      aws-sdk: 2.1313.0
+      concurrently: 7.6.0
+      debug: 4.3.4
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 8.1.0
+      github-slugger: 1.5.0
+      got: 11.8.6
+      lodash: 4.17.21
+      normalize-package-data: 3.0.3
+      semver: 7.5.4
+      shelljs: 0.8.5
+      tslib: 2.6.0
+      yeoman-environment: 3.19.3
+      yeoman-generator: 5.9.0_yeoman-environment@3.19.3
+      yosay: 2.0.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bluebird
+      - encoding
+      - mem-fs
+      - supports-color
+      - typescript
+    dev: false
 
   /oclif/3.9.1_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-gJ8gJrohFY8qEeVBOw7wgAFdwPt2CTTkEFXDTkfUeXap6URIy6ngP7g/E1A2zFt2I0wH/qQHwcfuTpfBbj1+Uw==}
@@ -10267,7 +10833,69 @@ packages:
       '@ts-morph/common': 0.18.1
       code-block-writer: 11.0.3
 
-  /ts-node/10.9.1_ozyin5stzrwwpdpivjxanfahiu:
+  /ts-node/10.9.1_dvq55o6ihfzbtkatyu52wpt2ee:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 20.4.7
+      acorn: 8.8.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+    optional: true
+
+  /ts-node/10.9.1_typescript@5.1.6:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      acorn: 8.8.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node/10.9.1_vliugzio5c6rxk3co27b7rq74a:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10293,40 +10921,9 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.4
+      typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: true
-
-  /ts-node/10.9.1_typescript@4.5.5:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      acorn: 8.8.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.5.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
 
   /ts-node/10.9.1_xwahr3c6nnleznukhncjhj6fk4:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -10382,6 +10979,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.5.5
+    dev: true
+
+  /tsutils/3.21.0_typescript@5.1.6:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.1.6
     dev: true
 
   /tuf-js/1.1.7:
@@ -10478,6 +11085,11 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
     dev: true
+
+  /typescript/5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   /typical/2.6.1:
     resolution: {integrity: sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==}


### PR DESCRIPTION
The logic in 'fluid-build' that determines when to recompile a TypeScript project includes enumerating the files and their hashes listed in "*.tsbuildinfo" and comparing these with the file's current hash.

In previous versions of TypeScript, the hash stored in *.tsbuildinfo was just the sha256 has of the file contents.  Newer versions of the TypeScript compiler preprocess the source file contents to strip the sourcemap comment at the end of the file (if any), which alters the resulting sha256 hash.

This change alters the TscTask to instead call into the TypeScript compiler's internals to compute the hash.