### PR TITLE
docs: Update FluidErrorBase docs to better take advantage of tsdoc syntax

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -119,7 +119,7 @@ export class GenericError extends LoggingError implements IGenericError, IFluidE
 // @public
 export const getCircularReplacer: () => (key: string, value: any) => any;
 
-// @public (undocumented)
+// @public
 export const hasErrorInstanceId: (x: any) => x is {
     errorInstanceId: string;
 };

--- a/packages/utils/telemetry-utils/src/fluidErrorBase.ts
+++ b/packages/utils/telemetry-utils/src/fluidErrorBase.ts
@@ -6,37 +6,64 @@
 import { ITelemetryProperties } from "@fluidframework/core-interfaces";
 
 /**
+ * An error emitted by the Fluid Framework.
+ *
+ * @remarks
+ *
  * All normalized errors flowing through the Fluid Framework adhere to this readonly interface.
- * It features errorType and errorInstanceId on top of Error's members as readonly,
- * and a getter/setter for telemetry props to be included when the error is logged.
+ *
+ * It features the members of {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error | Error}
+ * made readonly, as well as  {@link IFluidErrorBase.errorType} and {@link IFluidErrorBase.errorInstanceId}.
+ * It also features getters and setters for telemetry props to be included when the error is logged.
  */
 export interface IFluidErrorBase extends Error {
-	/** Classification of what type of error this is, used programmatically by consumers to interpret the error */
+	/**
+	 * Classification of what type of error this is.
+	 *
+	 * @remarks Used programmatically by consumers to interpret the error.
+	 */
 	readonly errorType: string;
 
 	/**
 	 * Error's message property, made readonly.
-	 * Be specific, but also take care when including variable data to consider suitability for aggregation in telemetry
-	 * Also avoid including any data that jeopardizes the user's privacy.  Add a tagged telemetry property instead.
+	 *
+	 * @remarks
+	 *
+	 * Recommendations:
+	 *
+	 * Be specific, but also take care when including variable data to consider suitability for aggregation in telemetry.
+	 * Also avoid including any data that jeopardizes the user's privacy. Add a tagged telemetry property instead.
 	 */
 	readonly message: string;
 
-	/** Error's stack property, made readonly */
+	/**
+	 * See {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack}.
+	 */
 	readonly stack?: string;
 
-	/** Error's name property, made readonly */
+	/**
+	 * See {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name}.
+	 */
 	readonly name: string;
 
 	/**
 	 * A Guid identifying this error instance.
-	 * Useful in telemetry for deduping multiple logging events arising from the same error,
+	 *
+	 * @remarks
+	 *
+	 * Useful in telemetry for deduplicating multiple logging events arising from the same error,
 	 * or correlating an error with an inner error that caused it, in case of error wrapping.
 	 */
 	readonly errorInstanceId: string;
 
-	/** Get the telemetry properties stashed on this error for logging */
+	/**
+	 * Get the telemetry properties stashed on this error for logging.
+	 */
 	getTelemetryProperties(): ITelemetryProperties;
-	/** Add telemetry properties to this error which will be logged with the error */
+
+	/**
+	 * Add telemetry properties to this error which will be logged with the error
+	 */
 	addTelemetryProperties: (props: ITelemetryProperties) => void;
 }
 
@@ -44,10 +71,15 @@ const hasTelemetryPropFunctions = (x: any): boolean =>
 	typeof x?.getTelemetryProperties === "function" &&
 	typeof x?.addTelemetryProperties === "function";
 
+/**
+ * Type guard for error data containing the {@link IFluidErrorBase.errorInstanceId} property.
+ */
 export const hasErrorInstanceId = (x: any): x is { errorInstanceId: string } =>
 	typeof x?.errorInstanceId === "string";
 
-/** type guard for IFluidErrorBase interface */
+/**
+ * Type guard for {@link IFluidErrorBase}.
+ */
 export function isFluidError(e: any): e is IFluidErrorBase {
 	return (
 		typeof e?.errorType === "string" &&
@@ -57,7 +89,9 @@ export function isFluidError(e: any): e is IFluidErrorBase {
 	);
 }
 
-/** type guard for old standard of valid/known errors */
+/**
+ * Type guard for old standard of valid/known errors.
+ */
 export function isValidLegacyError(e: any): e is Omit<IFluidErrorBase, "errorInstanceId"> {
 	return (
 		typeof e?.errorType === "string" &&


### PR DESCRIPTION
Updates docs to take better advantage of TSDoc syntax for our published API docs and to better adhere to our [guidelines](https://github.com/microsoft/FluidFramework/wiki/TSDoc-Guidelines).