### PR TITLE
refactor: Don't use `instanceof` checks against error classes

### DIFF
--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -8,6 +8,7 @@ import { createSandbox } from "sinon";
 import {
 	AttachState,
 	ContainerErrorType,
+	ContainerErrorTypes,
 	IContainerContext,
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
@@ -19,8 +20,6 @@ import {
 } from "@fluidframework/runtime-definitions";
 import {
 	ConfigTypes,
-	DataProcessingError,
-	GenericError,
 	IConfigProviderBase,
 	mixinMonitoringContext,
 	MockLogger,
@@ -217,7 +216,7 @@ describe("Runtime", () => {
 						);
 
 						const error = getFirstContainerError();
-						assert.ok(error instanceof GenericError);
+						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
 					});
 
@@ -231,7 +230,7 @@ describe("Runtime", () => {
 						);
 
 						const error = getFirstContainerError();
-						assert.ok(error instanceof GenericError);
+						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
 					});
 
@@ -247,7 +246,7 @@ describe("Runtime", () => {
 						});
 
 						const error = getFirstContainerError();
-						assert.ok(error instanceof GenericError);
+						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
 					});
 
@@ -259,7 +258,7 @@ describe("Runtime", () => {
 						);
 
 						const error = getFirstContainerError();
-						assert.ok(error instanceof GenericError);
+						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
 						assert.strictEqual(error.error.message, "Any");
 					});
@@ -274,7 +273,7 @@ describe("Runtime", () => {
 						);
 
 						const error = getFirstContainerError();
-						assert.ok(error instanceof GenericError);
+						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
 						assert.strictEqual(error.error.message, "Any");
 					});
@@ -783,7 +782,7 @@ describe("Runtime", () => {
 					// NOTE: any errors returned by getFirstContainerError() are from a variable set in a mock closeFn function passed
 					// around during test setup, which executes when the container runtime causes the context (container) to close.
 					const error = getFirstContainerError();
-					assert.ok(error instanceof DataProcessingError);
+					assert.strictEqual(error.errorType, ContainerErrorTypes.dataProcessingError);
 					assert.strictEqual(
 						error.message,
 						"Runtime detected too many reconnects with no progress syncing local ops.",
@@ -945,7 +944,7 @@ describe("Runtime", () => {
 					// NOTE: any errors returned by getFirstContainerError() are from a variable set in a mock closeFn function passed
 					// around during test setup, which executes when the container runtime causes the context (container) to close.
 					const error = getFirstContainerError();
-					assert.ok(error instanceof DataProcessingError);
+					assert.strictEqual(error.errorType, ContainerErrorTypes.dataProcessingError);
 					assert.strictEqual(
 						error.message,
 						"Runtime detected too many reconnects with no progress syncing local ops.",

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -21,12 +21,20 @@ import {
 import {
 	ConfigTypes,
 	IConfigProviderBase,
+	isFluidError,
+	isILoggingError,
 	mixinMonitoringContext,
 	MockLogger,
 } from "@fluidframework/telemetry-utils";
 import { MockDeltaManager, MockQuorumClients } from "@fluidframework/test-runtime-utils";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IErrorBase, IRequest, IResponse, FluidObject } from "@fluidframework/core-interfaces";
+import {
+	IErrorBase,
+	IRequest,
+	IResponse,
+	FluidObject,
+	IGenericError,
+} from "@fluidframework/core-interfaces";
 import {
 	CompressionAlgorithms,
 	ContainerMessageType,
@@ -258,9 +266,10 @@ describe("Runtime", () => {
 						);
 
 						const error = getFirstContainerError();
+						assert(isFluidError(error));
 						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
-						assert.strictEqual(error.error.message, "Any");
+						assert.strictEqual((error as IGenericError).error.message, "Any");
 					});
 
 					it("Errors propagate to the container when nested", () => {
@@ -273,9 +282,10 @@ describe("Runtime", () => {
 						);
 
 						const error = getFirstContainerError();
+						assert(isFluidError(error));
 						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
 						assert.strictEqual(error.message, expectedOrderSequentiallyErrorMessage);
-						assert.strictEqual(error.error.message, "Any");
+						assert.strictEqual((error as IGenericError).error.message, "Any");
 					});
 
 					it("Batching property set properly", () => {
@@ -787,6 +797,7 @@ describe("Runtime", () => {
 						error.message,
 						"Runtime detected too many reconnects with no progress syncing local ops.",
 					);
+					assert(isILoggingError(error));
 					assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
 					assert.strictEqual(
 						error.getTelemetryProperties().pendingMessages,
@@ -949,6 +960,7 @@ describe("Runtime", () => {
 						error.message,
 						"Runtime detected too many reconnects with no progress syncing local ops.",
 					);
+					assert(isILoggingError(error));
 					assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
 					assert.strictEqual(
 						error.getTelemetryProperties().pendingMessages,

--- a/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
@@ -4,7 +4,7 @@
  */
 import { strict as assert } from "assert";
 import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
-import { UsageError } from "@fluidframework/telemetry-utils";
+import { ContainerErrorTypes } from "@fluidframework/container-definitions";
 import { FluidDataStoreRegistry } from "../dataStoreRegistry";
 
 describe("Data Store Registry Creation Tests", () => {
@@ -20,7 +20,7 @@ describe("Data Store Registry Creation Tests", () => {
 			new FluidDataStoreRegistry(entries as NamedFluidDataStoreRegistryEntries);
 			assert.fail();
 		} catch (error: any) {
-			assert.strictEqual(error instanceof UsageError, true);
+			assert.strictEqual(error.errorType, ContainerErrorTypes.usageError);
 			assert.strictEqual(error.message, "Duplicate entry names exist");
 		}
 	});

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -4,12 +4,15 @@
  */
 
 import assert from "assert";
+import Deque from "double-ended-queue";
+
 import {
 	ContainerErrorTypes,
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import Deque from "double-ended-queue";
+import { isILoggingError } from "@fluidframework/telemetry-utils";
+
 import { IPendingMessageNew, PendingStateManager } from "../pendingStateManager";
 import { BatchManager, BatchMessage } from "../opLifecycle";
 import { ContainerMessageType, ContainerRuntimeMessage } from "..";
@@ -192,7 +195,8 @@ describe("Pending State Manager", () => {
 
 			submitBatch(messages);
 			process(messages);
-			assert.strictEqual(closeError?.errorType, ContainerErrorTypes.dataProcessingError);
+			assert(isILoggingError(closeError));
+			assert.strictEqual(closeError.errorType, ContainerErrorTypes.dataProcessingError);
 			assert.strictEqual(closeError.getTelemetryProperties().hasBatchStart, true);
 			assert.strictEqual(closeError.getTelemetryProperties().hasBatchEnd, false);
 		});
@@ -215,7 +219,8 @@ describe("Pending State Manager", () => {
 						type: "otherType",
 					})),
 				);
-				assert.strictEqual(closeError?.errorType, ContainerErrorTypes.dataProcessingError);
+				assert(isILoggingError(closeError));
+				assert.strictEqual(closeError.errorType, ContainerErrorTypes.dataProcessingError);
 				assert.strictEqual(
 					closeError.getTelemetryProperties().expectedMessageType,
 					MessageType.Operation,

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -4,9 +4,11 @@
  */
 
 import assert from "assert";
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
+import {
+	ContainerErrorTypes,
+	ICriticalContainerError,
+} from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { DataProcessingError } from "@fluidframework/telemetry-utils";
 import Deque from "double-ended-queue";
 import { IPendingMessageNew, PendingStateManager } from "../pendingStateManager";
 import { BatchManager, BatchMessage } from "../opLifecycle";
@@ -190,7 +192,7 @@ describe("Pending State Manager", () => {
 
 			submitBatch(messages);
 			process(messages);
-			assert(closeError instanceof DataProcessingError);
+			assert.strictEqual(closeError?.errorType, ContainerErrorTypes.dataProcessingError);
 			assert.strictEqual(closeError.getTelemetryProperties().hasBatchStart, true);
 			assert.strictEqual(closeError.getTelemetryProperties().hasBatchEnd, false);
 		});
@@ -213,7 +215,7 @@ describe("Pending State Manager", () => {
 						type: "otherType",
 					})),
 				);
-				assert(closeError instanceof DataProcessingError);
+				assert.strictEqual(closeError?.errorType, ContainerErrorTypes.dataProcessingError);
 				assert.strictEqual(
 					closeError.getTelemetryProperties().expectedMessageType,
 					MessageType.Operation,
@@ -238,7 +240,7 @@ describe("Pending State Manager", () => {
 						contents: undefined,
 					})),
 				);
-				assert(closeError instanceof DataProcessingError);
+				assert.strictEqual(closeError?.errorType, ContainerErrorTypes.dataProcessingError);
 			});
 
 			it("stringified message content does not match", () => {
@@ -259,7 +261,7 @@ describe("Pending State Manager", () => {
 						contents: { prop1: true },
 					})),
 				);
-				assert(closeError instanceof DataProcessingError);
+				assert.strictEqual(closeError?.errorType, ContainerErrorTypes.dataProcessingError);
 			});
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -12,7 +12,7 @@ import {
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider, TestFluidObject, timeoutPromise } from "@fluidframework/test-utils";
 import { describeNoCompat, itExpects } from "@fluid-internal/test-version-utils";
-import { DataProcessingError, isILoggingError } from "@fluidframework/telemetry-utils";
+import { isFluidError, isILoggingError } from "@fluidframework/telemetry-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
 	IDocumentMessage,
@@ -20,6 +20,7 @@ import {
 	ISequencedDocumentSystemMessage,
 } from "@fluidframework/protocol-definitions";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { FluidErrorTypes } from "@fluidframework/core-interfaces";
 
 /**
  * In all cases we end up with a permanently corrupt file.
@@ -377,7 +378,8 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
 					assert.fail("expected error");
 				} catch (e) {
 					assert(isILoggingError(e), `${e}`);
-					assert(e instanceof DataProcessingError);
+					assert(isFluidError(e));
+					assert(e.errorType === FluidErrorTypes.dataProcessingError);
 				}
 			},
 		);
@@ -458,7 +460,8 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
 					assert.fail("expected error");
 				} catch (e) {
 					assert(isILoggingError(e), `${e}`);
-					assert(e instanceof DataProcessingError);
+					assert(isFluidError(e));
+					assert(e.errorType === FluidErrorTypes.dataProcessingError);
 				}
 			},
 		);

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -379,7 +379,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
 				} catch (e) {
 					assert(isILoggingError(e), `${e}`);
 					assert(isFluidError(e));
-					assert(e.errorType === FluidErrorTypes.dataProcessingError);
+					assert.strictEqual(e.errorType, FluidErrorTypes.dataProcessingError);
 				}
 			},
 		);


### PR DESCRIPTION
The classes being referenced are in the process of being moved out of the `container-utils` package (which is scheduled for deletion). This PR replaces brittle `instanceof` checks with checks against the `errorType` field, which specifically exists for verifying the kind of error the framework has emitted.