### PR TITLE
Update codespaces to node 18

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'NODE_VERSION' to pick a Node version: 10, 12, 14
 		"args": {
-			"NODE_VERSION": "16"
+			"NODE_VERSION": "18"
 		}
 	},
 	"runArgs": ["--init"],


### PR DESCRIPTION
## Description

Follow-up to https://github.com/microsoft/FluidFramework/pull/16983 so the codespaces instances start getting Node 18.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
