### PR TITLE
Remove local runs from matrix plain test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
@@ -13,7 +13,7 @@
 				"stringSize": 100
 			},
 			"minSampleCount": 1,
-			"supportedEndpoints": ["local", "odsp"]
+			"supportedEndpoints": ["odsp"]
 		},
 		{
 			"testTitle": "Matrix 20k cells (1000 x 20 - 100 bytes each)",
@@ -28,7 +28,7 @@
 				"stringSize": 100
 			},
 			"minSampleCount": 1,
-			"supportedEndpoints": ["local", "odsp"]
+			"supportedEndpoints": ["odsp"]
 		},
 		{
 			"testTitle": "Matrix 20k cells (2000 x 10 - 100 bytes each)",
@@ -43,7 +43,7 @@
 				"stringSize": 100
 			},
 			"minSampleCount": 1,
-			"supportedEndpoints": ["local", "odsp"]
+			"supportedEndpoints": ["odsp"]
 		},
 		{
 			"testTitle": "Matrix 1M x 16k cells (20k with 100 bytes each)",
@@ -58,7 +58,7 @@
 				"stringSize": 100
 			},
 			"minSampleCount": 1,
-			"supportedEndpoints": ["local", "odsp"]
+			"supportedEndpoints": ["odsp"]
 		},
 		{
 			"testTitle": "1Mb Map",


### PR DESCRIPTION
## Description

We started to see some tinylicious failures after [this commit](https://github.com/microsoft/FluidFramework/commit/e3c62f166c9c6b04030d610e210c6cadde0b1d97) . To temporarily address the issue, we are switching the tests to only run against ODSP for now