### PR TITLE
Emit summarize event on every summarize event for better observability

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -6,7 +6,6 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
-import { EventEmitter } from 'events';
 import { FluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
@@ -95,7 +94,7 @@ export enum ContainerMessageType {
 }
 
 // @public
-export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements IContainerRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider {
+export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents & ISummarizerEvents> implements IContainerRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider {
     // Warning: (ae-forgotten-export) The symbol "IContainerRuntimeMetadata" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ISerializedElection" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "IBlobManagerLoadInfo" needs to be exported by the entry point index.d.ts
@@ -485,6 +484,18 @@ export interface ISubmitSummaryOptions extends ISummarizeOptions {
     readonly summaryLogger: ITelemetryLoggerExt;
 }
 
+// @public (undocumented)
+export interface ISummarizeEventProps {
+    // (undocumented)
+    currentAttempt: number;
+    // (undocumented)
+    error?: any;
+    // (undocumented)
+    maxAttempts: number;
+    // (undocumented)
+    result: "success" | "failure" | "canceled";
+}
+
 // @public
 export interface ISummarizeOptions {
     readonly fullTree?: boolean;
@@ -514,7 +525,8 @@ export interface ISummarizeResults {
 
 // @public (undocumented)
 export interface ISummarizerEvents extends IEvent {
-    (event: "summarizingError", listener: (error: ISummarizingWarning) => void): any;
+    // (undocumented)
+    (event: "summarize", listener: (props: ISummarizeEventProps) => void): any;
 }
 
 // @public (undocumented)
@@ -687,7 +699,7 @@ export interface SubmitSummaryFailureData extends IRetriableFailureResult {
 export type SubmitSummaryResult = IBaseSummarizeResult | IGenerateSummaryTreeResult | IUploadSummaryResult | ISubmitSummaryOpResult;
 
 // @public
-export class Summarizer extends EventEmitter implements ISummarizer {
+export class Summarizer extends TypedEventEmitter<ISummarizerEvents> implements ISummarizer {
     constructor(
     runtime: ISummarizerRuntime, configurationGetter: () => ISummaryConfiguration,
     internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection, runCoordinatorCreateFn: (runtime: IConnectableRuntime) => Promise<ICancellableSummarizerController>);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -153,6 +153,7 @@ import {
 	ISummarizeResults,
 	IEnqueueSummarizeOptions,
 	EnqueueSummarizeResult,
+	ISummarizerEvents,
 } from "./summary";
 import { formExponentialFn, Throttler } from "./throttler";
 import {
@@ -658,7 +659,7 @@ export const makeLegacySendBatchFn =
  * It will define the store level mappings.
  */
 export class ContainerRuntime
-	extends TypedEventEmitter<IContainerRuntimeEvents>
+	extends TypedEventEmitter<IContainerRuntimeEvents & ISummarizerEvents>
 	implements IContainerRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider
 {
 	/**
@@ -1618,6 +1619,9 @@ export class ContainerRuntime
 					},
 					this.heuristicsDisabled,
 				);
+				this.summaryManager.on("summarize", (eventProps) => {
+					this.emit("summarize", eventProps);
+				});
 				this.summaryManager.start();
 			}
 		}

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -73,6 +73,7 @@ export {
 	SubmitSummaryFailureData,
 	SummaryStage,
 	IRetriableFailureResult,
+	ISummarizeEventProps,
 } from "./summary";
 export { isStableId, generateStableId, assertIsStableId } from "./id-compressor";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle";

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -11,7 +11,7 @@ export {
 	OrderedClientCollection,
 	OrderedClientElection,
 } from "./orderedClientElection";
-export { RunningSummarizer } from "./runningSummarizer";
+export { defaultMaxAttemptsForSubmitFailures, RunningSummarizer } from "./runningSummarizer";
 export {
 	ICancellableSummarizerController,
 	neverCancelledSummaryToken,
@@ -65,6 +65,7 @@ export {
 	SubmitSummaryFailureData,
 	SummaryStage,
 	IRetriableFailureResult,
+	ISummarizeEventProps,
 } from "./summarizerTypes";
 export {
 	IAckedSummary,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -11,7 +11,13 @@ import {
 	createChildLogger,
 	UsageError,
 } from "@fluidframework/telemetry-utils";
-import { assert, delay, Deferred, PromiseTimer } from "@fluidframework/common-utils";
+import {
+	assert,
+	delay,
+	Deferred,
+	PromiseTimer,
+	TypedEventEmitter,
+} from "@fluidframework/common-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { ISummaryConfiguration } from "../containerRuntime";
@@ -33,6 +39,8 @@ import {
 	ISummarizerRuntime,
 	ISummarizeRunnerTelemetry,
 	IRefreshSummaryAckOptions,
+	ISummarizerEvents,
+	ISummarizeEventProps,
 } from "./summarizerTypes";
 import { IAckedSummary, IClientSummaryWatcher, SummaryCollection } from "./summaryCollection";
 import {
@@ -62,7 +70,7 @@ export const defaultMaxAttemptsForSubmitFailures = 5;
  * track of summaries that it is generating as they are broadcast and acked/nacked.
  * This object is created and controlled by Summarizer object.
  */
-export class RunningSummarizer implements IDisposable {
+export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> implements IDisposable {
 	public static async start(
 		logger: ITelemetryBaseLogger,
 		summaryWatcher: IClientSummaryWatcher,
@@ -177,6 +185,8 @@ export class RunningSummarizer implements IDisposable {
 		private readonly stopSummarizerCallback: (reason: SummarizerStopReason) => void,
 		private readonly runtime: ISummarizerRuntime,
 	) {
+		super();
+
 		const telemetryProps: ISummarizeRunnerTelemetry = {
 			summarizeCount: () => this.summarizeCount,
 			summarizerSuccessfulAttempts: () => this.totalSuccessfulAttempts,
@@ -724,24 +734,25 @@ export class RunningSummarizer implements IDisposable {
 		let maxAttempts = defaultMaxAttempts;
 		let currentAttempt = 0;
 		let retryAfterSeconds: number | undefined;
-		let success = false;
 		let done = false;
+		let result: "success" | "failure" | "canceled" = "success";
 		do {
+			currentAttempt++;
 			if (this.cancellationToken.cancelled) {
-				success = true;
+				result = "canceled";
 				done = true;
 				break;
 			}
 
 			const { summarizeProps, summarizeResult } = attemptSummarize(
-				++currentAttempt,
+				currentAttempt,
 				false /* finalAttempt */,
 			);
 
 			// Ack / nack is the final step, so if it succeeds we're done.
 			const ackNackResult = await summarizeResult.receivedSummaryAckOrNack;
 			if (ackNackResult.success) {
-				success = true;
+				result = "success";
 				done = true;
 				break;
 			}
@@ -759,9 +770,18 @@ export class RunningSummarizer implements IDisposable {
 				retryAfterSeconds = ackNackResult.data?.retryAfterSeconds;
 			}
 
+			// Emit "summarize" event for this failed attempt.
+			result = "failure";
+			const eventProps: ISummarizeEventProps = {
+				result,
+				currentAttempt,
+				maxAttempts,
+				error: ackNackResult.error,
+			};
+			this.emit("summarize", eventProps);
+
 			// If the failure doesn't have "retryAfterSeconds" or the max number of attempts have been done, we're done.
 			if (retryAfterSeconds === undefined || currentAttempt >= maxAttempts - 1) {
-				success = false;
 				done = true;
 			}
 
@@ -780,19 +800,30 @@ export class RunningSummarizer implements IDisposable {
 			}
 		} while (!done);
 
+		// If summarize attempt did not fail, emit "summarize" event and return. A failed attempt may be retried below.
+		if (result !== "failure") {
+			this.emit("summarize", { result, currentAttempt, maxAttempts });
+			return;
+		}
+
 		// If summarization wasn't successful above and the failure contains "retryAfterSeconds", perform one last
 		// attempt. This gives a chance to the runtime to perform additional steps in the last attempt.
-		if (!success && retryAfterSeconds !== undefined) {
+		if (retryAfterSeconds !== undefined) {
 			const { summarizeResult } = attemptSummarize(++currentAttempt, true /* finalAttempt */);
 			// Ack / nack is the final step, so if it succeeds we're done.
 			const ackNackResult = await summarizeResult.receivedSummaryAckOrNack;
-			if (ackNackResult.success) {
-				success = true;
-			}
+			result = ackNackResult.success ? "success" : "failure";
+			const eventProps: ISummarizeEventProps = {
+				result,
+				currentAttempt,
+				maxAttempts,
+				error: ackNackResult.success ? undefined : ackNackResult.error,
+			};
+			this.emit("summarize", eventProps);
 		}
 
 		// If summarization is still unsuccessful, stop the summarizer.
-		if (!success) {
+		if (result === "failure") {
 			this.stopSummarizerCallback("failToSummarize");
 		}
 	}

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -325,11 +325,14 @@ export type SummarizerStopReason =
 	 */
 	| "latestSummaryStateStale";
 
+export interface ISummarizeEventProps {
+	result: "success" | "failure" | "canceled";
+	currentAttempt: number;
+	maxAttempts: number;
+	error?: any;
+}
 export interface ISummarizerEvents extends IEvent {
-	/**
-	 * An event indicating that the Summarizer is having problems summarizing
-	 */
-	(event: "summarizingError", listener: (error: ISummarizingWarning) => void);
+	(event: "summarize", listener: (props: ISummarizeEventProps) => void);
 }
 
 export interface ISummarizer extends IEventProvider<ISummarizerEvents> {

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -38,6 +38,8 @@ import {
 	SubmitSummaryResult,
 	RetriableSummaryError,
 	IGeneratedSummaryStats,
+	ISummarizeEventProps,
+	ISummaryCancellationToken,
 } from "../../summary";
 import {
 	defaultMaxAttempts,
@@ -274,6 +276,7 @@ describe("Runtime", () => {
 			const startRunningSummarizer = async (
 				disableHeuristics?: boolean,
 				submitSummaryCallback: () => Promise<SubmitSummaryResult> = successfulSubmitSummary,
+				cancellationToken: ISummaryCancellationToken = neverCancelledSummaryToken,
 			): Promise<void> => {
 				heuristicData = new SummarizeHeuristicData(0, {
 					refSequenceNumber: 0,
@@ -299,7 +302,7 @@ describe("Runtime", () => {
 					async (options) => {},
 					heuristicData,
 					summaryCollection,
-					neverCancelledSummaryToken,
+					cancellationToken,
 					// stopSummarizerCallback
 					(reason) => {
 						stopCall++;
@@ -1838,6 +1841,174 @@ describe("Runtime", () => {
 
 					await emitNextOp(summaryConfig.maxOps + 1);
 					assertRunCounts(0, 0, 0, "Should not run summarizer");
+				});
+			});
+
+			describe("Summarize events", () => {
+				/**
+				 * Helper function that creates a promise that would resolve when "summarize" event is emitted.
+				 */
+				async function getSummarizeEventPromise() {
+					return new Promise<ISummarizeEventProps>((resolve) => {
+						const handler = (props: ISummarizeEventProps) => {
+							summarizer.off("summarize", handler);
+							resolve(props);
+						};
+						summarizer.on("summarize", handler);
+					});
+				}
+
+				beforeEach(async () => {
+					// Currently, summarize events are only logged with this feature.
+					settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+				});
+
+				it("should emit summarize event with success result", async () => {
+					await startRunningSummarizer();
+					const summarizePromiseP = getSummarizeEventPromise();
+
+					await emitNextOp(summaryConfig.maxOps + 1);
+					await emitAck();
+
+					const eventProps = await summarizePromiseP;
+					const expectedEventProps: ISummarizeEventProps = {
+						result: "success",
+						currentAttempt: 1,
+						maxAttempts: defaultMaxAttempts,
+					};
+					assert.deepStrictEqual(
+						eventProps,
+						expectedEventProps,
+						"Summarize event not as expected",
+					);
+				});
+
+				it("should emit summarize event with failed result", async () => {
+					await startRunningSummarizer();
+					const summarizePromiseP = getSummarizeEventPromise();
+
+					await emitNextOp(summaryConfig.maxOps + 1);
+					await emitNack();
+
+					const { error, ...eventProps } = await summarizePromiseP;
+					const expectedEventProps: ISummarizeEventProps = {
+						result: "failure",
+						currentAttempt: 1,
+						maxAttempts: defaultMaxAttempts,
+					};
+					assert.deepStrictEqual(
+						eventProps,
+						expectedEventProps,
+						"Summarize event not as expected",
+					);
+				});
+
+				it("should emit summarize event with canceled result", async () => {
+					await startRunningSummarizer(
+						undefined /* disableHeuristics */,
+						undefined /* submitSummaryCallback */,
+						{
+							cancelled: true,
+							waitCancelled: new Promise(() => {}),
+						},
+					);
+					const summarizePromiseP = getSummarizeEventPromise();
+
+					await emitNextOp(summaryConfig.maxOps + 1);
+					await emitNack();
+
+					const eventProps = await summarizePromiseP;
+					const expectedEventProps: ISummarizeEventProps = {
+						result: "canceled",
+						currentAttempt: 1,
+						maxAttempts: defaultMaxAttempts,
+					};
+					assert.deepStrictEqual(
+						eventProps,
+						expectedEventProps,
+						"Summarize event not as expected",
+					);
+				});
+
+				it("should emit summarize event for every attempt with nack failure", async () => {
+					await startRunningSummarizer();
+					const retryAfterSeconds = 5;
+					let summarizePromiseP = getSummarizeEventPromise();
+
+					await emitNextOp(summaryConfig.maxOps + 1);
+
+					// Nack failures are attempted defaultMaxAttempts times. Each attempt should emit "summarize" event.
+					for (
+						let attemptNumber = 1;
+						attemptNumber <= defaultMaxAttempts;
+						attemptNumber++
+					) {
+						await emitNack(retryAfterSeconds);
+						const { error, ...eventProps } = await summarizePromiseP;
+						const expectedEventProps: ISummarizeEventProps = {
+							result: "failure",
+							currentAttempt: attemptNumber,
+							maxAttempts: defaultMaxAttempts,
+						};
+						assert.deepStrictEqual(
+							eventProps,
+							expectedEventProps,
+							`Summarize event for attempt ${attemptNumber} not as expected`,
+						);
+
+						summarizePromiseP = getSummarizeEventPromise();
+
+						// Wait for "retryAfterSeconds". The next attempt should start after this.
+						await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+					}
+				});
+
+				it("should emit summarize event for every attempt with submit failure", async () => {
+					const retryAfterSeconds = 5;
+					// Callback that would result in summarization failed during submit.
+					const submitSummaryCallback = async (): Promise<SubmitSummaryResult> => {
+						const error = new RetriableSummaryError(
+							`Fail summarization at base stage`,
+							retryAfterSeconds,
+						);
+						const failedResult: Partial<SubmitSummaryResult> = {
+							stage: "base",
+							referenceSequenceNumber: lastRefSeq,
+							minimumSequenceNumber: 0,
+							error,
+						};
+						return failedResult as SubmitSummaryResult;
+					};
+
+					await startRunningSummarizer(
+						undefined /* disableHeuristics */,
+						submitSummaryCallback,
+					);
+					let summarizePromiseP = getSummarizeEventPromise();
+					await emitNextOp(summaryConfig.maxOps + 1);
+
+					// Submit failures are attempted defaultMaxAttemptsForSubmitFailures times.
+					// Each attempt should emit "summarize" event.
+					for (
+						let attemptNumber = 1;
+						attemptNumber <= defaultMaxAttemptsForSubmitFailures;
+						attemptNumber++
+					) {
+						const { error, ...eventProps } = await summarizePromiseP;
+						const expectedEventProps: ISummarizeEventProps = {
+							result: "failure",
+							currentAttempt: attemptNumber,
+							maxAttempts: defaultMaxAttemptsForSubmitFailures,
+						};
+						assert.deepStrictEqual(
+							eventProps,
+							expectedEventProps,
+							`Summarize event for attempt ${attemptNumber} not as expected`,
+						);
+						summarizePromiseP = getSummarizeEventPromise();
+						// Wait for "retryAfterSeconds". The next attempt should start after this.
+						await tickAndFlushPromises(retryAfterSeconds * 1000 + 1);
+					}
 				});
 			});
 		});


### PR DESCRIPTION
## Description
Added emitting a `summarize` event whenever a summarize attempt completes in `RunningSummarizer`. This event is propagated all the way to the summarizer's parent client where it is emitted by the container runtime. This should provide better observability into summarization and also help us write tests.
Added minimal properties when the event is generated. More properties can be added as and when required.

## Why is this needed
Currently, there is no way today to know when a summarization attempt fails. Summarization success can still be known by waiting for a summary op or ack. This makes it especially hard to write tests where we want to validate summarization attempt failures, retries, etc. For example, [this PR](https://github.com/microsoft/FluidFramework/pull/16961) adds the capability for summarization to succeed after 5 retries. There is no easy way to test this other than adding some nasty hacks.
The other thing that makes this hard is that there is no way to get hold of the summarizer client unless one is explicitly created. So, testing the states of heuristic based summarization is really hard. So, the "summarize" events have to be emitted by the parent client as well.

[AB#5349](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5349)