### PR TITLE
Skip test execution in T9s for op reentry tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -15,11 +15,7 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import {
-	describeNoCompat,
-	itExpectsSkipsFailureOnSpecificDrivers,
-	itSkipsFailureOnSpecificDrivers,
-} from "@fluid-internal/test-version-utils";
+import { describeNoCompat, itExpects } from "@fluid-internal/test-version-utils";
 import { SharedString } from "@fluidframework/sequence";
 import { IContainer } from "@fluidframework/container-definitions";
 import { IMergeTreeInsertMsg } from "@fluidframework/merge-tree";
@@ -89,7 +85,7 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 		await provider.ensureSynchronized();
 	};
 
-	itExpectsSkipsFailureOnSpecificDrivers(
+	itExpects(
 		"Should close the container when submitting an op while processing a batch",
 		[
 			{
@@ -97,8 +93,12 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 				error: "Op was submitted from within a `ensureNoDataModelChanges` callback",
 			},
 		],
-		["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-		async () => {
+		async function () {
+			if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+				// This test is flaky on Tinylicious. ADO:5010
+				this.skip();
+			}
+
 			await setupContainers({
 				...testContainerConfig,
 				runtimeOptions: {
@@ -130,124 +130,120 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 	);
 
 	[false, true].forEach((enableGroupedBatching) => {
-		itSkipsFailureOnSpecificDrivers(
-			`Eventual consistency with op reentry - ${
-				enableGroupedBatching ? "Grouped" : "Regular"
-			} batches`,
-			["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-			async () => {
-				await setupContainers({
-					...testContainerConfig,
-					runtimeOptions: {
-						enableGroupedBatching,
-					},
-				});
+		it(`Eventual consistency with op reentry - ${
+			enableGroupedBatching ? "Grouped" : "Regular"
+		} batches`, async function () {
+			if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+				// This test is flaky on Tinylicious. ADO:5010
+				this.skip();
+			}
 
-				sharedString1.insertText(0, "ad");
-				sharedString1.insertText(1, "c");
-				await provider.ensureSynchronized();
+			await setupContainers({
+				...testContainerConfig,
+				runtimeOptions: {
+					enableGroupedBatching,
+				},
+			});
 
-				sharedString2.on("sequenceDelta", (sequenceDeltaEvent) => {
-					if ((sequenceDeltaEvent.opArgs.op as IMergeTreeInsertMsg).seg === "b") {
-						sharedString2.insertText(3, "x");
-					}
-				});
-				sharedMap2.on("valueChanged", (changed1) => {
-					if (changed1.key !== "key2" && changed1.key !== "key3") {
-						sharedMap2.on("valueChanged", (changed2) => {
-							if (changed2.key !== "key3") {
-								sharedMap2.set("key3", `${sharedMap1.get("key1")} updated`);
-							}
-						});
+			sharedString1.insertText(0, "ad");
+			sharedString1.insertText(1, "c");
+			await provider.ensureSynchronized();
 
-						sharedMap2.set("key2", "3");
-					}
-				});
+			sharedString2.on("sequenceDelta", (sequenceDeltaEvent) => {
+				if ((sequenceDeltaEvent.opArgs.op as IMergeTreeInsertMsg).seg === "b") {
+					sharedString2.insertText(3, "x");
+				}
+			});
+			sharedMap2.on("valueChanged", (changed1) => {
+				if (changed1.key !== "key2" && changed1.key !== "key3") {
+					sharedMap2.on("valueChanged", (changed2) => {
+						if (changed2.key !== "key3") {
+							sharedMap2.set("key3", `${sharedMap1.get("key1")} updated`);
+						}
+					});
 
-				sharedMap1.set("key1", "1");
+					sharedMap2.set("key2", "3");
+				}
+			});
 
-				sharedString1.insertText(1, "b");
-				sharedString2.insertText(0, "y");
-				await provider.ensureSynchronized();
+			sharedMap1.set("key1", "1");
 
-				// The offending container is still alive
-				sharedString2.insertText(0, "z");
-				await provider.ensureSynchronized();
+			sharedString1.insertText(1, "b");
+			sharedString2.insertText(0, "y");
+			await provider.ensureSynchronized();
 
-				assert.strictEqual(sharedString1.getText(), "zyabxcd");
-				assert.strictEqual(
-					sharedString1.getText(),
-					sharedString2.getText(),
-					"SharedString eventual consistency broken",
-				);
+			// The offending container is still alive
+			sharedString2.insertText(0, "z");
+			await provider.ensureSynchronized();
 
-				assert.strictEqual(sharedMap1.get("key1"), "1");
-				assert.strictEqual(sharedMap1.get("key2"), "3");
-				assert.strictEqual(sharedMap1.get("key3"), "1 updated");
-				assert.ok(
-					mapsAreEqual(sharedMap1, sharedMap2),
-					"SharedMap eventual consistency broken",
-				);
+			assert.strictEqual(sharedString1.getText(), "zyabxcd");
+			assert.strictEqual(
+				sharedString1.getText(),
+				sharedString2.getText(),
+				"SharedString eventual consistency broken",
+			);
 
-				// Both containers are alive at the end
-				assert.ok(!container1.closed, "Local container is closed");
-				assert.ok(!container2.closed, "Remote container is closed");
-			},
-		);
+			assert.strictEqual(sharedMap1.get("key1"), "1");
+			assert.strictEqual(sharedMap1.get("key2"), "3");
+			assert.strictEqual(sharedMap1.get("key3"), "1 updated");
+			assert.ok(
+				mapsAreEqual(sharedMap1, sharedMap2),
+				"SharedMap eventual consistency broken",
+			);
 
-		itSkipsFailureOnSpecificDrivers(
-			`Eventual consistency for shared directories with op reentry - ${
-				enableGroupedBatching ? "Grouped" : "Regular"
-			} batches`,
-			["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-			async () => {
-				await setupContainers({
-					...testContainerConfig,
-					runtimeOptions: {
-						enableGroupedBatching,
-					},
-				});
+			// Both containers are alive at the end
+			assert.ok(!container1.closed, "Local container is closed");
+			assert.ok(!container2.closed, "Remote container is closed");
+		});
 
-				const concurrentValue = 10;
-				const topLevel = "root";
-				const innerLevel = "inner";
-				const key = "key";
-				sharedDirectory1
-					.createSubDirectory(topLevel)
-					.createSubDirectory(innerLevel)
-					.set(key, concurrentValue);
+		it(`Eventual consistency for shared directories with op reentry - ${
+			enableGroupedBatching ? "Grouped" : "Regular"
+		} batches`, async function () {
+			if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+				// This test is flaky on Tinylicious. ADO:5010
+				this.skip();
+			}
 
-				await provider.ensureSynchronized();
+			await setupContainers({
+				...testContainerConfig,
+				runtimeOptions: {
+					enableGroupedBatching,
+				},
+			});
 
-				const concurrentValue1 = concurrentValue + 10;
-				const concurrentValue2 = concurrentValue + 20;
+			const concurrentValue = 10;
+			const topLevel = "root";
+			const innerLevel = "inner";
+			const key = "key";
+			sharedDirectory1
+				.createSubDirectory(topLevel)
+				.createSubDirectory(innerLevel)
+				.set(key, concurrentValue);
 
-				sharedDirectory1
-					.getSubDirectory(topLevel)
-					?.getSubDirectory(innerLevel)
-					?.set(key, concurrentValue1);
-				sharedDirectory2
-					.getSubDirectory(topLevel)
-					?.getSubDirectory(innerLevel)
-					?.set(key, concurrentValue2);
+			await provider.ensureSynchronized();
 
-				await provider.ensureSynchronized();
-				assert.strictEqual(
-					sharedDirectory1
-						.getSubDirectory(topLevel)
-						?.getSubDirectory(innerLevel)
-						?.get(key),
-					sharedDirectory2
-						.getSubDirectory(topLevel)
-						?.getSubDirectory(innerLevel)
-						?.get(key),
-				);
-			},
-		);
+			const concurrentValue1 = concurrentValue + 10;
+			const concurrentValue2 = concurrentValue + 20;
+
+			sharedDirectory1
+				.getSubDirectory(topLevel)
+				?.getSubDirectory(innerLevel)
+				?.set(key, concurrentValue1);
+			sharedDirectory2
+				.getSubDirectory(topLevel)
+				?.getSubDirectory(innerLevel)
+				?.set(key, concurrentValue2);
+
+			await provider.ensureSynchronized();
+			assert.strictEqual(
+				sharedDirectory1.getSubDirectory(topLevel)?.getSubDirectory(innerLevel)?.get(key),
+				sharedDirectory2.getSubDirectory(topLevel)?.getSubDirectory(innerLevel)?.get(key),
+			);
+		});
 	});
 
 	describe("Reentry safeguards", () => {
-		itExpectsSkipsFailureOnSpecificDrivers(
+		itExpects(
 			"Flushing is not supported",
 			[
 				{
@@ -255,8 +251,12 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 					error: "Flushing is not supported inside DDS event handlers",
 				},
 			],
-			["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-			async () => {
+			async function () {
+				if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+					// This test is flaky on Tinylicious. ADO:5010
+					this.skip();
+				}
+
 				await setupContainers({
 					...testContainerConfig,
 					runtimeOptions: {
@@ -277,66 +277,68 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 			},
 		);
 
-		itSkipsFailureOnSpecificDrivers(
-			"Flushing is supported if it happens in the next batch",
-			["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-			async () => {
-				await setupContainers({
-					...testContainerConfig,
-					runtimeOptions: {
-						flushMode: FlushMode.Immediate,
-					},
-				});
+		it("Flushing is supported if it happens in the next batch", async function () {
+			if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+				// This test is flaky on Tinylicious. ADO:5010
+				this.skip();
+			}
 
-				sharedString1.on("sequenceDelta", (sequenceDeltaEvent) => {
-					if ((sequenceDeltaEvent.opArgs.op as IMergeTreeInsertMsg).seg === "ad") {
-						void Promise.resolve().then(() => {
-							sharedString1.insertText(0, "bc");
-						});
-					}
-				});
-
-				sharedString1.insertText(0, "ad");
-				await provider.ensureSynchronized();
-				assert.strictEqual(sharedString1.getText(), "bcad");
-			},
-		);
-	});
-
-	itSkipsFailureOnSpecificDrivers(
-		"Should throw when submitting an op while handling an event - offline",
-		["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-		async () => {
 			await setupContainers({
 				...testContainerConfig,
 				runtimeOptions: {
-					enableOpReentryCheck: true,
+					flushMode: FlushMode.Immediate,
 				},
 			});
 
-			await container1.deltaManager.inbound.pause();
-			await container1.deltaManager.outbound.pause();
-
-			sharedMap1.on("valueChanged", (changed) => {
-				if (changed.key !== "key2") {
-					sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
+			sharedString1.on("sequenceDelta", (sequenceDeltaEvent) => {
+				if ((sequenceDeltaEvent.opArgs.op as IMergeTreeInsertMsg).seg === "ad") {
+					void Promise.resolve().then(() => {
+						sharedString1.insertText(0, "bc");
+					});
 				}
 			});
 
-			assert.throws(() => {
-				sharedMap1.set("key1", "1");
-			});
-
-			container1.deltaManager.inbound.resume();
-			container1.deltaManager.outbound.resume();
-
+			sharedString1.insertText(0, "ad");
 			await provider.ensureSynchronized();
+			assert.strictEqual(sharedString1.getText(), "bcad");
+		});
+	});
 
-			// The offending container is not closed
-			assert.ok(!container1.closed);
-			assert.ok(!mapsAreEqual(sharedMap1, sharedMap2));
-		},
-	);
+	it("Should throw when submitting an op while handling an event - offline", async function () {
+		if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+			// This test is flaky on Tinylicious. ADO:5010
+			this.skip();
+		}
+
+		await setupContainers({
+			...testContainerConfig,
+			runtimeOptions: {
+				enableOpReentryCheck: true,
+			},
+		});
+
+		await container1.deltaManager.inbound.pause();
+		await container1.deltaManager.outbound.pause();
+
+		sharedMap1.on("valueChanged", (changed) => {
+			if (changed.key !== "key2") {
+				sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
+			}
+		});
+
+		assert.throws(() => {
+			sharedMap1.set("key1", "1");
+		});
+
+		container1.deltaManager.inbound.resume();
+		container1.deltaManager.outbound.resume();
+
+		await provider.ensureSynchronized();
+
+		// The offending container is not closed
+		assert.ok(!container1.closed);
+		assert.ok(!mapsAreEqual(sharedMap1, sharedMap2));
+	});
 
 	describe("Allow reentry", () =>
 		[
@@ -356,74 +358,76 @@ describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObje
 				name: "Enabled by options, disabled by feature gate",
 			},
 		].forEach((testConfig) => {
-			itSkipsFailureOnSpecificDrivers(
-				`Should not close the container when submitting an op while processing a batch [${testConfig.name}]`,
-				["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-				async () => {
-					await setupContainers(testConfig.options, testConfig.featureGates);
+			it(`Should not close the container when submitting an op while processing a batch [${testConfig.name}]`, async function () {
+				if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+					// This test is flaky on Tinylicious. ADO:5010
+					this.skip();
+				}
 
-					sharedMap1.on("valueChanged", (changed) => {
-						if (changed.key !== "key2") {
-							sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
-						}
-					});
+				await setupContainers(testConfig.options, testConfig.featureGates);
 
-					const outOfOrderObservations: string[] = [];
-					sharedMap1.on("valueChanged", (changed) => {
-						outOfOrderObservations.push(changed.key);
-					});
+				sharedMap1.on("valueChanged", (changed) => {
+					if (changed.key !== "key2") {
+						sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
+					}
+				});
 
-					sharedMap1.set("key1", "1");
-					sharedMap2.set("key2", "2");
-					await provider.ensureSynchronized();
+				const outOfOrderObservations: string[] = [];
+				sharedMap1.on("valueChanged", (changed) => {
+					outOfOrderObservations.push(changed.key);
+				});
 
-					// The offending container is not closed
-					assert.ok(!container1.closed);
-					assert.equal(sharedMap1.get("key2"), "1 updated");
+				sharedMap1.set("key1", "1");
+				sharedMap2.set("key2", "2");
+				await provider.ensureSynchronized();
 
-					// The other container is also fine
-					assert.equal(sharedMap2.get("key1"), "1");
-					assert.equal(sharedMap2.get("key2"), "1 updated");
+				// The offending container is not closed
+				assert.ok(!container1.closed);
+				assert.equal(sharedMap1.get("key2"), "1 updated");
 
-					// The second event handler didn't receive the events in the actual order of changes
-					assert.deepEqual(outOfOrderObservations, ["key2", "key1"]);
-					assert.ok(mapsAreEqual(sharedMap1, sharedMap2));
-				},
-			);
+				// The other container is also fine
+				assert.equal(sharedMap2.get("key1"), "1");
+				assert.equal(sharedMap2.get("key2"), "1 updated");
 
-			itSkipsFailureOnSpecificDrivers(
-				`Should not throw when submitting an op while processing a batch - offline [${testConfig.name}]`,
-				["tinylicious", "t9s"], // This test is flaky on Tinylicious. ADO:5010
-				async () => {
-					await setupContainers(testConfig.options, testConfig.featureGates);
+				// The second event handler didn't receive the events in the actual order of changes
+				assert.deepEqual(outOfOrderObservations, ["key2", "key1"]);
+				assert.ok(mapsAreEqual(sharedMap1, sharedMap2));
+			});
 
-					await container1.deltaManager.inbound.pause();
-					await container1.deltaManager.outbound.pause();
+			it(`Should not throw when submitting an op while processing a batch - offline [${testConfig.name}]`, async function () {
+				if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
+					// This test is flaky on Tinylicious. ADO:5010
+					this.skip();
+				}
 
-					sharedMap1.on("valueChanged", (changed) => {
-						if (changed.key !== "key2") {
-							sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
-						}
-					});
+				await setupContainers(testConfig.options, testConfig.featureGates);
 
-					const outOfOrderObservations: string[] = [];
-					sharedMap1.on("valueChanged", (changed) => {
-						outOfOrderObservations.push(changed.key);
-					});
+				await container1.deltaManager.inbound.pause();
+				await container1.deltaManager.outbound.pause();
 
-					sharedMap1.set("key1", "1");
+				sharedMap1.on("valueChanged", (changed) => {
+					if (changed.key !== "key2") {
+						sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
+					}
+				});
 
-					container1.deltaManager.inbound.resume();
-					container1.deltaManager.outbound.resume();
-					await provider.ensureSynchronized();
+				const outOfOrderObservations: string[] = [];
+				sharedMap1.on("valueChanged", (changed) => {
+					outOfOrderObservations.push(changed.key);
+				});
 
-					// The offending container is not closed
-					assert.ok(!container1.closed);
+				sharedMap1.set("key1", "1");
 
-					// The second event handler didn't receive the events in the actual order of changes
-					assert.deepEqual(outOfOrderObservations, ["key2", "key1"]);
-					assert.ok(mapsAreEqual(sharedMap1, sharedMap2));
-				},
-			);
+				container1.deltaManager.inbound.resume();
+				container1.deltaManager.outbound.resume();
+				await provider.ensureSynchronized();
+
+				// The offending container is not closed
+				assert.ok(!container1.closed);
+
+				// The second event handler didn't receive the events in the actual order of changes
+				assert.deepEqual(outOfOrderObservations, ["key2", "key1"]);
+				assert.ok(mapsAreEqual(sharedMap1, sharedMap2));
+			});
 		}));
 });


### PR DESCRIPTION
## Description

ADO:5010

These tests (and others) are flaky in t9s. `itExpectsSkipsFailureOnSpecificDrivers` still executes them, so there is the likelihood that if the tests fail due to leaky promises or timeouts, it may still register a test failure and block the CI.