### PR TITLE
feat(eslint-config): Update `unicorn/numeric-separators-style` rule in `recommended` eslint config to only validate consistency of separators

### DIFF
--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1344,7 +1344,10 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "off"
+            "error",
+            {
+                "onlyIfContainsSeparator": true
+            }
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1344,7 +1344,7 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -1418,7 +1418,7 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -1418,7 +1418,10 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "off"
+            "error",
+            {
+                "onlyIfContainsSeparator": true
+            }
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1344,7 +1344,10 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "off"
+            "error",
+            {
+                "onlyIfContainsSeparator": true
+            }
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1344,7 +1344,7 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1389,7 +1389,10 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "off"
+            "error",
+            {
+                "onlyIfContainsSeparator": true
+            }
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1389,7 +1389,7 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1344,7 +1344,10 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "off"
+            "error",
+            {
+                "onlyIfContainsSeparator": true
+            }
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1344,7 +1344,7 @@
             "error"
         ],
         "unicorn/numeric-separators-style": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-add-event-listener": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -57,9 +57,10 @@ module.exports = {
 		"unicorn/no-useless-undefined": "off",
 
 		/**
-		 * Conflicts with our internal error code formats.
+		 * By default, this rule conflicts with our internal error code formats.
+		 * Only enforce `_` separator consistency if any such separators appear in the number literal.
 		 */
-		"unicorn/numeric-separators-style": "off",
+		"unicorn/numeric-separators-style": ["error", { onlyIfContainsSeparator: true }],
 
 		/**
 		 * "node:" imports are not supported prior to Node.js v16.

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -57,6 +57,11 @@ module.exports = {
 		"unicorn/no-useless-undefined": "off",
 
 		/**
+		 * Conflicts with our internal error code formats.
+		 */
+		"unicorn/numeric-separators-style": "off",
+
+		/**
 		 * "node:" imports are not supported prior to Node.js v16.
 		 * TODO: re-enable this (remove override) once the repo has been updated to v16.
 		 */


### PR DESCRIPTION
See here for [rule](https://github.com/NickPoulden/eslint-unicorn/blob/main/docs/rules/numeric-separators-style.md) details.

The default rules conflict with our generated error codes.

Our settings now opt into the `onlyIfContainsSeparator` option. So rather than enforcing that we always use separators, it instead just validates the consistency of separators when present.