### PR TITLE
Call container dispose on load failure

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -429,7 +429,11 @@ export class Container
 								// Depending where error happens, we can be attempting to connect to web socket
 								// and continuously retrying (consider offline mode)
 								// Host has no container to close, so it's prudent to do it here
+								// Note: We could only dispose the container instead of just close but that would
+								// the telemetry where users sometimes search for ContainerClose event to look
+								// for load failures. So not removing this at this time.
 								container.close(err);
+								container.dispose(err);
 								onClosed(err);
 							},
 						);

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -126,6 +126,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 		"Load container unsuccessfully",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
+			{ eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
 			{
 				eventName: "TestException",
 				error: "expectedFailure",

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -19,7 +19,7 @@ import { describeNoCompat, itExpects } from "@fluid-internal/test-version-utils"
 import { ContainerErrorType } from "@fluidframework/container-definitions";
 
 // REVIEW: enable compat testing?
-describeNoCompat("Errorssss Types", (getTestObjectProvider) => {
+describeNoCompat("Errors Types", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -19,7 +19,7 @@ import { describeNoCompat, itExpects } from "@fluid-internal/test-version-utils"
 import { ContainerErrorType } from "@fluidframework/container-definitions";
 
 // REVIEW: enable compat testing?
-describeNoCompat("Errors Types", (getTestObjectProvider) => {
+describeNoCompat("Errorssss Types", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;
@@ -98,6 +98,45 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
 			}
 		},
 	);
+
+	it("Clear odsp driver cache on critical load error", async function () {
+		if (provider.driver.type !== "odsp") {
+			this.skip();
+		}
+		const documentServiceFactory = provider.documentServiceFactory;
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		const cache = documentServiceFactory["persistedCache"];
+		const cacheFileEntry = {
+			type: "snapshot",
+			key: "",
+			file: {
+				resolvedUrl: containerUrl,
+				docId: containerUrl.id,
+			},
+		};
+		assert(
+			(await cache?.get?.(cacheFileEntry)) !== undefined,
+			"create container should have cached the snapshot",
+		);
+		try {
+			const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
+			mockFactory.createDocumentService = async (resolvedUrl) => {
+				const service = await documentServiceFactory.createDocumentService(resolvedUrl);
+				service.connectToStorage = async () => {
+					throw new Error("Injected error");
+				};
+				return service;
+			};
+			await loadContainer({ documentServiceFactory: mockFactory });
+		} catch (e: any) {
+			assert(e.errorType === ContainerErrorType.genericError);
+			assert(e.message === "Injected error");
+		}
+		assert(
+			(await cache?.get?.(cacheFileEntry)) === undefined,
+			"odsp cache should have been cleared on critical error/container dispose",
+		);
+	});
 
 	function assertCustomPropertySupport(err: any) {
 		err.asdf = "asdf";


### PR DESCRIPTION
## Description

Currently we only call container close on load failure, but it does not free up all resources. Also, the app does not have the container at this stage to call dispose on it. So, it should be called on load failure.

This issue was caught when adding test to check whether ODSP cache was cleared on load failure with error or not. So, adding that test and also modify the other test to look for container dispose event too.