### PR TITLE
Stress: Fix pending check to handle undefined

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -234,20 +234,8 @@ async function runnerProcess(
 				},
 			});
 
-			let stashedOps = stashedOpP ? await stashedOpP : undefined;
+			const stashedOps = stashedOpP ? await stashedOpP : undefined;
 			stashedOpP = undefined; // delete to avoid reuse
-
-			// temp fix for #15538: remove clientId from empty stash blobs
-			if (stashedOps !== undefined) {
-				const parsed = JSON.parse(stashedOps);
-				if (
-					parsed?.pendingRuntimeState?.pending === undefined &&
-					Object.keys(parsed.pendingRuntimeState.pendingAttachmentBlobs).length === 0
-				) {
-					parsed.clientId = undefined;
-					stashedOps = JSON.stringify(parsed);
-				}
-			}
 
 			container = await loader.resolve({ url, headers }, stashedOps);
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -241,7 +241,7 @@ async function runnerProcess(
 			if (stashedOps !== undefined) {
 				const parsed = JSON.parse(stashedOps);
 				if (
-					parsed.pendingRuntimeState.pending === undefined &&
+					parsed?.pendingRuntimeState?.pending === undefined &&
 					Object.keys(parsed.pendingRuntimeState.pendingAttachmentBlobs).length === 0
 				) {
 					parsed.clientId = undefined;


### PR DESCRIPTION
Handle an error we are seeing in stress:

Data_eventName | Data_error | Data_message | count_ | max_Data_tenantId | any_Data_stack
-- | -- | -- | -- | -- | --
RunnerFailed | Cannot read properties of undefined (reading 'pending') |   | 236 |   | TypeError    at runnerProcess (/mnt/vss/_work/1/test/node_modules/@fluid-internal/test-service-load/dist/runner.js:193:48)    at async main (/mnt/vss/_work/1/test/node_modules/@fluid-internal/test-service-load/dist/runner.js:88:18)

