### PR TITLE
test(tree): more thorough anchor fuzz testing

### DIFF
--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -65,6 +65,7 @@ export {
 	topDownPath,
 	compareFieldUpPaths,
 	forEachNode,
+	forEachNodeInSubtree,
 	forEachField,
 	PathRootPrefix,
 	isSkipMark,

--- a/experimental/dds/tree2/src/core/tree/cursor.ts
+++ b/experimental/dds/tree2/src/core/tree/cursor.ts
@@ -388,6 +388,29 @@ export function forEachNode<TCursor extends ITreeCursor = ITreeCursor>(
 }
 
 /**
+ * @param cursor - cursor at a field or node.
+ * @param f - Function to invoke for each node.
+ * If `f` moves the cursor, it must put it back to where it was at the beginning of `f` before returning.
+ *
+ * Invokes `f` on each node in the subtree rooted at the current field or node.
+ * Traversal is pre-order.
+ * If the cursor is at a node, `f` will be invoked on that node.
+ *
+ * Returns the `cursor` to its initial position.
+ */
+export function forEachNodeInSubtree<TCursor extends ITreeCursor = ITreeCursor>(
+	cursor: TCursor,
+	f: (cursor: TCursor) => void,
+): void {
+	if (cursor.mode === CursorLocationType.Nodes) {
+		f(cursor);
+		forEachField(cursor, (c) => forEachNodeInSubtree(c, f));
+	} else {
+		forEachNode(cursor, (c) => forEachNodeInSubtree(c, f));
+	}
+}
+
+/**
  * Casts a cursor to an {@link ITreeCursorSynchronous}.
  *
  * TODO: #1404: Handle this properly for partial data loading support.

--- a/experimental/dds/tree2/src/core/tree/index.ts
+++ b/experimental/dds/tree2/src/core/tree/index.ts
@@ -20,6 +20,7 @@ export {
 	mapCursorField,
 	mapCursorFields,
 	forEachNode,
+	forEachNodeInSubtree,
 	forEachField,
 	ITreeCursorSynchronous,
 	PathRootPrefix,

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -61,7 +61,6 @@ describe("Fuzz - undo/redo", () => {
 			const tree = initialState.clients[0].channel;
 			initialState.initialTreeState = toJsonableTree(tree);
 			initialState.anchors = [];
-			// creates an initial anchor for each tree
 			for (const client of initialState.clients) {
 				initialState.anchors.push(createAnchors(client.channel));
 			}

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -12,8 +12,7 @@ import {
 	DDSFuzzHarnessEvents,
 } from "@fluid-internal/test-dds-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { compareUpPaths, rootFieldKey, UpPath, Anchor, JsonableTree } from "../../../core";
-import { brand } from "../../../util";
+import { UpPath, Anchor, JsonableTree, Value } from "../../../core";
 import {
 	SharedTreeTestFactory,
 	toJsonableTree,
@@ -22,7 +21,7 @@ import {
 } from "../../utils";
 import { makeOpGenerator, EditGeneratorOpWeights, FuzzTestState } from "./fuzzEditGenerators";
 import { fuzzReducer } from "./fuzzEditReducers";
-import { getFirstAnchor, onCreate } from "./fuzzUtils";
+import { createAnchors, onCreate, validateAnchors } from "./fuzzUtils";
 import { Operation } from "./operationTypes";
 
 /**
@@ -30,7 +29,7 @@ import { Operation } from "./operationTypes";
  */
 interface UndoRedoFuzzTestState extends FuzzTestState {
 	initialTreeState?: JsonableTree[];
-	firstAnchors?: Anchor[];
+	anchors?: Map<Anchor, [UpPath, Value]>[];
 }
 
 describe("Fuzz - undo/redo", () => {
@@ -59,11 +58,12 @@ describe("Fuzz - undo/redo", () => {
 		};
 		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: UndoRedoFuzzTestState) => {
-			initialState.initialTreeState = toJsonableTree(initialState.clients[0].channel);
-			initialState.firstAnchors = [];
+			const tree = initialState.clients[0].channel;
+			initialState.initialTreeState = toJsonableTree(tree);
+			initialState.anchors = [];
 			// creates an initial anchor for each tree
 			for (const client of initialState.clients) {
-				initialState.firstAnchors.push(getFirstAnchor(client.channel));
+				initialState.anchors.push(createAnchors(client.channel));
 			}
 		});
 		emitter.on("testEnd", (finalState: UndoRedoFuzzTestState) => {
@@ -89,24 +89,12 @@ describe("Fuzz - undo/redo", () => {
 			// synchronize clients after undo
 			finalState.containerRuntimeFactory.processAllMessages();
 
+			assert(finalState.anchors !== undefined);
 			// validate the current state of the clients with the initial state, and check anchor stability
 			for (const [i, client] of clients.entries()) {
 				assert(finalState.initialTreeState !== undefined);
 				validateTree(client.channel, finalState.initialTreeState);
-				// check anchor stability
-				const expectedPath: UpPath = {
-					parent: {
-						parent: undefined,
-						parentIndex: 0,
-						parentField: rootFieldKey,
-					},
-					parentField: brand("foo"),
-					parentIndex: 1,
-				};
-				assert(finalState.firstAnchors !== undefined);
-				assert(finalState.firstAnchors[i] !== undefined);
-				const anchorPath = client.channel.locate(finalState.firstAnchors[i]);
-				assert(compareUpPaths(expectedPath, anchorPath));
+				validateAnchors(client.channel, finalState.anchors[i], true);
 			}
 
 			// redo all of the undone changes and validate against the finalTreeState for each tree
@@ -142,10 +130,10 @@ describe("Fuzz - undo/redo", () => {
 		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: UndoRedoFuzzTestState) => {
 			initialState.initialTreeState = toJsonableTree(initialState.clients[0].channel);
-			initialState.firstAnchors = [];
+			initialState.anchors = [];
 			// creates an initial anchor for each tree
 			for (const client of initialState.clients) {
-				initialState.firstAnchors.push(getFirstAnchor(client.channel));
+				initialState.anchors.push(createAnchors(client.channel));
 			}
 		});
 		emitter.on("testEnd", (finalState: UndoRedoFuzzTestState) => {
@@ -168,23 +156,11 @@ describe("Fuzz - undo/redo", () => {
 			finalState.containerRuntimeFactory.processAllMessages();
 
 			// validate the current state of the clients with the initial state, and check anchor stability
+			assert(finalState.anchors !== undefined);
 			for (const [i, client] of clients.entries()) {
 				assert(finalState.initialTreeState !== undefined);
 				validateTree(client.channel, finalState.initialTreeState);
-				// check anchor stability
-				const expectedPath: UpPath = {
-					parent: {
-						parent: undefined,
-						parentIndex: 0,
-						parentField: rootFieldKey,
-					},
-					parentField: brand("foo"),
-					parentIndex: 1,
-				};
-				assert(finalState.firstAnchors !== undefined);
-				assert(finalState.firstAnchors[i] !== undefined);
-				const anchorPath = client.channel.locate(finalState.firstAnchors[i]);
-				assert(compareUpPaths(expectedPath, anchorPath));
+				validateAnchors(client.channel, finalState.anchors[i], true);
 			}
 		});
 		createDDSFuzzSuite(model, {


### PR DESCRIPTION
Updates fuzz tests that test anchors to make them test anchors for all nodes in the initial tree, instead of a single node.