### PR TITLE
Added tests for summary failures on pending ops

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3065,7 +3065,7 @@ export class ContainerRuntime
 							undefined,
 							{ pendingMessages: this.pendingMessagesCount },
 						);
-						summaryLogger.sendErrorEvent(
+						summaryNumberLogger.sendErrorEvent(
 							{
 								eventName: "SkipFailingIncorrectSummary",
 								referenceSequenceNumber: summaryRefSeqNum,
@@ -3074,9 +3074,14 @@ export class ContainerRuntime
 							error,
 						);
 					} else {
+						// Default retry delay is 1 second. This can be overridden via config so that we can adjust it
+						// based on telemetry while we decide on a stable number.
+						const retryDelayMs =
+							this.mc.config.getNumber("Fluid.Summarizer.PendingOpsRetryDelayMs") ??
+							1000;
 						const error = new RetriableSummaryError(
 							"PendingMessagesInSummary",
-							1 /* retryAfterSeconds */,
+							retryDelayMs / 1000,
 							{ count: this.pendingMessagesCount },
 						);
 						return {

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -480,6 +480,7 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 			);
 			rootDataObject._root.set("dataStore2", dataObject2.handle);
 			dataObject2._root.set("op", "value");
+			await provider.ensureSynchronized();
 
 			const props = await summarizePromiseP;
 			assert.strictEqual(props.result, "failure", "Summarization did not fail as expected");
@@ -563,7 +564,7 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 			);
 			rootDataObject._root.set("dataStore2", dataObject2.handle);
 			dataObject2._root.set("op", "value");
-			// await provider.ensureSynchronized();
+			await provider.ensureSynchronized();
 
 			const props = await summarizePromiseP;
 			assert.strictEqual(

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
 import {
+	ContainerRuntime,
 	DefaultSummaryConfiguration,
 	IContainerRuntimeOptions,
 	ISummaryConfiguration,
@@ -34,10 +35,16 @@ import {
 	IFluidHandle,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
+import {
+	defaultMaxAttemptsForSubmitFailures,
+	ISummarizeEventProps,
+	// eslint-disable-next-line import/no-internal-modules
+} from "@fluidframework/container-runtime/dist/summary/index.js";
 
-export const rootDataObjectType = "@fluid-example/rootDataObject";
-export const TestDataObjectType1 = "@fluid-example/test-dataStore1";
-
+/**
+ * Data object that creates another data object during initialization. This is used to create a scenario
+ * where data objects are created during summarization.
+ */
 class TestDataObject1 extends DataObject {
 	public get _root() {
 		return this.root;
@@ -84,6 +91,24 @@ class TestDataObject1 extends DataObject {
 	}
 }
 
+/**
+ * Data object that sends ops during initialization. This is used to create a scenario where ops are generated
+ * during summarization.
+ */
+class TestDataObject2 extends DataObject {
+	public get _root() {
+		return this.root;
+	}
+
+	public get _context() {
+		return this.context;
+	}
+
+	protected async hasInitialized() {
+		this.root.set("key", "value");
+	}
+}
+
 class RootTestDataObject extends DataObject {
 	public get _root() {
 		return this.root;
@@ -99,25 +124,41 @@ const getDataObject = async (runtime: FluidDataStoreRuntime) => {
 	return undefined;
 };
 
+// Search does something similar to this, where it loads the data object.
+const getDataObjectAndSendOps = async (runtime: FluidDataStoreRuntime) => {
+	const dataObject = (await DataObject.getDataObject(runtime)) as TestDataObject2;
+	dataObject._root.set("op", "value");
+	return undefined;
+};
+
 const rootDataObjectFactory = new DataObjectFactory(
-	rootDataObjectType,
+	"RootDataObject",
 	RootTestDataObject,
 	[],
 	[],
 	[],
 );
 const dataStoreFactory1 = new DataObjectFactory(
-	TestDataObjectType1,
+	"TestDataObject1",
 	TestDataObject1,
 	[],
 	[],
 	[],
 	mixinSummaryHandler(getDataObject),
 );
+const dataStoreFactory2 = new DataObjectFactory(
+	"TestDataObject2",
+	TestDataObject2,
+	[],
+	[],
+	[],
+	mixinSummaryHandler(getDataObjectAndSendOps),
+);
 
 const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 	[rootDataObjectFactory.type, Promise.resolve(rootDataObjectFactory)],
 	[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
+	[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],
 ]);
 
 let settings = {};
@@ -131,11 +172,12 @@ const createContainer = async (
 	if (disableSummary) {
 		summaryConfigOverrides = { state: "disabled" };
 	} else {
-		const IdleDetectionTime = 10;
+		const IdleDetectionTime = 100;
 		summaryConfigOverrides = {
 			...DefaultSummaryConfiguration,
 			...{
-				maxIdleTime: IdleDetectionTime,
+				minIdleTime: IdleDetectionTime,
+				maxIdleTime: IdleDetectionTime * 2,
 				maxTime: IdleDetectionTime * 12,
 				initialSummarizerDelayMs: 0,
 			},
@@ -194,6 +236,7 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 		settings = [];
 		settings["Fluid.ContainerRuntime.Test.SummaryStateUpdateMethodV2"] = "restart";
 		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 0;
+		settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
 	});
 
 	itExpects(
@@ -206,7 +249,6 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 			},
 		],
 		async () => {
-			settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
 			const container = await createContainer(provider);
 			await waitForContainerConnection(container);
 			const rootDataObject = await requestFluidObject<RootTestDataObject>(container, "/");
@@ -294,7 +336,6 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 				},
 			],
 			async () => {
-				settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
 				settings["Fluid.Summarizer.TryDynamicRetries"] = tryDynamicRetry;
 				const logger = new MockLogger();
 				const mainContainer = await createContainer(
@@ -366,4 +407,175 @@ describeNoCompat("Summarizer with local data stores", (getTestObjectProvider) =>
 			},
 		);
 	}
+
+	itExpects(
+		"All heuristics summary attempts should fail when there are pending ops",
+		[
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 1,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 2,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 3,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 4,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 5,
+				finalAttempt: true,
+				error: "PendingMessagesInSummary",
+			},
+		],
+		async () => {
+			settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+			settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
+			const container = await createContainer(provider, false /* disableSummary */);
+			await waitForContainerConnection(container);
+
+			const rootDataObject = await requestFluidObject<RootTestDataObject>(container, "/");
+			const containerRuntime = rootDataObject.containerRuntime as ContainerRuntime;
+
+			const summarizePromiseP = new Promise<ISummarizeEventProps>((resolve) => {
+				const handler = (eventProps: ISummarizeEventProps) => {
+					if (eventProps.result !== "failure") {
+						containerRuntime.off("summarize", handler);
+						resolve(eventProps);
+					} else {
+						assert(
+							eventProps.error?.message === "PendingMessagesInSummary",
+							"Unexpected summarization failure",
+						);
+						if (eventProps.currentAttempt === eventProps.maxAttempts) {
+							containerRuntime.off("summarize", handler);
+							resolve(eventProps);
+						}
+					}
+				};
+				containerRuntime.on("summarize", handler);
+			});
+
+			const dataObject2 = await dataStoreFactory2.createInstance(
+				rootDataObject.containerRuntime,
+			);
+			rootDataObject._root.set("dataStore2", dataObject2.handle);
+			dataObject2._root.set("op", "value");
+
+			const props = await summarizePromiseP;
+			assert.strictEqual(props.result, "failure", "Summarization did not fail as expected");
+			assert.strictEqual(
+				props.maxAttempts,
+				defaultMaxAttemptsForSubmitFailures,
+				`Unexpected summarize attempts`,
+			);
+		},
+	);
+
+	itExpects(
+		"SkipFailingIncorrectSummary = true. Final heuristics summary attempt should pass when there are pending ops",
+		[
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 1,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 2,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 3,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
+				clientType: "noninteractive/summarizer",
+				summaryAttempts: 4,
+				finalAttempt: false,
+				error: "PendingMessagesInSummary",
+			},
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:SkipFailingIncorrectSummary",
+				summaryAttempts: 5,
+				finalAttempt: true,
+				error: "Pending ops during summarization",
+			},
+		],
+		async () => {
+			settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+			settings["Fluid.Summarizer.SkipFailingIncorrectSummary"] = true;
+			settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
+			const container = await createContainer(provider, false /* disableSummary */);
+			await waitForContainerConnection(container);
+
+			const rootDataObject = await requestFluidObject<RootTestDataObject>(container, "/");
+			const containerRuntime = rootDataObject.containerRuntime as ContainerRuntime;
+
+			const summarizePromiseP = new Promise<ISummarizeEventProps>((resolve) => {
+				const handler = (eventProps: ISummarizeEventProps) => {
+					if (eventProps.result !== "failure") {
+						containerRuntime.off("summarize", handler);
+						resolve(eventProps);
+					} else {
+						assert(
+							eventProps.error?.message === "PendingMessagesInSummary",
+							"Unexpected summarization failure",
+						);
+						if (eventProps.currentAttempt === eventProps.maxAttempts) {
+							containerRuntime.off("summarize", handler);
+							resolve(eventProps);
+						}
+					}
+				};
+				containerRuntime.on("summarize", handler);
+			});
+
+			const dataObject2 = await dataStoreFactory2.createInstance(
+				rootDataObject.containerRuntime,
+			);
+			rootDataObject._root.set("dataStore2", dataObject2.handle);
+			dataObject2._root.set("op", "value");
+			// await provider.ensureSynchronized();
+
+			const props = await summarizePromiseP;
+			assert.strictEqual(
+				props.result,
+				"success",
+				"Summarization did not succeed as expected",
+			);
+			assert.strictEqual(
+				props.maxAttempts,
+				defaultMaxAttemptsForSubmitFailures,
+				`Unexpected summarize attempts`,
+			);
+		},
+	);
 });

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,20 +28,23 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				}
 			},
@@ -72,7 +75,8 @@
 				"routerlicious": {
 					"configurations": {
 						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false]
+						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				}
 			}
@@ -101,7 +105,9 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false]
+						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				}
 			}


### PR DESCRIPTION
#16961 added validation when there are pending ops during summarization. This adds tests that validate its working as expected. The tests are added separately because it required #17003 which is now merged.
Also, enabled feature flag `Fluid.Summarizer.SkipFailingIncorrectSummary` in stress tests which will skip failing because of pending ops in the final attempt.

[AB#5364](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5364)