### PR TITLE
Testing improvements for searchForMarker 

### DIFF
--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -99,7 +99,7 @@ describe("TestClient", () => {
 			assert.equal(exp, 4, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding marker based on label", () => {
+		it("Should be able to find forward marker position based on label", () => {
 			const markerLabel = "EOP";
 
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
@@ -108,8 +108,6 @@ describe("TestClient", () => {
 			});
 
 			client.insertTextLocal(0, "abc");
-
-			console.log(client.getText());
 
 			assert.equal(client.getLength(), 4, "length not expected");
 
@@ -126,7 +124,7 @@ describe("TestClient", () => {
 			assert.equal(exp, 3, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding marker position based on label from client with single marker", () => {
+		it("Should be able to find forward marker position based on label from client with single marker", () => {
 			const markerLabel = "EOP";
 			client.insertTextLocal(0, "abc d");
 
@@ -134,7 +132,6 @@ describe("TestClient", () => {
 				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
-			console.log(client.getText());
 
 			assert.equal(client.getLength(), 6, "length not expected");
 
@@ -150,7 +147,7 @@ describe("TestClient", () => {
 			assert.equal(exp, 1, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find preceding marker position based on label from client with multiple marker", () => {
+		it("Should be able to find backward marker position based on label from client with multiple marker", () => {
 			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
 				[reservedTileLabelsKey]: [markerLabel],
@@ -169,7 +166,6 @@ describe("TestClient", () => {
 				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
-			console.log(client.getText());
 
 			assert.equal(client.getLength(), 10, "length not expected");
 
@@ -186,7 +182,7 @@ describe("TestClient", () => {
 			assert.equal(exp, 0, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding marker position from client with multiple marker", () => {
+		it("Should be able to find forward marker position from client with multiple marker", () => {
 			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
 				[reservedTileLabelsKey]: [markerLabel],
@@ -205,7 +201,6 @@ describe("TestClient", () => {
 				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
-			console.log(client.getText());
 
 			assert.equal(client.getLength(), 10, "length not expected");
 
@@ -222,7 +217,7 @@ describe("TestClient", () => {
 			assert.equal(exp, 6, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding marker with multiple segments and markers", () => {
+		it("Should be able to find forward marker position with multiple segments and markers", () => {
 			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
@@ -250,7 +245,7 @@ describe("TestClient", () => {
 			}
 		});
 
-		it("Should be able to find preceding marker with multiple segments and markers", () => {
+		it("Should be able to find backward marker position with multiple segments and markers", () => {
 			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
@@ -278,6 +273,46 @@ describe("TestClient", () => {
 					index - (index % 3),
 					"Marker with label not at expected position",
 				);
+			}
+		});
+
+		it("Should be able to find forward marker position with few segments", () => {
+			const markerLabel = "EOP";
+			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
+				client.insertTextLocal(0, i.toString()),
+			);
+			for (let i = 10; i > 1; i -= 2) {
+				client.insertMarkerLocal(client.getLength() - i, ReferenceType.Tile, {
+					[reservedTileLabelsKey]: [markerLabel],
+					[reservedMarkerIdKey]: "some-id",
+				});
+			}
+
+			for (let index = 0; index < client.getLength(); index++) {
+				const exp = client.slowSearchForMarker(index, markerLabel, true);
+				const actual = client.searchForMarker(index, markerLabel, true);
+
+				assert.equal(exp, actual, "Marker with label not at expected position");
+			}
+		});
+
+		it("Should be able to find backward marker position with few segments", () => {
+			const markerLabel = "EOP";
+			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
+				client.insertTextLocal(0, i.toString()),
+			);
+			for (let i = 10; i > 1; i -= 2) {
+				client.insertMarkerLocal(client.getLength() - i, ReferenceType.Tile, {
+					[reservedTileLabelsKey]: [markerLabel],
+					[reservedMarkerIdKey]: "some-id",
+				});
+			}
+
+			for (let index = client.getLength() - 1; index >= 0; index--) {
+				const exp = client.slowSearchForMarker(index, markerLabel, false);
+				const actual = client.searchForMarker(index, markerLabel, false);
+
+				assert.equal(exp, actual, "Marker with label not at expected position");
 			}
 		});
 
@@ -330,8 +365,6 @@ describe("TestClient", () => {
 				[reservedMarkerIdKey]: "some-id",
 			});
 
-			console.log(client.getText());
-
 			assert.equal(client.getLength(), 1, "length not expected");
 
 			const marker = client.searchForMarker(client.getLength() - 1, markerLabel, false);
@@ -359,7 +392,7 @@ describe("TestClient", () => {
 			assert.equal(exp, 0, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find only preceding but not non preceding marker with index out of bound", () => {
+		it("Should not be able to find marker position with index out of bound", () => {
 			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
 				[reservedTileLabelsKey]: [markerLabel],
@@ -367,7 +400,6 @@ describe("TestClient", () => {
 			});
 
 			client.insertTextLocal(0, "abc");
-			console.log(client.getText());
 
 			assert.equal(client.getLength(), 4, "length not expected");
 
@@ -553,7 +585,6 @@ describe("TestClient", () => {
 		it("Should return undefined when trying to find marker from text without the specified marker", () => {
 			const markerLabel = "EOP";
 			client.insertTextLocal(0, "abc");
-			console.log(client.getText());
 
 			assert.equal(client.getLength(), 3, "length not expected");
 
@@ -576,6 +607,24 @@ describe("TestClient", () => {
 			const marker1 = client.searchForMarker(1, markerLabel, false);
 
 			assert.equal(marker1, undefined, "Returned marker should be undefined.");
+		});
+
+		it("Should return undefined when trying to find a removed marker", () => {
+			client.insertTextLocal(0, "abc");
+			client.insertMarkerLocal(0, ReferenceType.Tile, {
+				[reservedMarkerIdKey]: "marker",
+				[reservedTileLabelsKey]: ["Eop"],
+			});
+
+			assert.equal(client.getLength(), 4, "length not expected");
+
+			client.removeRangeLocal(0, 1);
+
+			assert.equal(client.getLength(), 3, "length not expected");
+
+			const marker = client.searchForMarker(0, "Eop", true);
+
+			assert.equal(marker, undefined, "Returned marker should be undefined");
 		});
 
 		describe("with remote client", () => {
@@ -624,6 +673,36 @@ describe("TestClient", () => {
 				);
 
 				assert.equal(exp, 0, "Marker with label not at expected position");
+			});
+
+			it("Should not be able to find remotely removed marker", () => {
+				let seq = 0;
+				const textMsg = client.makeOpMessage(client.insertTextLocal(0, "abc"), ++seq);
+				const mInsertMsg = client.makeOpMessage(
+					client.insertMarkerLocal(0, ReferenceType.Tile, {
+						[reservedMarkerIdKey]: "marker",
+						[reservedTileLabelsKey]: ["Eop"],
+					}),
+					seq,
+				);
+				client.applyMsg(textMsg);
+				client2.applyMsg(textMsg);
+				client.applyMsg(mInsertMsg);
+				client2.applyMsg(mInsertMsg);
+
+				assert.equal(client.getLength(), 4, "length not expected - client");
+				assert.equal(client2.getLength(), 4, "length not expected - client 2");
+
+				const mRemoveMsg = client2.makeOpMessage(client2.removeRangeLocal(0, 1), seq);
+				client.applyMsg(mRemoveMsg);
+				client2.applyMsg(mRemoveMsg);
+
+				assert.equal(client.getLength(), 3, "length not expected - client");
+				assert.equal(client2.getLength(), 3, "length not expected - client 2");
+
+				const marker = client.searchForMarker(0, "Eop", true);
+
+				assert.equal(marker, undefined, "Returned marker should be undefined.");
 			});
 		});
 	});

--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -31,7 +31,7 @@ describe("TestClient", () => {
 		client.startOrUpdateCollaboration(localUserLongId);
 	});
 
-	describe.only(".searchForMarker", () => {
+	describe(".searchForMarker", () => {
 		it("Should return marker at the search position in either direction", () => {
 			client.insertTextLocal(0, "abcdefg");
 			client.insertMarkerLocal(4, ReferenceType.Tile, {

--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -32,7 +32,7 @@ describe("TestClient", () => {
 	});
 
 	describe.only(".searchForMarker", () => {
-		it("Should return tile at the search position in either direction", () => {
+		it("Should return marker at the search position in either direction", () => {
 			client.insertTextLocal(0, "abcdefg");
 			client.insertMarkerLocal(4, ReferenceType.Tile, {
 				[reservedMarkerIdKey]: "marker",
@@ -40,32 +40,32 @@ describe("TestClient", () => {
 			});
 			assert.equal(client.getLength(), 8);
 
-			const tile1 = client.searchForMarker(4, "Eop", true);
+			const marker1 = client.searchForMarker(4, "Eop", true);
 
-			assert(tile1, "Returned tile undefined.");
+			assert(marker1, "Returned marker undefined.");
 
 			let exp = client.mergeTree.referencePositionToLocalPosition(
-				tile1,
+				marker1,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 4, "Tile with label not at expected position");
+			assert.equal(exp, 4, "Marker with label not at expected position");
 
-			const tile2 = client.searchForMarker(4, "Eop", false);
+			const marker2 = client.searchForMarker(4, "Eop", false);
 
-			assert(tile2, "Returned tile undefined.");
+			assert(marker2, "Returned marker undefined.");
 
 			exp = client.mergeTree.referencePositionToLocalPosition(
-				tile2,
+				marker2,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 4, "Tile with label not at expected position");
+			assert.equal(exp, 4, "Marker with label not at expected position");
 		});
 
-		it("Should return the tile at the search position in either direction from multiple blocks", () => {
+		it("Should return the marker at the search position in either direction from multiple blocks", () => {
 			client.insertTextLocal(0, "abcd");
 			client.insertTextLocal(4, "efg");
 			client.insertMarkerLocal(4, ReferenceType.Tile, {
@@ -74,36 +74,36 @@ describe("TestClient", () => {
 			});
 			assert.equal(client.getLength(), 8);
 
-			const tile1 = client.searchForMarker(4, "Eop", true);
+			const marker1 = client.searchForMarker(4, "Eop", true);
 
-			assert(tile1, "Returned tile undefined.");
+			assert(marker1, "Returned marker undefined.");
 
 			let exp = client.mergeTree.referencePositionToLocalPosition(
-				tile1,
+				marker1,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 4, "Tile with label not at expected position");
+			assert.equal(exp, 4, "Marker with label not at expected position");
 
-			const tile2 = client.searchForMarker(4, "Eop", false);
+			const marker2 = client.searchForMarker(4, "Eop", false);
 
-			assert(tile2, "Returned tile undefined.");
+			assert(marker2, "Returned marker undefined.");
 
 			exp = client.mergeTree.referencePositionToLocalPosition(
-				tile2,
+				marker2,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 4, "Tile with label not at expected position");
+			assert.equal(exp, 4, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding tile based on label", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find non preceding marker based on label", () => {
+			const markerLabel = "EOP";
 
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
@@ -113,172 +113,176 @@ describe("TestClient", () => {
 
 			assert.equal(client.getLength(), 4, "length not expected");
 
-			const tile = client.searchForMarker(0, tileLabel, true);
+			const marker = client.searchForMarker(0, markerLabel, true);
 
-			assert(tile, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			const exp = client.mergeTree.referencePositionToLocalPosition(
-				tile,
+				marker,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 3, "Tile with label not at expected position");
+			assert.equal(exp, 3, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding tile position based on label from client with single tile", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find non preceding marker position based on label from client with single marker", () => {
+			const markerLabel = "EOP";
 			client.insertTextLocal(0, "abc d");
 
 			client.insertMarkerLocal(1, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 			console.log(client.getText());
 
 			assert.equal(client.getLength(), 6, "length not expected");
 
-			const tile = client.searchForMarker(0, tileLabel, true);
+			const marker = client.searchForMarker(0, markerLabel, true);
 
-			assert(tile, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			const exp = client.mergeTree.referencePositionToLocalPosition(
-				tile,
+				marker,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
-			assert.equal(exp, 1, "Tile with label not at expected position");
+			assert.equal(exp, 1, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find preceding tile position based on label from client with multiple tile", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find preceding marker position based on label from client with multiple marker", () => {
+			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
 			client.insertTextLocal(0, "abc d");
 
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
 			client.insertTextLocal(7, "ef");
 			client.insertMarkerLocal(8, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 			console.log(client.getText());
 
 			assert.equal(client.getLength(), 10, "length not expected");
 
-			const tile = client.searchForMarker(5, tileLabel, false);
+			const marker = client.searchForMarker(5, markerLabel, false);
 
-			assert(tile, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			const exp = client.mergeTree.referencePositionToLocalPosition(
-				tile,
+				marker,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 0, "Tile with label not at expected position");
+			assert.equal(exp, 0, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding tile position from client with multiple tile", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find non preceding marker position from client with multiple marker", () => {
+			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
 			client.insertTextLocal(0, "abc d");
 
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
 			client.insertTextLocal(7, "ef");
 			client.insertMarkerLocal(8, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 			console.log(client.getText());
 
 			assert.equal(client.getLength(), 10, "length not expected");
 
-			const tile = client.searchForMarker(5, tileLabel, true);
+			const marker = client.searchForMarker(5, markerLabel, true);
 
-			assert(tile, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			const exp = client.mergeTree.referencePositionToLocalPosition(
-				tile,
+				marker,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 6, "Tile with label not at expected position");
+			assert.equal(exp, 6, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find non preceding tile with multiple segments and tiles", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find non preceding marker with multiple segments and markers", () => {
+			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
 			);
 			// pad the string with markers on both ends so we never get undefined solely for convenience of this test
 			for (let i = 0; i <= client.getLength(); i += 3) {
 				client.insertMarkerLocal(i, ReferenceType.Tile, {
-					[reservedTileLabelsKey]: [tileLabel],
+					[reservedTileLabelsKey]: [markerLabel],
 					[reservedMarkerIdKey]: "some-id",
 				});
 			}
 			for (let index = 0; index < client.getLength(); index++) {
-				const tile = client.searchForMarker(index, tileLabel, true);
+				const marker = client.searchForMarker(index, markerLabel, true);
 
-				assert(tile, `Returned tile undefined @ ${index}.`);
+				assert(marker, `Returned marker undefined @ ${index}.`);
 
 				const exp = client.mergeTree.referencePositionToLocalPosition(
-					tile,
+					marker,
 					UniversalSequenceNumber,
 					client.getClientId(),
 				);
 
 				const offset = index % 3 === 0 ? index % 3 : 3 - (index % 3);
-				assert.equal(exp, index + offset, "Tile with label not at expected position");
+				assert.equal(exp, index + offset, "Marker with label not at expected position");
 			}
 		});
 
-		it("Should be able to find preceding tile with multiple segments and tiles", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find preceding marker with multiple segments and markers", () => {
+			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
 			);
 			// pad the string with markers on both ends so we never get undefined solely for convenience of this test
 			for (let i = 0; i <= client.getLength(); i += 3) {
 				client.insertMarkerLocal(i, ReferenceType.Tile, {
-					[reservedTileLabelsKey]: [tileLabel],
+					[reservedTileLabelsKey]: [markerLabel],
 					[reservedMarkerIdKey]: "some-id",
 				});
 			}
 			for (let index = client.getLength() - 1; index >= 0; index--) {
-				const tile = client.searchForMarker(index, tileLabel, false);
+				const marker = client.searchForMarker(index, markerLabel, false);
 
-				assert(tile, `Returned tile undefined @ ${index}.`);
+				assert(marker, `Returned marker undefined @ ${index}.`);
 
 				const exp = client.mergeTree.referencePositionToLocalPosition(
-					tile,
+					marker,
 					UniversalSequenceNumber,
 					client.getClientId(),
 				);
 
-				assert.equal(exp, index - (index % 3), "Tile with label not at expected position");
+				assert.equal(
+					exp,
+					index - (index % 3),
+					"Marker with label not at expected position",
+				);
 			}
 		});
 
 		it("Should match results from forwardExcursion for many segments", () => {
-			const tileLabel = "EOP";
+			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock * 3 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
 			);
@@ -286,20 +290,20 @@ describe("TestClient", () => {
 			for (let i = 0; i <= client.getLength() / 6; i++) {
 				const pos = random.integer(0, client.getLength() - 1);
 				client.insertMarkerLocal(pos, ReferenceType.Tile, {
-					[reservedTileLabelsKey]: [tileLabel],
+					[reservedTileLabelsKey]: [markerLabel],
 					[reservedMarkerIdKey]: "some-id",
 				});
 			}
 			for (let index = 0; index < client.getLength(); index++) {
-				const exp = client.slowSearchForMarker(index, tileLabel, true);
-				const actual = client.searchForMarker(index, tileLabel, true);
+				const exp = client.slowSearchForMarker(index, markerLabel, true);
+				const actual = client.searchForMarker(index, markerLabel, true);
 
-				assert.equal(exp, actual, "Tile with label not at expected position");
+				assert.equal(exp, actual, "Marker with label not at expected position");
 			}
 		});
 
 		it("Should match results from backwardExcursion for many segments", () => {
-			const tileLabel = "EOP";
+			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock * 3 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
 			);
@@ -307,22 +311,22 @@ describe("TestClient", () => {
 			for (let i = 0; i <= client.getLength() / 6; i++) {
 				const pos = random.integer(0, client.getLength() - 1);
 				client.insertMarkerLocal(pos, ReferenceType.Tile, {
-					[reservedTileLabelsKey]: [tileLabel],
+					[reservedTileLabelsKey]: [markerLabel],
 					[reservedMarkerIdKey]: "some-id",
 				});
 			}
 			for (let index = 0; index < client.getLength(); index++) {
-				const exp = client.slowSearchForMarker(index, tileLabel, false);
-				const actual = client.searchForMarker(index, tileLabel, false);
+				const exp = client.slowSearchForMarker(index, markerLabel, false);
+				const actual = client.searchForMarker(index, markerLabel, false);
 
-				assert.equal(exp, actual, "Tile with label not at expected position");
+				assert.equal(exp, actual, "Marker with label not at expected position");
 			}
 		});
 
-		it("Should be able to find tile from client with text length 1", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find marker from client with text length 1", () => {
+			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
@@ -330,35 +334,35 @@ describe("TestClient", () => {
 
 			assert.equal(client.getLength(), 1, "length not expected");
 
-			const tile = client.searchForMarker(client.getLength() - 1, tileLabel, false);
+			const marker = client.searchForMarker(client.getLength() - 1, markerLabel, false);
 
-			assert(tile, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			let exp = client.mergeTree.referencePositionToLocalPosition(
-				tile,
+				marker,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 0, "Tile with label not at expected position");
+			assert.equal(exp, 0, "Marker with label not at expected position");
 
-			const tile1 = client.searchForMarker(0, tileLabel, true);
+			const marker1 = client.searchForMarker(0, markerLabel, true);
 
-			assert(tile1, "Returned tile undefined.");
+			assert(marker1, "Returned marker undefined.");
 
 			exp = client.mergeTree.referencePositionToLocalPosition(
-				tile,
+				marker,
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 0, "Tile with label not at expected position");
+			assert.equal(exp, 0, "Marker with label not at expected position");
 		});
 
-		it("Should be able to find only preceding but not non preceding tile with index out of bound", () => {
-			const tileLabel = "EOP";
+		it("Should be able to find only preceding but not non preceding marker with index out of bound", () => {
+			const markerLabel = "EOP";
 			client.insertMarkerLocal(0, ReferenceType.Tile, {
-				[reservedTileLabelsKey]: [tileLabel],
+				[reservedTileLabelsKey]: [markerLabel],
 				[reservedMarkerIdKey]: "some-id",
 			});
 
@@ -367,17 +371,17 @@ describe("TestClient", () => {
 
 			assert.equal(client.getLength(), 4, "length not expected");
 
-			const tile = client.searchForMarker(5, tileLabel, true);
+			const marker = client.searchForMarker(5, markerLabel, true);
 
-			assert.equal(tile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 
-			const tile1 = client.searchForMarker(5, tileLabel, false);
+			const marker1 = client.searchForMarker(5, markerLabel, false);
 
-			assert.equal(tile1, undefined, "Returned tile should be undefined.");
+			assert.equal(marker1, undefined, "Returned marker should be undefined.");
 
-			const tile2 = client.searchForMarker(-1, tileLabel, false);
+			const marker2 = client.searchForMarker(-1, markerLabel, false);
 
-			assert.equal(tile2, undefined, "Returned tile should be undefined.");
+			assert.equal(marker2, undefined, "Returned marker should be undefined.");
 		});
 
 		it("Should be able to find a deleted and rolled back marker", () => {
@@ -396,7 +400,7 @@ describe("TestClient", () => {
 
 			const marker = client.searchForMarker(0, "Eop", true);
 
-			assert(marker, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			const exp = client.mergeTree.referencePositionToLocalPosition(
 				marker,
@@ -404,7 +408,7 @@ describe("TestClient", () => {
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 0, "Tile with label not at expected position");
+			assert.equal(exp, 0, "Marker with label not at expected position");
 		});
 
 		it("Should not be able to find an inserted and rolled back marker", () => {
@@ -435,7 +439,7 @@ describe("TestClient", () => {
 
 			const marker = client.searchForMarker(0, "Eop", true);
 
-			assert(marker, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			let exp = client.mergeTree.referencePositionToLocalPosition(
 				marker,
@@ -443,11 +447,11 @@ describe("TestClient", () => {
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 0, "Tile with label not at expected position");
+			assert.equal(exp, 0, "Marker with label not at expected position");
 
 			const marker2 = client.searchForMarker(0, "Eop", false);
 
-			assert(marker2, "Returned tile undefined.");
+			assert(marker2, "Returned marker undefined.");
 
 			exp = client.mergeTree.referencePositionToLocalPosition(
 				marker2,
@@ -455,7 +459,7 @@ describe("TestClient", () => {
 				client.getClientId(),
 			);
 
-			assert.equal(exp, 0, "Tile with label not at expected position");
+			assert.equal(exp, 0, "Marker with label not at expected position");
 		});
 
 		it("Should be able to find a marker at length-1 searching at length-1 in both directions", () => {
@@ -470,7 +474,7 @@ describe("TestClient", () => {
 
 			const marker = client.searchForMarker(length - 1, "Eop", true);
 
-			assert(marker, "Returned tile undefined.");
+			assert(marker, "Returned marker undefined.");
 
 			let exp = client.mergeTree.referencePositionToLocalPosition(
 				marker,
@@ -478,11 +482,11 @@ describe("TestClient", () => {
 				client.getClientId(),
 			);
 
-			assert.equal(exp, length - 1, "Tile with label not at expected position");
+			assert.equal(exp, length - 1, "Marker with label not at expected position");
 
 			const marker2 = client.searchForMarker(length - 1, "Eop", false);
 
-			assert(marker2, "Returned tile undefined.");
+			assert(marker2, "Returned marker undefined.");
 
 			exp = client.mergeTree.referencePositionToLocalPosition(
 				marker2,
@@ -490,7 +494,7 @@ describe("TestClient", () => {
 				client.getClientId(),
 			);
 
-			assert.equal(exp, length - 1, "Tile with label not at expected position");
+			assert.equal(exp, length - 1, "Marker with label not at expected position");
 		});
 
 		it("Should return undefined when searching past the end of a string length 1", () => {
@@ -500,9 +504,9 @@ describe("TestClient", () => {
 			});
 
 			assert.equal(client.getLength(), 1);
-			const foundTile = client.searchForMarker(client.getLength(), "Eop", true);
+			const marker = client.searchForMarker(client.getLength(), "Eop", true);
 
-			assert.equal(foundTile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 		});
 
 		it("Should return undefined when searching before the start of a string length 1", () => {
@@ -513,9 +517,9 @@ describe("TestClient", () => {
 
 			assert.equal(client.getLength(), 1);
 
-			const foundTile = client.searchForMarker(-1, "Eop", false);
+			const marker = client.searchForMarker(-1, "Eop", false);
 
-			assert.equal(foundTile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 		});
 
 		it("Should return undefined when searching past the end of a string length > 1", () => {
@@ -527,9 +531,9 @@ describe("TestClient", () => {
 
 			assert.equal(client.getLength(), 4);
 
-			const foundTile = client.searchForMarker(client.getLength(), "Eop", true);
+			const marker = client.searchForMarker(client.getLength(), "Eop", true);
 
-			assert.equal(foundTile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 		});
 
 		it("Should return undefined when searching before the start of a string length > 1", () => {
@@ -541,37 +545,37 @@ describe("TestClient", () => {
 
 			assert.equal(client.getLength(), 4);
 
-			const foundTile = client.searchForMarker(-1, "Eop", false);
+			const marker = client.searchForMarker(-1, "Eop", false);
 
-			assert.equal(foundTile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 		});
 
-		it("Should return undefined when trying to find tile from text without the specified tile", () => {
-			const tileLabel = "EOP";
+		it("Should return undefined when trying to find marker from text without the specified marker", () => {
+			const markerLabel = "EOP";
 			client.insertTextLocal(0, "abc");
 			console.log(client.getText());
 
 			assert.equal(client.getLength(), 3, "length not expected");
 
-			const tile = client.searchForMarker(1, tileLabel);
+			const marker = client.searchForMarker(1, markerLabel);
 
-			assert.equal(tile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 
-			const tile1 = client.searchForMarker(1, tileLabel, false);
+			const marker1 = client.searchForMarker(1, markerLabel, false);
 
-			assert.equal(tile1, undefined, "Returned tile should be undefined.");
+			assert.equal(marker1, undefined, "Returned marker should be undefined.");
 		});
 
-		it("Should return undefined when trying to find tile from null text", () => {
-			const tileLabel = "EOP";
+		it("Should return undefined when trying to find marker from null text", () => {
+			const markerLabel = "EOP";
 
-			const tile = client.searchForMarker(1, tileLabel);
+			const marker = client.searchForMarker(1, markerLabel);
 
-			assert.equal(tile, undefined, "Returned tile should be undefined.");
+			assert.equal(marker, undefined, "Returned marker should be undefined.");
 
-			const tile1 = client.searchForMarker(1, tileLabel, false);
+			const marker1 = client.searchForMarker(1, markerLabel, false);
 
-			assert.equal(tile1, undefined, "Returned tile should be undefined.");
+			assert.equal(marker1, undefined, "Returned marker should be undefined.");
 		});
 
 		describe("with remote client", () => {
@@ -611,7 +615,7 @@ describe("TestClient", () => {
 
 				const marker = client.searchForMarker(0, "Eop", true);
 
-				assert(marker, "Returned tile undefined");
+				assert(marker, "Returned marker undefined");
 
 				const exp = client.mergeTree.referencePositionToLocalPosition(
 					marker,
@@ -619,7 +623,7 @@ describe("TestClient", () => {
 					client.getClientId(),
 				);
 
-				assert.equal(exp, 0, "Tile with label not at expected position");
+				assert.equal(exp, 0, "Marker with label not at expected position");
 			});
 		});
 	});

--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -276,7 +276,7 @@ describe("TestClient", () => {
 			}
 		});
 
-		it("Should be able to find forward marker position with few segments", () => {
+		it("Should be able to find distant forward marker", () => {
 			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),
@@ -296,7 +296,7 @@ describe("TestClient", () => {
 			}
 		});
 
-		it("Should be able to find backward marker position with few segments", () => {
+		it("Should be able to find distant backward marker", () => {
 			const markerLabel = "EOP";
 			Array.from({ length: MaxNodesInBlock ** 3 * 2 }).forEach((_, i) =>
 				client.insertTextLocal(0, i.toString()),


### PR DESCRIPTION
Addresses the testing gap found from investigations of the now deprecated findTile. Adds some tests for the new searchForMarker method and also cleans up some of the existing tests carried over from findTile. Some new tests were added previously in #16517 to help verify the new implementation of searchForMarker as well. 

New categories of tests:
- Inclusivity at string endpoints 
- Interactions with remotely added markers 
- Interactions with rollback 

[AB#5156](https://dev.azure.com/fluidframework/internal/_workitems/edit/5156)