### PR TITLE
adds unregister from webhook endpoint to external data service

### DIFF
--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -148,48 +148,55 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 
 	interface UnregisterWebhookRequest extends Request {
 		body: {
+			// The target URL to unsubscribe from change notifications
 			url: string;
 		};
 	}
-
+	/**
+	 * Unregister's the sender's URL from receiving notifications when the external task-list data changes.
+	 *
+	 * Expected input data format: {@link UnregisterWebhookRequest}
+	 */
 	expressApp.post("/unregister-webhook", (request: UnregisterWebhookRequest, result) => {
 		// 1. Validate request data
 		if (typeof request.body?.url !== "string") {
 			const errorMessage = "Missing or unexpected data in request body";
 			console.log(formatLogMessage(errorMessage));
 			result.status(400).json({ message: errorMessage });
-			result.send();
-			return;
-		}
-
-		// 1a. Extract SubscriberURL & externalTaskListId from object
-		const subscriberUrl = request.body.url;
-		const externalTaskListId = subscriberUrl.slice(
-			subscriberUrl.indexOf("externalTaskListId=") + "externalTaskListId=".length,
-		);
-
-		// 2. Find cooresponding webook for the given externalTaskListId
-		const webhook = webhookCollection.get(externalTaskListId);
-		if (webhook === undefined) {
-			const errorMessage = "Provided externalTaskListId has no outstanding webhooks";
+		} else if (isWebUri(request.body?.url) === undefined) {
+			const errorMessage = "Provided subscription URL is invalid.";
 			console.log(formatLogMessage(errorMessage));
 			result.status(400).json({ message: errorMessage });
 		} else {
-			// 3. Webhook exists, attempt to remove the subscriber from the webhook
-			// 3a. Webhooks exists but the provided subscriber is not subscribed with the webhook.
-			if (!webhook.subscribers.includes(subscriberUrl)) {
-				const errorMessage =
-					"Provided subscriberUrl does not have a webhook registered for the given externalTaskListId";
+			// 2. Extract SubscriberURL & externalTaskListId from object
+			const subscriberUrl = request.body.url;
+			const externalTaskListId = subscriberUrl.slice(
+				subscriberUrl.indexOf("externalTaskListId=") + "externalTaskListId=".length,
+			);
+
+			// 3. Find cooresponding webook for the given externalTaskListId
+			const webhook = webhookCollection.get(externalTaskListId);
+			if (webhook === undefined) {
+				const errorMessage = "Provided externalTaskListId has no outstanding webhooks";
 				console.log(formatLogMessage(errorMessage));
 				result.status(400).json({ message: errorMessage });
 			} else {
-				// 3b. Webhook exists and the provided subcriber is currently subscribed to it.
-				webhook.removeSubscriber(subscriberUrl);
-				console.log(
-					formatLogMessage(
-						`Unregistered webhook notification for externalTaskListId ${externalTaskListId} at subscriberUrl: "${subscriberUrl}".`,
-					),
-				);
+				// 4. Webhook exists, attempt to remove the subscriber from the webhook
+				if (!webhook.subscribers.includes(subscriberUrl)) {
+					// 4a. Webhooks exists but the provided subscriber is not subscribed with the webhook.
+					const errorMessage =
+						"Provided subscriberUrl does not have a webhook registered for the given externalTaskListId";
+					console.log(formatLogMessage(errorMessage));
+					result.status(400).json({ message: errorMessage });
+				} else {
+					// 4b. Webhook exists and the provided subcriber is currently subscribed to it.
+					webhook.removeSubscriber(subscriberUrl);
+					console.log(
+						formatLogMessage(
+							`Unregistered webhook notification for externalTaskListId ${externalTaskListId} at subscriberUrl: "${subscriberUrl}".`,
+						),
+					);
+				}
 			}
 		}
 

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -41,6 +41,17 @@ class InvalidRequestError extends ApiError {
 }
 
 /**
+ * Expected shape of the request that is handled by the
+ * webook unregister endpoint
+ */
+export interface UnregisterWebhookRequest extends express.Request {
+	body: {
+		// The target URL to unsubscribe from change notifications
+		url: string;
+	};
+}
+
+/**
  * {@link initializeExternalDataService} input properties.
  */
 export interface ServiceProps {
@@ -180,12 +191,6 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 		result.send();
 	});
 
-	interface UnregisterWebhookRequest extends express.Request {
-		body: {
-			// The target URL to unsubscribe from change notifications
-			url: string;
-		};
-	}
 	/**
 	 * Unregisters the senders URL from receiving notifications when this endpoint is called at the end of a collaboration session
 	 *
@@ -224,7 +229,7 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 				const resultMessage =
 					"Provided subscriberUrl does not have a webhook registered for the given externalTaskListId";
 				result.status(200).json({ message: resultMessage });
-				console.warn(formatLogMessage(resultMessage));
+				console.info(formatLogMessage(resultMessage));
 			} else {
 				// 3b. Webhook exists and the provided subcriber is currently subscribed to it.
 				webhook.removeSubscriber(subscriberUrl);

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -47,7 +47,7 @@ class InvalidRequestError extends ApiError {
 export interface RegisterWebhookRequest extends express.Request {
 	body: {
 		/**
-		 * The target URL to unsubscribe from change notifications
+		 * The target URL to subscribe to change notifications for
 		 */
 		url: string;
 		/**
@@ -161,7 +161,6 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 	 */
 	expressApp.post("/register-for-webhook", (request: RegisterWebhookRequest, result) => {
 		try {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const subscriberUrl = request.body.url;
 			if (subscriberUrl === undefined || typeof subscriberUrl !== "string") {
 				throw new InvalidRequestError(
@@ -205,7 +204,7 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 	});
 
 	/**
-	 * Unregisters the senders URL from receiving notifications when this endpoint is called at the end of a collaboration session
+	 * Unregisters the specified URL from receiving notifications for the specified external task list id.
 	 *
 	 * Expected request body format: {@link UnregisterWebhookRequest}
 	 */

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -46,7 +46,9 @@ class InvalidRequestError extends ApiError {
  */
 export interface UnregisterWebhookRequest extends express.Request {
 	body: {
-		// The target URL to unsubscribe from change notifications
+		/**
+		 * The target URL to unsubscribe from change notifications
+		 */
 		url: string;
 	};
 }

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -99,6 +99,7 @@ describe("mock-customer-service", () => {
 					},
 					body: JSON.stringify({
 						url: `http://localhost:${localServicePort}/broadcast-signal?externalTaskListId=${externalTaskListId}`,
+						externalTaskListId,
 					}),
 				},
 			);

--- a/examples/external-data/tests/externalDataService.test.ts
+++ b/examples/external-data/tests/externalDataService.test.ts
@@ -141,6 +141,18 @@ describe("mock-external-data-service", () => {
 			.expect(400);
 	});
 
+	it("unregister-webhook: Unregiserting fron an existing wbhook with a valid URI succeeds", async () => {
+		await request(externalDataService!)
+			.post(`/register-for-webhook?externalTaskListId=${externalTaskListId}`)
+			.send({ url: "https://www.fluidframework.com" })
+			.expect(200);
+
+		await request(externalDataService!)
+			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)
+			.send({ url: "https://www.fluidframework.com" })
+			.expect(200);
+	});
+
 	/* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
 });

--- a/examples/external-data/tests/externalDataService.test.ts
+++ b/examples/external-data/tests/externalDataService.test.ts
@@ -178,6 +178,7 @@ describe("mock-external-data-service", () => {
 			.send({ url: "not a url" })
 			.expect(400);
 	});
+
 	it("unregister-webhook: Invalid request with missing url fails", async () => {
 		await request(externalDataService!)
 			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)

--- a/examples/external-data/tests/externalDataService.test.ts
+++ b/examples/external-data/tests/externalDataService.test.ts
@@ -94,7 +94,7 @@ describe("mock-external-data-service", () => {
 			.expect(200, { taskList: expectedData });
 	});
 
-	// // TODO: figure out a way to mock the webhookCollection or instantiate in the tests so that this test passes
+	// TODO: figure out a way to mock the webhookCollection or instantiate in the tests so that this test passes
 	it("set-tasks: Ensure external data is updated with provided data", async () => {
 		await request(externalDataService!)
 			.post(`/set-tasks/${externalTaskListId}`)
@@ -200,18 +200,18 @@ describe("mock-external-data-service", () => {
 		// invalid url
 		await request(externalDataService!)
 			.post(`/unregister-webhook`)
-			.send({ url: "not a url" })
+			.send({ url: "not a url", externalTaskListId })
 			.expect(400);
 		// missing url
 		await request(externalDataService!).post(`/unregister-webhook`).send({}).expect(400);
 		// invalid data type
 		await request(externalDataService!)
 			.post(`/unregister-webhook`)
-			.send({ url: 123 })
+			.send({ url: 123, externalTaskListId })
 			.expect(400);
 	});
 
-	it("unregister-webhook: Invalid request with missing/invalid url externalTaskListId fails", async () => {
+	it("unregister-webhook: Invalid request with missing/invalid externalTaskListId fails", async () => {
 		// missing externalTaskListId
 		await request(externalDataService!)
 			.post(`/unregister-webhook`)

--- a/examples/external-data/tests/externalDataService.test.ts
+++ b/examples/external-data/tests/externalDataService.test.ts
@@ -129,60 +129,98 @@ describe("mock-external-data-service", () => {
 
 	it("register-for-webhook: Registering valid URI succeeds", async () => {
 		await request(externalDataService!)
-			.post(`/register-for-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "https://www.fluidframework.com" })
+			.post(`/register-for-webhook`)
+			.send({ url: "https://www.fluidframework.com", externalTaskListId })
 			.expect(200);
 	});
 
 	it("register-for-webhook: Registering invalid URI fails", async () => {
+		// missing url
 		await request(externalDataService!)
-			.post(`/register-for-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "I am not a URI" })
+			.post(`/register-for-webhook`)
+			.send({ externalTaskListId })
+			.expect(400);
+		// invalid uri
+		await request(externalDataService!)
+			.post(`/register-for-webhook`)
+			.send({ url: "I am not a URI", externalTaskListId })
+			.expect(400);
+		// invalid data type
+		await request(externalDataService!)
+			.post(`/register-for-webhook`)
+			.send({ url: 123, externalTaskListId })
+			.expect(400);
+	});
+
+	it("register-for-webhook: Registering missing/invalid externalTaskListId fails", async () => {
+		// missing externalTaskListId
+		await request(externalDataService!)
+			.post(`/register-for-webhook`)
+			.send({ url: "https://www.fluidframework.com" })
+			.expect(400);
+		// invalid data type
+		await request(externalDataService!)
+			.post(`/register-for-webhook`)
+			.send({ url: "https://www.fluidframework.com", externalTaskListId: 123 })
 			.expect(400);
 	});
 
 	it("unregister-webhook: Unregistering from an existing webhook with a valid URI succeeds", async () => {
 		await request(externalDataService!)
-			.post(`/register-for-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "https://www.fluidframework.com" })
+			.post(`/register-for-webhook`)
+			.send({ url: "https://www.fluidframework.com", externalTaskListId })
 			.expect(200);
 
 		await request(externalDataService!)
-			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "https://www.fluidframework.com" })
+			.post(`/unregister-webhook`)
+			.send({ url: "https://www.fluidframework.com", externalTaskListId })
 			.expect(200);
 	});
 
 	it("unregister-webhook: Unregistering from an webhook that doesn't exist fails", async () => {
 		await request(externalDataService!)
-			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "https://www.theSecondSubscriber.com" })
+			.post(`/unregister-webhook`)
+			.send({ url: "https://www.thefirstSubscriber.com", externalTaskListId })
 			.expect(400);
 	});
 
 	it("unregister-webhook: Unregistering from an webhook that exists but the provided subscriber is not subscribed to succeeds", async () => {
 		await request(externalDataService!)
-			.post(`/register-for-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "https://www.thefirstSubscriber.com" })
+			.post(`/register-for-webhook`)
+			.send({ url: "https://www.thefirstSubscriber.com", externalTaskListId })
 			.expect(200);
 
 		await request(externalDataService!)
-			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({ url: "https://www.theSecondSubscriber.com" })
+			.post(`/unregister-webhook`)
+			.send({ url: "https://www.theSecondSubscriber.com", externalTaskListId })
 			.expect(200);
 	});
 
-	it("unregister-webhook: Invalid request with malformed url fails", async () => {
+	it("unregister-webhook: Invalid request with missing/invalid url fails", async () => {
+		// invalid url
 		await request(externalDataService!)
-			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)
+			.post(`/unregister-webhook`)
 			.send({ url: "not a url" })
+			.expect(400);
+		// missing url
+		await request(externalDataService!).post(`/unregister-webhook`).send({}).expect(400);
+		// invalid data type
+		await request(externalDataService!)
+			.post(`/unregister-webhook`)
+			.send({ url: 123 })
 			.expect(400);
 	});
 
-	it("unregister-webhook: Invalid request with missing url fails", async () => {
+	it("unregister-webhook: Invalid request with missing/invalid url externalTaskListId fails", async () => {
+		// missing externalTaskListId
 		await request(externalDataService!)
-			.post(`/unregister-webhook?externalTaskListId=${externalTaskListId}`)
-			.send({})
+			.post(`/unregister-webhook`)
+			.send({ url: "https://www.thefirstSubscriber.com" })
+			.expect(400);
+		// invalid externalTaskListId data type
+		await request(externalDataService!)
+			.post(`/unregister-webhook`)
+			.send({ url: "https://www.thefirstSubscriber.com", externalTaskListId: 123 })
 			.expect(400);
 	});
 
@@ -230,7 +268,7 @@ describe("mock-external-data-service: webhook", () => {
 		try {
 			// Register with the external service for notifications
 			const webhookRegistrationResponse = await fetch(
-				`http://localhost:${externalDataServicePort}/register-for-webhook?externalTaskListId=${externalTaskListId}`,
+				`http://localhost:${externalDataServicePort}/register-for-webhook`,
 				{
 					method: "POST",
 					headers: {
@@ -239,6 +277,7 @@ describe("mock-external-data-service: webhook", () => {
 					},
 					body: JSON.stringify({
 						url: `http://localhost:${localServicePort}/broadcast-signal?externalTaskListId=${externalTaskListId}`,
+						externalTaskListId,
 					}),
 				},
 			);


### PR DESCRIPTION
## Description
Creates a new endpoint `unregister-webhook` endpoint in the mock-external-data-service (our pretend Jira or Trello service) in external-data example. The endpoint, as the name suggests, will unregister a subscriber from a webhook, if and only if the subscriber is currently subscribed to said webhook and the webhook exists.

## Updates:
-  I updated the URL parsing of externalTaskListId to use the nodejs builtin URL class because I ran into a bug where the way we were parsing the task-list-id was not parsing correctly
- There was an inconsistency with the 'register-for-webhook' test where the external task list id was being passed in the 'url' attribute of the request body instead of as a url parameter of the request itself.

## Breaking Changes
- none

## Reviewer Guidance
 - There are limited unit tests, let me know if we want something more robust. Make sure that code seems to cover edge cases.
 - The endpoint is 'unregister-webhook'