### PR TITLE
fix: Incorrect Audience if two clients connect to the same container too close to each other   

### DIFF
--- a/packages/test/local-server-tests/src/test/audience.spec.ts
+++ b/packages/test/local-server-tests/src/test/audience.spec.ts
@@ -1,0 +1,136 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	TestFluidObjectFactory,
+	timeoutPromise,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils";
+import {
+	ICodeDetailsLoader,
+	IContainer,
+	IFluidCodeDetails,
+} from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { SharedMap } from "@fluidframework/map";
+
+describe("Audience correctness", () => {
+	const mapId = "mapKey";
+	const codeDetails: IFluidCodeDetails = {
+		package: "connectionModeTestPackage",
+		config: {},
+	};
+
+	const factory: TestFluidObjectFactory = new TestFluidObjectFactory(
+		[[mapId, SharedMap.getFactory()]],
+		"default",
+	);
+
+	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(factory, [
+		[factory.type, Promise.resolve(factory)],
+	]);
+
+	/**
+	 * Function to wait for a client with the given clientId to be added to the audience of the given container.
+	 */
+	async function waitForClientAdd(container: IContainer, clientId: string, errorMsg: string) {
+		if (container.audience.getMember(clientId) === undefined) {
+			return timeoutPromise(
+				(resolve) => {
+					const listener = (newClientId: string) => {
+						if (newClientId === clientId) {
+							container.audience.off("addMember", listener);
+							resolve();
+						}
+					};
+					container.audience.on("addMember", (newClientId: string) =>
+						listener(newClientId),
+					);
+				},
+				// Wait for 2 seconds to get the client in audience. This wait is needed for a client to get added to its
+				// own audience and 2 seconds should be enough time. It it takes longer than this, we might need to
+				// reevaluate our assumptions around audience.
+				// Also see - https://github.com/microsoft/FluidFramework/issues/7275.
+				{ durationMs: 2000, errorMsg },
+			);
+		}
+	}
+
+	it.skip("second client should see first client in audience when it connects immediately after", async () => {
+		const codeLoader: ICodeDetailsLoader = {
+			// The code loader we pass to a loader just needs to ensure we get the runtime factory for our desired container
+			// so we don't need to use the code details parameter in this case.
+			load: async (source: IFluidCodeDetails) => {
+				return {
+					module: {
+						fluidExport: runtimeFactory,
+					},
+					details: source,
+				};
+			},
+		};
+
+		const testDocumentUrl = "https://localhost:8080/test_document_id";
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
+		const urlResolver = new LocalResolver();
+
+		// Create container in first client
+		const loader = new Loader({
+			urlResolver,
+			documentServiceFactory,
+			codeLoader,
+		});
+		const container1 = await loader.createDetachedContainer(codeDetails);
+		await container1.attach({
+			url: testDocumentUrl,
+			headers: {
+				createNew: true,
+			},
+		});
+
+		// Load container from a second client
+		const container2 = await loader.resolve({
+			url: testDocumentUrl,
+		});
+
+		await waitForContainerConnection(container1);
+		await waitForContainerConnection(container2);
+
+		// Validate that client1 is added to its own audience.
+		assert(container1.clientId !== undefined, "client1 does not have clientId");
+		await waitForClientAdd(
+			container1,
+			container1.clientId,
+			"client1's audience doesn't have self",
+		);
+
+		// Validate that client2 is added to its own audience.
+		assert(container2.clientId !== undefined, "client2 does not have clientId");
+		await waitForClientAdd(
+			container2,
+			container2.clientId,
+			"client2's audience doesn't have self",
+		);
+
+		// Validate that client2 is added to client1's audience.
+		await waitForClientAdd(
+			container1,
+			container2.clientId,
+			"client1's audience doesn't have client2",
+		);
+
+		// Validate that client1 is added to client2's audience.
+		await waitForClientAdd(
+			container2,
+			container1.clientId,
+			"client2's audience doesn't have client1",
+		);
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
@@ -229,4 +229,56 @@ describeFullCompat("Audience correctness", (getTestObjectProvider, apis) => {
 			"client2's audience should be removed",
 		);
 	});
+
+	it.skip("second client should see first client in audience when it connects immediately after", async () => {
+		const loader = provider.makeTestLoader();
+		const containerUrl = await provider.driver.createContainerUrl(provider.documentId);
+
+		// Create container in first client
+		const container1 = await loader.createDetachedContainer(provider.defaultCodeDetails);
+		await container1.attach({
+			url: containerUrl,
+			headers: {
+				createNew: true,
+			},
+		});
+
+		// Load container from a second client *immediately after attaching it on the first client*
+		const container2 = await loader.resolve({
+			url: containerUrl,
+		});
+
+		await waitForContainerConnection(container1);
+		await waitForContainerConnection(container2);
+
+		// Validate that client1 is added to its own audience.
+		assert(container1.clientId !== undefined, "client1 does not have clientId");
+		await waitForClientAdd(
+			container1,
+			container1.clientId,
+			"client1's audience doesn't have self",
+		);
+
+		// Validate that client2 is added to its own audience.
+		assert(container2.clientId !== undefined, "client2 does not have clientId");
+		await waitForClientAdd(
+			container2,
+			container2.clientId,
+			"client2's audience doesn't have self",
+		);
+
+		// Validate that client2 is added to client1's audience.
+		await waitForClientAdd(
+			container1,
+			container2.clientId,
+			"client1's audience doesn't have client2",
+		);
+
+		// Validate that client1 is added to client2's audience.
+		await waitForClientAdd(
+			container2,
+			container1.clientId,
+			"client2's audience doesn't have client1",
+		);
+	});
 });

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -335,6 +335,26 @@ export function configureWebSocketServices(
 
 			const clientId = generateClientId();
 
+			const room: IRoom = {
+				tenantId: claims.tenantId,
+				documentId: claims.documentId,
+			};
+
+			try {
+				// Subscribe to channels.
+				await Promise.all([
+					socket.join(getRoomId(room)),
+					socket.join(`client#${clientId}`),
+				]);
+			} catch (err) {
+				const errMsg = `Could not subscribe to channels. Error: ${safeStringify(
+					err,
+					undefined,
+					2,
+				)}`;
+				return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+			}
+
 			const lumberjackProperties = {
 				...getLumberBaseProperties(claims.documentId, claims.tenantId),
 				[CommonProperties.clientId]: clientId,
@@ -373,26 +393,6 @@ export function configureWebSocketServices(
 					false /* isFatal */,
 					5 * 60 * 1000 /* retryAfterMs (5 min) */,
 				);
-			}
-
-			const room: IRoom = {
-				tenantId: claims.tenantId,
-				documentId: claims.documentId,
-			};
-
-			try {
-				// Subscribe to channels.
-				await Promise.all([
-					socket.join(getRoomId(room)),
-					socket.join(`client#${clientId}`),
-				]);
-			} catch (err) {
-				const errMsg = `Could not subscribe to channels. Error: ${safeStringify(
-					err,
-					undefined,
-					2,
-				)}`;
-				return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
 			}
 
 			const connectedTimestamp = Date.now();

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -300,9 +300,39 @@ export function configureWebSocketServices(
 				throw new NetworkError(403, "Must provide an authorization token");
 			}
 
-			// Validate token signature and claims
+			// Validate token signature and claims, and check if it's revoked
 			const token = message.token;
 			const claims = validateTokenClaims(token, message.id, message.tenantId);
+			try {
+				if (revokedTokenChecker && claims.jti) {
+					const isTokenRevoked: boolean = await revokedTokenChecker.isTokenRevoked(
+						claims.tenantId,
+						claims.documentId,
+						claims.jti,
+					);
+					if (isTokenRevoked) {
+						throw new core.TokenRevokedError(
+							403,
+							"Permission denied. Token has been revoked",
+							false /* canRetry */,
+							true /* isFatal */,
+						);
+					}
+				}
+				await tenantManager.verifyToken(claims.tenantId, token);
+			} catch (error) {
+				if (isNetworkError(error)) {
+					throw error;
+				}
+				// We don't understand the error, so it is likely an internal service error.
+				const errMsg = `Could not verify connect document token. Error: ${safeStringify(
+					error,
+					undefined,
+					2,
+				)}`;
+				return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+			}
+
 			const clientId = generateClientId();
 
 			const lumberjackProperties = {
@@ -343,37 +373,6 @@ export function configureWebSocketServices(
 					false /* isFatal */,
 					5 * 60 * 1000 /* retryAfterMs (5 min) */,
 				);
-			}
-
-			try {
-				// Check if token is revoked
-				if (revokedTokenChecker && claims.jti) {
-					const isTokenRevoked: boolean = await revokedTokenChecker.isTokenRevoked(
-						claims.tenantId,
-						claims.documentId,
-						claims.jti,
-					);
-					if (isTokenRevoked) {
-						throw new core.TokenRevokedError(
-							403,
-							"Permission denied. Token has been revoked",
-							false /* canRetry */,
-							true /* isFatal */,
-						);
-					}
-				}
-				await tenantManager.verifyToken(claims.tenantId, token);
-			} catch (error) {
-				if (isNetworkError(error)) {
-					throw error;
-				}
-				// We don't understand the error, so it is likely an internal service error.
-				const errMsg = `Could not verify connect document token. Error: ${safeStringify(
-					error,
-					undefined,
-					2,
-				)}`;
-				return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
 			}
 
 			const room: IRoom = {


### PR DESCRIPTION
## Description

**Partially** fixes a race condition in server, where if two clients connect to the same container immediately one after another, the second one will not see the first one in its audience because the server won't include it in the `initialClients` property when responding to the second client's connection request. The race condition is triggered by `awaiting` async code in the server between the time when the list of clients is computed, and the time when it is put in the response message. The first client connects, hits that async code, the second client starts its connection in the meantime and sees an empty list of clients, then the async for the first client's request completes and the first client is added to the server's list of `initialClients` but it's too late already; the server will reply to the second client with an empty list of `initialClients`.

This will fix the race condition entirely for single-instance implementations of the service, like local server or tinylicious; but implementations that run multiple instances at a time could still run into this issue even after the fix is merged. More design and work is necessary in this space to fully address the problem. (See discussion in the comments below).

### What was done in this PR 

I moved the async code (token revocation check and channel/room subscription) that was between the two relevant steps, so it happens before the first step instead of between the first and the second. This also makes sense because we probably don't want to do _anything_ in the server if the token is not valid.

Also added a unit test for local server (in a package in the client release group), and an e2e test to prevent a regression in the single-instance server implementations. They're both skipped until the fix is merged, released, and the client release group consumes it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I confirmed that the tests pass with the fix by editing the `js` file for server code in node_modules directly.

[AB#5389](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5389)