### PR TITLE
Remove incorrect early exit in isDeltaVisible

### DIFF
--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -458,7 +458,6 @@ export function isDeltaVisible(delta: Delta.MarkList): boolean {
 				default:
 					unreachableCase(type);
 			}
-			return false;
 		}
 	}
 	return false;


### PR DESCRIPTION
## Description

Previous logic exited after checking a single mark.