### PR TITLE
fix:[Fluid Devtools] npm run test:coverage for browser extension OOMs locally and makes CI builds noticeably longer

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -53,8 +53,7 @@
 		],
 		"exclude-after-remap": false,
 		"include": [
-			"src/**/*.ts",
-			"dist/**/*.js"
+			"src/**/*.ts"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -51,8 +51,7 @@
 		],
 		"exclude-after-remap": false,
 		"include": [
-			"src/**/*.ts",
-			"dist/**/*.js"
+			"src/**/*.ts"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [


### PR DESCRIPTION
## Description

`npm run test:coverage` time duration bump from ~1m20s to ~3m30s. Example pipeline run: https://dev.azure.com/fluidframework/internal/_build/results?buildId=134923&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=38623822-d55d-5839-9078-a2164c1dcf41
 Example error:
~~~
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/background/BackgroundScript.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/background/Logging.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/Constants.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/index.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/Messages.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/Utilities.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/bootstrap' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/compat get default export' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/define property getters' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/ensure chunk' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/get javascript chunk filename' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/global' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/hasOwnProperty shorthand' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/jsonp chunk loading' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/load script' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/make namespace object' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/node module decorator' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/publicPath' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/AudienceMetadata.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/Container.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/FluidClientDebugger.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/index.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/Registry.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/messaging/Constants.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/messaging/index.js' does not exist (any more).

~~~
Remove unnecessary file from test coverage path.
