### PR TITLE
test: Simplify test structure to reduce boilerplate

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -534,7 +534,7 @@ describe("Op Size", () => {
 		const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
 		type OpKindDistribution = {
-			+readonly [OpKind in keyof typeof Operation]: number;
+			readonly [OpKind in keyof typeof Operation]: number;
 		};
 
 		const distributions: OpKindDistribution[] = [

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -530,8 +530,8 @@ describe("Op Size", () => {
 
 	describe("Insert, Delete & Edit Nodes", () => {
 		const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
-		const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-		const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
+		const seventyPercentCount = Math.floor(BENCHMARK_NODE_COUNT * 0.7);
+		const fifteenPercentCount = Math.floor(BENCHMARK_NODE_COUNT * 0.15);
 
 		type OpKindDistribution = {
 			readonly [OpKind in keyof typeof Operation]: number;

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -584,9 +584,35 @@ describe("Op Size", () => {
 				expectChildrenValues(tree, editPayload, editNodeCount);
 			};
 
-			describe("an equal distribution of operation type", () => {
-				const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
+			const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
 
+			type Distribution = {
+				+readonly [OpKind in keyof typeof Operation]: number;
+			};
+
+			const distributions: Distribution[] = [
+				{
+					[Operation.Insert]: oneThirdNodeCount,
+					[Operation.Edit]: oneThirdNodeCount,
+					[Operation.Delete]: oneThirdNodeCount,
+				},
+			];
+
+			for (const { description, style, extraDescription } of styles) {
+				describe(description, () => {
+					for (const { percentile, word } of sizes) {
+						it(`${BENCHMARK_NODE_COUNT} ${word} changes in ${extraDescription} containing ${
+							style === TransactionStyle.Individual
+								? "1 edit"
+								: `${BENCHMARK_NODE_COUNT} edits`
+						}`, () => {
+							benchmarkInsertDeleteEditNodesWithInvidiualTxs(style, percentile);
+						});
+					}
+				});
+			}
+
+			describe("an equal distribution of operation type", () => {
 				it(`insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
 					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -529,13 +529,48 @@ describe("Op Size", () => {
 	});
 
 	describe("Insert, Delete & Edit Nodes", () => {
+		const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
+		const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
+		const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
+
+		type OpKindDistribution = {
+			+readonly [OpKind in keyof typeof Operation]: number;
+		};
+
+		const distributions: OpKindDistribution[] = [
+			{
+				[Operation.Insert]: oneThirdNodeCount,
+				[Operation.Edit]: oneThirdNodeCount,
+				[Operation.Delete]: oneThirdNodeCount,
+			},
+			{
+				[Operation.Insert]: seventyPercentCount,
+				[Operation.Edit]: fifteenPercentCount,
+				[Operation.Delete]: fifteenPercentCount,
+			},
+			{
+				[Operation.Insert]: fifteenPercentCount,
+				[Operation.Edit]: seventyPercentCount,
+				[Operation.Delete]: fifteenPercentCount,
+			},
+			{
+				[Operation.Insert]: fifteenPercentCount,
+				[Operation.Edit]: fifteenPercentCount,
+				[Operation.Delete]: seventyPercentCount,
+			},
+		];
+
 		describe("Individual Transactions", () => {
 			const benchmarkInsertDeleteEditNodesWithInvidiualTxs = (
 				percentile: number,
-				insertNodeCount: number,
-				deleteNodeCount: number,
-				editNodeCount: number,
+				distribution: OpKindDistribution,
 			) => {
+				const {
+					Delete: deleteNodeCount,
+					Insert: insertNodeCount,
+					Edit: editNodeCount,
+				} = distribution;
+
 				const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
 				initializeOpDataCollection(tree);
 
@@ -584,158 +619,19 @@ describe("Op Size", () => {
 				expectChildrenValues(tree, editPayload, editNodeCount);
 			};
 
-			const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
-
-			type Distribution = {
-				+readonly [OpKind in keyof typeof Operation]: number;
-			};
-
-			const distributions: Distribution[] = [
-				{
-					[Operation.Insert]: oneThirdNodeCount,
-					[Operation.Edit]: oneThirdNodeCount,
-					[Operation.Delete]: oneThirdNodeCount,
-				},
-			];
-
-			for (const { description, style, extraDescription } of styles) {
-				describe(description, () => {
-					for (const { percentile, word } of sizes) {
-						it(`${BENCHMARK_NODE_COUNT} ${word} changes in ${extraDescription} containing ${
-							style === TransactionStyle.Individual
-								? "1 edit"
-								: `${BENCHMARK_NODE_COUNT} edits`
-						}`, () => {
-							benchmarkInsertDeleteEditNodesWithInvidiualTxs(style, percentile);
+			for (const distribution of distributions) {
+				const suiteDescription = `Distribution: ${distribution.Insert}% insert, ${distribution.Edit}% edit, ${distribution.Delete}% delete`;
+				describe(suiteDescription, () => {
+					for (const { percentile } of sizes) {
+						it(`Percentile: ${percentile}`, () => {
+							benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+								percentile,
+								distribution,
+							);
 						});
 					}
 				});
 			}
-
-			describe("an equal distribution of operation type", () => {
-				it(`insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.01,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-					);
-				});
-
-				it(`insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.5,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-					);
-				});
-
-				it(`insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						1,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-					);
-				});
-			});
-
-			describe("70% distribution of operations towards insert", () => {
-				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
-
-				it(`Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.01,
-						seventyPercentCount,
-						fifteenPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.5,
-						seventyPercentCount,
-						fifteenPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						1,
-						seventyPercentCount,
-						fifteenPercentCount,
-						fifteenPercentCount,
-					);
-				});
-			});
-
-			describe("70% distribution of operations towards delete", () => {
-				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
-
-				it(`Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.01,
-						fifteenPercentCount,
-						seventyPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.5,
-						fifteenPercentCount,
-						seventyPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						1,
-						fifteenPercentCount,
-						seventyPercentCount,
-						fifteenPercentCount,
-					);
-				});
-			});
-
-			describe("70% distribution of operations towards edit", () => {
-				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
-
-				it(`Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.01,
-						fifteenPercentCount,
-						fifteenPercentCount,
-						seventyPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						0.5,
-						fifteenPercentCount,
-						fifteenPercentCount,
-						seventyPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
-						1,
-						fifteenPercentCount,
-						fifteenPercentCount,
-						seventyPercentCount,
-					);
-				});
-			});
 		});
 
 		// TODO:
@@ -747,10 +643,14 @@ describe("Op Size", () => {
 		describe("Single Transactions", () => {
 			const benchmarkInsertDeleteEditNodesWithSingleTxs = (
 				percentile: number,
-				insertNodeCount: number,
-				deleteNodeCount: number,
-				editNodeCount: number,
+				distribution: OpKindDistribution,
 			) => {
+				const {
+					Delete: deleteNodeCount,
+					Insert: insertNodeCount,
+					Edit: editNodeCount,
+				} = distribution;
+
 				const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
 				initializeOpDataCollection(tree);
 
@@ -792,132 +692,16 @@ describe("Op Size", () => {
 				expectChildrenValues(tree, editPayload, editNodeCount);
 			};
 
-			describe("equal distribution of operation type", () => {
-				const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
-
-				it(`insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.01,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-					);
+			for (const distribution of distributions) {
+				const suiteDescription = `Distribution: ${distribution.Insert}% insert, ${distribution.Edit}% edit, ${distribution.Delete}% delete`;
+				describe(suiteDescription, () => {
+					for (const { percentile } of sizes) {
+						it(`Percentile: ${percentile}`, () => {
+							benchmarkInsertDeleteEditNodesWithSingleTxs(percentile, distribution);
+						});
+					}
 				});
-
-				it(`insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.5,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-					);
-				});
-
-				it(`insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						1,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-						oneThirdNodeCount,
-					);
-				});
-			});
-
-			describe("70% distribution of operations towards insert", () => {
-				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
-
-				it(`Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.01,
-						seventyPercentCount,
-						fifteenPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.5,
-						seventyPercentCount,
-						fifteenPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						1,
-						seventyPercentCount,
-						fifteenPercentCount,
-						fifteenPercentCount,
-					);
-				});
-			});
-
-			describe("70% distribution of operations towards delete", () => {
-				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
-
-				it(`Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.01,
-						fifteenPercentCount,
-						seventyPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.5,
-						fifteenPercentCount,
-						seventyPercentCount,
-						fifteenPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						1,
-						fifteenPercentCount,
-						seventyPercentCount,
-						fifteenPercentCount,
-					);
-				});
-			});
-
-			describe("70% distribution of operations towards edit", () => {
-				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
-				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
-
-				it(`Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.01,
-						fifteenPercentCount,
-						fifteenPercentCount,
-						seventyPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						0.5,
-						fifteenPercentCount,
-						fifteenPercentCount,
-						seventyPercentCount,
-					);
-				});
-
-				it(`Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
-					benchmarkInsertDeleteEditNodesWithSingleTxs(
-						1,
-						fifteenPercentCount,
-						fifteenPercentCount,
-						seventyPercentCount,
-					);
-				});
-			});
+			}
 		});
 	});
 });


### PR DESCRIPTION
Generates test variation expansions, rather than enumerating them explicitly.