### PR TITLE
feat(sequence): add side to fuzz tests

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -224,7 +224,7 @@ export class Interval implements ISerializableInterval {
     // (undocumented)
     getProperties(): PropertySet;
     // @internal
-    modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage): Interval | undefined;
+    modify(label: string, start?: SequencePlace, end?: SequencePlace, op?: ISequencedDocumentMessage): Interval | undefined;
     // (undocumented)
     overlaps(b: Interval): boolean;
     properties: PropertySet;

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -142,7 +142,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
     // (undocumented)
     readonly attached: boolean;
     attachIndex(index: IntervalIndex<TInterval>): void;
-    change(id: string, start?: number, end?: number): TInterval | undefined;
+    change(id: string, start?: SequencePlace, end?: SequencePlace): TInterval | undefined;
     changeProperties(id: string, props: PropertySet): any;
     // (undocumented)
     CreateBackwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -191,11 +191,18 @@ function toSequencePlace(pos: number | "start" | "end", side: Side): SequencePla
 	return typeof pos === "number" ? { pos, side } : pos;
 }
 
+function toOptionalSequencePlace(
+	pos: number | "start" | "end" | undefined,
+	side: Side = Side.Before,
+): SequencePlace | undefined {
+	return typeof pos === "number" ? { pos, side } : pos;
+}
+
 export function computeStickinessFromSide(
-	startPos: number | "start" | "end" | undefined,
-	startSide: Side,
-	endPos: number | "start" | "end" | undefined,
-	endSide: Side,
+	startPos: number | "start" | "end" | undefined = -1,
+	startSide: Side = Side.Before,
+	endPos: number | "start" | "end" | undefined = -1,
+	endSide: Side = Side.Before,
 ): IntervalStickiness {
 	let stickiness: IntervalStickiness = IntervalStickiness.NONE;
 
@@ -816,7 +823,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	 * @param end - New end value, if defined. `undefined` signifies this endpoint should be left unchanged.
 	 * @returns the interval that was changed, if it existed in the collection.
 	 */
-	change(id: string, start?: number, end?: number): TInterval | undefined;
+	change(id: string, start?: SequencePlace, end?: SequencePlace): TInterval | undefined;
 
 	attachDeserializer(onDeserialize: DeserializeCallback): void;
 	/**
@@ -1305,8 +1312,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 				return undefined;
 			}
 			const serializedInterval: SerializedIntervalDelta = interval.serialize();
-			serializedInterval.start = typeof start === "object" ? start.pos : start;
-			serializedInterval.end = typeof end === "object" ? end.pos : end;
+			const { startPos, startSide, endPos, endSide } = endpointPosAndSide(start, end);
+			const stickiness = computeStickinessFromSide(startPos, startSide, endPos, endSide);
+			serializedInterval.start = startPos;
+			serializedInterval.end = endPos;
+			serializedInterval.startSide = startSide;
+			serializedInterval.endSide = endSide;
+			serializedInterval.stickiness = stickiness;
 			// Emit a property bag containing only the ID, as we don't intend for this op to change any properties.
 			serializedInterval.properties = {
 				[reservedIntervalIdKey]: interval.getIntervalId(),
@@ -1443,7 +1455,12 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 				// If changeInterval gives us a new interval, work with that one. Otherwise keep working with
 				// the one we originally found in the tree.
 				newInterval =
-					this.localCollection.changeInterval(interval, start, end, op) ?? interval;
+					this.localCollection.changeInterval(
+						interval,
+						toOptionalSequencePlace(start, serializedInterval.startSide),
+						toOptionalSequencePlace(end, serializedInterval.endSide),
+						op,
+					) ?? interval;
 			}
 			const deltaProps = newInterval.addProperties(newProps, true, op.sequenceNumber);
 			if (this.onDeserialize) {
@@ -1547,8 +1564,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			// updates the local client's state to be consistent with the emitted op.
 			this.localCollection?.changeInterval(
 				localInterval,
-				startRebased,
-				endRebased,
+				toOptionalSequencePlace(startRebased, startSide),
+				toOptionalSequencePlace(endRebased, endSide),
 				undefined,
 				localSeq,
 			);

--- a/packages/dds/sequence/src/intervals/interval.ts
+++ b/packages/dds/sequence/src/intervals/interval.ts
@@ -186,9 +186,21 @@ export class Interval implements ISerializableInterval {
 	 * {@inheritDoc IInterval.modify}
 	 * @internal
 	 */
-	public modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage) {
-		const startPos = start ?? this.start;
-		const endPos = end ?? this.end;
+	public modify(
+		label: string,
+		start?: SequencePlace,
+		end?: SequencePlace,
+		op?: ISequencedDocumentMessage,
+	) {
+		if (typeof start === "string" || typeof end === "string") {
+			throw new UsageError(
+				"The start and end positions of a plain interval may not be on the special endpoint segments.",
+			);
+		}
+
+		const startPos = typeof start === "number" ? start : start?.pos ?? this.start;
+		const endPos = typeof end === "number" ? end : end?.pos ?? this.end;
+
 		if (this.start === startPos && this.end === endPos) {
 			// Return undefined to indicate that no change is necessary.
 			return;

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -206,9 +206,6 @@ export class SequenceInterval implements ISerializableInterval {
 		if (this.properties) {
 			serializedInterval.properties = this.properties;
 		}
-		if (this.stickiness !== IntervalStickiness.END) {
-			serializedInterval.stickiness = this.stickiness;
-		}
 
 		return serializedInterval;
 	}

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -24,7 +24,7 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import { FlushMode } from "@fluidframework/runtime-definitions";
-import { IIntervalCollection } from "../intervalCollection";
+import { IIntervalCollection, Side } from "../intervalCollection";
 import { SharedStringFactory } from "../sequenceFactory";
 import { SharedString } from "../sharedString";
 import { SequenceInterval } from "../intervals";
@@ -115,6 +115,8 @@ export function makeOperationGenerator(
 			...inclusiveRange(state),
 			collectionName: state.random.pick(options.intervalCollectionNamePool),
 			id: state.random.uuid4(),
+			startSide: state.random.pick([Side.Before, Side.After]),
+			endSide: state.random.pick([Side.Before, Side.After]),
 		};
 	}
 
@@ -131,6 +133,8 @@ export function makeOperationGenerator(
 			type: "changeInterval",
 			start: state.random.integer(0, 5) === 5 ? undefined : start,
 			end: state.random.integer(0, 5) === 5 ? undefined : end,
+			startSide: state.random.pick([Side.Before, Side.After]),
+			endSide: state.random.pick([Side.Before, Side.After]),
 			...interval(state),
 		};
 	}
@@ -266,7 +270,7 @@ describe("IntervalCollection fuzz testing", () => {
 			attachProbability: 0.2,
 		},
 		// Uncomment this line to replay a specific seed from its failure file:
-		// replay: 0,
+		// replay: 67,
 	});
 });
 

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -259,9 +259,9 @@ describe("IntervalCollection fuzz testing", () => {
 		// on segments that can be zamboni'd.
 		// TODO:AB#5337: re-enable these seeds.
 		skip: [
-			1, 3, 4, 7, 9, 11, 12, 13, 18, 19, 20, 25, 28, 31, 32, 33, 34, 36, 39, 41, 42, 43, 44,
-			45, 49, 50, 51, 52, 53, 55, 57, 58, 60, 61, 62, 63, 64, 65, 72, 74, 76, 78, 79, 82, 83,
-			86, 87, 89, 90, 91, 92, 94, 98, 99,
+			1, 2, 3, 4, 5, 7, 9, 11, 12, 13, 14, 15, 16, 18, 19, 20, 25, 26, 28, 31, 32, 33, 34, 36,
+			39, 40, 41, 42, 43, 44, 45, 46, 49, 50, 51, 52, 53, 55, 56, 57, 58, 60, 61, 62, 63, 64,
+			65, 72, 73, 74, 75, 76, 78, 79, 80, 82, 83, 84, 86, 87, 88, 89, 90, 91, 92, 94, 98, 99,
 		],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)
@@ -270,7 +270,7 @@ describe("IntervalCollection fuzz testing", () => {
 			attachProbability: 0.2,
 		},
 		// Uncomment this line to replay a specific seed from its failure file:
-		// replay: 67,
+		// replay: 0,
 	});
 });
 
@@ -293,7 +293,7 @@ describe("IntervalCollection no reconnect fuzz testing", () => {
 	createDDSFuzzSuite(noReconnectModel, {
 		...options,
 		// AB#4477: Same root cause as skipped regression test in intervalCollection.spec.ts--search for 4477.
-		skip: [9, 12, 33, 44, 80],
+		skip: [9, 12, 33, 40, 44, 80],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)
 		detachedStartOptions: {
@@ -314,7 +314,7 @@ describe("IntervalCollection fuzz testing with rebased batches", () => {
 	createDDSFuzzSuite(noReconnectWithRebaseModel, {
 		...defaultFuzzOptions,
 		// ADO:4477: Same root cause as skipped regression test in intervalCollection.spec.ts--search for 4477.
-		skip: [9, 12, 29],
+		skip: [9, 12, 18, 29],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)
 		detachedStartOptions: {

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -217,10 +217,23 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.removeRange(0, 1);
 		clients[0].sharedString.insertText(0, "D");
 		const collection_1 = clients[1].sharedString.getIntervalCollection("comments");
-		collection_1.add("start", 1, IntervalType.SlideOnRemove, {
+		collection_1.add({ pos: 0, side: Side.After }, 1, IntervalType.SlideOnRemove, {
 			intervalId: "1",
 		});
 		clients[2].sharedString.removeRange(1, 2);
+		containerRuntimeFactory.processAllMessages();
+		assertConsistent(clients);
+	});
+
+	it("maintains sliding preference on references after reconnect with special endpoint segment", () => {
+		clients[0].sharedString.insertText(0, "D");
+		clients[0].containerRuntime.connected = false;
+		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
+		const interval = collection_1.add("start", 0, IntervalType.SlideOnRemove, {
+			intervalId: "1",
+		});
+		assert.equal(interval.stickiness, IntervalStickiness.FULL);
+		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
 		assertConsistent(clients);
 	});
@@ -229,9 +242,15 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.insertText(0, "D");
 		clients[0].containerRuntime.connected = false;
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
-		collection_1.add("start", 0, IntervalType.SlideOnRemove, {
-			intervalId: "1",
-		});
+		const interval = collection_1.add(
+			{ pos: 0, side: Side.After },
+			0,
+			IntervalType.SlideOnRemove,
+			{
+				intervalId: "1",
+			},
+		);
+		assert.equal(interval.stickiness, IntervalStickiness.FULL);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
 		assertConsistent(clients);

--- a/packages/dds/sequence/src/test/intervalUtils.ts
+++ b/packages/dds/sequence/src/test/intervalUtils.ts
@@ -58,6 +58,12 @@ export function assertEquivalentSharedStrings(a: SharedString, b: SharedString) 
 			const otherInterval = collection2.getIntervalById(intervalId);
 			assert(otherInterval);
 			assert.equal(
+				interval.startSide,
+				otherInterval.startSide,
+				"interval start side not equal",
+			);
+			assert.equal(interval.endSide, otherInterval.endSide, "interval end side not equal");
+			assert.equal(
 				interval.stickiness,
 				otherInterval.stickiness,
 				"interval stickiness not equal",


### PR DESCRIPTION
This is somewhat related to [ADO#4942](https://dev.azure.com/fluidframework/internal/_workitems/edit/4942), with the main goal being to add code coverage to interval revertible<>stickiness interactions.

Stickiness _was_ part of fuzz tests prior to the switch to using the `Side` API. This change adds stickiness back to fuzz tests and also solves two separate bugs in which the side value was not properly sent to other clients.