### PR TITLE
Tree: Handle stashed schema ops

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
@@ -14,7 +14,6 @@ import {
 	ISummaryTreeWithStats,
 	IGarbageCollectionData,
 } from "@fluidframework/runtime-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
 import { ICodecOptions, IJsonCodec } from "../codec";
 import {
@@ -161,16 +160,18 @@ export class SchemaEditor<TRepository extends StoredSchemaRepository>
 	 * TODO: Shared tree needs a pattern for handling non-changeset operations.
 	 * See TODO on `SharedTree.processCore`.
 	 */
-	public tryHandleOp(message: ISequencedDocumentMessage): boolean {
-		const op = message.contents as JsonCompatibleReadOnly;
-		if (isJsonObject(op) && op.type === "SchemaOp") {
-			assert(typeof op.data === "string", 0x6ca /* SchemaOps should have string data */);
-			const data = this.codec.decode(op.data);
+	public tryHandleOp(encodedOp: JsonCompatibleReadOnly): boolean {
+		const op = this.tryDecodeOp(encodedOp);
+		if (op !== undefined) {
 			// TODO: This does not correctly handle concurrency of schema edits.
-			this.inner.update(data);
+			this.inner.update(op);
 			return true;
 		}
 		return false;
+	}
+
+	public tryApplyStashedOp(encodedOp: JsonCompatibleReadOnly): boolean {
+		return this.tryHandleOp(encodedOp);
 	}
 
 	/**
@@ -224,5 +225,17 @@ export class SchemaEditor<TRepository extends StoredSchemaRepository>
 
 	public get treeSchema(): ReadonlyMap<TreeSchemaIdentifier, TreeStoredSchema> {
 		return this.inner.treeSchema;
+	}
+
+	private tryDecodeOp(encodedOp: JsonCompatibleReadOnly): SchemaData | undefined {
+		if (isJsonObject(encodedOp) && encodedOp.type === "SchemaOp") {
+			assert(
+				typeof encodedOp.data === "string",
+				0x6ca /* SchemaOps should have string data */,
+			);
+			return this.codec.decode(encodedOp.data);
+		}
+
+		return undefined;
 	}
 }

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -212,7 +212,7 @@ export class SharedTree
 		local: boolean,
 		localOpMetadata: unknown,
 	) {
-		if (!this.schema.tryHandleOp(message)) {
+		if (!this.schema.tryHandleOp(message.contents)) {
 			super.processCore(message, local, localOpMetadata);
 		}
 	}
@@ -223,6 +223,12 @@ export class SharedTree
 	): void {
 		if (!this.schema.tryResubmitOp(content)) {
 			super.reSubmitCore(content, localOpMetadata);
+		}
+	}
+
+	protected override applyStashedOp(content: JsonCompatibleReadOnly): undefined {
+		if (!this.schema.tryApplyStashedOp(content)) {
+			return super.applyStashedOp(content);
 		}
 	}
 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -25,6 +25,7 @@ import {
 	SummarizeType,
 	TestTreeProvider,
 	TestTreeProviderLite,
+	jsonSequenceRootSchema,
 	namedTreeSchema,
 } from "../utils";
 import {
@@ -1259,7 +1260,11 @@ describe("SharedTree", () => {
 
 		it("rebases stashed ops with prior state present", async () => {
 			const provider = await TestTreeProvider.create(2);
-			insert(provider.trees[0], 0, "a");
+			provider.trees[0].schematize({
+				initialTree: ["a"],
+				schema: jsonSequenceRootSchema,
+				allowedSchemaModifications: AllowedUpdateType.None,
+			});
 			await provider.ensureSynchronized();
 
 			const pausedContainer: IContainerExperimental = provider.containers[0];


### PR DESCRIPTION
## Description
Added support for handling stashed schema ops instead of incorrectly interpreting them as normal editing ops.