### PR TITLE
Fix error as the deltamanager does not emit readonly event in case of initial NoDeltaStream connection

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -400,6 +400,7 @@ export class ConnectionManager implements IConnectionManager {
 			error,
 		};
 
+		const oldReadonlyValue = this.readonly;
 		// This raises "disconnect" event if we have active connection.
 		this.disconnectFromDeltaStream(disconnectReason);
 
@@ -407,7 +408,7 @@ export class ConnectionManager implements IConnectionManager {
 			// Notify everyone we are in read-only state.
 			// Useful for data stores in case we hit some critical error,
 			// to switch to a mode where user edits are not accepted
-			this.set_readonlyPermissions(true);
+			this.set_readonlyPermissions(true, oldReadonlyValue);
 		}
 	}
 
@@ -482,10 +483,12 @@ export class ConnectionManager implements IConnectionManager {
 		}
 	}
 
-	private set_readonlyPermissions(readonly: boolean) {
-		const oldValue = this.readonly;
-		this._readonlyPermissions = readonly;
-		if (oldValue !== this.readonly) {
+	private set_readonlyPermissions(
+		newReadonlyValue: boolean,
+		oldReadonlyValue: boolean | undefined,
+	) {
+		this._readonlyPermissions = newReadonlyValue;
+		if (oldReadonlyValue !== this.readonly) {
 			this.props.readonlyChangeHandler(this.readonly);
 		}
 	}
@@ -775,6 +778,7 @@ export class ConnectionManager implements IConnectionManager {
 
 		this.pendingConnection = undefined;
 
+		const oldReadonlyValue = this.readonly;
 		this.connection = connection;
 
 		// Does information in scopes & mode matches?
@@ -800,7 +804,7 @@ export class ConnectionManager implements IConnectionManager {
 			0x0e8 /* "readonly perf with write connection" */,
 		);
 
-		this.set_readonlyPermissions(readonly);
+		this.set_readonlyPermissions(readonly, oldReadonlyValue);
 
 		if (this._disposed) {
 			// Raise proper events, Log telemetry event and close connection.


### PR DESCRIPTION
## Description

Fix error as the deltamanager does not emit r`eadonly` event in case of initial `NoDeltaStream` connection for example when we DeltaStreamForbiddeen error. The `readonlyinfo` getter makes use of current connection object to find if it is readonly which is correct, and as that would be the newer connection as we already set that in the `setupNewSuccessfulConnection`, we use it get older value in the `set_readonlyPermissions` method which is wrong.