### PR TITLE
Revert "Add Telemetry to Log Error When Signal From Unknown Client"

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2335,19 +2335,6 @@ export class Container
 			this.protocolHandler.processSignal(message);
 		} else {
 			const local = this.clientId === message.clientId;
-			if (
-				typeof message.clientId === "string" &&
-				this.audience.getMember(message.clientId) === undefined
-			) {
-				// Right now this will just tell us if a signal comes form a client
-				// this client doesn't recognize. In the future we may decided to do something
-				// like disconnect and reconnect to refresh the audience, but we should see
-				// how often it hits before we decided to add that kind of recovery.
-				this.mc.logger.sendErrorEvent({
-					eventName: "SignalFromUnknownClient",
-					messageClientId: message.clientId,
-				});
-			}
 			this.runtime.processSignal(message, local);
 		}
 	}


### PR DESCRIPTION
Reverts microsoft/FluidFramework#17067

This firing a lot in stress. Reverting to reduce noise.

Data_eventName | Data_error | count_ |
-- | -- | -- 
fluid:telemetry:Container:SignalFromUnknownClient | SignalFromUnknownClient |  22027 
