### PR TITLE
docs(tree): Typos & similar

### DIFF
--- a/experimental/dds/tree2/README.md
+++ b/experimental/dds/tree2/README.md
@@ -49,7 +49,7 @@ The current feature focus is on:
     -   New field kinds to allow data-modeling with more specific merge semantics (ex: adding support for special collections like sets, or sorted sequences)
     -   New services (ex: to support permissions, server side indexing etc.)
 
-## Whats missing from existing DDSes?
+## What's missing from existing DDSes?
 
 `directory` and `map` can not provide merge resolution that guarantees well-formedness of trees while supporting the desired editing APIs (like subsequence move),
 and are missing (and cannot be practically extended to have) efficient ways to handle large data or schema.
@@ -85,7 +85,7 @@ This package can be developed using any of the [regular workflows for working on
 
 -   Open the [.vscode/Tree.code-workspace](.vscode/Tree.code-workspace) in VS Code.
     This will recommend a test runner extension, which should be installed.
--   Build the Client release group as normal (for example: `npm i && npm run build:fast` in the repository root).
+-   Build the Client release group as normal (for example: `pnpm i && npm run build:fast` in the repository root).
 -   After editing the tree project, run `npm run build` in its directory.
 -   Run tests using the "Testing" side panel in VS Code, or using the inline `Run | Debug` buttons which should show up above tests in the source:
     both of these are provided by the mocha testing extension thats recommended by the workspace.
@@ -142,7 +142,7 @@ Views may also have state from the application, including:
 -   registrations for application callbacks / events.
 
 [`shared-tree`](./src/shared-tree/) provides a default view which it owns, but applications can create more if desired, which they will own.
-Since views subscribe to events from `shared-tree`, explicitly disposing any additionally created ones of is required to avoid leaks.
+Since views subscribe to events from `shared-tree`, explicitly disposing any additionally created ones is required to avoid leaks.
 
 [transactions](./src/core/transaction/README.md) are created by `ISharedTreeView`s and are currently synchronous.
 Support for asynchronous transactions, with the application managing the lifetime and ensuring it does not exceed the lifetime of the view,
@@ -272,7 +272,7 @@ graph LR;
 ### Dependencies
 
 `@fluid-experimental/tree2` depends on the Fluid runtime (various packages in `@fluidframework/*`)
-and will be depended on directly by application using it (though at that time it will be moved out of `@fluid-internal`).
+and will be depended on directly by application using it (though at that time it will be moved out of `@fluid-experimental`).
 `@fluid-experimental/tree2` is also complex,
 so its implementation is broken up into several parts which have carefully controlled dependencies to help ensure the codebase is maintainable.
 The goal of this internal structuring is to make evolution and maintenance easy.
@@ -299,7 +299,7 @@ Some of the principles used to guide this are:
     This is important for testability, since complex conditional logic (like `ChangeRebaser` implementations) require extensive unit testing,
     which is very difficult (and often slow) for stateful systems and systems with lots of dependencies.
     If we instead took the pattern of putting the change rebasing policy in `Rebaser` subclasses,
-    this would violate this guiding principal and result in much harder to isolate and test policy logic.
+    this would violate this guiding principle and result in much harder to isolate and test policy logic.
 
     Another aspect of reducing transitive dependencies is reducing the required dependencies for particular scenarios.
     This means factoring out code that is not always required (such as support for extra features and optimizations) such that they can be omitted when not needed.

--- a/experimental/dds/tree2/docs/main/cell-model-of-collaborative-editing.md
+++ b/experimental/dds/tree2/docs/main/cell-model-of-collaborative-editing.md
@@ -83,7 +83,7 @@ It may either be empty or full.
 The contents of a (full) cell may be arbitrarily large or small (though a specific data model may constrain this in practice).
 
 > Note: the model does not prescribe for the cells to be explicitly reified.
-> While some cells may be represented at runtime some of the time, they are primarily a conceptual artefact.
+> While some cells may be represented at runtime some of the time, they are primarily a conceptual artifact.
 > An application would not have explicit access to the cell, and is likely not aware of the concept in the first place.
 
 A cell may be annotated with forwarding information that specifies a target destination cell.
@@ -204,7 +204,7 @@ The merge resolution logic can now exclude the possibility of having to merge op
 
 Since the merge resolution logic is specialized to each field kind, merge resolution logic becomes extensible: we can introduce new kind of fields with associated merge logic.
 This allows us to support new kinds of fields in the future, but more importantly it means that we can migrate from a less desirable set of merge semantics to a more desirable one.
-This dramatically reduces the negative impact of starting out with suboptimal the merge semantics in early SharedTree releases because we can implement better ones later on and offer them as new kinds of fields.
+This dramatically reduces the negative impact of starting out with suboptimal merge semantics in early SharedTree releases because we can implement better ones later on and offer them as new kinds of fields.
 
 ### Changeset Format
 

--- a/experimental/dds/tree2/docs/main/data-model.md
+++ b/experimental/dds/tree2/docs/main/data-model.md
@@ -93,7 +93,7 @@ Values are used to store scalar data, such as numbers and booleans.
 
 From the perspective of the SharedTree data model, values are [**_opaque_**](https://en.wikipedia.org/wiki/Opaque_data_type), immutable byte sequences.
 
-In practice, node values are Fluid [**_serializable_**](https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/datastore-definitions/src/serializable.ts) types and can be interpreted us such using schema information.
+In practice, node values are Fluid [**_serializable_**](https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/datastore-definitions/src/serializable.ts) types and can be interpreted as such using schema information.
 
 ### Field
 
@@ -142,7 +142,7 @@ This section covers fields that receive special treatment in the SharedTree data
 These fields are special because:
 
 -   They have reserved keys
--   They are universally available on all nodes (regardless of schema.)
+-   They are universally available on all nodes (regardless of schema)
 -   They can not be targeted by normal tree operations.
 
 #### Type
@@ -186,6 +186,6 @@ Of note:
 
 # Appendix A: Notes
 
--   We chose the term 'field' in because it is convenient to have a term that is distinct from the 'properties' that result when the domain model is projected to an API.
-    ('field' also happens to align with GraphQL.)
+-   We chose the term 'field' because it is convenient to have a term that is distinct from the 'properties' that result when the domain model is projected to an API
+    ('field' also happens to align with GraphQL).
 -   We chose the term 'key' because it sounds more opaque than 'name' or 'label', both of which conjure the notion of something that is human readable.

--- a/experimental/dds/tree2/docs/main/indexes-and-branches.md
+++ b/experimental/dds/tree2/docs/main/indexes-and-branches.md
@@ -8,7 +8,7 @@ To avoid needing an abstraction to storing the actual underlying document conten
 In database terms this means that we use [covering indexes](https://en.wikipedia.org/wiki/Database_index#Covering_index) to answer all queries.
 Concretely this is done by [shared-tree](../../src/shared-tree/README.md) providing a `ForestIndex` which is is a covering index (stores the actual data from each tree node), optimized for retrieving (and editing) parts of subtrees by path.
 Schema data is similarly handled by `SchemaIndex`.
-In the future we will have more index implementations, which can provide functionality like accelerating look of of nodes (in `ForestIndex`) by identifiers, text search etc.
+In the future we will have more index implementations, which can provide functionality like accelerating lookup of nodes (in `ForestIndex`) by identifiers, text search etc.
 
 Indexes are updated when the Fluid document (contents of the Shared Tree) is edited, and are persisted in Fluid summaries.
 
@@ -32,13 +32,13 @@ From the perspective of a single Fluid client, there can be several relevant bra
 -   The local branch: the sequenced branch, plus any local edits (ops for them have not yet been sequenced).
 
     In our `git` metaphor this is a feature branch in the local repository.
-    Every time `main` changes, it is rebased onto the new state of `main`
-    It is merged into main by making pull requests one commit at a time which are always merged using rebase.
+    Every time `main` changes, the feature branch is rebased onto the new state of `main` by making pull requests one
+    commit at a time which are always merged using rebase.
 
 -   The working copy: the local branch, plus the current state of an in progress transaction.
     If async transactions are supported with snapshot isolation, the version of the local branch that the transaction branches off from might not always be the latest.
 
-    In our `git` metaphor, this lines up with git's working copy, while the "local branch" in checked out.
+    In our `git` metaphor, this lines up with git's working copy, while the "local branch" is checked out.
     The in progress transaction aligns with the uncommitted changes.
 
 -   Remote branches: branches which replicate what remote clients had in their local branches when an op was sent.
@@ -51,7 +51,7 @@ From the perspective of a single Fluid client, there can be several relevant bra
 -   Long lived branches: branches explicitly created by the user that can live separately from the "main" branch for long periods of time.
 
     In our `git` metaphor this represents feature branches (eventually might be merged) or release branches (likely never merged).
-    They can be used to experiment with a copy of the document, work offline for expended periods while preserving history when merging,
+    They can be used to experiment with a copy of the document, work offline for extended periods while preserving history when merging,
     or just as a way to have a user-controlled snapshot.
 
     Currently shared-tree does not use or support this type of branches, but forward looking designs should consider them.

--- a/experimental/dds/tree2/docs/main/modular-change-family.md
+++ b/experimental/dds/tree2/docs/main/modular-change-family.md
@@ -49,14 +49,14 @@ are associated with the given revision.
 
 An undefined `revision` field can occur in three cases:
 
-    A) When a revision is specified on an ancestor of the current structure, in which case the changes the current structure (and all nested structures) are associated with that revision.
+    A) When a revision is specified on an ancestor of the current structure, in which case the changes to the current structure (and all nested structures) are associated with that revision.
     B) When the changes in the current structure (or its nested structures) are associated with multiple revisions.
     C) When the changes are associated with an anonymous (i.e., tag-less) edit.
 
 C) Is a special case that will likely be excluded in future implementations.
 For now it is treated as a special case of A).
 
-Note that #1 is special in that A) never applies to is (since it is the root).
+Note that #1 is special in that A) never applies to it (since it is the root).
 Similarly #4 is special in that B) never applies to it (since it only ever represents the change in value prescribed by a single revision).
 
 The above rules mean that, unless a change was contributed by an anonymous edit, at least one populated `revision` field should be encountered when walking down from the root to any given portion of a changeset.
@@ -80,14 +80,14 @@ If none of the three possibilities above yield revision information then an `und
 This can occur in two cases:
 
 -   The changes for the field were contributed by an anonymous change.
--   The change for the field were contributed by multiple changes.
+-   The changes for the field were contributed by multiple changes.
     In this latter case, the `FieldKind`-specific change data
     (which is opaque to `ModularChangeFamily`)
     may contain more precise information about which part of the changes are associated with various revisions,
     but that is entirely left up to the `FieldKind` implementation.
 
 When the `FieldKind`'s `invert` implementation recurses by calling the `NodeChangeInverter`,
-`ModularChangeFamily` is able determine the revision info of the `NodeChangeset` (and nested changes) by taking into account (in order of highest to lowest precedence):
+`ModularChangeFamily` is able to determine the revision info of the `NodeChangeset` (and nested changes) by taking into account (in order of highest to lowest precedence):
 
 -   The revision information associated with the field/value changes for that node (see #2 & #3) if present.
 -   The revision information for the field changes within which the `NodeChangeset` is contained (see #i, #ii, #iii).

--- a/experimental/dds/tree2/docs/main/repair-data.md
+++ b/experimental/dds/tree2/docs/main/repair-data.md
@@ -217,7 +217,7 @@ It therefore seems preferable to allow the repair data encoding to be applicatio
 and only convert it to a concrete application-agnostic encoding when it needs to be sent over the wire
 (e.g., in summaries).
 This also allows for the repair data to be encoded as an opaque token that only the application code can match to document data.
-This opaque token encoding simplifies clarifies the contract around repair data:
+This opaque token encoding simplifies the contract around repair data:
 the token can be cheaply copied and it does not allow for the repair data to be read or mutated.
 
 ### Deleting Revived Data
@@ -259,7 +259,7 @@ Interestingly, #2 is not possible if we follow the [Abstract Repair Data](#abstr
 While the [three contexts](#three-contexts) in which repair data exists operate independently,
 it is interesting to consider how repair data effectively flows between them:
 
--   Repair data from a successful transaction is dropped along with the transaction's repair data store
+-   Repair data from a successful transaction is dropped along with the transaction's repair data store.
     Equivalent repair data is added to the local branch's repair store.
 -   Repair data from a local edit that gets rebased is dropped from the local branch's repair store.
     Repair data from the rebased version of that local edit is added to the local branch's repair store.

--- a/experimental/dds/tree2/docs/main/schema2.md
+++ b/experimental/dds/tree2/docs/main/schema2.md
@@ -7,7 +7,7 @@ Proposal for changes to the [schema system](./stored-and-view-schema.md).
 The current schema system has several issues:
 
 1. It's cluttered with features that are not used in most cases. (ex: extraLocalFields, extraGlobalFields, global fields and values are not used on almost all schema)
-2. It's not clear to users which features when and why they all exist.
+2. It's not clear to users which features to use when and why they all exist.
 3. global value fields and extra global fields don't interact in a clear well defined way (would such value fields be required on all nodes with extraGlobalFields or are they implicitly made optional when used via extra global fields?)
 4. Extra local fields can result in types TypeScript can't model, since our schema system only applies the schema for the extra fields to all fields not explicitly listed. This [can't be done in TypeScript](https://www.typescriptlang.org/play?noPropertyAccessFromIndexSignature=true&ts=4.5.5#code/PTAEBUCcE9QFwPagLYEMDWBTUr7QA7YDuAFppNgGYCWmANgCagBEqzo1AzqJ3JNQDsA5gBocAphV44KoAQFdkAI3IAuAFDqQoACIJM3AQjigiCSOnVwC2AMrVk+OtgC8oAN7qAkAG0ssQR4+QSEAXVVQf1BMAA84TAluVnYAfiD+YVAIhWVyAG51AF8CrTA9AzljU3N0DWtCUFtg4U4AeTgySHASVAEAHnBouISGbl4MoQA+UDd-BEoPUD9MAIFQAApBgB90kIBKcMiVofjEiFA0gUwAN3Iso9hiqxtG5qE2jvJu3oAmAZORmM3tM3ABRGIAYzo8gYmD64xCYnAkxK2gAQsYSPAyJxsKhZAAreTSAAGCOEJOeDVsM1eEw+nW+-WSKKpdh+tKa9PajJ6Aj+LNRZX0hiqSnk1EY6kE8UglFQELsDicmA5ni8qAi5KEBV8UUCnEOckUKkgBSepV0IsqJnFkoY0oEsvlisayucau8mt2wl1y1WjSNOVN5pKEIQAmkAH0GKg4KgAIwReyOZy09w4CLMGLsJ7hyMmGNx1A-ZPu1yLb3Z5hiJQRACsoCe2gAAnBOABaWKECFwLuQSDmUyDzL504meqYdT56Ox+MAZjLqYrGe9jebYDbne7mF7-cHkGHEaEoDHCQnNmnEdnxYALEuVenMywc7Ws9Bc7rNF4gA)
 5. It requires use of symbols to avoid colliding with local field names in many places in the API, which has been confusing users (many TypeScript developers don't even know what Symbols are).
@@ -25,12 +25,12 @@ Instead of one kind of node in view schema, have 4, each with a subset of our cu
 2. Struct Node: finite list of fields (key+field type).
 3. Map Node: A node which maps all strings (as field keys) to fields.
    All possible fields get a single field schema (just like existing extraLocalFields).
-   This field schema allow the filed to be empty (for example an optional or sequence filed, but not a value field):
+   This field schema allow the field to be empty (for example an optional or sequence field, but not a value field):
    otherwise the tree would be required to have a non-empty field for all possible string keys (which would be an infinite sized tree) to be in schema.
    This is the same functionality currently done by making a node schema with extra local fields.
-4. Field Node: Has a single unnamed filed (using the empty field key).
+4. Field Node: Has a single unnamed field (using the empty field key).
    When reading in the editable tree API implicitly, unwraps to the field.
-   This provides the functionality currently done by making a node schema with a primary field (empty field key), which used for "array nodes".
+   This provides the functionality currently done by making a node schema with a primary field (empty field key), which is used for "array nodes".
 
 Each of these will get a separate API to declare (similar to SchemaBuilder.object and SchemaBuilder.primitive, except we will have 4 options).
 Each will also get its own API for accessing it in editable tree, though all will extend a common generic tree traversal API as well.
@@ -48,8 +48,8 @@ Since an app can rename the field without changing how data is persisted, requir
 This means Struct Nodes can have scheme-aware APIs that don't have to use symbols to avoid field name collisions.
 We will keep a method to look up fields by their keys to cover generic code as well.
 
-Custom field names make it practical to to use long collision resistant names for fields, and this usage pattern can replace most of the need for global field keys.
-The other use case, where the same field is desired on multiple schema can be handled in other ways, like putting it on a reused child node, or just putting the field directly on each schema its desired on.
+Custom field names make it practical to use long collision resistant names for fields, and this usage pattern can replace most of the need for global field keys.
+The other use case, where the same field is desired on multiple schema can be handled in other ways, like putting it on a reused child node, or just putting the field directly on each schema it is desired on.
 
 Map nodes will not expose a JavaScript object like API, and instead expose a JavaScript Map like API.
 This avoids the need to use a Proxy for any of the node implementations, as well as avoids needing to support custom field names for Map nodes to deal with possible API name collisions.
@@ -64,10 +64,10 @@ The real challenge is that different applications may have different view schema
 Our stored vs view schema already can model this, even without ExtraGlobalFields:
 each application can add their annotations as optional fields to the stored schema.
 
-The only thing thats really missing is how the applications should handle opening documents with stored fields like these.
-This an be addressed by supporting either one or both of the following:
+The only thing that's really missing is how the applications should handle opening documents with stored fields like these.
+This can be addressed by supporting either one or both of the following:
 
-1.  Allow field in the schema (stored and view) to indicate how applications which do not understand the field should treat the type containing the field.
+1.  Allow fields in the schema (stored and view) to indicate how applications which do not understand the field should treat the type containing the field.
     Some options are:
     1.  read+write, preserve unknown field where possible
     1.  read+write, clear unknown field on mutation
@@ -78,7 +78,7 @@ This an be addressed by supporting either one or both of the following:
 
 Additionally an API could be added to struct nodes to enumerate all unexpected fields.
 API wise this looks similar to the existing extra fields support, but it is distinct in its use-case and performance characteristics.
-Extra local fields were designed to allow allow arbitrary fields, without bloating the stored schema:
+Extra local fields were designed to allow arbitrary fields, without bloating the stored schema:
 in the previous system adding and removing N extra local fields with different keys currently makes no schema changes whereas adding a bunch of fields to the stored schema as unrecognized fields in the proposed schema system would bloat the document schema proportionally.
 Instead this feature is only intended for when an application has a view schema for a field that other applications using the document might not have.
 Thus any actual schema editing done as part of supporting these fields can be done implicitly as part of schematize based on the comparison of the view and stored schema,

--- a/experimental/dds/tree2/docs/roadmap.md
+++ b/experimental/dds/tree2/docs/roadmap.md
@@ -99,7 +99,8 @@ The operations available in the editing API (e.g., insert, delete) are rolled ou
 Supporting larger-than-memory data sets in the tree requires efficiently handling trees that contain large numbers of strong identifiers (UUIDs).
 To meet this requirement, Shared Tree leverages a novel distributed compression scheme that reduces the average storage cost of the identifiers to that of a small integer.
 This enables better scaling in scenarios where large numbers of these compressed IDs are needed (e.g., graph-like references).
-The documentation for this scheme can be found [here](../src/id-compressor/idCompressor.ts#L272).
+The id compressor now lives in the Fluid container runtime.
+Its documentation can be found [here](../../../../packages/runtime/container-runtime/src/id-compressor/idCompressor.ts#L206).
 
 ## Data model specification
 
@@ -126,11 +127,11 @@ The move operation is also not yet available.
 
 In most scenarios, the Shared Tree will construct an in-memory JavaScript representation of the tree.
 This milestone makes it possible to read and write data to the Shared Tree without creating (reifying) that in-memory JavaScript representation.
-This is particularly useful in scenarios where the client has memory constraints or wants to maintains a copy of the data on the other side of an interop boundary (e.g., WASM, C++).
+This is particularly useful in scenarios where the client has memory constraints or wants to maintain a copy of the data on the other side of an interop boundary (e.g., WASM, C++).
 It also allows clients/microservices to check permissions without loading the document and inspect changes without caring about the entire tree.
 
 To accomplish this, the underlying Shared Tree layer is built on a [cursor API](../src/core/tree/cursor.ts) that allows navigation of the tree by moving from node to node via explicit directional calls.
-Layers built on cursors are also able to remain agnostic to the structure of the tree it is navigating, allowing for flexible/multiple implementations.
+Layers built on cursors are also able to remain agnostic to the structure of the tree they are navigating, allowing for flexible/multiple implementations.
 This cursor API is intended to be an expert API as working with it is more cumbersome compared with the more ergonomic APIs exposed in future milestones.
 
 While this is an important architectural milestone to build in early, the benefits around reification will not be fully realized until the [Storage performance: incrementality and virtualization](#storage-performance-incrementality-and-virtualization) milestone, as downloading the entire tree on load is currently required.

--- a/experimental/dds/tree2/docs/roadmap.md
+++ b/experimental/dds/tree2/docs/roadmap.md
@@ -99,7 +99,7 @@ The operations available in the editing API (e.g., insert, delete) are rolled ou
 Supporting larger-than-memory data sets in the tree requires efficiently handling trees that contain large numbers of strong identifiers (UUIDs).
 To meet this requirement, Shared Tree leverages a novel distributed compression scheme that reduces the average storage cost of the identifiers to that of a small integer.
 This enables better scaling in scenarios where large numbers of these compressed IDs are needed (e.g., graph-like references).
-The id compressor now lives in the Fluid container runtime.
+The ID compressor now lives in the Fluid container runtime.
 Its documentation can be found [here](../../../../packages/runtime/container-runtime/src/id-compressor/idCompressor.ts#L206).
 
 ## Data model specification

--- a/experimental/dds/tree2/src/core/tree/anchorSet.ts
+++ b/experimental/dds/tree2/src/core/tree/anchorSet.ts
@@ -76,7 +76,7 @@ export interface AnchorEvents {
 	 *
 	 * @remarks
 	 * When this happens depends entirely on how the anchorSet is used.
-	 * It's possible nodes removed from the tree will be kept indefinably, and thus never trigger this event, or they may be discarded immediately.
+	 * It's possible nodes removed from the tree will be kept indefinitely, and thus never trigger this event, or they may be discarded immediately.
 	 */
 	afterDelete(anchor: AnchorNode): void;
 
@@ -90,7 +90,7 @@ export interface AnchorEvents {
 
 	/**
 	 * Something in this tree is changing.
-	 * The event can optionally return a {@link PathVisitor} to traverse the subtree
+	 * The event can optionally return a {@link PathVisitor} to traverse the subtree.
 	 * Called on every parent (transitively) when a change is occurring.
 	 * Includes changes to this node itself.
 	 */
@@ -127,7 +127,7 @@ export interface AnchorSetRootEvents {
 }
 
 /**
- * Node in an tree of anchors.
+ * Node in a tree of anchors.
  * @alpha
  */
 export interface AnchorNode extends UpPath<AnchorNode>, ISubscribable<AnchorEvents> {
@@ -151,7 +151,7 @@ export interface AnchorNode extends UpPath<AnchorNode>, ISubscribable<AnchorEven
 	child(key: FieldKey, index: number): UpPath<AnchorNode>;
 
 	/**
-	 * Gets a child AnchorNode (creating it if needed), and a Anchor owning a ref to it.
+	 * Gets a child AnchorNode (creating it if needed), and an Anchor owning a ref to it.
 	 * Caller is responsible for freeing the returned Anchor, and must not use the AnchorNode after that.
 	 */
 	getOrCreateChildRef(key: FieldKey, index: number): [Anchor, AnchorNode];
@@ -182,8 +182,8 @@ export function anchorSlot<TContent>(): AnchorSlot<TContent> {
  *
  * See `Rebaser` for how to update across revisions.
  *
- * TODO: this should either not be package exported.
- * If its needed outside the package an Interface should be used instead which can reduce its
+ * TODO: this should not be package exported.
+ * If it's needed outside the package an Interface should be used instead which can reduce its
  * API surface to a small subset.
  *
  * @sealed

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -98,7 +98,7 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * See {@link EditableTreeContext.unwrappedRoot} on how its setter works.
 	 *
 	 * Currently this editable tree's fields do not update on edits,
-	 * so holding onto this root object across edits will only work if its an unwrapped node.
+	 * so holding onto this root object across edits will only work if it's an unwrapped node.
 	 * TODO: Fix this issue.
 	 *
 	 * Currently any access to this view of the tree may allocate cursors and thus require
@@ -245,7 +245,7 @@ export interface ISharedTreeView extends AnchorLocator {
 
 	/**
 	 * Takes in a tree and returns a view of it that conforms to the view schema.
-	 * The returned view referees to and can edit the provided one: it is not a fork of it.
+	 * The returned view refers to and can edit the provided one: it is not a fork of it.
 	 * Updates the stored schema in the tree to match the provided one if requested by config and compatible.
 	 *
 	 * If the tree is uninitialized (has no nodes or schema at all),
@@ -254,16 +254,16 @@ export interface ISharedTreeView extends AnchorLocator {
 	 *
 	 * @remarks
 	 * Doing initialization here, regardless of `AllowedUpdateType`, allows a small API that is hard to use incorrectly.
-	 * Other approach tend to have leave easy to make mistakes.
+	 * Other approaches tend to have easy-to-make mistakes.
 	 * For example, having a separate initialization function means apps can forget to call it, making an app that can only open existing document,
 	 * or call it unconditionally leaving an app that can only create new documents.
-	 * It also would require the schema to be passed into to separate places and could cause issues if they didn't match.
+	 * It also would require the schema to be passed in to separate places and could cause issues if they didn't match.
 	 * Since the initialization function couldn't return a typed tree, the type checking wouldn't help catch that.
 	 * Also, if an app manages to create a document, but the initialization fails to get persisted, an app that only calls the initialization function
 	 * on the create code-path (for example how a schematized factory might do it),
 	 * would leave the document in an unusable state which could not be repaired when it is reopened (by the same or other clients).
 	 * Additionally, once out of schema content adapters are properly supported (with lazy document updates),
-	 * this initialization could become just another out of schema content adapter: at tha point it clearly belong here in schematize.
+	 * this initialization could become just another out of schema content adapter: at that point it clearly belongs here in schematize.
 	 *
 	 * TODO:
 	 * - Implement schema-aware API for return type.


### PR DESCRIPTION
## Description

Typos, grammar, etc. Also updates `npm i` to `pnpm i` in README.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
