### PR TITLE
Normalize client-utils mocha config and scripts

### DIFF
--- a/packages/common/client-utils/.mocharc.js
+++ b/packages/common/client-utils/.mocharc.js
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+"use strict";
+
+const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
+
+const packageDir = __dirname;
+const config = getFluidTestMochaConfig(packageDir);
+module.exports = config;

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -46,9 +46,7 @@
 		"test:jest": "jest",
 		"test:jest:report": "npm run test:jest -- --ci --coverage --reporters=default --reporters=jest-junit",
 		"test:mocha": "mocha --unhandled-rejections=strict  --recursive dist/test/mocha/**/*.spec.js --exit --project test/tsconfig.json",
-		"test:mocha:multireport": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:mocha",
-		"test:mocha:report": "npm run test:mocha -- -- --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
-		"test:report": "nyc npm run test:mocha:report && npm run test:jest:report",
+		"test:report": "nyc npm run test:mocha && npm run test:jest:report",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"


### PR DESCRIPTION
Use the common mocha config to get all the common test result reporters setup.