### PR TITLE
refactor(tree): Remove anchor management from the duties of branches/EditManager

### DIFF
--- a/experimental/dds/tree2/src/core/change-family/changeFamily.ts
+++ b/experimental/dds/tree2/src/core/change-family/changeFamily.ts
@@ -5,10 +5,10 @@
 
 import { ICodecFamily } from "../../codec";
 import { ChangeRebaser } from "../rebase";
-import { AnchorSet, Delta } from "../tree";
+import { Delta } from "../tree";
 
 export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
-	buildEditor(changeReceiver: (change: TChange) => void, anchorSet: AnchorSet): TEditor;
+	buildEditor(changeReceiver: (change: TChange) => void): TEditor;
 
 	/**
 	 * @param change - The change to convert into a delta.

--- a/experimental/dds/tree2/src/core/change-family/editBuilder.ts
+++ b/experimental/dds/tree2/src/core/change-family/editBuilder.ts
@@ -3,14 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { AnchorSet } from "../tree";
 import { ChangeFamily, ChangeFamilyEditor } from "./changeFamily";
 
 export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	public constructor(
 		protected readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>,
 		private readonly changeReceiver: (change: TChange) => void,
-		private readonly anchorSet: AnchorSet,
 	) {}
 
 	/**
@@ -19,7 +17,6 @@ export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	 * @sealed
 	 */
 	protected applyChange(change: TChange): void {
-		this.changeFamily.rebaser.rebaseAnchors(this.anchorSet, change);
 		this.changeReceiver(change);
 	}
 

--- a/experimental/dds/tree2/src/core/rebase/changeRebaser.ts
+++ b/experimental/dds/tree2/src/core/rebase/changeRebaser.ts
@@ -5,7 +5,6 @@
 
 import { Invariant } from "../../util";
 import { ReadonlyRepairDataStore } from "../repair";
-import { AnchorSet } from "../tree";
 import type { RevisionTag } from "./types";
 
 /**
@@ -84,11 +83,6 @@ export interface ChangeRebaser<TChangeset> {
 	 * - `rebase(compose([]), a)` is equal to `compose([])`.
 	 */
 	rebase(change: TChangeset, over: TaggedChange<TChangeset>): TChangeset;
-
-	// TODO: we are forcing a single AnchorSet implementation, but also making ChangeRebaser deal depend on/use it.
-	// This isn't ideal, but it might be fine?
-	// Performance and implications for custom Anchor types (ex: Place anchors) aren't clear.
-	rebaseAnchors(anchors: AnchorSet, over: TChangeset): void;
 }
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultChangeFamily.ts
@@ -7,7 +7,6 @@ import { ICodecFamily, ICodecOptions } from "../../codec";
 import {
 	ChangeFamily,
 	ChangeRebaser,
-	AnchorSet,
 	Delta,
 	UpPath,
 	ITreeCursor,
@@ -49,11 +48,8 @@ export class DefaultChangeFamily implements ChangeFamily<DefaultEditBuilder, Def
 		return this.modularFamily.intoDelta(change);
 	}
 
-	public buildEditor(
-		changeReceiver: (change: DefaultChangeset) => void,
-		anchorSet: AnchorSet,
-	): DefaultEditBuilder {
-		return new DefaultEditBuilder(this, changeReceiver, anchorSet);
+	public buildEditor(changeReceiver: (change: DefaultChangeset) => void): DefaultEditBuilder {
+		return new DefaultEditBuilder(this, changeReceiver);
 	}
 }
 
@@ -115,9 +111,8 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, DefaultChangeset>,
 		changeReceiver: (change: DefaultChangeset) => void,
-		anchors: AnchorSet,
 	) {
-		this.modularBuilder = new ModularEditBuilder(family, changeReceiver, anchors);
+		this.modularBuilder = new ModularEditBuilder(family, changeReceiver);
 	}
 
 	public enterTransaction(): void {

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -10,7 +10,6 @@ import {
 	EditBuilder,
 	ChangeRebaser,
 	FieldKindIdentifier,
-	AnchorSet,
 	Delta,
 	FieldKey,
 	UpPath,
@@ -710,10 +709,6 @@ export class ModularChangeFamily
 		}
 
 		return rebasedChange;
-	}
-
-	public rebaseAnchors(anchors: AnchorSet, over: ModularChangeset): void {
-		anchors.applyDelta(this.intoDelta(over));
 	}
 
 	public intoDelta(change: ModularChangeset): Delta.Root {

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -766,11 +766,8 @@ export class ModularChangeFamily
 		return modify;
 	}
 
-	public buildEditor(
-		changeReceiver: (change: ModularChangeset) => void,
-		anchors: AnchorSet,
-	): ModularEditBuilder {
-		return new ModularEditBuilder(this, changeReceiver, anchors);
+	public buildEditor(changeReceiver: (change: ModularChangeset) => void): ModularEditBuilder {
+		return new ModularEditBuilder(this, changeReceiver);
 	}
 }
 
@@ -1007,9 +1004,8 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>,
 		changeReceiver: (change: ModularChangeset) => void,
-		anchors: AnchorSet,
 	) {
-		super(family, changeReceiver, anchors);
+		super(family, changeReceiver);
 		this.idAllocator = idAllocatorFromMaxId();
 	}
 

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -7,7 +7,6 @@ import BTree from "sorted-btree";
 import { assert } from "@fluidframework/common-utils";
 import { brand, fail, getOrCreate, mapIterable, Mutable, RecursiveReadonly } from "../util";
 import {
-	AnchorSet,
 	assertIsRevisionTag,
 	ChangeFamily,
 	ChangeFamilyEditor,
@@ -139,14 +138,12 @@ export class EditManager<
 	 * @param changeFamily - the change family of changes on the trunk and local branch
 	 * @param localSessionId - the id of the local session that will be used for local commits
 	 * @param repairDataStoreProvider - used for undoing/redoing the local branch
-	 * @param anchors - an optional set of anchors to be rebased by the local branch when it changes
 	 */
 	public constructor(
 		public readonly changeFamily: TChangeFamily,
 		// TODO: Change this type to be the Session ID type provided by the IdCompressor when available.
 		public readonly localSessionId: SessionId,
 		repairDataStoreProvider: IRepairDataStoreProvider<TChangeset>,
-		anchors?: AnchorSet,
 	) {
 		super("EditManager");
 		this.trunkBase = {
@@ -167,7 +164,6 @@ export class EditManager<
 			changeFamily,
 			repairDataStoreProvider,
 			this.localBranchUndoRedoManager,
-			anchors,
 		);
 
 		// Track all forks of the local branch for purposes of trunk eviction. Unlike the local branch, they have

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -24,7 +24,6 @@ import {
 import { ICodecOptions, IJsonCodec } from "../codec";
 import {
 	ChangeFamily,
-	AnchorSet,
 	Delta,
 	ChangeFamilyEditor,
 	IRepairDataStoreProvider,
@@ -129,7 +128,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	 * @param summarizables - Summarizers for all indexes used by this tree
 	 * @param changeFamily - The change family
 	 * @param editManager - The edit manager
-	 * @param anchors - The anchor set
 	 * @param id - The id of the shared object
 	 * @param runtime - The IFluidDataStoreRuntime which contains the shared object
 	 * @param attributes - Attributes of the shared object
@@ -138,7 +136,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	public constructor(
 		summarizables: readonly Summarizable[],
 		private readonly changeFamily: ChangeFamily<TEditor, TChange>,
-		anchors: AnchorSet,
 		repairDataStoreProvider: IRepairDataStoreProvider<TChange>,
 		options: ICodecOptions,
 		// Base class arguments
@@ -156,12 +153,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		 */
 		// TODO: Change this type to be the Session ID type provided by the IdCompressor when available.
 		const localSessionId = generateStableId();
-		this.editManager = new EditManager(
-			changeFamily,
-			localSessionId,
-			repairDataStoreProvider,
-			anchors,
-		);
+		this.editManager = new EditManager(changeFamily, localSessionId, repairDataStoreProvider);
 		this.editManager.on("newTrunkHead", (head) => {
 			this.changeEvents.emit("newSequencedChange", head.change);
 		});

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -100,7 +100,6 @@ export class SharedTree
 		super(
 			[schemaSummarizer, forestSummarizer],
 			changeFamily,
-			forest.anchors,
 			repairProvider,
 			options,
 			id,

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -311,7 +311,6 @@ export function createSharedTreeView(args?: {
 			changeFamily,
 			repairDataStoreProvider,
 			undoRedoManager,
-			forest.anchors,
 		);
 	const nodeKeyManager = args?.nodeKeyManager ?? createNodeKeyManager();
 	const context = getEditableTreeContext(
@@ -433,6 +432,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 		branch.on("change", ({ change }) => {
 			if (change !== undefined) {
 				const delta = this.changeFamily.intoDelta(change);
+				this.forest.anchors.applyDelta(delta);
 				this.forest.applyDelta(delta);
 				this.nodeKeyIndex.scanKeys(this.context);
 				this.events.emit("afterBatch");
@@ -485,7 +485,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 			storedSchema,
 			(change: ModularChangeset) => this.changeFamily.intoDelta(change),
 		);
-		const branch = this.branch.fork(repairDataStoreProvider, anchors);
+		const branch = this.branch.fork(repairDataStoreProvider);
 		const context = getEditableTreeContext(
 			forest,
 			branch.editor,

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 import {
-	AnchorSet,
 	Delta,
 	FieldKey,
 	mintRevisionTag,
@@ -118,17 +117,13 @@ function initializeEditableForest(data?: JsonableTree): {
 	let currentRevision = mintRevisionTag();
 	const changes: TaggedChange<DefaultChangeset>[] = [];
 	const deltas: Delta.Root[] = [];
-	const builder = new DefaultEditBuilder(
-		family,
-		(change) => {
-			changes.push({ revision: currentRevision, change });
-			const delta = defaultChangeFamily.intoDelta(change);
-			deltas.push(delta);
-			forest.applyDelta(delta);
-			currentRevision = mintRevisionTag();
-		},
-		new AnchorSet(),
-	);
+	const builder = new DefaultEditBuilder(family, (change) => {
+		changes.push({ revision: currentRevision, change });
+		const delta = defaultChangeFamily.intoDelta(change);
+		deltas.push(delta);
+		forest.applyDelta(delta);
+		currentRevision = mintRevisionTag();
+	});
 	return {
 		forest,
 		builder,

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -22,7 +22,6 @@ import {
 	tagChange,
 	TaggedChange,
 	FieldKindIdentifier,
-	AnchorSet,
 	Delta,
 	FieldKey,
 	UpPath,
@@ -638,7 +637,7 @@ describe("ModularChangeFamily", () => {
 
 	it("build child change", () => {
 		const [changeReceiver, getChanges] = testChangeReceiver(family);
-		const editor = family.buildEditor(changeReceiver, new AnchorSet());
+		const editor = family.buildEditor(changeReceiver);
 		const path: UpPath = {
 			parent: undefined,
 			parentField: fieldA,

--- a/experimental/dds/tree2/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 import {
-	AnchorSet,
 	Delta,
 	FieldKey,
 	FieldKindIdentifier,
@@ -52,7 +51,7 @@ describe("ModularChangeFamily integration", () => {
 	describe("rebase", () => {
 		it("delete over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver, new AnchorSet());
+			const editor = new DefaultEditBuilder(family, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				1,
@@ -71,7 +70,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move over delete", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver, new AnchorSet());
+			const editor = new DefaultEditBuilder(family, changeReceiver);
 			editor.sequenceField({ parent: undefined, field: fieldA }).delete(1, 1);
 			editor.move(
 				{ parent: undefined, field: fieldA },
@@ -98,7 +97,7 @@ describe("ModularChangeFamily integration", () => {
 	describe("compose", () => {
 		it("cross-field move and nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver, new AnchorSet());
+			const editor = new DefaultEditBuilder(family, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -141,7 +140,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move and inverse with nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver, new AnchorSet());
+			const editor = new DefaultEditBuilder(family, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -190,7 +189,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("two cross-field moves of same node", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver, new AnchorSet());
+			const editor = new DefaultEditBuilder(family, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,

--- a/experimental/dds/tree2/src/test/rebase/generateFuzzyCombinedChange.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/generateFuzzyCombinedChange.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { ChangeRebaser, TaggedChange, AnchorSet } from "../../core";
+import { ChangeRebaser, TaggedChange } from "../../core";
 import { generateFuzzyCombinedChange } from "./fuzz";
 
 const testSeed = 432167897;
@@ -15,7 +15,6 @@ const testRebaser: ChangeRebaser<TestChange> = {
 	compose: (changes: TaggedChange<TestChange>[]) => changes.map((c) => c.change),
 	invert: (change: TaggedChange<TestChange>) => ({ I: change.change }),
 	rebase: (change: TestChange, over: TaggedChange<TestChange>) => ({ C: change, O: over.change }),
-	rebaseAnchors: (anchor: AnchorSet, over: TestChange) => {},
 };
 
 function generateRandomChange(seed: number) {

--- a/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
@@ -39,8 +39,6 @@ export class DummyChangeRebaser implements ChangeRebaser<typeof dummyChange> {
 	public rebase(): typeof dummyChange {
 		return {};
 	}
-
-	public rebaseAnchors(): void {}
 }
 
 describe("rebaser", () => {

--- a/experimental/dds/tree2/src/test/rebase/verifyChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/verifyChangeRebaser.spec.ts
@@ -4,14 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import { ChangeRebaser, TaggedChange, noFailure, verifyChangeRebaser, AnchorSet } from "../../core";
+import { ChangeRebaser, TaggedChange, noFailure, verifyChangeRebaser } from "../../core";
 
 const counterRebaser: ChangeRebaser<number> = {
 	compose: (changes: TaggedChange<number>[]) =>
 		changes.map((c) => c.change).reduce((a, b) => a + b, 0),
 	invert: (change: TaggedChange<number>) => -change.change,
 	rebase: (change: number, over: TaggedChange<number>) => change,
-	rebaseAnchors: (anchor: AnchorSet, over: number) => {},
 };
 
 const incorrectCounterRebaser: ChangeRebaser<number> = {
@@ -19,7 +18,6 @@ const incorrectCounterRebaser: ChangeRebaser<number> = {
 		changes.map((c) => c.change).reduce((a, b) => a + b - 1, 0),
 	invert: (change: TaggedChange<number>) => -change.change + 1,
 	rebase: (change: number, over: TaggedChange<number>) => change + 1,
-	rebaseAnchors: (anchor: AnchorSet, over: number) => {},
 };
 
 describe("verifyChangeRebaser", () => {

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -410,30 +410,6 @@ describe("EditManager", () => {
 			// TODO:#4593: Add test to ensure that peer branches don't pass in incorrect repairDataStoreProviders when rebasing
 		});
 
-		it("Rebases anchors over local changes", () => {
-			const { manager, anchors } = editManagerFactory({});
-			const change = TestChange.mint([], 1);
-			manager.localBranch.apply(change, mintRevisionTag());
-			assert.deepEqual(anchors.rebases, [change]);
-			assert.deepEqual(anchors.intentions, change.intentions);
-		});
-
-		it("Rebases anchors over sequenced changes", () => {
-			const { manager, anchors } = editManagerFactory({});
-			const change = TestChange.mint([], 1);
-			manager.addSequencedChange(
-				{
-					change,
-					revision: mintRevisionTag(),
-					sessionId: peer1,
-				},
-				brand(1),
-				brand(0),
-			);
-			assert.deepEqual(anchors.rebases, [change]);
-			assert.deepEqual(anchors.intentions, change.intentions);
-		});
-
 		it("Updates local branch when loading from summary", () => {
 			// This regression tests ensures that the local branch is rebased to the head of the trunk
 			// when the trunk is modified by a summary load
@@ -735,7 +711,7 @@ function runUnitTestScenario(
 	rebaser?: ChangeRebaser<TestChange>,
 ): void {
 	const run = (advanceMinimumSequenceNumber: boolean) => {
-		const { manager, anchors } = editManagerFactory({ rebaser });
+		const { manager } = editManagerFactory({ rebaser });
 		/**
 		 * An `EditManager` that is kept up to date with all sequenced edits.
 		 * Used as a source of summary data to spin-up `joiners`.
@@ -939,8 +915,6 @@ function runUnitTestScenario(
 				default:
 					unreachableCase(type);
 			}
-			// Anchors should be kept up to date with the known intentions
-			assert.deepEqual(anchors.intentions, knownToLocal);
 			// The exposed trunk and local changes should reflect what is known to the local client
 			checkChangeList(
 				manager,

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -583,7 +583,6 @@ describe("EditManager", () => {
 						rebaser.composedCount,
 						trunkEditCount * (rebasedEditCount * 2 + 1),
 					);
-					assert.equal(rebaser.rebaseAnchorCallsCount, trunkEditCount + rebasedEditCount);
 				});
 			}
 		});
@@ -600,7 +599,6 @@ describe("EditManager", () => {
 
 					assert.equal(rebaser.invertedCount, rebasedEditCount - 1);
 					assert.equal(rebaser.composedCount, trunkEditCount + rebasedEditCount);
-					assert.equal(rebaser.rebaseAnchorCallsCount, trunkEditCount + rebasedEditCount);
 				});
 			}
 		});

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
@@ -11,7 +11,6 @@ import {
 	mintRevisionTag,
 } from "../../core";
 import {
-	TestAnchorSet,
 	TestChangeFamily,
 	TestChange,
 	testChangeFamilyFactory,
@@ -28,17 +27,15 @@ export function editManagerFactory(options: {
 	sessionId?: SessionId;
 }): {
 	manager: TestEditManager;
-	anchors: TestAnchorSet;
 	family: ChangeFamily<ChangeFamilyEditor, TestChange>;
 } {
 	const family = testChangeFamilyFactory(options.rebaser);
-	const anchors = new TestAnchorSet();
 	const manager = new EditManager<
 		ChangeFamilyEditor,
 		TestChange,
 		ChangeFamily<ChangeFamilyEditor, TestChange>
-	>(family, options.sessionId ?? "0", new MockRepairDataStoreProvider(), anchors);
-	return { manager, anchors, family };
+	>(family, options.sessionId ?? "0", new MockRepairDataStoreProvider());
+	return { manager, family };
 }
 
 export function rebaseLocalEditsOverTrunkEdits(

--- a/experimental/dds/tree2/src/test/shared-tree-core/utils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/utils.ts
@@ -5,7 +5,6 @@
 import { IChannelAttributes, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { SharedTreeBranch, SharedTreeCore, Summarizable } from "../../shared-tree-core";
-import { AnchorSet } from "../../core";
 import { typeboxValidator } from "../../external-utilities";
 import { DefaultChangeFamily, DefaultChangeset, DefaultEditBuilder } from "../../feature-libraries";
 import { MockRepairDataStoreProvider } from "../utils";
@@ -26,12 +25,10 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 		runtime: IFluidDataStoreRuntime = new MockFluidDataStoreRuntime(),
 		id = "TestSharedTreeCore",
 		summarizables: readonly Summarizable[] = [],
-		anchors = new AnchorSet(),
 	) {
 		super(
 			summarizables,
 			new DefaultChangeFamily({ jsonValidator: typeboxValidator }),
-			anchors,
 			new MockRepairDataStoreProvider(),
 			{ jsonValidator: typeboxValidator },
 			id,


### PR DESCRIPTION
## Description

Moves anchor management out of branches/EditManager and into Forest