### PR TITLE
tree2: Fix tests for node 18

### DIFF
--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@sinclair/typebox": "^0.29.4",
-		"@ungap/structured-clone": "^0.3.4",
+		"@ungap/structured-clone": "^1.2.0",
 		"sorted-btree": "^1.8.0",
 		"uuid": "^9.0.0"
 	},

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -65,7 +65,7 @@ describe("editable-tree: editing", () => {
 
 		// create optional root
 		tree.setContent({ name: "Mike" });
-		assert.deepEqual(clone(tree.root), { name: "Mike" });
+		assert.deepEqual(clone(tree.root, { lossy: true }), { name: "Mike" });
 
 		// replace optional root
 		tree.setContent({ name: "Peter", adult: true });
@@ -159,7 +159,7 @@ describe("editable-tree: editing", () => {
 			}
 		}
 
-		const clonedPerson = clone(maybePerson);
+		const clonedPerson = clone(maybePerson, { lossy: true });
 		assert.deepEqual(clonedPerson, {
 			name: "Peter",
 			age: 150,
@@ -190,7 +190,7 @@ describe("editable-tree: editing", () => {
 
 		// check initial data
 		{
-			const clonedPerson = clone(person);
+			const clonedPerson = clone(person, { lossy: true });
 			assert.deepEqual(clonedPerson, {
 				name: "Adam",
 				age: 35,
@@ -240,7 +240,7 @@ describe("editable-tree: editing", () => {
 			// replace value field
 			person.address.zip = zip;
 
-			const clonedAddress = clone(person.address);
+			const clonedAddress = clone(person.address, { lossy: true });
 			assert.deepEqual(clonedAddress, {
 				street: "foo",
 				zip: 123,
@@ -262,7 +262,7 @@ describe("editable-tree: editing", () => {
 			person.address.phones[1] = simplePhones;
 			// create primitive node
 			person.address.phones[2] = brand(3);
-			const clonedPerson = clone(person);
+			const clonedPerson = clone(person, { lossy: true });
 			assert.deepEqual(clonedPerson, {
 				name: "Adam",
 				age: 32,
@@ -293,7 +293,7 @@ describe("editable-tree: editing", () => {
 				prefix: "456",
 				extraPhones: ["1234567"],
 			} as unknown as ComplexPhone; // TODO: fix up these strong types to reflect unwrapping
-			assert.deepEqual(clone(person.address.phones), {
+			assert.deepEqual(clone(person.address.phones, { lossy: true }), {
 				"0": "54321",
 				"1": { number: "123", prefix: "456", extraPhones: { "0": "1234567" } },
 				"2": 3,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -114,8 +114,8 @@ describe("editable-tree: read-only", () => {
 		// which are otherwise "hidden" behind a proxy.
 		// Usefull for debugging.
 		if (isEditableTree(addressDescriptor.value)) {
-			addressDescriptor.value = clone(addressDescriptor.value);
-			expected = clone(expected);
+			addressDescriptor.value = clone(addressDescriptor.value, { lossy: true });
+			expected = clone(expected, { lossy: true });
 		}
 		assert.deepEqual(addressDescriptor, {
 			configurable: true,
@@ -487,7 +487,7 @@ describe("editable-tree: read-only", () => {
 		assert.equal(proxy.name, "Adam");
 		assert.equal(proxy.age, 35);
 		assert.equal(proxy.salary, 10420.2);
-		const cloned = clone(proxy.friends);
+		const cloned = clone(proxy.friends, { lossy: true });
 		assert.deepEqual(cloned, { Mat: "Mat" });
 		assert(proxy.address !== undefined);
 		assert.deepEqual(Object.keys(proxy.address), ["zip", "street", "phones", "sequencePhones"]);
@@ -530,7 +530,7 @@ describe("editable-tree: read-only", () => {
 			} else if (isEditableField(phone)) {
 				assert.deepEqual([...phone], expectedPhone);
 			} else {
-				const cloned = clone(phone);
+				const cloned = clone(phone, { lossy: true });
 				assert.deepEqual(cloned, expectedPhone);
 			}
 		}
@@ -556,7 +556,7 @@ describe("editable-tree: read-only", () => {
 				} else if (isEditableField(phone)) {
 					return [...phone];
 				} else {
-					const cloned = clone(phone);
+					const cloned = clone(phone, { lossy: true });
 					return cloned;
 				}
 			},

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -42,9 +42,7 @@ export function asMutable<T>(readonly: T): Mutable<T> {
 	return readonly as Mutable<T>;
 }
 
-export function clone<T>(original: T): T {
-	return structuredClone(original);
-}
+export const clone = structuredClone;
 
 /**
  * @alpha

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5703,7 +5703,7 @@ importers:
       '@types/node': ^16.18.38
       '@types/ungap__structured-clone': ^0.3.0
       '@types/uuid': ^9.0.2
-      '@ungap/structured-clone': ^0.3.4
+      '@ungap/structured-clone': ^1.2.0
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -5734,7 +5734,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
       '@sinclair/typebox': 0.29.4
-      '@ungap/structured-clone': 0.3.4
+      '@ungap/structured-clone': 1.2.0
       sorted-btree: 1.8.1
       uuid: 9.0.0
     devDependencies:
@@ -24067,6 +24067,11 @@ packages:
 
   /@ungap/structured-clone/0.3.4:
     resolution: {integrity: sha512-TSVh8CpnwNAsPC5wXcIyh92Bv1gq6E9cNDeeLu7Z4h8V4/qWtXJp7y42qljRkqcpmsve1iozwv1wr+3BNdILCg==}
+    dev: true
+
+  /@ungap/structured-clone/1.2.0:
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    dev: false
 
   /@vitejs/plugin-react/4.0.4_vite@4.4.9:
     resolution: {integrity: sha512-7wU921ABnNYkETiMaZy7XqpueMnpu5VxvVps13MjmCo+utBdD79sZzrApHawHtVX66cCJQQTXFcjH0y9dSUK8g==}


### PR DESCRIPTION
## Description

Updates our cloning library which wraps Node's clone function, and pass "lazy" to it when its used with editableTree since it seems to have issues with it (likely due to proxies or symbols).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

