### PR TITLE
Simplfied SummarizerNode:refreshLatestSummary logic

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3654,7 +3654,7 @@ export class ContainerRuntime
 		// proposalHandle is always passed from RunningSummarizer.
 		assert(proposalHandle !== undefined, "proposalHandle should be available");
 		const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-		const isSummaryTracked = await this.summarizerNode.refreshLatestSummary(
+		const result = await this.summarizerNode.refreshLatestSummary(
 			proposalHandle,
 			summaryRefSeq,
 		);
@@ -3665,7 +3665,7 @@ export class ContainerRuntime
 		 * it needs to refresh its state. Today refresh is done by fetching the latest snapshot to update the cache
 		 * and then close as the current main client is likely to be re-elected as the parent summarizer again.
 		 */
-		if (!isSummaryTracked && summaryRefSeq > this.summarizerNode.referenceSequenceNumber) {
+		if (!result.isSummaryTracked && result.isSummaryNewer) {
 			const fetchResult = await this.fetchSnapshotFromStorage(
 				summaryLogger,
 				{
@@ -3707,7 +3707,7 @@ export class ContainerRuntime
 		}
 
 		// Notify the garbage collector so it can update its latest summary state.
-		await this.garbageCollector.refreshLatestSummary(isSummaryTracked);
+		await this.garbageCollector.refreshLatestSummary(result);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3651,19 +3651,21 @@ export class ContainerRuntime
 	/** Implementation of ISummarizerInternalsProvider.refreshLatestSummaryAck */
 	public async refreshLatestSummaryAck(options: IRefreshSummaryAckOptions) {
 		const { proposalHandle, ackHandle, summaryRefSeq, summaryLogger } = options;
+		// proposalHandle is always passed from RunningSummarizer.
+		assert(proposalHandle !== undefined, "proposalHandle should be available");
 		const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-		const result = await this.summarizerNode.refreshLatestSummary(
+		const isSummaryTracked = await this.summarizerNode.refreshLatestSummary(
 			proposalHandle,
 			summaryRefSeq,
 		);
 
 		/**
-		 * When refreshing a summary ack, this check indicates a new ack of a summary that was newer than the
+		 * When refreshing a summary ack, this check indicates a new ack of a summary that is newer than the
 		 * current summary that is tracked, but this summarizer runtime did not produce/track that summary. Thus
 		 * it needs to refresh its state. Today refresh is done by fetching the latest snapshot to update the cache
 		 * and then close as the current main client is likely to be re-elected as the parent summarizer again.
 		 */
-		if (result.latestSummaryUpdated && !result.wasSummaryTracked) {
+		if (!isSummaryTracked && summaryRefSeq > this.summarizerNode.referenceSequenceNumber) {
 			const fetchResult = await this.fetchSnapshotFromStorage(
 				summaryLogger,
 				{
@@ -3705,7 +3707,7 @@ export class ContainerRuntime
 		}
 
 		// Notify the garbage collector so it can update its latest summary state.
-		await this.garbageCollector.refreshLatestSummary(result);
+		await this.garbageCollector.refreshLatestSummary(isSummaryTracked);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -842,8 +842,7 @@ export class GarbageCollector implements IGarbageCollector {
 	}
 
 	/**
-	 * Called to refresh the latest summary state. This happens when either a pending summary is acked or a snapshot
-	 * is downloaded and should be used to update the state.
+	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
 	 */
 	public async refreshLatestSummary(isSummaryTracked: boolean): Promise<void> {
 		return this.summaryStateTracker.refreshLatestSummary(isSummaryTracked);

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -29,6 +29,7 @@ import {
 	RuntimeHeaders,
 } from "../containerRuntime";
 import { ClientSessionExpiredError } from "../error";
+import { IRefreshSummaryResult } from "../summary";
 import { generateGCConfigs } from "./gcConfigs";
 import {
 	GCNodeType,
@@ -844,8 +845,8 @@ export class GarbageCollector implements IGarbageCollector {
 	/**
 	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
 	 */
-	public async refreshLatestSummary(isSummaryTracked: boolean): Promise<void> {
-		return this.summaryStateTracker.refreshLatestSummary(isSummaryTracked);
+	public async refreshLatestSummary(result: IRefreshSummaryResult): Promise<void> {
+		return this.summaryStateTracker.refreshLatestSummary(result);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -29,7 +29,6 @@ import {
 	RuntimeHeaders,
 } from "../containerRuntime";
 import { ClientSessionExpiredError } from "../error";
-import { RefreshSummaryResult } from "../summary";
 import { generateGCConfigs } from "./gcConfigs";
 import {
 	GCNodeType,
@@ -846,8 +845,8 @@ export class GarbageCollector implements IGarbageCollector {
 	 * Called to refresh the latest summary state. This happens when either a pending summary is acked or a snapshot
 	 * is downloaded and should be used to update the state.
 	 */
-	public async refreshLatestSummary(result: RefreshSummaryResult): Promise<void> {
-		return this.summaryStateTracker.refreshLatestSummary(result);
+	public async refreshLatestSummary(isSummaryTracked: boolean): Promise<void> {
+		return this.summaryStateTracker.refreshLatestSummary(isSummaryTracked);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -14,7 +14,11 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
-import { IContainerRuntimeMetadata, ICreateContainerMetadata } from "../summary";
+import {
+	IContainerRuntimeMetadata,
+	ICreateContainerMetadata,
+	IRefreshSummaryResult,
+} from "../summary";
 
 export type GCVersion = number;
 
@@ -224,7 +228,7 @@ export interface IGarbageCollector {
 	/** Returns the GC details generated from the base snapshot. */
 	getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 	/** Called when the latest summary of the system has been refreshed. */
-	refreshLatestSummary(isSummaryTracked: boolean): Promise<void>;
+	refreshLatestSummary(result: IRefreshSummaryResult): Promise<void>;
 	/** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
 	nodeUpdated(
 		nodePath: string,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -14,11 +14,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
-import {
-	IContainerRuntimeMetadata,
-	ICreateContainerMetadata,
-	RefreshSummaryResult,
-} from "../summary";
+import { IContainerRuntimeMetadata, ICreateContainerMetadata } from "../summary";
 
 export type GCVersion = number;
 
@@ -228,7 +224,7 @@ export interface IGarbageCollector {
 	/** Returns the GC details generated from the base snapshot. */
 	getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 	/** Called when the latest summary of the system has been refreshed. */
-	refreshLatestSummary(result: RefreshSummaryResult): Promise<void>;
+	refreshLatestSummary(isSummaryTracked: boolean): Promise<void>;
 	/** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
 	nodeUpdated(
 		nodePath: string,

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -263,18 +263,19 @@ export class GCSummaryStateTracker {
 	}
 
 	/**
-	 * Called to refresh the latest summary state. This happens when either a pending summary is acked or a snapshot
-	 * is downloaded and should be used to update the state.
+	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
 	 */
 	public async refreshLatestSummary(isSummaryTracked: boolean): Promise<void> {
-		// If the summary is tracked, this client is the one that generated it. So, update wasGCRunInLatestSummary.
-		// Note that this has to be updated if GC did not run too. Otherwise, `gcStateNeedsReset` will always return
-		// true in scenarios where GC is disabled but enabled in the snapshot we loaded from.
-		if (isSummaryTracked) {
-			this.wasGCRunInLatestSummary = this.configs.shouldRunGC;
+		if (!isSummaryTracked) {
+			return;
 		}
 
-		if (!isSummaryTracked || !this.configs.shouldRunGC) {
+		// If the summary is tracked, this client is the one that generated it. So, update wasGCRunInLatestSummary.
+		// Note that this has to be updated if GC did not run too. Otherwise, `gcStateNeedsReset` will always return
+		// true in scenarios where GC is currently disabled but enabled in the snapshot we loaded from.
+		this.wasGCRunInLatestSummary = this.configs.shouldRunGC;
+
+		if (!this.configs.shouldRunGC) {
 			return;
 		}
 

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -13,7 +13,6 @@ import {
 	ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions";
 import { mergeStats, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
-import { RefreshSummaryResult } from "../summary";
 import { GCVersion, IGCStats } from "./gcDefinitions";
 import { generateSortedGCState } from "./gcHelpers";
 import { IGarbageCollectionSnapshotData, IGarbageCollectionState } from "./gcSummaryDefinitions";
@@ -267,28 +266,23 @@ export class GCSummaryStateTracker {
 	 * Called to refresh the latest summary state. This happens when either a pending summary is acked or a snapshot
 	 * is downloaded and should be used to update the state.
 	 */
-	public async refreshLatestSummary(result: RefreshSummaryResult): Promise<void> {
-		// If the latest summary was updated and the summary was tracked, this client is the one that generated this
-		// summary. So, update wasGCRunInLatestSummary.
+	public async refreshLatestSummary(isSummaryTracked: boolean): Promise<void> {
+		// If the summary is tracked, this client is the one that generated it. So, update wasGCRunInLatestSummary.
 		// Note that this has to be updated if GC did not run too. Otherwise, `gcStateNeedsReset` will always return
 		// true in scenarios where GC is disabled but enabled in the snapshot we loaded from.
-		if (result.latestSummaryUpdated && result.wasSummaryTracked) {
+		if (isSummaryTracked) {
 			this.wasGCRunInLatestSummary = this.configs.shouldRunGC;
 		}
 
-		if (!result.latestSummaryUpdated || !this.configs.shouldRunGC) {
+		if (!isSummaryTracked || !this.configs.shouldRunGC) {
 			return;
 		}
 
-		// If the summary was tracked by this client, it was the one that generated the summary in the first place.
-		// Update latest state from pending.
-		if (result.wasSummaryTracked) {
-			this.latestSummaryGCVersion = this.configs.gcVersionInEffect;
-			this.latestSummaryData = this.pendingSummaryData;
-			this.pendingSummaryData = undefined;
-			this.updatedDSCountSinceLastSummary = 0;
-			return;
-		}
+		this.latestSummaryGCVersion = this.configs.gcVersionInEffect;
+		this.latestSummaryData = this.pendingSummaryData;
+		this.pendingSummaryData = undefined;
+		this.updatedDSCountSinceLastSummary = 0;
+		return;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -13,10 +13,10 @@ import {
 	ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions";
 import { mergeStats, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
-import { GCVersion, IGCStats } from "./gcDefinitions";
+import { IRefreshSummaryResult } from "../summary";
+import { GCVersion, IGarbageCollectorConfigs, IGCStats } from "./gcDefinitions";
 import { generateSortedGCState } from "./gcHelpers";
 import { IGarbageCollectionSnapshotData, IGarbageCollectionState } from "./gcSummaryDefinitions";
-import { IGarbageCollectorConfigs } from ".";
 
 export const gcStateBlobKey = `${gcBlobPrefix}_root`;
 
@@ -265,8 +265,8 @@ export class GCSummaryStateTracker {
 	/**
 	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
 	 */
-	public async refreshLatestSummary(isSummaryTracked: boolean): Promise<void> {
-		if (!isSummaryTracked) {
+	public async refreshLatestSummary(result: IRefreshSummaryResult): Promise<void> {
+		if (!result.isSummaryTracked) {
 			return;
 		}
 

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -31,7 +31,6 @@ export {
 	IFetchSnapshotResult,
 	IRootSummarizerNode,
 	IRootSummarizerNodeWithGC,
-	RefreshSummaryResult,
 } from "./summarizerNode";
 export {
 	IConnectableRuntime,

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -28,7 +28,7 @@ export { SummarizeHeuristicData, SummarizeHeuristicRunner } from "./summarizerHe
 export {
 	createRootSummarizerNode,
 	createRootSummarizerNodeWithGC,
-	IFetchSnapshotResult,
+	IRefreshSummaryResult,
 	IRootSummarizerNode,
 	IRootSummarizerNodeWithGC,
 } from "./summarizerNode";

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/index.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/index.ts
@@ -6,7 +6,6 @@
 export {
 	IFetchSnapshotResult,
 	ISummarizerNodeRootContract,
-	RefreshSummaryResult,
 	ValidateSummaryResult,
 } from "./summarizerNodeUtils";
 export { IRootSummarizerNode, createRootSummarizerNode } from "./summarizerNode";

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/index.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/index.ts
@@ -4,7 +4,7 @@
  */
 
 export {
-	IFetchSnapshotResult,
+	IRefreshSummaryResult,
 	ISummarizerNodeRootContract,
 	ValidateSummaryResult,
 } from "./summarizerNodeUtils";

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -423,17 +423,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 							summaryRefSeq,
 						};
 					}
-
-					const props = {
-						summaryRefSeq,
-						pendingSize: this.pendingSummaries.size ?? undefined,
-					};
-					this.logger.sendTelemetryEvent({
-						eventName: "PendingSummaryNotFound",
-						proposalHandle,
-						referenceSequenceNumber: this.referenceSequenceNumber,
-						details: JSON.stringify(props),
-					});
 				}
 
 				// If the summary for which refresh is called is older than the latest tracked summary, ignore it.

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -35,6 +35,7 @@ import {
 	EscapedPath,
 	ICreateChildDetails,
 	IInitialSummary,
+	IRefreshSummaryResult,
 	ISummarizerNodeRootContract,
 	parseSummaryForSubtrees,
 	parseSummaryTreeForSubtrees,
@@ -372,7 +373,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 	public async refreshLatestSummary(
 		proposalHandle: string,
 		summaryRefSeq: number,
-	): Promise<boolean> {
+	): Promise<IRefreshSummaryResult> {
 		const eventProps: {
 			proposalHandle: string | undefined;
 			summaryRefSeq: number;
@@ -414,7 +415,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 					isSummaryTracked = true;
 				}
 				event.end({ ...eventProps, isSummaryNewer, pendingSummaryFound: isSummaryTracked });
-				return isSummaryTracked;
+				return { isSummaryTracked, isSummaryNewer };
 			},
 			{ start: true, end: true, cancel: "error" },
 		);

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
@@ -8,30 +8,6 @@ import { ISnapshotTree, ISummaryTree, SummaryObject } from "@fluidframework/prot
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 
 /**
- * Return type of refreshSummaryAck function. There can be three different scenarios based on the passed params:
- *
- * 1. The latest summary was not updated.
- *
- * 2. The latest summary was updated and the summary corresponding to the params was tracked by this client.
- *
- * 3. The latest summary was updated but the summary corresponding to the params was not tracked. The client should
- * close
- */
-export type RefreshSummaryResult =
-	| {
-			latestSummaryUpdated: false;
-	  }
-	| {
-			latestSummaryUpdated: true;
-			wasSummaryTracked: true;
-			summaryRefSeq: number;
-	  }
-	| {
-			latestSummaryUpdated: true;
-			wasSummaryTracked: false;
-	  };
-
-/**
  * Result of snapshot fetch during refreshing latest summary state.
  */
 export interface IFetchSnapshotResult {
@@ -66,10 +42,7 @@ export interface ISummarizerNodeRootContract {
 	validateSummary(): ValidateSummaryResult;
 	completeSummary(proposalHandle: string, validate: boolean): void;
 	clearSummary(): void;
-	refreshLatestSummary(
-		proposalHandle: string | undefined,
-		summaryRefSeq: number,
-	): Promise<RefreshSummaryResult>;
+	refreshLatestSummary(proposalHandle: string, summaryRefSeq: number): Promise<boolean>;
 }
 
 /** Path for nodes in a tree with escaped special characters */

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
@@ -7,12 +7,11 @@ import { ITelemetryLoggerExt, TelemetryDataTag } from "@fluidframework/telemetry
 import { ISnapshotTree, ISummaryTree, SummaryObject } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 
-/**
- * Result of snapshot fetch during refreshing latest summary state.
- */
-export interface IFetchSnapshotResult {
-	snapshotTree: ISnapshotTree;
-	snapshotRefSeq: number;
+export interface IRefreshSummaryResult {
+	/** Tells whether this summary is tracked by this client. */
+	isSummaryTracked: boolean;
+	/** Tells whether this summary is newer than the latest one tracked by this client. */
+	isSummaryNewer: boolean;
 }
 
 /**
@@ -42,7 +41,10 @@ export interface ISummarizerNodeRootContract {
 	validateSummary(): ValidateSummaryResult;
 	completeSummary(proposalHandle: string, validate: boolean): void;
 	clearSummary(): void;
-	refreshLatestSummary(proposalHandle: string, summaryRefSeq: number): Promise<boolean>;
+	refreshLatestSummary(
+		proposalHandle: string,
+		summaryRefSeq: number,
+	): Promise<IRefreshSummaryResult>;
 }
 
 /** Path for nodes in a tree with escaped special characters */

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -53,7 +53,6 @@ import {
 	dataStoreAttributesBlobName,
 	IContainerRuntimeMetadata,
 	metadataBlobName,
-	RefreshSummaryResult,
 } from "../../summary";
 import { pkgVersion } from "../../packageVersion";
 import { configProvider } from "./gcUnitTestHelpers";
@@ -1098,12 +1097,7 @@ describe("Garbage Collection Tests", () => {
 				"Deleted nodes state should be a handle",
 			);
 
-			const refreshSummaryResult: RefreshSummaryResult = {
-				latestSummaryUpdated: true,
-				wasSummaryTracked: true,
-				summaryRefSeq: 0,
-			};
-			await garbageCollector.refreshLatestSummary(refreshSummaryResult);
+			await garbageCollector.refreshLatestSummary(true /* isSummaryTracked */);
 
 			// Run GC and summarize again. The whole GC summary should now be a summary handle.
 			await garbageCollector.collectGarbage({});
@@ -1697,12 +1691,7 @@ describe("Garbage Collection Tests", () => {
 
 			checkGCSummaryType(tree1, SummaryType.Tree, "first");
 
-			await garbageCollector.refreshLatestSummary({
-				wasSummaryTracked: true,
-				latestSummaryUpdated: true,
-				summaryRefSeq: 0,
-			});
-
+			await garbageCollector.refreshLatestSummary(true /* isSummaryTracked */);
 			await garbageCollector.collectGarbage({});
 			const tree2 = garbageCollector.summarize(fullTree, trackState);
 

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -1097,7 +1097,10 @@ describe("Garbage Collection Tests", () => {
 				"Deleted nodes state should be a handle",
 			);
 
-			await garbageCollector.refreshLatestSummary(true /* isSummaryTracked */);
+			await garbageCollector.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: true,
+			});
 
 			// Run GC and summarize again. The whole GC summary should now be a summary handle.
 			await garbageCollector.collectGarbage({});
@@ -1691,7 +1694,10 @@ describe("Garbage Collection Tests", () => {
 
 			checkGCSummaryType(tree1, SummaryType.Tree, "first");
 
-			await garbageCollector.refreshLatestSummary(true /* isSummaryTracked */);
+			await garbageCollector.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: true,
+			});
 			await garbageCollector.collectGarbage({});
 			const tree2 = garbageCollector.summarize(fullTree, trackState);
 

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -40,7 +40,7 @@ describe("GCSummaryStateTracker tests", () => {
 			);
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
+			await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
 
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
@@ -88,7 +88,7 @@ describe("GCSummaryStateTracker tests", () => {
 			);
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
+			await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
 				false,
@@ -124,7 +124,7 @@ describe("GCSummaryStateTracker tests", () => {
 			assert.equal(tracker.doesGCStateNeedReset, true, "Should need reset");
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
+			await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
 			assert.equal(
 				tracker.doesGCStateNeedReset,
 				false,
@@ -145,7 +145,7 @@ describe("GCSummaryStateTracker tests", () => {
 			assert.equal(tracker.doesGCStateNeedReset, true, "Should need reset");
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
+			await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
 
 			assert.equal(
 				tracker.doesGCStateNeedReset,
@@ -364,7 +364,10 @@ describe("GCSummaryStateTracker tests", () => {
 			[],
 		);
 
-		await summaryStateTracker.refreshLatestSummary(true /* isSummaryTracked */);
+		await summaryStateTracker.refreshLatestSummary({
+			isSummaryTracked: true,
+			isSummaryNewer: true,
+		});
 		assert.strictEqual(
 			summaryStateTracker.updatedDSCountSinceLastSummary,
 			0,

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -14,7 +14,6 @@ import {
 	IGarbageCollectionState,
 	IGCStats,
 } from "../../gc";
-import { RefreshSummaryResult } from "../../summary";
 
 type GCSummaryStateTrackerWithPrivates = Omit<GCSummaryStateTracker, "latestSummaryGCVersion"> & {
 	latestSummaryGCVersion: GCVersion;
@@ -41,12 +40,7 @@ describe("GCSummaryStateTracker tests", () => {
 			);
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			const refreshSummaryResult: RefreshSummaryResult = {
-				latestSummaryUpdated: true,
-				wasSummaryTracked: true,
-				summaryRefSeq: 0,
-			};
-			await tracker.refreshLatestSummary(refreshSummaryResult);
+			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
 
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
@@ -94,12 +88,7 @@ describe("GCSummaryStateTracker tests", () => {
 			);
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			const refreshSummaryResult: RefreshSummaryResult = {
-				latestSummaryUpdated: true,
-				wasSummaryTracked: true,
-				summaryRefSeq: 0,
-			};
-			await tracker.refreshLatestSummary(refreshSummaryResult);
+			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
 			assert.equal(
 				tracker.doesSummaryStateNeedReset,
 				false,
@@ -135,12 +124,7 @@ describe("GCSummaryStateTracker tests", () => {
 			assert.equal(tracker.doesGCStateNeedReset, true, "Should need reset");
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			const refreshSummaryResult: RefreshSummaryResult = {
-				latestSummaryUpdated: true,
-				wasSummaryTracked: true,
-				summaryRefSeq: 0,
-			};
-			await tracker.refreshLatestSummary(refreshSummaryResult);
+			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
 			assert.equal(
 				tracker.doesGCStateNeedReset,
 				false,
@@ -161,12 +145,7 @@ describe("GCSummaryStateTracker tests", () => {
 			assert.equal(tracker.doesGCStateNeedReset, true, "Should need reset");
 
 			// After the first summary succeeds (refreshLatestSummary called), the state should not need reset.
-			const refreshSummaryResult: RefreshSummaryResult = {
-				latestSummaryUpdated: true,
-				wasSummaryTracked: true,
-				summaryRefSeq: 0,
-			};
-			await tracker.refreshLatestSummary(refreshSummaryResult);
+			await tracker.refreshLatestSummary(true /* isSummaryTracked */);
 
 			assert.equal(
 				tracker.doesGCStateNeedReset,
@@ -384,12 +363,8 @@ describe("GCSummaryStateTracker tests", () => {
 			new Set(),
 			[],
 		);
-		const refreshSummaryResult: RefreshSummaryResult = {
-			latestSummaryUpdated: true,
-			wasSummaryTracked: true,
-			summaryRefSeq: 0,
-		};
-		await summaryStateTracker.refreshLatestSummary(refreshSummaryResult);
+
+		await summaryStateTracker.refreshLatestSummary(true /* isSummaryTracked */);
 		assert.strictEqual(
 			summaryStateTracker.updatedDSCountSinceLastSummary,
 			0,

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -416,17 +416,13 @@ describe("Runtime", () => {
 			});
 
 			describe("Refresh Latest Summary", () => {
-				it("Should refresh from tree when no proposal handle provided", async () => {
-					createRoot();
-					const result = await rootNode.refreshLatestSummary(undefined, summaryRefSeq);
-					assert(result.latestSummaryUpdated === true, "should update");
-					assert(result.wasSummaryTracked === false, "should not be tracked");
-				});
-
 				it("Should not refresh latest if already passed ref seq number", async () => {
 					createRoot({ refSeq: summaryRefSeq });
-					const result = await rootNode.refreshLatestSummary(undefined, summaryRefSeq);
-					assert(result.latestSummaryUpdated === false, "we already got this summary");
+					const isSummaryTracked = await rootNode.refreshLatestSummary(
+						"test-handle",
+						summaryRefSeq,
+					);
+					assert(!isSummaryTracked, "we already got this summary");
 				});
 
 				it("Should refresh from pending", async () => {
@@ -437,12 +433,11 @@ describe("Runtime", () => {
 					await rootNode.summarize(false);
 					rootNode.completeSummary(proposalHandle, true /* validateSummary */);
 
-					const result = await rootNode.refreshLatestSummary(
+					const isSummaryTracked = await rootNode.refreshLatestSummary(
 						proposalHandle,
 						summaryRefSeq,
 					);
-					assert(result.latestSummaryUpdated === true, "should update");
-					assert(result.wasSummaryTracked === true, "should be tracked");
+					assert(isSummaryTracked, "should be tracked");
 				});
 
 				it("should fail refresh when summary is in progress", async () => {

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -418,11 +418,11 @@ describe("Runtime", () => {
 			describe("Refresh Latest Summary", () => {
 				it("Should not refresh latest if already passed ref seq number", async () => {
 					createRoot({ refSeq: summaryRefSeq });
-					const isSummaryTracked = await rootNode.refreshLatestSummary(
+					const result = await rootNode.refreshLatestSummary(
 						"test-handle",
 						summaryRefSeq,
 					);
-					assert(!isSummaryTracked, "we already got this summary");
+					assert(!result.isSummaryTracked, "we already got this summary");
 				});
 
 				it("Should refresh from pending", async () => {
@@ -433,11 +433,12 @@ describe("Runtime", () => {
 					await rootNode.summarize(false);
 					rootNode.completeSummary(proposalHandle, true /* validateSummary */);
 
-					const isSummaryTracked = await rootNode.refreshLatestSummary(
+					const result = await rootNode.refreshLatestSummary(
 						proposalHandle,
 						summaryRefSeq,
 					);
-					assert(isSummaryTracked, "should be tracked");
+					assert(result.isSummaryTracked, "should be tracked");
+					assert(result.isSummaryNewer === true, "should be newer");
 				});
 
 				it("should fail refresh when summary is in progress", async () => {

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -414,11 +414,9 @@ describe("SummarizerNodeWithGC Tests", () => {
 			await midNode?.summarize(false);
 			rootNode.completeSummary("test-handle1", true /* validateSummary */);
 
-			let isSummaryTracked = await rootNode.refreshLatestSummary(
-				"test-handle1",
-				summaryRefSeq,
-			);
-			assert(isSummaryTracked, "should be tracked");
+			let result = await rootNode.refreshLatestSummary("test-handle1", summaryRefSeq);
+			assert(result.isSummaryTracked, "should be tracked");
+			assert(result.isSummaryNewer === true, "should be newer");
 
 			rootNode.startSummary(summaryRefSeq++, logger);
 			rootNode.updateUsedRoutes([`/`, `/${ids[1]}`, `/${ids[1]}/${ids[2]}`]);
@@ -431,8 +429,9 @@ describe("SummarizerNodeWithGC Tests", () => {
 			// Create a new child node for which we will need to create a pending summary for.
 			createLeaf({ type: CreateSummarizerNodeSource.Local });
 
-			isSummaryTracked = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
-			assert(isSummaryTracked, "should be tracked");
+			result = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
+			assert(result.isSummaryTracked, "should be tracked");
+			assert(result.isSummaryNewer === true, "should be newer");
 			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
 			const leafNodeLatestSummary = (leafNode as SummarizerNodeWithGC).latestSummary;
 			assert.strictEqual(
@@ -453,11 +452,9 @@ describe("SummarizerNodeWithGC Tests", () => {
 			await midNode?.summarize(false);
 			rootNode.completeSummary("test-handle1", true /* validateSummary */);
 
-			let isSummaryTracked = await rootNode.refreshLatestSummary(
-				"test-handle1",
-				summaryRefSeq,
-			);
-			assert(isSummaryTracked, "should be tracked");
+			let result = await rootNode.refreshLatestSummary("test-handle1", summaryRefSeq);
+			assert(result.isSummaryTracked, "should be tracked");
+			assert(result.isSummaryNewer === true, "should be newer");
 
 			rootNode.startSummary(summaryRefSeq++, logger);
 			rootNode.updateUsedRoutes([""]);
@@ -470,8 +467,9 @@ describe("SummarizerNodeWithGC Tests", () => {
 			// Create a new child node for which we will need to create a pending summary for.
 			createLeaf({ type: CreateSummarizerNodeSource.Local });
 
-			isSummaryTracked = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
-			assert(isSummaryTracked, "should be tracked");
+			result = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
+			assert(result.isSummaryTracked, "should be tracked");
+			assert(result.isSummaryNewer === true, "should be newer");
 			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
 			const leafNodeLatestSummary = (leafNode as SummarizerNodeWithGC).latestSummary;
 			assert.strictEqual(

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -414,9 +414,11 @@ describe("SummarizerNodeWithGC Tests", () => {
 			await midNode?.summarize(false);
 			rootNode.completeSummary("test-handle1", true /* validateSummary */);
 
-			let result = await rootNode.refreshLatestSummary("test-handle1", summaryRefSeq);
-			assert(result.latestSummaryUpdated === true, "should update");
-			assert(result.wasSummaryTracked === true, "should be tracked");
+			let isSummaryTracked = await rootNode.refreshLatestSummary(
+				"test-handle1",
+				summaryRefSeq,
+			);
+			assert(isSummaryTracked, "should be tracked");
 
 			rootNode.startSummary(summaryRefSeq++, logger);
 			rootNode.updateUsedRoutes([`/`, `/${ids[1]}`, `/${ids[1]}/${ids[2]}`]);
@@ -429,9 +431,8 @@ describe("SummarizerNodeWithGC Tests", () => {
 			// Create a new child node for which we will need to create a pending summary for.
 			createLeaf({ type: CreateSummarizerNodeSource.Local });
 
-			result = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
-			assert(result.latestSummaryUpdated === true, "should update");
-			assert(result.wasSummaryTracked === true, "should be tracked");
+			isSummaryTracked = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
+			assert(isSummaryTracked, "should be tracked");
 			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
 			const leafNodeLatestSummary = (leafNode as SummarizerNodeWithGC).latestSummary;
 			assert.strictEqual(
@@ -452,9 +453,11 @@ describe("SummarizerNodeWithGC Tests", () => {
 			await midNode?.summarize(false);
 			rootNode.completeSummary("test-handle1", true /* validateSummary */);
 
-			let result = await rootNode.refreshLatestSummary("test-handle1", summaryRefSeq);
-			assert(result.latestSummaryUpdated === true, "should update");
-			assert(result.wasSummaryTracked === true, "should be tracked");
+			let isSummaryTracked = await rootNode.refreshLatestSummary(
+				"test-handle1",
+				summaryRefSeq,
+			);
+			assert(isSummaryTracked, "should be tracked");
 
 			rootNode.startSummary(summaryRefSeq++, logger);
 			rootNode.updateUsedRoutes([""]);
@@ -467,9 +470,8 @@ describe("SummarizerNodeWithGC Tests", () => {
 			// Create a new child node for which we will need to create a pending summary for.
 			createLeaf({ type: CreateSummarizerNodeSource.Local });
 
-			result = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
-			assert(result.latestSummaryUpdated === true, "should update");
-			assert(result.wasSummaryTracked === true, "should be tracked");
+			isSummaryTracked = await rootNode.refreshLatestSummary("test-handle2", summaryRefSeq);
+			assert(isSummaryTracked, "should be tracked");
 			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
 			const leafNodeLatestSummary = (leafNode as SummarizerNodeWithGC).latestSummary;
 			assert.strictEqual(


### PR DESCRIPTION
## Description
#16657 removed the logic to refresh a summary's state by downloading a snapshot. With it gone, summarizer node (and rest of the system) only updates state from a summary that it was tracking. This PR simplifies the logic in `SummarizerNode::refreshLatestSummary` to account for this. It also renames the properties in the returned object to give the caller more context on what happened and what action it can take.

Additionally, it removes logging the `PendingSummaryNotFound` telemetry. It is currently logged every time the summarizer loaded for the summary that is loaded from. The reason is that it processes the ack for the summary is loaded from and since the summary was not generated by this instance of the summarizer, this event is logged. Instead, added a property `pendingSummaryTracked` to the refreshLatestSummary_end event.

[AB#4435](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4435)