### PR TITLE
fluid-build: Use version of typescript specified by the project dynamically

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -2,28 +2,26 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as tsLib from "typescript";
+import type * as tsTypes from "typescript";
 
-import { getTscUtil } from "../../../common/tscUtils";
+import { getTscUtils } from "../../../common/tscUtils";
 import type { WorkerExecResult, WorkerMessage } from "./worker";
 
 export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 	const { command, cwd } = msg;
 	// Load the typescript version that is in the cwd scope
-	const tsPath = require.resolve("typescript", { paths: [cwd] });
-	const ts: typeof tsLib = require(tsPath);
+	const tscUtils = getTscUtils(cwd);
 
-	const TscUtils = getTscUtil(ts);
-
-	let commandLine = TscUtils.parseCommandLine(command);
-	const diagnostics: tsLib.Diagnostic[] = [];
+	const ts = tscUtils.tsLib;
+	let commandLine = tscUtils.parseCommandLine(command);
+	const diagnostics: tsTypes.Diagnostic[] = [];
 	if (commandLine) {
-		const configFileName = TscUtils.findConfigFile(cwd, commandLine);
+		const configFileName = tscUtils.findConfigFile(cwd, commandLine);
 		if (configFileName) {
 			commandLine = ts.getParsedCommandLineOfConfigFile(configFileName, commandLine.options, {
 				...ts.sys,
 				getCurrentDirectory: () => cwd,
-				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsLib.Diagnostic) => {
+				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsTypes.Diagnostic) => {
 					diagnostics.push(diagnostic);
 				},
 			});
@@ -37,7 +35,7 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 		const incremental = !!(commandLine.options.incremental || commandLine.options.composite);
 		const param = {
 			rootNames: commandLine.fileNames,
-			options: TscUtils.convertToOptionsWithAbsolutePath(commandLine.options, cwd),
+			options: tscUtils.convertToOptionsWithAbsolutePath(commandLine.options, cwd),
 			projectReferences: commandLine.projectReferences,
 		};
 		const program = incremental ? ts.createIncrementalProgram(param) : ts.createProgram(param);
@@ -64,9 +62,9 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 	if (diagnostics.length > 0) {
 		const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
 
-		const formatDiagnosticsHost: tsLib.FormatDiagnosticsHost = {
+		const formatDiagnosticsHost: tsTypes.FormatDiagnosticsHost = {
 			getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
-			getCanonicalFileName: TscUtils.getCanonicalFileName,
+			getCanonicalFileName: tscUtils.getCanonicalFileName,
 			getNewLine: () => ts.sys.newLine,
 		};
 


### PR DESCRIPTION
This enable `fluid-build` to be use with different versions of typescript (within limits) based on what is specified and installed with the repo
Currently, tested with 4.5.5 and 5.1.6.

This extends what we do for worker already, which dynamically load the correct version based on the project.