### PR TITLE
Deprecate createDeltaConnection on MockContainerRuntime

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,9 @@
 
 	// Custom dictionary for 'streetsidesoftware.code-spell-checker' extension.
 	"cSpell.words": [
+		"boop",
+		"contoso",
+		"denormalized",
 		"endregion",
 		"fluidframework",
 		"handlecache",
@@ -36,7 +39,9 @@
 		"nonfinite",
 		"pseudorandomly",
 		"Routerlicious",
+		"runtimes",
 		"snapshotlegacy",
+		"snapshotting",
 		"testconsumer",
 		"Tinylicious",
 		"tombstoned",
@@ -44,6 +49,7 @@
 		"unacked",
 		"unaugmented",
 		"undoprovider",
+		"unsequenced",
 	],
 
 	// Enable prettier as default formatter, and disable rules that disagree with it

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -103,11 +103,11 @@ export class MockContainerRuntime {
     clientId: string;
     // (undocumented)
     protected clientSequenceNumber: number;
-    // (undocumented)
+    // @deprecated (undocumented)
     createDeltaConnection(): MockDeltaConnection;
     // (undocumented)
     protected readonly dataStoreRuntime: MockFluidDataStoreRuntime;
-    // (undocumented)
+    // @deprecated (undocumented)
     protected readonly deltaConnections: MockDeltaConnection[];
     // (undocumented)
     dirty(): void;

--- a/experimental/PropertyDDS/packages/property-dds/src/test/reconnect.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/reconnect.spec.ts
@@ -40,7 +40,7 @@ describe("PropertyDDS", () => {
 				const containerRuntime =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 				const services = {
-					deltaConnection: containerRuntime.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				const tree = new SharedPropertyTree(

--- a/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
@@ -29,7 +29,7 @@ function createConnectedMap(id: string, runtimeFactory: MockContainerRuntimeFact
 
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -376,7 +376,7 @@ describe("Map", () => {
 				const services2 = MockSharedObjectServices.createFromSummary(
 					map1.getAttachSummary().summary,
 				);
-				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+				services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 				const map2 = new TestMap("testMap2", dataStoreRuntime2, MapFactory.Attributes);
 				await map2.load(services2);
@@ -386,7 +386,7 @@ describe("Map", () => {
 				const containerRuntime1 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(undefined),
 				};
 				map1.connect(services1);

--- a/experimental/dds/attributable-map/src/test/mocha/reconnection.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/reconnection.spec.ts
@@ -27,7 +27,7 @@ describe("Reconnection", () => {
 			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			map1 = new AttributableMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
@@ -37,7 +37,7 @@ describe("Reconnection", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			map2 = new AttributableMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);

--- a/experimental/dds/ot/ot/src/test/ot.spec.ts
+++ b/experimental/dds/ot/ot/src/test/ot.spec.ts
@@ -19,9 +19,9 @@ const createLocalOT = (id: string) => {
 function createConnectedOT(id: string, runtimeFactory: MockContainerRuntimeFactory) {
 	// Create and connect a second SharedCell.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 

--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -20,9 +20,9 @@ const createLocalOT = (id: string) => {
 function createConnectedOT(id: string, runtimeFactory: MockContainerRuntimeFactory) {
 	// Create and connect a second SharedCell.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 

--- a/experimental/dds/sequence-deprecated/src/test/sharedObjectSequence.spec.ts
+++ b/experimental/dds/sequence-deprecated/src/test/sharedObjectSequence.spec.ts
@@ -20,9 +20,9 @@ function createConnectedSequence(id: string, runtimeFactory: MockContainerRuntim
 		id,
 		SharedObjectSequenceFactory.Attributes,
 	);
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(undefined),
 	};
 	sequence.connect(services);

--- a/experimental/dds/sequence-deprecated/src/test/sparseMatrix.spec.ts
+++ b/experimental/dds/sequence-deprecated/src/test/sparseMatrix.spec.ts
@@ -128,10 +128,9 @@ describe("SparseMatrix", () => {
 
 				// Create and connect the first SparseMatrix.
 				const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
-				const containerRuntime1 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 				const services1: IChannelServices = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				matrix1 = new SparseMatrix(
@@ -144,10 +143,9 @@ describe("SparseMatrix", () => {
 
 				// Create and connect the second SparseMatrix.
 				const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-				const containerRuntime2 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 				const services2: IChannelServices = {
-					deltaConnection: containerRuntime2.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				matrix2 = new SparseMatrix(
@@ -281,7 +279,7 @@ describe("SparseMatrix", () => {
 					containerRuntimeFactory as MockContainerRuntimeFactoryForReconnection
 				).createContainerRuntime(dataStoreRuntime1);
 				const services1: IChannelServices = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				matrix1 = new SparseMatrix(
@@ -298,7 +296,7 @@ describe("SparseMatrix", () => {
 					containerRuntimeFactory as MockContainerRuntimeFactoryForReconnection
 				).createContainerRuntime(dataStoreRuntime2);
 				const services2: IChannelServices = {
-					deltaConnection: containerRuntime2.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				matrix2 = new SparseMatrix(

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -199,7 +199,7 @@ export function setUpTestSharedTree(
 	} else {
 		const containerRuntime = newContainerRuntimeFactory.createContainerRuntime(componentRuntime);
 		const services = {
-			deltaConnection: containerRuntime.createDeltaConnection(),
+			deltaConnection: componentRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(undefined),
 		};
 		tree.connect(services);

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -369,9 +369,9 @@ export class TestTreeProviderLite {
 				id: "test",
 			});
 			const tree = this.factory.create(runtime, TestTreeProviderLite.treeId);
-			const containerRuntime = this.runtimeFactory.createContainerRuntime(runtime);
+			this.runtimeFactory.createContainerRuntime(runtime);
 			tree.connect({
-				deltaConnection: containerRuntime.createDeltaConnection(),
+				deltaConnection: runtime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			});
 			t.push(tree);

--- a/packages/dds/cell/src/test/cell.spec.ts
+++ b/packages/dds/cell/src/test/cell.spec.ts
@@ -26,9 +26,9 @@ function createConnectedCell(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	dataStoreRuntime.options = options ?? dataStoreRuntime.options;
 
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -51,7 +51,7 @@ function createCellForReconnection(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -132,22 +132,22 @@ describe("Cell", () => {
 				// Load a new SharedCell in connected state from the snapshot of the first one.
 				const containerRuntimeFactory = new MockContainerRuntimeFactory();
 				const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-				const containerRuntime2 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 				const services2 = MockSharedObjectServices.createFromSummary(
 					cell1.getAttachSummary().summary,
 				);
-				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+				services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 				const cell2 = new SharedCell("cell2", dataStoreRuntime2, CellFactory.Attributes);
 				await cell2.load(services2);
 
 				// Now connect the first SharedCell
 				dataStoreRuntime1.local = false;
-				const containerRuntime1 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
+
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				cell1.connect(services1);
@@ -157,7 +157,7 @@ describe("Cell", () => {
 				assert.equal(cell2.get(), value, "The second cell does not have the key");
 
 				// Set a new value in the second SharedCell.
-				const newValue = "newvalue";
+				const newValue = "newValue";
 				cell2.set(newValue);
 
 				// Process the message.
@@ -170,7 +170,7 @@ describe("Cell", () => {
 		});
 
 		describe("Attributor", () => {
-			it("should retrive proper attribution in detached state", async () => {
+			it("should retrieve proper attribution in detached state", async () => {
 				// overwrite the cell with attribution tracking enabled
 				const options: ICellOptions = { attribution: { track: true } };
 				cell = createDetachedCell("cell", options);
@@ -305,7 +305,7 @@ describe("Cell", () => {
 				cell2 = createConnectedCell("cell2", containerRuntimeFactory, options);
 			});
 
-			it("Retrive proper attribution information in connected state", () => {
+			it("Retrieve proper attribution information in connected state", () => {
 				const value1 = "value1";
 				const value2 = "value2";
 				cell1.set(value1);
@@ -364,7 +364,7 @@ describe("Cell", () => {
 				);
 			});
 
-			it("Retrive proper attribution information after summarization/loading", async () => {
+			it("Retrieve proper attribution information after summarization/loading", async () => {
 				const value1 = "value1";
 				const value2 = "value2";
 				cell1.set(value1);

--- a/packages/dds/counter/src/test/counter.spec.ts
+++ b/packages/dds/counter/src/test/counter.spec.ts
@@ -37,7 +37,7 @@ describe("SharedCounter", () => {
 		describe("constructor", () => {
 			it("Can create a counter with default value", () => {
 				assert.ok(testCounter, "Count not create the SharedCounter");
-				assert.equal(testCounter.value, 0, "The defaul value is incorrect");
+				assert.equal(testCounter.value, 0, "The default value is incorrect");
 			});
 		});
 
@@ -128,20 +128,20 @@ describe("SharedCounter", () => {
 
 			// Connect the first SharedCounter.
 			dataStoreRuntime.local = false;
-			const containerRuntime1 =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			testCounter.connect(services1);
 
 			// Create and connect a second SharedCounter.
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-			const containerRuntime2 =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 
@@ -216,7 +216,7 @@ describe("SharedCounter", () => {
 			dataStoreRuntime.local = false;
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			testCounter.connect(services1);
@@ -225,7 +225,7 @@ describe("SharedCounter", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 

--- a/packages/dds/ink/src/test/ink.spec.ts
+++ b/packages/dds/ink/src/test/ink.spec.ts
@@ -122,22 +122,20 @@ describe("Ink", () => {
 			// Load a new Ink in connected state from the snapshot of the first one.
 			const containerRuntimeFactory = new MockContainerRuntimeFactory();
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-			const containerRuntime2 =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = MockSharedObjectServices.createFromSummary(
 				ink.getAttachSummary().summary,
 			);
-			services2.deltaConnection = containerRuntime2.createDeltaConnection();
+			services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 			const ink2 = new Ink(dataStoreRuntime2, "ink2", InkFactory.Attributes);
 			await ink2.load(services2);
 
 			// Now connect the first Ink
 			dataStoreRuntime.local = false;
-			const containerRuntime1 =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(undefined),
 			};
 			ink.connect(services1);
@@ -182,20 +180,18 @@ describe("Ink", () => {
 
 			// Connect the first Ink.
 			dataStoreRuntime.local = false;
-			const containerRuntime1 =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			ink.connect(services1);
 
 			// Create and connect a second Ink.
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-			const containerRuntime2 =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 
@@ -218,7 +214,7 @@ describe("Ink", () => {
 
 			// Verify that the remote ink has the correct stroke.
 			const stroke2 = ink2.getStroke(strokeId);
-			assert.ok(stroke2, "Could not retrieve the stroke in rmeote client");
+			assert.ok(stroke2, "Could not retrieve the stroke in remote client");
 			assert.equal(stroke2.id, strokeId, "The stroke's id is incorrect in remote client");
 			assert.deepEqual(stroke2.pen, pen, "The stroke's pen is incorrect in remote client");
 		});
@@ -350,7 +346,7 @@ describe("Ink", () => {
 			dataStoreRuntime.local = false;
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			ink.connect(services1);
@@ -359,7 +355,7 @@ describe("Ink", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -20,8 +20,6 @@ import { DirectoryFactory, IDirectoryNewStorageFormat, SharedDirectory } from ".
 import { IDirectory, IDirectoryValueChanged, ISharedMap } from "../../interfaces";
 import { assertEquivalentDirectories } from "./directoryEquivalenceUtils";
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-
 function createConnectedDirectory(
 	id: string,
 	runtimeFactory: MockContainerRuntimeFactory,
@@ -29,7 +27,7 @@ function createConnectedDirectory(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 	const directory = new SharedDirectory(id, dataStoreRuntime, DirectoryFactory.Attributes);
@@ -322,7 +320,7 @@ describe("Directory", () => {
 					);
 				});
 
-				// Test dispose on subdirectory delete
+				// Test dispose on subDirectory delete
 				let subDirectoryDisposed = false;
 				const subDirectory = directory.createSubDirectory("rock");
 				subDirectory.on("disposed", (value: IDirectory) => {
@@ -394,19 +392,17 @@ describe("Directory", () => {
 					directory.set(undefined as unknown as string, "testValue");
 				}, "Should throw for key of undefined");
 				assert.throws(() => {
-					// eslint-disable-next-line unicorn/no-null
 					directory.set(null as unknown as string, "testValue");
 				}, "Should throw for key of null");
 			});
 
-			it("Rejects subdirectories with undefined and null names", () => {
+			it("Rejects subDirectories with undefined and null names", () => {
 				assert.throws(() => {
 					directory.createSubDirectory(undefined as unknown as string);
-				}, "Should throw for undefined subdirectory name");
+				}, "Should throw for undefined subDirectory name");
 				assert.throws(() => {
-					// eslint-disable-next-line unicorn/no-null
 					directory.createSubDirectory(null as unknown as string);
-				}, "Should throw for null subdirectory name");
+				}, "Should throw for null subDirectory name");
 			});
 		});
 
@@ -416,7 +412,7 @@ describe("Directory", () => {
 				assert.equal(serialized, '{"ci":{"csn":0,"ccIds":[]}}');
 			});
 
-			it("Should serialize a directory without subdirectories as a JSON object", () => {
+			it("Should serialize a directory without subDirectories as a JSON object", () => {
 				directory.set("first", "second");
 				directory.set("third", "fourth");
 				directory.set("fifth", "sixth");
@@ -430,7 +426,7 @@ describe("Directory", () => {
 				assert.equal(serialized, expected);
 			});
 
-			it("Should serialize a directory with subdirectories as a JSON object", () => {
+			it("Should serialize a directory with subDirectories as a JSON object", () => {
 				directory.set("first", "second");
 				directory.set("third", "fourth");
 				directory.set("fifth", "sixth");
@@ -445,7 +441,7 @@ describe("Directory", () => {
 
 				const subMapHandleUrl = subMap.handle.absolutePath;
 				const serialized = serialize(directory);
-				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subdirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subdirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subDirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subDirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subDirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
 				assert.equal(serialized, expected);
 			});
 
@@ -467,7 +463,7 @@ describe("Directory", () => {
 
 				const subMapHandleUrl = subMap.handle.absolutePath;
 				const serialized = serialize(directory);
-				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subdirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subdirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subDirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subDirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subDirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
 				assert.equal(serialized, expected);
 			});
 		});
@@ -479,9 +475,9 @@ describe("Directory", () => {
 				directory.set("testKey", "testValue");
 				assert.equal(directory.get("testKey"), "testValue", "Failed to set testKey");
 				directory.createSubDirectory("testSubDir").set("testSubKey", "testSubValue");
-				const subdir = directory.getWorkingDirectory("testSubDir");
-				assert(subdir);
-				assert.equal(subdir.get("testSubKey"), "testSubValue", "Failed to set testSubKey");
+				const subDir = directory.getWorkingDirectory("testSubDir");
+				assert(subDir);
+				assert.equal(subDir.get("testSubKey"), "testSubValue", "Failed to set testSubKey");
 			});
 
 			it("Should populate the directory from a basic JSON object (old format)", async () => {
@@ -496,7 +492,7 @@ describe("Directory", () => {
 							value: "testValue5",
 						},
 					},
-					subdirectories: {
+					subDirectories: {
 						foo: {
 							storage: {
 								testKey: {
@@ -546,7 +542,7 @@ describe("Directory", () => {
 							type: "Plain",
 						},
 					},
-					subdirectories: {
+					subDirectories: {
 						foo: {
 							storage: {
 								testKey: {
@@ -664,7 +660,7 @@ describe("Directory", () => {
 				const services2 = MockSharedObjectServices.createFromSummary(
 					directory.getAttachSummary().summary,
 				);
-				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+				services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 				const directory2 = new SharedDirectory(
 					"directory2",
@@ -675,28 +671,27 @@ describe("Directory", () => {
 
 				// Now connect the first SharedDirectory
 				dataStoreRuntime.local = false;
-				const containerRuntime1 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime.createDeltaConnection(),
 					objectStorage: new MockStorage(undefined),
 				};
 				directory.connect(services1);
 
-				// Create a sub direcotry in a sub directory and queue up keys to be set in it
+				// Create a sub directory in a sub directory and queue up keys to be set in it
 				const someParentDir1 = directory.createSubDirectory("lists");
 
-				const subdir1 = someParentDir1.createSubDirectory("ListLevels-0");
-				subdir1.set("random1", 1);
-				subdir1.set("random2", 2);
+				const subDir1 = someParentDir1.createSubDirectory("ListLevels-0");
+				subDir1.set("random1", 1);
+				subDir1.set("random2", 2);
 
 				// Let everything get stamped and round-trip back to us
 				containerRuntimeFactory.processAllMessages();
 
 				// Now, let's be tricky. Let's set one of the keys again...
 				const dir1 = directory.getSubDirectory("lists");
-				const subdirDir11 = dir1?.getSubDirectory("ListLevels-0");
-				subdirDir11?.set("random1", 3);
+				const subDirDir11 = dir1?.getSubDirectory("ListLevels-0");
+				subDirDir11?.set("random1", 3);
 
 				// ... then delete the sub directory and its parent, create a new sub directory
 				// and parent with the exact same paths. We need to set at least one of the same
@@ -706,8 +701,8 @@ describe("Directory", () => {
 				directory.deleteSubDirectory("lists");
 
 				const someParentDir2 = directory.createSubDirectory("lists");
-				const subdir2 = someParentDir2.createSubDirectory("ListLevels-0");
-				subdir2.set("random1", 4);
+				const subDir2 = someParentDir2.createSubDirectory("ListLevels-0");
+				subDir2.set("random1", 4);
 
 				// Let everything get stamped and round-trip back to us
 				containerRuntimeFactory.processAllMessages();
@@ -717,8 +712,8 @@ describe("Directory", () => {
 				const testSubDir2 = directory2
 					.getSubDirectory("lists")
 					?.getSubDirectory("ListLevels-0");
-				assert(testSubDir1 !== undefined, "second level subdir should exists in dir1");
-				assert(testSubDir2 !== undefined, "second level subdir should exists in dir2");
+				assert(testSubDir1 !== undefined, "second level subDir should exists in dir1");
+				assert(testSubDir2 !== undefined, "second level subDir should exists in dir2");
 				assert(testSubDir1.get("random1") === 4, "value should be correct in dir1");
 				assert(testSubDir2.get("random1") === 4, "value should be correct in dir2");
 				assert(
@@ -743,7 +738,7 @@ describe("Directory", () => {
 				const services2 = MockSharedObjectServices.createFromSummary(
 					directory.getAttachSummary().summary,
 				);
-				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+				services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 				const directory2 = new SharedDirectory(
 					"directory2",
@@ -809,7 +804,7 @@ describe("Directory", () => {
 				const services2 = MockSharedObjectServices.createFromSummary(
 					directory.getAttachSummary().summary,
 				);
-				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+				services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 				const directory2 = new SharedDirectory(
 					"directory2",
@@ -820,10 +815,9 @@ describe("Directory", () => {
 
 				// Now connect the first SharedDirectory
 				dataStoreRuntime.local = false;
-				const containerRuntime1 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime.createDeltaConnection(),
 					objectStorage: new MockStorage(undefined),
 				};
 				directory.connect(services1);
@@ -841,7 +835,7 @@ describe("Directory", () => {
 				);
 
 				// Set a new value for the same key in the second SharedDirectory.
-				const newValue = "newvalue";
+				const newValue = "newValue";
 				directory2.set(key, newValue);
 
 				// Process the message.
@@ -860,7 +854,7 @@ describe("Directory", () => {
 				);
 			});
 
-			it("should correctly process subdirectory operations sent in local state", async () => {
+			it("should correctly process subDirectory operations sent in local state", async () => {
 				// Set the data store runtime to local.
 				dataStoreRuntime.local = true;
 
@@ -876,7 +870,7 @@ describe("Directory", () => {
 				const services2 = MockSharedObjectServices.createFromSummary(
 					directory.getAttachSummary().summary,
 				);
-				services2.deltaConnection = containerRuntime2.createDeltaConnection();
+				services2.deltaConnection = dataStoreRuntime2.createDeltaConnection();
 
 				const directory2 = new SharedDirectory(
 					"directory2",
@@ -887,10 +881,9 @@ describe("Directory", () => {
 
 				// Now connect the first SharedDirectory
 				dataStoreRuntime.local = false;
-				const containerRuntime1 =
-					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime.createDeltaConnection(),
 					objectStorage: new MockStorage(undefined),
 				};
 				directory.connect(services1);
@@ -910,7 +903,7 @@ describe("Directory", () => {
 
 				assertEquivalentDirectories(directory, directory2);
 
-				// Delete the subdirectory in the second SharedDirectory.
+				// Delete the subDirectory in the second SharedDirectory.
 				directory2.deleteSubDirectory(subDirName);
 
 				// Process the message.
@@ -1292,7 +1285,7 @@ describe("Directory", () => {
 		});
 
 		describe("SubDirectory", () => {
-			it("Can iterate over the subdirectories in the root", () => {
+			it("Can iterate over the subDirectories in the root", () => {
 				directory1.createSubDirectory("foo");
 				directory1.createSubDirectory("bar");
 
@@ -1313,7 +1306,7 @@ describe("Directory", () => {
 				assert.ok(expectedDirectories.size === 0);
 			});
 
-			it("Can get a subdirectory", () => {
+			it("Can get a subDirectory", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				fooDirectory.set("testKey", "testValue");
@@ -1350,7 +1343,7 @@ describe("Directory", () => {
 				assert.equal(barDirectory2.absolutePath, "/foo/bar");
 			});
 
-			it("Can get and set keys from a subdirectory using relative paths", () => {
+			it("Can get and set keys from a subDirectory using relative paths", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				fooDirectory.set("testKey", "testValue");
@@ -1360,13 +1353,13 @@ describe("Directory", () => {
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				const testSubdir = directory1.getWorkingDirectory("/foo");
-				assert(testSubdir);
-				assert.equal(testSubdir.has("testKey"), true);
-				assert.equal(testSubdir.has("garbage"), false);
-				assert.equal(testSubdir.get("testKey"), "testValue");
-				assert.equal(testSubdir.get("testKey2"), "testValue2");
-				assert.equal(testSubdir.get("testKey3"), undefined);
+				const testSubDir = directory1.getWorkingDirectory("/foo");
+				assert(testSubDir);
+				assert.equal(testSubDir.has("testKey"), true);
+				assert.equal(testSubDir.has("garbage"), false);
+				assert.equal(testSubDir.get("testKey"), "testValue");
+				assert.equal(testSubDir.get("testKey2"), "testValue2");
+				assert.equal(testSubDir.get("testKey3"), undefined);
 
 				// Verify the remote SharedDirectory
 				const barSubDir = directory2.getWorkingDirectory("/foo");
@@ -1378,24 +1371,24 @@ describe("Directory", () => {
 				assert.equal(barSubDir.get("testKey3"), undefined);
 
 				// Set value in sub directory1.
-				testSubdir.set("fromSubdir", "testValue4");
+				testSubDir.set("fromSubDir", "testValue4");
 
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local sub directory1
 				assert.equal(
-					directory1.getWorkingDirectory("foo")?.get("fromSubdir"),
+					directory1.getWorkingDirectory("foo")?.get("fromSubDir"),
 					"testValue4",
 				);
 
 				// Verify the remote sub directory1
 				assert.equal(
-					directory2.getWorkingDirectory("foo")?.get("fromSubdir"),
+					directory2.getWorkingDirectory("foo")?.get("fromSubDir"),
 					"testValue4",
 				);
 			});
 
-			it("raises the containedValueChanged event when keys are set and deleted from a subdirectory", () => {
+			it("raises the containedValueChanged event when keys are set and deleted from a subDirectory", () => {
 				directory1.createSubDirectory("foo");
 				directory1.createSubDirectory("bar");
 				containerRuntimeFactory.processAllMessages();
@@ -1424,22 +1417,22 @@ describe("Directory", () => {
 				assert.strictEqual(
 					called1,
 					1,
-					"containedValueChanged on local foo subdirectory after set()",
+					"containedValueChanged on local foo subDirectory after set()",
 				);
 				assert.strictEqual(
 					called2,
 					1,
-					"containedValueChanged on remote foo subdirectory after set()",
+					"containedValueChanged on remote foo subDirectory after set()",
 				);
 				assert.strictEqual(
 					called3,
 					0,
-					"containedValueChanged on local bar subdirectory after set()",
+					"containedValueChanged on local bar subDirectory after set()",
 				);
 				assert.strictEqual(
 					called4,
 					0,
-					"containedValueChanged on remote bar subdirectory after set()",
+					"containedValueChanged on remote bar subDirectory after set()",
 				);
 
 				foo1.delete("testKey");
@@ -1448,26 +1441,26 @@ describe("Directory", () => {
 				assert.strictEqual(
 					called1,
 					2,
-					"containedValueChanged on local subdirectory after delete()",
+					"containedValueChanged on local subDirectory after delete()",
 				);
 				assert.strictEqual(
 					called2,
 					2,
-					"containedValueChanged on remote subdirectory after delete()",
+					"containedValueChanged on remote subDirectory after delete()",
 				);
 				assert.strictEqual(
 					called3,
 					0,
-					"containedValueChanged on local bar subdirectory after delete()",
+					"containedValueChanged on local bar subDirectory after delete()",
 				);
 				assert.strictEqual(
 					called4,
 					0,
-					"containedValueChanged on remote bar subdirectory after delete()",
+					"containedValueChanged on remote bar subDirectory after delete()",
 				);
 			});
 
-			it("Can be cleared from the subdirectory", () => {
+			it("Can be cleared from the subDirectory", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				fooDirectory.set("testKey", "testValue");
@@ -1475,9 +1468,9 @@ describe("Directory", () => {
 				barDirectory.set("testKey3", "testValue3");
 				directory1.set("testKey", "testValue4");
 				directory1.set("testKey2", "testValue5");
-				const testSubdir = directory1.getWorkingDirectory("/foo");
-				assert(testSubdir);
-				testSubdir.clear();
+				const testSubDir = directory1.getWorkingDirectory("/foo");
+				assert(testSubDir);
+				testSubDir.clear();
 
 				containerRuntimeFactory.processAllMessages();
 
@@ -1500,7 +1493,7 @@ describe("Directory", () => {
 				assert.equal(directory2.getWorkingDirectory(".")?.get("testKey2"), "testValue5");
 			});
 
-			it("Can delete keys from the subdirectory", () => {
+			it("Can delete keys from the subDirectory", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				fooDirectory.set("testKey", "testValue");
@@ -1508,12 +1501,12 @@ describe("Directory", () => {
 				barDirectory.set("testKey3", "testValue3");
 				directory1.set("testKey", "testValue4");
 				directory1.set("testKey2", "testValue5");
-				const testSubdirFoo = directory1.getWorkingDirectory("/foo");
-				assert(testSubdirFoo);
-				testSubdirFoo.delete("testKey2");
-				const testSubdirBar = directory1.getWorkingDirectory("/bar");
-				assert(testSubdirBar);
-				testSubdirBar.delete("testKey3");
+				const testSubDirFoo = directory1.getWorkingDirectory("/foo");
+				assert(testSubDirFoo);
+				testSubDirFoo.delete("testKey2");
+				const testSubDirBar = directory1.getWorkingDirectory("/bar");
+				assert(testSubDirBar);
+				testSubDirBar.delete("testKey3");
 
 				containerRuntimeFactory.processAllMessages();
 
@@ -1540,7 +1533,7 @@ describe("Directory", () => {
 				assert.equal(directory2.get("testKey2"), "testValue5");
 			});
 
-			it("Knows the size of the subdirectory", () => {
+			it("Knows the size of the subDirectory", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				fooDirectory.set("testKey", "testValue");
@@ -1552,61 +1545,61 @@ describe("Directory", () => {
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				const testSubdirFoo = directory1.getWorkingDirectory("/foo");
-				assert(testSubdirFoo);
-				assert.equal(testSubdirFoo.size, 2);
+				const testSubDirFoo = directory1.getWorkingDirectory("/foo");
+				assert(testSubDirFoo);
+				assert.equal(testSubDirFoo.size, 2);
 				// Verify the remote SharedDirectory
-				const testSubdirFoo2 = directory2.getWorkingDirectory("/foo");
-				assert(testSubdirFoo2);
-				assert.equal(testSubdirFoo2.size, 2);
+				const testSubDirFoo2 = directory2.getWorkingDirectory("/foo");
+				assert(testSubDirFoo2);
+				assert.equal(testSubDirFoo2.size, 2);
 
-				testSubdirFoo.delete("testKey2");
+				testSubDirFoo.delete("testKey2");
 
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				assert.equal(testSubdirFoo.size, 1);
+				assert.equal(testSubDirFoo.size, 1);
 				// Verify the remote SharedDirectory
-				assert.equal(testSubdirFoo2.size, 1);
+				assert.equal(testSubDirFoo2.size, 1);
 
 				directory1.delete("testKey");
 
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				assert.equal(testSubdirFoo.size, 1);
+				assert.equal(testSubDirFoo.size, 1);
 				// Verify the remote SharedDirectory
-				assert.equal(testSubdirFoo2.size, 1);
+				assert.equal(testSubDirFoo2.size, 1);
 
-				const testSubdirBar = directory1.getWorkingDirectory("/bar");
-				assert(testSubdirBar);
-				testSubdirBar.delete("testKey3");
+				const testSubDirBar = directory1.getWorkingDirectory("/bar");
+				assert(testSubDirBar);
+				testSubDirBar.delete("testKey3");
 
 				// Verify the local SharedDirectory
-				assert.equal(testSubdirFoo.size, 1);
+				assert.equal(testSubDirFoo.size, 1);
 				// Verify the remote SharedDirectory
-				assert.equal(testSubdirFoo2.size, 1);
+				assert.equal(testSubDirFoo2.size, 1);
 
 				directory1.clear();
 
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				assert.equal(testSubdirFoo.size, 1);
+				assert.equal(testSubDirFoo.size, 1);
 				// Verify the remote SharedDirectory
-				assert.equal(testSubdirFoo2.size, 1);
+				assert.equal(testSubDirFoo2.size, 1);
 
-				testSubdirFoo.clear();
+				testSubDirFoo.clear();
 
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				assert.equal(testSubdirFoo.size, 0);
+				assert.equal(testSubDirFoo.size, 0);
 				// Verify the remote SharedDirectory
-				assert.equal(testSubdirFoo2.size, 0);
+				assert.equal(testSubDirFoo2.size, 0);
 			});
 
-			it("Can get a subdirectory from a subdirectory", () => {
+			it("Can get a subDirectory from a subDirectory", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				const bazDirectory = barDirectory.createSubDirectory("baz");
@@ -1618,21 +1611,21 @@ describe("Directory", () => {
 				containerRuntimeFactory.processAllMessages();
 
 				// Verify the local SharedDirectory
-				const barSubdir = directory1.getWorkingDirectory("/bar");
-				assert.ok(barSubdir);
-				const bazSubDir = barSubdir.getWorkingDirectory("./baz");
+				const barSubDir = directory1.getWorkingDirectory("/bar");
+				assert.ok(barSubDir);
+				const bazSubDir = barSubDir.getWorkingDirectory("./baz");
 				assert.ok(bazSubDir);
 				assert.equal(bazSubDir.get("testKey4"), "testValue4");
 
 				// Verify the remote SharedDirectory
-				const barSubdir2 = directory2.getWorkingDirectory("/bar");
-				assert.ok(barSubdir2);
-				const bazSubDir2 = barSubdir2.getWorkingDirectory("./baz");
+				const barSubDir2 = directory2.getWorkingDirectory("/bar");
+				assert.ok(barSubDir2);
+				const bazSubDir2 = barSubDir2.getWorkingDirectory("./baz");
 				assert.ok(bazSubDir2);
 				assert.equal(bazSubDir2.get("testKey4"), "testValue4");
 			});
 
-			it("Can delete a child subdirectory", () => {
+			it("Can delete a child subDirectory", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				const bazDirectory = barDirectory.createSubDirectory("baz");
@@ -1653,7 +1646,7 @@ describe("Directory", () => {
 				assert.equal(barDirectory2.getWorkingDirectory("baz"), undefined);
 			});
 
-			it("Can delete a child subdirectory with children", () => {
+			it("Can delete a child subDirectory with children", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				const barDirectory = directory1.createSubDirectory("bar");
 				const bazDirectory = barDirectory.createSubDirectory("baz");
@@ -1856,7 +1849,7 @@ describe("Directory", () => {
 				assert.ok(expectedEntries2.size === 0);
 			});
 
-			it("Can iterate over its subdirectories", () => {
+			it("Can iterate over its subDirectories", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				fooDirectory.createSubDirectory("bar");
 				fooDirectory.createSubDirectory("baz");
@@ -1882,7 +1875,7 @@ describe("Directory", () => {
 				assert.ok(expectedDirectories2.size === 0);
 			});
 
-			it("Only creates a subdirectory once", () => {
+			it("Only creates a subDirectory once", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				fooDirectory.set("testKey", "testValue");
 				const fooDirectory2 = directory1.createSubDirectory("foo");
@@ -1890,7 +1883,7 @@ describe("Directory", () => {
 				assert.strictEqual(
 					fooDirectory,
 					fooDirectory2,
-					"Created two separate subdirectories",
+					"Created two separate subDirectories",
 				);
 				assert.strictEqual(
 					fooDirectory.get("testKey2"),
@@ -1971,7 +1964,6 @@ describe("Directory", () => {
 
 				const subMapId = `subMap-${this.subMapCount}`;
 
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				const deletedHandle = fooDirectory.get(subMapId);
 				assert(deletedHandle, "Route must be added before deleting");
 
@@ -2010,5 +2002,3 @@ describe("Directory", () => {
 		runGCTests(GCSharedDirectoryProvider);
 	});
 });
-
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -396,7 +396,7 @@ describe("Directory", () => {
 				}, "Should throw for key of null");
 			});
 
-			it("Rejects subDirectories with undefined and null names", () => {
+			it("Rejects subdirectories with undefined and null names", () => {
 				assert.throws(() => {
 					directory.createSubDirectory(undefined as unknown as string);
 				}, "Should throw for undefined subDirectory name");
@@ -412,7 +412,7 @@ describe("Directory", () => {
 				assert.equal(serialized, '{"ci":{"csn":0,"ccIds":[]}}');
 			});
 
-			it("Should serialize a directory without subDirectories as a JSON object", () => {
+			it("Should serialize a directory without subdirectories as a JSON object", () => {
 				directory.set("first", "second");
 				directory.set("third", "fourth");
 				directory.set("fifth", "sixth");
@@ -426,7 +426,7 @@ describe("Directory", () => {
 				assert.equal(serialized, expected);
 			});
 
-			it("Should serialize a directory with subDirectories as a JSON object", () => {
+			it("Should serialize a directory with subdirectories as a JSON object", () => {
 				directory.set("first", "second");
 				directory.set("third", "fourth");
 				directory.set("fifth", "sixth");
@@ -441,7 +441,7 @@ describe("Directory", () => {
 
 				const subMapHandleUrl = subMap.handle.absolutePath;
 				const serialized = serialize(directory);
-				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subDirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subDirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subDirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subdirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subdirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
 				assert.equal(serialized, expected);
 			});
 
@@ -463,7 +463,7 @@ describe("Directory", () => {
 
 				const subMapHandleUrl = subMap.handle.absolutePath;
 				const serialized = serialize(directory);
-				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subDirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subDirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subDirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+				const expected = `{"ci":{"csn":0,"ccIds":[]},"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subdirectories":{"nested":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"subdirectories":{"nested3":{"ci":{"csn":0,"ccIds":["${dataStoreRuntime.clientId}"]},"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
 				assert.equal(serialized, expected);
 			});
 		});
@@ -492,7 +492,7 @@ describe("Directory", () => {
 							value: "testValue5",
 						},
 					},
-					subDirectories: {
+					subdirectories: {
 						foo: {
 							storage: {
 								testKey: {
@@ -542,7 +542,7 @@ describe("Directory", () => {
 							type: "Plain",
 						},
 					},
-					subDirectories: {
+					subdirectories: {
 						foo: {
 							storage: {
 								testKey: {
@@ -1285,7 +1285,7 @@ describe("Directory", () => {
 		});
 
 		describe("SubDirectory", () => {
-			it("Can iterate over the subDirectories in the root", () => {
+			it("Can iterate over the subdirectories in the root", () => {
 				directory1.createSubDirectory("foo");
 				directory1.createSubDirectory("bar");
 
@@ -1849,7 +1849,7 @@ describe("Directory", () => {
 				assert.ok(expectedEntries2.size === 0);
 			});
 
-			it("Can iterate over its subDirectories", () => {
+			it("Can iterate over its subdirectories", () => {
 				const fooDirectory = directory1.createSubDirectory("foo");
 				fooDirectory.createSubDirectory("bar");
 				fooDirectory.createSubDirectory("baz");
@@ -1883,7 +1883,7 @@ describe("Directory", () => {
 				assert.strictEqual(
 					fooDirectory,
 					fooDirectory2,
-					"Created two separate subDirectories",
+					"Created two separate subdirectories",
 				);
 				assert.strictEqual(
 					fooDirectory.get("testKey2"),

--- a/packages/dds/map/src/test/mocha/rebasing.spec.ts
+++ b/packages/dds/map/src/test/mocha/rebasing.spec.ts
@@ -45,7 +45,7 @@ describe("Rebasing", () => {
 				containerRuntime1 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				map1 = new SharedMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
@@ -55,7 +55,7 @@ describe("Rebasing", () => {
 				containerRuntime2 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 				const services2 = {
-					deltaConnection: containerRuntime2.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				map2 = new SharedMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);
@@ -107,7 +107,7 @@ describe("Rebasing", () => {
 				containerRuntime1 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 				const services1 = {
-					deltaConnection: containerRuntime1.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				dir1 = new SharedDirectory(
@@ -122,7 +122,7 @@ describe("Rebasing", () => {
 				containerRuntime2 =
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 				const services2 = {
-					deltaConnection: containerRuntime2.createDeltaConnection(),
+					deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
 				dir2 = new SharedDirectory(

--- a/packages/dds/map/src/test/mocha/reconnection.spec.ts
+++ b/packages/dds/map/src/test/mocha/reconnection.spec.ts
@@ -29,7 +29,7 @@ describe("Reconnection", () => {
 			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			map1 = new SharedMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
@@ -39,7 +39,7 @@ describe("Reconnection", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			map2 = new SharedMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);
@@ -131,7 +131,7 @@ describe("Reconnection", () => {
 			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			directory1 = new SharedDirectory(
@@ -145,7 +145,7 @@ describe("Reconnection", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			directory2 = new SharedDirectory(
@@ -283,14 +283,14 @@ describe("Reconnection", () => {
 			directory2.deleteSubDirectory(subDirName);
 			directory2.createSubDirectory(subDirName);
 			containerRuntimeFactory.processAllMessages();
-			// Now client1 rconnects causing it to delete the /subdir, so that the create /subdir/subdir will not be submitted
+			// Now client1 reconnects causing it to delete the /subDir, so that the create /subDir/subDir will not be submitted
 			containerRuntime1.connected = true;
 
 			containerRuntimeFactory.processAllMessages();
-			assert(directory1.getSubDirectory(subDirName) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName)?.getSubDirectory(subDirName) === undefined,
-				"/subdir/subdir should not exist",
+				"/subDir/subDir should not exist",
 			);
 			assertEquivalentDirectories(directory1, directory2);
 		});
@@ -310,19 +310,19 @@ describe("Reconnection", () => {
 			directory2.deleteSubDirectory(subDirName);
 			directory2.createSubDirectory(subDirName);
 			containerRuntimeFactory.processAllMessages();
-			// Now client1 rconnects causing it to delete the /subdir, so that the set /subdir/testSubDirKey will not be submitted.
+			// Now client1 reconnects causing it to delete the /subDir, so that the set /subDir/testSubDirKey will not be submitted.
 			containerRuntime1.connected = true;
 
 			containerRuntimeFactory.processAllMessages();
-			assert(directory1.getSubDirectory(subDirName) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName)?.get(subDirKey) === undefined,
-				"/subdir(testSubDirKey) should not exist",
+				"/subDir(testSubDirKey) should not exist",
 			);
 			assertEquivalentDirectories(directory1, directory2);
 		});
 
-		it("does not delete pending create subdirs on reconnection", async () => {
+		it("does not delete pending create subDirs on reconnection", async () => {
 			const subDirName1 = "subDir";
 			const subDirName2 = "subDir2";
 
@@ -338,59 +338,59 @@ describe("Reconnection", () => {
 			containerRuntimeFactory.processAllMessages();
 			containerRuntime1.connected = true;
 
-			// When op for deleting /subdir comes, it will not delete subdirectories who are created locally and
+			// When op for deleting /subDir comes, it will not delete subdirectories who are created locally and
 			// ack is pending as they will recreated again. Both directories will contain /subDir/subDir but
 			// no /subDir/subDir2.
 			containerRuntimeFactory.processAllMessages();
-			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName1)?.getSubDirectory(subDirName1) !== undefined,
-				"/subdir/subdir should exist",
+				"/subDir/subDir should exist",
 			);
 			assert(
 				directory1.getSubDirectory(subDirName1)?.getSubDirectory(subDirName2) === undefined,
-				"/subdir/subdir2 should not exist",
+				"/subDir/subDir2 should not exist",
 			);
 
 			assertEquivalentDirectories(directory1, directory2);
 		});
 
-		it("does not delete pending keys within pending subdirs on reconnection", async () => {
+		it("does not delete pending keys within pending subDirs on reconnection", async () => {
 			const subDirName = "subDir";
 			const subDirKey = "testSubDirKey";
 			const subDirValue = "testSubDirValue";
 
 			containerRuntime1.connected = false;
 			const subDir = directory1.createSubDirectory(subDirName);
-			const subdir2 = subDir.createSubDirectory(subDirName);
-			subdir2.set(subDirKey, subDirValue);
+			const subDir2 = subDir.createSubDirectory(subDirName);
+			subDir2.set(subDirKey, subDirValue);
 
 			directory2.createSubDirectory(subDirName);
 			directory2.deleteSubDirectory(subDirName);
 			containerRuntimeFactory.processAllMessages();
 			containerRuntime1.connected = true;
 
-			// When op for deleting /subdir comes, it will not delete subdirectories who are created locally and
+			// When op for deleting /subDir comes, it will not delete subdirectories who are created locally and
 			// ack is pending as they will recreated again. Both directories will contain /subDir/subDir but
-			// no /subDir/subDir2. It will also not delete pending keys in pending subdirs.
+			// no /subDir/subDir2. It will also not delete pending keys in pending subDirs.
 			containerRuntimeFactory.processAllMessages();
 
-			assert(directory1.getSubDirectory(subDirName) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName)?.getSubDirectory(subDirName) !== undefined,
-				"/subdir/subdir should exist",
+				"/subDir/subDir should exist",
 			);
 			assert(
 				directory1
 					.getSubDirectory(subDirName)
 					?.getSubDirectory(subDirName)
 					?.get(subDirKey) === subDirValue,
-				"/subdir/subdir(subdirkey) should exist",
+				"/subDir/subDir(subDirKey) should exist",
 			);
 			assertEquivalentDirectories(directory1, directory2);
 		});
 
-		it("multiple create/delete subdirs on disconnection/reconnection 1", async () => {
+		it("multiple create/delete subDirs on disconnection/reconnection 1", async () => {
 			const subDirName1 = "subDir";
 
 			const subDir = directory1.createSubDirectory(subDirName1);
@@ -407,17 +407,17 @@ describe("Reconnection", () => {
 			containerRuntimeFactory.processAllMessages();
 			containerRuntime1.connected = true;
 
-			// /subdir/subdir should exist in the end
+			// /subDir/subDir should exist in the end
 			containerRuntimeFactory.processAllMessages();
-			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName1)?.getSubDirectory(subDirName1) !== undefined,
-				"/subdir/subdir should exist",
+				"/subDir/subDir should exist",
 			);
 			assertEquivalentDirectories(directory1, directory2);
 		});
 
-		it("multiple create/delete subdirs on disconnection/reconnection 2", async () => {
+		it("multiple create/delete subDirs on disconnection/reconnection 2", async () => {
 			const subDirName1 = "subDir";
 
 			containerRuntime1.connected = false;
@@ -432,17 +432,17 @@ describe("Reconnection", () => {
 			containerRuntimeFactory.processAllMessages();
 			containerRuntime1.connected = true;
 
-			// /subdir/subdir should not exist in the end as /subDir was deleted after it was created
+			// /subDir/subDir should not exist in the end as /subDir was deleted after it was created
 			containerRuntimeFactory.processAllMessages();
-			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName1)?.getSubDirectory(subDirName1) === undefined,
-				"/subdir/subdir should not exist",
+				"/subDir/subDir should not exist",
 			);
 			assertEquivalentDirectories(directory1, directory2);
 		});
 
-		it("multiple create/delete subdirs on disconnection/reconnection 3", async () => {
+		it("multiple create/delete subDirs on disconnection/reconnection 3", async () => {
 			const subDirName1 = "subDir";
 
 			containerRuntime1.connected = false;
@@ -455,12 +455,12 @@ describe("Reconnection", () => {
 			containerRuntimeFactory.processAllMessages();
 			containerRuntime1.connected = true;
 
-			// /subdir/subdir should not exist in the end as /subDir was deleted after it was created
+			// /subDir/subDir should not exist in the end as /subDir was deleted after it was created
 			containerRuntimeFactory.processAllMessages();
-			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subdir should exist");
+			assert(directory1.getSubDirectory(subDirName1) !== undefined, "/subDir should exist");
 			assert(
 				directory1.getSubDirectory(subDirName1)?.getSubDirectory(subDirName1) === undefined,
-				"/subdir/subdir should not exist",
+				"/subDir/subDir should not exist",
 			);
 			assertEquivalentDirectories(directory1, directory2);
 		});

--- a/packages/dds/matrix/src/test/matrix.big.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.big.spec.ts
@@ -63,7 +63,7 @@ describe("Big Matrix", function () {
 			const containerRuntime1 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1: IChannelServices = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			matrix1 = new SharedMatrix(
@@ -78,7 +78,7 @@ describe("Big Matrix", function () {
 			const containerRuntime2 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2: IChannelServices = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			matrix2 = new SharedMatrix(

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -681,7 +681,7 @@ describe("Matrix", () => {
 			//           length = 3
 			//           end    = -1 + 3 = 2
 			//
-			//       In which case, pass the empty segment into 'findReconnectionPostilion()'.
+			//       In which case, pass the empty segment into 'findReconnectionPosition()'.
 
 			matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 3);
 

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -43,7 +43,7 @@ function createMatrixForReconnection(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -69,7 +69,7 @@ describe("Matrix", () => {
 			const dataStoreRuntime = new MockFluidDataStoreRuntime();
 			dataStoreRuntime.local = true;
 
-			// Load the summmary into a newly created 2nd SharedMatrix.
+			// Load the summary into a newly created 2nd SharedMatrix.
 			const matrix2 = new SharedMatrix<T>(
 				dataStoreRuntime,
 				`load(${matrix.id})`,
@@ -276,7 +276,7 @@ describe("Matrix", () => {
 				matrix.insertRows(0, 2);
 				matrix.setCells(0, 0, 2, [0, 1, 2, 3]);
 
-				// The 'matrix' returned by 'expect' is the result of summarizeting and loading 'matrix'.
+				// The 'matrix' returned by 'expect' is the result of summarizing and loading 'matrix'.
 				const matrix2 = await expect([
 					[0, 1],
 					[2, 3],
@@ -681,7 +681,7 @@ describe("Matrix", () => {
 			//           length = 3
 			//           end    = -1 + 3 = 2
 			//
-			//       In which case, pass the empty segment into 'findReconnectionPostition()'.
+			//       In which case, pass the empty segment into 'findReconnectionPostilion()'.
 
 			matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 3);
 
@@ -710,7 +710,7 @@ describe("Matrix", () => {
 			//           length = 3
 			//           end    = -1 + 3 = 2
 			//
-			//       In which case, pass the empty segment into 'findReconnectionPostition()'.
+			//       In which case, pass the empty segment into 'findReconnectionPostilion()'.
 
 			matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 3);
 

--- a/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -20,9 +20,9 @@ import { acquireAndComplete, waitAcquireAndComplete } from "../testUtils";
 
 function createConnectedCollection(id: string, runtimeFactory: MockContainerRuntimeFactory) {
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services: IChannelServices = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -44,7 +44,7 @@ function createCollectionForReconnection(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services: IChannelServices = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 

--- a/packages/dds/pact-map/src/test/pactMap.spec.ts
+++ b/packages/dds/pact-map/src/test/pactMap.spec.ts
@@ -18,9 +18,9 @@ import { IPactMap } from "../interfaces";
 function createConnectedPactMap(id: string, runtimeFactory: MockContainerRuntimeFactory): PactMap {
 	// Create and connect a PactMap.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -248,8 +248,7 @@ describe("PactMap", () => {
 		it("Can set and delete values before attaching and functions normally after attaching", async () => {
 			// Create a detached PactMap.
 			const dataStoreRuntime = new MockFluidDataStoreRuntime();
-			const containerRuntime =
-				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 
 			const pactMap = new PactMap("pactMap", dataStoreRuntime, PactMapFactory.Attributes);
 			assert.strict(!pactMap.isAttached(), "PactMap is attached earlier than expected");
@@ -283,7 +282,7 @@ describe("PactMap", () => {
 
 			// Attach the PactMap
 			const services = {
-				deltaConnection: containerRuntime.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			pactMap.connect(services);
@@ -324,7 +323,7 @@ describe("PactMap", () => {
 			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			pactMap1 = new PactMap("pact-map-1", dataStoreRuntime1, PactMapFactory.Attributes);
@@ -334,7 +333,7 @@ describe("PactMap", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			pactMap2 = new PactMap("pact-map-2", dataStoreRuntime2, PactMapFactory.Attributes);

--- a/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -21,9 +21,9 @@ import { IConsensusRegisterCollection } from "../interfaces";
 
 function createConnectedCollection(id: string, runtimeFactory: MockContainerRuntimeFactory) {
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -45,7 +45,7 @@ function createCollectionForReconnection(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -240,7 +240,7 @@ describe("ConsensusRegisterCollection", () => {
 			beforeEach(() => {
 				containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 				const response1 = createCollectionForReconnection(
-					"colllection1",
+					"collection1",
 					containerRuntimeFactory,
 				);
 				testCollection1 = response1.collection;
@@ -310,7 +310,7 @@ describe("ConsensusRegisterCollection", () => {
 				const winner = await writeP;
 				assert.equal(winner, true, "Write was not successful");
 
-				// Verify that the remote register collection recieved the write.
+				// Verify that the remote register collection received the write.
 				assert.equal(receivedKey, testKey, "The remote client did not receive the key");
 				assert.equal(
 					receivedValue,
@@ -333,7 +333,7 @@ describe("ConsensusRegisterCollection", () => {
 	});
 
 	describe("Garbage Collection", () => {
-		class GCRegistedCollectionProvider implements IGCTestProvider {
+		class GCRegisteredCollectionProvider implements IGCTestProvider {
 			private subCollectionCount = 0;
 			private _expectedRoutes: string[] = [];
 			private readonly collection1: IConsensusRegisterCollection;
@@ -406,6 +406,6 @@ describe("ConsensusRegisterCollection", () => {
 			}
 		}
 
-		runGCTests(GCRegistedCollectionProvider);
+		runGCTests(GCRegisteredCollectionProvider);
 	});
 });

--- a/packages/dds/sequence/src/test/intervalCollection.events.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.events.spec.ts
@@ -43,7 +43,7 @@ describe("SharedString interval collection event spec", () => {
 		dataStoreRuntime1.local = false;
 		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 		const services1 = {
-			deltaConnection: containerRuntime1.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 		sharedString.initializeLocal();
@@ -53,7 +53,7 @@ describe("SharedString interval collection event spec", () => {
 		const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 		const services2 = {
-			deltaConnection: containerRuntime2.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 

--- a/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
@@ -25,7 +25,7 @@ async function loadSharedString(
 	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 	dataStoreRuntime.deltaManager.lastSequenceNumber = containerRuntimeFactory.sequenceNumber;
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: MockStorage.createFromSummary(summary),
 	};
 	const sharedString = new SharedString(dataStoreRuntime, id, SharedStringFactory.Attributes);
@@ -39,9 +39,9 @@ async function getSingleIntervalSummary(): Promise<{ summary: ISummaryTree; seq:
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	dataStoreRuntime.local = false;
 	dataStoreRuntime.options = { intervalStickinessEnabled: true };
-	const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime1.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 	const sharedString = new SharedString(dataStoreRuntime, "", SharedStringFactory.Attributes);

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -133,7 +133,7 @@ describe("SharedString interval collections", () => {
 			const containerRuntime1 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString.initializeLocal();
@@ -145,7 +145,7 @@ describe("SharedString interval collections", () => {
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			dataStoreRuntime2.options = { intervalStickinessEnabled: true };
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 
@@ -1034,7 +1034,7 @@ describe("SharedString interval collections", () => {
 			const containerRuntime1 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1: IChannelServices = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString.initializeLocal();
@@ -1049,7 +1049,7 @@ describe("SharedString interval collections", () => {
 				SharedStringFactory.Attributes,
 			);
 			const services2: IChannelServices = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: runtime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString2.initializeLocal();
@@ -1440,7 +1440,7 @@ describe("SharedString interval collections", () => {
 			// Connect the first SharedString.
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1: IChannelServices = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString.initializeLocal();
@@ -1455,7 +1455,7 @@ describe("SharedString interval collections", () => {
 				SharedStringFactory.Attributes,
 			);
 			const services2: IChannelServices = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: runtime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString2.initializeLocal();

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -27,7 +27,7 @@ function constructClients(
 		);
 		const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 		const services: IChannelServices = {
-			deltaConnection: containerRuntime.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 

--- a/packages/dds/sequence/src/test/partialLoad.spec.ts
+++ b/packages/dds/sequence/src/test/partialLoad.spec.ts
@@ -52,7 +52,7 @@ function generateSummaryTree(
 	// Connect the first SharedString.
 	const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 	const services1: IChannelServices = {
-		deltaConnection: containerRuntime1.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 	const sharedString = new SharedString(
@@ -73,7 +73,7 @@ function generateSummaryTree(
 		SharedStringFactory.Attributes,
 	);
 	const services2: IChannelServices = {
-		deltaConnection: containerRuntime2.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 	sharedString2.initializeLocal();
@@ -100,10 +100,9 @@ describe("SharedString Partial Load", () => {
 
 		const localDataStoreRuntime = new MockFluidDataStoreRuntime();
 		localDataStoreRuntime.options = options;
-		const localContainerRuntime =
-			containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
 		const localServices = {
-			deltaConnection: localContainerRuntime.createDeltaConnection(),
+			deltaConnection: localDataStoreRuntime.createDeltaConnection(),
 			objectStorage: MockStorage.createFromSummary(summaryTree),
 		};
 		const localSharedString = new SharedString(
@@ -127,10 +126,9 @@ describe("SharedString Partial Load", () => {
 
 		const localDataStoreRuntime = new MockFluidDataStoreRuntime();
 		localDataStoreRuntime.options = options;
-		const localContainerRuntime =
-			containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
 		const localServices = {
-			deltaConnection: localContainerRuntime.createDeltaConnection(),
+			deltaConnection: localDataStoreRuntime.createDeltaConnection(),
 			objectStorage: MockStorage.createFromSummary(summaryTree),
 		};
 		const localSharedString = new SharedString(
@@ -158,10 +156,9 @@ describe("SharedString Partial Load", () => {
 
 		const localDataStoreRuntime = new MockFluidDataStoreRuntime();
 		localDataStoreRuntime.options = options;
-		const localContainerRuntime =
-			containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
 		const localServices = {
-			deltaConnection: localContainerRuntime.createDeltaConnection(),
+			deltaConnection: localDataStoreRuntime.createDeltaConnection(),
 			objectStorage: MockStorage.createFromSummary(summaryTree),
 		};
 		const localSharedString = new SharedString(
@@ -193,10 +190,9 @@ describe("SharedString Partial Load", () => {
 
 		const localDataStoreRuntime = new MockFluidDataStoreRuntime();
 		localDataStoreRuntime.options = options;
-		const localContainerRuntime =
-			containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
 		const localServices = {
-			deltaConnection: localContainerRuntime.createDeltaConnection(),
+			deltaConnection: localDataStoreRuntime.createDeltaConnection(),
 			objectStorage: MockStorage.createFromSummary(summaryTree),
 		};
 		const localSharedString = new SharedString(
@@ -243,10 +239,9 @@ describe("SharedString Partial Load", () => {
 
 		const localDataStoreRuntime = new MockFluidDataStoreRuntime();
 		localDataStoreRuntime.options = options;
-		const localContainerRuntime =
-			containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
 		const localServices = {
-			deltaConnection: localContainerRuntime.createDeltaConnection(),
+			deltaConnection: localDataStoreRuntime.createDeltaConnection(),
 			objectStorage: MockStorage.createFromSummary(summaryTree),
 		};
 		const localSharedString = new SharedString(
@@ -290,10 +285,9 @@ describe("SharedString Partial Load", () => {
 
 		const localDataStoreRuntime = new MockFluidDataStoreRuntime();
 		localDataStoreRuntime.options = options;
-		const localContainerRuntime =
-			containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
 		const localServices = {
-			deltaConnection: localContainerRuntime.createDeltaConnection(),
+			deltaConnection: localDataStoreRuntime.createDeltaConnection(),
 			objectStorage: MockStorage.createFromSummary(summaryTree),
 		};
 		const localSharedString = new SharedString(

--- a/packages/dds/sequence/src/test/rebasing.spec.ts
+++ b/packages/dds/sequence/src/test/rebasing.spec.ts
@@ -45,7 +45,7 @@ import { SharedStringFactory } from "../sequenceFactory";
 			dataStoreRuntime.local = false;
 			const containerRuntime = factory.createContainerRuntime(dataStoreRuntime);
 			const services = {
-				deltaConnection: containerRuntime.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			const sharedString = new SharedString(

--- a/packages/dds/sequence/src/test/reentrancy.spec.ts
+++ b/packages/dds/sequence/src/test/reentrancy.spec.ts
@@ -77,7 +77,7 @@ describe("SharedString op-reentrancy", () => {
 			const containerRuntime1 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString.connect(services1);
@@ -88,7 +88,7 @@ describe("SharedString op-reentrancy", () => {
 			const containerRuntime2 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -41,7 +41,7 @@ describe("Sequence.Revertibles with Local Edits", () => {
 
 		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 		const services1 = {
-			deltaConnection: containerRuntime1.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 		sharedString.initializeLocal();
@@ -307,7 +307,7 @@ describe("Sequence.Revertibles with Remote Edits", () => {
 		dataStoreRuntime1.local = false;
 		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 		const services1 = {
-			deltaConnection: containerRuntime1.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 		sharedString.initializeLocal();
@@ -317,7 +317,7 @@ describe("Sequence.Revertibles with Remote Edits", () => {
 		const dataStoreRuntime2 = new MockFluidDataStoreRuntime({ clientId: "2" });
 		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 		const services2 = {
-			deltaConnection: containerRuntime2.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 
@@ -650,7 +650,7 @@ describe("Undo/redo for string remove containing intervals", () => {
 		dataStoreRuntime1.local = false;
 		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 		const services1 = {
-			deltaConnection: containerRuntime1.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 		sharedString.initializeLocal();
@@ -668,7 +668,7 @@ describe("Undo/redo for string remove containing intervals", () => {
 			const containerRuntime2 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 

--- a/packages/dds/sequence/src/test/sharedIntervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/sharedIntervalCollection.spec.ts
@@ -70,7 +70,7 @@ function createConnectedIntervalCollection(
 	);
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(undefined),
 	};
 	intervals.connect(services);

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -47,7 +47,7 @@ describe("SharedString", () => {
 			dataStoreRuntime1.local = true;
 		});
 
-		// Creates a new SharedString and loads it from the passed snaphost tree.
+		// Creates a new SharedString and loads it from the passed snapshot tree.
 		async function CreateStringAndCompare(summaryTree: ISummaryTree): Promise<void> {
 			const services: IChannelServices = {
 				deltaConnection: new MockEmptyDeltaConnection(),
@@ -203,7 +203,7 @@ describe("SharedString", () => {
 			assert.equal(
 				simpleMarker?.properties?.markerSimpleType,
 				"markerKeyValue",
-				"markerSimpleType is incorrrect",
+				"markerSimpleType is incorrect",
 			);
 
 			// Insert a tile marker.
@@ -385,7 +385,7 @@ describe("SharedString", () => {
 			const containerRuntime2 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2: IChannelServices = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: MockStorage.createFromSummary(
 					sharedString.getAttachSummary().summary,
 				),
@@ -403,7 +403,7 @@ describe("SharedString", () => {
 			const containerRuntime1 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(undefined),
 			};
 			sharedString.connect(services1);
@@ -452,7 +452,7 @@ describe("SharedString", () => {
 			const containerRuntime1 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString.initializeLocal();
@@ -463,7 +463,7 @@ describe("SharedString", () => {
 			const containerRuntime2 =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 
@@ -563,7 +563,7 @@ describe("SharedString", () => {
 				);
 			}
 
-			// Annote the properties.
+			// Annotate the properties.
 			const colorProps = { color: "green" };
 			sharedString.annotateRange(6, text.length, colorProps);
 
@@ -596,12 +596,12 @@ describe("SharedString", () => {
 				assert.equal(
 					marker.properties.markerSimpleType,
 					simpleKey,
-					"markerSimpleType is incorrrect",
+					"markerSimpleType is incorrect",
 				);
 				assert.equal(
 					marker.properties.referenceTileLabels[0],
 					label,
-					"markerSimpleType is incorrrect",
+					"markerSimpleType is incorrect",
 				);
 			};
 
@@ -670,7 +670,7 @@ describe("SharedString", () => {
 			// Connect the first SharedString.
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1: IChannelServices = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString.initializeLocal();
@@ -685,7 +685,7 @@ describe("SharedString", () => {
 				SharedStringFactory.Attributes,
 			);
 			const services2: IChannelServices = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: runtime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			sharedString2.initializeLocal();

--- a/packages/dds/sequence/src/test/snapshotEmptyProps.spec.ts
+++ b/packages/dds/sequence/src/test/snapshotEmptyProps.spec.ts
@@ -27,7 +27,7 @@ describe("SharedString Snapshot Version - Empty Props", () => {
 		const dataStoreRuntime = new MockFluidDataStoreRuntime();
 		const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 		const services = {
-			deltaConnection: containerRuntime.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(JSON.parse(serializedSnapshot)),
 		};
 		const sharedString = new SharedString(dataStoreRuntime, id, SharedStringFactory.Attributes);

--- a/packages/dds/sequence/src/test/snapshotVersion.spec.ts
+++ b/packages/dds/sequence/src/test/snapshotVersion.spec.ts
@@ -64,14 +64,14 @@ function assertSharedStringsAreEquivalent(
 }
 
 describe("SharedString Snapshot Version", () => {
-	let filebase: string;
+	let fileBase: string;
 	const message =
 		"SharedString snapshot format has changed. " +
 		"Please update the snapshotFormatVersion if appropriate " +
 		"and then run npm test:newsnapfiles to create new snapshot test files.";
 
 	before(() => {
-		filebase = path.join(__dirname, `../../${LocationBase}`);
+		fileBase = path.join(__dirname, `../../${LocationBase}`);
 	});
 
 	async function loadSharedString(id: string, serializedSnapshot: string): Promise<SharedString> {
@@ -79,7 +79,7 @@ describe("SharedString Snapshot Version", () => {
 		const dataStoreRuntime = new MockFluidDataStoreRuntime();
 		const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 		const services = {
-			deltaConnection: containerRuntime.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(JSON.parse(serializedSnapshot)),
 		};
 		const sharedString = new SharedString(dataStoreRuntime, id, SharedStringFactory.Attributes);
@@ -94,7 +94,7 @@ describe("SharedString Snapshot Version", () => {
 		normalized: boolean,
 	) {
 		it(name, async () => {
-			const filename = `${filebase}${name}.json`;
+			const filename = `${fileBase}${name}.json`;
 			assert(fs.existsSync(filename), `test snapshot file does not exist: ${filename}`);
 			const data = fs.readFileSync(filename, "utf8");
 			const sharedString = await loadSharedString("fakeId", data);
@@ -136,7 +136,7 @@ describe("SharedString Snapshot Version", () => {
 
 	function generateSnapshotDiffTest(name: string, testString: SharedString) {
 		it(name, async () => {
-			const filename = `${filebase}${name}.json`;
+			const filename = `${fileBase}${name}.json`;
 			assert(fs.existsSync(filename), `test snapshot file does not exist: ${filename}`);
 			const data = fs.readFileSync(filename, "utf8").trim();
 			const dataObject = JSON.parse(data);

--- a/packages/dds/task-manager/src/test/taskManager.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.spec.ts
@@ -19,9 +19,9 @@ import { ITaskManager } from "../interfaces";
 function createConnectedTaskManager(id: string, runtimeFactory: MockContainerRuntimeFactory) {
 	// Create and connect a TaskManager.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
@@ -36,14 +36,14 @@ function createDetachedTaskManager(
 ): { taskManager: TaskManager; attach: () => Promise<void> } {
 	// Create a detached TaskManager.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	dataStoreRuntime.local = true;
 	const clientId = dataStoreRuntime.clientId;
 
 	const taskManager = new TaskManager(id, dataStoreRuntime, TaskManagerFactory.Attributes);
 	const attach = async () => {
 		const services = {
-			deltaConnection: containerRuntime.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 
@@ -477,7 +477,7 @@ describe("TaskManager", () => {
 		});
 	});
 
-	// Note: Since read/write modes are not yet implemented in mocks, tests are limited to simulate these secnarios.
+	// Note: Since read/write modes are not yet implemented in mocks, tests are limited to simulate these scenarios.
 	describe("Read/Write Mode", () => {
 		let taskManager1: ITaskManager;
 		let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
@@ -485,7 +485,7 @@ describe("TaskManager", () => {
 
 		const setReadOnlyInfo = (readOnlyInfo: ReadOnlyInfo) => {
 			(taskManager1 as any).runtime.deltaManager.readOnlyInfo = readOnlyInfo;
-			// Force connection to simulate read mode (TaskManager consideres the client disconnected in read mode)
+			// Force connection to simulate read mode (TaskManager considered the client disconnected in read mode)
 			containerRuntime1.connected = readOnlyInfo.readonly === false;
 		};
 
@@ -494,7 +494,7 @@ describe("TaskManager", () => {
 			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			taskManager1 = new TaskManager(
@@ -888,7 +888,7 @@ describe("TaskManager", () => {
 			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 			const services1 = {
-				deltaConnection: containerRuntime1.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			taskManager1 = new TaskManager(
@@ -902,7 +902,7 @@ describe("TaskManager", () => {
 			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
 			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 			const services2 = {
-				deltaConnection: containerRuntime2.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			taskManager2 = new TaskManager(

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -33,6 +33,7 @@ import { TypedEventEmitter, unreachableCase } from "@fluidframework/common-utils
 
 export interface Client<TChannelFactory extends IChannelFactory> {
 	channel: ReturnType<TChannelFactory["create"]>;
+	dataStoreRuntime: MockFluidDataStoreRuntime;
 	containerRuntime: MockContainerRuntimeForReconnection;
 }
 
@@ -532,7 +533,7 @@ export function mixinAttach<
 			assert.equal(state.clients.length, 1);
 			const clientA = state.clients[0];
 			const services: IChannelServices = {
-				deltaConnection: clientA.containerRuntime.createDeltaConnection(),
+				deltaConnection: clientA.dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 			clientA.channel.connect(services);
@@ -769,7 +770,7 @@ export function mixinClientSelection<
 	};
 }
 
-function makeUnreachableCodepathProxy<T extends object>(name: string): T {
+function makeUnreachableCodePathProxy<T extends object>(name: string): T {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 	return new Proxy({} as T, {
 		get: (): never => {
@@ -798,6 +799,7 @@ function createDetachedClient<TChannelFactory extends IChannelFactory>(
 	// than IChannel here.
 	const newClient: Client<TChannelFactory> = {
 		containerRuntime,
+		dataStoreRuntime,
 		channel: channel as ReturnType<TChannelFactory["create"]>,
 	};
 	options.emitter.emit("clientCreate", newClient);
@@ -817,7 +819,7 @@ async function loadClient<TChannelFactory extends IChannelFactory>(
 		minimumSequenceNumber: containerRuntimeFactory.sequenceNumber,
 	});
 	const services: IChannelServices = {
-		deltaConnection: containerRuntime.createDeltaConnection(),
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: MockStorage.createFromSummary(summary),
 	};
 
@@ -831,6 +833,7 @@ async function loadClient<TChannelFactory extends IChannelFactory>(
 	const newClient: Client<TChannelFactory> = {
 		channel,
 		containerRuntime,
+		dataStoreRuntime,
 	};
 	options.emitter.emit("clientCreate", newClient);
 	return newClient;
@@ -873,7 +876,7 @@ export async function runTestForSeed<
 	);
 	if (!startDetached) {
 		const services: IChannelServices = {
-			deltaConnection: initialClient.containerRuntime.createDeltaConnection(),
+			deltaConnection: initialClient.dataStoreRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		};
 		initialClient.channel.connect(services);
@@ -901,8 +904,8 @@ export async function runTestForSeed<
 		// These properties should always be injected into the state by the mixed in reducer/generator
 		// for any user code. We initialize them to proxies which throw errors on any property access
 		// to catch bugs in that setup.
-		channel: makeUnreachableCodepathProxy("channel"),
-		client: makeUnreachableCodepathProxy("client"),
+		channel: makeUnreachableCodePathProxy("channel"),
+		client: makeUnreachableCodePathProxy("client"),
 		isDetached: startDetached,
 	};
 
@@ -962,7 +965,7 @@ export async function replayTest<
 
 	const model = {
 		..._model,
-		// We lose some typesafety here because the options interface isn't generic
+		// We lose some type safety here because the options interface isn't generic
 		generatorFactory: (): Generator<TOperation, unknown> => generatorFromArray(operations),
 	};
 
@@ -1018,11 +1021,10 @@ export function createDDSFuzzSuite<
 
 				const replayModel = {
 					...model,
-					// We lose some typesafety here because the options interface isn't generic
+					// We lose some type safety here because the options interface isn't generic
 					generatorFactory: (): Generator<TOperation, unknown> =>
 						generatorFromArray(operations as TOperation[]),
 				};
-				// eslint-disable-next-line unicorn/no-useless-undefined
 				runTest(replayModel, options, seed, undefined);
 			});
 		}

--- a/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
+++ b/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
@@ -127,12 +127,12 @@ type Operation = TextOperation | Synchronize;
 interface OperationGenerationConfig {
 	/**
 	 * Maximum length of the SharedString (locally) before no further AddText operations are generated.
-	 * Note due to concurency, during test execution the actual length of the string may exceed this.
+	 * Note due to concurrency, during test execution the actual length of the string may exceed this.
 	 */
 	maxStringLength?: number;
 	/**
 	 * Maximum number of intervals (locally) before no further AddInterval operations are generated.
-	 * Note due to concurency, during test execution the actual number of intervals may exceed this.
+	 * Note due to concurrency, during test execution the actual number of intervals may exceed this.
 	 */
 	maxIntervals?: number;
 	maxInsertLength?: number;
@@ -273,7 +273,7 @@ function createSharedString(
 			const containerRuntime =
 				containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 			const services: IChannelServices = {
-				deltaConnection: containerRuntime.createDeltaConnection(),
+				deltaConnection: dataStoreRuntime.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
 

--- a/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
+++ b/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
@@ -51,9 +51,9 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
 		const dataStoreRuntime = new MockFluidDataStoreRuntime();
 
 		containerRuntimeFactory = new MockContainerRuntimeFactory();
-		const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+		containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
 		const services = {
-			deltaConnection: containerRuntime.createDeltaConnection(),
+			deltaConnection: dataStoreRuntime.createDeltaConnection(),
 			objectStorage: new MockStorage(undefined),
 		};
 

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -146,6 +146,9 @@ export class MockContainerRuntime {
 	public clientId: string;
 	protected clientSequenceNumber: number = 0;
 	private readonly deltaManager: MockDeltaManager;
+	/**
+	 * @deprecated use the associated datastore to create the delta connection
+	 */
 	protected readonly deltaConnections: MockDeltaConnection[] = [];
 	protected readonly pendingMessages: IMockContainerRuntimePendingMessage[] = [];
 	private readonly outbox: IInternalMockRuntimeMessage[] = [];
@@ -181,6 +184,9 @@ export class MockContainerRuntime {
 		);
 	}
 
+	/**
+	 * @deprecated - use the associated datastore to create the delta connection
+	 */
 	public createDeltaConnection(): MockDeltaConnection {
 		const deltaConnection = this.dataStoreRuntime.createDeltaConnection();
 		this.deltaConnections.push(deltaConnection);
@@ -360,7 +366,7 @@ export class MockContainerRuntimeFactory {
 		let minimumSequenceNumber: number | undefined;
 		for (const [client, clientSequenceNumber] of this.minSeq) {
 			// We have to make sure, a client is part of the quorum, when
-			// we compute the msn. We assume that the quoarum accurately
+			// we compute the msn. We assume that the quorum accurately
 			// represents the currently connected clients. In some tests
 			// for reconnects, we will remove clients from the quorum
 			// to indicate they are currently not connected. In that case,
@@ -751,6 +757,10 @@ export class MockFluidDataStoreRuntime
 	}
 
 	public setConnectionState(connected: boolean, clientId?: string) {
+		if (connected && clientId !== undefined) {
+			this.clientId = clientId;
+		}
+		this.deltaConnections.forEach((dc) => dc.setConnectionState(connected));
 		return;
 	}
 

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -55,9 +55,7 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 		}
 
 		// Let the DDSes know that the connection state changed.
-		this.deltaConnections.forEach((dc) => {
-			dc.setConnectionState(this.connected);
-		});
+		this.dataStoreRuntime.setConnectionState(this.connected, this.clientId);
 	}
 
 	private _connected = true;


### PR DESCRIPTION
This change deprecates and removes usages of createDeltaConnection on MockContainerRuntime, and unifies on MockFluidDataStoreRuntime instead. This decouples MockContainerRuntime from the concept of DeltaConnection and only leaves it as part of the MockFluidDataStoreRuntime which is the more accurate with how delta connections work in non-mocks. The primary impetus behind this change is to allow using MockContainerRuntime with things that are not MockFluidDataStoreRuntime's, like BlobManger and PendingStateManger.