### PR TITLE
chore(sequence): deprecate compareStarts and compareEnds on IIntervalHelpers

### DIFF
--- a/.changeset/poor-friends-search.md
+++ b/.changeset/poor-friends-search.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/sequence": minor
+---
+
+deprecate compareStarts and compareEnds on IIntervalHelpers
+
+these functions will be removed in a future version. use the methods IInterval.compareStart and IInterval.compareEnd respectively instead

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -175,9 +175,9 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 
 // @public @sealed (undocumented)
 export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
-    // (undocumented)
+    // @deprecated (undocumented)
     compareEnds(a: TInterval, b: TInterval): number;
-    // (undocumented)
+    // @deprecated (undocumented)
     compareStarts?(a: TInterval, b: TInterval): number;
     // (undocumented)
     create(label: string, start: number | undefined, end: number | undefined, client: Client | undefined, intervalType: IntervalType, op?: ISequencedDocumentMessage, fromSnapshot?: boolean, stickiness?: IntervalStickiness): TInterval;

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -168,7 +168,14 @@ export type CompressedSerializedInterval =
  * @sealed
  */
 export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
+	/**
+	 * @deprecated Use the method `IInterval.compareEnd` instead
+	 */
 	compareEnds(a: TInterval, b: TInterval): number;
+
+	/**
+	 * @deprecated Use the method `IInterval.compareStart` instead
+	 */
 	compareStarts?(a: TInterval, b: TInterval): number;
 	/**
 	 *


### PR DESCRIPTION
Deprecates redundant methods on `IIntervalHelpers`. See https://github.com/microsoft/FluidFramework/pull/17125 for their subsequent removal and additional context.