### PR TITLE
build(common-utils): Bump to version 2.0.0

### DIFF
--- a/common/lib/common-utils/CHANGELOG.md
+++ b/common/lib/common-utils/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @fluidframework/common-utils Changelog
 
-## [1.2.0](https://github.com/microsoft/FluidFramework/releases/tag/common-utils_v1.2.0)
+## [2.0.0](https://github.com/microsoft/FluidFramework/releases/tag/common-utils_v2.0.0)
 
 ### Deprecated classes and functions
 

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/common-utils",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"description": "Collection of utility functions for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumps common-utils to the next major version in preparation for release. We'll release 2.0.0 with deprecations, and then release 3.0 with removals.