### PR TITLE
LoaderContainerTracker: Move patching container's clone function before any filtering

### DIFF
--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -76,31 +76,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	 * @param container - container to add
 	 */
 	private addContainer(container: IContainer) {
-		// ignore summarizer
-		if (
-			!container.deltaManager.clientDetails.capabilities.interactive &&
-			!this.syncSummarizerClients
-		) {
-			return;
-		}
-
-		// don't add container that is already tracked
-		if (this.containers.has(container)) {
-			return;
-		}
-
-		const record = {
-			index: this.containers.size,
-			paused: false,
-			startTrailingNoOps: 0,
-			trailingNoOps: 0,
-			lastProposal: 0,
-		};
-		this.containers.set(container, record);
-		this.trackTrailingNoOps(container, record);
-		this.trackLastProposal(container);
-		this.setupTrace(container, record.index);
-
 		// Container has a `clone` method that can be used to create another container without going through
 		// the Loader. Such containers won't be added by the `add` method so do it here. For example, summarizer
 		// containers are created via the `clone` method.
@@ -125,6 +100,31 @@ export class LoaderContainerTracker implements IOpProcessingController {
 			};
 			containerWithClone.clone = patch(containerWithClone.clone);
 		}
+
+		// ignore summarizer
+		if (
+			!container.deltaManager.clientDetails.capabilities.interactive &&
+			!this.syncSummarizerClients
+		) {
+			return;
+		}
+
+		// don't add container that is already tracked
+		if (this.containers.has(container)) {
+			return;
+		}
+
+		const record = {
+			index: this.containers.size,
+			paused: false,
+			startTrailingNoOps: 0,
+			trailingNoOps: 0,
+			lastProposal: 0,
+		};
+		this.containers.set(container, record);
+		this.trackTrailingNoOps(container, record);
+		this.trackLastProposal(container);
+		this.setupTrace(container, record.index);
 	}
 
 	/**

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -76,6 +76,11 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	 * @param container - container to add
 	 */
 	private addContainer(container: IContainer) {
+		// don't add container that is already tracked
+		if (this.containers.has(container)) {
+			return;
+		}
+
 		// Container has a `clone` method that can be used to create another container without going through
 		// the Loader. Such containers won't be added by the `add` method so do it here. For example, summarizer
 		// containers are created via the `clone` method.
@@ -106,11 +111,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
 			!container.deltaManager.clientDetails.capabilities.interactive &&
 			!this.syncSummarizerClients
 		) {
-			return;
-		}
-
-		// don't add container that is already tracked
-		if (this.containers.has(container)) {
 			return;
 		}
 


### PR DESCRIPTION
Follow up to #16987. Moved the patching of container's clone function to the beginning of `addContainer` before any filtering happens. The reason is that LoaderContainerTracker should be aware of all containers that are created and it decides whether to track it or not.