### PR TITLE
tree2:  Cleanup use of InMemoryStoredSchemaRepository

### DIFF
--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -123,6 +123,7 @@ export {
 	SchemaEvents,
 	forbiddenFieldKindIdentifier,
 	storedEmptyFieldSchema,
+	cloneSchemaData,
 } from "./schema-stored";
 
 export { ChangeFamily, ChangeFamilyEditor, EditBuilder } from "./change-family";

--- a/experimental/dds/tree2/src/core/schema-stored/index.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/index.ts
@@ -25,5 +25,6 @@ export {
 	InMemoryStoredSchemaRepository,
 	schemaDataIsEmpty,
 	SchemaEvents,
+	cloneSchemaData,
 } from "./storedSchemaRepository";
 export { treeSchema, fieldSchema, emptyMap, emptySet, TreeSchemaBuilder } from "./builders";

--- a/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
@@ -49,7 +49,7 @@ export interface StoredSchemaRepository extends Dependee, ISubscribable<SchemaEv
  * StoredSchemaRepository for in memory use:
  * not hooked up to Fluid (does not create Fluid ops when editing).
  */
-export class InMemoryStoredSchemaRepository<TPolicy = unknown>
+export class InMemoryStoredSchemaRepository
 	extends SimpleDependee
 	implements StoredSchemaRepository
 {
@@ -68,20 +68,13 @@ export class InMemoryStoredSchemaRepository<TPolicy = unknown>
 	 * Combined with support for such namespaces in the allowed sets in the schema objects,
 	 * that might provide a decent alternative to mapFields (which is a bit odd).
 	 */
-	public constructor(public readonly policy: TPolicy, data?: SchemaData) {
+	public constructor(data?: SchemaData) {
 		super("StoredSchemaRepository");
-		this.data = {
-			treeSchema: new Map(data?.treeSchema ?? []),
-			rootFieldSchema: data?.rootFieldSchema ?? storedEmptyFieldSchema,
-		};
+		this.data = cloneSchemaData(data ?? defaultSchemaData);
 	}
 
 	public on<K extends keyof SchemaEvents>(eventName: K, listener: SchemaEvents[K]): () => void {
 		return this.events.on(eventName, listener);
-	}
-
-	public clone(): InMemoryStoredSchemaRepository {
-		return new InMemoryStoredSchemaRepository(this.policy, this.data);
 	}
 
 	public get rootFieldSchema(): FieldStoredSchema {
@@ -106,11 +99,23 @@ export class InMemoryStoredSchemaRepository<TPolicy = unknown>
 	}
 }
 
-interface MutableSchemaData extends SchemaData {
+export interface MutableSchemaData extends SchemaData {
 	rootFieldSchema: FieldStoredSchema;
 	treeSchema: Map<TreeSchemaIdentifier, TreeStoredSchema>;
 }
 
 export function schemaDataIsEmpty(data: SchemaData): boolean {
 	return data.treeSchema.size === 0;
+}
+
+export const defaultSchemaData: SchemaData = {
+	treeSchema: new Map(),
+	rootFieldSchema: storedEmptyFieldSchema,
+};
+
+export function cloneSchemaData(data: SchemaData): MutableSchemaData {
+	return {
+		treeSchema: new Map(data?.treeSchema ?? []),
+		rootFieldSchema: data?.rootFieldSchema ?? storedEmptyFieldSchema,
+	};
 }

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -89,7 +89,7 @@ export class SharedTree
 		telemetryContextPrefix: string,
 	) {
 		const options = { ...defaultSharedTreeOptions, ...optionsParam };
-		const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const schema = new InMemoryStoredSchemaRepository();
 		const forest =
 			options.forest === ForestType.Optimized
 				? buildChunkedForest(makeTreeChunker(schema, defaultSchemaPolicy), new AnchorSet())

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -29,7 +29,6 @@ import {
 	NodeKeyIndex,
 	buildForest,
 	DefaultChangeFamily,
-	defaultSchemaPolicy,
 	getEditableTreeContext,
 	ForestRepairDataStoreProvider,
 	DefaultEditBuilder,
@@ -284,14 +283,14 @@ export interface ISharedTreeView extends AnchorLocator {
 export function createSharedTreeView(args?: {
 	branch?: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>;
 	changeFamily?: DefaultChangeFamily;
-	schema?: InMemoryStoredSchemaRepository;
+	schema?: StoredSchemaRepository;
 	forest?: IEditableForest;
 	repairProvider?: ForestRepairDataStoreProvider<DefaultChangeset>;
 	nodeKeyManager?: NodeKeyManager;
 	nodeKeyIndex?: NodeKeyIndex;
 	events?: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>;
 }): ISharedTreeView {
-	const schema = args?.schema ?? new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+	const schema = args?.schema ?? new InMemoryStoredSchemaRepository();
 	const forest = args?.forest ?? buildForest(schema, new AnchorSet());
 	const changeFamily =
 		args?.changeFamily ?? new DefaultChangeFamily({ jsonValidator: noopValidator });
@@ -420,7 +419,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 		public readonly transaction: ITransaction,
 		private readonly branch: SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>,
 		private readonly changeFamily: DefaultChangeFamily,
-		public readonly storedSchema: InMemoryStoredSchemaRepository,
+		public readonly storedSchema: StoredSchemaRepository,
 		public readonly forest: IEditableForest,
 		public readonly context: EditableTreeContext,
 		private readonly nodeKeyManager: NodeKeyManager,
@@ -478,7 +477,8 @@ export class SharedTreeView implements ISharedTreeBranchView {
 
 	public fork(): SharedTreeView {
 		const anchors = new AnchorSet();
-		const storedSchema = this.storedSchema.clone();
+		// TODO: ensure editing this clone of the schema does the right thing.
+		const storedSchema = new InMemoryStoredSchemaRepository(this.storedSchema);
 		const forest = this.forest.clone(storedSchema, anchors);
 		const repairDataStoreProvider = new ForestRepairDataStoreProvider(
 			forest,

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -57,7 +57,7 @@ function bench(
 		{},
 		jsonSchema,
 	).intoDocumentSchema(SchemaBuilder.fieldOptional(...jsonRoot));
-	const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy, schemaCollection);
+	const schema = new InMemoryStoredSchemaRepository(schemaCollection);
 	for (const { name, getJson, dataConsumer } of data) {
 		describe(name, () => {
 			let json: JsonCompatible;

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -113,10 +113,7 @@ describe("ChunkedForest", () => {
 
 			it("doesn't copy data when capturing and restoring repair data", () => {
 				const initialState: JsonableTree = { type: jsonObject.name };
-				const schema = new InMemoryStoredSchemaRepository(
-					defaultSchemaPolicy,
-					jsonSequenceRootSchema,
-				);
+				const schema = new InMemoryStoredSchemaRepository(jsonSequenceRootSchema);
 				const forest = buildChunkedForest(chunker(schema));
 				const chunk = basicChunkTree(singleTextCursor(initialState), basicOnlyChunkPolicy);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -24,7 +24,6 @@ import {
 	DefaultChangeFamily,
 	DefaultChangeset,
 	DefaultEditBuilder,
-	defaultSchemaPolicy,
 	buildForest,
 	singleTextCursor,
 	jsonableTreeFromCursor,
@@ -109,7 +108,7 @@ function initializeEditableForest(data?: JsonableTree): {
 	changes: TaggedChange<DefaultChangeset>[];
 	deltas: Delta.Root[];
 } {
-	const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+	const schema = new InMemoryStoredSchemaRepository();
 	const forest = buildForest(schema);
 	if (data !== undefined) {
 		initializeForest(forest, [singleTextCursor(data)]);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -17,7 +17,6 @@ import {
 	ContextuallyTypedNodeData,
 	buildForest,
 	cursorsFromContextualData,
-	defaultSchemaPolicy,
 	getEditableTreeContext,
 	FieldSchema,
 	SchemaBuilder,
@@ -254,7 +253,7 @@ export function setupForest<T extends FieldSchema>(
 	schema: TypedSchemaCollection<T>,
 	data: ContextuallyTypedNodeData | undefined,
 ): IEditableForest {
-	const schemaRepo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy, schema);
+	const schemaRepo = new InMemoryStoredSchemaRepository(schema);
 	const forest = buildForest(schemaRepo);
 	const root = cursorsFromContextualData(
 		{

--- a/experimental/dds/tree2/src/test/feature-libraries/forestRepairDataStore.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/forestRepairDataStore.spec.ts
@@ -17,7 +17,6 @@ import {
 import { jsonNumber, jsonObject } from "../../domains";
 import {
 	buildForest,
-	defaultSchemaPolicy,
 	ForestRepairDataStore,
 	jsonableTreeFromCursor,
 	singleTextCursor,
@@ -37,7 +36,7 @@ const root: UpPath = {
 
 describe("ForestRepairDataStore", () => {
 	it("Captures deleted nodes", () => {
-		const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const schema = new InMemoryStoredSchemaRepository();
 		const forest = buildForest(schema);
 		const store = new ForestRepairDataStore(forest, mockIntoDelta);
 		const capture1 = [

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -111,7 +111,7 @@ describe("Schema Comparison", () => {
 	}
 
 	it("isNeverField", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		assert(isNeverField(defaultSchemaPolicy, repo, neverField));
 		updateTreeSchema(repo, brand("never"), neverTree);
 		const neverField2: FieldStoredSchema = fieldSchema(FieldKinds.value, [brand("never")]);
@@ -135,7 +135,7 @@ describe("Schema Comparison", () => {
 	});
 
 	it("isNeverTree", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		assert(isNeverTree(defaultSchemaPolicy, repo, neverTree));
 		assert(
 			isNeverTree(defaultSchemaPolicy, repo, {
@@ -170,7 +170,7 @@ describe("Schema Comparison", () => {
 	});
 
 	it("isNeverTreeRecursive", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		const recursiveField = fieldSchema(FieldKinds.value, [brand("recursive")]);
 		const recursiveType = treeSchema({
 			mapFields: recursiveField,
@@ -180,7 +180,7 @@ describe("Schema Comparison", () => {
 	});
 
 	it("isNeverTreeRecursive non-never", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		const recursiveField = fieldSchema(FieldKinds.value, [brand("recursive"), emptyTree.name]);
 		const recursiveType = treeSchema({
 			mapFields: recursiveField,
@@ -242,7 +242,7 @@ describe("Schema Comparison", () => {
 	});
 
 	it("allowsFieldSuperset", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		updateTreeSchema(repo, brand("never"), neverTree);
 		updateTreeSchema(repo, emptyTree.name, emptyTree);
 		const neverField2: FieldStoredSchema = fieldSchema(FieldKinds.value, [brand("never")]);
@@ -277,7 +277,7 @@ describe("Schema Comparison", () => {
 	});
 
 	it("allowsTreeSuperset-no leaf values", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		updateTreeSchema(repo, emptyTree.name, emptyTree);
 		const compare = (
 			a: TreeStoredSchema | undefined,
@@ -304,7 +304,7 @@ describe("Schema Comparison", () => {
 	});
 
 	it("allowsTreeSuperset-leaf values", () => {
-		const repo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+		const repo = new InMemoryStoredSchemaRepository();
 		updateTreeSchema(repo, emptyTree.name, emptyTree);
 		const compare = (
 			a: TreeStoredSchema | undefined,

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -23,17 +23,15 @@ import {
 	Adapters,
 	Compatibility,
 	storedEmptyFieldSchema,
+	SchemaData,
 } from "../../../core";
 import { brand } from "../../../util";
 // eslint-disable-next-line import/no-internal-modules
 import { allowsFieldSuperset, allowsTreeSuperset } from "../../../feature-libraries/modular-schema";
 
-class TestSchemaRepository extends InMemoryStoredSchemaRepository<FullSchemaPolicy> {
-	public clone(): TestSchemaRepository {
-		return new TestSchemaRepository(this.policy, {
-			treeSchema: new Map(this.data.treeSchema),
-			rootFieldSchema: this.data.rootFieldSchema,
-		});
+class TestSchemaRepository extends InMemoryStoredSchemaRepository {
+	public constructor(public readonly policy: FullSchemaPolicy, data?: SchemaData) {
+		super(data);
 	}
 
 	/**

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -96,7 +96,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			];
 			for (const [name, data] of testCases) {
 				it(name, () => {
-					const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
+					const schema = new InMemoryStoredSchemaRepository();
 					const forest = factory(schema);
 
 					const rootFieldSchema = SchemaBuilder.field(FieldKinds.optional, ...jsonRoot);
@@ -122,9 +122,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("cursor use", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
 
 			const reader = forest.allocateCursor();
@@ -155,18 +153,14 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("isEmpty: rootFieldKey", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 			assert(forest.isEmpty);
 			initializeForest(forest, [singleJsonCursor([])]);
 			assert(!forest.isEmpty);
 		});
 
 		it("isEmpty: other root", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 			assert(forest.isEmpty);
 
 			const insert: Delta.Insert = {
@@ -178,16 +172,14 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("moving a cursor to the root of an empty forest fails", () => {
-			const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
+			const forest = factory(new InMemoryStoredSchemaRepository());
 			const cursor = forest.allocateCursor();
 			moveToDetachedField(forest, cursor);
 			assert.equal(cursor.firstNode(), false);
 		});
 
 		it("tryMoveCursorToNode", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
 
@@ -223,9 +215,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("tryMoveCursorToField", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
 
@@ -262,9 +252,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("anchors creation and use", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
 
 			const cursor = forest.allocateCursor();
@@ -327,9 +315,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("using an anchor that went away returns NotFound", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
 
@@ -354,7 +340,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		describe("can clone", () => {
 			it("an empty forest", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
+				const forest = factory(new InMemoryStoredSchemaRepository());
 				const clone = forest.clone(forest.schema, forest.anchors);
 				const reader = clone.allocateCursor();
 				moveToDetachedField(clone, reader);
@@ -363,9 +349,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("primitive nodes", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 				const content: JsonCompatible[] = [1, true, "test"];
 				initializeForest(forest, content.map(singleJsonCursor));
 
@@ -382,9 +366,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("multiple fields", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const clone = forest.clone(forest.schema, forest.anchors);
@@ -396,9 +378,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("with anchors", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const forestReader = forest.allocateCursor();
@@ -416,9 +396,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("editing a cloned forest does not modify the original", () => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 			const content: JsonableTree[] = [
 				{ type: jsonNumber.name, value: 1 },
 				{ type: jsonBoolean.name, value: true },
@@ -447,9 +425,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		describe("can apply deltas with", () => {
 			if (!config.skipCursorErrorCheck) {
 				it("ensures cursors are cleared before applying deltas", () => {
-					const forest = factory(
-						new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-					);
+					const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 					initializeForest(forest, [singleJsonCursor(1)]);
 					const cursor = forest.allocateCursor();
 					moveToDetachedField(forest, cursor);
@@ -461,9 +437,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			}
 
 			it("set fields", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const setField: Delta.Modify = {
@@ -498,9 +472,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("delete", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 				const content: JsonCompatible[] = [1, 2];
 				initializeForest(forest, content.map(singleJsonCursor));
 
@@ -517,9 +489,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("a skip", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 				const content: JsonCompatible[] = [1, 2];
 				initializeForest(forest, content.map(singleJsonCursor));
 				const cursor = forest.allocateCursor();
@@ -541,9 +511,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("insert", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 				const content: JsonCompatible[] = [1, 2];
 				initializeForest(forest, content.map(singleJsonCursor));
 
@@ -566,9 +534,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("move-out under transient node", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonDocumentSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 
 				const moveId: Delta.MoveId = brand(1);
 				const moveOut: Delta.MoveOut = {
@@ -599,9 +565,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("move out and move in", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
@@ -635,9 +599,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("insert and modify", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				const content: JsonCompatible[] = [1, 2];
 				initializeForest(forest, content.map(singleJsonCursor));
 
@@ -678,9 +640,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("modify and delete", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
@@ -705,9 +665,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("modify and move out", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
@@ -761,9 +719,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		describe("top level invalidation", () => {
 			it("data editing", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				const dependent = new MockDependent("dependent");
 				recordDependency(dependent, forest);
 
@@ -787,9 +743,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("schema editing", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				const dependent = new MockDependent("dependent");
 				recordDependency(dependent, forest);
 				forest.schema.update(jsonSchema);
@@ -800,9 +754,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		describe("Does not leave an empty field", () => {
 			it("when deleting the last node in the field", () => {
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
 				const delta: Delta.Root = new Map([
 					[
 						rootFieldKey,
@@ -842,9 +794,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				});
 				const schema = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(root));
 
-				const forest = factory(
-					new InMemoryStoredSchemaRepository(defaultSchemaPolicy, schema),
-				);
+				const forest = factory(new InMemoryStoredSchemaRepository(schema));
 				initializeForest(forest, [
 					cursorForTypedTreeData({ schema }, root, {
 						x: [2],
@@ -888,9 +838,7 @@ export function testForest(config: ForestTestConfiguration): void {
 	testGeneralPurposeTreeCursor(
 		"forest cursor",
 		(data): ITreeCursor => {
-			const forest = factory(
-				new InMemoryStoredSchemaRepository(defaultSchemaPolicy, testTreeSchema),
-			);
+			const forest = factory(new InMemoryStoredSchemaRepository(testTreeSchema));
 			initializeForest(forest, [singleTextCursor(data)]);
 			const cursor = forest.allocateCursor();
 			moveToDetachedField(forest, cursor);

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -45,7 +45,6 @@ import {
 	DefaultChangeFamily,
 	DefaultChangeset,
 	DefaultEditBuilder,
-	defaultSchemaPolicy,
 	ForestRepairDataStoreProvider,
 	jsonableTreeFromCursor,
 	mapFieldMarks,
@@ -91,6 +90,7 @@ import {
 	IForestSubscription,
 	InMemoryStoredSchemaRepository,
 	initializeForest,
+	IEditableForest,
 } from "../core";
 import { JsonCompatible, Named, brand, makeArray } from "../util";
 import { ICodecFamily, withSchemaValidation } from "../codec";
@@ -581,14 +581,19 @@ export function viewWithContent(
 		events?: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>;
 	},
 ): ISharedTreeView {
-	const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy, content.schema);
+	const forest = forestWithContent(content);
+	const view = createSharedTreeView({ ...args, forest, schema: forest.schema });
+	return view;
+}
+
+export function forestWithContent(content: TreeContent): IEditableForest {
+	const schema = new InMemoryStoredSchemaRepository(content.schema);
 	const forest = buildForest(schema);
 	initializeForest(
 		forest,
 		normalizeNewFieldContent({ schema }, schema.rootFieldSchema, content.initialTree),
 	);
-	const view = createSharedTreeView({ ...args, forest, schema });
-	return view;
+	return forest;
 }
 
 const jsonSequenceRootField = SchemaBuilder.fieldSequence(...jsonRoot);


### PR DESCRIPTION
## Description

InMemoryStoredSchemaRepository is a specific implementation of SchemaRepository, and a lot of our code needlessly required that specific implementation due to how it was typed. This made implementing the forestWithContent helper messy, so was fixed.

While doing this, places that cloned InMemoryStoredSchemaRepository were adjusted accordingly, and commented with regards to how why shoul dhandeling editing. The SchemaRepository type only exists to provide editability and change events ontop of SchemaData, so places that clone it should be clear about what they do with edits or not clone it or use SchemaData instead.

Additionally the policy in InMemoryStoredSchemaRepository is no longer needed (since default schema handling was changed a while ago) so it was removed as a simplification.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

