### PR TITLE
build(common-utils): Correct package version

### DIFF
--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/common-utils",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"description": "Collection of utility functions for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
The change in #17120 was not complete. The version of the package in package.json was not updated; now it is.