### PR TITLE
Scribe uncaught exceptions

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -18,7 +18,7 @@ import { DocumentContext } from "./documentContext";
 
 export class DocumentPartition {
 	private readonly q: QueueObject<IQueuedMessage>;
-	private readonly lambdaP: Promise<IPartitionLambda>;
+	private readonly lambdaP: Promise<IPartitionLambda> | Promise<void>;
 	private lambda: IPartitionLambda | undefined;
 	private corrupt = false;
 	private closed = false;
@@ -78,8 +78,8 @@ export class DocumentPartition {
 		});
 
 		// Create the lambda to handle the document messages
-		this.lambdaP = factory.create(documentConfig, context, this.updateActivityTime.bind(this));
-		this.lambdaP
+		this.lambdaP = factory
+			.create(documentConfig, context, this.updateActivityTime.bind(this))
 			.then((lambda) => {
 				this.lambda = lambda;
 				this.q.resume();

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -25,7 +25,7 @@ import { Context } from "./context";
  */
 export class Partition extends EventEmitter {
 	private readonly q: QueueObject<IQueuedMessage>;
-	private lambdaP: Promise<IPartitionLambda> | undefined;
+	private lambdaP: Promise<IPartitionLambda> | Promise<void> | undefined;
 	private lambda: IPartitionLambda | undefined;
 	private readonly checkpointManager: CheckpointManager;
 	private readonly context: Context;
@@ -64,8 +64,8 @@ export class Partition extends EventEmitter {
 		}, 1);
 		this.q.pause();
 
-		this.lambdaP = factory.create(undefined, this.context);
-		this.lambdaP
+		this.lambdaP = factory
+			.create(undefined, this.context)
 			.then((lambda) => {
 				this.lambda = lambda;
 				this.lambdaP = undefined;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -212,7 +212,16 @@ export class ScribeLambdaFactory
 				"scribe",
 				document,
 			)) as IScribe;
-			opMessages = await this.getOpMessages(documentId, tenantId, lastCheckpoint);
+
+			try {
+				opMessages = await this.getOpMessages(documentId, tenantId, lastCheckpoint);
+			} catch (error) {
+				Lumberjack.error(
+					`Error getting pending messages after last checkpoint.`,
+					lumberProperties,
+					error,
+				);
+			}
 		}
 
 		if (lastCheckpoint.isCorrupt) {


### PR DESCRIPTION
Catches an error in scribe when getting pending messages after latest checkpoint. Also includes an additional fix for the promise `then/catch` pattern we have identified