### PR TITLE
tree2: Decouple Forest and Schema.

### DIFF
--- a/.changeset/new-feet-joke.md
+++ b/.changeset/new-feet-joke.md
@@ -1,0 +1,7 @@
+---
+"@fluid-experimental/tree2": minor
+---
+
+Decouple Forest and Schema.
+
+Forest no longer exports the schema, nor invalidates when schema changes.

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -870,7 +870,6 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
     clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
     readonly isEmpty: boolean;
-    readonly schema: StoredSchemaRepository;
     tryMoveCursorToField(destination: FieldAnchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
     tryMoveCursorToNode(destination: Anchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
 }

--- a/experimental/dds/tree2/src/core/forest/forest.ts
+++ b/experimental/dds/tree2/src/core/forest/forest.ts
@@ -46,8 +46,9 @@ export interface ForestEvents {
 }
 
 /**
- * Invalidates whenever `current` changes.
+ * Invalidates whenever the tree content changes.
  * For now (might change later) downloading new parts of the forest counts as a change.
+ * Not invalidated when schema changes.
  *
  * When invalidating, all outstanding cursors must be freed or cleared.
  * @alpha
@@ -59,14 +60,6 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 	 * The new copy will not invalidate observers (dependents) of the old one.
 	 */
 	clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
-
-	/**
-	 * Schema used within this forest.
-	 * All data must conform to these schema.
-	 *
-	 * The root's schema is tracked under {@link rootFieldKey}.
-	 */
-	readonly schema: StoredSchemaRepository;
 
 	/**
 	 * Allocates a cursor in the "cleared" state.

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-	recordDependency,
 	SimpleDependee,
 	SimpleObservingDependent,
 	ITreeSubscriptionCursor,
@@ -64,8 +63,6 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		public readonly anchors: AnchorSet = new AnchorSet(),
 	) {
 		super("object-forest.ChunkedForest");
-		// Invalidate forest if schema change.
-		recordDependency(this.dependent, this.schema);
 	}
 
 	public get isEmpty(): boolean {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -125,6 +125,7 @@ export class ProxyContext implements EditableTreeContext {
 	 */
 	public constructor(
 		public readonly forest: IEditableForest,
+		public readonly schema: SchemaData,
 		public readonly editor: DefaultEditBuilder,
 		public readonly nodeKeys: NodeKeyManager,
 		public readonly nodeKeyFieldKey?: FieldKey,
@@ -193,10 +194,6 @@ export class ProxyContext implements EditableTreeContext {
 		return proxifiedField;
 	}
 
-	public get schema(): SchemaData {
-		return this.forest.schema;
-	}
-
 	public on<K extends keyof ForestEvents>(eventName: K, listener: ForestEvents[K]): () => void {
 		return this.forest.on(eventName, listener);
 	}
@@ -215,9 +212,10 @@ export class ProxyContext implements EditableTreeContext {
  */
 export function getEditableTreeContext(
 	forest: IEditableForest,
+	schema: SchemaData,
 	editor: DefaultEditBuilder,
 	nodeKeyManager: NodeKeyManager,
 	nodeKeyFieldKey?: FieldKey,
 ): EditableTreeContext {
-	return new ProxyContext(forest, editor, nodeKeyManager, nodeKeyFieldKey);
+	return new ProxyContext(forest, schema, editor, nodeKeyManager, nodeKeyFieldKey);
 }

--- a/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-	recordDependency,
 	SimpleDependee,
 	SimpleObservingDependent,
 	ITreeSubscriptionCursor,
@@ -60,13 +59,8 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 
 	private readonly events = createEmitter<ForestEvents>();
 
-	public constructor(
-		public readonly schema: StoredSchemaRepository,
-		public readonly anchors: AnchorSet = new AnchorSet(),
-	) {
+	public constructor(public readonly anchors: AnchorSet = new AnchorSet()) {
 		super("object-forest.ObjectForest");
-		// Invalidate forest if schema change.
-		recordDependency(this.dependent, this.schema);
 	}
 
 	public get isEmpty(): boolean {
@@ -78,7 +72,7 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 	}
 
 	public clone(schema: StoredSchemaRepository, anchors: AnchorSet): ObjectForest {
-		const forest = new ObjectForest(schema, anchors);
+		const forest = new ObjectForest(anchors);
 		// Deep copy the trees.
 		for (const [key, value] of this.roots.fields) {
 			// TODO: this references the existing TreeValues instead of copying them:
@@ -455,6 +449,6 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
  */
-export function buildForest(schema: StoredSchemaRepository, anchors?: AnchorSet): IEditableForest {
-	return new ObjectForest(schema, anchors);
+export function buildForest(anchors?: AnchorSet): IEditableForest {
+	return new ObjectForest(anchors);
 }

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -16,7 +16,6 @@ import { ICodecOptions, noopValidator } from "../codec";
 import {
 	InMemoryStoredSchemaRepository,
 	Anchor,
-	AnchorSet,
 	AnchorNode,
 	AnchorSetRootEvents,
 	StoredSchemaRepository,
@@ -92,8 +91,8 @@ export class SharedTree
 		const schema = new InMemoryStoredSchemaRepository();
 		const forest =
 			options.forest === ForestType.Optimized
-				? buildChunkedForest(makeTreeChunker(schema, defaultSchemaPolicy), new AnchorSet())
-				: buildForest(schema, new AnchorSet());
+				? buildChunkedForest(makeTreeChunker(schema, defaultSchemaPolicy))
+				: buildForest();
 		const schemaSummarizer = new SchemaSummarizer(runtime, schema, options);
 		const forestSummarizer = new ForestSummarizer(forest);
 		const changeFamily = new DefaultChangeFamily(options);

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -291,7 +291,7 @@ export function createSharedTreeView(args?: {
 	events?: ISubscribable<ViewEvents> & IEmitter<ViewEvents> & HasListeners<ViewEvents>;
 }): ISharedTreeView {
 	const schema = args?.schema ?? new InMemoryStoredSchemaRepository();
-	const forest = args?.forest ?? buildForest(schema, new AnchorSet());
+	const forest = args?.forest ?? buildForest();
 	const changeFamily =
 		args?.changeFamily ?? new DefaultChangeFamily({ jsonValidator: noopValidator });
 	const repairDataStoreProvider =
@@ -314,6 +314,7 @@ export function createSharedTreeView(args?: {
 	const nodeKeyManager = args?.nodeKeyManager ?? createNodeKeyManager();
 	const context = getEditableTreeContext(
 		forest,
+		schema,
 		branch.editor,
 		nodeKeyManager,
 		brand(nodeKeyFieldKey),
@@ -488,6 +489,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 		const branch = this.branch.fork(repairDataStoreProvider);
 		const context = getEditableTreeContext(
 			forest,
+			storedSchema,
 			branch.editor,
 			this.nodeKeyManager,
 			this.nodeKeyIndex.fieldKey,

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -94,7 +94,7 @@ function bench(
 				[
 					"object-forest Cursor",
 					() => {
-						const forest = buildForest(schema);
+						const forest = buildForest();
 						initializeForest(forest, [singleTextCursor(encodedTree)]);
 						const cursor = forest.allocateCursor();
 						moveToDetachedField(forest, cursor);

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -10,7 +10,6 @@ import {
 	mintRevisionTag,
 	IForestSubscription,
 	initializeForest,
-	InMemoryStoredSchemaRepository,
 	ITreeCursorSynchronous,
 	JsonableTree,
 	mapCursorField,
@@ -108,8 +107,7 @@ function initializeEditableForest(data?: JsonableTree): {
 	changes: TaggedChange<DefaultChangeset>[];
 	deltas: Delta.Root[];
 } {
-	const schema = new InMemoryStoredSchemaRepository();
-	const forest = buildForest(schema);
+	const forest = buildForest();
 	if (data !== undefined) {
 		initializeForest(forest, [singleTextCursor(data)]);
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.events.spec.ts
@@ -124,7 +124,7 @@ function accessEmitters(forest: IEditableForest, ...steps: [PathStep, ...PathSte
 
 function retrieveAddressNode() {
 	const forest = setupForest(fullSchemaData, personData);
-	const context = getReadonlyEditableTreeContext(forest);
+	const context = getReadonlyEditableTreeContext(forest, fullSchemaData);
 	const root = context.root.getNode(0);
 	const address = root[getField](fieldAddress).getNode(0);
 	return { address, forest };

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -256,8 +256,8 @@ describe("editable-tree: read-only", () => {
 
 	it("traverse a complete tree by iteration", () => {
 		const forest = setupForest(fullSchemaData, personData);
-		const context = getReadonlyEditableTreeContext(forest);
-		expectFieldEquals(forest.schema, context.root, [personJsonableTree()]);
+		const context = getReadonlyEditableTreeContext(forest, fullSchemaData);
+		expectFieldEquals(fullSchemaData, context.root, [personJsonableTree()]);
 	});
 
 	it('"in" works as expected', () => {
@@ -319,28 +319,28 @@ describe("editable-tree: read-only", () => {
 		// Test empty
 		{
 			const forest = setupForest(schemaData, []);
-			const context = getReadonlyEditableTreeContext(forest);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
 			assert(isEditableField(context.unwrappedRoot));
 			assert.deepEqual([...context.unwrappedRoot], []);
-			expectFieldEquals(forest.schema, context.root, []);
+			expectFieldEquals(schemaData, context.root, []);
 			context.free();
 		}
 		// Test 1 item
 		{
 			const forest = setupForest(schemaData, [{}]);
-			const context = getReadonlyEditableTreeContext(forest);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
 			assert(isEditableField(context.unwrappedRoot));
-			expectTreeSequence(forest.schema, context.unwrappedRoot, [emptyNode]);
-			expectFieldEquals(forest.schema, context.root, [emptyNode]);
+			expectTreeSequence(schemaData, context.unwrappedRoot, [emptyNode]);
+			expectFieldEquals(schemaData, context.root, [emptyNode]);
 			context.free();
 		}
 		// Test 2 items
 		{
 			const forest = setupForest(schemaData, [{}, {}]);
-			const context = getReadonlyEditableTreeContext(forest);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
 			assert(isEditableField(context.unwrappedRoot));
-			expectTreeSequence(forest.schema, context.unwrappedRoot, [emptyNode, emptyNode]);
-			expectFieldEquals(forest.schema, context.root, [emptyNode, emptyNode]);
+			expectTreeSequence(schemaData, context.unwrappedRoot, [emptyNode, emptyNode]);
+			expectFieldEquals(schemaData, context.root, [emptyNode, emptyNode]);
 			context.free();
 		}
 	});
@@ -348,9 +348,9 @@ describe("editable-tree: read-only", () => {
 	it("value roots are unwrapped", () => {
 		const schemaData = buildTestSchema(SchemaBuilder.fieldValue(optionalChildSchema));
 		const forest = setupForest(schemaData, {});
-		const context = getReadonlyEditableTreeContext(forest);
+		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert(isEditableTree(context.unwrappedRoot));
-		expectTreeEquals(forest.schema, context.unwrappedRoot, emptyNode);
+		expectTreeEquals(schemaData, context.unwrappedRoot, emptyNode);
 		context.free();
 	});
 
@@ -359,17 +359,17 @@ describe("editable-tree: read-only", () => {
 		// Empty
 		{
 			const forest = setupForest(schemaData, undefined);
-			const context = getReadonlyEditableTreeContext(forest);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
 			assert.equal(context.unwrappedRoot, undefined);
-			expectFieldEquals(forest.schema, context.root, []);
+			expectFieldEquals(schemaData, context.root, []);
 			context.free();
 		}
 		// With value
 		{
 			const forest = setupForest(schemaData, {});
-			const context = getReadonlyEditableTreeContext(forest);
-			expectTreeEquals(forest.schema, context.unwrappedRoot, emptyNode);
-			expectFieldEquals(forest.schema, context.root, [emptyNode]);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
+			expectTreeEquals(schemaData, context.unwrappedRoot, emptyNode);
+			expectFieldEquals(schemaData, context.root, [emptyNode]);
 			context.free();
 		}
 	});
@@ -378,9 +378,9 @@ describe("editable-tree: read-only", () => {
 		const rootSchema = SchemaBuilder.field(FieldKinds.value, int32Schema);
 		const schemaData = buildTestSchema(rootSchema);
 		const forest = setupForest(schemaData, 1);
-		const context = getReadonlyEditableTreeContext(forest);
+		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert.equal(context.unwrappedRoot, 1);
-		expectFieldEquals(forest.schema, context.root, [{ type: int32Schema.name, value: 1 }]);
+		expectFieldEquals(schemaData, context.root, [{ type: int32Schema.name, value: 1 }]);
 		context.free();
 	});
 
@@ -392,14 +392,14 @@ describe("editable-tree: read-only", () => {
 		const rootSchema = SchemaBuilder.field(FieldKinds.value, parentSchema);
 		const schemaData = builder.intoDocumentSchema(rootSchema);
 		const forest = setupForest(schemaData, { child: "x" });
-		const context = getReadonlyEditableTreeContext(forest);
+		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert(isEditableTree(context.unwrappedRoot));
 		assert.equal(context.unwrappedRoot["child" as FieldKey], "x");
 
 		// access without unwrapping
 		const child = context.unwrappedRoot[getField](brand("child"));
 		assert(isEditableField(child));
-		expectFieldEquals(forest.schema, child, [{ type: stringSchema.name, value: "x" }]);
+		expectFieldEquals(schemaData, child, [{ type: stringSchema.name, value: "x" }]);
 		context.free();
 	});
 
@@ -411,12 +411,12 @@ describe("editable-tree: read-only", () => {
 		// Empty
 		{
 			const forest = setupForest(schemaData, []);
-			const context = getReadonlyEditableTreeContext(forest);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
 			assert(isEditableField(context.unwrappedRoot));
 			assert.equal(context.unwrappedRoot.length, 0);
 			assert.deepEqual([...context.unwrappedRoot], []);
-			expectTreeEquals(forest.schema, context.unwrappedRoot, { type: phonesSchema.name });
-			expectFieldEquals(forest.schema, context.unwrappedRoot, []);
+			expectTreeEquals(schemaData, context.unwrappedRoot, { type: phonesSchema.name });
+			expectFieldEquals(schemaData, context.unwrappedRoot, []);
 			assert.throws(
 				() => (context.unwrappedRoot as EditableField).getNode(0),
 				(e: Error) =>
@@ -437,11 +437,11 @@ describe("editable-tree: read-only", () => {
 				},
 			];
 			const forest = setupForest(schemaData, [1]);
-			const context = getReadonlyEditableTreeContext(forest);
+			const context = getReadonlyEditableTreeContext(forest, schemaData);
 			assert(isEditableField(context.unwrappedRoot));
 			assert.equal(context.unwrappedRoot.length, 1);
 			assert.deepEqual([...context.unwrappedRoot], [1]);
-			expectFieldEquals(forest.schema, context.root, data);
+			expectFieldEquals(schemaData, context.root, data);
 			context.free();
 		}
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -243,10 +243,13 @@ export function buildTestSchema<T extends FieldSchema>(rootField: T) {
 	);
 }
 
-export function getReadonlyEditableTreeContext(forest: IEditableForest): EditableTreeContext {
+export function getReadonlyEditableTreeContext(
+	forest: IEditableForest,
+	schema: SchemaData,
+): EditableTreeContext {
 	// This will error if someone tries to call mutation methods on it
 	const dummyEditor = {} as unknown as DefaultEditBuilder;
-	return getEditableTreeContext(forest, dummyEditor, createMockNodeKeyManager());
+	return getEditableTreeContext(forest, schema, dummyEditor, createMockNodeKeyManager());
 }
 
 export function setupForest<T extends FieldSchema>(
@@ -254,7 +257,7 @@ export function setupForest<T extends FieldSchema>(
 	data: ContextuallyTypedNodeData | undefined,
 ): IEditableForest {
 	const schemaRepo = new InMemoryStoredSchemaRepository(schema);
-	const forest = buildForest(schemaRepo);
+	const forest = buildForest();
 	const root = cursorsFromContextualData(
 		{
 			schema: schemaRepo,
@@ -272,7 +275,7 @@ export function buildTestTree(
 ): EditableTreeContext {
 	const schema = buildTestSchema(rootField);
 	const forest = setupForest(schema, data);
-	const context = getReadonlyEditableTreeContext(forest);
+	const context = getReadonlyEditableTreeContext(forest, schema);
 	return context;
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/forestRepairDataStore.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/forestRepairDataStore.spec.ts
@@ -9,7 +9,6 @@ import {
 	FieldKey,
 	mintRevisionTag,
 	initializeForest,
-	InMemoryStoredSchemaRepository,
 	RevisionTag,
 	rootFieldKey,
 	UpPath,
@@ -36,8 +35,7 @@ const root: UpPath = {
 
 describe("ForestRepairDataStore", () => {
 	it("Captures deleted nodes", () => {
-		const schema = new InMemoryStoredSchemaRepository();
-		const forest = buildForest(schema);
+		const forest = buildForest();
 		const store = new ForestRepairDataStore(forest, mockIntoDelta);
 		const capture1 = [
 			{ type: jsonNumber.name, value: 1 },

--- a/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
@@ -11,5 +11,5 @@ import { testForest } from "../forestTestSuite";
 
 testForest({
 	suiteName: "object-forest",
-	factory: (schema) => buildForest(schema),
+	factory: (schema) => buildForest(),
 });

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -582,16 +582,23 @@ export function viewWithContent(
 	},
 ): ISharedTreeView {
 	const forest = forestWithContent(content);
-	const view = createSharedTreeView({ ...args, forest, schema: forest.schema });
+	const view = createSharedTreeView({
+		...args,
+		forest,
+		schema: new InMemoryStoredSchemaRepository(content.schema),
+	});
 	return view;
 }
 
 export function forestWithContent(content: TreeContent): IEditableForest {
-	const schema = new InMemoryStoredSchemaRepository(content.schema);
-	const forest = buildForest(schema);
+	const forest = buildForest();
 	initializeForest(
 		forest,
-		normalizeNewFieldContent({ schema }, schema.rootFieldSchema, content.initialTree),
+		normalizeNewFieldContent(
+			{ schema: content.schema },
+			content.schema.rootFieldSchema,
+			content.initialTree,
+		),
 	);
 	return forest;
 }


### PR DESCRIPTION
## Description

This reduces coupling between forest and schema. This simplifies the codebase and is particularly useful as schema is being reworked and this avoids having to address if forest is exporting the stored or view schema.

This decoupling is not complete since a schema is still provided to the forest when cloning and when building a chunked forest. This allows the forest to use the schema for heuristic purposes (like inferring good chunk shapes): this will still need some clarification for stored vs view, but becomes simpler after this change.

## Breaking Changes

Forest no longer exports the schema, nor invalidates when schema changes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

