### PR TITLE
build(client-utils): Make private=false and use correct test names

### DIFF
--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -85,7 +85,6 @@
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
-		"@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@fluid-internal/client-utils",
 	"version": "2.0.0-internal.6.3.0",
-	"private": true,
 	"description": "Not intended for use outside the Fluid Framework.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/src/index.ts
+++ b/packages/common/client-utils/src/index.ts
@@ -11,7 +11,7 @@ export { EventForwarder } from "./eventForwarder";
  * Because the two files don't have fully isomorphic exports, using named exports for the full API surface
  * is problematic if that named export includes values not in their intersection.
  *
- * In a future breaking change of common-utils, we could use a named export for their intersection if we
+ * In a future breaking change of client-utils, we could use a named export for their intersection if we
  * desired.
  */
 // eslint-disable-next-line no-restricted-syntax

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -89,7 +89,7 @@ async function evaluateBrowserGitHash(page, file: Buffer): Promise<string> {
 	return evaluateBrowserHash(page, hashBuffer);
 }
 
-describe("Common-Utils", () => {
+describe("Client-Utils", () => {
 	let xmlFile: Buffer;
 	let svgFile: Buffer;
 	let pdfFile: Buffer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5982,7 +5982,6 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
-      '@fluidframework/common-utils-previous': npm:@fluidframework/common-utils@1.0.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
@@ -6038,7 +6037,6 @@ importers:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.40
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.40
-      '@fluidframework/common-utils-previous': /@fluidframework/common-utils/1.0.0
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.9_@types+node@16.18.40
@@ -17341,18 +17339,6 @@ packages:
 
   /@fluidframework/common-definitions/0.20.1:
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
-
-  /@fluidframework/common-utils/1.0.0:
-    resolution: {integrity: sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@types/events': 3.0.0
-      base64-js: 1.5.1
-      buffer: 6.0.3
-      events: 3.3.0
-      lodash: 4.17.21
-      sha.js: 2.4.11
-    dev: true
 
   /@fluidframework/common-utils/1.1.1:
     resolution: {integrity: sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==}


### PR DESCRIPTION
I haven't received objections to using the fluid-internal scope for this package, so I'm removing its private property so there aren't any issues when we try to release it.

The test names for the hash tests were the old "common-utils" so I fixed those. I also removed an unused previous version dependency.