### PR TITLE
refactor: Replace internal uses of deprecated ContainerRuntime.load with ContainerRuntime.loadRuntime

### DIFF
--- a/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
+++ b/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
@@ -50,15 +50,18 @@ export abstract class ModelContainerRuntimeFactoryWithAttribution<ModelType>
 		const attributor = createRuntimeAttributor();
 		const scope: FluidObject<IProvideRuntimeAttributor> = { IRuntimeAttributor: attributor };
 
-		const runtime = await containerRuntimeWithAttribution.load(
+		const runtime = await containerRuntimeWithAttribution.loadRuntime({
 			context,
-			this.registryEntries,
+			registryEntries: this.registryEntries,
 			// eslint-disable-next-line import/no-deprecated
-			makeModelRequestHandler(this.createModel.bind(this)),
-			this.runtimeOptions,
-			scope, // scope
+			requestHandler: makeModelRequestHandler(this.createModel.bind(this)),
+			runtimeOptions: this.runtimeOptions,
+			containerScope: scope,
 			existing,
-		);
+			provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+				throw new Error("TODO: what's the correct thing to return?");
+			},
+		});
 
 		if (!existing) {
 			await this.containerInitializingFirstTime(runtime);

--- a/examples/data-objects/codemirror/src/index.ts
+++ b/examples/data-objects/codemirror/src/index.ts
@@ -63,22 +63,23 @@ class CodeMirrorFactory extends RuntimeFactoryHelper {
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<ContainerRuntime> {
-		const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
+		const registryEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 			[smde.type, Promise.resolve(smde)],
 		]);
 
-		const runtime: ContainerRuntime = await ContainerRuntime.load(
+		const runtime: ContainerRuntime = await ContainerRuntime.loadRuntime({
 			context,
-			registry,
+			registryEntries,
 			// eslint-disable-next-line import/no-deprecated
-			buildRuntimeRequestHandler(
+			requestHandler: buildRuntimeRequestHandler(
 				// eslint-disable-next-line import/no-deprecated
 				mountableViewRequestHandler(MountableView, [viewRequestHandler]),
 			),
-			undefined, // runtimeOptions
-			undefined, // containerScope
 			existing,
-		);
+			provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+				throw new Error("TODO: what's the correct thing to return?");
+			},
+		});
 
 		return runtime;
 	}

--- a/examples/data-objects/prosemirror/src/index.ts
+++ b/examples/data-objects/prosemirror/src/index.ts
@@ -59,22 +59,23 @@ class ProseMirrorRuntimeFactory extends RuntimeFactoryHelper {
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<ContainerRuntime> {
-		const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
+		const registryEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 			[smde.type, Promise.resolve(smde)],
 		]);
 
-		const runtime = await ContainerRuntime.load(
+		const runtime = await ContainerRuntime.loadRuntime({
 			context,
-			registry,
+			registryEntries,
 			// eslint-disable-next-line import/no-deprecated
-			buildRuntimeRequestHandler(
+			requestHandler: buildRuntimeRequestHandler(
 				// eslint-disable-next-line import/no-deprecated
 				mountableViewRequestHandler(MountableView, [viewRequestHandler]),
 			),
-			undefined, // runtimeOptions
-			undefined, // containerScope
 			existing,
-		);
+			provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+				throw new Error("TODO: what's the correct thing to return?");
+			},
+		});
 
 		return runtime;
 	}

--- a/examples/data-objects/smde/src/index.ts
+++ b/examples/data-objects/smde/src/index.ts
@@ -59,22 +59,23 @@ class SmdeContainerFactory extends RuntimeFactoryHelper {
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<ContainerRuntime> {
-		const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
+		const registryEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 			[smde.type, Promise.resolve(smde)],
 		]);
 
-		const runtime: ContainerRuntime = await ContainerRuntime.load(
+		const runtime: ContainerRuntime = await ContainerRuntime.loadRuntime({
 			context,
-			registry,
+			registryEntries,
 			// eslint-disable-next-line import/no-deprecated
-			buildRuntimeRequestHandler(
+			requestHandler: buildRuntimeRequestHandler(
 				// eslint-disable-next-line import/no-deprecated
 				mountableViewRequestHandler(MountableView, [viewRequestHandler]),
 			),
-			undefined, // runtimeOptions
-			undefined, // containerScope
 			existing,
-		);
+			provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+				throw new Error("TODO: what's the correct thing to return?");
+			},
+		});
 
 		return runtime;
 	}

--- a/examples/utils/bundle-size-tests/src/containerRuntime.ts
+++ b/examples/utils/bundle-size-tests/src/containerRuntime.ts
@@ -7,5 +7,5 @@ import { ContainerRuntime } from "@fluidframework/container-runtime";
 export function apisToBundle() {
 	// Pass through dummy parameters, this file is only used for bundle analysis
 	// eslint-disable-next-line @typescript-eslint/no-floating-promises
-	ContainerRuntime.load(undefined as any, undefined as any);
+	ContainerRuntime.loadRuntime(undefined as any);
 }

--- a/examples/utils/example-utils/src/modelLoader/modelContainerRuntimeFactory.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelContainerRuntimeFactory.ts
@@ -37,15 +37,17 @@ export abstract class ModelContainerRuntimeFactory<ModelType> implements IRuntim
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<IRuntime> {
-		const runtime = await ContainerRuntime.load(
+		const runtime = await ContainerRuntime.loadRuntime({
 			context,
-			this.registryEntries,
+			registryEntries: this.registryEntries,
 			// eslint-disable-next-line import/no-deprecated
-			makeModelRequestHandler(this.createModel.bind(this)),
-			this.runtimeOptions,
-			undefined, // scope
+			requestHandler: makeModelRequestHandler(this.createModel.bind(this)),
+			runtimeOptions: this.runtimeOptions,
 			existing,
-		);
+			provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+				throw new Error("TODO: what's the correct thing to return?");
+			},
+		});
 
 		if (!existing) {
 			await this.containerInitializingFirstTime(runtime);

--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -122,6 +122,9 @@ export const mixinAttributor = (Base: typeof ContainerRuntime = ContainerRuntime
 				runtimeOptions,
 				containerScope,
 				containerRuntimeCtor: ctor,
+				provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+					throw new Error("TODO: what's the correct thing to return?");
+				},
 			});
 		}
 
@@ -133,6 +136,7 @@ export const mixinAttributor = (Base: typeof ContainerRuntime = ContainerRuntime
 				runtimeOptions?: IContainerRuntimeOptions;
 				containerScope?: FluidObject;
 				containerRuntimeCtor?: typeof ContainerRuntime;
+				provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 			} & (
 				| {
 						requestHandler?: (
@@ -157,6 +161,7 @@ export const mixinAttributor = (Base: typeof ContainerRuntime = ContainerRuntime
 				runtimeOptions = {},
 				containerScope = {},
 				containerRuntimeCtor = ContainerRuntime,
+				provideEntryPoint,
 			} = params;
 
 			const runtimeAttributor = (
@@ -195,6 +200,7 @@ export const mixinAttributor = (Base: typeof ContainerRuntime = ContainerRuntime
 				containerScope,
 				existing,
 				containerRuntimeCtor,
+				provideEntryPoint,
 			})) as ContainerRuntimeWithAttributor;
 			runtime.runtimeAttributor = runtimeAttributor as RuntimeAttributor;
 

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -85,198 +85,398 @@ describe("mixinAttributor", () => {
 
 	const AttributingContainerRuntime = mixinAttributor();
 
-	it("Attributes ops", async () => {
-		setEnableOnNew(true);
-		const context = getMockContext() as IContainerContext;
-		const containerRuntime = await AttributingContainerRuntime.load(
-			context,
-			[],
-			undefined, // requestHandler
-			{}, // runtimeOptions
-			getScope(),
-		);
+	describe("using ContainerRuntime.load()", () => {
+		it("Attributes ops", async () => {
+			setEnableOnNew(true);
+			const context = getMockContext() as IContainerContext;
+			const containerRuntime = await AttributingContainerRuntime.load(
+				context,
+				[],
+				undefined, // requestHandler
+				{}, // runtimeOptions
+				getScope(),
+			);
 
-		const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
-			containerRuntime.scope;
-		assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
-		const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
+			const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
+				containerRuntime.scope;
+			assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
+			const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
 
-		const op: Partial<ISequencedDocumentMessage> = {
-			type: "op",
-			sequenceNumber: 7,
-			clientId,
-			timestamp: 1006,
-		};
+			const op: Partial<ISequencedDocumentMessage> = {
+				type: "op",
+				sequenceNumber: 7,
+				clientId,
+				timestamp: 1006,
+			};
 
-		(context.deltaManager as MockDeltaManager).emit("op", op);
+			(context.deltaManager as MockDeltaManager).emit("op", op);
 
-		assert.deepEqual(runtimeAttribution.get({ type: "op", seq: op.sequenceNumber! }), {
-			timestamp: op.timestamp,
-			user: context.audience?.getMember(op.clientId!)?.user,
-		});
-	});
-
-	it("includes attribution association data in the summary tree", async () => {
-		setEnableOnNew(true);
-		const context = getMockContext() as IContainerContext;
-		const containerRuntime = await AttributingContainerRuntime.load(
-			context,
-			[],
-			undefined, // requestHandler
-			{}, // runtimeOptions
-			getScope(),
-		);
-
-		const op: Partial<ISequencedDocumentMessage> = {
-			type: "op",
-			sequenceNumber: 7,
-			clientId,
-			timestamp: 1006,
-		};
-
-		(context.deltaManager as MockDeltaManager).emit("op", op);
-		const { summary } = await containerRuntime.summarize({
-			fullTree: true,
-			trackState: false,
-			runGC: false,
-		});
-
-		const { ".attributor": attributor } = summary.tree;
-		assert(
-			attributor !== undefined && attributor.type === SummaryType.Tree,
-			"summary should contain attributor data",
-		);
-		const opAttributorBlob = attributor.tree.op;
-		assert(
-			opAttributorBlob.type === SummaryType.Blob &&
-				typeof opAttributorBlob.content === "string",
-		);
-		const decoder = chain(
-			new AttributorSerializer((entries) => new Attributor(entries), deltaEncoder),
-			makeLZ4Encoder(),
-		);
-		const decoded = decoder.decode(opAttributorBlob.content);
-		assert.deepEqual(decoded.getAttributionInfo(op.sequenceNumber!), {
-			timestamp: op.timestamp,
-			user: context.audience?.getMember(op.clientId!)?.user,
-		});
-	});
-
-	it("repopulates attribution association data using the summary tree", async () => {
-		const op: Partial<ISequencedDocumentMessage> = {
-			sequenceNumber: 7,
-			clientId,
-			timestamp: 1006,
-		};
-
-		const encoder = chain(
-			new AttributorSerializer((entries) => new Attributor(entries), deltaEncoder),
-			makeLZ4Encoder(),
-		);
-		const context = getMockContext() as Mutable<IContainerContext>;
-		const sampleAttributor = new Attributor([
-			[
-				op.sequenceNumber!,
-				{ timestamp: op.timestamp!, user: context.audience!.getMember(op.clientId!)!.user },
-			],
-		]);
-
-		const opAttributorBlobId = "mock attributor blob id";
-		const mockStorage: IDocumentStorageService = {
-			readBlob: async (blobId: string) => {
-				assert(blobId === opAttributorBlobId);
-				return encoder.encode(sampleAttributor);
-			},
-		} as unknown as IDocumentStorageService;
-		const snapshot: ISnapshotTree = {
-			blobs: {},
-			trees: {
-				".attributor": {
-					blobs: { op: opAttributorBlobId },
-					trees: {},
-				},
-			},
-		};
-		context.baseSnapshot = snapshot;
-		context.storage = mockStorage;
-		const containerRuntime = await AttributingContainerRuntime.load(
-			context,
-			[],
-			undefined, // requestHandler
-			{}, // runtimeOptions
-			getScope(),
-		);
-
-		const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
-			containerRuntime.scope;
-		assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
-		const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
-
-		assert.deepEqual(runtimeAttribution.get({ type: "op", seq: op.sequenceNumber! }), {
-			timestamp: op.timestamp,
-			user: context.audience?.getMember(op.clientId!)?.user,
-		});
-	});
-
-	describe("Doesn't summarize attributor", () => {
-		const testCases: { getContext: () => IContainerContext; testName: string }[] = [
-			{
-				testName: "for existing documents that had no attributor",
-				getContext: () => {
-					setEnableOnNew(true);
-					const context = getMockContext() as Mutable<IContainerContext>;
-					const snapshot: ISnapshotTree = {
-						blobs: {},
-						trees: {},
-					};
-					context.baseSnapshot = snapshot;
-					return context;
-				},
-			},
-			{
-				testName: `for new documents with ${enableOnNewFileKey} unset`,
-				getContext: () => {
-					return getMockContext() as IContainerContext;
-				},
-			},
-			{
-				testName: `for new documents with ${enableOnNewFileKey} set to false`,
-				getContext: () => {
-					setEnableOnNew(false);
-					const context = getMockContext() as Mutable<IContainerContext>;
-					const snapshot: ISnapshotTree = {
-						blobs: {},
-						trees: {},
-					};
-					context.baseSnapshot = snapshot;
-					return context;
-				},
-			},
-		];
-
-		for (const { getContext, testName } of testCases) {
-			it(testName, async () => {
-				const context = getContext();
-				const containerRuntime = await AttributingContainerRuntime.load(
-					context,
-					[],
-					undefined, // requestHandler
-					{}, // runtimeOptions
-					getScope(),
-				);
-
-				const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
-					containerRuntime.scope;
-				assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
-
-				const { summary } = await containerRuntime.summarize({
-					fullTree: true,
-					trackState: false,
-					runGC: false,
-				});
-				assert(summary.tree[".attributor"] === undefined);
+			assert.deepEqual(runtimeAttribution.get({ type: "op", seq: op.sequenceNumber! }), {
+				timestamp: op.timestamp,
+				user: context.audience?.getMember(op.clientId!)?.user,
 			});
-		}
+		});
+
+		it("includes attribution association data in the summary tree", async () => {
+			setEnableOnNew(true);
+			const context = getMockContext() as IContainerContext;
+			const containerRuntime = await AttributingContainerRuntime.load(
+				context,
+				[],
+				undefined, // requestHandler
+				{}, // runtimeOptions
+				getScope(),
+			);
+
+			const op: Partial<ISequencedDocumentMessage> = {
+				type: "op",
+				sequenceNumber: 7,
+				clientId,
+				timestamp: 1006,
+			};
+
+			(context.deltaManager as MockDeltaManager).emit("op", op);
+			const { summary } = await containerRuntime.summarize({
+				fullTree: true,
+				trackState: false,
+				runGC: false,
+			});
+
+			const { ".attributor": attributor } = summary.tree;
+			assert(
+				attributor !== undefined && attributor.type === SummaryType.Tree,
+				"summary should contain attributor data",
+			);
+			const opAttributorBlob = attributor.tree.op;
+			assert(
+				opAttributorBlob.type === SummaryType.Blob &&
+					typeof opAttributorBlob.content === "string",
+			);
+			const decoder = chain(
+				new AttributorSerializer((entries) => new Attributor(entries), deltaEncoder),
+				makeLZ4Encoder(),
+			);
+			const decoded = decoder.decode(opAttributorBlob.content);
+			assert.deepEqual(decoded.getAttributionInfo(op.sequenceNumber!), {
+				timestamp: op.timestamp,
+				user: context.audience?.getMember(op.clientId!)?.user,
+			});
+		});
+
+		it("repopulates attribution association data using the summary tree", async () => {
+			const op: Partial<ISequencedDocumentMessage> = {
+				sequenceNumber: 7,
+				clientId,
+				timestamp: 1006,
+			};
+
+			const encoder = chain(
+				new AttributorSerializer((entries) => new Attributor(entries), deltaEncoder),
+				makeLZ4Encoder(),
+			);
+			const context = getMockContext() as Mutable<IContainerContext>;
+			const sampleAttributor = new Attributor([
+				[
+					op.sequenceNumber!,
+					{
+						timestamp: op.timestamp!,
+						user: context.audience!.getMember(op.clientId!)!.user,
+					},
+				],
+			]);
+
+			const opAttributorBlobId = "mock attributor blob id";
+			const mockStorage: IDocumentStorageService = {
+				readBlob: async (blobId: string) => {
+					assert(blobId === opAttributorBlobId);
+					return encoder.encode(sampleAttributor);
+				},
+			} as unknown as IDocumentStorageService;
+			const snapshot: ISnapshotTree = {
+				blobs: {},
+				trees: {
+					".attributor": {
+						blobs: { op: opAttributorBlobId },
+						trees: {},
+					},
+				},
+			};
+			context.baseSnapshot = snapshot;
+			context.storage = mockStorage;
+			const containerRuntime = await AttributingContainerRuntime.load(
+				context,
+				[],
+				undefined, // requestHandler
+				{}, // runtimeOptions
+				getScope(),
+			);
+
+			const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
+				containerRuntime.scope;
+			assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
+			const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
+
+			assert.deepEqual(runtimeAttribution.get({ type: "op", seq: op.sequenceNumber! }), {
+				timestamp: op.timestamp,
+				user: context.audience?.getMember(op.clientId!)?.user,
+			});
+		});
+
+		describe("Doesn't summarize attributor", () => {
+			const testCases: { getContext: () => IContainerContext; testName: string }[] = [
+				{
+					testName: "for existing documents that had no attributor",
+					getContext: () => {
+						setEnableOnNew(true);
+						const context = getMockContext() as Mutable<IContainerContext>;
+						const snapshot: ISnapshotTree = {
+							blobs: {},
+							trees: {},
+						};
+						context.baseSnapshot = snapshot;
+						return context;
+					},
+				},
+				{
+					testName: `for new documents with ${enableOnNewFileKey} unset`,
+					getContext: () => {
+						return getMockContext() as IContainerContext;
+					},
+				},
+				{
+					testName: `for new documents with ${enableOnNewFileKey} set to false`,
+					getContext: () => {
+						setEnableOnNew(false);
+						const context = getMockContext() as Mutable<IContainerContext>;
+						const snapshot: ISnapshotTree = {
+							blobs: {},
+							trees: {},
+						};
+						context.baseSnapshot = snapshot;
+						return context;
+					},
+				},
+			];
+
+			for (const { getContext, testName } of testCases) {
+				it(testName, async () => {
+					const context = getContext();
+					const containerRuntime = await AttributingContainerRuntime.load(
+						context,
+						[],
+						undefined, // requestHandler
+						{}, // runtimeOptions
+						getScope(),
+					);
+
+					const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
+						containerRuntime.scope;
+					assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
+
+					const { summary } = await containerRuntime.summarize({
+						fullTree: true,
+						trackState: false,
+						runGC: false,
+					});
+					assert(summary.tree[".attributor"] === undefined);
+				});
+			}
+		});
+	});
+
+	describe("using ContainerRuntime.loadRuntime()", () => {
+		it("Attributes ops", async () => {
+			setEnableOnNew(true);
+			const context = getMockContext() as IContainerContext;
+			const containerRuntime = await AttributingContainerRuntime.loadRuntime({
+				context,
+				registryEntries: [],
+				containerScope: getScope(),
+				existing: false,
+			});
+
+			const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
+				containerRuntime.scope;
+			assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
+			const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
+
+			const op: Partial<ISequencedDocumentMessage> = {
+				type: "op",
+				sequenceNumber: 7,
+				clientId,
+				timestamp: 1006,
+			};
+
+			(context.deltaManager as MockDeltaManager).emit("op", op);
+
+			assert.deepEqual(runtimeAttribution.get({ type: "op", seq: op.sequenceNumber! }), {
+				timestamp: op.timestamp,
+				user: context.audience?.getMember(op.clientId!)?.user,
+			});
+		});
+
+		it("includes attribution association data in the summary tree", async () => {
+			setEnableOnNew(true);
+			const context = getMockContext() as IContainerContext;
+			const containerRuntime = await AttributingContainerRuntime.loadRuntime({
+				context,
+				registryEntries: [],
+				containerScope: getScope(),
+				existing: false,
+			});
+
+			const op: Partial<ISequencedDocumentMessage> = {
+				type: "op",
+				sequenceNumber: 7,
+				clientId,
+				timestamp: 1006,
+			};
+
+			(context.deltaManager as MockDeltaManager).emit("op", op);
+			const { summary } = await containerRuntime.summarize({
+				fullTree: true,
+				trackState: false,
+				runGC: false,
+			});
+
+			const { ".attributor": attributor } = summary.tree;
+			assert(
+				attributor !== undefined && attributor.type === SummaryType.Tree,
+				"summary should contain attributor data",
+			);
+			const opAttributorBlob = attributor.tree.op;
+			assert(
+				opAttributorBlob.type === SummaryType.Blob &&
+					typeof opAttributorBlob.content === "string",
+			);
+			const decoder = chain(
+				new AttributorSerializer((entries) => new Attributor(entries), deltaEncoder),
+				makeLZ4Encoder(),
+			);
+			const decoded = decoder.decode(opAttributorBlob.content);
+			assert.deepEqual(decoded.getAttributionInfo(op.sequenceNumber!), {
+				timestamp: op.timestamp,
+				user: context.audience?.getMember(op.clientId!)?.user,
+			});
+		});
+
+		it("repopulates attribution association data using the summary tree", async () => {
+			const op: Partial<ISequencedDocumentMessage> = {
+				sequenceNumber: 7,
+				clientId,
+				timestamp: 1006,
+			};
+
+			const encoder = chain(
+				new AttributorSerializer((entries) => new Attributor(entries), deltaEncoder),
+				makeLZ4Encoder(),
+			);
+			const context = getMockContext() as Mutable<IContainerContext>;
+			const sampleAttributor = new Attributor([
+				[
+					op.sequenceNumber!,
+					{
+						timestamp: op.timestamp!,
+						user: context.audience!.getMember(op.clientId!)!.user,
+					},
+				],
+			]);
+
+			const opAttributorBlobId = "mock attributor blob id";
+			const mockStorage: IDocumentStorageService = {
+				readBlob: async (blobId: string) => {
+					assert(blobId === opAttributorBlobId);
+					return encoder.encode(sampleAttributor);
+				},
+			} as unknown as IDocumentStorageService;
+			const snapshot: ISnapshotTree = {
+				blobs: {},
+				trees: {
+					".attributor": {
+						blobs: { op: opAttributorBlobId },
+						trees: {},
+					},
+				},
+			};
+			context.baseSnapshot = snapshot;
+			context.storage = mockStorage;
+			const containerRuntime = await AttributingContainerRuntime.loadRuntime({
+				context,
+				registryEntries: [],
+				containerScope: getScope(),
+				existing: false,
+			});
+
+			const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
+				containerRuntime.scope;
+			assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
+			const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
+
+			assert.deepEqual(runtimeAttribution.get({ type: "op", seq: op.sequenceNumber! }), {
+				timestamp: op.timestamp,
+				user: context.audience?.getMember(op.clientId!)?.user,
+			});
+		});
+
+		describe("Doesn't summarize attributor", () => {
+			const testCases: { getContext: () => IContainerContext; testName: string }[] = [
+				{
+					testName: "for existing documents that had no attributor",
+					getContext: () => {
+						setEnableOnNew(true);
+						const context = getMockContext() as Mutable<IContainerContext>;
+						const snapshot: ISnapshotTree = {
+							blobs: {},
+							trees: {},
+						};
+						context.baseSnapshot = snapshot;
+						return context;
+					},
+				},
+				{
+					testName: `for new documents with ${enableOnNewFileKey} unset`,
+					getContext: () => {
+						return getMockContext() as IContainerContext;
+					},
+				},
+				{
+					testName: `for new documents with ${enableOnNewFileKey} set to false`,
+					getContext: () => {
+						setEnableOnNew(false);
+						const context = getMockContext() as Mutable<IContainerContext>;
+						const snapshot: ISnapshotTree = {
+							blobs: {},
+							trees: {},
+						};
+						context.baseSnapshot = snapshot;
+						return context;
+					},
+				},
+			];
+
+			for (const { getContext, testName } of testCases) {
+				it(testName, async () => {
+					const context = getContext();
+					const containerRuntime = await AttributingContainerRuntime.loadRuntime({
+						context,
+						registryEntries: [],
+						containerScope: getScope(),
+						existing: false,
+					});
+
+					const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> =
+						containerRuntime.scope;
+					assert(maybeProvidesAttributor.IRuntimeAttributor !== undefined);
+
+					const { summary } = await containerRuntime.summarize({
+						fullTree: true,
+						trackState: false,
+						runGC: false,
+					});
+					assert(summary.tree[".attributor"] === undefined);
+				});
+			}
+		});
 	});
 });
 

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -61,22 +61,25 @@ export const createTestContainerRuntimeFactory = (
 			context: IContainerContext,
 			existing: boolean,
 		): Promise<IRuntime & IContainerRuntime> {
-			const runtime: ContainerRuntime = await containerRuntimeCtor.load(
+			const runtime: ContainerRuntime = await containerRuntimeCtor.loadRuntime({
 				context,
-				[
+				registryEntries: [
 					["default", Promise.resolve(this.dataStoreFactory)],
 					[this.type, Promise.resolve(this.dataStoreFactory)],
 				],
 				// eslint-disable-next-line import/no-deprecated
-				buildRuntimeRequestHandler(
+				requestHandler: buildRuntimeRequestHandler(
 					// eslint-disable-next-line import/no-deprecated
 					defaultRouteRequestHandler("default"),
 					...this.requestHandlers,
 				),
-				this.runtimeOptions,
-				context.scope,
+				runtimeOptions: this.runtimeOptions,
+				containerScope: context.scope,
 				existing,
-			);
+				provideEntryPoint: async (containerRuntime: IContainerRuntime) => {
+					throw new Error("TODO: what's the correct thing to return?");
+				},
+			});
 
 			return runtime;
 		}


### PR DESCRIPTION
## Description

Updates internal code to use the recommended `ContainerRuntime.loadRuntime()` API instead of the deprecated `ContainerRuntime.load()` (which just wraps the new one). This removes the last usage of the deprecated API within the repo.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
