### PR TITLE
Add configs for getDeltas api optimizations

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -120,7 +120,14 @@ data:
             "socketIo" : {
                 "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
             },
-            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }}
+            "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }},
+            "getDeltasEndingGapDisableFallback": {{ .Values.alfred.getDeltasEndingGapDisableFallback }},
+            "getDeltasDbRetryConfig": {
+                "enable": {{ Values.alfred.getDeltasDbRetryConfig.enable }},
+                "retryCount" : {{ Values.alfred.getDeltasDbRetryConfig.retryCount }}
+                "retryIntervalMs" : {{ Values.alfred.getDeltasDbRetryConfig.retryIntervalMs }}
+            },
+            "getDeltasOptimizationTenants": {{ toJson .Values.alfred.getDeltasOptimizationTenants }}
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -126,7 +126,7 @@ data:
             },
             "getDeltasDbRetryConfig": {
                 "enableTenants": {{ toJson .Values.alfred.getDeltasDbRetryConfig.enableTenants }},
-                "retryCount" : {{ .Values.alfred.getDeltasDbRetryConfig.retryCount }}
+                "retryCount" : {{ .Values.alfred.getDeltasDbRetryConfig.retryCount }},
                 "retryIntervalMs" : {{ .Values.alfred.getDeltasDbRetryConfig.retryIntervalMs }}
             }
         },

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -121,13 +121,14 @@ data:
                 "perMessageDeflate": {{ .Values.alfred.socketIo.perMessageDeflate}}
             },
             "getDeltasRequestMaxOpsRange": {{ .Values.alfred.getDeltasRequestMaxOpsRange }},
-            "getDeltasEndingGapDisableFallback": {{ .Values.alfred.getDeltasEndingGapDisableFallback }},
-            "getDeltasDbRetryConfig": {
-                "enable": {{ Values.alfred.getDeltasDbRetryConfig.enable }},
-                "retryCount" : {{ Values.alfred.getDeltasDbRetryConfig.retryCount }}
-                "retryIntervalMs" : {{ Values.alfred.getDeltasDbRetryConfig.retryIntervalMs }}
+            "getDeltasEndingGapDisableFallback": {
+                "enableTenants": {{ toJson .Values.alfred.getDeltasEndingGapDisableFallback.enableTenants }}
             },
-            "getDeltasOptimizationTenants": {{ toJson .Values.alfred.getDeltasOptimizationTenants }}
+            "getDeltasDbRetryConfig": {
+                "enableTenants": {{ toJson .Values.alfred.getDeltasDbRetryConfig.enableTenants }},
+                "retryCount" : {{ .Values.alfred.getDeltasDbRetryConfig.retryCount }}
+                "retryIntervalMs" : {{ .Values.alfred.getDeltasDbRetryConfig.retryIntervalMs }}
+            }
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -50,6 +50,12 @@ alfred:
   socketIo:
     perMessageDeflate: true
   getDeltasRequestMaxOpsRange: 2000
+  getDeltasEndingGapDisableFallback: false
+  getDeltasDbRetryConfig:
+    enable: false
+    retryCount: 3
+    retryIntervalMs: 100
+  getDeltasOptimizationTenants: []
 
 storage:
   enableWholeSummaryUpload: false

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -50,12 +50,12 @@ alfred:
   socketIo:
     perMessageDeflate: true
   getDeltasRequestMaxOpsRange: 2000
-  getDeltasEndingGapDisableFallback: false
+  getDeltasEndingGapDisableFallback:
+    enableTenants: []
   getDeltasDbRetryConfig:
-    enable: false
+    enableTenants: []
     retryCount: 3
     retryIntervalMs: 100
-  getDeltasOptimizationTenants: []
 
 storage:
   enableWholeSummaryUpload: false

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -38,10 +38,10 @@ export function create(
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");
 	const getDeltasRequestMaxOpsRange =
 		(config.get("alfred:getDeltasRequestMaxOpsRange") as number) ?? 2000;
-	const getDeltasEndingGapDisableFallback =
-		(config.get("alfred:getDeltasEndingGapDisableFallback") as boolean) ?? false;
+	const getDeltasEndingGapDisableFallback = config.get(
+		"alfred:getDeltasEndingGapDisableFallback",
+	);
 	const getDeltasDbRetryConfig = config.get("alfred:getDeltasDbRetryConfig");
-	const getDeltasOptimizationTenants = config.get("alfred:getDeltasOptimizationTenants") ?? [];
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -175,7 +175,6 @@ export function create(
 				{
 					getDeltasEndingGapDisableFallback,
 					getDeltasDbRetryConfig,
-					getDeltasOptimizationTenants,
 				},
 			);
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -38,6 +38,10 @@ export function create(
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");
 	const getDeltasRequestMaxOpsRange =
 		(config.get("alfred:getDeltasRequestMaxOpsRange") as number) ?? 2000;
+	const getDeltasEndingGapDisableFallback =
+		(config.get("alfred:getDeltasEndingGapDisableFallback") as boolean) ?? false;
+	const getDeltasDbRetryConfig = config.get("alfred:getDeltasDbRetryConfig");
+	const getDeltasOptimizationTenants = config.get("alfred:getDeltasOptimizationTenants") ?? [];
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -168,6 +172,11 @@ export function create(
 				from,
 				to,
 				caller,
+				{
+					getDeltasEndingGapDisableFallback,
+					getDeltasDbRetryConfig,
+					getDeltasOptimizationTenants,
+				},
 			);
 
 			handleResponse(deltasP, response, undefined, 500);

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -117,7 +117,14 @@
 		"jwtTokenCache": {
 			"enable": true
 		},
-		"getDeltasRequestMaxOpsRange": 2000
+		"getDeltasRequestMaxOpsRange": 2000,
+		"getDeltasEndingGapDisableFallback": false,
+		"getDeltasDbRetryConfig": {
+			"enable": false,
+			"retryCount": 3,
+			"retryIntervalMs": 100
+		},
+		"getDeltasOptimizationTenants": []
 	},
 	"client": {
 		"type": "browser",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -118,13 +118,14 @@
 			"enable": true
 		},
 		"getDeltasRequestMaxOpsRange": 2000,
-		"getDeltasEndingGapDisableFallback": false,
+		"getDeltasEndingGapDisableFallback": {
+			"enableTenants": []
+		},
 		"getDeltasDbRetryConfig": {
-			"enable": false,
+			"enableTenants": [],
 			"retryCount": 3,
 			"retryIntervalMs": 100
-		},
-		"getDeltasOptimizationTenants": []
+		}
 	},
 	"client": {
 		"type": "browser",

--- a/server/routerlicious/packages/services-core/src/delta.ts
+++ b/server/routerlicious/packages/services-core/src/delta.ts
@@ -13,6 +13,7 @@ export interface IDeltaService {
 		from?: number,
 		to?: number,
 		caller?: string,
+		config?: Record<string, any>,
 	): Promise<ISequencedDocumentMessage[]>;
 
 	getDeltasFromStorage(


### PR DESCRIPTION
## Description

Adding a few configs and passing them over to the get deltas api handler, i.e. `deltaService.getDelta`. These will be used in the FRS fallbackDeltaService.ts

Following configs are added:

- getDeltasEndingGapDisableFallback : config to disable azure storage fallback in case of ending gaps after the db call (irrespective of the range of ops requested by the client)
- getDeltasDbRetryConfig: config to retry the db call to fetch the missing ops before falling back to azure storage

Both the configs can be enabled for a list of tenants. The plan is to first enable these for tenants used in ff stress testing.