### PR TITLE
Make summarizer feature flag names consistent

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1555,8 +1555,7 @@ export class ContainerRuntime
 		);
 		this.closeSummarizerDelayMs = closeSummarizerDelayOverride ?? defaultCloseSummarizerDelayMs;
 		this.validateSummaryBeforeUpload =
-			this.mc.config.getBoolean("Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload") ??
-			false;
+			this.mc.config.getBoolean("Fluid.Summarizer.ValidateSummaryBeforeUpload") ?? false;
 
 		this.summaryCollection = new SummaryCollection(this.deltaManager, this.logger);
 
@@ -2974,9 +2973,8 @@ export class ContainerRuntime
 			const countBefore = this.pendingMessagesCount;
 			// The timeout for waiting for pending ops can be overridden via configurations.
 			const pendingOpsTimeout =
-				this.mc.config.getNumber(
-					"Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeoutMs",
-				) ?? defaultPendingOpsWaitTimeoutMs;
+				this.mc.config.getNumber("Fluid.Summarizer.waitForPendingOpsTimeoutMs") ??
+				defaultPendingOpsWaitTimeoutMs;
 			await new Promise<void>((resolve, reject) => {
 				const timeoutId = setTimeout(() => resolve(), pendingOpsTimeout);
 				this.once("saved", () => {

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -606,7 +606,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 				this.beforeSummaryAction();
 			},
 			async () => {
-				return this.mc.config.getBoolean("Fluid.Summarizer.TryDynamicRetries")
+				return this.mc.config.getBoolean("Fluid.Summarizer.UseDynamicRetries")
 					? this.trySummarizeWithRetries(reason)
 					: this.trySummarizeWithStaticAttempts(reason);
 			},

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1527,7 +1527,7 @@ describe("Runtime", () => {
 
 			beforeEach(async () => {
 				const settings = {};
-				settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
+				settings["Fluid.Summarizer.ValidateSummaryBeforeUpload"] = true;
 				containerRuntime = await ContainerRuntime.loadRuntime({
 					context: getMockContext(settings) as IContainerContext,
 					registryEntries: [],

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -768,7 +768,7 @@ describe("Runtime", () => {
 
 			describe("Summarization attempts with retry", () => {
 				beforeEach(async () => {
-					settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+					settings["Fluid.Summarizer.UseDynamicRetries"] = true;
 					shouldDeferGenerateSummary = false;
 					deferGenerateSummary = undefined;
 				});
@@ -1860,7 +1860,7 @@ describe("Runtime", () => {
 
 				beforeEach(async () => {
 					// Currently, summarize events are only logged with this feature.
-					settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+					settings["Fluid.Summarizer.UseDynamicRetries"] = true;
 				});
 
 				it("should emit summarize event with success result", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -459,7 +459,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 				},
 			],
 			async () => {
-				settings["Fluid.Summarizer.TryDynamicRetries"] = tryDynamicRetry;
+				settings["Fluid.Summarizer.UseDynamicRetries"] = tryDynamicRetry;
 				const logger = new MockLogger();
 				const mainContainer = await createContainer(
 					provider,
@@ -571,7 +571,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 			},
 		],
 		async () => {
-			settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+			settings["Fluid.Summarizer.UseDynamicRetries"] = true;
 			const container = await createContainer(provider, false /* disableSummary */);
 			await waitForContainerConnection(container);
 
@@ -653,7 +653,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 			},
 		],
 		async () => {
-			settings["Fluid.Summarizer.TryDynamicRetries"] = true;
+			settings["Fluid.Summarizer.UseDynamicRetries"] = true;
 			settings["Fluid.Summarizer.SkipFailingIncorrectSummary"] = true;
 			settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
 			const container = await createContainer(provider, false /* disableSummary */);

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -224,7 +224,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 		}
 		settings = {};
 		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 0;
-		settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = true;
+		settings["Fluid.Summarizer.ValidateSummaryBeforeUpload"] = true;
 		settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
 	});
 
@@ -285,7 +285,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 			},
 		],
 		async () => {
-			settings["Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload"] = false;
+			settings["Fluid.Summarizer.ValidateSummaryBeforeUpload"] = false;
 			const container = await createContainer(provider);
 			await waitForContainerConnection(container);
 			const rootDataObject = await requestFluidObject<RootTestDataObject>(container, "/");
@@ -333,8 +333,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 		async () => {
 			// Wait for 100 ms for pending ops to be saved.
 			const pendingOpsTimeoutMs = 100;
-			settings["Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeoutMs"] =
-				pendingOpsTimeoutMs;
+			settings["Fluid.Summarizer.waitForPendingOpsTimeoutMs"] = pendingOpsTimeoutMs;
 			const mockLogger = new MockLogger();
 			const container1 = await provider.makeTestContainer();
 			const { summarizer, container: summarizerContainer } = await createSummarizer(

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -27,7 +27,7 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.TryDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
@@ -35,14 +35,14 @@
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.TryDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.TryDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
@@ -74,7 +74,7 @@
 			"optionOverrides": {
 				"routerlicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.TryDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
@@ -105,7 +105,7 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.TryDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,7 +28,7 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.UseDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				},
@@ -36,14 +36,14 @@
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.UseDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.UseDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				}
@@ -75,7 +75,7 @@
 				"routerlicious": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.UseDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				}
@@ -106,7 +106,7 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
+						"Fluid.Summarizer.UseDynamicRetries": [true, false],
 						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				}


### PR DESCRIPTION
The feature flag name for couple of the recent features are inconsstent. This PR updates them to all have the "Fluid.Summarizer" prefix to make it consistent with other related feature flag names.
- `Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload` -> `Fluid.Summarizer.ValidateSummaryBeforeUpload`.
- `Fluid.ContainerRuntime.SubmitSummary.waitForPendingOpsTimeoutMs` -> `Fluid.Summarizer.waitForPendingOpsTimeoutMs`