### PR TITLE
Make getAliasedDataStoreEntryPoint required

### DIFF
--- a/.changeset/ripe-results-check.md
+++ b/.changeset/ripe-results-check.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-runtime-definitions": major
+---
+
+`getAliasedDataStoreEntryPoint` in `IContainerRuntime` is now required.
+
+`getAliasedDataStoreEntryPoint` was added to `IContainerRuntime` in 2.0.0-internal.6.0 and is now required.

--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -38,7 +38,7 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     // (undocumented)
     readonly flushMode: FlushMode;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-    getAliasedDataStoreEntryPoint?(alias: string): Promise<IFluidHandle<FluidObject> | undefined>;
+    getAliasedDataStoreEntryPoint(alias: string): Promise<IFluidHandle<FluidObject> | undefined>;
     // @deprecated
     getRootDataStore(id: string, wait?: boolean): Promise<IFluidRouter>;
     readonly isDirty: boolean;

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -57,6 +57,9 @@
 			"RemovedInterfaceDeclaration_IDataStoreWithBindToContext_Deprecated": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IContainerRuntime": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -67,7 +67,7 @@ export interface IContainerRuntime
 	 * @returns - The data store's entry point (IFluidHandle) if it exists and is aliased. Returns undefined if no
 	 * data store has been assigned the given alias.
 	 */
-	getAliasedDataStoreEntryPoint?(alias: string): Promise<IFluidHandle<FluidObject> | undefined>;
+	getAliasedDataStoreEntryPoint(alias: string): Promise<IFluidHandle<FluidObject> | undefined>;
 
 	/**
 	 * Creates detached data store context. Data store initialization is considered complete

--- a/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
@@ -23,6 +23,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: TypeOnly<current.IContainerRuntime>);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -79,9 +79,7 @@ describeFullCompat("GC Data Store Aliased Full Compat", (getTestObjectProvider) 
 		const containerRuntime2 = mainDataStore2._context
 			.containerRuntime as unknown as IContainerRuntime;
 		assert.doesNotThrow(
-			async () =>
-				containerRuntime2.getAliasedDataStoreEntryPoint?.(alias) ??
-				containerRuntime2.getRootDataStore(alias),
+			async () => containerRuntime2.getAliasedDataStoreEntryPoint(alias),
 			"Aliased datastore should be root as it is aliased!",
 		);
 		summaryWithStats = await waitForSummary(container2);

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -220,11 +220,7 @@ describeFullCompat("Named root data stores", (getTestObjectProvider) => {
 				const datastores: IFluidRouter[] = [];
 				const createAliasedDataStore = async () => {
 					try {
-						const datastore = await getAliasedDataStoreEntryPoint(dataObject1, alias);
-						if (datastore === undefined) {
-							throw new Error("Aliased data store doesn't exist yet");
-						}
-						return datastore;
+						await getAliasedDataStoreEntryPoint(dataObject1, alias);
 					} catch (err) {
 						const newDataStore = await runtimeOf(dataObject1).createDataStore(
 							packageName,

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -91,9 +91,7 @@ describeFullCompat("Named root data stores", (getTestObjectProvider) => {
 	 * Gets an aliased data store with the given id. Throws an error if the data store cannot be retrieved.
 	 */
 	async function getAliasedDataStoreEntryPoint(dataObject: ITestFluidObject, id: string) {
-		// back-compat: Older container runtime did not have getAliasedDataStoreEntryPoint.
-		const dataStore = await (runtimeOf(dataObject).getAliasedDataStoreEntryPoint?.(id) ??
-			runtimeOf(dataObject).getRootDataStore(id, false /* wait */));
+		const dataStore = await runtimeOf(dataObject).getAliasedDataStoreEntryPoint(id);
 		if (dataStore === undefined) {
 			throw new Error("Could not get aliased data store");
 		}

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -52,8 +52,7 @@ export const createTestContainerRuntimeFactory = (
 		public async instantiateFromExisting(runtime: ContainerRuntime): Promise<void> {
 			// Validate we can load root data stores.
 			// We should be able to load any data store that was created in initializeFirstTime!
-			await (runtime.getAliasedDataStoreEntryPoint?.("default") ??
-				runtime.getRootDataStore("default"));
+			await runtime.getAliasedDataStoreEntryPoint("default");
 		}
 
 		async preInitialize(


### PR DESCRIPTION
## Description
`getAliasedDataStoreEntryPoint` was added by #16558 in the previous major release. This PR makes it required.