### PR TITLE
entryPoint loader/runtime compat tests

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -182,13 +182,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
         runtimeOptions?: IContainerRuntimeOptions;
         containerScope?: FluidObject;
         containerRuntimeCtor?: typeof ContainerRuntime;
-    } & ({
         requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>;
-        initializeEntryPoint?: undefined;
-    } | {
-        requestHandler?: undefined;
-        initializeEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>;
-    })): Promise<ContainerRuntime>;
+        initializeEntryPoint?: (containerRuntime: IContainerRuntime) => Promise<FluidObject>;
+    }): Promise<ContainerRuntime>;
     // (undocumented)
     readonly logger: ITelemetryLoggerExt;
     // (undocumented)

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -81,17 +81,14 @@ export class BaseContainerRuntimeFactory
 			scope.IFluidDependencySynthesizer = dc;
 		}
 
-		const augment = this.initializeEntryPoint
-			? { initializeEntryPoint: this.initializeEntryPoint }
-			: { requestHandler: buildRuntimeRequestHandler(...this.requestHandlers) };
-
 		return ContainerRuntime.loadRuntime({
 			context,
 			existing,
 			runtimeOptions: this.runtimeOptions,
 			registryEntries: this.registryEntries,
 			containerScope: scope,
-			...augment,
+			requestHandler: buildRuntimeRequestHandler(...this.requestHandlers),
+			initializeEntryPoint: this.initializeEntryPoint,
 		});
 	}
 

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -44,15 +44,12 @@ export class RuntimeFactory extends RuntimeFactoryHelper {
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<ContainerRuntime> {
-		const augment = this.initializeEntryPoint
-			? { initializeEntryPoint: this.initializeEntryPoint }
-			: { requestHandler: buildRuntimeRequestHandler(...this.requestHandlers) };
-
 		const runtime: ContainerRuntime = await ContainerRuntime.loadRuntime({
 			context,
 			registryEntries: this.registry,
 			existing,
-			...augment,
+			requestHandler: buildRuntimeRequestHandler(...this.requestHandlers),
+			initializeEntryPoint: this.initializeEntryPoint,
 		});
 
 		return runtime;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -725,30 +725,16 @@ export class ContainerRuntime
 	 * - initializeEntryPoint - Promise that resolves to an object which will act as entryPoint for the Container.
 	 * This object should provide all the functionality that the Container is expected to provide to the loader layer.
 	 */
-	public static async loadRuntime(
-		params: {
-			context: IContainerContext;
-			registryEntries: NamedFluidDataStoreRegistryEntries;
-			existing: boolean;
-			runtimeOptions?: IContainerRuntimeOptions;
-			containerScope?: FluidObject;
-			containerRuntimeCtor?: typeof ContainerRuntime;
-		} & (
-			| {
-					requestHandler?: (
-						request: IRequest,
-						runtime: IContainerRuntime,
-					) => Promise<IResponse>;
-					initializeEntryPoint?: undefined;
-			  }
-			| {
-					requestHandler?: undefined;
-					initializeEntryPoint: (
-						containerRuntime: IContainerRuntime,
-					) => Promise<FluidObject>;
-			  }
-		),
-	): Promise<ContainerRuntime> {
+	public static async loadRuntime(params: {
+		context: IContainerContext;
+		registryEntries: NamedFluidDataStoreRegistryEntries;
+		existing: boolean;
+		runtimeOptions?: IContainerRuntimeOptions;
+		containerScope?: FluidObject;
+		containerRuntimeCtor?: typeof ContainerRuntime;
+		requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>;
+		initializeEntryPoint?: (containerRuntime: IContainerRuntime) => Promise<FluidObject>;
+	}): Promise<ContainerRuntime> {
 		const {
 			context,
 			registryEntries,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1296,6 +1296,39 @@ describe("Runtime", () => {
 				);
 			});
 
+			// TODO: Remove this test in internal.7.0 when initializeEntryPoint becomes required AB#4992
+			it("loadRuntime only passed requestHandlers", async () => {
+				const myResponse: IResponse = {
+					mimeType: "fluid/object",
+					value: "hello!",
+					status: 200,
+				};
+
+				const containerRuntime = await ContainerRuntime.loadRuntime({
+					context: getMockContext() as IContainerContext,
+					requestHandler: async (req, ctrRuntime) => myResponse,
+					existing: false,
+					registryEntries: [],
+				});
+
+				// Calling request on the runtime should use the request handler we passed in the runtime's constructor.
+				const responseFromRequestMethod = await containerRuntime.request({ url: "/" });
+				assert.deepEqual(
+					responseFromRequestMethod,
+					myResponse,
+					"request method in runtime did not return the expected object",
+				);
+
+				// The entryPoint should use the request handler we passed in the runtime's constructor
+				assert(containerRuntime.getEntryPoint !== undefined);
+				const actualEntryPoint = await containerRuntime.getEntryPoint?.();
+				assert.notStrictEqual(
+					actualEntryPoint,
+					undefined,
+					"entryPoint was not the expected object",
+				);
+			});
+
 			it("loadRuntime accepts both requestHandlers and entryPoint", async () => {
 				const myResponse: IResponse = {
 					mimeType: "fluid/object",

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1295,6 +1295,42 @@ describe("Runtime", () => {
 					"entryPoint does not match expected object",
 				);
 			});
+
+			it("loadRuntime accepts both requestHandlers and entryPoint", async () => {
+				const myResponse: IResponse = {
+					mimeType: "fluid/object",
+					value: "hello!",
+					status: 200,
+				};
+				const myEntryPoint: FluidObject = {
+					myProp: "myValue",
+				};
+
+				const containerRuntime = await ContainerRuntime.loadRuntime({
+					context: getMockContext() as IContainerContext,
+					requestHandler: async (req, ctrRuntime) => myResponse,
+					initializeEntryPoint: async (ctrRuntime) => myEntryPoint,
+					existing: false,
+					registryEntries: [],
+				});
+
+				// Calling request on the runtime should use the request handler we passed in the runtime's constructor.
+				const responseFromRequestMethod = await containerRuntime.request({ url: "/" });
+				assert.deepEqual(
+					responseFromRequestMethod,
+					myResponse,
+					"request method in runtime did not return the expected object",
+				);
+
+				// The entryPoint should come from the provided initialization function.
+				const actualEntryPoint = await containerRuntime.getEntryPoint?.();
+				assert(actualEntryPoint !== undefined, "entryPoint was not initialized");
+				assert.deepEqual(
+					actualEntryPoint,
+					myEntryPoint,
+					"entryPoint does not match expected object",
+				);
+			});
 		});
 
 		describe("Op content modification", () => {

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -1,0 +1,118 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { describeLoaderCompat, describeNoCompat } from "@fluid-internal/test-version-utils";
+import {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	DataObject,
+	DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { FluidObject } from "@fluidframework/core-interfaces";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+
+describe("entryPoint compat", () => {
+	let provider: ITestObjectProvider;
+
+	class TestDataObject extends DataObject {
+		public get _root() {
+			return this.root;
+		}
+		public get _context() {
+			return this.context;
+		}
+	}
+
+	async function getDefaultFluidObject(runtime: IContainerRuntime): Promise<FluidObject> {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		return (await runtime.getAliasedDataStoreEntryPoint?.("default"))!.get();
+	}
+
+	async function createRequestOnlyContainer(): Promise<IContainer> {
+		const dataObjectFactory = new DataObjectFactory("TestDataObject", TestDataObject, [], []);
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(dataObjectFactory, [
+			[dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
+		]);
+
+		return provider.createContainer(runtimeFactory);
+	}
+
+	async function createContainer(): Promise<IContainer> {
+		const dataObjectFactory = new DataObjectFactory("TestDataObject", TestDataObject, [], []);
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+			dataObjectFactory,
+			[[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
+			undefined,
+			undefined,
+			undefined,
+			async (runtime: IContainerRuntime) => getDefaultFluidObject(runtime),
+		);
+
+		return provider.createContainer(runtimeFactory);
+	}
+
+	describeNoCompat("no compat", (getTestObjectProvider) => {
+		beforeEach(async () => {
+			provider = getTestObjectProvider();
+		});
+
+		it("entryPoint pattern", async () => {
+			const container = await createContainer();
+			const entryPoint = await container.getEntryPoint?.();
+			assert.notStrictEqual(entryPoint, undefined, "entryPoint was undefined");
+		});
+
+		it("request pattern", async () => {
+			const container = await createRequestOnlyContainer();
+			const requestResult = await container.request({ url: "/" });
+
+			assert.strictEqual(requestResult.status, 200, requestResult.value);
+			assert.notStrictEqual(requestResult.value, undefined, "requestResult was undefined");
+		});
+
+		it("both entryPoint and request pattern", async () => {
+			const container = await createContainer();
+			const entryPoint = await container.getEntryPoint?.();
+			const requestResult = await container.request({ url: "/" });
+
+			assert.strictEqual(requestResult.status, 200, requestResult.value);
+			assert.strictEqual(
+				entryPoint,
+				requestResult.value,
+				"entryPoint and requestResult expected to be the same",
+			);
+		});
+	});
+
+	// Simulating old loader code
+	describeLoaderCompat("loader compat", (getTestObjectProvider) => {
+		beforeEach(async () => {
+			provider = getTestObjectProvider();
+		});
+
+		it("something", () => {
+			// have unit test in containerRuntime.spec.ts to verify you can use both load and loadRuntime
+		});
+
+		it("request pattern works", async () => {
+			const container = await createRequestOnlyContainer();
+			const requestResult = await container.request({ url: "/" });
+
+			assert.strictEqual(requestResult.status, 200, requestResult.value);
+			assert.notStrictEqual(requestResult.value, undefined, "requestResult was undefined");
+		});
+
+		it("request pattern works when entryPoint is available", async () => {
+			const container = await createContainer();
+			const requestResult = await container.request({ url: "/" });
+
+			// Verify request pattern still works for older loaders (even with entryPoint available)
+			assert.strictEqual(requestResult.status, 200, requestResult.value);
+			assert.notStrictEqual(requestResult.value, undefined, "requestResult was undefined");
+		});
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -94,10 +94,6 @@ describe("entryPoint compat", () => {
 			provider = getTestObjectProvider();
 		});
 
-		it("something", () => {
-			// have unit test in containerRuntime.spec.ts to verify you can use both load and loadRuntime
-		});
-
 		it("request pattern works", async () => {
 			const container = await createRequestOnlyContainer();
 			const requestResult = await container.request({ url: "/" });


### PR DESCRIPTION
Adds tests to verify compat between old loaders and newer runtimes is respecting in regards to the `request` pattern.

Note: This PR cherry-picks https://github.com/microsoft/FluidFramework/pull/17153