### PR TITLE
Revert timeout for t9s e2e tests back to 5sec

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -49,7 +49,7 @@
 		"test:realsvc:tinylicious": "npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:t9s",
 		"test:realsvc:tinylicious:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:t9s",
-		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s --timeout=20s",
+		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s --timeout=5s",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
 	},
 	"nyc": {


### PR DESCRIPTION
#### Description 

https://github.com/microsoft/FluidFramework/pull/17022

This PR reverts the timeout back to 5 second from 20 seconds related to a flaky test in `t9s` package.
