### PR TITLE
fix(driver-definitions): Add missing flag to `DriverErrorTypes`.

### DIFF
--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -66,6 +66,7 @@ export const DriverErrorTypes: {
     readonly locationRedirection: "locationRedirection";
     readonly fluidInvalidSchema: "fluidInvalidSchema";
     readonly fileIsLocked: "fileIsLocked";
+    readonly outOfStorageError: "outOfStorageError";
     readonly genericError: "genericError";
     readonly throttlingError: "throttlingError";
     readonly usageError: "usageError";

--- a/packages/common/driver-definitions/src/driverError.ts
+++ b/packages/common/driver-definitions/src/driverError.ts
@@ -98,6 +98,11 @@ export const DriverErrorTypes = {
 	 * File is locked for read/write by storage, e.g. whole collection is locked and access denied.
 	 */
 	fileIsLocked: "fileIsLocked",
+
+	/**
+	 * Storage is out of space
+	 */
+	outOfStorageError: "outOfStorageError",
 } as const;
 export type DriverErrorTypes = typeof DriverErrorTypes[keyof typeof DriverErrorTypes];
 


### PR DESCRIPTION
PR #17078 on main introduced `DriverErrorTypes` and deprecated `DriverErrorType`. Around the same time, PR #17131 on next added the flag `outOfStorageError` to `DriverErrorType`. This PR adds that flag to `DriverErrorTypes` to bring the two back inline with each other.