### PR TITLE
[GC stress] Fix feature flags names and values

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -15,9 +15,8 @@
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					},
 					"container": {
 						"gcOptions": {
@@ -34,9 +33,8 @@
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					},
 					"container": {
 						"gcOptions": {
@@ -66,9 +64,8 @@
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					},
 					"container": {
 						"gcOptions": {
@@ -87,9 +84,8 @@
 						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [300000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1560000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					},
 					"container": {
 						"gcOptions": {
@@ -118,9 +114,8 @@
 					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					},
 					"container": {
 						"gcOptions": {
@@ -138,9 +133,8 @@
 					"configurations": {
 						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [300000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1560000],
-						"Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.TryDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.TryDynamicRetries": [true, false]
 					},
 					"container": {
 						"gcOptions": {
@@ -183,23 +177,20 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.UseDynamicRetries": [true, false]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.UseDynamicRetries": [true, false]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.UseDynamicRetries": [true, false]
 					}
 				}
 			},
@@ -230,8 +221,7 @@
 				"routerlicious": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.UseDynamicRetries": [true, false]
 					}
 				}
 			}
@@ -261,8 +251,7 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.UseDynamicRetries": [true, false]
 					}
 				}
 			}


### PR DESCRIPTION
Updated the following feature flags in testConfig.json:
- Renamed `Fluid.ContainerRuntime.Test.ValidateSummaryBeforeUpload` -> `Fluid.Summarizer.ValidateSummaryBeforeUpload` that was recently changed.
- Removed `Fluid.Summarizer.PendingOpsRetryDelayMs` whose value was incorrectly set to boolean. It has a default value so there is no need to provide an override.