### PR TITLE
build: fix up `package.json` module fields

### DIFF
--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -15,7 +15,6 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:genver": "gen-version",
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"clean": "rimraf --glob \"dist\" \"lib\" \"*.tsbuildinfo\" \"*.build.log\"",

--- a/azure/packages/test/scenario-runner/tsconfig.esnext.json
+++ b/azure/packages/test/scenario-runner/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -746,6 +746,9 @@ export const handlers: Handler[] = [
 		name: "npm-package-json-test-scripts",
 		match,
 		handler: (file, root) => {
+			// This rules enforces that if the package have test files (in 'src/test', excluding 'src/test/types'),
+			// or mocha/jest dependencies, it should have a test scripts so that the pipeline will pick it up
+
 			let json;
 
 			try {
@@ -793,6 +796,9 @@ export const handlers: Handler[] = [
 		name: "npm-package-json-test-scripts-split",
 		match,
 		handler: (file, root) => {
+			// This rule enforces that because the pipeline split running these test in different steps, each project
+			// has the split set up property (into test:mocha, test:jest and test:realsvc). Release groups that doesn't
+			// have splits in the pipeline is excluded in the "handlerExclusions" in the fluidBuild.config.cjs
 			let json;
 
 			try {
@@ -838,8 +844,8 @@ export const handlers: Handler[] = [
 		name: "npm-package-json-script-mocha-config",
 		match,
 		handler: (file, root) => {
+			// This rule enforces that mocha will use a config file and setup both the console, json and xml reporters.
 			let json;
-
 			try {
 				json = JSON.parse(readFile(file));
 			} catch (err) {
@@ -876,6 +882,7 @@ export const handlers: Handler[] = [
 		name: "npm-package-json-script-jest-config",
 		match,
 		handler: (file, root) => {
+			// This rule enforces that jest will use a config file and setup both the default (console) and junit reporters.
 			let json;
 
 			try {
@@ -927,6 +934,43 @@ export const handlers: Handler[] = [
 
 			if (json["jest-junit"] !== undefined) {
 				return `Extraneous jest-unit config in ${file}`;
+			}
+		},
+	},
+	{
+		name: "npm-package-json-esm",
+		match,
+		handler: (file, root) => {
+			// This rule enforces that we have a module field in the package iff we have a ESM build
+			// So that tools like webpack will pack up the right version.
+			let json;
+
+			try {
+				json = JSON.parse(readFile(file));
+			} catch (err) {
+				return "Error parsing JSON file: " + file;
+			}
+
+			const scripts = json.scripts;
+			if (scripts === undefined) {
+				return undefined;
+			}
+			// Using the heuristic that our package use "build:esnext" or "tsc:esnext" to indicate
+			// that it has a ESM build.
+			const esnextScriptsNames = ["build:esnext", "tsc:esnext"];
+			const hasBuildEsNext = esnextScriptsNames.some((name) => scripts[name] !== undefined);
+			const hasModuleOutput = json.module !== undefined;
+
+			if (hasBuildEsNext) {
+				if (!hasModuleOutput) {
+					return "Missing 'module' field in package.json for ESM build";
+				}
+			} else {
+				// If we don't have a separate esnext build, it's still ok to have the "module"
+				// field if it is the same as "main"
+				if (hasModuleOutput && json.main !== json.module) {
+					return "Missing ESM build script while package.json has 'module' field";
+				}
 			}
 		},
 	},

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -797,7 +797,7 @@ export const handlers: Handler[] = [
 		match,
 		handler: (file, root) => {
 			// This rule enforces that because the pipeline split running these test in different steps, each project
-			// has the split set up property (into test:mocha, test:jest and test:realsvc). Release groups that doesn't
+			// has the split set up property (into test:mocha, test:jest and test:realsvc). Release groups that don't
 			// have splits in the pipeline is excluded in the "handlerExclusions" in the fluidBuild.config.cjs
 			let json;
 

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -11,7 +11,6 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",

--- a/examples/apps/collaborative-textarea/jest.config.js
+++ b/examples/apps/collaborative-textarea/jest.config.js
@@ -20,6 +20,16 @@ module.exports = {
 	transform: {
 		"^.+\\.ts?$": "ts-jest",
 	},
+	reporters: [
+		"default",
+		[
+			"jest-junit",
+			{
+				outputDirectory: "nyc",
+				outputName: "jest-junit-report.xml",
+			},
+		],
+	],
 	// While we still have transitive dependencies on 'uuid<9.0.0', force the CJS entry point:
 	// See: https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library
 	moduleNameMapper: { "^uuid$": "uuid" },

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -11,8 +11,9 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/expressApp.js",
-	"types": "dist/expressApp.d.ts",
+	"main": "lib/expressApp.js",
+	"module": "lib/expressApp.js",
+	"types": "lib/expressApp.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/tsconfig.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/tsconfig.json
@@ -6,7 +6,6 @@
 		"outDir": "lib",
 		"jsx": "react",
 		"composite": true,
-		"types": ["node"],
 	},
 	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -12,7 +12,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
+	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -61,10 +61,6 @@
 		"rimraf": "^4.4.0",
 		"typescript": "~4.5.5"
 	},
-	"jest-junit": {
-		"outputDirectory": "nyc",
-		"outputName": "jest-junit-report.xml"
-	},
 	"typeValidation": {
 		"broken": {}
 	}

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -12,7 +12,6 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
-	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -13,6 +13,7 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
+	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -13,7 +13,6 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
-	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -12,7 +12,6 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
-	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"bench": "mocha --recursive dist/test --timeout 999999 -r node_modules/@fluidframework/mocha-test-setup --perfMode --parentProcess --fgrep @Benchmark --reporter \"../../../node_modules/@fluid-tools/benchmark/dist/MochaReporter.js\"",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -12,7 +12,6 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
-	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -147,11 +147,7 @@
 					"webpack"
 				],
 				"script": false
-			},
-			"webpack": [
-				"@fluid-experimental/devtools-core#tsc",
-				"@fluid-experimental/devtools-view#tsc"
-			]
+			}
 		}
 	},
 	"typeValidation": {

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -12,6 +12,7 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
+	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -12,6 +12,7 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
+	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -19,7 +19,6 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"clean": "rimraf --glob \"dist\" \"lib\" \"*.tsbuildinfo\" \"*.build.log\"",
 		"eslint": "eslint --format stylish src",

--- a/packages/tools/fluid-runner/tsconfig.esnext.json
+++ b/packages/tools/fluid-runner/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}


### PR DESCRIPTION
While we will switch to use the newer "export" field in the package to specify the file to export in the future, in the meantime, we should specify the ESM output in the "module" fields to that webpack can pick them up.

Added repo policy to enforce if we have `build:esnext` script, we should have a `module` field in `package.json` and fix up the repo.
- Remove unnecessary ESM build from `fluid-runner` and `azure-scenario-runner` package
- Remove module fields that points to non-existent ESM builds in `bundle-size-tools`, `file-driver`, `local-server-tests`, `stochastic-test-utils`, `test-utils` and PropertyDDS example schema packages.
- Add missing module field to `devtools-core`, `devtools`, PropertyDDS `property-proxy` packages. 

Also:
- `odspsnapshotfetch-perftestapp` for the browser, so it should need `node` types in `tsconfig.json`.
- Fix the build rules for `devtools-browser-extension` webpack, now that `devtools-core` has ESM Build from #16333 
- Added comments to some of the newer repo policy rules.
- Fix up some new violation that the new rules flagged (the new rules aren't released and fully enforced yet).