### PR TITLE
Fix data store context's packageName not always logged

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -351,27 +351,20 @@ export class SampledTelemetryHelper implements IDisposable {
 export const sessionStorageConfigProvider: Lazy<IConfigProviderBase>;
 
 // @public
-export function tagCodeArtifacts<T extends Record<string, TelemetryBaseEventPropertyType>>(values: T): {
-    [P in keyof T]: {
+export const tagCodeArtifacts: <T extends Record<string, TelemetryEventPropertyType | (() => TelemetryBaseEventPropertyType)>>(values: T) => { [P in keyof T]: (T[P] extends () => TelemetryBaseEventPropertyType ? () => {
+        value: ReturnType<T[P]>;
+        tag: TelemetryDataTag.CodeArtifact;
+    } : {
         value: Exclude<T[P], undefined>;
         tag: TelemetryDataTag.CodeArtifact;
-    } | (T[P] extends undefined ? undefined : never);
-};
+    }) | (T[P] extends undefined ? undefined : never); };
 
 // @public (undocumented)
-export function tagCodeArtifacts<T extends TelemetryBaseEventPropertyType, V extends Record<string, () => T>>(values: V): {
-    [P in keyof V]: (() => {
-        value: Exclude<T, undefined>;
-        tag: TelemetryDataTag.CodeArtifact;
-    }) | (V[P] extends undefined ? undefined : never);
-};
-
-// @public (undocumented)
-export const tagData: <T extends TelemetryDataTag, U extends TelemetryEventPropertyType, V extends Record<string, U | (() => U)>>(tag: T, values: V) => { [P in keyof V]: {
-        value: Exclude<U, undefined>;
+export const tagData: <T extends TelemetryDataTag, V extends Record<string, TelemetryEventPropertyType | (() => TelemetryBaseEventPropertyType)>>(tag: T, values: V) => { [P in keyof V]: (V[P] extends () => TelemetryBaseEventPropertyType ? () => {
+        value: ReturnType<V[P]>;
         tag: T;
-    } | (() => {
-        value: Exclude<U, undefined>;
+    } : {
+        value: Exclude<V[P], undefined>;
         tag: T;
     }) | (V[P] extends undefined ? undefined : never); };
 

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -23,6 +23,8 @@ import { IUsageError } from '@fluidframework/core-interfaces';
 import { Lazy } from '@fluidframework/core-utils';
 import { LogLevel } from '@fluidframework/core-interfaces';
 import { Tagged } from '@fluidframework/core-interfaces';
+import { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces';
+import { TelemetryEventPropertyType } from '@fluidframework/core-interfaces';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @public (undocumented)
@@ -349,7 +351,7 @@ export class SampledTelemetryHelper implements IDisposable {
 export const sessionStorageConfigProvider: Lazy<IConfigProviderBase>;
 
 // @public
-export function tagCodeArtifacts<T extends Record<string, TelemetryEventPropertyType>>(values: T): {
+export function tagCodeArtifacts<T extends Record<string, TelemetryBaseEventPropertyType>>(values: T): {
     [P in keyof T]: {
         value: Exclude<T[P], undefined>;
         tag: TelemetryDataTag.CodeArtifact;
@@ -357,7 +359,7 @@ export function tagCodeArtifacts<T extends Record<string, TelemetryEventProperty
 };
 
 // @public (undocumented)
-export function tagCodeArtifacts<T extends TelemetryEventPropertyType, V extends Record<string, () => T>>(values: V): {
+export function tagCodeArtifacts<T extends TelemetryBaseEventPropertyType, V extends Record<string, () => T>>(values: V): {
     [P in keyof V]: (() => {
         value: Exclude<T, undefined>;
         tag: TelemetryDataTag.CodeArtifact;

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -348,17 +348,30 @@ export class SampledTelemetryHelper implements IDisposable {
 // @public
 export const sessionStorageConfigProvider: Lazy<IConfigProviderBase>;
 
-// @public (undocumented)
-export const tagCodeArtifacts: <T extends Record<string, TelemetryEventPropertyTypeExt>>(values: T) => { [P in keyof T]: {
+// @public
+export function tagCodeArtifacts<T extends Record<string, TelemetryEventPropertyType>>(values: T): {
+    [P in keyof T]: {
         value: Exclude<T[P], undefined>;
         tag: TelemetryDataTag.CodeArtifact;
-    } | (T[P] extends undefined ? undefined : never); };
+    } | (T[P] extends undefined ? undefined : never);
+};
 
 // @public (undocumented)
-export const tagData: <T extends TelemetryDataTag, V extends Record<string, TelemetryEventPropertyTypeExt>>(tag: T, values: V) => { [P in keyof V]: {
-        value: Exclude<V[P], undefined>;
+export function tagCodeArtifacts<T extends TelemetryEventPropertyType, V extends Record<string, () => T>>(values: V): {
+    [P in keyof V]: (() => {
+        value: Exclude<T, undefined>;
+        tag: TelemetryDataTag.CodeArtifact;
+    }) | (V[P] extends undefined ? undefined : never);
+};
+
+// @public (undocumented)
+export const tagData: <T extends TelemetryDataTag, U extends TelemetryEventPropertyType, V extends Record<string, U | (() => U)>>(tag: T, values: V) => { [P in keyof V]: {
+        value: Exclude<U, undefined>;
         tag: T;
-    } | (V[P] extends undefined ? undefined : never); };
+    } | (() => {
+        value: Exclude<U, undefined>;
+        tag: T;
+    }) | (V[P] extends undefined ? undefined : never); };
 
 // @public @deprecated (undocumented)
 export class TaggedLoggerAdapter implements ITelemetryBaseLogger {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -315,8 +315,6 @@ export abstract class FluidDataStoreContext
 				all: {
 					...tagCodeArtifacts({
 						fluidDataStoreId: this.id,
-					}),
-					...tagCodeArtifacts({
 						// The package name is a getter because `this.pkg` may not be initialized during construction.
 						// For data stores loaded from summary, it is initialized during data store realization.
 						fullPackageName: () => this.pkg?.join("/"),

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -65,6 +65,7 @@ import {
 	LoggingError,
 	MonitoringContext,
 	tagCodeArtifacts,
+	TelemetryDataTag,
 	ThresholdCounter,
 } from "@fluidframework/telemetry-utils";
 import {
@@ -312,10 +313,19 @@ export abstract class FluidDataStoreContext
 			logger: this.logger,
 			namespace: "FluidDataStoreContext",
 			properties: {
-				all: tagCodeArtifacts({
-					fluidDataStoreId: this.id,
-					fullPackageName: this.pkg?.join("/"),
-				}),
+				all: {
+					...tagCodeArtifacts({
+						fluidDataStoreId: this.id,
+					}),
+					// The package name is a getter because `this.pkg` may not be initialized during construction.
+					// For data stores loaded from summary, it is initialized during data store realization.
+					fullPackageName: () => {
+						return {
+							value: this.pkg?.join("/"),
+							tag: TelemetryDataTag.CodeArtifact,
+						};
+					},
+				},
 			},
 		});
 		this.thresholdOpsCounter = new ThresholdCounter(

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -312,14 +312,12 @@ export abstract class FluidDataStoreContext
 			logger: this.logger,
 			namespace: "FluidDataStoreContext",
 			properties: {
-				all: {
-					...tagCodeArtifacts({
-						fluidDataStoreId: this.id,
-						// The package name is a getter because `this.pkg` may not be initialized during construction.
-						// For data stores loaded from summary, it is initialized during data store realization.
-						fullPackageName: () => this.pkg?.join("/"),
-					}),
-				},
+				all: tagCodeArtifacts({
+					fluidDataStoreId: this.id,
+					// The package name is a getter because `this.pkg` may not be initialized during construction.
+					// For data stores loaded from summary, it is initialized during data store realization.
+					fullPackageName: () => this.pkg?.join("/"),
+				}),
 			},
 		});
 		this.thresholdOpsCounter = new ThresholdCounter(

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -65,7 +65,6 @@ import {
 	LoggingError,
 	MonitoringContext,
 	tagCodeArtifacts,
-	TelemetryDataTag,
 	ThresholdCounter,
 } from "@fluidframework/telemetry-utils";
 import {
@@ -317,14 +316,11 @@ export abstract class FluidDataStoreContext
 					...tagCodeArtifacts({
 						fluidDataStoreId: this.id,
 					}),
-					// The package name is a getter because `this.pkg` may not be initialized during construction.
-					// For data stores loaded from summary, it is initialized during data store realization.
-					fullPackageName: () => {
-						return {
-							value: this.pkg?.join("/"),
-							tag: TelemetryDataTag.CodeArtifact,
-						};
-					},
+					...tagCodeArtifacts({
+						// The package name is a getter because `this.pkg` may not be initialized during construction.
+						// For data stores loaded from summary, it is initialized during data store realization.
+						fullPackageName: () => this.pkg?.join("/"),
+					}),
 				},
 			},
 		});

--- a/packages/runtime/container-runtime/src/gc/gcHelpers.ts
+++ b/packages/runtime/container-runtime/src/gc/gcHelpers.ts
@@ -12,7 +12,6 @@ import {
 	IGarbageCollectionData,
 	IGarbageCollectionDetailsBase,
 } from "@fluidframework/runtime-definitions";
-import { TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { GCFeatureMatrix, GCVersion, IGCMetadata } from "./gcDefinitions";
 import {
 	IGarbageCollectionNodeData,
@@ -303,15 +302,4 @@ export function unpackChildNodesGCDetails(gcDetails: IGarbageCollectionDetailsBa
  */
 export function trimLeadingAndTrailingSlashes(str: string) {
 	return str.replace(/^\/+|\/+$/g, "");
-}
-
-/**
- * Tags the passed value as a CodeArtifact and returns the tagged value.
- * @deprecated - Use telemetry-utils tagCodeArtifacts instead
- */
-export function tagAsCodeArtifact(value: string) {
-	return {
-		value,
-		tag: TelemetryDataTag.CodeArtifact,
-	};
 }

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -23,8 +23,6 @@ import {
 	runSweepKey,
 } from "./gcDefinitions";
 import { UnreferencedStateTracker } from "./gcUnreferencedStateTracker";
-// eslint-disable-next-line import/no-deprecated
-import { tagAsCodeArtifact } from "./gcHelpers";
 
 type NodeUsageType = "Changed" | "Loaded" | "Revived";
 
@@ -184,8 +182,7 @@ export class GCTelemetryTracker {
 				{
 					eventName: `GC_Tombstone_${nodeType}_Revived`,
 					category: "generic",
-					// eslint-disable-next-line import/no-deprecated
-					url: tagAsCodeArtifact(id),
+					...tagCodeArtifacts({ url: id }),
 					gcTombstoneEnforcementAllowed: this.gcTombstoneEnforcementAllowed,
 				},
 				undefined /* packagePath */,

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -42,7 +42,6 @@ export {
 	shouldAllowGcSweep,
 	trimLeadingAndTrailingSlashes,
 	unpackChildNodesGCDetails,
-	tagAsCodeArtifact,
 } from "./gcHelpers";
 export { runGarbageCollection } from "./gcReferenceGraphAlgorithm";
 export {

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -46,7 +46,6 @@ import {
 	GCVersion,
 	disableSweepLogKey,
 	stableGCVersion,
-	tagAsCodeArtifact,
 	IGarbageCollectionSnapshotData,
 } from "../../gc";
 import {
@@ -77,10 +76,7 @@ describe("Garbage Collection Tests", () => {
 	const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
 	// Nodes in the reference graph.
 	const nodes: string[] = ["/node1", "/node2", "/node3", "/node4"];
-
 	const testPkgPath = ["testPkg"];
-	// The package data is tagged in the telemetry event.
-	const eventPkg = tagAsCodeArtifact(testPkgPath.join("/"));
 
 	let injectedSettings: Record<string, ConfigTypes> = {};
 	let mockLogger: MockLogger;
@@ -318,29 +314,25 @@ describe("Garbage Collection Tests", () => {
 					{
 						eventName: loadedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[2] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[2], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 					{
 						eventName: changedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[2] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[2], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 					{
 						eventName: loadedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[3] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 					{
 						eventName: changedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[3] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 				);
@@ -358,8 +350,11 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: revivedEventName,
 							timeout,
-							pkg: eventPkg,
-							...tagCodeArtifacts({ id: nodes[3], fromId: nodes[1] }),
+							...tagCodeArtifacts({
+								id: nodes[3],
+								fromId: nodes[1],
+								pkg: testPkgPath.join("/"),
+							}),
 						},
 					],
 					"revived event not generated as expected",
@@ -404,8 +399,11 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: revivedEventName,
 							timeout,
-							pkg: eventPkg,
-							...tagCodeArtifacts({ id: nodes[2], fromId: nodes[1] }),
+							...tagCodeArtifacts({
+								id: nodes[2],
+								fromId: nodes[1],
+								pkg: testPkgPath.join("/"),
+							}),
 						},
 					],
 					"revived event not logged as expected",
@@ -446,14 +444,12 @@ describe("Garbage Collection Tests", () => {
 					{
 						eventName: loadedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[3] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 					},
 					{
 						eventName: changedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[3] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 					},
 				);
 				mockLogger.assertMatch(
@@ -534,14 +530,12 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: loadedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[3] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						},
 						{
 							eventName: changedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[3] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						},
 					],
 					"all events not generated as expected",
@@ -556,8 +550,11 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: revivedEventName,
 							timeout,
-							pkg: eventPkg,
-							...tagCodeArtifacts({ id: nodes[3], fromId: nodes[2] }),
+							...tagCodeArtifacts({
+								id: nodes[3],
+								fromId: nodes[2],
+								pkg: testPkgPath.join("/"),
+							}),
 						},
 					],
 					"revived event not generated as expected",
@@ -615,14 +612,12 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: loadedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[3] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						},
 						{
 							eventName: changedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[3] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						},
 					],
 					"all events not generated as expected",
@@ -637,8 +632,11 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: revivedEventName,
 							timeout,
-							pkg: eventPkg,
-							...tagCodeArtifacts({ id: nodes[3], fromId: nodes[2] }),
+							...tagCodeArtifacts({
+								id: nodes[3],
+								fromId: nodes[2],
+								pkg: testPkgPath.join("/"),
+							}),
 						},
 					],
 					"revived event not generated as expected",
@@ -705,9 +703,9 @@ describe("Garbage Collection Tests", () => {
 							{
 								eventName: deleteEventName,
 								timeout,
-								id: tagAsCodeArtifact(
-									JSON.stringify([nodes[1], nodes[2], nodes[3]]),
-								),
+								...tagCodeArtifacts({
+									id: JSON.stringify([nodes[1], nodes[2], nodes[3]]),
+								}),
 							},
 						],
 						"sweep ready event not generated as expected",
@@ -730,20 +728,17 @@ describe("Garbage Collection Tests", () => {
 						{
 							eventName: loadedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[3] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[3], pkg: testPkgPath.join("/") }),
 						},
 						{
 							eventName: changedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[1] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[1], pkg: testPkgPath.join("/") }),
 						},
 						{
 							eventName: changedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[2] }),
-							pkg: eventPkg,
+							...tagCodeArtifacts({ id: nodes[2], pkg: testPkgPath.join("/") }),
 						},
 					],
 					"all events not generated as expected",

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -24,7 +24,6 @@ import {
 	disableSweepLogKey,
 	UnreferencedStateTracker,
 	cloneGCData,
-	tagAsCodeArtifact,
 } from "../../gc";
 import { pkgVersion } from "../../packageVersion";
 import { BlobManager } from "../../blobManager";
@@ -281,7 +280,7 @@ describe("GC Telemetry Tracker", () => {
 				[
 					{
 						eventName: "GarbageCollector:GC_Tombstone_DataStore_Revived",
-						url: tagAsCodeArtifact(nodes[2]),
+						...tagCodeArtifacts({ url: nodes[2] }),
 					},
 				],
 				"inactive events not as expected",
@@ -368,29 +367,25 @@ describe("GC Telemetry Tracker", () => {
 					{
 						eventName: loadedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[1] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[1], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 					{
 						eventName: changedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[1] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[1], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 					{
 						eventName: loadedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[2] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[2], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 					{
 						eventName: changedEventName,
 						timeout,
-						...tagCodeArtifacts({ id: nodes[2] }),
-						pkg: eventPkg,
+						...tagCodeArtifacts({ id: nodes[2], pkg: testPkgPath.join("/") }),
 						createContainerRuntimeVersion: pkgVersion,
 					},
 				);
@@ -404,9 +399,11 @@ describe("GC Telemetry Tracker", () => {
 						{
 							eventName: revivedEventName,
 							timeout,
-							...tagCodeArtifacts({ id: nodes[2] }),
-							pkg: eventPkg,
-							fromId: tagAsCodeArtifact(nodes[0]),
+							...tagCodeArtifacts({
+								id: nodes[2],
+								fromId: nodes[0],
+								pkg: testPkgPath.join("/"),
+							}),
 						},
 					],
 					"revived event not as expected",
@@ -499,9 +496,11 @@ describe("GC Telemetry Tracker", () => {
 							{
 								eventName: revivedEventName,
 								timeout,
-								...tagCodeArtifacts({ id: nodes[2] }),
-								pkg: eventPkg,
-								fromId: tagAsCodeArtifact(nodes[1]),
+								...tagCodeArtifacts({
+									id: nodes[2],
+									fromId: nodes[1],
+									pkg: testPkgPath.join("/"),
+								}),
 							},
 						],
 						"revived event not as expected",

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -14,6 +14,7 @@ import {
 	LogLevel,
 	Tagged,
 	ITelemetryBaseProperties,
+	TelemetryBaseEventPropertyType,
 } from "@fluidframework/core-interfaces";
 import { IsomorphicPerformance, performance } from "@fluid-internal/client-utils";
 import { CachedConfigProvider, loggerIsMonitoringContext, mixinMonitoringContext } from "./config";
@@ -784,7 +785,7 @@ function convertToBasePropertyTypeUntagged(
 
 export const tagData = <
 	T extends TelemetryDataTag,
-	U extends TelemetryEventPropertyType,
+	U extends TelemetryBaseEventPropertyType,
 	V extends Record<string, U | (() => U)>,
 >(
 	tag: T,
@@ -831,9 +832,9 @@ export const tagData = <
 
 /**
  * Helper functions to tag telemetry properties as CodeArtifacts. These functions support properties of type
- * TelemetryEventPropertyType as well as getters that return TelemetryEventPropertyType.
+ * TelemetryBaseEventPropertyType as well as getters that return TelemetryBaseEventPropertyType.
  */
-export function tagCodeArtifacts<T extends Record<string, TelemetryEventPropertyType>>(
+export function tagCodeArtifacts<T extends Record<string, TelemetryBaseEventPropertyType>>(
 	values: T,
 ): {
 	[P in keyof T]:
@@ -844,7 +845,7 @@ export function tagCodeArtifacts<T extends Record<string, TelemetryEventProperty
 		| (T[P] extends undefined ? undefined : never);
 };
 export function tagCodeArtifacts<
-	T extends TelemetryEventPropertyType,
+	T extends TelemetryBaseEventPropertyType,
 	V extends Record<string, () => T>,
 >(
 	values: V,
@@ -857,7 +858,7 @@ export function tagCodeArtifacts<
 		| (V[P] extends undefined ? undefined : never);
 };
 export function tagCodeArtifacts<
-	T extends TelemetryEventPropertyType,
+	T extends TelemetryBaseEventPropertyType,
 	V extends Record<string, T | (() => T)>,
 >(
 	values: V,

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -816,13 +816,14 @@ export const tagData = <
 				  })
 				| (V[P] extends undefined ? undefined : never);
 		}>((pv, cv) => {
-			if (typeof cv[1] === "function") {
+			const [key, value] = cv;
+			if (typeof value === "function") {
 				// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-				pv[cv[0]] = () => {
-					return { tag, value: (cv[1] as () => Exclude<U, undefined>)() };
+				pv[key] = () => {
+					return { tag, value: (value as () => Exclude<U, undefined>)() };
 				};
 			} else {
-				pv[cv[0]] = { tag, value: cv[1] as Exclude<U, undefined> };
+				pv[key] = { tag, value: value as Exclude<U, undefined> };
 			}
 			return pv;
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { logIfFalse } from "../utils";
-import { TelemetryDataTag, tagData } from "../logger";
+import { TelemetryDataTag, tagCodeArtifacts, tagData } from "../logger";
 
 class TestLogger implements ITelemetryBaseLogger {
 	send(event: ITelemetryBaseEvent): void {
@@ -18,15 +18,15 @@ class TestLogger implements ITelemetryBaseLogger {
 describe("logIfFalse", () => {
 	it("logIfFalse undefined value is not undefined", () => {
 		const logger = new TestLogger();
-		const somthing: number | undefined = undefined;
-		const val = logIfFalse(somthing !== undefined, logger, "it's undefined");
+		const something: number | undefined = undefined;
+		const val = logIfFalse(something !== undefined, logger, "it's undefined");
 		assert.strictEqual(val, false);
 		assert.strictEqual(logger.events.length, 1);
 	});
 	it("logIfFalse value is not undefined", () => {
 		const logger = new TestLogger();
-		const somthing: number | undefined = 1;
-		const val = logIfFalse(somthing !== undefined, logger, "it's undefined");
+		const something: number | undefined = 1;
+		const val = logIfFalse(something !== undefined, logger, "it's undefined");
 		assert.strictEqual(val, true);
 		assert.strictEqual(logger.events.length, 0);
 	});
@@ -67,5 +67,77 @@ describe("tagData", () => {
 		};
 
 		assert.deepEqual(taggedData, expected);
+	});
+});
+
+describe("tagCodeArtifacts", () => {
+	it("tagCodeArtifacts with undefined", () => {
+		const taggedData = tagCodeArtifacts({ node: undefined });
+		const expected: Partial<typeof taggedData> = {};
+		assert.deepStrictEqual(taggedData, expected, "undefined not tagged as expected");
+	});
+
+	it("tagCodeArtifacts with TelemetryEventPropertyType", () => {
+		const taggedData = tagCodeArtifacts({
+			string: "foo",
+			number: 0,
+			boolean: true,
+			none: undefined,
+		});
+		const expected: Partial<typeof taggedData> = {
+			string: {
+				value: "foo",
+				tag: TelemetryDataTag.CodeArtifact,
+			},
+			number: {
+				value: 0,
+				tag: TelemetryDataTag.CodeArtifact,
+			},
+			boolean: {
+				value: true,
+				tag: TelemetryDataTag.CodeArtifact,
+			},
+		};
+		assert.deepStrictEqual(
+			taggedData,
+			expected,
+			"TelemetryEventPropertyType not tagged as expected",
+		);
+	});
+
+	it("tagCodeArtifacts with TelemetryEventPropertyType getters", () => {
+		const taggedData = tagCodeArtifacts({
+			string: () => "foo",
+			number: () => 0,
+			boolean: () => true,
+		});
+		const stringValue = taggedData.string();
+		const numberValue = taggedData.number();
+		const booleanValue = taggedData.boolean();
+
+		assert.deepStrictEqual(
+			stringValue,
+			{
+				tag: TelemetryDataTag.CodeArtifact,
+				value: "foo",
+			},
+			"string getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			numberValue,
+			{
+				tag: TelemetryDataTag.CodeArtifact,
+				value: 0,
+			},
+			"number getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			booleanValue,
+			{
+				tag: TelemetryDataTag.CodeArtifact,
+				value: true,
+			},
+			"boolean getter not tagged as expected",
+		);
 	});
 });

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -77,7 +77,7 @@ describe("tagCodeArtifacts", () => {
 		assert.deepStrictEqual(taggedData, expected, "undefined not tagged as expected");
 	});
 
-	it("tagCodeArtifacts with TelemetryEventPropertyType", () => {
+	it("tagCodeArtifacts with TelemetryBaseEventPropertyType", () => {
 		const taggedData = tagCodeArtifacts({
 			string: "foo",
 			number: 0,
@@ -101,11 +101,11 @@ describe("tagCodeArtifacts", () => {
 		assert.deepStrictEqual(
 			taggedData,
 			expected,
-			"TelemetryEventPropertyType not tagged as expected",
+			"TelemetryBaseEventPropertyType not tagged as expected",
 		);
 	});
 
-	it("tagCodeArtifacts with TelemetryEventPropertyType getters", () => {
+	it("tagCodeArtifacts with TelemetryBaseEventPropertyType getters", () => {
 		const taggedData = tagCodeArtifacts({
 			string: () => "foo",
 			number: () => 0,

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -77,7 +77,7 @@ describe("tagCodeArtifacts", () => {
 		assert.deepStrictEqual(taggedData, expected, "undefined not tagged as expected");
 	});
 
-	it("tagCodeArtifacts with TelemetryBaseEventPropertyType", () => {
+	it("tagCodeArtifacts with TelemetryBaseEventPropertyType properties", () => {
 		const taggedData = tagCodeArtifacts({
 			string: "foo",
 			number: 0,
@@ -137,6 +137,67 @@ describe("tagCodeArtifacts", () => {
 				tag: TelemetryDataTag.CodeArtifact,
 				value: true,
 			},
+			"boolean getter not tagged as expected",
+		);
+	});
+
+	it("tagCodeArtifacts with both TelemetryBaseEventPropertyType properties and getters", () => {
+		const expectedStringValue = {
+			tag: TelemetryDataTag.CodeArtifact,
+			value: "foo",
+		};
+		const expectedNumberValue = {
+			tag: TelemetryDataTag.CodeArtifact,
+			value: 0,
+		};
+		const expectedBooleanValue = {
+			tag: TelemetryDataTag.CodeArtifact,
+			value: true,
+		};
+
+		const taggedData = tagCodeArtifacts({
+			string: "foo",
+			number: 0,
+			boolean: true,
+			stringGetter: () => "foo",
+			numberGetter: () => 0,
+			booleanGetter: () => true,
+		});
+
+		// Validate basic properties are tagged.
+		assert.deepStrictEqual(
+			taggedData.string,
+			expectedStringValue,
+			"string property not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			taggedData.number,
+			expectedNumberValue,
+			"number property not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			taggedData.boolean,
+			expectedBooleanValue,
+			"boolean property not tagged as expected",
+		);
+
+		// Validate getters are tagged.
+		const stringValue = taggedData.stringGetter();
+		const numberValue = taggedData.numberGetter();
+		const booleanValue = taggedData.booleanGetter();
+		assert.deepStrictEqual(
+			stringValue,
+			expectedStringValue,
+			"string getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			numberValue,
+			expectedNumberValue,
+			"number getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			booleanValue,
+			expectedBooleanValue,
 			"boolean getter not tagged as expected",
 		);
 	});


### PR DESCRIPTION
## Description
#16520 changed how data store context's package name is logged. However, it doesn't work for scenarios where the data store is loaded from a snapshot - the package name will always be undefined because `this.pkg` will be initialized when the data store is realized.
This PR fixes that by making the following changes:
- Update `tagCodeArtifacts` to support passing in a getter property. The typings are really complex and the only way it worked was by adding function overrides that either support regular properties or getters.
- Updated data store context's logic to call `tagCodeArtifacts` twice - once for regular property and once for the getter for package.

Also, the deprecated `tagAsCodeArtifact` fuction usage by GC is removed.

[AB#5432](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5432)