### PR TITLE
Upload test results in multiple step to work around the force merge limit

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -129,6 +129,11 @@ extends:
       - ci:test:realsvc:tinylicious:full
     - ci:test:stress:tinylicious
     - test:copyresults
+    testResultDirs:
+    - nyc/azure
+    - nyc/examples
+    - nyc/experimental
+    - nyc/packages
     checks:
     - syncpack:deps
     - syncpack:versions

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -32,6 +32,11 @@ parameters:
   default:
   - ci:test
 
+- name: testResultDirs
+  type: object
+  default:
+  - nyc
+
 - name: taskBundleAnalysis
   type: boolean
   default: false
@@ -181,6 +186,7 @@ stages:
                 Lint=${{ parameters.taskLint }}
                 LintName: ${{ parameters.taskLintName }}
                 Test=${{ convertToJson(parameters.taskTest) }}
+                TestResultDirs=${{ convertToJson(parameters.testResultDirs) }}
                 BuildDoc=${{ parameters.taskBuildDocs }}
                 PublishDocs=${{ parameters.publishDocs }}
                 TestCoverage=$(testCoverage)
@@ -356,14 +362,15 @@ stages:
               condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
 
           # Test - Upload results
-          - task: PublishTestResults@2
-            displayName: Publish Test Results
-            inputs:
-              testResultsFormat: 'JUnit'
-              testResultsFiles: '**/*junit-report.xml'
-              searchFolder: ${{ parameters.buildDirectory }}/nyc
-              mergeTestResults: false
-            condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+          - ${{ each testResultDir in parameters.testResultDirs }}:
+            - task: PublishTestResults@2
+              displayName: Publish Test Results in ${{ testResultDir }}
+              inputs:
+                testResultsFormat: 'JUnit'
+                testResultsFiles: '**/*junit-report.xml'
+                searchFolder: ${{ parameters.buildDirectory }}/${{ testResultDir }}
+                mergeTestResults: false
+              condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
           # Publish tinylicious log for troubleshooting
           - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -32,7 +32,7 @@ parameters:
   default:
   - ci:test
 
-# A list of directory to run the PublishTestREsults task on in separate steps.
+# A list of directories (under the buildDirectory) to run the PublishTestResults task on in separate steps.
 # Used to avoid the force merge limit of 100 result files.
 - name: testResultDirs
   type: object

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -32,6 +32,8 @@ parameters:
   default:
   - ci:test
 
+# A list of directory to run the PublishTestREsults task on in separate steps.
+# Used to avoid the force merge limit of 100 result files.
 - name: testResultDirs
   type: object
   default:


### PR DESCRIPTION
ADO `PublishTestResults` task has a hard code force merge limit of 100 result files.  Merging the result of different packages makes it hard to navigate in the ADO UI.  So split the task into multiple ones to work around it.