### PR TITLE
fix: Wait for asynchronous code to fix flaky tests

### DIFF
--- a/common/lib/common-utils/src/test/jest/gitHash.spec.ts
+++ b/common/lib/common-utils/src/test/jest/gitHash.spec.ts
@@ -5,6 +5,7 @@
 
 import fs from "fs";
 import http from "http";
+import { AddressInfo } from "net";
 import path from "path";
 import rewire from "rewire";
 import * as HashNode from "../../hashFileNode";
@@ -105,9 +106,22 @@ describe("Common-Utils", () => {
 			res.setHeader("Content-Type", "text/plain");
 			res.end("basic test server");
 		});
-		server.listen(8080, "localhost");
+
+		await new Promise<void>((resolve) => {
+			server.listen(0, "localhost");
+			server.on("listening", () => {
+				resolve();
+			});
+			server.on("error", (err) => {
+				throw err;
+			});
+		});
+
+		// Since we're listening on an http port, address() will return an AddressInfo and not just a string
+		const port: number = (server.address() as AddressInfo).port;
+
 		// Navigate to the local test server so crypto is available
-		await page.goto("http://localhost:8080", { waitUntil: "load", timeout: 0 });
+		await page.goto(`http://localhost:${port}`, { waitUntil: "load", timeout: 0 });
 
 		xmlFile = await getFileContents(path.join(__dirname, `${dataDir}/assets/book.xml`));
 		svgFile = await getFileContents(path.join(__dirname, `${dataDir}/assets/bindy.svg`));
@@ -115,8 +129,10 @@ describe("Common-Utils", () => {
 		gifFile = await getFileContents(path.join(__dirname, `${dataDir}/assets/grid.gif`));
 	});
 
-	afterAll(() => {
-		server?.close();
+	afterAll(async () => {
+		await new Promise((resolve) => {
+			server?.close(resolve);
+		});
 	});
 
 	// Expected hashes are from git hash-object file...

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -5,6 +5,7 @@
 
 import fs from "fs";
 import http from "http";
+import { AddressInfo } from "net";
 import path from "path";
 import rewire from "rewire";
 import * as HashNode from "../../hashFileNode";
@@ -105,9 +106,22 @@ describe("Client-Utils", () => {
 			res.setHeader("Content-Type", "text/plain");
 			res.end("basic test server");
 		});
-		server.listen(8080, "localhost");
+
+		await new Promise<void>((resolve) => {
+			server.listen(0, "localhost");
+			server.on("listening", () => {
+				resolve();
+			});
+			server.on("error", (err) => {
+				throw err;
+			});
+		});
+
+		// Since we're listening on an http port, address() will return an AddressInfo and not just a string
+		const port: number = (server.address() as AddressInfo).port;
+
 		// Navigate to the local test server so crypto is available
-		await page.goto("http://localhost:8080", { waitUntil: "load", timeout: 0 });
+		await page.goto(`http://localhost:${port}`, { waitUntil: "load", timeout: 0 });
 
 		xmlFile = await getFileContents(path.join(__dirname, `${dataDir}/assets/book.xml`));
 		svgFile = await getFileContents(path.join(__dirname, `${dataDir}/assets/bindy.svg`));
@@ -115,8 +129,10 @@ describe("Client-Utils", () => {
 		gifFile = await getFileContents(path.join(__dirname, `${dataDir}/assets/grid.gif`));
 	});
 
-	afterAll(() => {
-		server?.close();
+	afterAll(async () => {
+		await new Promise((resolve) => {
+			server?.close(resolve);
+		});
 	});
 
 	// Expected hashes are from git hash-object file...


### PR DESCRIPTION
## Description

Since https://github.com/microsoft/FluidFramework/pull/16856 was merged we've seen the tests that were copied to the new client-utils package failing every now and then, complaining of `Error: net::ERR_CONNECTION_REFUSED at http://localhost:8080`. I realized the code that starts the server is not waiting for the server to finish initialization (`server.listen()` is not `async` but [docs](https://nodejs.org/docs/latest-v18.x/api/net.html#serverlisten) are clear that it's asynchronous and the `listening` event is emitted when the server is ready), so I imagine every now and then it'll try to navigate to the URL before the server is ready.

I applied the same fix to the tear-down of the server object to address a warning we were hitting sometimes: `A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.`. This seems to have added a few seconds to the overall test run time for client-utils but I think it's not too bad for clean output.

Finally, I removed the explicit port 8080 so the OS can assign an unused one. Not an issue today, but should make things a bit more robust against port collisions if we start having other tests that start http servers.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I was able to reproduce the `ERR_CONNECTION_REFUSED` problem locally _a few times_ by pushing a Codespaces instance to 100% CPU usage with the `stress` tool. I could not reproduce it with the change applied, but note that it also did not reproduce consistently even at 100% CPU usage.

I tried using our `timeoutPromise` utility from `@fluidframework/test-utils` to try to prevent potential long timeouts from unexpected hangs, but adding a dependency on `"@fluidframework/test-utils": "workspace:~"`, to client-utils causes a circular dependency:

```
[152][21:23:13] npm run build

> @fluid-internal/client-utils@2.0.0-internal.6.3.0 build
> fluid-build . --task build

Fluid Repo Root: /workspaces/FluidFramework
        @fluid-internal/client-utils matched (.)
Symlink in isolated mode
ERROR: Circular Reference detected @fluidframework/aqueduct -> @fluid-internal/client-utils
```

Maybe we should move `packages/test/test-utils/src/timeoutUtils.ts` to the `core-utils` package.