### PR TITLE
Fix pipeline script error when there are test errors

### DIFF
--- a/scripts/report-parser.js
+++ b/scripts/report-parser.js
@@ -5,18 +5,19 @@
 
 /**
  * Parsing script which finds all test reports ending with "junit-report.json"
- * in a given directory and prints failed tests into the console
+ * in a given directory and prints ADO pipeline errors into the console
  */
 
 var fs = require("fs");
-var util = require("util");
 var path = require("path");
 
 var directory = process.argv.slice(2)[0];
 
-let files = [];
-
 const getJunitTestReports = (directory) => {
+	if (!fs.existsSync(directory)) {
+		throw new Error(`'${directory}' does not exist`);
+	}
+	const files = [];
 	const filesInDirectory = fs.readdirSync(directory);
 	for (const file of filesInDirectory) {
 		const absolute = path.join(directory, file);
@@ -26,17 +27,21 @@ const getJunitTestReports = (directory) => {
 			files.push(absolute);
 		}
 	}
+	return files;
 };
 
-getJunitTestReports(directory);
+const files = getJunitTestReports(directory);
 
-let output = [];
 for (const filename of files) {
-	const jsonData = fs.readFileSync(filename, "utf8");
+	const content = fs.readFileSync(filename, "utf8");
+	const json = JSON.parse(content);
+	const failedTests = json.failures;
 
-	const failedTests = JSON.parse(jsonData).failures;
-
-	if (failedTests.length > 0) output.push(failedTests);
+	if (failedTests.length > 0) {
+		console.log(
+			failedTests
+				.map((e) => `##vso[task.logissue type=error;sourcepath=${e.file}]${e.fullTitle}`)
+				.join("\n"),
+		);
+	}
 }
-
-console.log(util.inspect(output, false, null, true));

--- a/scripts/report-parser.js
+++ b/scripts/report-parser.js
@@ -15,7 +15,8 @@ var directory = process.argv.slice(2)[0];
 
 const getJunitTestReports = (directory) => {
 	if (!fs.existsSync(directory)) {
-		throw new Error(`'${directory}' does not exist`);
+		console.log(`##vso[task.logissue type=warning]${directory} does not exist`);
+		return [];
 	}
 	const files = [];
 	const filesInDirectory = fs.readdirSync(directory);

--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -41,6 +41,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -58,6 +59,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -53,6 +53,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
     # Relevant to the test-azure-frs pipeline
     - packages/dds/map
     - packages/drivers/routerlicious-driver
@@ -84,6 +85,7 @@ pr:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
     # Relevant to the test-azure-frs pipeline
     - packages/dds/map
     - packages/drivers/routerlicious-driver

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -45,6 +45,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -62,6 +63,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -64,6 +65,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -56,6 +56,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -73,6 +74,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -71,6 +71,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -98,6 +99,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -64,6 +65,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -64,6 +65,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -44,6 +44,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -58,6 +59,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -44,6 +44,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -58,6 +59,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-docs-site.yml
+++ b/tools/pipelines/build-docs-site.yml
@@ -24,6 +24,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -44,6 +44,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -58,6 +59,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -64,6 +65,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-markdown-magic.yml
+++ b/tools/pipelines/build-markdown-magic.yml
@@ -41,6 +41,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -58,6 +59,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -64,6 +65,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -44,6 +44,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -60,6 +61,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 pr:
   branches:
@@ -64,6 +65,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/include-log-test-failures.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/templates/include-log-test-failures.yml
+++ b/tools/pipelines/templates/include-log-test-failures.yml
@@ -7,28 +7,11 @@ parameters:
 
 # Log test failures
 steps:
-  # Check Published Tests
-  - task: Bash@3
-    displayName: 'Check for nyc directory'
-    inputs:
-      targetType: 'inline'
-      workingDirectory: ${{ parameters.buildDirectory }}
-      script: |
-        test -d nyc && echo '##vso[task.setvariable variable=TestReportsExists;]true' || echo 'No nyc directory'
-    condition: succeededOrFailed()
-
   # Console Log Failed Tests
   - task: Bash@3
     displayName: Log Failed Tests
     inputs:
       targetType: inline
-      script: |
-        failedTests=$(node report-parser.js '$(Build.SourcesDirectory)/nyc')
-        if [ $failedTests == [] ]
-        then
-          echo "No failed tests."
-        else
-          echo "##[error] $failedTests"
-        fi
-      workingDirectory: scripts
-    condition: eq(variables['TestReportsExists'], 'true')
+      script: node $(Build.SourcesDirectory)/scripts/report-parser.js 'nyc'
+      workingDirectory: ${{ parameters.buildDirectory }}
+    condition: succeededOrFailed()


### PR DESCRIPTION
When there are script error, the "Log Test error" steps would have a script error `[: too many arguments` because of lack of quotes.

While fixing this, I improved how it works:
- Simplify the shell script to just invoking the `report-parser.js` and having the JS script output the ADO messages.
- Change to use ADO logissue message to get it into the UI.

Now if there are test errors, it will show up in the run UI instead of having to dig into the Test tab.  For example:

![image](https://github.com/microsoft/FluidFramework/assets/12101885/32eea400-a6a6-4c49-89ac-95302c31fc62)

Also add the pipeline template as a dependency so that change to the template will trigger the pipelines that uses it.
