### PR TITLE
test: Increase timeout for SharedMatrix stress tests in response to flaky tests

### DIFF
--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -390,7 +390,7 @@ describe("Matrix", () => {
 				.toString(16)
 				.padStart(8, "0")})`, async function () {
 				// Note: Must use 'function' rather than arrow '() => { .. }' in order to set 'this.timeout(..)'
-				this.timeout(20000);
+				this.timeout(25000);
 
 				await stress(
 					numClients,


### PR DESCRIPTION
## Description

Increase timeout for matrix stress tests. We've had a few recent failures of this test in CI ([here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=187420&view=ms.vss-test-web.build-test-results-tab), [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=187156&view=ms.vss-test-web.build-test-results-tab)) because it goes above the 20s timeout, specifically for the 0x655c763b seed which consistently takes ~14.5s locally with almost no other CPU usage.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

