### PR TITLE
Events listener customer service endpoint

### DIFF
--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -68,7 +68,7 @@ export interface SessionEndEventsListenerRequest extends EventsListenerRequest {
 		 */
 		type: "session-end";
 		/**
-		 * The url of the Fluid container whose session has ended.
+		 * The URL of the Fluid container whose session has ended.
 		 */
 		containerUrl: string;
 	};
@@ -220,7 +220,7 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 	 *
 	 * Note: Implementers choice --can choose to break up containerUrl into multiple pieces
 	 * containing tenantId, documentId and socketStreamURL separately and send them as a json
-	 * object. The URL also contains all this information so for simplicity I use the url here.
+	 * object. The URL also contains all this information so for simplicity I use the URL here.
 	 */
 	expressApp.post("/register-session-url", (request, result) => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -248,7 +248,7 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 					"Content-Type": "application/json",
 				},
 				body: JSON.stringify({
-					// External data service will call our webhook echoer to notify our subscribers of the data changes.
+					// The external data service will call this service's own webhook echoer endpoint which will in turn notify our subscribers of the data changes.
 					url: `http://localhost:${port}/external-data-webhook?externalTaskListId=${externalTaskListId}`,
 					externalTaskListId,
 				}),
@@ -276,9 +276,9 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 	/**
 	 * An 'events' endpoint that can be called by Fluid services.
 	 *
-	 * For the 'session-end' event {@link SessionEndEventsListenerRequest}: If, after unregistering the given client url, there are any task ids that have an outstanding
-	 * webhook registered using this services internal '/external-data-webhook' endpoint but has no respective active client sessions mapped to it anymore,
-	 * then that webhook will be deregistered.
+	 * For the 'session-end' event {@link SessionEndEventsListenerRequest}: If after unregistering the given client URL, there are any task ids that have an outstanding
+	 * webhook registered using this service's internal '/external-data-webhook' endpoint but has no respective active client sessions mapped to them anymore,
+	 * then those webhooks will be deregistered.
 	 *
 	 * @remarks Currently, the only supported request type is 'session-end' {@link SessionEndEventsListenerRequest} which enables the Fluid service to notify this service
 	 * that a particular Fluid session has ended which in turn causes this service to unregister any related webhooks to the respective Fluid session.

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -280,8 +280,9 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 	/**
 	 * An 'events' endpoint that can be called by Fluid services.
 	 *
-	 * For the 'session-end' event: If, after unregistering the given url, there are any task ids that has an outstanding webhook registered using this services internal
-	 * '/external-data-webhook' endpoint but has no respective active client sessions mapped to it anymore, then that webhook will be deregistered.
+	 * For the 'session-end' event {@link SessionEndEventsListenerRequest}: If, after unregistering the given client url, there are any task ids that have an outstanding
+	 * webhook registered using this services internal '/external-data-webhook' endpoint but has no respective active client sessions mapped to it anymore,
+	 * then that webhook will be deregistered.
 	 *
 	 * @remarks Currently, the only supported request type is 'session-end' {@link SessionEndEventsListenerRequest} which enables the Fluid service to notify this service
 	 * that a particular Fluid session has ended which in turn causes this service to unregister any related webhooks to the respective Fluid session.

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -71,10 +71,6 @@ export interface SessionEndEventsListenerRequest extends EventsListenerRequest {
 		 * The url of the Fluid container whose session has ended.
 		 */
 		containerUrl: string;
-		/**
-		 * The external task list id that the container was subscribed to change notifications for.
-		 */
-		externalTaskListId: string;
 	};
 }
 
@@ -295,12 +291,6 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 			const containerUrl = typedRequest.body?.containerUrl;
 			if (containerUrl === undefined || typeof containerUrl !== "string") {
 				const errorMessage = `Missing or malformed containerUrl: ${containerUrl}`;
-				result.status(400).json({ message: errorMessage });
-				return;
-			}
-			const externalTaskListId = typedRequest.body?.externalTaskListId;
-			if (externalTaskListId === undefined || typeof externalTaskListId !== "string") {
-				const errorMessage = `Missing or malformed externalTaskListIdValue: ${externalTaskListId}`;
 				result.status(400).json({ message: errorMessage });
 				return;
 			}

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -68,7 +68,7 @@ export interface SessionEndEventsListenerRequest extends EventsListenerRequest {
 		 */
 		type: "session-end";
 		/**
-		 * The url of the fluid container whose session has ended.
+		 * The url of the Fluid container whose session has ended.
 		 */
 		containerUrl: string;
 		/**
@@ -280,8 +280,8 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 	/**
 	 * An 'events' endpoint that can be called by Fluid services.
 	 *
-	 * @remarks Currently, the only supported request type is 'session-end' {@link SessionEndEventsListenerRequest} which enables a the fluid service to notify this service
-	 * that a particular fluid session has ended which in turn causes this service to unregister any related webhooks to the respective fluid session.
+	 * @remarks Currently, the only supported request type is 'session-end' {@link SessionEndEventsListenerRequest} which enables the Fluid service to notify this service
+	 * that a particular Fluid session has ended which in turn causes this service to unregister any related webhooks to the respective Fluid session.
 	 */
 	expressApp.post("/events-listener", (request: EventsListenerRequest, result) => {
 		const eventType = request.body?.type;

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -323,8 +323,8 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 				});
 			}
 		} else {
-			const errorMessage = `Unexpected event type; ${eventType}`;
-			console.error(formatLogMessage(`Unexpected event type; ${eventType}`));
+			const errorMessage = `Unexpected event type: ${eventType}`;
+			console.error(formatLogMessage(errorMessage));
 			result.status(400).json({ errorMessage });
 		}
 

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -279,7 +279,8 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 
 	/**
 	 * An 'events' endpoint that can be called by Fluid services.
-	 * Currently, the only supported request type is 'session-end' {@link SessionEndEventsListenerRequest} which enables a the fluid service to notify this service
+	 *
+	 * @remarks Currently, the only supported request type is 'session-end' {@link SessionEndEventsListenerRequest} which enables a the fluid service to notify this service
 	 * that a particular fluid session has ended which in turn causes this service to unregister any related webhooks to the respective fluid session.
 	 */
 	expressApp.post("/events-listener", (request: EventsListenerRequest, result) => {

--- a/examples/external-data/src/mock-customer-service/start.ts
+++ b/examples/external-data/src/mock-customer-service/start.ts
@@ -14,6 +14,7 @@ import { initializeCustomerService } from "./service";
 initializeCustomerService({
 	port: customerServicePort,
 	externalDataServiceWebhookRegistrationUrl: `http://localhost:${externalDataServicePort}/register-for-webhook`,
+	externalDataServiceWebhookUnregistrationUrl: `http://localhost:${externalDataServicePort}/unregister-webhook`,
 	fluidServiceUrl: `http://localhost:${fluidServicePort}/broadcast-signal`,
 }).catch((error) => {
 	console.error(`There was an error initializing the mock customer service:\n${error}`);

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -243,8 +243,8 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 				// 3a. Webhook exists but the provided subscriber is not subscribed with the webhook.
 				const resultMessage =
 					"Provided subscriberUrl does not have a webhook registered for the given externalTaskListId";
-				result.status(200).json({ message: resultMessage });
 				console.info(formatLogMessage(resultMessage));
+				result.status(200).json({ message: resultMessage });
 			} else {
 				// 3b. Webhook exists and the provided subcriber is currently subscribed to it.
 				webhook.removeSubscriber(subscriberUrl);

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -51,7 +51,7 @@ export interface RegisterWebhookRequest extends express.Request {
 		 */
 		url: string;
 		/**
-		 * The id of the task list to subscribe to change notifications for
+		 * The ID of the task list to subscribe to change notifications for
 		 */
 		externalTaskListId: string;
 	};
@@ -68,7 +68,7 @@ export interface UnregisterWebhookRequest extends express.Request {
 		 */
 		url: string;
 		/**
-		 * The id of the task list to unsubscribe to change notifications for
+		 * The ID of the task list to unsubscribe to change notifications for
 		 */
 		externalTaskListId: string;
 	};
@@ -192,7 +192,11 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 			);
 		} catch (error) {
 			if (error instanceof ApiError) {
-				console.warn(formatLogMessage(error.message));
+				if (error.code >= 500) {
+					console.error(formatLogMessage(error.message));
+				} else {
+					console.warn(formatLogMessage(error.message));
+				}
 				result.status(error.code).json({ message: error.message });
 			} else {
 				console.error(error);

--- a/examples/external-data/src/utilities/clientManager.ts
+++ b/examples/external-data/src/utilities/clientManager.ts
@@ -93,4 +93,29 @@ export class ClientManager<TData = unknown> {
 			taskListClients.delete(client);
 		}
 	}
+
+	/**
+	 * De-registers the provided subscriber URL from future notifications for all existing tasks it is subscribed to.
+	 * @returns A list of task list id's who no longer have any client sessions mapped to them.
+	 */
+	public removeAllClientTaskListRegistrations(client: ClientSessionUrl): string[] {
+		const clientTaskListIds = this._clientMapping.get(client);
+		const emptyTaskListRegistrationIds: string[] = [];
+		if (clientTaskListIds !== undefined) {
+			for (const taskListId of clientTaskListIds) {
+				const taskListClients = this._taskListMapping.get(taskListId);
+				// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+				if (taskListClients !== undefined && taskListClients.has(client)) {
+					taskListClients.delete(client);
+					if (taskListClients.size === 0) {
+						emptyTaskListRegistrationIds.push(taskListId);
+						this._taskListMapping.delete(taskListId);
+					}
+				}
+			}
+			clientTaskListIds.clear();
+		}
+
+		return emptyTaskListRegistrationIds;
+	}
 }

--- a/examples/external-data/src/utilities/clientManager.ts
+++ b/examples/external-data/src/utilities/clientManager.ts
@@ -96,7 +96,7 @@ export class ClientManager<TData = unknown> {
 
 	/**
 	 * De-registers the provided subscriber URL from future notifications for all existing tasks it is subscribed to.
-	 * @returns A list of task list id's who no longer have any client sessions mapped to them.
+	 * @returns A list of task list ID's that no longer have any client sessions mapped to them.
 	 */
 	public removeAllClientTaskListRegistrations(client: ClientSessionUrl): string[] {
 		const clientTaskListIds = this._clientMapping.get(client);

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -70,6 +70,15 @@ const registerSessionWithCustomerService = async (
 };
 
 /**
+ * Helper function to configure a local express server meant to simulate the Fluid service.
+ */
+const initializeMockFluidService = (localServiceApp: express.Express): express.Express => {
+	localServiceApp.use(express.json());
+	localServiceApp.use(cors());
+	return localServiceApp;
+};
+
+/**
  * @remarks
  *
  * These tests spin up their own Express server instances so we can directly test against it
@@ -124,9 +133,7 @@ describe("mock-customer-service", () => {
 	// So for these tests we have to live with `any`.
 	it("register-for-webhook: Complete data flow", async () => {
 		// Set up mock local service, which will be registered as webhook listener
-		const localServiceApp = express();
-		localServiceApp.use(express.json());
-		localServiceApp.use(cors());
+		const localServiceApp = initializeMockFluidService(express());
 
 		// Bind listener
 		let wasFluidNotifiedForChange = false;
@@ -190,10 +197,8 @@ describe("mock-customer-service", () => {
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
 	it("register-session-url: Complete data flow", async () => {
-		// Set up mock local service, which will be registered as webhook listener
-		const localServiceApp = express();
-		localServiceApp.use(express.json());
-		localServiceApp.use(cors());
+		// Set up mock local Fluid service, which will be registered as webhook listener
+		const localServiceApp = initializeMockFluidService(express());
 
 		// Bind listener
 		let webhookChangeNotification;
@@ -245,10 +250,8 @@ describe("mock-customer-service", () => {
 	});
 
 	it("events-listener: Complete data flow for session-end event", async () => {
-		// Set up mock local service, which will be registered as webhook listener
-		const localServiceApp = express();
-		localServiceApp.use(express.json());
-		localServiceApp.use(cors());
+		// Set up mock local Fluid service, which will be registered as webhook listener
+		const localServiceApp = initializeMockFluidService(express());
 
 		// Bind listener
 		let webhookChangeNotification;

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -305,7 +305,6 @@ describe("mock-customer-service", () => {
 					body: JSON.stringify({
 						type: "session-end",
 						containerUrl,
-						externalTaskListId,
 					}),
 				},
 			);

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -7,7 +7,7 @@ import type { Server } from "http";
 
 import cors from "cors";
 import express from "express";
-import fetch from "node-fetch";
+import fetch, { Response } from "node-fetch";
 
 import { delay } from "@fluidframework/core-utils";
 
@@ -20,6 +20,55 @@ import { closeServer } from "./utilities";
 
 const localServicePort = 5002;
 const externalTaskListId = "task-list-1";
+
+/**
+ * Helper function for updating data within the external data service.
+ * It also tests the response for a given code as well and will fail if it doesnt match.
+ */
+const updateExternalData = async (data: ITaskData, taskListId: string): Promise<Response> => {
+	const dataUpdateResponse = await fetch(
+		`http://localhost:${externalDataServicePort}/set-tasks/${taskListId}`,
+		{
+			method: "POST",
+			headers: {
+				"Access-Control-Allow-Origin": "*",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				taskList: {
+					...data,
+				},
+			}),
+		},
+	);
+
+	return dataUpdateResponse;
+};
+
+/**
+ * Helper function for registering a Fluid session with the customer service.
+ */
+const registerSessionWithCustomerService = async (
+	taskListId: string,
+	containerUrl: string,
+): Promise<Response> => {
+	const registerSessionUrl = await fetch(
+		`http://localhost:${customerServicePort}/register-session-url`,
+		{
+			method: "POST",
+			headers: {
+				"Access-Control-Allow-Origin": "*",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				externalTaskListId: taskListId,
+				containerUrl,
+			}),
+		},
+	);
+	return registerSessionUrl;
+};
+
 /**
  * @remarks
  *
@@ -53,6 +102,7 @@ describe("mock-customer-service", () => {
 		customerService = await initializeCustomerService({
 			port: customerServicePort,
 			externalDataServiceWebhookRegistrationUrl: `http://localhost:${externalDataServicePort}/register-for-webhook`,
+			externalDataServiceWebhookUnregistrationUrl: `http://localhost:${externalDataServicePort}/unregister-webhook`,
 			fluidServiceUrl: `http://localhost:${localServicePort}/broadcast-signal`,
 		});
 	});
@@ -80,7 +130,10 @@ describe("mock-customer-service", () => {
 
 		// Bind listener
 		let wasFluidNotifiedForChange = false;
-		localServiceApp.post("/broadcast-signal", (_, result) => {
+		let webhookChangeNotification;
+		localServiceApp.post("/broadcast-signal", (request, result) => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			webhookChangeNotification = request.body;
 			wasFluidNotifiedForChange = true;
 			result.send();
 		});
@@ -109,27 +162,15 @@ describe("mock-customer-service", () => {
 			}
 
 			// Update external data
-			const dataUpdateResponse = await fetch(
-				`http://localhost:${externalDataServicePort}/set-tasks/${externalTaskListId}`,
-				{
-					method: "POST",
-					headers: {
-						"Access-Control-Allow-Origin": "*",
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({
-						taskList: {
-							42: {
-								name: "Determine the meaning of life",
-								priority: 37,
-							},
-						},
-					}),
+			const taskDataUpdate = {
+				42: {
+					name: "Determine the meaning of life",
+					priority: 37,
 				},
-			);
-
-			if (!dataUpdateResponse.ok) {
-				fail(`Data update failed. Code: ${dataUpdateResponse.status}.`);
+			};
+			const dataUpdateResponse = await updateExternalData(taskDataUpdate, externalTaskListId);
+			if (dataUpdateResponse.status !== 200) {
+				fail(`Data update failed. Code: ${dataUpdateResponse.status}`);
 			}
 
 			// Delay for a bit to ensure time enough for our webhook listener to have been called.
@@ -137,6 +178,9 @@ describe("mock-customer-service", () => {
 
 			// Verify our listener was notified of data change.
 			expect(wasFluidNotifiedForChange).toBe(true);
+			expect(webhookChangeNotification).toMatchObject({
+				data: taskDataUpdate,
+			});
 		} catch (error) {
 			fail(error);
 		} finally {
@@ -144,4 +188,151 @@ describe("mock-customer-service", () => {
 		}
 	});
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+	it("register-session-url: Complete data flow", async () => {
+		// Set up mock local service, which will be registered as webhook listener
+		const localServiceApp = express();
+		localServiceApp.use(express.json());
+		localServiceApp.use(cors());
+
+		// Bind listener
+		let webhookChangeNotification;
+		localServiceApp.post("/broadcast-signal", (request, result) => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			webhookChangeNotification = request.body;
+			result.send();
+		});
+
+		const localService: Server = localServiceApp.listen(localServicePort);
+
+		const containerUrl = "https://www.mockFluidFrameworkService.com/container1";
+
+		try {
+			// 1. Register Fluid container url for notifications with the customer service
+			const registerSessionUrl = await registerSessionWithCustomerService(
+				externalTaskListId,
+				containerUrl,
+			);
+			expect(registerSessionUrl.status).toBe(200);
+
+			// 2. Update external data within the external data service,
+			// which should relay the changes to the customer notification service.
+			const taskDataUpdate = {
+				42: {
+					name: "Determine the meaning of life",
+					priority: 37,
+				},
+			};
+			const dataUpdateResponse = await updateExternalData(taskDataUpdate, externalTaskListId);
+			if (dataUpdateResponse.status !== 200) {
+				fail(`Data update failed. Code: ${dataUpdateResponse.status}`);
+			}
+
+			// Delay for a bit to ensure time enough for our webhook listener to have been called.
+			await delay(1000);
+
+			// Verify our listener was notified of data change.
+			expect(webhookChangeNotification).toMatchObject({
+				containerUrl,
+				externalTaskListId,
+				taskData: taskDataUpdate,
+			});
+		} catch (error) {
+			fail(error);
+		} finally {
+			await closeServer(localService);
+		}
+	});
+
+	it("events-listener: Complete data flow for session-end event", async () => {
+		// Set up mock local service, which will be registered as webhook listener
+		const localServiceApp = express();
+		localServiceApp.use(express.json());
+		localServiceApp.use(cors());
+
+		// Bind listener
+		let webhookChangeNotification;
+		localServiceApp.post("/broadcast-signal", (request, result) => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			webhookChangeNotification = request.body;
+			result.send();
+		});
+
+		const localService: Server = localServiceApp.listen(localServicePort);
+
+		const containerUrl = "https://www.mockFluidFrameworkService.com/container1";
+
+		try {
+			// 1. Register Fluid container url for notifications with the customer service
+			const registerSessionUrl = await registerSessionWithCustomerService(
+				externalTaskListId,
+				containerUrl,
+			);
+			expect(registerSessionUrl.status).toBe(200);
+
+			// 2. Update external data within the external data service,
+			// which should relay the changes to the customer notification service.
+			const taskDataUpdate = {
+				42: {
+					name: "Determine the meaning of life",
+					priority: 37,
+				},
+			};
+			const dataUpdateResponse = await updateExternalData(taskDataUpdate, externalTaskListId);
+			expect(dataUpdateResponse.status).toBe(200);
+
+			// Delay for a bit to ensure time enough for our webhook listener to have been called.
+			await delay(1000);
+			// Verify our listener was notified of data change.
+			expect(webhookChangeNotification).toMatchObject({
+				containerUrl,
+				externalTaskListId,
+				taskData: taskDataUpdate,
+			});
+			// Set the webhookChangeNotification variable back to undefined.
+			webhookChangeNotification = undefined;
+
+			// 3. Tell the customer service that the session has ended, which should
+			// unregister the outstanding webhook for the given container url and task list id
+			const sessionEndEventResponse = await fetch(
+				`http://localhost:${customerServicePort}/events-listener`,
+				{
+					method: "POST",
+					headers: {
+						"Access-Control-Allow-Origin": "*",
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						type: "session-end",
+						containerUrl,
+						externalTaskListId,
+					}),
+				},
+			);
+			expect(sessionEndEventResponse.status).toBe(200);
+
+			// 4. Update external data within the external data service,
+			// which should relay the changes to the customer notification service.
+			const taskDataUpdate2 = {
+				42: {
+					name: "Some other task name",
+					priority: 52,
+				},
+			};
+			const dataUpdateResponse2 = await updateExternalData(
+				taskDataUpdate2,
+				externalTaskListId,
+			);
+			expect(dataUpdateResponse2.status).toBe(200);
+
+			// Delay for a bit to ensure time enough for our webhook listener to have been called.
+			await delay(1000);
+			// Verify that we did not recieve a new change notification
+			expect(webhookChangeNotification).toBeUndefined();
+		} catch (error) {
+			fail(error);
+		} finally {
+			await closeServer(localService);
+		}
+	});
 });

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -208,7 +208,7 @@ describe("mock-customer-service", () => {
 		const containerUrl = "https://www.mockFluidFrameworkService.com/container1";
 
 		try {
-			// 1. Register Fluid container url for notifications with the customer service
+			// 1. Register Fluid container URL for notifications with the customer service
 			const registerSessionUrl = await registerSessionWithCustomerService(
 				externalTaskListId,
 				containerUrl,
@@ -263,7 +263,7 @@ describe("mock-customer-service", () => {
 		const containerUrl = "https://www.mockFluidFrameworkService.com/container1";
 
 		try {
-			// 1. Register Fluid container url for notifications with the customer service
+			// 1. Register Fluid container URL for notifications with the customer service
 			const registerSessionUrl = await registerSessionWithCustomerService(
 				externalTaskListId,
 				containerUrl,
@@ -293,7 +293,7 @@ describe("mock-customer-service", () => {
 			webhookChangeNotification = undefined;
 
 			// 3. Tell the customer service that the session has ended, which should
-			// unregister the outstanding webhook for the given container url and task list id
+			// unregister the outstanding webhook for the given container URL and task list id
 			const sessionEndEventResponse = await fetch(
 				`http://localhost:${customerServicePort}/events-listener`,
 				{


### PR DESCRIPTION
## Description
- Creates a new `/events-listener` endpoint in the mock customer service that
1) Check what kind of event it is. The only kind we'll send right now is a "session-end" one.
2) If the event is "session-end", then: call ClientManager to remove it's mapping of Session to client.
3) Call the External Service API to remove the subscription to External Service (might need to create a new endpoint in order to do this in External Service)

This PR is built on top of the changes in https://github.com/microsoft/FluidFramework/pull/17036,
Just look at the following files for the additional changes:
- `/mock-customer-service/service.ts`
- `/mock-customer-service/start.ts`
- `/tests/customerService.test.ts`

I decided to add a new test for `/register-session-url` since that was missing.

## Breaking Changes

- none

## Reviewer Guidance
- Consider the idea that the current state of the session end endpoint only allows you to unregister a single task list id from a given container. Realistically, a container may have multiple task list ids. At the moment I think this app is structured such that a single containerUrl is mapped to a single external task list id so it may be best to have a different task for this refactor.


