### PR TITLE
[Data Migration] Initial stub-out for SameContainerMigrator

### DIFF
--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -50,6 +50,12 @@ export class SameContainerMigrator
 	 * If migration is in progress, the promise that will resolve when it completes.  Mutually exclusive with
 	 * _migratedLoadP promise.
 	 */
+	private _migrationPrepareP: Promise<void> | undefined;
+
+	/**
+	 * If migration is in progress, the promise that will resolve when it completes.  Mutually exclusive with
+	 * _migratedLoadP promise.
+	 */
 	private _migrationP: Promise<void> | undefined;
 
 	/**
@@ -73,181 +79,138 @@ export class SameContainerMigrator
 		this._currentModel = initialMigratable;
 		this._currentModelId = initialId;
 		this._currentModel.migrationTool.setContainerRef(this._currentModel.container);
-		this.takeAppropriateActionForCurrentMigratable();
+		this.ensureMigration();
 	}
 
-	/**
-	 * This method makes no assumptions about the state of the current migratable - this is particularly important
-	 * for the case that we just finished loading a migrated container, but that migrated container is also either
-	 * in the process of migrating or already migrated (and thus we need to load again).  It is not safe to assume
-	 * that a freshly-loaded migrated container is in collaborating state.
-	 */
-	private readonly takeAppropriateActionForCurrentMigratable = () => {
-		// TODO: Real stuff
-		// const migrationState = this._currentModel.migrationTool.migrationState;
-		// if (migrationState === "migrating") {
-		// 	this.ensureMigrating();
-		// } else if (migrationState === "migrated") {
-		// 	this.ensureLoading();
-		// } else {
-		// 	this._currentModel.migrationTool.once(
-		// 		"migrating",
-		// 		this.takeAppropriateActionForCurrentMigratable,
-		// 	);
-		// }
-		// TODO: One responsibility here will be generating the v2 summary
-
-		// TODO: Remove this log when actually using.
-		console.info(
-			"Just logging these to quiet the 'unused member' error: ",
-			this.ensureMigrating,
-			this.ensureLoading,
-		);
-	};
-
-	private readonly ensureMigrating = () => {
-		// ensureMigrating() is called when we reach the "migrating" state. This should likely only happen once, but
-		// can happen multiple times if we disconnect during the migration process.
-
-		if (!this.connected) {
-			// If we are not connected we should wait until we reconnect and try again. Note: we re-enter the state
-			// machine, since its possible another client has already completed the migration by the time we reconnect.
-			this.currentModel.once("connected", this.takeAppropriateActionForCurrentMigratable);
+	private readonly prepareMigration = async () => {
+		if (this._migrationPrepareP !== undefined) {
 			return;
 		}
 
+		if (this._migrationPrepareP !== undefined) {
+			throw new Error("Cannot prepare migration, we are currently migrating");
+		}
+
+		if (this._migratedLoadP !== undefined) {
+			throw new Error("Cannot prepare migration, we are currently trying to load");
+		}
+
+		const prepare = async () => {
+			this.emit("migrating");
+			const migratable = this._currentModel;
+			const acceptedVersion = migratable.migrationTool.acceptedVersion;
+			if (acceptedVersion === undefined) {
+				throw new Error("Expect an accepted version before migration starts");
+			}
+			// It's possible that our modelLoader is older and doesn't understand the new acceptedVersion.
+			// Currently this fails the migration gracefully and emits an event so the app developer can know
+			// they're stuck. Ideally the app developer would find a way to acquire a new ModelLoader and move
+			// forward, or at least advise the end user to refresh the page or something.
+			// TODO: Does the app developer have everything they need to dispose gracefully when recovering with
+			// a new ModelLoader?
+			const migrationSupported = await this.modelLoader.supportsVersion(acceptedVersion);
+			if (!migrationSupported) {
+				this.emit("migrationNotSupported", acceptedVersion);
+				this._migrationP = undefined;
+				return;
+			}
+
+			const detachedModel = await this.modelLoader.createDetached(acceptedVersion);
+			const migratedModel = detachedModel.model;
+
+			const acceptedSeqNum = this.currentModel.migrationTool.acceptedSeqNum;
+			assert(acceptedSeqNum !== undefined, "acceptedSeqNum should be defined");
+			this._pausedModel = await this.modelLoader.loadExistingPaused(
+				this._currentModelId,
+				acceptedSeqNum,
+			);
+			assert(
+				this.pausedModel.container.deltaManager.lastSequenceNumber === acceptedSeqNum,
+				"paused model should be at accepted sequence number",
+			);
+			const exportedData = await this.pausedModel.exportData();
+
+			// TODO: Is there a reasonable way to validate at proposal time whether we'll be able to get the
+			// exported data into a format that the new model can import?  If we can determine it early, then
+			// clients with old ModelLoaders can use that opportunity to dispose early and try to get new
+			// ModelLoaders.
+			let transformedData: unknown;
+			if (migratedModel.supportsDataFormat(exportedData)) {
+				// If the migrated model already supports the data format, go ahead with the migration.
+				transformedData = exportedData;
+			} else if (this.dataTransformationCallback !== undefined) {
+				// Otherwise, try using the dataTransformationCallback if provided to get the exported data into
+				// a format that we can import.
+				try {
+					transformedData = await this.dataTransformationCallback(
+						exportedData,
+						migratedModel.version,
+					);
+				} catch {
+					// TODO: This implies that the contract is to throw if the data can't be transformed, which
+					// isn't great.  How should the dataTransformationCallback indicate failure?
+					this.emit("migrationNotSupported", acceptedVersion);
+					this._migrationP = undefined;
+					return;
+				}
+			} else {
+				// We can't get the data into a format that we can import, give up.
+				this.emit("migrationNotSupported", acceptedVersion);
+				this._migrationP = undefined;
+				return;
+			}
+			await migratedModel.importData(transformedData);
+
+			// Store the detached model for later use and retry scenarios
+			this._preparedDetachedModel = detachedModel;
+			this._migrationPrepareP = undefined;
+		};
+
+		this._migrationPrepareP = prepare();
+		await this._migrationPrepareP;
+	};
+
+	private readonly completeMigration = async () => {
 		if (this._migrationP !== undefined) {
 			return;
+		}
+
+		if (this._migrationPrepareP !== undefined) {
+			throw new Error("Cannot perform migration before migration is prepared");
 		}
 
 		if (this._migratedLoadP !== undefined) {
 			throw new Error("Cannot perform migration, we are currently trying to load");
 		}
 
-		const migratable = this._currentModel;
-		const acceptedVersion = migratable.migrationTool.acceptedVersion;
-		if (acceptedVersion === undefined) {
-			throw new Error("Expect an accepted version before migration starts");
-		}
+		const complete = async () => {
+			assert(
+				this._preparedDetachedModel !== undefined,
+				"this._preparedDetachedModel should be defined",
+			);
 
-		const doTheMigration = async () => {
-			// doTheMigration() is called at the start of migration and should only resolve in two cases. First, is if
-			// either the local or another client successfully completes the migration. Second, is if we disconnect
-			// during the migration process. In both cases we should re-enter the state machine and take the
-			// appropriate action (see then() block below).
+			// TODO: Complete migration flow, should include generating v2 summary
 
-			const prepareTheMigration = async () => {
-				// It's possible that our modelLoader is older and doesn't understand the new acceptedVersion.
-				// Currently this fails the migration gracefully and emits an event so the app developer can know
-				// they're stuck. Ideally the app developer would find a way to acquire a new ModelLoader and move
-				// forward, or at least advise the end user to refresh the page or something.
-				// TODO: Does the app developer have everything they need to dispose gracefully when recovering with
-				// a new ModelLoader?
-				const migrationSupported = await this.modelLoader.supportsVersion(acceptedVersion);
-				if (!migrationSupported) {
-					this.emit("migrationNotSupported", acceptedVersion);
-					this._migrationP = undefined;
-					return;
-				}
-
-				const detachedModel = await this.modelLoader.createDetached(acceptedVersion);
-				const migratedModel = detachedModel.model;
-
-				const acceptedSeqNum = this.currentModel.migrationTool.acceptedSeqNum;
-				assert(acceptedSeqNum !== undefined, "acceptedSeqNum should be defined");
-				this._pausedModel = await this.modelLoader.loadExistingPaused(
-					this._currentModelId,
-					acceptedSeqNum,
-				);
-				assert(
-					this.pausedModel.container.deltaManager.lastSequenceNumber === acceptedSeqNum,
-					"paused model should be at accepted sequence number",
-				);
-				const exportedData = await this.pausedModel.exportData();
-
-				// TODO: Is there a reasonable way to validate at proposal time whether we'll be able to get the
-				// exported data into a format that the new model can import?  If we can determine it early, then
-				// clients with old ModelLoaders can use that opportunity to dispose early and try to get new
-				// ModelLoaders.
-				let transformedData: unknown;
-				if (migratedModel.supportsDataFormat(exportedData)) {
-					// If the migrated model already supports the data format, go ahead with the migration.
-					transformedData = exportedData;
-				} else if (this.dataTransformationCallback !== undefined) {
-					// Otherwise, try using the dataTransformationCallback if provided to get the exported data into
-					// a format that we can import.
-					try {
-						transformedData = await this.dataTransformationCallback(
-							exportedData,
-							migratedModel.version,
-						);
-					} catch {
-						// TODO: This implies that the contract is to throw if the data can't be transformed, which
-						// isn't great.  How should the dataTransformationCallback indicate failure?
-						this.emit("migrationNotSupported", acceptedVersion);
-						this._migrationP = undefined;
-						return;
-					}
-				} else {
-					// We can't get the data into a format that we can import, give up.
-					this.emit("migrationNotSupported", acceptedVersion);
-					this._migrationP = undefined;
-					return;
-				}
-				await migratedModel.importData(transformedData);
-
-				// Store the detached model for later use and retry scenarios
-				this._preparedDetachedModel = detachedModel;
-			};
-
-			const completeTheMigration = async () => {
-				assert(
-					this._preparedDetachedModel !== undefined,
-					"this._preparedDetachedModel should be defined",
-				);
-
-				// TODO: This is substantially different now
-			};
-
-			// Prepare the detached model if we haven't already.
-			if (this._preparedDetachedModel === undefined) {
-				await prepareTheMigration();
+			// TODO: this may not be necessary once we automatically generate the v2 summary
+			if (this.currentModel.migrationTool.migrationState !== "migrated") {
+				await new Promise<void>((resolve) => {
+					this._currentModel.migrationTool.once("migrated", resolve);
+				});
 			}
-
-			// Ensure another client has not already completed the migration.
-			// TODO: Real stuff
-			// if (this.migrationState !== "migrating") {
-			// 	return;
-			// }
-
-			await completeTheMigration();
+			this._migrationP = undefined;
 		};
 
-		this.emit("migrating");
-
-		this._migrationP = doTheMigration()
-			.then(() => {
-				// We assume that if we resolved that either the migration was completed or we disconnected.
-				// In either case, we should re-enter the state machine to take the appropriate action.
-				if (this.connected) {
-					// We assume if we are still connected after exiting the loop, then we should be in the "migrated"
-					// state. The following assert validates this assumption.
-					// assert(
-					// 	this.currentModel.migrationTool.newContainerId !== undefined,
-					// 	"newContainerId should be defined",
-					// );
-				}
-				this._migrationP = undefined;
-				this.takeAppropriateActionForCurrentMigratable();
-			})
-			.catch(console.error);
+		this._migrationP = complete();
+		await this._migrationP;
 	};
 
-	private readonly ensureLoading = () => {
-		// We assume ensureLoading() is called a single time after we reach the "migrated" state.
-
+	private readonly loadMigration = async () => {
 		if (this._migratedLoadP !== undefined) {
 			return;
+		}
+
+		if (this._migrationPrepareP !== undefined) {
+			throw new Error("Cannot start loading the migrated before migration is prepared");
 		}
 
 		if (this._migrationP !== undefined) {
@@ -260,16 +223,14 @@ export class SameContainerMigrator
 			throw new Error("Expect an accepted version before migration starts");
 		}
 
-		const doTheLoad = async () => {
-			// doTheLoad() should only be called once. It will resolve once we complete loading.
-
+		const load = async () => {
 			const migrationSupported = await this.modelLoader.supportsVersion(acceptedVersion);
 			if (!migrationSupported) {
 				this.emit("migrationNotSupported", acceptedVersion);
 				this._migratedLoadP = undefined;
 				return;
 			}
-			// TODO this should be a reload of the same container basically
+			// TODO: this should be a reload of the same container basically
 			const migratedId = "foobar";
 			const migrated = await this.modelLoader.loadExisting(migratedId);
 			// Note: I'm choosing not to close the old migratable here, and instead allow the lifecycle management
@@ -283,11 +244,46 @@ export class SameContainerMigrator
 
 			// Reset retry values
 			this._preparedDetachedModel = undefined;
-
-			// Only once we've completely finished with the old migratable, start on the new one.
-			this.takeAppropriateActionForCurrentMigratable();
 		};
 
-		this._migratedLoadP = doTheLoad().catch(console.error);
+		this._migratedLoadP = load();
+		await this._migratedLoadP;
+	};
+
+	private readonly ensureMigration = () => {
+		const overseeStages = async () => {
+			if (this._preparedDetachedModel === undefined) {
+				console.log("Preparing...");
+				await this.prepareMigration();
+			}
+
+			console.log("Completing...");
+			await this.completeMigration();
+
+			console.log("Loading...");
+			await this.loadMigration();
+		};
+
+		if (!this.connected) {
+			this.currentModel.once("connected", () => {
+				this.ensureMigration();
+				return;
+			});
+		}
+		if (this.currentModel.migrationTool.migrationState !== "readyForMigration") {
+			this.currentModel.migrationTool.once("readyForMigration", () => {
+				this.ensureMigration();
+				return;
+			});
+		}
+
+		overseeStages()
+			.then(() => {
+				console.log("done!");
+			})
+			.catch((e) => {
+				// TODO: error handling/retry
+				console.error(e);
+			});
 	};
 }

--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -46,11 +46,25 @@ export class SameContainerMigrator
 		return this._currentModel.connected();
 	}
 
-	// Retry values
+	/**
+	 * Accepted version from the migration tool. This is stored for retry scenarios.
+	 */
 	private _acceptedVersion: string | undefined;
+	/**
+	 * Detached model that is not yet ready to attach. This is stored for retry scenarios.
+	 */
 	private _detachedModel: IDetachedModel<ISameContainerMigratableModel> | undefined;
+	/**
+	 * Migrated model used to import transformed data. This is stored for retry scenarios.
+	 */
 	private _migratedModel: ISameContainerMigratableModel | undefined;
+	/**
+	 * Exported data from the paused v1 container. This is stored for retry scenarios.
+	 */
 	private _exportedData: unknown | undefined;
+	/**
+	 * Transformed v1 data ready to be imported into the migrated model. This is stored for retry scenarios.
+	 */
 	private _transformedData: unknown | undefined;
 	/**
 	 * Detached model that is ready to attach. This is stored for retry scenarios.

--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -264,7 +264,7 @@ export class SameContainerMigrator
 			await this.loadMigration();
 		};
 
-		if (!this.connected) {
+		if (!this.currentModel.connected()) {
 			this.currentModel.once("connected", () => {
 				this.ensureMigration();
 			});

--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -267,14 +267,14 @@ export class SameContainerMigrator
 		if (!this.connected) {
 			this.currentModel.once("connected", () => {
 				this.ensureMigration();
-				return;
 			});
+			return;
 		}
 		if (this.currentModel.migrationTool.migrationState !== "readyForMigration") {
 			this.currentModel.migrationTool.once("readyForMigration", () => {
 				this.ensureMigration();
-				return;
 			});
+			return;
 		}
 
 		overseeStages()

--- a/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
+++ b/examples/utils/example-utils/src/migrator/sameContainerMigrator.ts
@@ -214,6 +214,7 @@ export class SameContainerMigrator
 		this._acceptedVersion = undefined;
 		this._pausedModel = undefined;
 		this._exportedData = undefined;
+		this._detachedModel = undefined;
 		this._transformedData = undefined;
 		this._preparedDetachedModel = undefined;
 	};
@@ -245,18 +246,16 @@ export class SameContainerMigrator
 			await this.getExportedData();
 		}
 
-		console.log("Migration stage: loadDetachedModel");
-		if (this._detachedModel === undefined) {
-			await this.loadDetachedModel();
-		}
-
-		console.log("Migration stage: generateTransformedData");
-		if (this._transformedData === undefined) {
-			await this.generateTransformedData();
-		}
-
-		console.log("Migration stage: importDataIntoDetachedModel");
+		// These stages are grouped together because we should not try to retry with a detached model that could have
+		// partially imported data.
 		if (this._preparedDetachedModel === undefined) {
+			console.log("Migration stage: loadDetachedModel");
+			await this.loadDetachedModel();
+
+			console.log("Migration stage: generateTransformedData");
+			await this.generateTransformedData();
+
+			console.log("Migration stage: importDataIntoDetachedModel");
 			await this.importDataIntoDetachedModel();
 		}
 


### PR DESCRIPTION
## Description

This PR adds the initial stub-out for the SameContainerMigrator migration flow. It is a linear flow with three phases - Preparation, Completion, and Loading. 

The goal of this PR is to setup a skeleton for the SameContainerMigrator migration flow with the expectation that the actual implementation and retry logic can be easily added in the future.

## Reviewer Guidance
- If the structure of the flow makes sense
- If it should be broken down into further stages 

## Misc
[AB#5449](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5449)
