### PR TITLE
Add mint functionality to MemoizedRangeIdAllocator

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1306,7 +1306,6 @@ export type MatchPolicy = "subtree" | "path";
 export interface MemoizedIdRangeAllocator {
     allocate(revision: RevisionTag | undefined, startId: ChangesetLocalId, count?: number): IdRange[];
     mint(count?: number): IdRange[];
-    nextId: number;
 }
 
 // @alpha (undocumented)

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1305,7 +1305,7 @@ export type MatchPolicy = "subtree" | "path";
 // @alpha
 export interface MemoizedIdRangeAllocator {
     allocate(revision: RevisionTag | undefined, startId: ChangesetLocalId, count?: number): IdRange[];
-    mint(count?: number): IdRange[];
+    mint(count?: number): ChangesetLocalId;
 }
 
 // @alpha (undocumented)

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1303,7 +1303,11 @@ const MarkType: {
 export type MatchPolicy = "subtree" | "path";
 
 // @alpha
-export type MemoizedIdRangeAllocator = (revision: RevisionTag | undefined, startId: ChangesetLocalId, count?: number) => IdRange[];
+export interface MemoizedIdRangeAllocator {
+    allocate(revision: RevisionTag | undefined, startId: ChangesetLocalId, count?: number): IdRange[];
+    mint(count?: number): IdRange[];
+    nextId: number;
+}
 
 // @alpha (undocumented)
 export const MemoizedIdRangeAllocator: {

--- a/experimental/dds/tree2/src/feature-libraries/memoizedIdRangeAllocator.ts
+++ b/experimental/dds/tree2/src/feature-libraries/memoizedIdRangeAllocator.ts
@@ -11,23 +11,40 @@ import {
 	setInRangeMap,
 	Mutable,
 	brand,
+	generateStableId,
 } from "../util";
 
 /**
- * An unique ID allocator that returns the output ID for the same input ID.
- * "The same" here includes cases where a prior call allocated a range of IDs that partially or fully overlap with the
- * current call.
- * @alpha
+ * A unique ID allocator that returns the output ID for the same input ID.
  *
- * @param revision - The revision associated with the range of IDs to allocate.
- * @param startId - The first ID to allocate.
- * @param count - The number of IDs to allocate. Interpreted as 1 if undefined.
+ * @alpha
  */
-export type MemoizedIdRangeAllocator = (
-	revision: RevisionTag | undefined,
-	startId: ChangesetLocalId,
-	count?: number,
-) => IdRange[];
+export interface MemoizedIdRangeAllocator {
+	/**
+	 * The next ID to allocate.
+	 */
+	nextId: number;
+	/**
+	 * A unique ID allocator that returns the output ID for the same input ID.
+	 *
+	 * "The same" here includes cases where a prior call allocated a range of IDs that partially or fully overlap with the
+	 * current call.
+	 * @param revision - The revision associated with the range of IDs to allocate.
+	 * @param startId - The first ID to allocate.
+	 * @param count - The number of IDs to allocate. Interpreted as 1 if undefined.
+	 */
+	allocate(
+		revision: RevisionTag | undefined,
+		startId: ChangesetLocalId,
+		count?: number,
+	): IdRange[];
+	/**
+	 * Allocates a new range of IDs starting from the nextId.
+	 *
+	 * @param count - The number of IDs to allocate. Interpreted as 1 if undefined.
+	 */
+	mint(count?: number): IdRange[];
+}
 
 /**
  * @alpha
@@ -42,55 +59,75 @@ export interface IdRange {
  */
 export const MemoizedIdRangeAllocator = {
 	fromNextId(nextId: number = 0): MemoizedIdRangeAllocator {
-		let _nextId = nextId;
 		const rangeMap: Map<RevisionTag | undefined, RangeMap<number>> = new Map();
-		return (key: string | number | undefined, startId: number, length?: number): IdRange[] => {
-			let count = length ?? 1;
-			const out: IdRange[] = [];
-			const ranges = getOrAddEmptyToMap(rangeMap, key);
-			let currId = startId;
-			while (count > 0) {
-				const firstRange = getFirstFromRangeMap(ranges, currId, count);
-				if (firstRange === undefined) {
-					const newId = _nextId;
-					_nextId += count;
+		return {
+			nextId,
+			allocate(
+				key: string | number | undefined,
+				startId: number,
+				length?: number,
+			): IdRange[] {
+				let count = length ?? 1;
+				const out: IdRange[] = [];
+				const ranges = getOrAddEmptyToMap(rangeMap, key);
+				let currId = startId;
+				while (count > 0) {
+					const firstRange = getFirstFromRangeMap(ranges, currId, count);
+					if (firstRange === undefined) {
+						const newId = this.nextId;
+						this.nextId += count;
+						setInRangeMap(ranges, currId, count, newId);
+						out.push({ first: brand(newId), count });
+						count = 0;
+					} else {
+						const idRange: Mutable<IdRange> = {
+							first: brand(firstRange.value),
+							count: firstRange.length,
+						};
+						if (currId < firstRange.start) {
+							const countToAdd = firstRange.start - currId;
+							setInRangeMap(ranges, currId, countToAdd, this.nextId);
+							out.push({ first: brand(this.nextId), count: countToAdd });
+							this.nextId += countToAdd;
+							currId += countToAdd;
+							count -= countToAdd;
+						} else if (firstRange.start < currId) {
+							const countToTrim = currId - firstRange.start;
+							idRange.first = brand((idRange.first as number) + countToTrim);
+							idRange.count -= countToTrim;
+						}
+						if (idRange.count > count) {
+							idRange.count = count;
+						} else if (
+							idRange.count < count &&
+							firstRange.value + firstRange.length === this.nextId
+						) {
+							// The existing range can be extended
+							this.nextId += count - idRange.count;
+							firstRange.length = count;
+							idRange.count = count;
+						}
+						out.push(idRange);
+						count -= idRange.count;
+						currId += idRange.count;
+					}
+				}
+				return out;
+			},
+			mint(length?: number): IdRange[] {
+				let count = length ?? 1;
+				const out: IdRange[] = [];
+				const ranges = getOrAddEmptyToMap(rangeMap, generateStableId());
+				const currId = this.nextId;
+				while (count > 0) {
+					const newId = this.nextId;
+					this.nextId += count;
 					setInRangeMap(ranges, currId, count, newId);
 					out.push({ first: brand(newId), count });
 					count = 0;
-				} else {
-					const idRange: Mutable<IdRange> = {
-						first: brand(firstRange.value),
-						count: firstRange.length,
-					};
-					if (currId < firstRange.start) {
-						const countToAdd = firstRange.start - currId;
-						setInRangeMap(ranges, currId, countToAdd, _nextId);
-						out.push({ first: brand(_nextId), count: countToAdd });
-						_nextId += countToAdd;
-						currId += countToAdd;
-						count -= countToAdd;
-					} else if (firstRange.start < currId) {
-						const countToTrim = currId - firstRange.start;
-						idRange.first = brand((idRange.first as number) + countToTrim);
-						idRange.count -= countToTrim;
-					}
-					if (idRange.count > count) {
-						idRange.count = count;
-					} else if (
-						idRange.count < count &&
-						firstRange.value + firstRange.length === _nextId
-					) {
-						// The existing range can be extended
-						_nextId += count - idRange.count;
-						firstRange.length = count;
-						idRange.count = count;
-					}
-					out.push(idRange);
-					count -= idRange.count;
-					currId += idRange.count;
 				}
-			}
-			return out;
+				return out;
+			},
 		};
 	},
 };

--- a/experimental/dds/tree2/src/feature-libraries/memoizedIdRangeAllocator.ts
+++ b/experimental/dds/tree2/src/feature-libraries/memoizedIdRangeAllocator.ts
@@ -11,7 +11,6 @@ import {
 	setInRangeMap,
 	Mutable,
 	brand,
-	generateStableId,
 } from "../util";
 
 /**
@@ -39,7 +38,7 @@ export interface MemoizedIdRangeAllocator {
 	 *
 	 * @param count - The number of IDs to allocate. Interpreted as 1 if undefined.
 	 */
-	mint(count?: number): IdRange[];
+	mint(count?: number): ChangesetLocalId;
 }
 
 /**
@@ -110,19 +109,11 @@ export const MemoizedIdRangeAllocator = {
 				}
 				return out;
 			},
-			mint(length?: number): IdRange[] {
-				let count = length ?? 1;
-				const out: IdRange[] = [];
-				const ranges = getOrAddEmptyToMap(rangeMap, generateStableId());
-				const currId = _nextId;
-				while (count > 0) {
-					const newId = _nextId;
-					_nextId += count;
-					setInRangeMap(ranges, currId, count, newId);
-					out.push({ first: brand(newId), count });
-					count = 0;
-				}
-				return out;
+			mint(length?: number): ChangesetLocalId {
+				const count = length ?? 1;
+				const out = _nextId;
+				_nextId += count;
+				return brand(out);
 			},
 		};
 	},

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -76,7 +76,7 @@ function cellDeltaFromMark<TNodeChange>(
 			}
 			case "MoveIn":
 			case "ReturnTo": {
-				const ranges = idAllocator(mark.revision ?? revision, mark.id, mark.count);
+				const ranges = idAllocator.allocate(mark.revision ?? revision, mark.id, mark.count);
 				return ranges.map(({ first, count }) => ({
 					type: Delta.MarkType.MoveIn,
 					moveId: brandOpaque<Delta.MoveId>(first),
@@ -96,7 +96,7 @@ function cellDeltaFromMark<TNodeChange>(
 			}
 			case "MoveOut":
 			case "ReturnFrom": {
-				const ranges = idAllocator(mark.revision ?? revision, mark.id, mark.count);
+				const ranges = idAllocator.allocate(mark.revision ?? revision, mark.id, mark.count);
 				return ranges.map(({ first, count }) => ({
 					type: Delta.MarkType.MoveOut,
 					moveId: brandOpaque<Delta.MoveId>(first),

--- a/experimental/dds/tree2/src/test/feature-libraries/memoizedIdRangeAllocator.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/memoizedIdRangeAllocator.spec.ts
@@ -14,9 +14,9 @@ const tag2: RevisionTag = mintRevisionTag();
 describe("MemoizedIdRangeAllocator", () => {
 	it("Allocates unique IDs given unique inputs", () => {
 		const allocator = MemoizedIdRangeAllocator.fromNextId();
-		const id0 = allocator(tag1, brand(0), 1);
-		const id12 = allocator(tag1, brand(1), 2);
-		const id3 = allocator(tag2, brand(0), 1);
+		const id0 = allocator.allocate(tag1, brand(0), 1);
+		const id12 = allocator.allocate(tag1, brand(1), 2);
+		const id3 = allocator.allocate(tag2, brand(0), 1);
 		assert.deepEqual(id0, [{ first: 0, count: 1 }]);
 		assert.deepEqual(id12, [{ first: 1, count: 2 }]);
 		assert.deepEqual(id3, [{ first: 3, count: 1 }]);
@@ -24,12 +24,12 @@ describe("MemoizedIdRangeAllocator", () => {
 
 	it("Returns the same IDs given the same inputs", () => {
 		const allocator = MemoizedIdRangeAllocator.fromNextId();
-		const fst_id0 = allocator(tag1, brand(0), 1);
-		const fst_id12 = allocator(tag1, brand(1), 2);
-		const fst_id3 = allocator(tag2, brand(0), 1);
-		const snd_id0 = allocator(tag1, brand(0), 1);
-		const snd_id12 = allocator(tag1, brand(1), 2);
-		const snd_id3 = allocator(tag2, brand(0), 1);
+		const fst_id0 = allocator.allocate(tag1, brand(0), 1);
+		const fst_id12 = allocator.allocate(tag1, brand(1), 2);
+		const fst_id3 = allocator.allocate(tag2, brand(0), 1);
+		const snd_id0 = allocator.allocate(tag1, brand(0), 1);
+		const snd_id12 = allocator.allocate(tag1, brand(1), 2);
+		const snd_id3 = allocator.allocate(tag2, brand(0), 1);
 		assert.deepEqual(fst_id0, snd_id0);
 		assert.deepEqual(fst_id12, snd_id12);
 		assert.deepEqual(fst_id3, snd_id3);
@@ -37,18 +37,18 @@ describe("MemoizedIdRangeAllocator", () => {
 
 	it("Handles subset range overlaps", () => {
 		const allocator = MemoizedIdRangeAllocator.fromNextId(1);
-		const id123456 = allocator(tag1, brand(1), 6);
+		const id123456 = allocator.allocate(tag1, brand(1), 6);
 		assert.deepEqual(id123456, [{ first: 1, count: 6 }]);
-		const id23 = allocator(tag1, brand(2), 2);
+		const id23 = allocator.allocate(tag1, brand(2), 2);
 		const expected = [{ first: 2, count: 2 }];
 		assert.deepEqual(id23, expected);
 	});
 
 	it("Handles superset range overlaps", () => {
 		const allocator = MemoizedIdRangeAllocator.fromNextId(1);
-		const id23 = allocator(tag1, brand(2), 2);
+		const id23 = allocator.allocate(tag1, brand(2), 2);
 		assert.deepEqual(id23, [{ first: 1, count: 2 }]);
-		const id123456 = allocator(tag1, brand(1), 6);
+		const id123456 = allocator.allocate(tag1, brand(1), 6);
 		const expected = [
 			{ first: 3, count: 1 },
 			{ first: 1, count: 2 },
@@ -59,16 +59,26 @@ describe("MemoizedIdRangeAllocator", () => {
 
 	it("Can extend an existing range when valid", () => {
 		const allocator = MemoizedIdRangeAllocator.fromNextId(1);
-		const id1 = allocator(tag1, brand(1), 1);
+		const id1 = allocator.allocate(tag1, brand(1), 1);
 		assert.deepEqual(id1, [{ first: 1, count: 1 }]);
-		const id123 = allocator(tag1, brand(1), 3);
+		const id123 = allocator.allocate(tag1, brand(1), 3);
 		assert.deepEqual(id123, [{ first: 1, count: 3 }]);
-		const id4 = allocator(tag2, brand(1), 1);
+		const id4 = allocator.allocate(tag2, brand(1), 1);
 		assert.deepEqual(id4, [{ first: 4, count: 1 }]);
-		const id1234 = allocator(tag1, brand(1), 4);
+		const id1234 = allocator.allocate(tag1, brand(1), 4);
 		assert.deepEqual(id1234, [
 			{ first: 1, count: 3 },
 			{ first: 5, count: 1 },
 		]);
+	});
+
+	it("can mint ID ranges with only a count", () => {
+		const allocator = MemoizedIdRangeAllocator.fromNextId(1);
+		const id1 = allocator.mint(1);
+		assert.deepEqual(id1, [{ first: 1, count: 1 }]);
+		const id234 = allocator.mint(3);
+		assert.deepEqual(id234, [{ first: 2, count: 3 }]);
+		const id5 = allocator.mint(1);
+		assert.deepEqual(id5, [{ first: 5, count: 1 }]);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/memoizedIdRangeAllocator.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/memoizedIdRangeAllocator.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { MemoizedIdRangeAllocator } from "../../feature-libraries";
-import { RevisionTag, mintRevisionTag } from "../../core";
+import { ChangesetLocalId, RevisionTag, mintRevisionTag } from "../../core";
 import { brand } from "../../util";
 
 const tag1: RevisionTag = mintRevisionTag();
@@ -75,10 +75,13 @@ describe("MemoizedIdRangeAllocator", () => {
 	it("can mint ID ranges with only a count", () => {
 		const allocator = MemoizedIdRangeAllocator.fromNextId(1);
 		const id1 = allocator.mint(1);
-		assert.deepEqual(id1, [{ first: 1, count: 1 }]);
+		const expectedId1: ChangesetLocalId = brand(1);
+		assert.deepEqual(id1, expectedId1);
 		const id234 = allocator.mint(3);
-		assert.deepEqual(id234, [{ first: 2, count: 3 }]);
+		const expectedId234: ChangesetLocalId = brand(2);
+		assert.deepEqual(id234, expectedId234);
 		const id5 = allocator.mint(1);
-		assert.deepEqual(id5, [{ first: 5, count: 1 }]);
+		const expectedId5: ChangesetLocalId = brand(5);
+		assert.deepEqual(id5, expectedId5);
 	});
 });


### PR DESCRIPTION
## Description

- Refactors MemoizedRangeIdAllocator into an interface
- Adds `mint` function to allocate IDs without inputs other than count
