### PR TITLE
Improve call stack on ObtainSnapshot_cancel

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -309,7 +309,7 @@ export function normalizeError(error: unknown, annotations?: IFluidErrorAnnotati
 // @public
 export function numberFromString(str: string | null | undefined): string | number | undefined;
 
-// @public
+// @internal
 export function overwriteStack(error: IFluidErrorBase | LoggingError, stack: string): void;
 
 // @public

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -310,6 +310,9 @@ export function normalizeError(error: unknown, annotations?: IFluidErrorAnnotati
 export function numberFromString(str: string | null | undefined): string | number | undefined;
 
 // @public
+export function overwriteStack(error: IFluidErrorBase | LoggingError, stack: string): void;
+
+// @public
 export class PerformanceEvent {
     protected constructor(logger: ITelemetryLoggerExt, event: ITelemetryGenericEvent, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean);
     // (undocumented)

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -4,8 +4,10 @@
  */
 
 import {
+	generateStack,
 	ITelemetryLoggerExt,
 	loggerToMonitoringContext,
+	LoggingError,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
 import { performance } from "@fluid-internal/client-utils";
@@ -312,13 +314,29 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 							if (retrievedSnapshot === undefined) {
 								// if network failed -> wait for cache ( then return network failure)
 								// If cache returned empty or failed -> wait for network (success of failure)
-								if (promiseRaceWinner.index === 1) {
-									retrievedSnapshot = await cachedSnapshotP;
-									method = "cache";
-								}
-								if (retrievedSnapshot === undefined) {
-									retrievedSnapshot = await networkSnapshotP;
-									method = "network";
+								try {
+									if (promiseRaceWinner.index === 1) {
+										retrievedSnapshot = await cachedSnapshotP;
+										method = "cache";
+									}
+									if (retrievedSnapshot === undefined) {
+										retrievedSnapshot = await networkSnapshotP;
+										method = "network";
+									}
+								} catch (err: any) {
+									// The call stacks of any errors thrown by cached snapshot or network snapshot aren't very useful:
+									// they get truncated at this stack frame due to the promise race and how v8 tracks async stack traces--
+									// see https://v8.dev/docs/stack-trace-api#async-stack-traces and the "zero-cost async stack traces" document
+									// linked there. https://v8.dev/blog/fast-async#await-under-the-hood may also be helpful for context on internals.
+									// Regenerating the stack at this level provides more information for logged errors.
+									// Once FF uses an ES2021 target, we could convert the above promise race to use `Promise.any` + AggregateError and
+									// get similar quality stacks with less hand-crafted code.
+									if (err instanceof LoggingError) {
+										const originalStack = err.stack;
+										err.addTelemetryProperties({ originalStack });
+										err.stack = generateStack();
+									}
+									throw err;
 								}
 							}
 						} else {

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -284,8 +284,13 @@ export function wrapErrorAndLog<T extends LoggingError>(
 	return newError;
 }
 
-function overwriteStack(error: IFluidErrorBase | LoggingError, stack: string): void {
-	// supposedly setting stack on an Error can throw.
+/**
+ * Attempts to overwrite the error's stack
+ *
+ * There have been reports of certain JS environments where overwriting stack will throw.
+ * If that happens, this adds the given stack as the telemetry property "stack2"
+ */
+export function overwriteStack(error: IFluidErrorBase | LoggingError, stack: string): void {
 	try {
 		Object.assign(error, { stack });
 	} catch {

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -289,6 +289,8 @@ export function wrapErrorAndLog<T extends LoggingError>(
  *
  * There have been reports of certain JS environments where overwriting stack will throw.
  * If that happens, this adds the given stack as the telemetry property "stack2"
+ *
+ * @internal
  */
 export function overwriteStack(error: IFluidErrorBase | LoggingError, stack: string): void {
 	try {

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -31,6 +31,7 @@ export {
 	LoggingError,
 	NORMALIZED_ERROR_TYPE,
 	normalizeError,
+	overwriteStack,
 	wrapError,
 	wrapErrorAndLog,
 } from "./errorLogging";


### PR DESCRIPTION
Clone of #16183, which was closed automatically for being stale. I'm making some tweaks in response to comments over there myself and will work with @Abe27342 to merge.

## Description

Tweaks error surfacing in `getVersions` by regenerating the error stack. This event is a frequent cause of document access issues for partners on odsp--e.g. auth failure gets surfaced via this error. Having a more clear stack that's understandable for application authors seems like a nice value add.
