### PR TITLE
Add source-map-support for mocha test by default

### DIFF
--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -122,7 +122,6 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^2.0.0",
-		"source-map-support": "^0.5.16",
 		"style-loader": "^1.0.0",
 		"ts-loader": "^9.3.0",
 		"ts-node": "^10.9.1",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -106,7 +106,6 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^2.0.0",
-		"source-map-support": "^0.5.16",
 		"typedoc": "^0.12.0",
 		"typescript": "~4.5.5",
 		"webpack": "^5.82.0"

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -100,7 +100,6 @@
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",
 		"source-map-loader": "^2.0.0",
-		"source-map-support": "^0.5.16",
 		"svg-sprite-loader": "^6.0.11",
 		"svgo": "^1.1.1",
 		"svgo-loader": "^2.1.0",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -56,7 +56,6 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^2.0.0",
-		"source-map-support": "^0.5.16",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",
 		"typescript": "~4.5.5",

--- a/experimental/dds/tree2/.mocharc.js
+++ b/experimental/dds/tree2/.mocharc.js
@@ -8,6 +8,6 @@
 const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
-const config = getFluidTestMochaConfig(packageDir, ["source-map-support/register"]);
+const config = getFluidTestMochaConfig(packageDir);
 config.spec = "dist/test";
 module.exports = config;

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -115,7 +115,6 @@
 		"moment": "^2.21.0",
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
-		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {

--- a/experimental/framework/tree-react-api/.mocharc.js
+++ b/experimental/framework/tree-react-api/.mocharc.js
@@ -8,6 +8,6 @@
 const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
-const config = getFluidTestMochaConfig(packageDir, ["source-map-support/register"]);
+const config = getFluidTestMochaConfig(packageDir);
 config.spec = "dist/test";
 module.exports = config;

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -87,7 +87,6 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",
-		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {

--- a/packages/common/core-utils/.mocharc.js
+++ b/packages/common/core-utils/.mocharc.js
@@ -8,6 +8,6 @@
 const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
-const config = getFluidTestMochaConfig(packageDir, ["source-map-support/register"]);
+const config = getFluidTestMochaConfig(packageDir);
 config.spec = "dist/test";
 module.exports = config;

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -84,7 +84,6 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",
-		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -102,7 +102,6 @@
 		"moment": "^2.21.0",
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
-		"source-map-support": "^0.5.16",
 		"ts-node": "^10.9.1",
 		"typescript": "~4.5.5",
 		"uuid": "^9.0.0"

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -37,7 +37,7 @@
 		"test": "npm run test:mocha",
 		"test:benchmark:report": "mocha \"dist/test/*.perf.spec.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r @fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup -r source-map-support/register",
+		"test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"test:stress": "cross-env FUZZ_STRESS_RUN=1 FUZZ_TEST_COUNT=1 npm run test:mocha",
 		"tsc": "tsc",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -102,7 +102,6 @@
 		"moment": "^2.21.0",
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
-		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {

--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -14,7 +14,8 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 	const requiredModules = [
 		// General mocha setup e.g. suppresses console.log,
 		// This has to be before others (except logger) so that registerMochaTestWrapperFuncs is available
-		`@fluidframework/mocha-test-setup`,
+		"@fluidframework/mocha-test-setup",
+		"source-map-support/register",
 		...(additionalRequiredModules ? additionalRequiredModules : []),
 	];
 

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -38,7 +38,8 @@
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/test-driver-definitions": "workspace:~",
-		"mocha": "^10.2.0"
+		"mocha": "^10.2.0",
+		"source-map-support": "^0.5.21"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -118,7 +118,6 @@
 		"mocha": "^10.2.0",
 		"semver": "^7.5.3",
 		"sinon": "^7.4.2",
-		"source-map-support": "^0.5.16",
 		"start-server-and-test": "^1.11.7",
 		"tinylicious": "^1.0.0",
 		"url": "^0.11.0",

--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
@@ -7,5 +7,5 @@
 
 const packageDir = `${__dirname}/../..`;
 const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.cjs");
-const config = getFluidTestMochaConfig(packageDir, ["source-map-support/register"]);
+const config = getFluidTestMochaConfig(packageDir);
 module.exports = config;

--- a/packages/test/test-service-load/.mocharc.js
+++ b/packages/test/test-service-load/.mocharc.js
@@ -8,7 +8,7 @@
 const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
-const config = getFluidTestMochaConfig(packageDir, ["source-map-support/register"]);
+const config = getFluidTestMochaConfig(packageDir);
 config.spec = "dist/test";
 config.timeout = false;
 module.exports = config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9572,11 +9572,13 @@ importers:
       mocha: ^10.2.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
+      source-map-support: ^0.5.21
       typescript: ~4.5.5
     dependencies:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/test-driver-definitions': link:../test-driver-definitions
       mocha: 10.2.0
+      source-map-support: 0.5.21
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3127,7 +3127,6 @@ importers:
       react-dom: ^17.0.1
       rimraf: ^4.4.0
       source-map-loader: ^2.0.0
-      source-map-support: ^0.5.16
       style-loader: ^1.0.0
       ts-loader: ^9.3.0
       ts-node: ^10.9.1
@@ -3187,7 +3186,6 @@ importers:
       prettier: 2.6.2
       rimraf: 4.4.1
       source-map-loader: 2.0.2_webpack@5.83.0
-      source-map-support: 0.5.21
       style-loader: 1.3.0_webpack@5.83.0
       ts-loader: 9.4.2_hcl6ts7uxfbhh3j3zbefwug5my
       ts-node: 10.9.1_vy4ah4eawmaxtqslmps6irc47e
@@ -4426,7 +4424,6 @@ importers:
       prettier: ~2.6.2
       rimraf: ^4.4.0
       source-map-loader: ^2.0.0
-      source-map-support: ^0.5.16
       typedoc: ^0.12.0
       typescript: ~4.5.5
       underscore: ^1.13.6
@@ -4472,7 +4469,6 @@ importers:
       prettier: 2.6.2
       rimraf: 4.4.1
       source-map-loader: 2.0.2_webpack@5.83.0
-      source-map-support: 0.5.21
       typedoc: 0.12.0
       typescript: 4.5.5
       webpack: 5.83.0
@@ -4774,7 +4770,6 @@ importers:
       rimraf: ^4.4.0
       sinon: ^7.4.2
       source-map-loader: ^2.0.0
-      source-map-support: ^0.5.16
       svg-sprite-loader: ^6.0.11
       svgo: ^1.1.1
       svgo-loader: ^2.1.0
@@ -4845,7 +4840,6 @@ importers:
       rimraf: 4.4.1
       sinon: 7.5.0
       source-map-loader: 2.0.2_webpack@5.83.0
-      source-map-support: 0.5.21
       svg-sprite-loader: 6.0.11
       svgo: 1.3.2
       svgo-loader: 2.2.2_svgo@1.3.2
@@ -4936,7 +4930,6 @@ importers:
       prettier: ~2.6.2
       rimraf: ^4.4.0
       source-map-loader: ^2.0.0
-      source-map-support: ^0.5.16
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
       typescript: ~4.5.5
@@ -4960,7 +4953,6 @@ importers:
       prettier: 2.6.2
       rimraf: 4.4.1
       source-map-loader: 2.0.2_webpack@5.83.0
-      source-map-support: 0.5.21
       ts-jest: 29.1.1_dvaf5zpxucc7ezp6i74on5bko4
       ts-loader: 9.4.2_hcl6ts7uxfbhh3j3zbefwug5my
       typescript: 4.5.5
@@ -5603,7 +5595,6 @@ importers:
       prettier: ~2.6.2
       rimraf: ^4.4.0
       sorted-btree: ^1.8.0
-      source-map-support: ^0.5.16
       typescript: ~4.5.5
       uuid: ^9.0.0
     dependencies:
@@ -5656,7 +5647,6 @@ importers:
       moment: 2.29.4
       prettier: 2.6.2
       rimraf: 4.4.1
-      source-map-support: 0.5.21
       typescript: 4.5.5
 
   experimental/framework/data-objects:
@@ -5815,7 +5805,6 @@ importers:
       react: ^17.0.1
       rimraf: ^4.4.0
       sinon: ^7.4.2
-      source-map-support: ^0.5.16
       typescript: ~4.5.5
     dependencies:
       '@fluid-experimental/tree2': link:../../dds/tree2
@@ -5844,7 +5833,6 @@ importers:
       prettier: 2.6.2
       rimraf: 4.4.1
       sinon: 7.5.0
-      source-map-support: 0.5.21
       typescript: 4.5.5
 
   packages/common/client-utils:
@@ -6033,7 +6021,6 @@ importers:
       prettier: ~2.6.2
       rimraf: ^4.4.0
       sinon: ^7.4.2
-      source-map-support: ^0.5.16
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/benchmark': 0.47.0
@@ -6058,7 +6045,6 @@ importers:
       prettier: 2.6.2
       rimraf: 4.4.1
       sinon: 7.5.0
-      source-map-support: 0.5.21
       typescript: 4.5.5
 
   packages/common/driver-definitions:
@@ -6392,7 +6378,6 @@ importers:
       moment: ^2.21.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      source-map-support: ^0.5.16
       ts-node: ^10.9.1
       tslib: ^1.10.0
       typescript: ~4.5.5
@@ -6438,7 +6423,6 @@ importers:
       moment: 2.29.4
       prettier: 2.6.2
       rimraf: 4.4.1
-      source-map-support: 0.5.21
       ts-node: 10.9.1_vy4ah4eawmaxtqslmps6irc47e
       typescript: 4.5.5
       uuid: 9.0.0
@@ -6480,7 +6464,6 @@ importers:
       moment: ^2.21.0
       prettier: ~2.6.2
       rimraf: ^4.4.0
-      source-map-support: ^0.5.16
       typescript: ~4.5.5
     dependencies:
       '@fluid-internal/client-utils': link:../../common/client-utils
@@ -6519,7 +6502,6 @@ importers:
       moment: 2.29.4
       prettier: 2.6.2
       rimraf: 4.4.1
-      source-map-support: 0.5.21
       typescript: 4.5.5
 
   packages/dds/ordered-collection:
@@ -9924,7 +9906,6 @@ importers:
       rimraf: ^4.4.0
       semver: ^7.5.3
       sinon: ^7.4.2
-      source-map-support: ^0.5.16
       start-server-and-test: ^1.11.7
       tinylicious: ^1.0.0
       typescript: ~4.5.5
@@ -9976,7 +9957,6 @@ importers:
       mocha: 10.2.0
       semver: 7.5.3
       sinon: 7.5.0
-      source-map-support: 0.5.21
       start-server-and-test: 1.15.5
       tinylicious: 1.0.0
       url: 0.11.0


### PR DESCRIPTION
`source-map-support` will enable using source map to show stack traces in the original source file (e.g., *.ts).
Default to include it in the common setup so all the test relying on it will have it on.