### PR TITLE
Throw more accurate errors from merge-tree

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -51,7 +51,7 @@ export function createMultiSinkLogger(props: {
 
 // @public
 export class DataCorruptionError extends LoggingError implements IErrorBase, IFluidErrorBase {
-    constructor(message: string, props: ITelemetryProperties);
+    constructor(message: string, props: ITelemetryBaseProperties);
     // (undocumented)
     readonly canRetry = false;
     // (undocumented)
@@ -62,7 +62,7 @@ export class DataCorruptionError extends LoggingError implements IErrorBase, IFl
 export class DataProcessingError extends LoggingError implements IErrorBase, IFluidErrorBase {
     // (undocumented)
     readonly canRetry = false;
-    static create(errorMessage: string, dataProcessingCodepath: string, sequencedMessage?: ISequencedDocumentMessage, props?: ITelemetryProperties): IFluidErrorBase;
+    static create(errorMessage: string, dataProcessingCodepath: string, sequencedMessage?: ISequencedDocumentMessage, props?: ITelemetryBaseProperties): IFluidErrorBase;
     readonly errorType: "dataProcessingError";
     static wrapIfUnrecognized(originalError: unknown, dataProcessingCodepath: string, messageLike?: Partial<Pick<ISequencedDocumentMessage, "clientId" | "sequenceNumber" | "clientSequenceNumber" | "referenceSequenceNumber" | "minimumSequenceNumber" | "timestamp">>): IFluidErrorBase;
 }
@@ -108,7 +108,7 @@ export function generateStack(): string | undefined;
 
 // @public
 export class GenericError extends LoggingError implements IGenericError, IFluidErrorBase {
-    constructor(message: string, error?: any, props?: ITelemetryProperties);
+    constructor(message: string, error?: any, props?: ITelemetryBaseProperties);
     // (undocumented)
     readonly error?: any;
     // (undocumented)
@@ -406,7 +406,7 @@ export class ThresholdCounter {
 
 // @public
 export class UsageError extends LoggingError implements IUsageError, IFluidErrorBase {
-    constructor(message: string, props?: ITelemetryProperties);
+    constructor(message: string, props?: ITelemetryBaseProperties);
     // (undocumented)
     readonly errorType: "usageError";
 }

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -9,8 +9,7 @@
 /* eslint-disable @typescript-eslint/prefer-optional-chain, no-bitwise */
 
 import { assert } from "@fluidframework/core-utils";
-import { UsageError } from "@fluidframework/telemetry-utils";
-import { IAttributionCollectionSerializer } from "./attributionCollection";
+import { DataProcessingError, UsageError } from "@fluidframework/telemetry-utils";
 import { Comparer, Heap, List, ListNode, Stack } from "./collections";
 import {
 	LocalClientId,
@@ -1757,7 +1756,10 @@ export class MergeTree {
 				});
 
 				if (newSegment.parent === undefined) {
-					throw new UsageError("MergeTree insert failed", {
+					// Indicates an attempt to insert past the end of the merge-tree's content.
+					const errorConstructor =
+						localSeq !== undefined ? UsageError : DataProcessingError;
+					throw new errorConstructor("MergeTree insert failed", {
 						currentSeq: this.collabWindow.currentSeq,
 						minSeq: this.collabWindow.minSeq,
 						segSeq: newSegment.seq,

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -10,6 +10,7 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { DataProcessingError, UsageError } from "@fluidframework/telemetry-utils";
+import { IAttributionCollectionSerializer } from "./attributionCollection";
 import { Comparer, Heap, List, ListNode, Stack } from "./collections";
 import {
 	LocalClientId,

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -224,7 +224,9 @@ export function appendToMergeTreeDeltaRevertibles(
 			break;
 
 		default:
-			throw new UsageError(`Unsupported event delta type: ${deltaArgs.operation}`);
+			throw new UsageError("Unsupported event delta type", {
+				operation: deltaArgs.operation,
+			});
 	}
 }
 

--- a/packages/utils/telemetry-utils/src/error.ts
+++ b/packages/utils/telemetry-utils/src/error.ts
@@ -7,7 +7,7 @@ import {
 	FluidErrorTypes,
 	IGenericError,
 	IErrorBase,
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 	IUsageError,
 } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -35,7 +35,7 @@ export class GenericError extends LoggingError implements IGenericError, IFluidE
 	 */
 	// TODO: Use `unknown` instead (API breaking change because error is not just an input parameter, but a public member of the class)
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-	constructor(message: string, public readonly error?: any, props?: ITelemetryProperties) {
+	constructor(message: string, public readonly error?: any, props?: ITelemetryBaseProperties) {
 		// Don't try to log the inner error
 		super(message, props, new Set(["error"]));
 	}
@@ -47,7 +47,7 @@ export class GenericError extends LoggingError implements IGenericError, IFluidE
 export class UsageError extends LoggingError implements IUsageError, IFluidErrorBase {
 	readonly errorType = FluidErrorTypes.usageError;
 
-	constructor(message: string, props?: ITelemetryProperties) {
+	constructor(message: string, props?: ITelemetryBaseProperties) {
 		super(message, { ...props, usageError: true });
 	}
 }
@@ -60,7 +60,7 @@ export class DataCorruptionError extends LoggingError implements IErrorBase, IFl
 	readonly errorType = FluidErrorTypes.dataCorruptionError;
 	readonly canRetry = false;
 
-	constructor(message: string, props: ITelemetryProperties) {
+	constructor(message: string, props: ITelemetryBaseProperties) {
 		super(message, { ...props, dataProcessingError: 1 });
 	}
 }
@@ -82,8 +82,8 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
 
 	public readonly canRetry = false;
 
-	private constructor(errorMessage: string) {
-		super(errorMessage);
+	private constructor(errorMessage: string, props?: ITelemetryBaseProperties) {
+		super(errorMessage, props);
 	}
 
 	/**
@@ -93,7 +93,7 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
 		errorMessage: string,
 		dataProcessingCodepath: string,
 		sequencedMessage?: ISequencedDocumentMessage,
-		props: ITelemetryProperties = {},
+		props: ITelemetryBaseProperties = {},
 	): IFluidErrorBase {
 		const dataProcessingError = DataProcessingError.wrapIfUnrecognized(
 			errorMessage,


### PR DESCRIPTION
## Description

Adjusts `MergeTree insert failed` to be a DataProcessingError when encountered in a non-local codepath. Previous logic to wrap errors thrown from within op processing would result in telemetry which showed "usageError" for errorType but "dataProcessingError: 1" as an additional property.

Couple extra misc changes:
- updated another merge-tree UsageError to use the props arg, which I noticed while auditing some other merge-tree errors
- used `ITelemetryBaseProperties` over deprecated `ITelemetryProperties` in error types
