### PR TITLE
docs: Fix `@example` comments to adhere to TSDoc spec

### DIFF
--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -160,6 +160,7 @@ export const testModeFlag = Flags.boolean({
  * You must use these flags in your command logic in order for them to have any effect.
  *
  * @example
+ *
  * All of the check flags can be used like this:
  *
  * ```
@@ -169,6 +170,7 @@ export const testModeFlag = Flags.boolean({
  * ```
  *
  * @example
+ *
  * You can also use them individually like so:
  *
  * ```

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -41,16 +41,15 @@ export const REQUIRED_PRERELEASE_IDENTIFIER = "internal";
  * Fluid internal version strings *always* include the string "internal" in the first position of the pre-release
  * section.
  *
- * In the following example, the public version is `a.b.c`, while the internal version is `x.y.z`.
- *
  * @example
  *
- * a.b.c-internal.x.y.z
+ * Public version `a.b.c` and internal version `x.y.z` yields `a.b.c-internal.x.y.z`.
  *
  * @param internalVersion - A version in the Fluid internal version scheme.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
  * @param allowAnyPrereleaseId - If true, allows any prerelease identifier string. When false, only allows
  * {@link REQUIRED_PRERELEASE_IDENTIFIER}.
+ *
  * @returns A tuple of [publicVersion, internalVersion, prereleaseIdentifier]
  */
 export function fromInternalScheme(
@@ -107,13 +106,14 @@ export function fromInternalScheme(
  *
  * @example
  *
- * a.b.c-internal.x.y.z
+ * Public version `a.b.c` and internal version `x.y.z` yields `a.b.c-internal.x.y.z`.
  *
  * @param publicVersion - The public version.
  * @param version - The internal version.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
  * @param prereleaseIdentifier - The prerelease indentifier to use in the Fluid internal version. Defaults to
  * {@link REQUIRED_PRERELEASE_IDENTIFIER}.
+ *
  * @returns A version in the Fluid internal version scheme.
  */
 export function toInternalScheme(

--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -27,6 +27,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
 	 * Local map of focus status for clients
 	 *
 	 * @example
+	 *
 	 * ```typescript
 	 * Map<userId, Map<clientid, hasFocus>>
 	 * ```

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBinder.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBinder.ts
@@ -164,6 +164,7 @@ const _popUserData = function (in_context: Utils.TraversalContext) {
  * These data bindings are notified of the modification and removal of the underlying property.
  *
  * @example
+ *
  * ```typescript
  * const databinder = new DataBinder(propertyTree);
  * databinder.defineDataBinding(...);
@@ -2576,6 +2577,7 @@ export class DataBinder {
 	 * before they begin to be built.
 	 *
 	 * @example
+	 *
 	 * ```javascript
 	 * // Register a generator for runtime representations for the Dog Property
 	 * myDataBinder.defineRepresentation('PETSTORE', 'Types:Dog-1.0.0', (property) => new DogRepresentation());

--- a/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
@@ -2076,7 +2076,9 @@ export namespace Utils {
 	 * The final ChangeSet will only include the paths in question starting from the root of
 	 * the ChangeSet.
 	 *
-	 * @example Given the following change set:
+	 * @example
+	 *
+	 * Given the following change set:
 	 *
 	 * ```json
 	 * 'insert': {
@@ -2383,7 +2385,9 @@ export namespace Utils {
 	 * The final ChangeSet will exclude the paths in question starting from the root of
 	 * the ChangeSet.
 	 *
-	 * @example Given the following change set:
+	 * @example
+	 *
+	 * Given the following change set:
 	 *
 	 * ```json
 	 * 'insert': {

--- a/experimental/PropertyDDS/packages/property-common/src/constants.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/constants.ts
@@ -40,6 +40,7 @@ const SchemaValidatorError = {
 	 * Your property template should include a typeid attribute.
 	 *
 	 * @example
+	 *
 	 *```json
 	 * {
 	 *  "typeid": "my.example:point2d-1.0.0",
@@ -58,7 +59,9 @@ const SchemaValidatorError = {
 	 *
 	 * Typeid should contain a template version number.
 	 *
-	 * @example “typeid: my.example:point2d-1.0.0”
+	 * @example
+	 *
+	 * “typeid: my.example:point2d-1.0.0”
 	 */
 	MISSING_VERSION: "SV-005: Missing template version in 'typeid' attribute: ",
 
@@ -413,6 +416,7 @@ const PropertyError = {
 	 * Workspace.get and Property.get take in an id (string or number) or an array of ids.
 	 *
 	 * @example
+	 *
 	 * ```typescript
 	 *.get(‘position’).get(‘x’) or .get([‘property’, ‘x’])
 	 * ```
@@ -870,12 +874,14 @@ const PropertyError = {
 	 * The token DEREFERENCE_TOKEN should only be used with .get when the in_ids passed to .get is an array.
 	 * the DEREFERENCE_TOKEN should follow a path to a reference.
 	 *
-	 * @example Valid:
+	 * @example Valid
+	 *
 	 * ```typescript
 	 * myProp.get(['myReference', TOKENS.DEREFERENCE_TOKEN])
 	 * ```
 	 *
-	 * @example Not valid:
+	 * @example Not valid
+	 *
 	 * ```typescript
 	 * myProp.get('myReference').get(TOKENS.DEREFERENCE_TOKEN)
 	 * ```
@@ -1072,6 +1078,7 @@ const PropertyFactoryError = {
 	 * When using ‘inherits’ in your property template, it must be a string or an array.
 	 *
 	 * @example
+	 *
 	 * ```json
 	 * {
 	 * typeid:'my.example:point2d-1.0.0',
@@ -1267,6 +1274,7 @@ const PropertyFactoryError = {
 	 * You need a ‘typeid’ field in your template schema.
 	 *
 	 * @example
+	 *
 	 * ```json
 	 * {
 	 *   ‘typeid’: 'autodesk.test:set.set-1.0.0',
@@ -1296,6 +1304,7 @@ const PropertyFactoryError = {
 	 * Each entry in your enum property array must have an id.
 	 *
 	 * @example
+	 *
 	 * ```json
 	 * {
 	 *   "typeid": "Adsk.Core:Units.Metric-1.0.0",
@@ -1317,6 +1326,7 @@ const PropertyFactoryError = {
 	 * Each entry in your enum property must have a value that is a number.
 	 *
 	 * @example
+	 *
 	 * ```json
 	 * {
 	 *   "typeid": "Adsk.Core:Units.Metric-1.0.0",

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
@@ -207,6 +207,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
 	 * Returns an object with all the nested values contained in this property.
 	 *
 	 * @example
+	 *
 	 * ```javascript
 	 * {
 	 *   position: {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
@@ -182,6 +182,7 @@ export class MapProperty extends IndexedCollectionBaseProperty {
 	 * Returns an object with all the nested values contained in this property.
 	 *
 	 * @example
+	 *
 	 * ```javascript
 	 * {
 	 *   'firstString': {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/referenceMapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/referenceMapProperty.js
@@ -93,6 +93,7 @@ export class ReferenceMapProperty extends StringMapProperty {
 	 * Returns an object with all the nested path values.
 	 *
 	 * @example
+	 *
 	 * ```javascript
 	 * {
 	 *   'firstPath': '/path',

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/valueMapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/valueMapProperty.js
@@ -48,6 +48,7 @@ export class ValueMapProperty extends MapProperty {
 	 * Returns an object with all the nested values contained in this property.
 	 *
 	 * @example
+	 *
 	 * ```javascript
 	 * {
 	 *   'firstString': 'test1',

--- a/experimental/PropertyDDS/packages/property-proxy/src/propertyProxy.ts
+++ b/experimental/PropertyDDS/packages/property-proxy/src/propertyProxy.ts
@@ -116,6 +116,7 @@ export namespace PropertyProxy {
 	 * if the specified property name does not yet exist on the parent and the parent is dynamic.
 	 *
 	 * @example
+	 *
 	 * ```typescript
 	 * // The data can be accessed and modified using standard JavaScript syntax. Operations directly
 	 * // happen on the PropertyTree data, nothing is cached.

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/promise_utils.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/promise_utils.js
@@ -43,9 +43,14 @@
 
 	/**
 	 * Delays / Waits / Sleeps for the specified duration.
+	 *
 	 * @example
+	 *
+	 * ```javascript
 	 * // Sleeps for a second:
 	 * await sleep(1000);
+	 * ```
+	 *
 	 * @param {number} timeoutMilliSec The sleep timeout, in milliseconds.
 	 * @return {Promise} A promise that resolves after the specified timeout.
 	 */

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/retry_task.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/retry_task.js
@@ -50,7 +50,10 @@ class RetryTask {
 	 *   between retries. When left undefined, the timeout between retries grows indefinitely.
 	 * @param {taskFunction} taskFn A function that returns an asynchronous task to start or retry.
 	 * @param {string} [taskName=undefined] The task name. Used in debug logs only.
+	 *
 	 * @example
+	 *
+	 * ```javascript
 	 * // retry interval of 250, 200, 300, 400, 500, 500, 500 ...
 	 * const task = new RetryTask ({
 	 *    maxRetryCount: 10,
@@ -69,6 +72,7 @@ class RetryTask {
 	 * try {
 	 *   await result = task.start;
 	 * } catch {}
+	 * ```
 	 */
 	constructor(config, taskFn, taskName) {
 		this._taskFn = taskFn;

--- a/experimental/PropertyDDS/services/property-query-service/src/server/utils/base_server.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/server/utils/base_server.js
@@ -200,17 +200,22 @@ const defaultInstanceMonitor = {
 	 * Sets the basic auth params for services that require basic authentication, such as the
 	 * LoggerController. Classes that implement the base server call this method after loading
 	 * the credentials from the settings, like in the example.
+	 *
 	 * @example
-	 *  SomeServer.prototype.init = function() {
-	 *    var that = this;
-	 *    return BaseServer.prototype.init.call(this)
-	 *      .then(function() {
-	 *        that.setBasicAuth({
-	 *          username: settings.get('basicAuthName'),
-	 *          password: settings.get('basicAuthPassword'),
-	 *          passwordList: settings.get('basicAuthPasswordList'),
-	 *        });
-	 *      });
+	 *
+	 * ```javascript
+	 * SomeServer.prototype.init = function() {
+	 *   var that = this;
+	 *   return BaseServer.prototype.init.call(this)
+	 *     .then(function() {
+	 *       that.setBasicAuth({
+	 *         username: settings.get('basicAuthName'),
+	 *         password: settings.get('basicAuthPassword'),
+	 *         passwordList: settings.get('basicAuthPasswordList'),
+	 *       });
+	 *     });
+	 * ```
+	 *
 	 * @param {Object} basicAuthParams The basic auth parameters.
 	 * @param {string} basicAuthParams.username The username to use for authentication.
 	 * @param {Object[]} basicAuthParams.passwordList The password list to use for authentication

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -95,12 +95,15 @@ export class MapFactory implements IChannelFactory {
  */
 export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
 	/**
-	 * Create a new shared map.
-	 * @param runtime - The data store runtime that the new shared map belongs to.
-	 * @param id - Optional name of the shared map.
-	 * @returns Newly created shared map.
+	 * Create a new attributable map.
+	 *
+	 * @param runtime - The data store runtime that the new attributable map belongs to.
+	 * @param id - Optional name of the attributable map.
+	 *
+	 * @returns Newly created attributable map.
 	 *
 	 * @example
+	 *
 	 * To create a `AttributableMap`, call the static create method:
 	 *
 	 * ```typescript

--- a/experimental/dds/tree/src/ChangeTypes.ts
+++ b/experimental/dds/tree/src/ChangeTypes.ts
@@ -35,9 +35,16 @@ export enum ChangeType {
 /**
  * A change that composes an Edit.
  *
+ * @remarks
+ *
  * `Change` objects can be conveniently constructed with the helper methods exported on a constant of the same name.
+ *
  * @example
+ *
+ * ```typescript
  * Change.insert(sourceId, destination)
+ * ```
+ *
  * @public
  */
 export type Change = Insert | Detach | Build | SetValue | Constraint;
@@ -275,9 +282,14 @@ export const Change = {
  * The anchor (`referenceSibling` or `referenceTrait`) used for a particular `StablePlace` can have an impact in collaborative scenarios.
  *
  * `StablePlace` objects can be conveniently constructed with the helper methods exported on a constant of the same name.
+ *
  * @example
+ *
+ * ```typescript
  * StablePlace.before(node)
  * StablePlace.atStartOf(trait)
+ * ```
+ *
  * @public
  */
 export interface StablePlace {
@@ -307,9 +319,16 @@ export interface StablePlace {
  *
  * See {@link (StablePlace:interface)} for what it means for a place to be "after" another place.
  *
+ * @remarks
+ *
  * `StableRange` objects can be conveniently constructed with the helper methods exported on a constant of the same name.
+ *
  * @example
+ *
+ * ```typescript
  * StableRange.from(StablePlace.before(startNode)).to(StablePlace.after(endNode))
+ * ```
+ *
  * @public
  */
 export interface StableRange {
@@ -358,8 +377,12 @@ export const StablePlace = {
 export const StableRange = {
 	/**
 	 * Factory for producing a `StableRange` from a start `StablePlace` to an end `StablePlace`.
+	 *
 	 * @example
+	 *
+	 * ```typescript
 	 * StableRange.from(StablePlace.before(startNode)).to(StablePlace.after(endNode))
+	 * ```
 	 */
 	from: (start: StablePlace): { to: (end: StablePlace) => StableRange } => ({
 		to: (end: StablePlace): StableRange => {

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -148,6 +148,7 @@ export function assertArrayOfOne<T>(array: readonly T[], message = 'array value 
  * `Object.defineProperty`, but it is useful for caching public getters on first read.
  *
  * @example
+ *
  * ```typescript
  * // `randomOnce()` will return a random number, but always the same random number.
  * {
@@ -156,6 +157,7 @@ export function assertArrayOfOne<T>(array: readonly T[], message = 'array value 
  *   }
  * }
  * ```
+ *
  * @param object - The object containing the property
  * @param propName - The name of the property on the object
  * @param value - The value of the property
@@ -353,6 +355,7 @@ export function setPropertyIfDefined<TDst, P extends keyof TDst>(
 
 /**
  * @example
+ *
  * ```typescript
  * function (thing: ObjectWithMaybeFoo) {
  * 	   const x: MyActualType = {
@@ -364,7 +367,6 @@ export function setPropertyIfDefined<TDst, P extends keyof TDst>(
  * }
  * ```
  */
-
 function breakOnDifference(): { break: boolean } {
 	return { break: true };
 }

--- a/experimental/dds/tree/src/id-compressor/persisted-types/0.0.1.ts
+++ b/experimental/dds/tree/src/id-compressor/persisted-types/0.0.1.ts
@@ -150,8 +150,10 @@ export interface SerializedIdCompressorWithOngoingSession extends SerializedIdCo
  * A range is composed of local IDs that were generated. Some of these may have overrides.
  *
  * @example
+ *
  * Suppose an IdCompressor generated a sequence of local IDs as follows:
- * ```
+ *
+ * ```typescripot
  * compressor.generateLocalId()
  * compressor.generateLocalId('0093cf29-9454-4034-8940-33b1077b41c3')
  * compressor.generateLocalId()
@@ -160,8 +162,10 @@ export interface SerializedIdCompressorWithOngoingSession extends SerializedIdCo
  * compressor.generateLocalId()
  * compressor.takeNextCreationRange()
  * ```
+ *
  * This would result in the following range:
- * ```
+ *
+ * ```typescript
  * {
  *     first: localId1,
  *     last: localId6,

--- a/experimental/dds/tree/src/persisted-types/0.1.1.ts
+++ b/experimental/dds/tree/src/persisted-types/0.1.1.ts
@@ -413,8 +413,12 @@ export const StablePlaceInternal = {
 export const StableRangeInternal = {
 	/**
 	 * Factory for producing a `StableRange` from a start `StablePlace` to an end `StablePlace`.
+	 *
 	 * @example
+	 *
+	 * ```typescript
 	 * StableRange.from(StablePlace.before(startNode)).to(StablePlace.after(endNode))
+	 * ```
 	 */
 	from: (start: StablePlaceInternal): { to: (end: StablePlaceInternal) => StableRangeInternal } => ({
 		to: (end: StablePlaceInternal): StableRangeInternal => {

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -379,8 +379,10 @@ export function findAncestor<T extends { parent?: T }>(
  * but otherwise including `descendant`).
  * @param predicate - a function which will be evaluated on every ancestor of `descendant` until it returns true.
  * @returns the closest ancestor of `descendant` that satisfies `predicate`, or `undefined` if no such ancestor exists.
+ *
  * @example
- * ```ts
+ *
+ * ```typescript
  * interface Parented {
  *   id: string;
  *   parent?: Parented;
@@ -430,8 +432,10 @@ export function findAncestor<T extends { parent?: T }>(
  * @param descendantB - another descendant. If an empty `path` array is included, it will be populated
  * with the chain of commits from the ancestor to `descendantB` (not including the ancestor).
  * @returns the common ancestor of `descendantA` and `descendantB`, or `undefined` if no such ancestor exists.
+ *
  * @example
- * ```ts
+ *
+ * ```typescript
  * interface Parented {
  *   parent?: Parented;
  * }

--- a/experimental/dds/tree2/src/events/events.ts
+++ b/experimental/dds/tree2/src/events/events.ts
@@ -24,15 +24,21 @@ export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : fals
 
 /**
  * Used to specify the kinds of events emitted by an {@link ISubscribable}.
+ *
+ * @remarks
+ *
+ * Any object type is a valid {@link Events}, but only the event-like properties of that
+ * type will be included.
+ *
  * @example
- * ```ts
+ *
+ * ```typescript
  * interface MyEvents {
  *   load: (user: string, data: IUserData) => void;
  *   error: (errorCode: number) => void;
  * }
  * ```
- * Any object type is a valid {@link Events}, but only the event-like properties of that
- * type will be included.
+ *
  * @alpha
  */
 export type Events<E> = {
@@ -44,8 +50,10 @@ export type Events<E> = {
  * by an IEventProvider from `@fluidframework/core-interfaces`.
  * @param E - the `Events` type to transform
  * @param Target - an optional `IEvent` type that will be merged into the result along with the transformed `E`
+ *
  * @example
- * ```ts
+ *
+ * ```typescript
  * interface MyEvents {
  *   load: (user: string, data: IUserData) => void;
  *   error: (errorCode: number) => void;
@@ -153,9 +161,12 @@ export interface HasListeners<E extends Events<E>> {
 
 /**
  * Provides an API for subscribing to and listening to events.
- * Classes wishing to emit events may either extend this class:
- * @example
- * ```ts
+ *
+ * @remarks Classes wishing to emit events may either extend this class or compose over it.
+ *
+ * @example Extending this class
+ *
+ * ```typescript
  * interface MyEvents {
  *   "loaded": () => void;
  * }
@@ -166,9 +177,10 @@ export interface HasListeners<E extends Events<E>> {
  *   }
  * }
  * ```
- * Or, compose over it:
- * @example
- * ```ts
+ *
+ * @example Composing over this class
+ *
+ * ```typescript
  * class MyClass implements ISubscribable<MyEvents> {
  *   private readonly events = EventEmitter.create<MyEvents>();
  *

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -203,7 +203,8 @@ export class TestTreeProvider {
 	 * @param factory - The factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
 	 *
 	 * @example
-	 * ```ts
+	 *
+	 * ```typescript
 	 * const provider = await TestTreeProvider.create(2);
 	 * assert(provider.trees[0].isAttached());
 	 * assert(provider.trees[1].isAttached());
@@ -350,7 +351,8 @@ export class TestTreeProviderLite {
 	 * @param factory - an optional factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
 	 *
 	 * @example
-	 * ```ts
+	 *
+	 * ```typescript
 	 * const provider = new TestTreeProviderLite(2);
 	 * assert(provider.trees[0].isAttached());
 	 * assert(provider.trees[1].isAttached());

--- a/experimental/dds/tree2/src/util/typeCheck.ts
+++ b/experimental/dds/tree2/src/util/typeCheck.ts
@@ -74,6 +74,7 @@ export type { EnforceTypeCheckTests } from "./typeCheckTests";
  * See: {@link https://dev.azure.com/intentional/intent/_wiki/wikis/NP%20Platform/7146/Nominal-vs-Structural-Types}
  *
  * @example
+ *
  * ```typescript
  * protected _typeCheck?: MakeNominal;
  * ```
@@ -86,6 +87,7 @@ export interface MakeNominal {}
  * Constrain generic type parameters to Contravariant.
  *
  * @example
+ *
  * ```typescript
  * protected _typeCheck?: Contravariant<T>;
  * ```
@@ -100,6 +102,7 @@ export interface Contravariant<T> {
  * Constrain generic type parameters to Covariant.
  *
  * @example
+ *
  * ```typescript
  * protected _typeCheck?: Covariant<T>;
  * ```
@@ -118,6 +121,7 @@ export interface Covariant<T> {
  * other.
  *
  * @example
+ *
  * ```typescript
  * protected _typeCheck?: Bivariant<T>;
  * ```
@@ -135,6 +139,7 @@ export interface Bivariant<T> {
  * Constrain generic type parameters to Invariant.
  *
  * @example
+ *
  * ```typescript
  * protected _typeCheck?: Invariant<T>;
  * ```

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -288,11 +288,11 @@ let deterministicStableIdCount: number | undefined;
  * Runs `f` with {@link generateStableId} altered to return sequential StableIds starting as a fixed seed.
  * Used to make test logic that uses {@link generateStableId} deterministic.
  *
- * @remarks
- * Only use this function for testing purposes.
+ * @remarks Only use this function for testing purposes.
  *
  * @example
- * ```ts
+ *
+ * ```typescript
  * function f() {
  *    const id = generateStableId();
  *    ...

--- a/packages/common/core-interfaces/src/events.ts
+++ b/packages/common/core-interfaces/src/events.ts
@@ -58,6 +58,7 @@ export interface IEventProvider<TEvent extends IEvent> {
  * Allows an interface to extend interfaces that already extend an {@link IEventProvider}.
  *
  * @example
+ *
  * ``` typescript
  * interface AEvents extends IEvent{
  *  (event: "a-event",listener: (a: number)=>void);
@@ -73,6 +74,7 @@ export interface IEventProvider<TEvent extends IEvent> {
  *  b: boolean;
  * };
  * ```
+ *
  * interface B will now extend interface A and its events
  *
  */

--- a/packages/common/core-interfaces/src/provider.ts
+++ b/packages/common/core-interfaces/src/provider.ts
@@ -4,13 +4,18 @@
  */
 
 /**
- * This utility type is meant for internal use by {@link FluidObject}
  * Produces a valid FluidObject key given a type and a property.
+ *
+ * @remarks
+ *
  * A valid FluidObject key is a property that exists on the incoming type
  * as well as on the type of the property itself. For example: `IProvideFoo.IFoo.IFoo`
  * This aligns with the FluidObject pattern expected to be used with all FluidObjects.
  *
+ * This utility type is meant for internal use by {@link FluidObject}
+ *
  * @example
+ *
  * ```typescript
  * interface IProvideFoo{
  *  IFoo: IFoo
@@ -19,9 +24,9 @@
  *  foobar();
  * }
  * ```
- * This pattern enables discovery, and delegation in a standard way which is central
- * to FluidObject pattern
  *
+ * This pattern enables discovery, and delegation in a standard way which is central
+ * to FluidObject pattern.
  */
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp
 	? never
@@ -42,7 +47,9 @@ export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string
  * FluidObject without a generic argument.
  *
  * @example
- * For example, if we have an interface like below
+ *
+ * For example, if we have an interface like the following:
+ *
  * ```typescript
  * interface IProvideFoo{
  *  IFoo: IFoo

--- a/packages/dds/cell/src/interfaces.ts
+++ b/packages/dds/cell/src/interfaces.ts
@@ -31,7 +31,7 @@ export interface ISharedCellEvents<T> extends ISharedObjectEvents {
  *
  * @typeParam T - The type of cell data. Must be serializable.
  *
- * @example Creation:
+ * @example Creation
  *
  * To create a `SharedCell`, call the static create method:
  *
@@ -39,7 +39,7 @@ export interface ISharedCellEvents<T> extends ISharedObjectEvents {
  * const myCell = SharedCell.create(this.runtime, id);
  * ```
  *
- * @example Usage:
+ * @example Usage
  *
  * The value stored in the cell can be set with the `.set()` method and retrieved with the `.get()` method:
  *
@@ -68,7 +68,7 @@ export interface ISharedCellEvents<T> extends ISharedObjectEvents {
  * }
  * ```
  *
- * @example Eventing:
+ * @example Eventing
  *
  * `SharedCell` is an `EventEmitter`, and will emit events when other clients make modifications. You should
  * register for these events and respond appropriately as the data is modified. `valueChanged` will be emitted

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -46,7 +46,7 @@ const snapshotFileName = "header";
  *
  * @remarks Note that `SharedCounter` only operates on integer values. This is validated at runtime.
  *
- * @example Creating a `SharedCounter`:
+ * @example Creating a `SharedCounter`
  *
  * First, get the factory and call {@link @fluidframework/datastore-definitions#IChannelFactory.create}
  * with a runtime and string ID:
@@ -60,7 +60,7 @@ const snapshotFileName = "header";
  * If you wish to initialize the counter to a different value, you may call {@link SharedCounter.increment} before
  * attaching the Container, or before inserting it into an existing shared object.
  *
- * @example Using the `SharedCounter`:
+ * @example Using the `SharedCounter`
  *
  * Once created, you can call {@link SharedCounter.increment} to modify the value with either a positive or
  * negative number:

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -317,6 +317,7 @@ export class DirectoryFactory implements IChannelFactory {
  * {@inheritDoc ISharedDirectory}
  *
  * @example
+ *
  * ```typescript
  * mySharedDirectory.createSubDirectory("a").createSubDirectory("b").createSubDirectory("c").set("foo", val1);
  * const mySubDir = mySharedDirectory.getWorkingDirectory("/a/b/c");

--- a/packages/dds/merge-tree/docs/Obliterate.md
+++ b/packages/dds/merge-tree/docs/Obliterate.md
@@ -98,7 +98,10 @@ This may look as follows:
 ```typescript
 /**
  * Tracks information about when and where this segment was moved to.
- * @example - Suppose a merge tree had 3 TextSegments "X", "A", and "B", and
+ *
+ * @example
+ *
+ * Suppose a merge tree had 3 TextSegments "X", "A", and "B", and
  * received the operation `move({ start: 0, end: 1 }, { dest: 3 }, { seq: 30 })` (moving the "X"
  * after the "A" and the "B").
  * After processing this operation, it would have the segments `[<moved "X" tombstone>, "A", "B", "X"]`.

--- a/packages/dds/merge-tree/src/referencePositions.ts
+++ b/packages/dds/merge-tree/src/referencePositions.ts
@@ -75,7 +75,9 @@ export interface ReferencePosition {
 
 	/**
 	 * Gets the offset for this reference position within its associated segment.
+	 *
 	 * @example
+	 *
 	 * If a merge-tree has 3 leaf segments ["hello", " ", "world"] and a ReferencePosition refers to the "l"
 	 * in "world", that reference's offset would be 3 as "l" is the character at index 3 within "world".
 	 */

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -489,6 +489,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	 * @returns An iterable object that enumerates the IntervalCollection labels.
 	 *
 	 * @example
+	 *
 	 * ```typescript
 	 * const iter = this.getIntervalCollectionKeys();
 	 * for (key of iter)

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -147,25 +147,33 @@ export interface ISequenceDeltaRange<
 > {
 	/**
 	 * The type of operation that changed this range.
-	 * @remarks - Consuming code should typically compare this to the enum values defined in
+	 *
+	 * @remarks Consuming code should typically compare this to the enum values defined in
 	 * `MergeTreeDeltaOperationTypes`.
 	 */
 	operation: TOperation;
+
 	/**
 	 * The index of the start of the range.
 	 */
 	position: number;
+
 	/**
 	 * The segment that corresponds to the range.
 	 */
 	segment: ISegment;
+
 	/**
 	 * Deltas object which contains all modified properties with their previous values.
 	 * Since `undefined` doesn't survive a round-trip through JSON serialization, the old value being absent
 	 * is instead encoded with `null`.
-	 * @remarks - This object is motivated by undo/redo scenarios, and provides a convenient "inverse op" to apply to
+	 *
+	 * @remarks This object is motivated by undo/redo scenarios, and provides a convenient "inverse op" to apply to
 	 * undo a property change.
-	 * @example - If a segment initially had properties `{ foo: "1", bar: 2 }` and it was annotated with
+	 *
+	 * @example
+	 *
+	 * If a segment initially had properties `{ foo: "1", bar: 2 }` and it was annotated with
 	 * `{ foo: 3, baz: 5 }`, the corresponding event would have a `propertyDeltas` of `{ foo: "1", baz: null }`.
 	 */
 	propertyDeltas: PropertySet;

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -119,8 +119,11 @@ function getSaveInfo(
 /**
  * Represents a generic fuzz model for testing eventual consistency of a DDS.
  *
+ * @remarks
+ *
  * Typical DDSes will parameterize this with their SharedObject factory and a serializable set
  * of operations corresponding to valid edits in the DDS's public API.
+ *
  * @example
  * A simplified SharedString data structure exposing the APIs `insertAt(index, contentString)` and `removeRange(start, end)`
  * might represent their API with the following operations:
@@ -332,11 +335,14 @@ export interface DDSFuzzSuiteOptions {
 
 	/**
 	 * Runs only the provided seeds.
+	 *
 	 * @example
+	 *
 	 * ```typescript
 	 * // Runs only seed 42 for the given model.
 	 * createDDSFuzzSuite(model, { only: [42] });
 	 * ```
+	 *
 	 * @remarks
 	 * If you prefer, a variant of the standard `.only` syntax works. See {@link createDDSFuzzSuite.only}.
 	 */
@@ -344,11 +350,14 @@ export interface DDSFuzzSuiteOptions {
 
 	/**
 	 * Skips the provided seeds.
+	 *
 	 * @example
+	 *
 	 * ```typescript
 	 * // Skips seed 42 for the given model.
 	 * createDDSFuzzSuite(model, { skip: [42] });
 	 * ```
+	 *
 	 * @remarks
 	 * If you prefer, a variant of the standard `.skip` syntax works. See {@link createDDSFuzzSuite.skip}.
 	 */
@@ -1055,7 +1064,9 @@ const getFullModel = <TChannelFactory extends IChannelFactory, TOperation extend
 
 /**
  * Runs only the provided seeds.
+ *
  * @example
+ *
  * ```typescript
  * // Runs only seed 42 for the given model.
  * createDDSFuzzSuite.only(42)(model);
@@ -1074,7 +1085,9 @@ createDDSFuzzSuite.only =
 
 /**
  * Skips the provided seeds.
+ *
  * @example
+ *
  * ```typescript
  * // Skips seed 42 for the given model.
  * createDDSFuzzSuite.skip(42)(model);

--- a/packages/drivers/odsp-driver/src/createNewContainerOnExistingFile.ts
+++ b/packages/drivers/odsp-driver/src/createNewContainerOnExistingFile.ts
@@ -27,10 +27,14 @@ import { ClpCompliantAppHeader } from "./contractsPublic";
 
 /**
  * Creates a new Fluid container on an existing file.
- * This requires service's capability to manage Fluid container inside an existing file.
- * @example - This enables a scenario where Fluid data is not stored as a standalone file but in a way that is managed
- *  by an existing file. For example, SharePoint Pages is able to store Fluid container in an
- *  "alternative file partition" where the main File stub is an ASPX page.
+ *
+ * @remarks This requires service's capability to manage Fluid container inside an existing file.
+ *
+ * @example
+ *
+ * This enables a scenario where Fluid data is not stored as a standalone file but in a way that is managed
+ * by an existing file. For example, SharePoint Pages is able to store Fluid container in an
+ * "alternative file partition" where the main File stub is an ASPX page.
  */
 export async function createNewContainerOnExistingFile(
 	getStorageToken: InstrumentedStorageTokenFetcher,

--- a/packages/framework/synthesize/src/types.ts
+++ b/packages/framework/synthesize/src/types.ts
@@ -3,12 +3,17 @@
  * Licensed under the MIT License.
  */
 import { IFluidDependencySynthesizer } from ".";
+
 /**
  * This is a condensed version of Record that requires the object has all
  * the FluidObject properties as its type mapped to a string representation
  * of that property.
  *
- * @example - \{ IFoo: "IFoo" \}
+ * @example
+ *
+ * ```typescript
+ * { IFoo: "IFoo" }
+ * ```
  */
 export type FluidObjectSymbolProvider<T> = {
 	[P in keyof T]?: P;

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -187,7 +187,9 @@ export const dataStoreAttributesBlobName = ".component";
  * @param summarizeResult - Summary tree and stats to modify
  *
  * @example
+ *
  * Converts from:
+ *
  * ```typescript
  * {
  *     type: SummaryType.Tree,
@@ -208,6 +210,7 @@ export const dataStoreAttributesBlobName = ".component";
  *     },
  * }
  * ```
+ *
  * And adds +1 to treeNodeCount in stats.
  */
 export function wrapSummaryInChannelsTree(summarizeResult: ISummaryTreeWithStats): void {

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -227,6 +227,8 @@ export interface IChannelServices {
 /**
  * Definitions of a channel factory.
  *
+ * @remarks
+ *
  * The runtime must be able to produce "channels" of the correct in-memory object type for the collaborative session.
  * Here "channels" are typically distributed data structures (DDSs).
  *
@@ -235,10 +237,12 @@ export interface IChannelServices {
  * (ops), which indicate a new instance of a channel being introduced to the collaboration session, to produce the
  * appropriate in-memory object.
  *
- * @example If a collaboration includes a {@link https://fluidframework.com/docs/data-structures/map/ | SharedMap},
- * the collaborating clients will need to have access to a factory that can produce the `SharedMap` object.
+ * Factories follow a common model but enable custom behavior.
  *
- * @remarks Factories follow a common model but enable custom behavior.
+ * @example
+ *
+ * If a collaboration includes a {@link https://fluidframework.com/docs/data-structures/map/ | SharedMap},
+ * the collaborating clients will need to have access to a factory that can produce the `SharedMap` object.
  */
 export interface IChannelFactory {
 	/**

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -35,10 +35,10 @@
  * Using `Jsonable` (with no type parameters) or `Jsonable<any>` is just a type alias for `any`
  * and should not be used if type safety is desired.
  *
- * @example
- * Typical usage:
- * ```ts
- *      function foo<T>(value: Jsonable<T>) { ... }
+ * @example Typical usage
+ *
+ * ```typescript
+ * function foo<T>(value: Jsonable<T>) { ... }
  * ```
  */
 export type Jsonable<T = any, TReplaced = void> = T extends

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -17,10 +17,10 @@ import { Jsonable } from "./jsonable";
  * Important: `T extends Serializable<T>` is generally incorrect.
  * (Any value of `T` extends the serializable subset of itself.)
  *
- * @example
- * Typical usage:
+ * @example Typical usage
+ *
  * ```typescript
- *      function serialize<T>(value: Serializable<T>) { ... }
+ * function serialize<T>(value: Serializable<T>) { ... }
  * ```
  */
 export type Serializable<T = any> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -56,7 +56,8 @@ export interface ISummarizeResult {
  * the data store summaries are wrapped around an array of labels identified by pathPartsForChildren.
  *
  * @example
- * ```
+ *
+ * ```typescript
  * id:""
  * pathPartsForChildren: ["path1"]
  * stats: ...

--- a/packages/test/stochastic-test-utils/src/generators.ts
+++ b/packages/test/stochastic-test-utils/src/generators.ts
@@ -22,6 +22,7 @@ import {
  * chosen for a particular input state.
  *
  * @example
+ *
  * ```typescript
  * const modifyGenerator = ({ random, list }) => {
  *     return { type: "modify", index: random.integer(0, list.length - 1) };
@@ -172,6 +173,7 @@ export enum ExitBehavior {
  * provided, instead exits as soon as the next element it would produce is `done`.
  *
  * @example
+ *
  * ```typescript
  * // Assume gen1 produces 1, 2, 3, ... and gen2 produces "a", "b", "c", ...
  * interleave(gen1, gen2) // 1, a, 2, b, 3, c, ...
@@ -263,6 +265,7 @@ export function repeat<T, TState = void>(t: T): Generator<T, TState> {
  * chosen for a particular input state.
  *
  * @example
+ *
  * ```typescript
  * const modifyGenerator = async ({ random, list }) => {
  *     return { type: "modify", index: random.integer(0, list.length - 1) };

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -134,6 +134,7 @@ export type ChannelFactoryRegistry = Iterable<[string | undefined, IChannelFacto
  * Fluid object so that it can create a shared object for each.
  *
  * @example
+ *
  * The following will create a Fluid object that creates and loads a SharedString and SharedDirectory.
  * It will add SparseMatrix to the data store's factory so that it can be created later.
  *
@@ -152,7 +153,7 @@ export type ChannelFactoryRegistry = Iterable<[string | undefined, IChannelFacto
  * sharedDir = testFluidObject.getSharedObject<SharedDirectory>("sharedDirectory");
  * ```
  *
- * @privateRemarks - Beware that using this class generally forfeits some compatibility coverage
+ * @privateRemarks Beware that using this class generally forfeits some compatibility coverage
  * `describeCompat` aims to provide:
  * `SharedMap`s always reference the current version of SharedMap.
  * AB#4670 tracks improving this situation.

--- a/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
@@ -8,7 +8,9 @@
  *
  * @remarks Each Container registered with the Devtools must be assigned a unique `containerKey`.
  *
- * @example "Canvas Container"
+ * @example
+ *
+ * "Canvas Container"
  *
  * @public
  */

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -63,6 +63,7 @@ export function compareWithReferenceSnapshot(
 	 * package versions with X before we compare them.
 	 *
 	 * @example
+	 *
 	 * This is how it will look:
 	 * Before replace:
 	 *

--- a/packages/utils/odsp-doclib-utils/src/parseAuthErrorTenant.ts
+++ b/packages/utils/odsp-doclib-utils/src/parseAuthErrorTenant.ts
@@ -11,8 +11,7 @@ const oAuthBearerScheme = "Bearer";
  * Tenant id is represented by "realm" property. More details can be found here:
  * {@link https://tools.ietf.org/html/rfc2617#page-8}
  *
- * @example
- * Header sample:
+ * @example Header sample
  *
  * ```
  * www-authenticate=Bearer realm="03d0c210-38e8-47d7-9bc9-9ff2cd5ea7bc",

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemUtilities.ts
@@ -213,7 +213,9 @@ export function getLinkUrlForApiItem(
 /**
  * Gets the unscoped version of the provided package's name.
  *
- * @example For the package `@foo/bar`, this would return `bar`.
+ * @example
+ *
+ * For the package `@foo/bar`, this would return `bar`.
  */
 export function getUnscopedPackageName(apiPackage: ApiPackage): string {
 	return PackageName.getUnscopedName(apiPackage.displayName);

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
@@ -28,6 +28,7 @@ import {
  * Also note that `EntryPoint` items will always be ignored by the system, even if specified here.
  *
  * @example
+ *
  * A configuration like the following:
  *
  * ```typescript
@@ -51,6 +52,7 @@ export type DocumentBoundaries = ApiMemberKind[];
  * not specified.
  *
  * @example
+ *
  * A configuration like the following:
  *
  * ```typescript
@@ -127,7 +129,6 @@ export interface DocumentationSuiteOptions {
 	 * @example
 	 *
 	 * We are given a class API item "Bar" in package "Foo", and this returns "foo".
-	 *
 	 * The final file name in this case might be something like "foo-bar-class".
 	 *
 	 * @param apiItem - The API item for which the pre-modification file name is being generated.

--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -317,6 +317,7 @@ export type HookFunction = () => void | Promise<unknown>;
  * Note that this approach is slightly misleading in the data it measures: if this library chooses a cycle size of 10k,
  * the time reported per iteration is really an average of the time taken to insert 10k elements at the start, and not
  * the average time to insert an element to the start of the empty list as the test body might suggest at a glance.
+ *
  * @example
  *
  * ```typescript


### PR DESCRIPTION
The TSDoc spec notes that an `@example` comment with contents on the same line as the tag should treat the first line as the title of that example. We had a number of comments that had example body contents on the same line as the tag. This PR adjusts contents to better adhere to the spec.

It also makes some line spacing improvements to enhance readability, and makes some other misc. comment improvements.

`@example` spec: https://tsdoc.org/pages/tags/example/

