### PR TITLE
Fix SharedString Event and Submit Order to Avoid Reentrancy (#16815)

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -233,7 +233,7 @@ export function createAnnotateRangeOp(start: number, end: number, props: Propert
 // @public (undocumented)
 export function createDetachedLocalReferencePosition(refType?: ReferenceType): LocalReferencePosition;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createGroupOp(...ops: IMergeTreeDeltaOp[]): IMergeTreeGroupMsg;
 
 // @alpha (undocumented)
@@ -464,9 +464,10 @@ export interface IMergeTreeDeltaOpArgs {
     readonly groupOp?: IMergeTreeGroupMsg;
     readonly op: IMergeTreeOp;
     readonly sequencedMessage?: ISequencedDocumentMessage;
+    readonly stashed?: boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     // (undocumented)
     ops: IMergeTreeDeltaOp[];

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -549,7 +549,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     };
     // (undocumented)
     getStackContext(startPos: number, rangeLabels: string[]): RangeStackMap;
-    // (undocumented)
+    // @deprecated (undocumented)
     groupOperation(groupOp: IMergeTreeGroupMsg): void;
     // (undocumented)
     id: string;
@@ -580,7 +580,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     protected reSubmitCore(content: any, localOpMetadata: unknown): void;
     // (undocumented)
     readonly segmentFromSpec: (spec: IJSONSegment) => ISegment;
-    // (undocumented)
+    // @deprecated (undocumented)
     submitSequenceMessage(message: IMergeTreeOp): void;
     // (undocumented)
     protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -5,14 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import {
-	BaseSegment,
-	createGroupOp,
-	IJSONSegment,
-	IMergeTreeDeltaOp,
-	ISegment,
-	PropertySet,
-} from "@fluidframework/merge-tree";
+import { BaseSegment, IJSONSegment, ISegment, PropertySet } from "@fluidframework/merge-tree";
 import {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -319,10 +312,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 		const size = maxCols * numRows;
 		const segment = new PaddingSegment(size);
 
-		const insertOp = this.client.insertSegmentLocal(pos, segment);
-		if (insertOp) {
-			this.submitSequenceMessage(insertOp);
-		}
+		this.client.insertSegmentLocal(pos, segment);
 	}
 
 	public removeRows(row: number, numRows: number) {
@@ -354,25 +344,13 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 	private moveAsPadding(srcCol: number, destCol: number, numCols: number) {
 		const removeColStart = srcCol;
 		const removeColEnd = srcCol + numCols;
-		const ops: IMergeTreeDeltaOp[] = [];
 
 		for (let r = 0, rowStart = 0; r < this.numRows; r++, rowStart += maxCols) {
-			const removeMsg = this.client.removeRangeLocal(
-				rowStart + removeColStart,
-				rowStart + removeColEnd,
-			);
-			if (removeMsg) {
-				ops.push(removeMsg);
-			}
+			this.client.removeRangeLocal(rowStart + removeColStart, rowStart + removeColEnd);
 			const insertPos = rowStart + destCol;
 			const segment = new PaddingSegment(numCols);
-			const insertMsg = this.client.insertSegmentLocal(insertPos, segment);
-			if (insertMsg) {
-				ops.push(insertMsg);
-			}
+			this.client.insertSegmentLocal(insertPos, segment);
 		}
-
-		this.submitSequenceMessage(createGroupOp(...ops));
 	}
 
 	private getSegment(row: number, col: number) {

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -836,17 +836,18 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	public applyStashedOp(op: IMergeTreeOp): SegmentGroup | SegmentGroup[];
 	public applyStashedOp(op: IMergeTreeOp): SegmentGroup | SegmentGroup[] {
 		let metadata: SegmentGroup | SegmentGroup[] | undefined;
+		const stashed = true;
 		switch (op.type) {
 			case MergeTreeDeltaType.INSERT:
-				this.applyInsertOp({ op });
+				this.applyInsertOp({ op, stashed });
 				metadata = this.peekPendingSegmentGroups();
 				break;
 			case MergeTreeDeltaType.REMOVE:
-				this.applyRemoveRangeOp({ op });
+				this.applyRemoveRangeOp({ op, stashed });
 				metadata = this.peekPendingSegmentGroups();
 				break;
 			case MergeTreeDeltaType.ANNOTATE:
-				this.applyAnnotateRangeOp({ op });
+				this.applyAnnotateRangeOp({ op, stashed });
 				metadata = this.peekPendingSegmentGroups();
 				break;
 			case MergeTreeDeltaType.GROUP:

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -78,6 +78,11 @@ export interface IMergeTreeDeltaOpArgs {
 	 * Delta op args are for an unacked local change
 	 */
 	readonly sequencedMessage?: ISequencedDocumentMessage;
+
+	/**
+	 * If the operation is being applied as a stashed op, which means it may have been previously submitted, and therefore should not be resubmitted
+	 */
+	readonly stashed?: boolean;
 }
 
 export interface IMergeTreeClientSequenceArgs {

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -98,6 +98,8 @@ export function createInsertOp(pos: number, segSpec: any): IMergeTreeInsertMsg {
 /**
  *
  * @param ops - The ops to group
+ *
+ * @deprecated - The ability to create group ops will be removed in an upcoming release, as group ops are redundant with he native batching capabilities of the runtime
  */
 export function createGroupOp(...ops: IMergeTreeDeltaOp[]): IMergeTreeGroupMsg {
 	return {

--- a/packages/dds/merge-tree/src/ops.ts
+++ b/packages/dds/merge-tree/src/ops.ts
@@ -44,6 +44,9 @@ export const MergeTreeDeltaType = {
 	INSERT: 0,
 	REMOVE: 1,
 	ANNOTATE: 2,
+	/**
+	 * @deprecated - The ability to create group ops will be removed in an upcoming release, as group ops are redundant with he native batching capabilities of the runtime
+	 */
 	GROUP: 3,
 } as const;
 
@@ -110,6 +113,9 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 	combiningOp?: ICombiningOp;
 }
 
+/**
+ * @deprecated - The ability to create group ops will be removed in an upcoming release, as group ops are redundant with he native batching capabilities of the runtime
+ */
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.GROUP;
 	ops: IMergeTreeDeltaOp[];

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -118,10 +118,7 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
 		if (props) {
 			segment.addProperties(props);
 		}
-		const insertOp = this.client.insertSegmentLocal(pos, segment);
-		if (insertOp) {
-			this.submitSequenceMessage(insertOp);
-		}
+		this.client.insertSegmentLocal(pos, segment);
 	}
 
 	/**

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -118,10 +118,7 @@ export class SharedString
 		}
 
 		const pos = this.posFromRelativePos(relativePos1);
-		const insertOp = this.client.insertSegmentLocal(pos, segment);
-		if (insertOp) {
-			this.submitSequenceMessage(insertOp);
-		}
+		this.client.insertSegmentLocal(pos, segment);
 	}
 
 	/**
@@ -137,11 +134,7 @@ export class SharedString
 			segment.addProperties(props);
 		}
 
-		const insertOp = this.client.insertSegmentLocal(pos, segment);
-		if (insertOp) {
-			this.submitSequenceMessage(insertOp);
-		}
-		return insertOp;
+		return this.client.insertSegmentLocal(pos, segment);
 	}
 
 	/**
@@ -157,10 +150,7 @@ export class SharedString
 		}
 
 		const pos = this.posFromRelativePos(relativePos1);
-		const insertOp = this.client.insertSegmentLocal(pos, segment);
-		if (insertOp) {
-			this.submitSequenceMessage(insertOp);
-		}
+		this.client.insertSegmentLocal(pos, segment);
 	}
 
 	/**
@@ -172,10 +162,7 @@ export class SharedString
 			segment.addProperties(props);
 		}
 
-		const insertOp = this.client.insertSegmentLocal(pos, segment);
-		if (insertOp) {
-			this.submitSequenceMessage(insertOp);
-		}
+		this.client.insertSegmentLocal(pos, segment);
 	}
 
 	/**
@@ -210,10 +197,7 @@ export class SharedString
 		props: PropertySet,
 		callback: (m: Marker) => void,
 	) {
-		const annotateOp = this.client.annotateMarkerNotifyConsensus(marker, props, callback);
-		if (annotateOp) {
-			this.submitSequenceMessage(annotateOp);
-		}
+		this.client.annotateMarkerNotifyConsensus(marker, props, callback);
 	}
 
 	/**
@@ -223,10 +207,7 @@ export class SharedString
 	 * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.
 	 */
 	public annotateMarker(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp) {
-		const annotateOp = this.client.annotateMarker(marker, props, combiningOp);
-		if (annotateOp) {
-			this.submitSequenceMessage(annotateOp);
-		}
+		this.client.annotateMarker(marker, props, combiningOp);
 	}
 
 	/**


### PR DESCRIPTION
This change primarily addresses a problem in sequence where the event
for a change is triggered before the op for the change is submitted.
This is a problem as if an application does reentrancy, specifically
creates more changes in the event for a change, it will lead to the
subsequent changes, made is the event, to be submitted before the
original change. This can result in document corruption.

We fix this issue by explicitly submitting before we fire the event.
Since we now submit on all events, it is also necessary to not submit in
some cases, specifically where there are stashed ops, as these may have
already been submitted.

Lastly, this change deprecates grouped ops, which also have reentrancy
concerns, specifically that if a change is made during the application
of a group op, that change cannot be correctly applied, as the group op
only has a single sequence number so there is no way to identify at
which sub-op the new change should be made after. Remote client will end
up processing the new change after the group op is complete, which is
not when the new change was generated, and can lead to eventual
consistency issues.

cherry-pick of #16815.