### PR TITLE
[next] Remove some deprecated ContainerRuntime bits

### DIFF
--- a/.changeset/few-suits-join.md
+++ b/.changeset/few-suits-join.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-runtime": major
+---
+
+Removing some deprecated and likely unused ContainerRuntime APIs
+
+-   `IGCRuntimeOptions.sweepAllowed`
+-   `ContainerRuntime.reSubmitFn`

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -398,8 +398,6 @@ export interface IGCRuntimeOptions {
     gcAllowed?: boolean;
     runFullGC?: boolean;
     sessionExpiryTimeoutMs?: number;
-    // @deprecated (undocumented)
-    sweepAllowed?: boolean;
 }
 
 // @public

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -207,8 +207,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // @deprecated
     request(request: IRequest): Promise<IResponse>;
     resolveHandle(request: IRequest): Promise<IResponse>;
-    // @deprecated (undocumented)
-    get reSubmitFn(): (type: ContainerMessageType, contents: any, localOpMetadata: unknown, opMetadata: Record<string, unknown> | undefined) => void;
     // (undocumented)
     get scope(): FluidObject;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -927,17 +927,6 @@ export class ContainerRuntime
 		return this._storage;
 	}
 
-	/** @deprecated - The functionality is no longer exposed publicly */
-	public get reSubmitFn() {
-		return (
-			type: ContainerMessageType,
-			contents: any,
-			localOpMetadata: unknown,
-			opMetadata: Record<string, unknown> | undefined,
-		) => this.reSubmitCore({ type, contents }, localOpMetadata, opMetadata);
-		// Note: compatDetails is not included in this deprecated API
-	}
-
 	private readonly submitFn: (
 		type: MessageType,
 		contents: any,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -268,23 +268,11 @@ export interface IGCRuntimeOptions {
 	 * GC has mark phase and sweep phase. In mark phase, unreferenced objects are identified
 	 * and marked as such in the summary. This option enables the mark phase.
 	 * In sweep phase, unreferenced objects are eventually deleted from the container if they meet certain conditions.
-	 * Sweep phase can be enabled via the "sweepAllowed" option.
+	 * Sweep phase can be enabled using the "gcSweepGeneration" option.
 	 *
 	 * Note: This setting is persisted in the container's summary and cannot be changed.
 	 */
 	gcAllowed?: boolean;
-
-	/**
-	 * @deprecated -  @see gcSweepGenerationOptionName and @see GCFeatureMatrix.sweepGeneration
-	 *
-	 * Flag that if true, enables GC's sweep phase for a new container.
-	 *
-	 * This will allow GC to eventually delete unreferenced objects from the container.
-	 * This flag should only be set to true if "gcAllowed" is true.
-	 *
-	 * Note: This setting is persisted in the container's summary and cannot be changed.
-	 */
-	sweepAllowed?: boolean;
 
 	/**
 	 * Flag that if true, will disable garbage collection for the session.

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -327,14 +327,6 @@ describe("Garbage Collection configurations", () => {
 			gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false });
 			assert(!gc.configs.gcEnabled, "gcEnabled incorrect");
 		});
-		it("sweepAllowed ignored", () => {
-			gc = createGcWithPrivateMembers(undefined /* metadata */, {
-				gcAllowed: false,
-				sweepAllowed: true, // ignored. Not even checked against gcAllowed.
-				// no sweepGeneration option set
-			});
-			assert(!gc.configs.sweepEnabled, "sweepEnabled incorrect");
-		});
 		it("sweepGeneration specified, gcAllowed false", () => {
 			assert.throws(
 				() => {
@@ -414,7 +406,6 @@ describe("Garbage Collection configurations", () => {
 				gcFeatureMatrix: { tombstoneGeneration: 2, sweepGeneration: 2 },
 			};
 			gc = createGcWithPrivateMembers(undefined /* metadata */, {
-				sweepAllowed: true, // ignored
 				[gcTombstoneGenerationOptionName]: 2,
 				[gcSweepGenerationOptionName]: 2,
 			});
@@ -451,7 +442,6 @@ describe("Garbage Collection configurations", () => {
 				gcFeatureMatrix: { sweepGeneration: 2, tombstoneGeneration: undefined },
 			};
 			gc = createGcWithPrivateMembers(undefined /* metadata */, {
-				sweepAllowed: true, // ignored
 				[gcSweepGenerationOptionName]: 2,
 			});
 			const outputMetadata = gc.getMetadata();

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -66,7 +66,6 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
 	disableGC: booleanCases,
 	gcAllowed: booleanCases,
 	runFullGC: booleanCases,
-	sweepAllowed: [false],
 	sessionExpiryTimeoutMs: [undefined], // Don't want coverage here
 };
 


### PR DESCRIPTION
Fixes [AB#4189](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4189) and [AB#5450](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5450)

## Description

Remove some deprecated things in ContainerRuntime:

* `IGCRuntimeOptions.sweepAllowed`
* `ContainerRuntime.reSubmitFn`

## Breaking Changes

Yes.  They were announced previously.
