### PR TITLE
Prevent reversed interval endpoints

### DIFF
--- a/.changeset/blue-rooms-lose.md
+++ b/.changeset/blue-rooms-lose.md
@@ -4,6 +4,8 @@
 
 Disallow setting interval endpoints where start > end
 
-Adding or changing intervals where the position of start is greater than end will throw a UsageError. It is still possible to have reversed interval endpoints created by older clients. Ensure your desired endpoint positions are not reversed before setting them.
+Adding or changing intervals where the position of start is greater than end will throw a UsageError.
+It is still possible to have reversed interval endpoints created by older clients.
+Ensure your desired endpoint positions are not reversed before setting them.
 
-If using the Stickiness feature, start Side as Side.Before and end Side as Side.After when they are at the same position will also fail since inserting content at this position will cause the endpoint positions to reverse.
+If using the Stickiness feature, start Side as Side.After and end Side as Side.Before at the same position is also disallowed.

--- a/.changeset/blue-rooms-lose.md
+++ b/.changeset/blue-rooms-lose.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/sequence": major
+---
+
+Disallow setting interval endpoints where start > end
+
+Adding or changing intervals where the position of start is greater than end will throw a UsageError. It is still possible to have reversed interval endpoints created by older clients. Ensure your desired endpoint positions are not reversed before setting them.
+
+If using the Stickiness feature, start Side as Side.Before and end Side as Side.After when they are at the same position will also fail.

--- a/.changeset/blue-rooms-lose.md
+++ b/.changeset/blue-rooms-lose.md
@@ -6,4 +6,4 @@ Disallow setting interval endpoints where start > end
 
 Adding or changing intervals where the position of start is greater than end will throw a UsageError. It is still possible to have reversed interval endpoints created by older clients. Ensure your desired endpoint positions are not reversed before setting them.
 
-If using the Stickiness feature, start Side as Side.Before and end Side as Side.After when they are at the same position will also fail.
+If using the Stickiness feature, start Side as Side.Before and end Side as Side.After when they are at the same position will also fail since inserting content at this position will cause the endpoint positions to reverse.

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -674,7 +674,9 @@ export type SharedStringSegment = TextSegment | Marker;
 
 // @public
 export enum Side {
+    // (undocumented)
     After = 1,
+    // (undocumented)
     Before = 0
 }
 

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -674,9 +674,7 @@ export type SharedStringSegment = TextSegment | Marker;
 
 // @public
 export enum Side {
-    // (undocumented)
     After = 1,
-    // (undocumented)
     Before = 0
 }
 

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -101,13 +101,7 @@ export interface InteriorSequencePlace {
  * @remarks See {@link SequencePlace} for additional context on usage.
  */
 export enum Side {
-	/**
-	 * Content inserted will be placed before the endpoint
-	 */
 	Before = 0,
-	/**
-	 * Content inserted will be placed after the endpoint
-	 */
 	After = 1,
 }
 
@@ -1184,17 +1178,12 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			"start and end cannot be undefined because they were not passed in as undefined",
 		);
 
-		const startIndex = this.getIndex(start);
-		const endIndex = this.getIndex(end);
+		const startIndex = this.getComparisonIndex(start);
+		const endIndex = this.getComparisonIndex(end);
 		if (startIndex !== undefined && endIndex !== undefined && startIndex > endIndex) {
 			throw new UsageError("interval start cannot be greater than end");
-		} else if (
-			startIndex !== undefined &&
-			startIndex === endIndex &&
-			startSide === Side.Before &&
-			endSide === Side.After
-		) {
-			throw new UsageError("interval startSide Before and endSide After at same position");
+		} else if (startIndex !== undefined && startIndex === endIndex && startSide > endSide) {
+			throw new UsageError("interval startSide After and endSide Before at same position");
 		}
 
 		const stickiness = computeStickinessFromSide(startPos, startSide, endPos, endSide);
@@ -1312,11 +1301,11 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		}
 	}
 
-	private getIndex(place: SequencePlace) {
+	private getComparisonIndex(place: SequencePlace) {
 		if (typeof place === "number") {
 			return place;
 		} else if (place === "start") {
-			return 0;
+			return -1;
 		} else if (place === "end") {
 			return this.client?.getLength();
 		}
@@ -1336,8 +1325,8 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			throw new LoggingError("Change API requires an ID that is a string");
 		}
 
-		const startIndex = this.getIndex(start);
-		const endIndex = this.getIndex(end);
+		const startIndex = this.getComparisonIndex(start);
+		const endIndex = this.getComparisonIndex(end);
 		if (startIndex !== undefined && endIndex !== undefined && startIndex > endIndex) {
 			throw new UsageError("interval start cannot be greater than end");
 		}
@@ -1345,15 +1334,16 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		const interval = this.getIntervalById(id);
 		if (interval) {
 			if (
+				typeof start !== "string" &&
 				startIndex !== undefined &&
 				startIndex === endIndex &&
 				interval instanceof SequenceInterval
 			) {
 				const newStartSide = typeof start === "object" ? start.side : interval.startSide;
 				const newEndSide = typeof end === "object" ? end.side : interval.endSide;
-				if (newStartSide === Side.Before && newEndSide === Side.After) {
+				if (newStartSide > newEndSide) {
 					throw new UsageError(
-						"interval startSide Before and endSide After at same position",
+						"interval startSide After and endSide Before at same position",
 					);
 				}
 			}

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -101,7 +101,13 @@ export interface InteriorSequencePlace {
  * @remarks See {@link SequencePlace} for additional context on usage.
  */
 export enum Side {
+	/**
+	 * Content inserted will be placed before the endpoint
+	 */
 	Before = 0,
+	/**
+	 * Content inserted will be placed after the endpoint
+	 */
 	After = 1,
 }
 
@@ -1182,10 +1188,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		const endIndex = this.getIndex(end);
 		if (startIndex !== undefined && endIndex !== undefined && startIndex > endIndex) {
 			throw new UsageError("interval start cannot be greater than end");
-		} else if (startIndex !== undefined && startIndex === endIndex && startSide < endSide) {
-			throw new UsageError(
-				"interval start side cannot be greater than end side at same position",
-			);
+		} else if (
+			startIndex !== undefined &&
+			startIndex === endIndex &&
+			startSide === Side.Before &&
+			endSide === Side.After
+		) {
+			throw new UsageError("interval startSide Before and endSide After at same position");
 		}
 
 		const stickiness = computeStickinessFromSide(startPos, startSide, endPos, endSide);
@@ -1342,9 +1351,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			) {
 				const newStartSide = typeof start === "object" ? start.side : interval.startSide;
 				const newEndSide = typeof end === "object" ? end.side : interval.endSide;
-				if (newStartSide < newEndSide) {
+				if (newStartSide === Side.Before && newEndSide === Side.After) {
 					throw new UsageError(
-						`interval start side ${start} ${newStartSide} cannot be greater than end side ${end} ${newEndSide} at same position`,
+						"interval startSide Before and endSide After at same position",
 					);
 				}
 			}

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -19,7 +19,9 @@ import {
 	revertMergeTreeDeltaRevertibles,
 	SortedSet,
 	getSlideToSegoff,
+	SlidingPreference,
 } from "@fluidframework/merge-tree";
+import { InteriorSequencePlace, Side } from "./intervalCollection";
 import { IntervalOpType, SequenceInterval } from "./intervals";
 import { SharedString, SharedStringSegment } from "./sharedString";
 import { ISequenceDeltaRange, SequenceDeltaEvent } from "./sequenceDeltaEvent";
@@ -387,13 +389,22 @@ function getSlidePosition(string: SharedString, lref: LocalReferencePosition, po
 		: pos;
 }
 
-function isValidRange(start: number, end: number, string: SharedString) {
+function isValidRange(
+	start: number,
+	startSlide: SlidingPreference | undefined,
+	end: number,
+	endSlide: SlidingPreference | undefined,
+	string: SharedString,
+) {
 	return (
 		start >= 0 &&
 		start < string.getLength() &&
 		end >= 0 &&
 		end < string.getLength() &&
-		start <= end
+		(start < end ||
+			(start === end &&
+				(startSlide === SlidingPreference.BACKWARD ||
+					endSlide !== SlidingPreference.BACKWARD)))
 	);
 }
 
@@ -404,6 +415,26 @@ function revertLocalAdd(
 	const id = getUpdatedIdFromInterval(revertible.interval);
 	const label = revertible.interval.properties.referenceRangeLabels[0];
 	string.getIntervalCollection(label).removeIntervalById(id);
+}
+
+function createSequencePlace(
+	pos: number,
+	newSlidingPreference: SlidingPreference | undefined,
+	oldSlidingPreference: SlidingPreference | undefined = undefined,
+): number | InteriorSequencePlace {
+	return newSlidingPreference === SlidingPreference.BACKWARD ||
+		(newSlidingPreference === undefined && oldSlidingPreference === SlidingPreference.BACKWARD)
+		? {
+				pos,
+				side: Side.After,
+		  }
+		: newSlidingPreference === SlidingPreference.FORWARD &&
+		  oldSlidingPreference === SlidingPreference.BACKWARD
+		? {
+				pos,
+				side: Side.Before,
+		  }
+		: pos; // Avoid setting side if possible since stickiness may not be enabled
 }
 
 function revertLocalDelete(
@@ -419,8 +450,21 @@ function revertLocalDelete(
 	const type = revertible.interval.intervalType;
 	// reusing the id causes eventual consistency bugs, so it is removed here and recreated in add
 	const { intervalId, ...props } = revertible.interval.properties;
-	if (isValidRange(startSlidePos, endSlidePos, string)) {
-		const int = collection.add(startSlidePos, endSlidePos, type, props);
+	if (
+		isValidRange(
+			startSlidePos,
+			revertible.start.slidingPreference,
+			endSlidePos,
+			revertible.end.slidingPreference,
+			string,
+		)
+	) {
+		const int = collection.add(
+			createSequencePlace(startSlidePos, revertible.start.slidingPreference),
+			createSequencePlace(endSlidePos, revertible.end.slidingPreference),
+			type,
+			props,
+		);
 
 		idMap.forEach((newId, oldId) => {
 			if (intervalId === newId) {
@@ -445,8 +489,30 @@ function revertLocalChange(
 	const startSlidePos = getSlidePosition(string, revertible.start, start);
 	const end = string.localReferencePositionToPosition(revertible.end);
 	const endSlidePos = getSlidePosition(string, revertible.end, end);
-	if (isValidRange(startSlidePos, endSlidePos, string)) {
-		collection.change(id, startSlidePos, endSlidePos);
+	const interval = collection.getIntervalById(id);
+	if (
+		interval !== undefined &&
+		isValidRange(
+			startSlidePos,
+			revertible.start.slidingPreference ?? interval.start.slidingPreference,
+			endSlidePos,
+			revertible.end.slidingPreference ?? interval.end.slidingPreference,
+			string,
+		)
+	) {
+		collection.change(
+			id,
+			createSequencePlace(
+				startSlidePos,
+				revertible.start.slidingPreference,
+				interval.start.slidingPreference,
+			),
+			createSequencePlace(
+				endSlidePos,
+				revertible.end.slidingPreference,
+				interval.end.slidingPreference,
+			),
+		);
 	}
 
 	string.removeLocalReferencePosition(revertible.start);
@@ -534,8 +600,20 @@ function revertLocalSequenceRemove(
 			const end =
 				newEndpointPosition(intervalInfo.endOffset, restoredRanges, sharedString) ??
 				sharedString.localReferencePositionToPosition(interval.end);
-			if (start <= end) {
-				intervalCollection.change(intervalId, start, end);
+			if (
+				isValidRange(
+					start,
+					interval.start.slidingPreference,
+					end,
+					interval.end.slidingPreference,
+					sharedString,
+				)
+			) {
+				intervalCollection.change(
+					intervalId,
+					createSequencePlace(start, interval.start.slidingPreference),
+					createSequencePlace(end, interval.end.slidingPreference),
+				);
 			}
 		}
 	});
@@ -556,6 +634,7 @@ function revertLocalSequenceRemove(
 					pos.offset,
 					ReferenceType.StayOnRemove | ReferenceType.RangeBegin,
 					{ revertible: revertibleRef.revertible },
+					revertibleRef.revertible.start.slidingPreference,
 				);
 				revertibleRef.revertible.start = newRef;
 			} else {
@@ -565,6 +644,7 @@ function revertLocalSequenceRemove(
 					pos.offset,
 					ReferenceType.StayOnRemove | ReferenceType.RangeEnd,
 					{ revertible: revertibleRef.revertible },
+					revertibleRef.revertible.end.slidingPreference,
 				);
 				revertibleRef.revertible.end = newRef;
 			}

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -403,8 +403,8 @@ function isValidRange(
 		end < string.getLength() &&
 		(start < end ||
 			(start === end &&
-				(startSlide === SlidingPreference.BACKWARD ||
-					endSlide !== SlidingPreference.BACKWARD)))
+				(startSlide === SlidingPreference.FORWARD ||
+					endSlide !== SlidingPreference.FORWARD)))
 	);
 }
 

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -266,8 +266,8 @@ describe("IntervalCollection fuzz testing", () => {
 		// on segments that can be zamboni'd.
 		// TODO:AB#5337: re-enable these seeds.
 		skip: [
-			0, 1, 6, 7, 8, 9, 18, 20, 23, 27, 29, 32, 36, 39, 43, 45, 48, 49, 56, 57, 58, 61, 63, 69,
-			72, 75, 79, 81, 84, 86, 88, 92, 95, 96,
+			0, 1, 6, 7, 8, 9, 18, 20, 23, 27, 29, 32, 36, 39, 43, 45, 48, 49, 56, 57, 58, 61, 63,
+			69, 72, 75, 79, 81, 84, 86, 88, 92, 95, 96,
 		],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -112,8 +112,8 @@ export function makeOperationGenerator(
 	function sides(state: ClientOpState, range: RangeSpec): { startSide: Side; endSide: Side } {
 		const startSide = state.random.pick([Side.Before, Side.After]);
 		const endSide =
-			range.start === range.end && startSide === Side.Before
-				? Side.Before
+			range.start === range.end && startSide === Side.After
+				? Side.After
 				: state.random.pick([Side.Before, Side.After]);
 		return { startSide, endSide };
 	}
@@ -266,8 +266,8 @@ describe("IntervalCollection fuzz testing", () => {
 		// on segments that can be zamboni'd.
 		// TODO:AB#5337: re-enable these seeds.
 		skip: [
-			2, 4, 9, 14, 16, 18, 22, 27, 29, 31, 32, 35, 43, 44, 45, 46, 48, 52, 53, 56, 58, 59, 60,
-			63, 69, 76, 80, 83, 85, 87, 88, 92, 95,
+			0, 1, 6, 7, 8, 9, 18, 20, 23, 27, 29, 32, 36, 39, 43, 45, 48, 49, 56, 57, 58, 61, 63, 69,
+			72, 75, 79, 81, 84, 86, 88, 92, 95, 96,
 		],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)
@@ -299,7 +299,7 @@ describe("IntervalCollection no reconnect fuzz testing", () => {
 	createDDSFuzzSuite(noReconnectModel, {
 		...options,
 		// AB#4477: Same root cause as skipped regression test in intervalCollection.spec.ts--search for 4477.
-		skip: [],
+		skip: [92],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)
 		detachedStartOptions: {
@@ -320,7 +320,7 @@ describe("IntervalCollection fuzz testing with rebased batches", () => {
 	createDDSFuzzSuite(noReconnectWithRebaseModel, {
 		...defaultFuzzOptions,
 		// ADO:4477: Same root cause as skipped regression test in intervalCollection.spec.ts--search for 4477.
-		skip: [31],
+		skip: [],
 		// TODO:AB#5338: IntervalCollection doesn't correctly handle edits made while detached. Once supported,
 		// this config should be enabled (deleting is sufficient: detached start is enabled by default)
 		detachedStartOptions: {

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -1962,14 +1962,14 @@ describe("SharedString interval collections", () => {
 			assert.equal(interval1.end.slidingPreference, SlidingPreference.FORWARD);
 		});
 
-		it("can't add an interval with zero width range and none stickiness", () => {
+		it("can't add an interval with reversed sides", () => {
 			const collection = sharedString.getIntervalCollection("test");
 			sharedString.insertText(0, "abc");
 			assert.throws(
 				() => {
 					collection.add(
-						{ pos: 1, side: Side.Before },
 						{ pos: 1, side: Side.After },
+						{ pos: 1, side: Side.Before },
 						IntervalType.SlideOnRemove,
 						undefined,
 					);
@@ -1980,7 +1980,7 @@ describe("SharedString interval collections", () => {
 			assertIntervals(sharedString, collection, []);
 		});
 
-		it("can't change an interval to zero width range and none stickiness", () => {
+		it("can't change an interval to reversed sides", () => {
 			const collection = sharedString.getIntervalCollection("test");
 			sharedString.insertText(0, "abc");
 			const interval = collection.add(0, 1, IntervalType.SlideOnRemove);
@@ -1988,8 +1988,8 @@ describe("SharedString interval collections", () => {
 				() => {
 					collection.change(
 						interval.getIntervalId(),
-						{ pos: 1, side: Side.Before },
 						{ pos: 1, side: Side.After },
+						{ pos: 1, side: Side.Before },
 					);
 				},
 				UsageError,

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -243,14 +243,14 @@ describe("interval rebasing", () => {
 		clients[0].containerRuntime.connected = false;
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
 		const interval = collection_1.add(
-			{ pos: 0, side: Side.After },
 			0,
+			{ pos: 0, side: Side.After },
 			IntervalType.SlideOnRemove,
 			{
 				intervalId: "1",
 			},
 		);
-		assert.equal(interval.stickiness, IntervalStickiness.FULL);
+		assert.equal(interval.stickiness, IntervalStickiness.NONE);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
 		assertConsistent(clients);

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -19,9 +19,9 @@ import {
 	SharedStringRevertible,
 } from "../revertibles";
 import { SharedString } from "../sharedString";
-import { IIntervalCollection } from "../intervalCollection";
+import { IIntervalCollection, Side } from "../intervalCollection";
 import { SharedStringFactory } from "../sequenceFactory";
-import { IntervalType, SequenceInterval } from "../intervals";
+import { IntervalStickiness, IntervalType, SequenceInterval } from "../intervals";
 import { assertIntervals } from "./intervalUtils";
 
 describe("Sequence.Revertibles with Local Edits", () => {
@@ -1124,5 +1124,170 @@ describe("Undo/redo for string remove containing intervals", () => {
 			assert.equal(sharedString.getText(), "hello world");
 			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
 		});
+	});
+});
+
+describe("Sequence.Revertibles with stickiness", () => {
+	let sharedString: SharedString;
+	let dataStoreRuntime1: MockFluidDataStoreRuntime;
+	let collection: IIntervalCollection<SequenceInterval>;
+	let revertibles: SharedStringRevertible[];
+	let containerRuntimeFactory: MockContainerRuntimeFactory;
+	const stringFactory = new SharedStringFactory();
+
+	beforeEach(() => {
+		containerRuntimeFactory = new MockContainerRuntimeFactory();
+
+		dataStoreRuntime1 = new MockFluidDataStoreRuntime({ clientId: "1" });
+		dataStoreRuntime1.local = false;
+		dataStoreRuntime1.options = {
+			intervalStickinessEnabled: true,
+			mergeTreeReferencesCanSlideToEndpoint: true,
+		};
+		sharedString = stringFactory.create(dataStoreRuntime1, "shared-string-1");
+
+		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
+		const services1 = {
+			deltaConnection: containerRuntime1.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		};
+		sharedString.initializeLocal();
+		sharedString.connect(services1);
+
+		collection = sharedString.getIntervalCollection("test");
+		revertibles = [];
+	});
+
+	it("fails to revert interval remove of reversed endpoints", () => {
+		collection.on("deleteInterval", (interval) => {
+			appendDeleteIntervalToRevertibles(sharedString, interval, revertibles);
+		});
+
+		sharedString.insertText(0, "hello world");
+		const id = collection
+			.add(
+				{ pos: 4, side: Side.Before },
+				{ pos: 5, side: Side.After },
+				IntervalType.SlideOnRemove,
+			)
+			.getIntervalId();
+		sharedString.removeText(3, 6);
+		collection.removeIntervalById(id);
+
+		revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+		assertIntervals(sharedString, collection, []);
+	});
+
+	it("fails to revert interval change to reversed endpoints", () => {
+		collection.on("changeInterval", (interval, previousInterval) => {
+			appendChangeIntervalToRevertibles(
+				sharedString,
+				interval,
+				previousInterval,
+				revertibles,
+			);
+		});
+
+		sharedString.insertText(0, "hello world");
+		const id = collection
+			.add(
+				{ pos: 4, side: Side.Before },
+				{ pos: 5, side: Side.After },
+				IntervalType.SlideOnRemove,
+			)
+			.getIntervalId();
+		sharedString.removeText(3, 6);
+		collection.change(id, 1, 6);
+
+		revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+		assertIntervals(sharedString, collection, [{ start: 1, end: 6 }]);
+	});
+
+	it("reverts stickiness on interval remove", () => {
+		collection.on("deleteInterval", (interval) => {
+			appendDeleteIntervalToRevertibles(sharedString, interval, revertibles);
+		});
+
+		sharedString.insertText(0, "hello world");
+		const id = collection
+			.add(
+				{ pos: 4, side: Side.After },
+				{ pos: 5, side: Side.After },
+				IntervalType.SlideOnRemove,
+			)
+			.getIntervalId();
+		collection.removeIntervalById(id);
+
+		revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+		const intervals = Array.from(collection);
+		assert.equal(intervals.length, 1, `wrong number of intervals ${intervals.length}`);
+		const int = intervals[0];
+		assert.equal(
+			int.stickiness,
+			IntervalStickiness.START,
+			`unexpected stickiness ${int.stickiness}`,
+		);
+		assert.equal(int.startSide, Side.After, "start side is Before");
+		assert.equal(int.endSide, Side.After, "end side is Before");
+	});
+
+	it("reverts stickiness on interval change", () => {
+		collection.on("changeInterval", (interval, previousInterval) => {
+			appendChangeIntervalToRevertibles(
+				sharedString,
+				interval,
+				previousInterval,
+				revertibles,
+			);
+		});
+
+		sharedString.insertText(0, "hello world");
+		const id = collection
+			.add(
+				{ pos: 4, side: Side.After },
+				{ pos: 5, side: Side.After },
+				IntervalType.SlideOnRemove,
+			)
+			.getIntervalId();
+		collection.change(id, { pos: 1, side: Side.Before }, { pos: 6, side: Side.Before });
+
+		revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+		const int = collection.getIntervalById(id);
+		assert.notEqual(int, undefined, "no interval");
+		assert.equal(
+			int?.stickiness,
+			IntervalStickiness.START,
+			`unexpected stickiness ${int?.stickiness}`,
+		);
+		assert.equal(int.startSide, Side.After, "start side is Before");
+		assert.equal(int.endSide, Side.After, "end side is Before");
+	});
+
+	it("preserves stickiness on remove range", () => {
+		sharedString.insertText(0, "hello world");
+
+		sharedString.on("sequenceDelta", (op) => {
+			appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+		});
+
+		const id = collection
+			.add(
+				{ pos: 2, side: Side.After },
+				{ pos: 4, side: Side.After },
+				IntervalType.SlideOnRemove,
+			)
+			.getIntervalId();
+		sharedString.removeRange(0, 6);
+		revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+		const interval = collection.getIntervalById(id);
+		assert.notEqual(interval, undefined, "no interval");
+		assert.equal(
+			interval?.stickiness,
+			IntervalStickiness.START,
+			`unexpected stickiness ${interval?.stickiness}`,
+		);
+		assert.equal(interval.startSide, Side.After, "start side is Before");
+		assert.equal(interval.endSide, Side.After, "end side is Before");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -93,12 +93,9 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 	intervalArray[0] = intervalCollection.add(0, 0, IntervalType.SlideOnRemove);
 	intervalArray[1] = intervalCollection.add(0, 1, IntervalType.SlideOnRemove);
 	intervalArray[2] = intervalCollection.add(0, 2, IntervalType.SlideOnRemove);
-	intervalArray[3] = intervalCollection.add(1, 0, IntervalType.SlideOnRemove);
-	intervalArray[4] = intervalCollection.add(1, 1, IntervalType.SlideOnRemove);
-	intervalArray[5] = intervalCollection.add(1, 2, IntervalType.SlideOnRemove);
-	intervalArray[6] = intervalCollection.add(2, 0, IntervalType.SlideOnRemove);
-	intervalArray[7] = intervalCollection.add(2, 1, IntervalType.SlideOnRemove);
-	intervalArray[8] = intervalCollection.add(2, 2, IntervalType.SlideOnRemove);
+	intervalArray[3] = intervalCollection.add(1, 1, IntervalType.SlideOnRemove);
+	intervalArray[4] = intervalCollection.add(1, 2, IntervalType.SlideOnRemove);
+	intervalArray[5] = intervalCollection.add(2, 2, IntervalType.SlideOnRemove);
 
 	let i: number;
 	let result;
@@ -106,7 +103,6 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 	let iterator = intervalCollection.CreateForwardIteratorWithStartPosition(1);
 	tempArray[0] = intervalArray[3];
 	tempArray[1] = intervalArray[4];
-	tempArray[2] = intervalArray[5];
 	for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
 		interval = result.value;
 		assert.strictEqual(
@@ -124,8 +120,8 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 	iterator = intervalCollection.CreateForwardIteratorWithEndPosition(2);
 	tempArray = [];
 	tempArray[0] = intervalArray[2];
-	tempArray[1] = intervalArray[5];
-	tempArray[2] = intervalArray[8];
+	tempArray[1] = intervalArray[4];
+	tempArray[2] = intervalArray[5];
 	for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
 		interval = result.value;
 		assert.strictEqual(
@@ -162,8 +158,8 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 	iterator = intervalCollection.CreateForwardIteratorWithEndPosition(2);
 	tempArray = [];
 	tempArray[0] = intervalArray[2];
-	tempArray[1] = intervalArray[5];
-	tempArray[2] = intervalArray[8];
+	tempArray[1] = intervalArray[4];
+	tempArray[2] = intervalArray[5];
 	for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
 		interval = result.value;
 		assert.strictEqual(
@@ -180,9 +176,8 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 
 	iterator = intervalCollection.CreateBackwardIteratorWithEndPosition(1);
 	tempArray = [];
-	tempArray[0] = intervalArray[7];
-	tempArray[1] = intervalArray[4];
-	tempArray[2] = intervalArray[1];
+	tempArray[0] = intervalArray[3];
+	tempArray[1] = intervalArray[1];
 	for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
 		interval = result.value;
 		assert.strictEqual(
@@ -446,12 +441,9 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 			intervalArray[0] = intervals1.add(0, 0, IntervalType.SlideOnRemove);
 			intervalArray[1] = intervals1.add(0, 1, IntervalType.SlideOnRemove);
 			intervalArray[2] = intervals1.add(0, 2, IntervalType.SlideOnRemove);
-			intervalArray[3] = intervals1.add(1, 0, IntervalType.SlideOnRemove);
-			intervalArray[4] = intervals1.add(1, 1, IntervalType.SlideOnRemove);
-			intervalArray[5] = intervals1.add(1, 2, IntervalType.SlideOnRemove);
-			intervalArray[6] = intervals1.add(2, 0, IntervalType.SlideOnRemove);
-			intervalArray[7] = intervals1.add(2, 1, IntervalType.SlideOnRemove);
-			intervalArray[8] = intervals1.add(2, 2, IntervalType.SlideOnRemove);
+			intervalArray[3] = intervals1.add(1, 1, IntervalType.SlideOnRemove);
+			intervalArray[4] = intervals1.add(1, 2, IntervalType.SlideOnRemove);
+			intervalArray[5] = intervals1.add(2, 2, IntervalType.SlideOnRemove);
 
 			// Load the Container that was created by the first client.
 			const container2 = await provider.loadTestContainer(testContainerConfig);
@@ -471,7 +463,6 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 			let iterator = intervals2.CreateForwardIteratorWithStartPosition(1);
 			tempArray[0] = intervalArray[3];
 			tempArray[1] = intervalArray[4];
-			tempArray[2] = intervalArray[5];
 			for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
 				checkIdEquals(
 					result.value,
@@ -505,9 +496,8 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 
 			iterator = intervals2.CreateBackwardIteratorWithEndPosition(1);
 			tempArray = [];
-			tempArray[0] = intervalArray[7];
-			tempArray[1] = intervalArray[4];
-			tempArray[2] = intervalArray[1];
+			tempArray[0] = intervalArray[3];
+			tempArray[1] = intervalArray[1];
 			for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
 				checkIdEquals(
 					result.value,
@@ -659,7 +649,7 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 			) {
 				// Conflicting changes
 				intervals1.change(id1, 1, 2);
-				intervals2.change(id1, 2, 1);
+				intervals2.change(id1, 2, 3);
 
 				await provider.ensureSynchronized();
 


### PR DESCRIPTION
## Description

This checks the requested start and end for IntervalCollection.add and .change, and throws UsageError if they are reversed, including reversed/FULL stickiness at the same position. Data at rest and ops from older clients that have reversed endpoints still work.

This change also sets stickiness when reverting revertibles (previously we were capturing the state but not restoring it).

I added unit tests and fixed up the fuzz tests to avoid reversed endpoints.

## Breaking Changes

This is a breaking change but not to any behaviour that anyone wants, I think.

## Reviewer Guidance

I implemented it such that revertibles don't revert interval changes if they would cause reversed endpoints, but I'm not sure if this is good behavior. It's possible that intervals get reversed when they have NONE stickiness and the text containing the interval is deleted (or edits from old clients) and now you can't undo interval edits away from that state.