### PR TITLE
Only stash blobs when closing

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -918,7 +918,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		}
 	}
 
-	public async getPendingBlobs(waitBlobsToAttach?: boolean): Promise<IPendingBlobs | undefined> {
+	public async attachAndGetPendingBlobs(): Promise<IPendingBlobs | undefined> {
 		return PerformanceEvent.timedExecAsync(
 			this.mc.logger,
 			{ eventName: "GetPendingBlobs" },
@@ -933,34 +933,32 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 					for (const [id, entry] of this.pendingBlobs) {
 						if (!localBlobs.has(entry)) {
 							localBlobs.add(entry);
-							if (waitBlobsToAttach) {
-								if (!entry.opsent) {
-									this.sendBlobAttachOp(id, entry.storageId);
-								}
-								entry.handleP.resolve(this.getBlobHandle(id));
-								attachBlobsP.push(
-									new Promise<void>((resolve) => {
-										const onBlobAttached = (attachedEntry) => {
-											if (attachedEntry === entry) {
-												this.off("blobAttached", onBlobAttached);
-												resolve();
-											}
-										};
-										if (!entry.attached) {
-											this.on("blobAttached", onBlobAttached);
-										} else {
+							if (!entry.opsent) {
+								this.sendBlobAttachOp(id, entry.storageId);
+							}
+							entry.handleP.resolve(this.getBlobHandle(id));
+							attachBlobsP.push(
+								new Promise<void>((resolve) => {
+									const onBlobAttached = (attachedEntry) => {
+										if (attachedEntry === entry) {
+											this.off("blobAttached", onBlobAttached);
 											resolve();
 										}
-									}),
-								);
-							}
+									};
+									if (!entry.attached) {
+										this.on("blobAttached", onBlobAttached);
+									} else {
+										resolve();
+									}
+								}),
+							);
 						}
 					}
 					await Promise.all(attachBlobsP);
 				}
-				// another for is needed to correctly mark attach state
-				// future optimization won't add unattached blobs to the list
+
 				for (const [id, entry] of this.pendingBlobs) {
+					assert(entry.attached === true, "stashed blob should be attached");
 					blobs[id] = {
 						blob: bufferToString(entry.blob, "base64"),
 						storageId: entry.storageId,
@@ -970,7 +968,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 						uploadTime: entry.uploadTime,
 					};
 				}
-				return blobs;
+				return Object.keys(blobs).length > 0 ? blobs : undefined;
 			},
 		);
 	}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3910,9 +3910,10 @@ export class ContainerRuntime
 				if (this._orderSequentiallyCalls !== 0) {
 					throw new UsageError("can't get state during orderSequentially");
 				}
-				const pendingAttachmentBlobs = await this.blobManager.getPendingBlobs(
-					waitBlobsToAttach,
-				);
+				const pendingAttachmentBlobs = waitBlobsToAttach
+					? await this.blobManager.attachAndGetPendingBlobs()
+					: undefined;
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
 				const pending = this.pendingStateManager.getLocalState();
 				if (!pendingAttachmentBlobs && !this.hasPendingMessages()) {
 					return; // no pending state to save

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3910,6 +3910,10 @@ export class ContainerRuntime
 				if (this._orderSequentiallyCalls !== 0) {
 					throw new UsageError("can't get state during orderSequentially");
 				}
+				// Flush pending batch.
+				// getPendingLocalState() is only exposed through Container.closeAndGetPendingLocalState(), so it's safe
+				// to close current batch.
+				this.flush();
 				const pendingAttachmentBlobs = waitBlobsToAttach
 					? await this.blobManager.attachAndGetPendingBlobs()
 					: undefined;
@@ -3917,10 +3921,6 @@ export class ContainerRuntime
 				if (!pendingAttachmentBlobs && !this.hasPendingMessages()) {
 					return; // no pending state to save
 				}
-				// Flush pending batch.
-				// getPendingLocalState() is only exposed through Container.closeAndGetPendingLocalState(), so it's safe
-				// to close current batch.
-				this.flush();
 
 				const pendingState: IPendingRuntimeState = {
 					pending,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3913,7 +3913,6 @@ export class ContainerRuntime
 				const pendingAttachmentBlobs = waitBlobsToAttach
 					? await this.blobManager.attachAndGetPendingBlobs()
 					: undefined;
-				await new Promise<void>((resolve) => setTimeout(resolve, 0));
 				const pending = this.pendingStateManager.getLocalState();
 				if (!pendingAttachmentBlobs && !this.hasPendingMessages()) {
 					return; // no pending state to save

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -147,8 +147,8 @@ export class MockRuntime
 		return this.blobManager.getBlob(blobId);
 	}
 
-	public async getPendingLocalState(waitBlobsToAttach: boolean) {
-		const pendingBlobs = await this.blobManager.getPendingBlobs(waitBlobsToAttach);
+	public async getPendingLocalState() {
+		const pendingBlobs = await this.blobManager.attachAndGetPendingBlobs();
 		return [[...this.ops], pendingBlobs];
 	}
 

--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -26,7 +26,7 @@ describe("getPendingLocalState", () => {
 		await runtime.connect();
 		const blob = IsoBuffer.from("blob", "utf8");
 		const handleP = runtime.createBlob(blob);
-		const pendingStateP = runtime.getPendingLocalState(true);
+		const pendingStateP = runtime.getPendingLocalState();
 		await runtime.processHandles();
 		await assert.doesNotReject(handleP);
 		const pendingState = await pendingStateP;
@@ -57,7 +57,7 @@ describe("getPendingLocalState", () => {
 		const blob = IsoBuffer.from("blob", "utf8");
 		const handleP = runtime.createBlob(blob);
 		await runtime.processBlobs();
-		const pendingStateP = runtime.getPendingLocalState(true);
+		const pendingStateP = runtime.getPendingLocalState();
 		await runtime.processHandles();
 		await assert.doesNotReject(handleP);
 		const pendingState = await pendingStateP;
@@ -90,7 +90,7 @@ describe("getPendingLocalState", () => {
 		await runtime.processBlobs();
 		const blob2 = IsoBuffer.from("blob2", "utf8");
 		const handleP2 = runtime.createBlob(blob2);
-		const pendingStateP = runtime.getPendingLocalState(true);
+		const pendingStateP = runtime.getPendingLocalState();
 		await runtime.processHandles();
 		await assert.doesNotReject(handleP);
 		await assert.doesNotReject(handleP2);
@@ -121,7 +121,7 @@ describe("getPendingLocalState", () => {
 		await runtime.processBlobs();
 		const blob2 = IsoBuffer.from("blob2", "utf8");
 		const handleP2 = runtime.createBlob(blob2);
-		const pendingStateP = runtime.getPendingLocalState(true);
+		const pendingStateP = runtime.getPendingLocalState();
 		await runtime.processHandles();
 		const handleP3 = runtime.createBlob(IsoBuffer.from("blob3", "utf8"));
 		await runtime.processBlobs();

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -642,11 +642,9 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 		container1.disconnect();
 		container1.connect();
 		await waitForContainerConnection(container1);
-
+		// sending some ops to confirm pending blob is not blocking other ops
 		dataStore1._root.set("key", "value");
 		dataStore1._root.set("another key", "another value");
-		resolveUploadBlob();
-		await assert.doesNotReject(handleP);
 
 		const container2 = await provider.loadTestContainer(testContainerConfig);
 		const dataStore2 = await requestFluidObject<ITestDataObject>(container2, "default");
@@ -655,6 +653,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 		assert.strictEqual(dataStore2._root.get("key"), "value");
 		assert.strictEqual(dataStore2._root.get("another key"), "another value");
 
+		resolveUploadBlob();
+		await assert.doesNotReject(handleP);
 		runtimeStorage.uploadBlob = delayedUploadBlob;
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -29,8 +29,6 @@ import {
 } from "@fluid-internal/test-version-utils";
 import { v4 as uuid } from "uuid";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-// eslint-disable-next-line import/no-internal-modules
-import { IPendingRuntimeState, IPendingBlobs } from "@fluidframework/container-runtime/src/test";
 import {
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
@@ -645,24 +643,18 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 		container1.connect();
 		await waitForContainerConnection(container1);
 
-		let pendingBlobs: IPendingBlobs = await (container1 as any).runtime
-			.getPendingLocalState()
-			.then((s) => (s as IPendingRuntimeState).pendingAttachmentBlobs);
-		assert.strictEqual(Object.values<any>(pendingBlobs).length, 1);
-		const acked = Object.values<any>(pendingBlobs)[0].acked;
-		assert.strictEqual(acked, false, "reconnection should not reupload pending blobs");
-		// sending some ops to confirm pending blob is not blocking other ops
 		dataStore1._root.set("key", "value");
 		dataStore1._root.set("another key", "another value");
+		resolveUploadBlob();
+		await assert.doesNotReject(handleP);
+
+		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const dataStore2 = await requestFluidObject<ITestDataObject>(container2, "default");
 		await provider.ensureSynchronized();
 
-		resolveUploadBlob();
+		assert.strictEqual(dataStore2._root.get("key"), "value");
+		assert.strictEqual(dataStore2._root.get("another key"), "another value");
 
-		await assert.doesNotReject(handleP);
-		pendingBlobs = await (container1 as any).runtime
-			.getPendingLocalState()
-			.then((s) => (s as IPendingRuntimeState).pendingAttachmentBlobs);
-		assert.strictEqual(Object.values<any>(pendingBlobs)[0].acked, true);
 		runtimeStorage.uploadBlob = delayedUploadBlob;
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -78,6 +78,7 @@ describeNoCompat("blob handle isAttached", (getTestObjectProvider) => {
 		it("blob is aborted after upload succeds", async function () {
 			const testString = "this is a test string";
 			const dataStore1 = await requestFluidObject<ITestFluidObject>(container, "default");
+			const map = await dataStore1.getSharedObject<SharedMap>(mapId);
 			const ac = new AbortController();
 			let blob: IFluidHandle<ArrayBufferLike>;
 			try {
@@ -86,15 +87,14 @@ describeNoCompat("blob handle isAttached", (getTestObjectProvider) => {
 					ac.signal,
 				);
 				ac.abort();
+				map.set("key", blob);
 			} catch (error: any) {
 				assert.fail("Should succeed");
 			}
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
+			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState({notifyImminentClosure: true})) as
 				| IPendingRuntimeState
 				| undefined;
-			const acked = Object.values<any>(pendingState?.pendingAttachmentBlobs ?? {})[0].acked;
-			assert.strictEqual(blob.isAttached, false);
-			assert.strictEqual(acked, true);
+			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
 		});
 
 		it("blob is attached after usage in map", async function () {
@@ -121,16 +121,15 @@ describeNoCompat("blob handle isAttached", (getTestObjectProvider) => {
 			assert.strictEqual(blob.isAttached, true);
 		});
 
-		it("blob is acked after upload", async function () {
+		it("removes pending blob when waiting for blob to be attached", async function () {
 			const testString = "this is a test string";
 			const dataStore1 = await requestFluidObject<ITestFluidObject>(container, "default");
+			const map = await dataStore1.getSharedObject<SharedMap>(mapId);
 			const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
-				| IPendingRuntimeState
-				| undefined;
-			const acked = Object.values<any>(pendingState?.pendingAttachmentBlobs ?? {})[0].acked;
-			assert.strictEqual(blob.isAttached, false);
-			assert.strictEqual(acked, true);
+			const pendingStateP: any = (runtimeOf(dataStore1).getPendingLocalState({notifyImminentClosure: true}));
+			map.set("key", blob);
+			const pendingState = await pendingStateP;
+			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
 		});
 
 		it("removes pending blob after attached and acked", async function () {

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -91,9 +91,9 @@ describeNoCompat("blob handle isAttached", (getTestObjectProvider) => {
 			} catch (error: any) {
 				assert.fail("Should succeed");
 			}
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState({notifyImminentClosure: true})) as
-				| IPendingRuntimeState
-				| undefined;
+			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState({
+				notifyImminentClosure: true,
+			})) as IPendingRuntimeState | undefined;
 			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
 		});
 
@@ -126,7 +126,9 @@ describeNoCompat("blob handle isAttached", (getTestObjectProvider) => {
 			const dataStore1 = await requestFluidObject<ITestFluidObject>(container, "default");
 			const map = await dataStore1.getSharedObject<SharedMap>(mapId);
 			const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-			const pendingStateP: any = (runtimeOf(dataStore1).getPendingLocalState({notifyImminentClosure: true}));
+			const pendingStateP: any = runtimeOf(dataStore1).getPendingLocalState({
+				notifyImminentClosure: true,
+			});
 			map.set("key", blob);
 			const pendingState = await pendingStateP;
 			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1268,30 +1268,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 		);
 	});
 
-	it("get pending blob without close while online", async function () {
-		const dataStore = await requestFluidObject<ITestFluidObject>(container1, "default");
-		const map = await dataStore.getSharedObject<SharedMap>(mapId);
-		await provider.ensureSynchronized();
-
-		const handle = await dataStore.runtime.uploadBlob(stringToBuffer("blob contents", "utf8"));
-		const pendingOps = await container1.getPendingLocalState?.();
-		map.set("blob handle", handle);
-
-		const container2 = await loader.resolve({ url }, pendingOps);
-		const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
-		const map2 = await dataStore2.getSharedObject<SharedMap>(mapId);
-
-		await provider.ensureSynchronized();
-		assert.strictEqual(
-			bufferToString(await map1.get("blob handle").get(), "utf8"),
-			"blob contents",
-		);
-		assert.strictEqual(
-			bufferToString(await map2.get("blob handle").get(), "utf8"),
-			"blob contents",
-		);
-	});
-
 	it("close while uploading multiple blob", async function () {
 		const dataStore = await requestFluidObject<ITestFluidObject>(container1, "default");
 		const map = await dataStore.getSharedObject<SharedMap>(mapId);

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1268,6 +1268,30 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 		);
 	});
 
+	it("get pending blob without close while online", async function () {
+		const dataStore = await requestFluidObject<ITestFluidObject>(container1, "default");
+		const map = await dataStore.getSharedObject<SharedMap>(mapId);
+		await provider.ensureSynchronized();
+
+		const handle = await dataStore.runtime.uploadBlob(stringToBuffer("blob contents", "utf8"));
+		const pendingOps = await container1.getPendingLocalState?.();
+		map.set("blob handle", handle);
+
+		const container2 = await loader.resolve({ url }, pendingOps);
+		const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+		const map2 = await dataStore2.getSharedObject<SharedMap>(mapId);
+
+		await provider.ensureSynchronized();
+		assert.strictEqual(
+			bufferToString(await map1.get("blob handle").get(), "utf8"),
+			"blob contents",
+		);
+		assert.strictEqual(
+			bufferToString(await map2.get("blob handle").get(), "utf8"),
+			"blob contents",
+		);
+	});
+
 	it("close while uploading multiple blob", async function () {
 		const dataStore = await requestFluidObject<ITestFluidObject>(container1, "default");
 		const map = await dataStore.getSharedObject<SharedMap>(mapId);

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1022,9 +1022,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 
 			[...Array(lots).keys()].map((i) => dataStore.root.set(`test op #${i}`, i));
 
-			// wait for flush to happen and see added ops in the pending queue
-			await new Promise<void>((resolve) => setTimeout(resolve, 0));
-
 			const pendingState = await container.getPendingLocalState?.();
 
 			const container2 = await loader.resolve({ url }, pendingState);
@@ -1193,8 +1190,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 			await provider.opProcessingController.pauseProcessing(container2);
 			assert(dataStore2.runtime.deltaManager.outbound.paused);
 			[...Array(lots).keys()].map((i) => map2.set((i + lots).toString(), i + lots));
-			// wait for flush to happen and see added ops in the pending queue
-			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 			const morePendingOps = await container2.getPendingLocalState?.();
 			assert.ok(morePendingOps);

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1022,6 +1022,9 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 
 			[...Array(lots).keys()].map((i) => dataStore.root.set(`test op #${i}`, i));
 
+			// wait for flush to happen and see added ops in the pending queue
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 			const pendingState = await container.getPendingLocalState?.();
 
 			const container2 = await loader.resolve({ url }, pendingState);
@@ -1190,6 +1193,8 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 			await provider.opProcessingController.pauseProcessing(container2);
 			assert(dataStore2.runtime.deltaManager.outbound.paused);
 			[...Array(lots).keys()].map((i) => map2.set((i + lots).toString(), i + lots));
+			// wait for flush to happen and see added ops in the pending queue
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 			const morePendingOps = await container2.getPendingLocalState?.();
 			assert.ok(morePendingOps);


### PR DESCRIPTION
This change makes getPendingLocalState to stash blobs only in closeAndGetPendingLocalState case (notifyImminentClosure = true). getPendingLocalState without closing can't stash blobs given that their reference could not be included in the pending state, having as a result a blob handle without any reference, dds that uses it. 

Some tests relied on being able to read pending attachment blobs which is not possible now, so I changed some asserts and ways to confirm correct behavior. There is one test we're losing here "blob is acked after upload". Given that we can't collect pending blobs if they are not attached, there is no way to know if the stashed blob is purely acked.  I substituted that test with "removes pending blob when waiting for blob to be attached" which indirectly checks the same thing, given that only blobs who are attacked and acked are removed.