### PR TITLE
Fix release tags

### DIFF
--- a/api-report/client-utils.api.md
+++ b/api-report/client-utils.api.md
@@ -11,7 +11,7 @@ import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IEventTransformer } from '@fluidframework/core-interfaces';
 import { TransformedEvent } from '@fluidframework/core-interfaces';
 
-// @alpha
+// @public
 export class Buffer extends Uint8Array {
     // (undocumented)
     static from(value: any, encodingOrOffset?: any, length?: any): IsoBuffer;
@@ -56,10 +56,10 @@ export function gitHashFile(file: IsoBuffer): Promise<string>;
 // @internal
 export function hashFile(file: IsoBuffer, algorithm?: "SHA-1" | "SHA-256", hashEncoding?: "hex" | "base64"): Promise<string>;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export const IsoBuffer: typeof Buffer;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type IsoBuffer = Buffer;
 
 // @internal

--- a/api-report/client-utils.api.md
+++ b/api-report/client-utils.api.md
@@ -11,7 +11,7 @@ import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IEventTransformer } from '@fluidframework/core-interfaces';
 import { TransformedEvent } from '@fluidframework/core-interfaces';
 
-// @internal
+// @alpha
 export class Buffer extends Uint8Array {
     // (undocumented)
     static from(value: any, encodingOrOffset?: any, length?: any): IsoBuffer;
@@ -56,10 +56,10 @@ export function gitHashFile(file: IsoBuffer): Promise<string>;
 // @internal
 export function hashFile(file: IsoBuffer, algorithm?: "SHA-1" | "SHA-256", hashEncoding?: "hex" | "base64"): Promise<string>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const IsoBuffer: typeof Buffer;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type IsoBuffer = Buffer;
 
 // @internal

--- a/packages/common/client-utils/src/bufferNode.ts
+++ b/packages/common/client-utils/src/bufferNode.ts
@@ -8,7 +8,7 @@
  * exposing the entirely of Node's typings.  This should match the public interface
  * of the browser implementation, so any changes made in one should be made in both.
  *
- * @alpha
+ * @public
  */
 export declare class Buffer extends Uint8Array {
 	toString(encoding?: string): string;
@@ -22,12 +22,12 @@ export declare class Buffer extends Uint8Array {
 }
 
 /**
- * @alpha
+ * @public
  */
 export const IsoBuffer = Buffer;
 
 /**
- * @alpha
+ * @public
  */
 export type IsoBuffer = Buffer;
 

--- a/packages/common/client-utils/src/bufferNode.ts
+++ b/packages/common/client-utils/src/bufferNode.ts
@@ -8,7 +8,7 @@
  * exposing the entirely of Node's typings.  This should match the public interface
  * of the browser implementation, so any changes made in one should be made in both.
  *
- * @internal
+ * @alpha
  */
 export declare class Buffer extends Uint8Array {
 	toString(encoding?: string): string;
@@ -22,12 +22,12 @@ export declare class Buffer extends Uint8Array {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export const IsoBuffer = Buffer;
 
 /**
- * @internal
+ * @alpha
  */
 export type IsoBuffer = Buffer;
 


### PR DESCRIPTION
The release tags in client-utils were referenced incorrectly. The `IBinaryCodec` interface which is part of `@fluid-experimental-tree2` references `IsoBuffer` which is marked `internal`.

```ts
/**
 * @remarks - TODO: We might consider using DataView or some kind of writer instead of IsoBuffer.
 * @alpha
 */
export interface IBinaryCodec<TDecoded>
	extends IEncoder<TDecoded, IsoBuffer>,
		IDecoder<TDecoded, IsoBuffer> {}
 ```
```ts
 /**
 * @internal
 */
export const IsoBuffer = Buffer;
```
