### PR TITLE
Optionally require the fluid signature when decoding the fluid locator value

### DIFF
--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -63,7 +63,7 @@ export function getApiRoot(origin: string): string;
 export function getHashedDocumentId(driveId: string, itemId: string): Promise<string>;
 
 // @public
-export function getLocatorFromOdspUrl(url: URL): OdspFluidDataStoreLocator | undefined;
+export function getLocatorFromOdspUrl(url: URL, requireFluidSignature?: boolean): OdspFluidDataStoreLocator | undefined;
 
 // @public
 export function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefined>;

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -61,11 +61,12 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
 function decodeOdspFluidDataStoreLocator(
 	encodedLocatorValue: string,
 	siteOriginUrl: string,
+	requireFluidSignature: boolean = true,
 ): OdspFluidDataStoreLocator | undefined {
 	const locatorInfo = new URLSearchParams(fromBase64ToUtf8(encodedLocatorValue));
 
 	const signatureValue = locatorInfo.get(fluidSignatureParamName);
-	if (signatureValue !== "1") {
+	if (requireFluidSignature && signatureValue !== "1") {
 		return undefined;
 	}
 
@@ -128,7 +129,10 @@ export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocat
  * @param url - ODSP url representing Fluid file link
  * @returns object representing Fluid data store location in ODSP terms
  */
-export function getLocatorFromOdspUrl(url: URL): OdspFluidDataStoreLocator | undefined {
+export function getLocatorFromOdspUrl(
+	url: URL,
+	requireFluidSignature?: boolean,
+): OdspFluidDataStoreLocator | undefined {
 	// NOTE: No need to apply decodeURIComponent when accessing query params via URLSearchParams class.
 	const encodedLocatorValue = url.searchParams.get(locatorQueryParamName);
 	if (!encodedLocatorValue) {
@@ -140,5 +144,9 @@ export function getLocatorFromOdspUrl(url: URL): OdspFluidDataStoreLocator | und
 	const siteOriginUrl =
 		url.origin.toLowerCase() === OdcFileSiteOrigin ? OdcApiSiteOrigin : url.origin;
 
-	return decodeOdspFluidDataStoreLocator(encodedLocatorValue, siteOriginUrl);
+	return decodeOdspFluidDataStoreLocator(
+		encodedLocatorValue,
+		siteOriginUrl,
+		requireFluidSignature,
+	);
 }

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -56,7 +56,7 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
  * @param encodedLocatorValue - encoded Fluid data store locator value which was produced by
  * {@link encodeOdspFluidDataStoreLocator} function
  * @param siteOriginUrl - site origin that will be appended to encoded relative path to form absolute file url
- * @param requireFluidSignature - flag representing if the fluid signature is expected in the url, default true
+ * @param requireFluidSignature - flag representing if the Fluid signature is expected in the url, default true
  * @returns object representing Fluid data store location in ODSP terms
  */
 function decodeOdspFluidDataStoreLocator(
@@ -128,7 +128,7 @@ export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocat
  * Extract ODSP Fluid data store locator object from given ODSP url. This extracts things like
  * driveId, ItemId, siteUrl etc from a url where these are encoded in nav query param.
  * @param url - ODSP url representing Fluid file link
- * @param requireFluidSignature - flag representing if the fluid signature is expected in the url, default true
+ * @param requireFluidSignature - flag representing if the Fluid signature is expected in the url, default true
  * @returns object representing Fluid data store location in ODSP terms
  */
 export function getLocatorFromOdspUrl(

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -56,6 +56,7 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
  * @param encodedLocatorValue - encoded Fluid data store locator value which was produced by
  * {@link encodeOdspFluidDataStoreLocator} function
  * @param siteOriginUrl - site origin that will be appended to encoded relative path to form absolute file url
+ * @param requireFluidSignature - flag representing if the fluid signature is expected in the url, default true
  * @returns object representing Fluid data store location in ODSP terms
  */
 function decodeOdspFluidDataStoreLocator(
@@ -127,6 +128,7 @@ export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocat
  * Extract ODSP Fluid data store locator object from given ODSP url. This extracts things like
  * driveId, ItemId, siteUrl etc from a url where these are encoded in nav query param.
  * @param url - ODSP url representing Fluid file link
+ * @param requireFluidSignature - flag representing if the fluid signature is expected in the url, optional
  * @returns object representing Fluid data store location in ODSP terms
  */
 export function getLocatorFromOdspUrl(

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -128,12 +128,12 @@ export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocat
  * Extract ODSP Fluid data store locator object from given ODSP url. This extracts things like
  * driveId, ItemId, siteUrl etc from a url where these are encoded in nav query param.
  * @param url - ODSP url representing Fluid file link
- * @param requireFluidSignature - flag representing if the fluid signature is expected in the url, optional
+ * @param requireFluidSignature - flag representing if the fluid signature is expected in the url, default true
  * @returns object representing Fluid data store location in ODSP terms
  */
 export function getLocatorFromOdspUrl(
 	url: URL,
-	requireFluidSignature?: boolean,
+	requireFluidSignature: boolean = true,
 ): OdspFluidDataStoreLocator | undefined {
 	// NOTE: No need to apply decodeURIComponent when accessing query params via URLSearchParams class.
 	const encodedLocatorValue = url.searchParams.get(locatorQueryParamName);


### PR DESCRIPTION
## Description

This PR opens up the use of the `getLocatorFromOdspUrl` function for urls that have encoded locators but no fluid signature (for example: share links for Loop pages). Backwards compatibility is maintained with a default parameter value of `requireFluidSignature = true`.