### PR TITLE
refactor(container-definitions): Promote eslint config from "minimal" to "recommended" and fix violations

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -475,13 +475,13 @@ export interface IRuntimeFactory extends IProvideRuntimeFactory {
 }
 
 // @public
-export const isFluidBrowserPackage: (maybePkg: any) => maybePkg is Readonly<IFluidBrowserPackage>;
+export const isFluidBrowserPackage: (maybePkg: unknown) => maybePkg is Readonly<IFluidBrowserPackage>;
 
 // @public (undocumented)
 export const isFluidCodeDetails: (details: unknown) => details is Readonly<IFluidCodeDetails>;
 
 // @public
-export const isFluidPackage: (pkg: any) => pkg is Readonly<IFluidPackage>;
+export const isFluidPackage: (pkg: unknown) => pkg is Readonly<IFluidPackage>;
 
 // @public
 export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
 	plugins: ["deprecation"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/types/tsconfig.json"],

--- a/packages/common/container-definitions/src/browserPackage.ts
+++ b/packages/common/container-definitions/src/browserPackage.ts
@@ -51,7 +51,9 @@ export interface IFluidBrowserPackage extends IFluidPackage {
  * Determines if any object is an IFluidBrowserPackage
  * @param maybePkg - The object to check for compatibility with IFluidBrowserPackage
  */
-export const isFluidBrowserPackage = (maybePkg: any): maybePkg is Readonly<IFluidBrowserPackage> =>
+export const isFluidBrowserPackage = (
+	maybePkg: unknown,
+): maybePkg is Readonly<IFluidBrowserPackage> =>
 	isFluidPackage(maybePkg) &&
 	typeof maybePkg?.fluid?.browser?.umd?.library === "string" &&
 	Array.isArray(maybePkg?.fluid?.browser?.umd?.files);

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -300,21 +300,26 @@ export type ReadOnlyInfo =
 	  }
 	| {
 			readonly readonly: true;
+
 			/**
-			 * read-only because forceReadOnly() was called
+			 * Read-only because `forceReadOnly()` was called.
 			 */
 			readonly forced: boolean;
+
 			/**
-			 * read-only because client does not have write permissions for document
+			 * Read-only because client does not have write permissions for document.
 			 */
 			readonly permissions: boolean | undefined;
+
 			/**
-			 * read-only with no delta stream connection
+			 * Read-only with no delta stream connection.
 			 */
 			readonly storageOnly: boolean;
+
 			/**
-			 * extra info on why connection to delta stream is not possible. This info might be provided
-			 * if storageOnly is set to true
+			 * Extra info on why connection to delta stream is not possible.
+			 *
+			 * @remarks This info might be provided if {@link ReadOnlyInfo.storageOnly} is set to `true`.
 			 */
 			readonly storageOnlyReason?: string;
 	  };

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -52,6 +52,7 @@ export interface IDeltaManagerEvents extends IEvent {
 	/**
 	 * @deprecated No replacement API recommended.
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(event: "prepareSend", listener: (messageBuffer: any[]) => void);
 
 	/**
@@ -121,28 +122,44 @@ export interface IDeltaManagerEvents extends IEvent {
  * Manages the transmission of ops between the runtime and storage.
  */
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender {
-	/** The queue of inbound delta messages */
+	/**
+	 * The queue of inbound delta messages
+	 */
 	readonly inbound: IDeltaQueue<T>;
 
-	/** The queue of outbound delta messages */
+	/**
+	 * The queue of outbound delta messages
+	 */
 	readonly outbound: IDeltaQueue<U[]>;
 
-	/** The queue of inbound delta signals */
+	/**
+	 * The queue of inbound delta signals
+	 */
 	readonly inboundSignal: IDeltaQueue<ISignalMessage>;
 
-	/** The current minimum sequence number */
+	/**
+	 * The current minimum sequence number
+	 */
 	readonly minimumSequenceNumber: number;
 
-	/** The last sequence number processed by the delta manager */
+	/**
+	 * The last sequence number processed by the delta manager
+	 */
 	readonly lastSequenceNumber: number;
 
-	/** The last message processed by the delta manager */
+	/**
+	 * The last message processed by the delta manager
+	 */
 	readonly lastMessage: ISequencedDocumentMessage | undefined;
 
-	/** The latest sequence number the delta manager is aware of */
+	/**
+	 * The latest sequence number the delta manager is aware of
+	 */
 	readonly lastKnownSeqNumber: number;
 
-	/** The initial sequence number set when attaching the op handler */
+	/**
+	 * The initial sequence number set when attaching the op handler
+	 */
 	readonly initialSequenceNumber: number;
 
 	/**
@@ -151,24 +168,38 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 	 */
 	readonly hasCheckpointSequenceNumber: boolean;
 
-	/** Details of client */
+	/**
+	 * Details of client
+	 */
 	readonly clientDetails: IClientDetails;
 
-	/** Protocol version being used to communicate with the service */
+	/**
+	 * Protocol version being used to communicate with the service
+	 */
 	readonly version: string;
 
-	/** Max message size allowed to the delta manager */
+	/**
+	 * Max message size allowed to the delta manager
+	 */
 	readonly maxMessageSize: number;
 
-	/** Service configuration provided by the service. */
+	/**
+	 * Service configuration provided by the service.
+	 */
 	readonly serviceConfiguration: IClientConfiguration | undefined;
 
-	/** Flag to indicate whether the client can write or not. */
+	/**
+	 * Flag to indicate whether the client can write or not.
+	 */
 	readonly active: boolean;
 
 	readonly readOnlyInfo: ReadOnlyInfo;
 
-	/** Submit a signal to the service to be broadcast to other connected clients, but not persisted */
+	/**
+	 * Submit a signal to the service to be broadcast to other connected clients, but not persisted
+	 */
+	// TODO: use `unknown` instead (API breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	submitSignal(content: any): void;
 }
 
@@ -269,13 +300,21 @@ export type ReadOnlyInfo =
 	  }
 	| {
 			readonly readonly: true;
-			/** read-only because forceReadOnly() was called */
+			/**
+			 * read-only because forceReadOnly() was called
+			 */
 			readonly forced: boolean;
-			/** read-only because client does not have write permissions for document */
+			/**
+			 * read-only because client does not have write permissions for document
+			 */
 			readonly permissions: boolean | undefined;
-			/** read-only with no delta stream connection */
+			/**
+			 * read-only with no delta stream connection
+			 */
 			readonly storageOnly: boolean;
-			/** extra info on why connection to delta stream is not possible. This info might be provided
-			 * if storageOnly is set to true */
+			/**
+			 * extra info on why connection to delta stream is not possible. This info might be provided
+			 * if storageOnly is set to true
+			 */
 			readonly storageOnlyReason?: string;
 	  };

--- a/packages/common/container-definitions/src/fluidPackage.ts
+++ b/packages/common/container-definitions/src/fluidPackage.ts
@@ -63,8 +63,10 @@ export interface IFluidPackage {
  * Check if the package.json defines a Fluid package
  * @param pkg - the package json data to check if it is a Fluid package.
  */
-export const isFluidPackage = (pkg: any): pkg is Readonly<IFluidPackage> =>
-	typeof pkg === "object" && typeof pkg?.name === "string" && typeof pkg?.fluid === "object";
+export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
+	typeof pkg === "object" &&
+	typeof (pkg as Partial<IFluidPackage>)?.name === "string" &&
+	typeof (pkg as Partial<IFluidPackage>)?.fluid === "object";
 
 /**
  * Package manager configuration. Provides a key value mapping of config values

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -544,6 +544,7 @@ export interface IHostLoader extends ILoader {
 }
 
 export type ILoaderOptions = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[key in string | number]: any;
 } & {
 	/**

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -76,6 +76,8 @@ export interface IRuntime extends IDisposable {
 	/**
 	 * Processes the given signal
 	 */
+	// TODO: use `unknown` instead (API breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	processSignal(message: any, local: boolean);
 
 	/**
@@ -147,14 +149,21 @@ export interface IContainerContext {
 	readonly storage: IDocumentStorageService;
 	readonly connected: boolean;
 	readonly baseSnapshot: ISnapshotTree | undefined;
-	/** @deprecated Please use submitBatchFn & submitSummaryFn */
+	/**
+	 * @deprecated Please use submitBatchFn & submitSummaryFn
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
-	/** @returns clientSequenceNumber of last message in a batch */
+	/**
+	 * @returns clientSequenceNumber of last message in a batch
+	 */
 	readonly submitBatchFn: (batch: IBatchMessage[], referenceSequenceNumber?: number) => number;
 	readonly submitSummaryFn: (
 		summaryOp: ISummaryContent,
 		referenceSequenceNumber?: number,
 	) => number;
+	// TODO: use `unknown` instead (API breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	readonly submitSignalFn: (contents: any) => void;
 	readonly disposeFn?: (error?: ICriticalContainerError) => void;
 	readonly closeFn: (error?: ICriticalContainerError) => void;


### PR DESCRIPTION
Production packages should not be using our "minimal" eslint config. Updates `container-definitions` to use our "recommended" config instead. Fixes violations, save for those that would be API breaking.