### PR TITLE
Temporarily enable debug logs for all runs of stress tests

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -30,6 +30,11 @@ variables:
 - name: testPackage
   value: "@fluid-internal/test-service-load"
   readonly: true
+# Temporarily enabling debug logs for all pipeline runs to be able to better troubleshoot when the odsp/odsp-df stages
+# time out and produce no output even though we know the tests did run.
+# TODO : remove this after troubleshooting.
+- name: system.debug
+  value: true
 
 lockBehavior: sequential
 stages:


### PR DESCRIPTION
## Description

In trying to troubleshoot the issues with the odsp/odsp-df stages in stress tests sometimes timing out, we noticed that when that happens, the stage logs no output at all, even though we know the tests are actually running, because we see telemetry in Kusto. We also know that if they're running, they should be producing some output to console, which we see when those pipeline stages don't time out.

Since we can't predict when the pipeline will run into that issue, we're temporarily enabling debug logs for all runs of the pipeline. This might affect performance of the pipeline so we plan to disable them once we get debug logs for at least one run where the stages time out.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
