### PR TITLE
refactor(tree): move IdAllocator to utils

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -819,7 +819,7 @@ export interface ICodecOptions {
 }
 
 // @alpha
-export type IdAllocator = (count?: number) => ChangesetLocalId;
+export type IdAllocator = (count?: number) => number;
 
 // @alpha (undocumented)
 export interface IDecoder<TDecoded, TEncoded> {

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
@@ -12,7 +12,7 @@ import {
 	tagChange,
 	ChangesetLocalId,
 } from "../../core";
-import { fail, Mutable } from "../../util";
+import { fail, IdAllocator, Mutable } from "../../util";
 import { singleTextCursor, jsonableTreeFromCursor } from "../treeTextCursor";
 import {
 	ToDelta,
@@ -23,7 +23,6 @@ import {
 	NodeChangeset,
 	FieldEditor,
 	NodeReviver,
-	IdAllocator,
 	CrossFieldManager,
 	RevisionMetadataSource,
 	getIntention,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -100,7 +100,6 @@ import * as SequenceField from "./sequence-field";
 export { SequenceField };
 
 export {
-	idAllocatorFromMaxId,
 	isNeverField,
 	ModularEditBuilder,
 	EditDescription,
@@ -113,7 +112,6 @@ export {
 	FieldChangeset,
 	ToDelta,
 	ModularChangeset,
-	IdAllocator,
 	NodeChangeComposer,
 	NodeChangeInverter,
 	NodeChangeRebaser,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/crossFieldQueries.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/crossFieldQueries.ts
@@ -3,17 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils";
 import { ChangesetLocalId, RevisionTag } from "../../core";
 import {
 	RangeEntry,
 	RangeMap,
-	brand,
 	getFirstFromRangeMap,
 	getOrAddInMap,
 	setInRangeMap,
 } from "../../util";
-import { IdAllocator } from "./fieldChangeHandler";
 
 export type CrossFieldMap<T> = Map<RevisionTag | undefined, RangeMap<T>>;
 export type CrossFieldQuerySet = CrossFieldMap<boolean>;
@@ -85,25 +82,4 @@ export interface CrossFieldManager<T = unknown> {
 		newValue: T,
 		invalidateDependents: boolean,
 	): void;
-}
-
-export interface IdAllocationState {
-	maxId: ChangesetLocalId;
-}
-
-/**
- * @alpha
- */
-export function idAllocatorFromMaxId(maxId: ChangesetLocalId | undefined = undefined): IdAllocator {
-	return idAllocatorFromState({ maxId: maxId ?? brand(-1) });
-}
-
-export function idAllocatorFromState(state: IdAllocationState): IdAllocator {
-	return (c?: number) => {
-		const count = c ?? 1;
-		assert(count > 0, 0x5cf /* Must allocate at least one ID */);
-		const id: ChangesetLocalId = brand((state.maxId as number) + 1);
-		state.maxId = brand((state.maxId as number) + count);
-		return id;
-	};
 }

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Delta, TaggedChange, RevisionTag, ChangesetLocalId } from "../../core";
-import { fail, Invariant } from "../../util";
+import { Delta, TaggedChange, RevisionTag } from "../../core";
+import { fail, IdAllocator, Invariant } from "../../util";
 import { ICodecFamily, IJsonCodec } from "../../codec";
 import { MemoizedIdRangeAllocator } from "../memoizedIdRangeAllocator";
 import { CrossFieldManager } from "./crossFieldQueries";
@@ -205,13 +205,6 @@ export type NodeChangeRebaser = (
  * @alpha
  */
 export type NodeChangeComposer = (changes: TaggedChange<NodeChangeset>[]) => NodeChangeset;
-
-/**
- * Allocates a block of `count` consecutive IDs and returns the first ID in the block.
- * For convenience can be called with no parameters to allocate a single ID.
- * @alpha
- */
-export type IdAllocator = (count?: number) => ChangesetLocalId;
 
 /**
  * A callback that returns the index of the changeset associated with the given RevisionTag among the changesets being

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -4,7 +4,7 @@
  */
 
 import { Delta, makeAnonChange, tagChange, TaggedChange } from "../../core";
-import { brand, fail } from "../../util";
+import { brand, fail, IdAllocator } from "../../util";
 import { CrossFieldManager } from "./crossFieldQueries";
 import {
 	FieldChangeHandler,
@@ -12,7 +12,6 @@ import {
 	NodeChangeComposer,
 	NodeChangeInverter,
 	NodeChangeRebaser,
-	IdAllocator,
 	RevisionMetadataSource,
 } from "./fieldChangeHandler";
 import { FieldKind, Multiplicity } from "./fieldKind";

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/index.ts
@@ -17,7 +17,6 @@ export {
 	CrossFieldMap,
 	CrossFieldQuerySet,
 	CrossFieldTarget,
-	idAllocatorFromMaxId,
 	setInCrossFieldMap,
 } from "./crossFieldQueries";
 export { ChangesetLocalIdSchema, EncodedChangeAtomId } from "./modularChangeFormat";
@@ -29,7 +28,6 @@ export {
 	brandedFieldKind,
 } from "./fieldKind";
 export {
-	IdAllocator,
 	FieldChangeHandler,
 	FieldChangeRebaser,
 	FieldEditor,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -440,7 +440,7 @@ export class ModularChangeFamily
 		over: TaggedChange<ModularChangeset>,
 	): ModularChangeset {
 		const maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
-		const idState: IdAllocationState = { maxId: maxId };
+		const idState: IdAllocationState = { maxId };
 		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable: RebaseTable = {
 			...newCrossFieldTable<FieldChange>(),

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -22,7 +22,15 @@ import {
 	FieldUpPath,
 	ChangesetLocalId,
 } from "../../core";
-import { brand, getOrAddEmptyToMap, Mutable } from "../../util";
+import {
+	brand,
+	getOrAddEmptyToMap,
+	IdAllocationState,
+	IdAllocator,
+	idAllocatorFromMaxId,
+	idAllocatorFromState,
+	Mutable,
+} from "../../util";
 import { dummyRepairDataStore } from "../fakeRepairDataStore";
 import { MemoizedIdRangeAllocator } from "../memoizedIdRangeAllocator";
 import {
@@ -30,16 +38,12 @@ import {
 	CrossFieldMap,
 	CrossFieldQuerySet,
 	CrossFieldTarget,
-	IdAllocationState,
 	addCrossFieldQuery,
 	getFirstFromCrossFieldMap,
-	idAllocatorFromMaxId,
-	idAllocatorFromState,
 	setInCrossFieldMap,
 } from "./crossFieldQueries";
 import {
 	FieldChangeHandler,
-	IdAllocator,
 	RevisionMetadataSource,
 	NodeExistenceState,
 } from "./fieldChangeHandler";
@@ -293,7 +297,10 @@ export class ModularChangeFamily
 			return makeModularChangeset(new Map());
 		}
 
-		const idState: IdAllocationState = { maxId: brand(change.change.maxId ?? -1) };
+		const idState: IdAllocationState = { maxId: change.change.maxId ?? -1 };
+		// This idState is used for the whole of the IdAllocator's lifetime, which allows
+		// this function to read the updated idState.maxId after more IDs are allocated.
+		// TODO: add a getMax function to IdAllocator to make for a clearer contract.
 		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable = newCrossFieldTable<InvertData>();
 		const resolvedRepairStore = repairStore ?? dummyRepairDataStore;
@@ -433,7 +440,7 @@ export class ModularChangeFamily
 		over: TaggedChange<ModularChangeset>,
 	): ModularChangeset {
 		const maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
-		const idState: IdAllocationState = { maxId: brand(maxId) };
+		const idState: IdAllocationState = { maxId: maxId };
 		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable: RebaseTable = {
 			...newCrossFieldTable<FieldChange>(),
@@ -1056,7 +1063,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	}
 
 	public generateId(count?: number): ChangesetLocalId {
-		return this.idAllocator(count);
+		return brand(this.idAllocator(count));
 	}
 
 	private buildChangeMap(

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -5,12 +5,11 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { ChangeAtomId, makeAnonChange, RevisionTag, tagChange, TaggedChange } from "../../core";
-import { asMutable, brand, fail } from "../../util";
+import { asMutable, brand, fail, IdAllocator } from "../../util";
 import {
 	CrossFieldManager,
 	CrossFieldTarget,
 	getIntention,
-	IdAllocator,
 	RevisionMetadataSource,
 } from "../modular-schema";
 import { Changeset, Mark, MarkList, MoveId, NoopMarkType, CellId, NoopMark } from "./format";

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -5,8 +5,8 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { ChangeAtomId, RevisionTag, TaggedChange } from "../../core";
-import { fail } from "../../util";
-import { CrossFieldManager, CrossFieldTarget, IdAllocator, NodeReviver } from "../modular-schema";
+import { IdAllocator, fail } from "../../util";
+import { CrossFieldManager, CrossFieldTarget, NodeReviver } from "../modular-schema";
 import {
 	Changeset,
 	Mark,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
@@ -5,10 +5,10 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { RevisionTag } from "../../core";
+import { IdAllocator } from "../../util";
 import { Mark } from "./format";
 import { applyMoveEffectsToMark, MoveEffectTable } from "./moveEffectTable";
 import { splitMark } from "./utils";
-import { IdAllocator } from "../../util";
 
 export class MarkQueue<T> {
 	private readonly stack: Mark<T>[] = [];

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
@@ -5,10 +5,10 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { RevisionTag } from "../../core";
-import { IdAllocator } from "../modular-schema";
 import { Mark } from "./format";
 import { applyMoveEffectsToMark, MoveEffectTable } from "./moveEffectTable";
 import { splitMark } from "./utils";
+import { IdAllocator } from "../../util";
 
 export class MarkQueue<T> {
 	private readonly stack: Mark<T>[] = [];

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -5,12 +5,11 @@
 
 import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { StableId } from "@fluidframework/runtime-definitions";
-import { fail } from "../../util";
+import { IdAllocator, fail } from "../../util";
 import { ChangeAtomId, ChangesetLocalId, RevisionTag, TaggedChange } from "../../core";
 import {
 	CrossFieldManager,
 	CrossFieldTarget,
-	IdAllocator,
 	NodeExistenceState,
 	RevisionMetadataSource,
 } from "../modular-schema";

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -91,6 +91,7 @@ export {
 	JsonCompatibleObject,
 	NestedMap,
 	fail,
+	IdAllocator,
 	TransactionResult,
 	BrandedKey,
 	BrandedMapSubset,
@@ -123,7 +124,6 @@ export {
 } from "./domains";
 
 export {
-	IdAllocator,
 	MemoizedIdRangeAllocator,
 	IdRange,
 	ModularChangeset,

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -4,12 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import {
-	FieldChangeHandler,
-	IdAllocator,
-	NodeChangeset,
-	CrossFieldManager,
-} from "../../../feature-libraries";
+import { FieldChangeHandler, NodeChangeset, CrossFieldManager } from "../../../feature-libraries";
 import {
 	ValueFieldEditor,
 	valueChangeHandler,
@@ -18,7 +13,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/default-field-kinds/defaultFieldKinds";
 import { makeAnonChange, TaggedChange, mintRevisionTag, tagChange } from "../../../core";
-import { brand } from "../../../util";
+import { IdAllocator, brand } from "../../../util";
 import { defaultRevisionMetadataFromChanges, fakeTaggedRepair as fakeRepair } from "../../utils";
 // eslint-disable-next-line import/no-internal-modules
 import { OptionalChangeset } from "../../../feature-libraries/default-field-kinds/defaultFieldChangeTypes";

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalField.spec.ts
@@ -4,12 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import {
-	CrossFieldManager,
-	IdAllocator,
-	NodeChangeset,
-	NodeReviver,
-} from "../../../feature-libraries";
+import { CrossFieldManager, NodeChangeset, NodeReviver } from "../../../feature-libraries";
 import {
 	makeAnonChange,
 	RevisionTag,
@@ -19,7 +14,7 @@ import {
 	tagChange,
 	tagRollbackInverse,
 } from "../../../core";
-import { brand } from "../../../util";
+import { IdAllocator, brand } from "../../../util";
 import {
 	assertMarkListEqual,
 	defaultRevisionMetadataFromChanges,

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -8,13 +8,12 @@ import {
 	NodeChangeset,
 	GenericChangeset,
 	genericFieldKind,
-	IdAllocator,
 	CrossFieldManager,
 	RevisionMetadataSource,
 	MemoizedIdRangeAllocator,
 } from "../../../feature-libraries";
 import { makeAnonChange, tagChange, TaggedChange, Delta, FieldKey } from "../../../core";
-import { brand } from "../../../util";
+import { IdAllocator, brand } from "../../../util";
 import {
 	EncodingTestData,
 	fakeTaggedRepair as fakeRepair,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
@@ -5,8 +5,6 @@
 
 import { assert } from "@fluidframework/core-utils";
 import {
-	IdAllocator,
-	idAllocatorFromMaxId,
 	MemoizedIdRangeAllocator,
 	RevisionInfo,
 	revisionMetadataSourceFromInfo,
@@ -20,7 +18,7 @@ import {
 	defaultRevisionMetadataFromChanges,
 	fakeTaggedRepair as fakeRepair,
 } from "../../utils";
-import { brand, fail } from "../../../util";
+import { brand, fail, IdAllocator, idAllocatorFromMaxId } from "../../../util";
 import { TestChangeset } from "./testEdits";
 
 export function composeAnonChanges(changes: TestChangeset[]): TestChangeset {

--- a/experimental/dds/tree2/src/util/idAllocator.ts
+++ b/experimental/dds/tree2/src/util/idAllocator.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/core-utils";
+
+/**
+ * Allocates a block of `count` consecutive IDs and returns the first ID in the block.
+ * For convenience can be called with no parameters to allocate a single ID.
+ * @alpha
+ */
+export type IdAllocator = (count?: number) => number;
+
+export interface IdAllocationState {
+	maxId: number;
+}
+
+/**
+ * @alpha
+ */
+export function idAllocatorFromMaxId(maxId: number | undefined = undefined): IdAllocator {
+	return idAllocatorFromState({ maxId: maxId ?? -1 });
+}
+
+export function idAllocatorFromState(state: IdAllocationState): IdAllocator {
+	return (c?: number) => {
+		const count = c ?? 1;
+		assert(count > 0, 0x5cf /* Must allocate at least one ID */);
+		const id: number = state.maxId + 1;
+		state.maxId += count;
+		return id;
+	};
+}

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -96,3 +96,10 @@ export {
 } from "./brandedMap";
 
 export { getFirstFromRangeMap, RangeEntry, RangeMap, setInRangeMap } from "./rangeMap";
+
+export {
+	IdAllocator,
+	idAllocatorFromMaxId,
+	idAllocatorFromState,
+	IdAllocationState,
+} from "./idAllocator";


### PR DESCRIPTION
Motivation: it will need to be imported in core/tree in a future PR, which violates our fencing rules.