### PR TITLE
refactor(core-interfaces): Promote eslint config from "minimal" to "recommended"

### DIFF
--- a/api-report/core-interfaces.api.md
+++ b/api-report/core-interfaces.api.md
@@ -399,7 +399,7 @@ export interface IResponse {
 export const isFluidCodeDetails: (details: unknown) => details is Readonly<IFluidCodeDetails>;
 
 // @public @deprecated
-export const isFluidPackage: (pkg: any) => pkg is Readonly<IFluidPackage>;
+export const isFluidPackage: (pkg: unknown) => pkg is Readonly<IFluidPackage>;
 
 // @public @deprecated (undocumented)
 export interface ITaggedTelemetryPropertyType {

--- a/packages/common/core-interfaces/.eslintrc.js
+++ b/packages/common/core-interfaces/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/common/core-interfaces/src/error.ts
+++ b/packages/common/core-interfaces/src/error.ts
@@ -93,6 +93,9 @@ export interface IGenericError extends IErrorBase {
 	 * {@inheritDoc IErrorBase.errorType}
 	 */
 	readonly errorType: typeof FluidErrorTypes.genericError;
+
+	// TODO: Use `unknown` instead (API-Breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	error?: any;
 }
 

--- a/packages/common/core-interfaces/src/fluidLoadable.ts
+++ b/packages/common/core-interfaces/src/fluidLoadable.ts
@@ -24,6 +24,8 @@ export interface IProvideFluidRunnable {
 	readonly IFluidRunnable: IFluidRunnable;
 }
 export interface IFluidRunnable {
+	// TODO: Use `unknown` instead (API-Breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	run(...args: any[]): Promise<void>;
 	stop(reason?: string): void;
 }

--- a/packages/common/core-interfaces/src/fluidPackage.ts
+++ b/packages/common/core-interfaces/src/fluidPackage.ts
@@ -73,8 +73,10 @@ export interface IFluidPackage {
  *
  * @param pkg - The package json data to check if it is a Fluid package.
  */
-export const isFluidPackage = (pkg: any): pkg is Readonly<IFluidPackage> =>
-	typeof pkg === "object" && typeof pkg?.name === "string" && typeof pkg?.fluid === "object";
+export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
+	typeof pkg === "object" &&
+	typeof (pkg as Partial<IFluidPackage>)?.name === "string" &&
+	typeof (pkg as Partial<IFluidPackage>)?.fluid === "object";
 
 /**
  * Package manager configuration. Provides a key value mapping of config values.
@@ -105,6 +107,7 @@ export interface IFluidCodeDetails {
 	readonly config?: IFluidCodeDetailsConfig;
 }
 
+// eslint-disable-next-line jsdoc/require-description
 /**
  * @deprecated in favor of {@link @fluidframework/container-definitions#isFluidCodeDetails}
  * to have code loading modules in same package.

--- a/packages/common/core-interfaces/src/fluidRouter.ts
+++ b/packages/common/core-interfaces/src/fluidRouter.ts
@@ -4,6 +4,8 @@
  */
 
 export interface IRequestHeader {
+	// TODO: Use `unknown` instead (API-Breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[index: string]: any;
 }
 
@@ -15,7 +17,11 @@ export interface IRequest {
 export interface IResponse {
 	mimeType: string;
 	status: number;
+	// TODO: Use `unknown` instead (API-Breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	value: any;
+	// TODO: Use `unknown` instead (API-Breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	headers?: { [key: string]: any };
 	stack?: string;
 }

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -164,9 +164,10 @@ export interface ITelemetryLogger extends ITelemetryBaseLogger {
 	 * @param error - optional error object to log
 	 * @param logLevel - optional level of the log.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	sendTelemetryEvent(
 		event: ITelemetryGenericEvent,
+		// TODO: Use `unknown` instead (API-Breaking)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		error?: any,
 		logLevel?: typeof LogLevel.verbose | typeof LogLevel.default,
 	): void;
@@ -185,9 +186,10 @@ export interface ITelemetryLogger extends ITelemetryBaseLogger {
 	 * @param error - optional error object to log
 	 * @param logLevel - optional level of the log.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	sendPerformanceEvent(
 		event: ITelemetryPerformanceEvent,
+		// TODO: Use `unknown` instead (API-Breaking)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		error?: any,
 		logLevel?: typeof LogLevel.verbose | typeof LogLevel.default,
 	): void;

--- a/packages/common/core-interfaces/src/test/types/fluidObjectTypes.ts
+++ b/packages/common/core-interfaces/src/test/types/fluidObjectTypes.ts
@@ -2,6 +2,11 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 import { IFluidLoadable, IProvideFluidLoadable, FluidObject, FluidObjectKeys } from "../../";
 
 declare function getFluidObject(): FluidObject;
@@ -15,7 +20,7 @@ declare function useProviderKey<T, TKey extends FluidObjectKeys<T> = FluidObject
 declare function useLoadable(params: FluidObject<IFluidLoadable> | undefined): void;
 declare function getLoadable(): IFluidLoadable;
 
-declare function use(obj: any);
+declare function use(obj: unknown);
 // test implicit conversions between FluidObject and a FluidObject with a provides interface
 {
     const provider: FluidObject<IProvideFluidLoadable> = getFluidObject();


### PR DESCRIPTION
Production packages should not be using our "minimal" config. This PR updates the core-interfaces package to use the shared "recommended" config instead and fixes violations (without introducing API-breaking changes).