### PR TITLE
VS Code settings: Tweak search.exclude to not exclude common/lib source files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,9 +83,10 @@
 		"**/*.tsbuildinfo": true,
 		"**/_api-extractor-temp": true,
 		"**/dist/*": true,
-		"**/lib/*": true,
+		"**/src/../lib/*": true,
 		"**/nyc/*": true,
 		"**/*.log": true,
 		"**/DS_Store": true,
 	},
+	"search.": {},
 }


### PR DESCRIPTION
## Description

#16284 added some nice excluded paths to search.exclude setting, but unfortunately `common/lib` matches `**/lib` so you can't find stuff under that source code.

This hacks it to try to find only the build output lib dir.