### PR TITLE
tools: restore common/lib to search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,8 +82,13 @@
 		"**/*build.log": true,
 		"**/*.tsbuildinfo": true,
 		"**/_api-extractor-temp": true,
+		// exclude built `dist` folders
 		"**/dist/*": true,
-		"**/lib/*": true,
+		// exclude built `lib` folders but preserve ./common/lib
+		//   paths with packages container
+		"**/packages/**/lib/*": true,
+		//   other sets known to build `lib`
+		"{common/lib,examples,experimental}/**/lib/*": true,
 		"**/nyc/*": true,
 		"**/*.log": true,
 		"**/DS_Store": true,


### PR DESCRIPTION
with common/lib excluded, search by filename (Ctrl+P) doesn't even work