### PR TITLE
refactor(client-utils): Promote eslint config from "minimal" to "recommended" and fix violations

### DIFF
--- a/api-report/client-utils.api.md
+++ b/api-report/client-utils.api.md
@@ -13,10 +13,9 @@ import { TransformedEvent } from '@fluidframework/core-interfaces';
 
 // @internal
 export class Buffer extends Uint8Array {
+    static from(value: unknown, encodingOrOffset?: unknown, length?: unknown): IsoBuffer;
     // (undocumented)
-    static from(value: any, encodingOrOffset?: any, length?: any): IsoBuffer;
-    // (undocumented)
-    static isBuffer(obj: any): obj is Buffer;
+    static isBuffer(obj: unknown): obj is Buffer;
     // (undocumented)
     toString(encoding?: string): string;
 }

--- a/packages/common/client-utils/.eslintrc.js
+++ b/packages/common/client-utils/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: [
 			"./tsconfig.json",
@@ -12,9 +12,5 @@ module.exports = {
 			"./src/test/jest/tsconfig.json",
 			"./src/test/types/tsconfig.json",
 		],
-	},
-	rules: {
-		// TODO: Remove once this config extends `recommended` or `strict` above.
-		"@typescript-eslint/explicit-function-return-type": "error",
 	},
 };

--- a/packages/common/client-utils/src/bufferBrowser.ts
+++ b/packages/common/client-utils/src/bufferBrowser.ts
@@ -107,15 +107,17 @@ export class IsoBuffer extends Uint8Array {
 	 *
 	 * @privateRemarks TODO: Use actual types
 	 */
-	static from(value: unknown, encodingOrOffset?: unknown, length?: unknown): IsoBuffer {
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+	static from(value: any, encodingOrOffset?: any, length?: any): IsoBuffer {
 		if (typeof value === "string") {
 			return IsoBuffer.fromString(value, encodingOrOffset as string | undefined);
 			// Capture any typed arrays, including Uint8Array (and thus - IsoBuffer!)
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		} else if (value !== null && typeof value === "object" && isArrayBuffer(value.buffer)) {
 			// The version of the from function for the node buffer, which takes a buffer or typed array
 			// as first parameter, does not have any offset or length parameters. Those are just silently
 			// ignored and not taken into account
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
 			return IsoBuffer.fromArrayBuffer(value.buffer, value.byteOffset, value.byteLength);
 		} else if (isArrayBuffer(value)) {
 			return IsoBuffer.fromArrayBuffer(

--- a/packages/common/client-utils/src/bufferBrowser.ts
+++ b/packages/common/client-utils/src/bufferBrowser.ts
@@ -69,7 +69,7 @@ export const bufferToString = (blob: ArrayBufferLike, encoding: string): string 
  *
  * @internal
  */
-export function isArrayBuffer(obj: any): obj is ArrayBuffer {
+export function isArrayBuffer(obj: unknown): obj is ArrayBuffer {
 	const maybe = obj as (Partial<ArrayBuffer> & Partial<Uint8Array>) | undefined;
 	return (
 		obj instanceof ArrayBuffer ||
@@ -100,11 +100,14 @@ export class IsoBuffer extends Uint8Array {
 	}
 
 	/**
+	 * Static constructor
 	 * @param value - (string | ArrayBuffer)
 	 * @param encodingOrOffset - (string | number)
 	 * @param length - (number)
+	 *
+	 * @privateRemarks TODO: Use actual types
 	 */
-	static from(value, encodingOrOffset?, length?): IsoBuffer {
+	static from(value: unknown, encodingOrOffset?: unknown, length?: unknown): IsoBuffer {
 		if (typeof value === "string") {
 			return IsoBuffer.fromString(value, encodingOrOffset as string | undefined);
 			// Capture any typed arrays, including Uint8Array (and thus - IsoBuffer!)
@@ -112,11 +115,16 @@ export class IsoBuffer extends Uint8Array {
 			// The version of the from function for the node buffer, which takes a buffer or typed array
 			// as first parameter, does not have any offset or length parameters. Those are just silently
 			// ignored and not taken into account
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			return IsoBuffer.fromArrayBuffer(value.buffer, value.byteOffset, value.byteLength);
 		} else if (isArrayBuffer(value)) {
-			return IsoBuffer.fromArrayBuffer(value, encodingOrOffset as number | undefined, length);
+			return IsoBuffer.fromArrayBuffer(
+				value,
+				encodingOrOffset as number | undefined,
+				length as number,
+			);
 		} else {
-			throw new TypeError();
+			throw new TypeError("Input value was neither a string nor an ArrayBuffer.");
 		}
 	}
 
@@ -133,7 +141,7 @@ export class IsoBuffer extends Uint8Array {
 			validLength < 0 ||
 			validLength + offset > arrayBuffer.byteLength
 		) {
-			throw new RangeError();
+			throw new RangeError("Invalid range specified.");
 		}
 
 		return new IsoBuffer(arrayBuffer, offset, validLength);
@@ -158,7 +166,7 @@ export class IsoBuffer extends Uint8Array {
 		}
 	}
 
-	static isBuffer(obj: any): boolean {
+	static isBuffer(obj: unknown): boolean {
 		throw new Error("unimplemented");
 	}
 

--- a/packages/common/client-utils/src/bufferNode.ts
+++ b/packages/common/client-utils/src/bufferNode.ts
@@ -12,13 +12,18 @@
  */
 export declare class Buffer extends Uint8Array {
 	toString(encoding?: string): string;
+
 	/**
+	 * Static constructor
+	 *
 	 * @param value - (string | ArrayBuffer).
 	 * @param encodingOrOffset - (string | number).
 	 * @param length - (number).
+	 *
+	 * @privateRemarks TODO: Use actual types
 	 */
-	static from(value, encodingOrOffset?, length?): IsoBuffer;
-	static isBuffer(obj: any): obj is Buffer;
+	static from(value: unknown, encodingOrOffset?: unknown, length?: unknown): IsoBuffer;
+	static isBuffer(obj: unknown): obj is Buffer;
 }
 
 /**

--- a/packages/common/client-utils/src/eventForwarder.ts
+++ b/packages/common/client-utils/src/eventForwarder.ts
@@ -89,7 +89,7 @@ export class EventForwarder<TEvent = IEvent>
 					this.forwardingEvents.set(event, sources);
 				}
 				if (!sources.has(source)) {
-					const listener = (...args: any[]): boolean => this.emit(event, ...args);
+					const listener = (...args: unknown[]): boolean => this.emit(event, ...args);
 					sources.set(source, () => source.off(event, listener));
 					source.on(event, listener);
 				}

--- a/packages/common/client-utils/src/hashFileBrowser.ts
+++ b/packages/common/client-utils/src/hashFileBrowser.ts
@@ -17,6 +17,7 @@ function encodeDigest(hashArray: Uint8Array, encoding: "hex" | "base64"): string
 		case "hex": {
 			const hashHex = Array.prototype.map
 				.call(hashArray, (byte) => {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 					return byte.toString(16).padStart(2, "0") as string;
 				})
 				.join("");
@@ -74,6 +75,7 @@ export async function hashFile(
  */
 export async function gitHashFile(file: IsoBuffer): Promise<string> {
 	const size = file.byteLength;
+	// eslint-disable-next-line unicorn/prefer-code-point
 	const filePrefix = `blob ${size.toString()}${String.fromCharCode(0)}`;
 	const hashBuffer = IsoBuffer.from(filePrefix + file.toString());
 

--- a/packages/common/client-utils/src/hashFileNode.ts
+++ b/packages/common/client-utils/src/hashFileNode.ts
@@ -1,12 +1,12 @@
+/* eslint-disable unicorn/prefer-code-point */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-internal-modules
-import sha1 from "sha.js/sha1";
-// eslint-disable-next-line import/no-internal-modules
-import sha256 from "sha.js/sha256";
+// eslint-disable-next-line import/no-nodejs-modules
+import { Hash } from "crypto";
+import { sha1, sha256 } from "sha.js";
 import { IsoBuffer } from "./bufferNode";
 
 /**
@@ -27,7 +27,7 @@ export async function hashFile(
 	algorithm: "SHA-1" | "SHA-256" = "SHA-1",
 	hashEncoding: "hex" | "base64" = "hex",
 ): Promise<string> {
-	let engine;
+	let engine: Hash;
 	// eslint-disable-next-line default-case
 	switch (algorithm) {
 		case "SHA-1": {
@@ -39,7 +39,7 @@ export async function hashFile(
 			break;
 		}
 	}
-	return engine.update(file).digest(hashEncoding) as string;
+	return engine.update(file).digest(hashEncoding);
 }
 
 /**
@@ -55,5 +55,5 @@ export async function gitHashFile(file: IsoBuffer): Promise<string> {
 	const size = file.byteLength;
 	const filePrefix = `blob ${size.toString()}${String.fromCharCode(0)}`;
 	const engine = new sha1();
-	return engine.update(filePrefix).update(file).digest("hex") as string;
+	return engine.update(filePrefix).update(file).digest("hex");
 }

--- a/packages/common/client-utils/src/hashFileNode.ts
+++ b/packages/common/client-utils/src/hashFileNode.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable unicorn/prefer-code-point */
+// eslint-disable-next-line import/no-internal-modules
+import sha1 from "sha.js/sha1";
+// eslint-disable-next-line import/no-internal-modules
+import sha256 from "sha.js/sha256";
 
-// eslint-disable-next-line import/no-nodejs-modules
-import { Hash } from "crypto";
-import { sha1, sha256 } from "sha.js";
-import { IsoBuffer } from "./bufferNode";
+import type { IsoBuffer } from "./bufferNode";
 
 /**
  * Hash a file. Consistent within a session, but should not be persisted and
@@ -28,19 +28,22 @@ export async function hashFile(
 	algorithm: "SHA-1" | "SHA-256" = "SHA-1",
 	hashEncoding: "hex" | "base64" = "hex",
 ): Promise<string> {
-	let engine: Hash;
+	let engine;
 	// eslint-disable-next-line default-case
 	switch (algorithm) {
 		case "SHA-1": {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 			engine = new sha1();
 			break;
 		}
 		case "SHA-256": {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 			engine = new sha256();
 			break;
 		}
 	}
-	return engine.update(file).digest(hashEncoding);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+	return engine.update(file).digest(hashEncoding) as string;
 }
 
 /**
@@ -54,7 +57,10 @@ export async function hashFile(
  */
 export async function gitHashFile(file: IsoBuffer): Promise<string> {
 	const size = file.byteLength;
+	// eslint-disable-next-line unicorn/prefer-code-point
 	const filePrefix = `blob ${size.toString()}${String.fromCharCode(0)}`;
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 	const engine = new sha1();
-	return engine.update(filePrefix).update(file).digest("hex");
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+	return engine.update(filePrefix).update(file).digest("hex") as string;
 }

--- a/packages/common/client-utils/src/hashFileNode.ts
+++ b/packages/common/client-utils/src/hashFileNode.ts
@@ -1,8 +1,9 @@
-/* eslint-disable unicorn/prefer-code-point */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable unicorn/prefer-code-point */
 
 // eslint-disable-next-line import/no-nodejs-modules
 import { Hash } from "crypto";

--- a/packages/common/client-utils/src/test/jest/buffer.spec.ts
+++ b/packages/common/client-utils/src/test/jest/buffer.spec.ts
@@ -14,8 +14,8 @@ describe("Buffer isomorphism", () => {
 			"比特币", // non-ascii range
 			"😂💁🏼‍♂️💁🏼‍💁‍♂", // surrogate pairs with glyph modifiers
 			"\u0080\u0080", // invalid sequence of utf-8 continuation codes
-			"\ud800", // single utf-16 surrogate without pair
-			"\u2962\u0000\uffff\uaaaa", // garbage
+			"\uD800", // single utf-16 surrogate without pair
+			"\u2962\u0000\uFFFF\uAAAA", // garbage
 		];
 
 		for (const item of testArray) {

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -79,6 +79,7 @@ async function evaluateBrowserHash(
 	);
 
 	// reconstruct the Uint8Array from the string
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const charCodes = Array.prototype.map.call([...hashCharCodeString], (char: string) => {
 		return char.charCodeAt(0);
 	}) as number[];

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -50,9 +50,11 @@ async function evaluateBrowserHash(
 	// do only the crypto.subtle part in page.evaluate and do the other half outside
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 	const browserHashFn = HashBrowser.__get__("digestBuffer").toString();
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const hashCharCodeString = await page.evaluate(
 		async (fn, f, alg) => {
 			// convert back into Uint8Array
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const fileCharCodes = Array.prototype.map.call([...f], (char: string) => {
 				return char.charCodeAt(0);
 			}) as number[];

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -49,12 +49,11 @@ async function evaluateBrowserHash(
 	// there are also issues around nested function calls when using page.exposeFunction, so
 	// do only the crypto.subtle part in page.evaluate and do the other half outside
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-	const browserHashFn = HashBrowser.__get__("digestBuffer").toString();
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const hashCharCodeString = await page.evaluate(
-		async (fn, f, alg) => {
+	const browserHashFn: string = HashBrowser.__get__("digestBuffer").toString();
+
+	const hashCharCodeString = (await page.evaluate(
+		async (fn: string, f: string, alg: "SHA-1" | "SHA-256") => {
 			// convert back into Uint8Array
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const fileCharCodes = Array.prototype.map.call([...f], (char: string) => {
 				return char.charCodeAt(0);
 			}) as number[];
@@ -76,7 +75,7 @@ async function evaluateBrowserHash(
 		browserHashFn,
 		fileCharCodeString,
 		algorithm,
-	);
+	)) as string;
 
 	// reconstruct the Uint8Array from the string
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -10,7 +10,6 @@ import fs from "fs";
 import http from "http";
 import { AddressInfo } from "net";
 import path from "path";
-import { Page } from "puppeteer";
 import rewire from "rewire";
 
 import * as HashNode from "../../hashFileNode";
@@ -32,7 +31,6 @@ async function getFileContents(p: string): Promise<Buffer> {
 const dataDir = "../../../src/test/jest";
 
 async function evaluateBrowserHash(
-	page: Page,
 	file: Buffer,
 	algorithm: "SHA-1" | "SHA-256" = "SHA-1",
 	hashEncoding: "hex" | "base64" = "hex",
@@ -91,13 +89,13 @@ async function evaluateBrowserHash(
  * Same as evaluateBrowserHash above except prepends the
  * `blob ${size.toString()}${String.fromCharCode(0)}` prefix for git
  * */
-async function evaluateBrowserGitHash(page: Page, file: Buffer): Promise<string> {
+async function evaluateBrowserGitHash(file: Buffer): Promise<string> {
 	// Add the prefix for git hashing
 	const size = file.byteLength;
 	const filePrefix = `blob ${size.toString()}${String.fromCharCode(0)}`;
 	const prefixBuffer = Buffer.from(filePrefix, "utf-8");
 	const hashBuffer = Buffer.concat([prefixBuffer, file], prefixBuffer.length + file.length);
-	return evaluateBrowserHash(page, hashBuffer);
+	return evaluateBrowserHash(hashBuffer);
 }
 
 describe("Client-Utils", () => {
@@ -151,7 +149,7 @@ describe("Client-Utils", () => {
 		test("XML should Hash", async () => {
 			const expectedHash = "64056b04956fb446b4014cb8d159d2e2494ed0fc";
 			const hashNode = await HashNode.gitHashFile(xmlFile);
-			const hashBrowser = await evaluateBrowserGitHash(page, xmlFile);
+			const hashBrowser = await evaluateBrowserGitHash(xmlFile);
 
 			expect(hashNode).toEqual(expectedHash);
 			expect(hashBrowser).toEqual(expectedHash);
@@ -160,7 +158,7 @@ describe("Client-Utils", () => {
 		test("SVG should Hash", async () => {
 			const expectedHash = "c741e46ae4a5f1ca19debf0ac609aabc5fe94add";
 			const hashNode = await HashNode.gitHashFile(svgFile);
-			const hashBrowser = await evaluateBrowserGitHash(page, svgFile);
+			const hashBrowser = await evaluateBrowserGitHash(svgFile);
 
 			expect(hashNode).toEqual(expectedHash);
 			expect(hashBrowser).toEqual(expectedHash);
@@ -169,7 +167,7 @@ describe("Client-Utils", () => {
 		test("AKA PDF should Hash", async () => {
 			const expectedHash = "f3423703f542852aa7f3d1a13e73f0de0d8c9c0f";
 			const hashNode = await HashNode.gitHashFile(pdfFile);
-			const hashBrowser = await evaluateBrowserGitHash(page, pdfFile);
+			const hashBrowser = await evaluateBrowserGitHash(pdfFile);
 
 			expect(hashNode).toEqual(expectedHash);
 			expect(hashBrowser).toEqual(expectedHash);
@@ -178,7 +176,7 @@ describe("Client-Utils", () => {
 		test("Grid GIF should Hash", async () => {
 			const expectedHash = "a7d63376bbcb05d0a6fa749594048c8ce6be23fb";
 			const hashNode = await HashNode.gitHashFile(gifFile);
-			const hashBrowser = await evaluateBrowserGitHash(page, gifFile);
+			const hashBrowser = await evaluateBrowserGitHash(gifFile);
 
 			expect(hashNode).toEqual(expectedHash);
 			expect(hashBrowser).toEqual(expectedHash);
@@ -189,8 +187,8 @@ describe("Client-Utils", () => {
 			const hash2Node = await HashNode.gitHashFile(svgFile);
 			expect(hash1Node).toEqual(hash2Node);
 
-			const hash1Browser = await evaluateBrowserGitHash(page, svgFile);
-			const hash2Browser = await evaluateBrowserGitHash(page, svgFile);
+			const hash1Browser = await evaluateBrowserGitHash(svgFile);
+			const hash2Browser = await evaluateBrowserGitHash(svgFile);
 			expect(hash1Browser).toEqual(hash2Browser);
 		});
 	});
@@ -199,7 +197,7 @@ describe("Client-Utils", () => {
 		test("SHA256 hashes match", async () => {
 			const expectedHash = "9b8abd0b90324ffce0b6a9630e5c4301972c364ed9aeb7e7329e424a4ae8a630";
 			const hashNode = await HashNode.hashFile(svgFile, "SHA-256");
-			const hashBrowser = await evaluateBrowserHash(page, svgFile, "SHA-256");
+			const hashBrowser = await evaluateBrowserHash(svgFile, "SHA-256");
 			expect(hashNode).toEqual(expectedHash);
 			expect(hashBrowser).toEqual(expectedHash);
 		});
@@ -207,13 +205,13 @@ describe("Client-Utils", () => {
 		test("base64 encoded hashes match", async () => {
 			const expectedHash1 = "4/nXhjtBQhhvXTNNSNq/cJgb4sQ=";
 			const hashNode1 = await HashNode.hashFile(xmlFile, "SHA-1", "base64");
-			const hashBrowser1 = await evaluateBrowserHash(page, xmlFile, "SHA-1", "base64");
+			const hashBrowser1 = await evaluateBrowserHash(xmlFile, "SHA-1", "base64");
 			expect(hashNode1).toEqual(expectedHash1);
 			expect(hashBrowser1).toEqual(expectedHash1);
 
 			const expectedHash256 = "QPQh34aj1TNmyo34aPDA0vMIU7r5QC/6KNgIzlLYiFY=";
 			const hashNode256 = await HashNode.hashFile(pdfFile, "SHA-256", "base64");
-			const hashBrowser256 = await evaluateBrowserHash(page, pdfFile, "SHA-256", "base64");
+			const hashBrowser256 = await evaluateBrowserHash(pdfFile, "SHA-256", "base64");
 			expect(hashNode256).toEqual(expectedHash256);
 			expect(hashBrowser256).toEqual(expectedHash256);
 		});

--- a/packages/common/client-utils/src/test/mocha/eventForwarder.spec.ts
+++ b/packages/common/client-utils/src/test/mocha/eventForwarder.spec.ts
@@ -27,7 +27,6 @@ describe("Loader", () => {
 				});
 
 				afterEach(() => {
-					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 					if (!forwarder.disposed) {
 						forwarder.dispose();
 					}

--- a/packages/common/client-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/packages/common/client-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -30,6 +30,7 @@ describe("TypedEventEmitter", () => {
 		const tee = new TypedEventEmitter<IErrorEvent>();
 		let newListenerCalls = 0;
 		let removeListenerCalls = 0;
+		// eslint-disable-next-line unicorn/consistent-function-scoping
 		const errListener = (): void => {};
 		tee.on("removeListener", (event, listener) => {
 			assert.equal(event, "error");

--- a/packages/common/client-utils/src/typedEventEmitter.ts
+++ b/packages/common/client-utils/src/typedEventEmitter.ts
@@ -19,6 +19,7 @@ import {
  *
  * @internal
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EventEmitterEventType = EventEmitter extends { on(event: infer E, listener: any) }
 	? E
 	: never;
@@ -34,11 +35,13 @@ export type TypedEventTransform<TThis, TEvent> =
 	TransformedEvent<
 		TThis,
 		"newListener" | "removeListener",
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		Parameters<(event: string, listener: (...args: any[]) => void) => void>
 	> &
 		// Expose all the events provides by TEvent
 		IEventTransformer<TThis, TEvent & IEvent> &
 		// Add the default overload so this is covertable to EventEmitter regardless of environment
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 /**


### PR DESCRIPTION
Production packages should not be using our "minimal" eslint config. This PR updates the package to extend our "recommended" config instead, and fixes violations (without making breaking changes to the API).