### PR TITLE
Dispose data store channel during realization if the context is disposed

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -458,6 +458,11 @@ export abstract class FluidDataStoreContext
 		const channel = await factory.instantiateDataStore(this, existing);
 		assert(channel !== undefined, 0x140 /* "undefined channel on datastore context" */);
 		this.bindRuntime(channel);
+		// This data store may have been disposed before the channel is created during realization. If so,
+		// dispose the channel now.
+		if (this.disposed) {
+			channel.dispose();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Bug
If data store runtime has not been created (which happens during realize) when a data store context is disposed, it will never be disposed. See code [here](https://github.com/microsoft/FluidFramework/blob/d43b532c3579fa5ac687569a1cb69f09b41e1805/packages/runtime/container-runtime/src/dataStoreContext.ts#L347) where dispose on channel is called only if `this.channelDeferred` exists:

This means that anyone checking for disposed at data store runtime or below layers (including DDS) won't know that the data store is disposed.

## Fix
During realization, after the data store channel is created, call dispose() on it if the data store context is disposed.

## Limitation
The limitation of this fix is that the data store runtime will be created and any initialization including creation / loading of DDS will have happened before dispose() is called. The reason to not do it sooner is explained in alternatives below.

## Alternative fixes
- Dispose the data store runtime in its constructor. For this to happen, `disposed` will have to be exposed on `IFluidDataStoreContext` which it currently isn't. That seems fine to do but it may break existing patterns in production that unintentionally rely on initialization of such data stores to succeed. Note that this may break with the current fix as well since things happen async.
- Fail `realize` if the data store context is disposed. This may be the simplest solution but the reason I did not go this route is because it can cause regressions where someone has unintentional dependency on this succeeding.
 
[AB#5478](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5478)