### PR TITLE
refactor: Increase timeout for r11s e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -41,7 +41,7 @@
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
 		"test:realsvc:odsp:report": "npm run test:realsvc:odsp --",
-		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=5s --use-openssl-ca",
+		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s --use-openssl-ca",
 		"test:realsvc:routerlicious": "npm run test:realsvc:r11s",
 		"test:realsvc:routerlicious:report": "npm run test:realsvc:r11s --",
 		"test:realsvc:run": "mocha dist/test --config src/test/.mocharc.cjs --exclude dist/test/benchmark/**/* --verbose",


### PR DESCRIPTION
## Description

I've been investigating why the routerlicious e2e tests went from passing at 99.9% rate [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174884&view=results) to mostly timing out at 5s and ending up at <60% pass rate [in the immediate next CI build](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174918). The second build is for a commit that is the grandchild of the first, and [the only difference between them is md files](https://github.com/microsoft/FluidFramework/compare/f0eb76a..53539acb52edbbe67dbfd69e35e851ddab2b20d2) (easier to see in the two PRs between them, [here](https://github.com/microsoft/FluidFramework/pull/16300/files) and [here](https://github.com/microsoft/FluidFramework/pull/16345/files)) so I can't explain why the difference. Starting with the second build, the tests stayed at <60% consistently forever more (in `main`) so it doesn't seem like a fluke.

I checked if it was a deployment to our r11s environment in AKS and couldn't find evidence of any changes that would have taken effect between the two CI builds above.

Comparing the runtime of the tests when they were succeeding in the first CI run linked above (and the ones before) does not suggest they were running close to the edge and suddenly all went over at the same time. E.g.: [434ms](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174884&view=ms.vss-test-web.build-test-results-tab&runId=4189065&resultId=100086&paneView=debug) vs [5s](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174918&view=ms.vss-test-web.build-test-results-tab&runId=4189846&resultId=100061&paneView=debug); [406ms](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174884&view=ms.vss-test-web.build-test-results-tab&runId=4189065&resultId=100176&paneView=debug) vs [5s](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174918&view=ms.vss-test-web.build-test-results-tab&runId=4189846&resultId=100129&paneView=debug); [1.37s](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174884&view=ms.vss-test-web.build-test-results-tab&runId=4189065&resultId=100362&paneView=debug) vs [5s](https://dev.azure.com/fluidframework/internal/_build/results?buildId=174918&view=ms.vss-test-web.build-test-results-tab&runId=4189846&resultId=100205&paneView=debug).

Running the tests locally, I took a small set and confirmed that they complete successfully if given more than 5s. In a Codespaces instance with 16 cores, 64 GB RAM, they mostly finish within 10 seconds (with a weird outlier at the very end taking 20s after twice taking less than 5s):

![image](https://github.com/microsoft/FluidFramework/assets/716334/481da29f-11ad-463d-8356-6a8e04a9e856)

And in my local WSL environment, the same tests take longer, sometimes failing due to network issues, but mostly still complete with consistent runtimes:

![image](https://github.com/microsoft/FluidFramework/assets/716334/dc60a3f2-50e8-47db-b80d-fe6228e1bea9)

I have no good idea of what's up here, but I propose we increase the timeout for the e2e r11s tests so we at least see them succeeding _or actually failing_ in pipeline runs, instead of getting zero information from those runs for all the tests that are timing out. There's work underway to have a monitor that alerts us if the test pass rates of each of the e2e test stages falls beneath some threshold, but if we can't tell if tests are really succeeding or failing, that work wouldn't provide as much value.

I'll create an ADO item to track investigation into what happened that caused all tests to take so much longer all of a sudden.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
