### PR TITLE
Capitalize "S" in TypeScript

### DIFF
--- a/examples/data-objects/monaco/src/view.tsx
+++ b/examples/data-objects/monaco/src/view.tsx
@@ -10,7 +10,7 @@ import * as monaco from "monaco-editor";
 import React, { useEffect, useRef } from "react";
 
 /**
- * Compilation options for Monaco to use on Typescript
+ * Compilation options for Monaco to use on TypeScript
  */
 const defaultCompilerOptions = {
 	noImplicitAny: true,

--- a/experimental/dds/tree2/docs/main/stored-and-view-schema-options.md
+++ b/experimental/dds/tree2/docs/main/stored-and-view-schema-options.md
@@ -91,7 +91,7 @@ Readonly (for most people) public schema documents would compose interestingly w
 
 Even if we can't make it work as a separate DDS, it should be implemented such that it would be easy to reuse the code as a schema-DDS.
 
-## Typescript Typing
+## TypeScript Typing
 
 It is be possible to have an embedded DSL for schema declaration in the style of [typebox](https://www.npmjs.com/package/@sinclair/typebox) which produces both compile time types and runtime schema data.
 This allows for schema-aware APIs (for example for tree reading and editing) to be provided without code gen.

--- a/experimental/dds/tree2/docs/main/stored-and-view-schema.md
+++ b/experimental/dds/tree2/docs/main/stored-and-view-schema.md
@@ -307,7 +307,7 @@ Readonly (for most people) public schema documents would compose interestingly w
 
 Even if we can't make it work as a separate DDS, it should be implemented such that it would be easy to reuse the code as a schema-DDS.
 
-## Typescript Typing
+## TypeScript Typing
 
 It is be possible to have an embedded DSL for schema declaration in the style of [typebox](https://www.npmjs.com/package/@sinclair/typebox) which produces both compile time types and runtime schema data.
 This allows for schema-aware APIs (for example for tree reading and editing) to be provided without code gen.

--- a/experimental/dds/tree2/src/codec/codec.ts
+++ b/experimental/dds/tree2/src/codec/codec.ts
@@ -75,7 +75,7 @@ export interface ICodecOptions {
 
 /**
  * @alpha
- * @remarks `TEncoded` should always be valid Json (i.e. not contain functions), but due to Typescript's handling
+ * @remarks `TEncoded` should always be valid Json (i.e. not contain functions), but due to TypeScript's handling
  * of index signatures and `JsonCompatibleReadOnly`'s index signature in the Json object case, specifying this as a
  * type-system level constraint makes code that uses this interface more difficult to write.
  */

--- a/experimental/dds/tree2/src/util/typeCheck.ts
+++ b/experimental/dds/tree2/src/util/typeCheck.ts
@@ -16,9 +16,9 @@ export type { EnforceTypeCheckTests } from "./typeCheckTests";
  *
  * @remarks
  * Note: much of this library (the variance parts)
- * will be able to be replaced with Typescript 4.7 explicit variance annotations.
+ * will be able to be replaced with TypeScript 4.7 explicit variance annotations.
  *
- * Typescript uses structural typing if there are no private or protected members,
+ * TypeScript uses structural typing if there are no private or protected members,
  * and variance of generic type parameters depends on their usages.
  * Thus when trying to constrain code by adding extra type information,
  * it often fails to actually constrain as desired, and these utilities can help with those cases.

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -42,7 +42,7 @@ export {
 	IProvideFluidCodeDetailsComparer,
 } from "./fluidPackage";
 
-// Typescript forgets the index signature when customers augment IRequestHeader if we export *.
+// TypeScript forgets the index signature when customers augment IRequestHeader if we export *.
 // So we export the explicit members as a workaround:
 // https://github.com/microsoft/TypeScript/issues/18877#issuecomment-476921038
 export {


### PR DESCRIPTION
## Description

Capitalize "S" in TypeScript

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

