### PR TITLE
refactor(tree): reduce duplication of path declaration in tests

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -12,6 +12,17 @@ import { makeTreeFromJson, remove, insert, expectJsonTree } from "../utils";
 import { ISharedTreeView } from "../../shared-tree";
 import { singleTextCursor } from "../../feature-libraries";
 
+const rootField: FieldUpPath = {
+	parent: undefined,
+	field: rootFieldKey,
+};
+
+const rootNode: UpPath = {
+	parent: undefined,
+	parentField: rootFieldKey,
+	parentIndex: 0,
+};
+
 describe("Editing", () => {
 	describe("Sequence Field", () => {
 		it("concurrent inserts", () => {
@@ -37,13 +48,7 @@ describe("Editing", () => {
 			tree2.rebaseOnto(tree1);
 
 			// Move b before a
-			tree1.editor.move(
-				{ parent: undefined, field: rootFieldKey },
-				1,
-				1,
-				{ parent: undefined, field: rootFieldKey },
-				0,
-			);
+			tree1.editor.move(rootField, 1, 1, rootField, 0);
 
 			// Delete b
 			remove(tree2, 1, 1);
@@ -65,20 +70,14 @@ describe("Editing", () => {
 
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
 			const fooArrayPath: UpPath = {
-				parent: rootPath,
+				parent: rootNode,
 				parentField: brand("foo"),
 				parentIndex: 0,
 			};
 
 			const barArrayPath: UpPath = {
-				parent: rootPath,
+				parent: rootNode,
 				parentField: brand("bar"),
 				parentIndex: 0,
 			};
@@ -117,20 +116,14 @@ describe("Editing", () => {
 
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
 			const fooArrayPath: UpPath = {
-				parent: rootPath,
+				parent: rootNode,
 				parentField: brand("foo"),
 				parentIndex: 0,
 			};
 
 			const barArrayPath: UpPath = {
-				parent: rootPath,
+				parent: rootNode,
 				parentField: brand("bar"),
 				parentIndex: 0,
 			};
@@ -195,11 +188,10 @@ describe("Editing", () => {
 
 			insert(tree2, 1, "C");
 			tree3.editor
-				.sequenceField({ parent: undefined, field: rootFieldKey })
+				.sequenceField(rootField)
 				.insert(0, singleTextCursor({ type: jsonObject.name, fields: { foo: [] } }));
 
-			const rootPath = { parent: undefined, parentField: rootFieldKey, parentIndex: 0 };
-			const aEditor = tree3.editor.sequenceField({ parent: rootPath, field: brand("foo") });
+			const aEditor = tree3.editor.sequenceField({ parent: rootNode, field: brand("foo") });
 			aEditor.insert(0, singleTextCursor({ type: jsonString.name, value: "a" }));
 
 			tree1.merge(tree2, false);
@@ -411,12 +403,7 @@ describe("Editing", () => {
 		it("intra-field move", () => {
 			const tree1 = makeTreeFromJson(["A", "B"]);
 
-			tree1.editor
-				.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.move(0, 1, 1);
+			tree1.editor.sequenceField(rootField).move(0, 1, 1);
 
 			expectJsonTree(tree1, ["B", "A"]);
 		});
@@ -430,12 +417,7 @@ describe("Editing", () => {
 
 			insert(tree1, 2, "C");
 
-			tree2.editor
-				.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.move(0, 1, 1);
+			tree2.editor.sequenceField(rootField).move(0, 1, 1);
 
 			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
@@ -452,13 +434,7 @@ describe("Editing", () => {
 			editor.set(singleTextCursor({ type: jsonString.name, value: "C" }));
 
 			// Move B before A.
-			tree2.editor.move(
-				{ parent: undefined, field: rootFieldKey },
-				1,
-				1,
-				{ parent: undefined, field: rootFieldKey },
-				0,
-			);
+			tree2.editor.move(rootField, 1, 1, rootField, 0);
 
 			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
@@ -473,16 +449,9 @@ describe("Editing", () => {
 			const tree2 = tree1.fork();
 
 			// Move B before A.
-			tree1.editor.move(
-				{ parent: undefined, field: rootFieldKey },
-				1,
-				1,
-				{ parent: undefined, field: rootFieldKey },
-				0,
-			);
+			tree1.editor.move(rootField, 1, 1, rootField, 0);
 
-			const parent = { parent: undefined, parentField: rootFieldKey, parentIndex: 0 };
-			const editor = tree1.editor.valueField({ parent, field: brand("foo") });
+			const editor = tree1.editor.valueField({ parent: rootNode, field: brand("foo") });
 			editor.set(singleTextCursor({ type: jsonString.name, value: "C" }));
 
 			tree1.merge(tree2, false);
@@ -500,14 +469,8 @@ describe("Editing", () => {
 			});
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 
 			// Change value of A to C
 			const editor = tree1.editor.valueField({
@@ -544,14 +507,7 @@ describe("Editing", () => {
 			});
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-			const rootField = { parent: undefined, field: rootFieldKey };
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
 
 			// Move A out of foo.
 			tree1.editor.move({ parent: fooList, field: brand("") }, 0, 1, rootField, 0);
@@ -574,14 +530,8 @@ describe("Editing", () => {
 			});
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 
 			// Move A after B.
 			tree1.editor.move(
@@ -616,24 +566,16 @@ describe("Editing", () => {
 
 			tree1.transaction.start();
 
-			const node1: UpPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
 			const listNode: UpPath = {
-				parent: node1,
+				parent: rootNode,
 				parentField: brand("foo"),
 				parentIndex: 0,
 			};
 			const fooField = tree1.editor.sequenceField({ parent: listNode, field: brand("") });
 			fooField.move(0, 1, 1);
 
-			const rootField = tree1.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
-			rootField.move(0, 1, 1);
+			const rootSequence = tree1.editor.sequenceField(rootField);
+			rootSequence.move(0, 1, 1);
 
 			tree1.transaction.commit();
 
@@ -646,10 +588,7 @@ describe("Editing", () => {
 
 			tree2.transaction.start();
 
-			const sequence = tree2.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree2.editor.sequenceField(rootField);
 			sequence.move(1, 1, 0);
 			sequence.move(2, 1, 3);
 			tree2.transaction.commit();
@@ -663,10 +602,7 @@ describe("Editing", () => {
 
 			tree2.transaction.start();
 
-			const sequence = tree2.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree2.editor.sequenceField(rootField);
 			sequence.move(0, 1, 1);
 			sequence.move(3, 1, 2);
 			tree2.transaction.commit();
@@ -691,10 +627,7 @@ describe("Editing", () => {
 				parentField: rootFieldKey,
 			};
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete destination's ancestor concurrently
 			sequence.delete(1, 1);
@@ -730,10 +663,7 @@ describe("Editing", () => {
 				parentField: rootFieldKey,
 			};
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete source's ancestor concurrently
 			sequence.delete(0, 1);
@@ -768,10 +698,7 @@ describe("Editing", () => {
 				parentField: rootFieldKey,
 			};
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete source's ancestor concurrently
 			sequence.delete(0, 1);
@@ -808,10 +735,7 @@ describe("Editing", () => {
 				parentField: rootFieldKey,
 			};
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete source's ancestor concurrently
 			sequence.delete(0, 1);
@@ -850,10 +774,7 @@ describe("Editing", () => {
 				parentField: rootFieldKey,
 			};
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete "a"
 			tree.editor.sequenceField({ parent: first, field: brand("foo") }).delete(0, 1);
@@ -901,10 +822,7 @@ describe("Editing", () => {
 
 			const tree2 = tree.fork();
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete ancestor of "a"
 			sequence.delete(1, 1);
@@ -942,10 +860,7 @@ describe("Editing", () => {
 
 			const tree2 = tree.fork();
 
-			const sequence = tree.editor.sequenceField({
-				parent: undefined,
-				field: rootFieldKey,
-			});
+			const sequence = tree.editor.sequenceField(rootField);
 
 			// Delete destination ancestor
 			sequence.delete(0, 1);
@@ -964,14 +879,8 @@ describe("Editing", () => {
 				bar: ["E"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move nodes from foo into bar.
@@ -1009,15 +918,9 @@ describe("Editing", () => {
 				baz: ["I", "J", "K", "L"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
-			const bazList: UpPath = { parent: rootPath, parentField: brand("baz"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
+			const bazList: UpPath = { parent: rootNode, parentField: brand("baz"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move nodes from foo into bar.
@@ -1063,14 +966,8 @@ describe("Editing", () => {
 				bar: ["E"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// inserts nodes to move
@@ -1104,14 +1001,8 @@ describe("Editing", () => {
 				bar: ["E"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move nodes from foo into bar.
@@ -1143,14 +1034,8 @@ describe("Editing", () => {
 				bar: ["F"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move nodes from foo into bar.
@@ -1183,15 +1068,9 @@ describe("Editing", () => {
 				baz: ["F"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
-			const bazList: UpPath = { parent: rootPath, parentField: brand("baz"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
+			const bazList: UpPath = { parent: rootNode, parentField: brand("baz"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move nodes from foo into bar.
@@ -1231,20 +1110,14 @@ describe("Editing", () => {
 				baz: ["D"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
 			const barListChild: UpPath = {
 				parent: barList,
 				parentField: brand(""),
 				parentIndex: 0,
 			};
-			const bazList: UpPath = { parent: rootPath, parentField: brand("baz"), parentIndex: 0 };
+			const bazList: UpPath = { parent: rootNode, parentField: brand("baz"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move node from foo into bar.
@@ -1283,20 +1156,14 @@ describe("Editing", () => {
 				baz: ["D"],
 			});
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const fooList: UpPath = { parent: rootPath, parentField: brand("foo"), parentIndex: 0 };
+			const fooList: UpPath = { parent: rootNode, parentField: brand("foo"), parentIndex: 0 };
 			const fooListChild: UpPath = {
 				parent: fooList,
 				parentField: brand(""),
 				parentIndex: 1,
 			};
-			const barList: UpPath = { parent: rootPath, parentField: brand("bar"), parentIndex: 0 };
-			const bazList: UpPath = { parent: rootPath, parentField: brand("baz"), parentIndex: 0 };
+			const barList: UpPath = { parent: rootNode, parentField: brand("bar"), parentIndex: 0 };
+			const bazList: UpPath = { parent: rootNode, parentField: brand("baz"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move child node from foo into baz.
@@ -1330,13 +1197,8 @@ describe("Editing", () => {
 
 		it("can move a node out from under its parent, and delete that parent from its containing sequence field", () => {
 			const tree = makeTreeFromJson({ src: ["A"], dst: ["B"] });
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
-			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootNode, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootNode, parentField: brand("dst"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move node from foo into rootField.
@@ -1349,7 +1211,7 @@ describe("Editing", () => {
 			);
 			// Deletes parent node
 			const field = tree.editor.sequenceField({
-				parent: rootPath,
+				parent: rootNode,
 				field: brand("src"),
 			});
 			field.delete(0, 1);
@@ -1361,13 +1223,8 @@ describe("Editing", () => {
 
 		it("can move a node out from under its parent, and delete that parent from its containing optional field", () => {
 			const tree = makeTreeFromJson({ src: ["A"], dst: ["B"] });
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
-			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootNode, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootNode, parentField: brand("dst"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move node from foo into rootField.
@@ -1380,7 +1237,7 @@ describe("Editing", () => {
 			);
 			// Deletes parent node
 			const field = tree.editor.optionalField({
-				parent: rootPath,
+				parent: rootNode,
 				field: brand("src"),
 			});
 			field.set(undefined, false);
@@ -1392,13 +1249,8 @@ describe("Editing", () => {
 
 		it("can move a node out from under its parent, and delete that parent from its containing value field", () => {
 			const tree = makeTreeFromJson({ src: ["A"], dst: ["B"] });
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
-			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootNode, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootNode, parentField: brand("dst"), parentIndex: 0 };
 
 			tree.transaction.start();
 			// Move node from foo into rootField.
@@ -1411,7 +1263,7 @@ describe("Editing", () => {
 			);
 			// Deletes parent node
 			const field = tree.editor.valueField({
-				parent: rootPath,
+				parent: rootNode,
 				field: brand("src"),
 			});
 			field.set(singleTextCursor({ type: jsonObject.name }));
@@ -1425,14 +1277,8 @@ describe("Editing", () => {
 			const tree = makeTreeFromJson({ src: ["A", "B"], dst: ["C", "D"] });
 			const childBranch = tree.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
-			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootNode, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootNode, parentField: brand("dst"), parentIndex: 0 };
 
 			// In the child branch, move a node from src to dst.
 			childBranch.editor.move(
@@ -1445,7 +1291,7 @@ describe("Editing", () => {
 
 			// Deletes parent node of the src field
 			tree.editor
-				.optionalField({ parent: rootPath, field: brand("src") })
+				.optionalField({ parent: rootNode, field: brand("src") })
 				.set(undefined, false);
 
 			// Edits to deleted subtrees are currently ignored
@@ -1462,14 +1308,8 @@ describe("Editing", () => {
 			const tree = makeTreeFromJson({ src: ["A", "B"], dst: ["C", "D"] });
 			const childBranch = tree.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
-			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootNode, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootNode, parentField: brand("dst"), parentIndex: 0 };
 
 			// In the child branch, move a node from src to dst.
 			childBranch.editor.move(
@@ -1482,7 +1322,7 @@ describe("Editing", () => {
 
 			// Deletes parent node of the src field
 			tree.editor
-				.optionalField({ parent: rootPath, field: brand("dst") })
+				.optionalField({ parent: rootNode, field: brand("dst") })
 				.set(undefined, false);
 
 			// Edits to deleted subtrees are currently ignored
@@ -1499,14 +1339,8 @@ describe("Editing", () => {
 			const tree = makeTreeFromJson({ src: ["A", "B"], dst: ["C", "D"] });
 			const childBranch = tree.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const srcList: UpPath = { parent: rootPath, parentField: brand("src"), parentIndex: 0 };
-			const dstList: UpPath = { parent: rootPath, parentField: brand("dst"), parentIndex: 0 };
+			const srcList: UpPath = { parent: rootNode, parentField: brand("src"), parentIndex: 0 };
+			const dstList: UpPath = { parent: rootNode, parentField: brand("dst"), parentIndex: 0 };
 
 			// In the child branch, move a node from src to dst.
 			childBranch.editor.move(
@@ -1520,11 +1354,11 @@ describe("Editing", () => {
 			tree.transaction.start();
 			// Deletes parent node of the src field
 			tree.editor
-				.optionalField({ parent: rootPath, field: brand("src") })
+				.optionalField({ parent: rootNode, field: brand("src") })
 				.set(undefined, false);
 			// Deletes parent node of the dst field
 			tree.editor
-				.optionalField({ parent: rootPath, field: brand("dst") })
+				.optionalField({ parent: rootNode, field: brand("dst") })
 				.set(undefined, false);
 			tree.transaction.commit();
 
@@ -1543,11 +1377,6 @@ describe("Editing", () => {
 			const tree1 = tree.fork();
 			const tree2 = tree.fork();
 
-			const rootNode: UpPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
 			const fooList: UpPath = {
 				parent: rootNode,
 				parentField: brand("foo"),
@@ -1688,7 +1517,7 @@ describe("Editing", () => {
 			}
 
 			const delAction = (peer: ISharedTreeView, idx: number) => remove(peer, idx, 1);
-			const srcField: FieldUpPath = { parent: undefined, field: rootFieldKey };
+			const srcField: FieldUpPath = rootField;
 			const dstField: FieldUpPath = { parent: undefined, field: brand("dst") };
 			const moveAction = (peer: ISharedTreeView, idx: number) =>
 				peer.editor.move(srcField, idx, 1, dstField, 0);
@@ -1792,27 +1621,11 @@ describe("Editing", () => {
 			const tree1 = makeTreeFromJson([]);
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
+			tree1.editor.optionalField(rootField).set(singleJsonCursor("41"), true);
 
-			tree1.editor
-				.optionalField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.set(singleJsonCursor("41"), true);
+			tree2.editor.optionalField(rootField).set(singleJsonCursor({ foo: "42" }), true);
 
-			tree2.editor
-				.optionalField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.set(singleJsonCursor({ foo: "42" }), true);
-
-			const editor = tree2.editor.valueField({ parent: rootPath, field: brand("foo") });
+			const editor = tree2.editor.valueField({ parent: rootNode, field: brand("foo") });
 			editor.set(singleTextCursor({ type: jsonString.name, value: "43" }));
 
 			tree1.merge(tree2, false);
@@ -1825,22 +1638,11 @@ describe("Editing", () => {
 			const tree1 = makeTreeFromJson([{ foo: "40" }]);
 			const tree2 = tree1.fork();
 
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			tree1.editor
-				.optionalField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.set(singleJsonCursor({ foo: "41" }), false);
+			tree1.editor.optionalField(rootField).set(singleJsonCursor({ foo: "41" }), false);
 
 			tree1.undo();
 
-			const editor = tree2.editor.valueField({ parent: rootPath, field: brand("foo") });
+			const editor = tree2.editor.valueField({ parent: rootNode, field: brand("foo") });
 			editor.set(singleTextCursor({ type: jsonString.name, value: "42" }));
 
 			tree1.merge(tree2, false);
@@ -1852,12 +1654,7 @@ describe("Editing", () => {
 		it("can replace and restore a node", () => {
 			const tree1 = makeTreeFromJson(["42"]);
 
-			tree1.editor
-				.optionalField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.set(singleJsonCursor("43"), false);
+			tree1.editor.optionalField(rootField).set(singleJsonCursor("43"), false);
 
 			expectJsonTree(tree1, ["43"]);
 
@@ -1870,16 +1667,9 @@ describe("Editing", () => {
 			const tree = makeTreeFromJson(["42"]);
 			const tree2 = tree.fork();
 
-			tree.editor
-				.optionalField({
-					parent: undefined,
-					field: rootFieldKey,
-				})
-				.set(singleJsonCursor("43"), false);
+			tree.editor.optionalField(rootField).set(singleJsonCursor("43"), false);
 
-			tree2.editor
-				.optionalField({ parent: undefined, field: rootFieldKey })
-				.set(undefined, false);
+			tree2.editor.optionalField(rootField).set(undefined, false);
 
 			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
@@ -1898,19 +1688,10 @@ describe("Editing", () => {
 			it("handles ancestor revive", () => {
 				const tree = makeTreeFromJson([]);
 
-				const aPath = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, singleTextCursor({ type: jsonObject.name }));
 				const treeSequence = tree.editor.sequenceField({
-					parent: aPath,
+					parent: rootNode,
 					field: brand("foo"),
 				});
 				treeSequence.insert(0, singleTextCursor({ type: jsonString.name, value: "bar" }));
@@ -1926,14 +1707,11 @@ describe("Editing", () => {
 				// Put existence constraint on child field of a
 				// Constraint should be not be violated after undo
 				tree2.editor.addNodeExistsConstraint({
-					parent: aPath,
+					parent: rootNode,
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
-				const tree2Sequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2Sequence = tree2.editor.sequenceField(rootField);
 				tree2Sequence.insert(1, singleJsonCursor("b"));
 				tree2.transaction.commit();
 
@@ -1946,19 +1724,10 @@ describe("Editing", () => {
 			it("handles ancestor delete", () => {
 				const tree = makeTreeFromJson([]);
 
-				const aPath = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, singleTextCursor({ type: jsonObject.name }));
 				const treeSequence = tree.editor.sequenceField({
-					parent: aPath,
+					parent: rootNode,
 					field: brand("foo"),
 				});
 				treeSequence.insert(0, singleTextCursor({ type: jsonString.name, value: "bar" }));
@@ -1971,14 +1740,11 @@ describe("Editing", () => {
 				tree2.transaction.start();
 				// Put existence constraint on child field of a
 				tree2.editor.addNodeExistsConstraint({
-					parent: aPath,
+					parent: rootNode,
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
-				const tree2Sequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2Sequence = tree2.editor.sequenceField(rootField);
 				tree2Sequence.insert(1, singleTextCursor({ type: jsonString.name, value: "b" }));
 				tree2.transaction.commit();
 
@@ -2005,10 +1771,7 @@ describe("Editing", () => {
 				tree2.transaction.start();
 				// Put an existence constraint on b
 				tree2.editor.addNodeExistsConstraint(bPath);
-				const tree2RootSequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2RootSequence = tree2.editor.sequenceField(rootField);
 				// Should not be inserted because b has been concurrently deleted
 				tree2RootSequence.insert(
 					0,
@@ -2039,10 +1802,7 @@ describe("Editing", () => {
 
 				tree2.transaction.start();
 				tree2.editor.addNodeExistsConstraint(bPath);
-				const sequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const sequence = tree2.editor.sequenceField(rootField);
 				sequence.insert(0, singleTextCursor({ type: jsonString.name, value: "c" }));
 				tree2.transaction.commit();
 
@@ -2054,17 +1814,12 @@ describe("Editing", () => {
 
 			it("optional field node exists constraint", () => {
 				const tree = makeTreeFromJson([]);
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, singleTextCursor({ type: jsonObject.name }));
-				const path = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-				const optional = tree.editor.optionalField({ parent: path, field: brand("foo") });
+				const optional = tree.editor.optionalField({
+					parent: rootNode,
+					field: brand("foo"),
+				});
 				optional.set(singleTextCursor({ type: jsonString.name, value: "x" }), true);
 
 				const tree2 = tree.fork();
@@ -2074,12 +1829,12 @@ describe("Editing", () => {
 
 				tree2.transaction.start();
 				tree2.editor.addNodeExistsConstraint({
-					parent: path,
+					parent: rootNode,
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
 				tree2.editor
-					.sequenceField({ parent: path, field: brand("bar") })
+					.sequenceField({ parent: rootNode, field: brand("bar") })
 					.insert(0, singleJsonCursor(1));
 				tree2.transaction.commit();
 
@@ -2091,19 +1846,13 @@ describe("Editing", () => {
 
 			it("revived optional field node exists constraint", () => {
 				const tree = makeTreeFromJson([]);
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, singleTextCursor({ type: jsonObject.name }));
 
-				const path = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-
-				const optional = tree.editor.optionalField({ parent: path, field: brand("foo") });
+				const optional = tree.editor.optionalField({
+					parent: rootNode,
+					field: brand("foo"),
+				});
 				optional.set(singleTextCursor({ type: jsonString.name, value: "x" }), true);
 
 				const tree2 = tree.fork();
@@ -2113,12 +1862,12 @@ describe("Editing", () => {
 
 				tree2.transaction.start();
 				tree2.editor.addNodeExistsConstraint({
-					parent: path,
+					parent: rootNode,
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
 				tree2.editor
-					.sequenceField({ parent: path, field: brand("bar") })
+					.sequenceField({ parent: rootNode, field: brand("bar") })
 					.insert(0, singleJsonCursor(1));
 				tree2.transaction.commit();
 
@@ -2134,33 +1883,20 @@ describe("Editing", () => {
 
 				// Insert "a"
 				// State should be: ["a"]
-				const sequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const sequence = tree.editor.sequenceField(rootField);
 				sequence.insert(0, singleTextCursor({ type: jsonString.name, value: "a" }));
 
 				// Insert "b" after "a" with constraint that "a" exists.
 				// State should be: ["a", "b"]
 				tree.transaction.start();
-				tree.editor.addNodeExistsConstraint({
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				});
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				tree.editor.addNodeExistsConstraint(rootNode);
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(1, singleTextCursor({ type: jsonString.name, value: "b" }));
 				tree.transaction.commit();
 
 				// Make a concurrent edit to rebase over that inserts into root sequence
 				// State should be (to tree2): ["c"]
-				const tree2RootSequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2RootSequence = tree2.editor.sequenceField(rootField);
 				tree2RootSequence.insert(
 					0,
 					singleTextCursor({ type: jsonString.name, value: "c" }),
@@ -2176,39 +1912,27 @@ describe("Editing", () => {
 				const tree = makeTreeFromJson([{}]);
 				const tree2 = tree.fork();
 
-				const rootPath: UpPath = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-
 				// Constrain on "a" existing and insert "b" if it does
 				// State should be (if "a" exists): [{ foo: "a"}, "b"]
 				tree.transaction.start();
 				const sequence = tree.editor.sequenceField({
-					parent: rootPath,
+					parent: rootNode,
 					field: brand("foo"),
 				});
 				sequence.insert(0, singleTextCursor({ type: jsonString.name, value: "a" }));
 
 				tree.editor.addNodeExistsConstraint({
-					parent: rootPath,
+					parent: rootNode,
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(1, singleTextCursor({ type: jsonString.name, value: "b" }));
 				tree.transaction.commit();
 
 				// Insert "c" concurrently so that we rebase over something
 				// State should be (to tree2): [{}, "c"]
-				const tree2Sequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2Sequence = tree2.editor.sequenceField(rootField);
 				tree2Sequence.insert(1, singleTextCursor({ type: jsonString.name, value: "c" }));
 
 				tree.merge(tree2, false);
@@ -2223,17 +1947,8 @@ describe("Editing", () => {
 				const tree = makeTreeFromJson([{}]);
 				const tree2 = tree.fork();
 
-				const rootPath: UpPath = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-
 				// Delete node from root sequence
-				const tree1RootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree1RootSequence = tree.editor.sequenceField(rootField);
 				tree1RootSequence.delete(0, 1);
 
 				// Constrain on "a" existing and insert "b" if it does
@@ -2241,20 +1956,17 @@ describe("Editing", () => {
 				// concurrently deleted
 				tree2.transaction.start();
 				const sequence = tree2.editor.sequenceField({
-					parent: rootPath,
+					parent: rootNode,
 					field: brand("foo"),
 				});
 				sequence.insert(0, singleTextCursor({ type: jsonString.name, value: "a" }));
 
 				tree2.editor.addNodeExistsConstraint({
-					parent: rootPath,
+					parent: rootNode,
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
-				const rootSequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree2.editor.sequenceField(rootField);
 				rootSequence.insert(1, singleTextCursor({ type: jsonString.name, value: "b" }));
 				tree2.transaction.commit();
 
@@ -2291,10 +2003,7 @@ describe("Editing", () => {
 					0,
 				);
 
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.delete(0, 1);
 				tree.transaction.commit();
 
@@ -2304,10 +2013,7 @@ describe("Editing", () => {
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
-				const tree2RootSequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2RootSequence = tree2.editor.sequenceField(rootField);
 				tree2RootSequence.insert(2, singleTextCursor({ type: jsonObject.name }));
 				tree2.transaction.commit();
 
@@ -2348,10 +2054,7 @@ describe("Editing", () => {
 					0,
 				);
 
-				const rootSequence = tree.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.delete(1, 1);
 				tree.transaction.commit();
 
@@ -2363,10 +2066,7 @@ describe("Editing", () => {
 					parentField: brand("foo"),
 					parentIndex: 0,
 				});
-				const tree2RootSequence = tree2.editor.sequenceField({
-					parent: undefined,
-					field: rootFieldKey,
-				});
+				const tree2RootSequence = tree2.editor.sequenceField(rootField);
 				tree2RootSequence.insert(
 					2,
 					singleTextCursor({ type: jsonString.name, value: "b" }),


### PR DESCRIPTION
Reduces duplication in test code by reusing the same paths instead of declaring new ones.