### PR TITLE
Parse Handle When Applying Stashed Ops

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -751,7 +751,8 @@ export class SharedMatrix<T = any>
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObjectCore.applyStashedOp}
 	 */
-	protected applyStashedOp(content: any): unknown {
+	protected applyStashedOp(op: any): unknown {
+		const content = parseHandles(op, this.serializer);
 		if (content.target === SnapshotPath.cols || content.target === SnapshotPath.rows) {
 			const op = content as IMergeTreeOp;
 			const currentVector = content.target === SnapshotPath.cols ? this.cols : this.rows;

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -751,12 +751,17 @@ export class SharedMatrix<T = any>
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObjectCore.applyStashedOp}
 	 */
-	protected applyStashedOp(op: any): unknown {
-		const content = parseHandles(op, this.serializer);
-		if (content.target === SnapshotPath.cols || content.target === SnapshotPath.rows) {
-			const op = content as IMergeTreeOp;
-			const currentVector = content.target === SnapshotPath.cols ? this.cols : this.rows;
-			const oppositeVector = content.target === SnapshotPath.cols ? this.rows : this.cols;
+	protected applyStashedOp(content: any): unknown {
+		const parsedContent = parseHandles(content, this.serializer);
+		if (
+			parsedContent.target === SnapshotPath.cols ||
+			parsedContent.target === SnapshotPath.rows
+		) {
+			const op = parsedContent as IMergeTreeOp;
+			const currentVector =
+				parsedContent.target === SnapshotPath.cols ? this.cols : this.rows;
+			const oppositeVector =
+				parsedContent.target === SnapshotPath.cols ? this.rows : this.cols;
 			const metadata = currentVector.applyStashedOp(op);
 			const localSeq = currentVector.getCollabWindow().localSeq;
 			const oppositeWindow = oppositeVector.getCollabWindow();
@@ -771,9 +776,12 @@ export class SharedMatrix<T = any>
 
 			return metadata;
 		} else {
-			assert(content.type === MatrixOp.set, 0x2da /* "Unknown SharedMatrix 'op' type." */);
+			assert(
+				parsedContent.type === MatrixOp.set,
+				0x2da /* "Unknown SharedMatrix 'op' type." */,
+			);
 
-			const setOp = content as ISetOp<T>;
+			const setOp = parsedContent as ISetOp<T>;
 			const rowHandle = this.rows.getAllocatedHandle(setOp.row);
 			const colHandle = this.cols.getAllocatedHandle(setOp.col);
 			const rowsRefSeq = this.rows.getCollabWindow().currentSeq;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -705,7 +705,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObjectCore.applyStashedOp}
 	 */
 	protected applyStashedOp(content: any): unknown {
-		return this.client.applyStashedOp(content);
+		return this.client.applyStashedOp(parseHandles(content, this.serializer));
 	}
 
 	private summarizeMergeTree(serializer: IFluidSerializer): ISummaryTreeWithStats {


### PR DESCRIPTION
A stashed op may include a previously serialized handle. When we apply the stashed op to the dds, we need to parse those, and turn them back into real handle before we apply to the op to the dds.