### PR TITLE
get tree state history for provided seed

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzTestTreeStateHistory.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzTestTreeStateHistory.ts
@@ -20,7 +20,7 @@ import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	defaultDDSFuzzSuiteOptions,
 	runTestForSeed,
-// eslint-disable-next-line import/no-internal-modules
+	// eslint-disable-next-line import/no-internal-modules
 } from "@fluid-internal/test-dds-utils/dist/ddsFuzzHarness";
 import { SharedTreeTestFactory, toJsonableTree } from "../../utils";
 import { makeOpGenerator, EditGeneratorOpWeights, FuzzTestState } from "./fuzzEditGenerators";
@@ -40,7 +40,7 @@ interface FuzzTestStateWithHistory extends FuzzTestState {
 const fuzzReducerWithHistory = combineReducersAsync<Operation, FuzzTestStateWithHistory>({
 	edit: async (state, operation) => {
 		const { contents } = operation;
-		updateEmptyClientHistory(state)
+		updateEmptyClientHistory(state);
 		switch (contents.type) {
 			case "fieldEdit": {
 				const tree = state.channel.view;
@@ -55,7 +55,7 @@ const fuzzReducerWithHistory = combineReducersAsync<Operation, FuzzTestStateWith
 		return state;
 	},
 	transaction: async (state, operation) => {
-		updateEmptyClientHistory(state)
+		updateEmptyClientHistory(state);
 		const { contents } = operation;
 		const tree = state.channel;
 		applyTransactionEdit(tree.view, contents);
@@ -63,7 +63,7 @@ const fuzzReducerWithHistory = combineReducersAsync<Operation, FuzzTestStateWith
 		return state;
 	},
 	undoRedo: async (state, operation) => {
-		updateEmptyClientHistory(state)
+		updateEmptyClientHistory(state);
 		const { contents } = operation;
 		const tree = state.channel;
 		applyUndoRedoEdit(tree.view, contents);
@@ -71,16 +71,16 @@ const fuzzReducerWithHistory = combineReducersAsync<Operation, FuzzTestStateWith
 		return state;
 	},
 	synchronizeTrees: async (state) => {
-		updateEmptyClientHistory(state)
+		updateEmptyClientHistory(state);
 		applySynchronizationOp(state);
 		updateStateHistory(state);
 		return state;
 	},
 });
 
-function updateEmptyClientHistory(state: FuzzTestStateWithHistory){
-	if (state.history?.get(state.client) === undefined){
-		state.history?.set(state.client, [JSON.stringify(toJsonableTree(state.channel.view))])
+function updateEmptyClientHistory(state: FuzzTestStateWithHistory) {
+	if (state.history?.get(state.client) === undefined) {
+		state.history?.set(state.client, [JSON.stringify(toJsonableTree(state.channel.view))]);
 	}
 }
 
@@ -95,7 +95,7 @@ export async function getFuzzTestTreeStates(seed: number, numberOfClients: numbe
 		insert: 1,
 		delete: 1,
 		start: 0,
-		commit: 0
+		commit: 0,
 	};
 	const opsPerRun = 20;
 	const runsPerBatch = 1;
@@ -146,7 +146,6 @@ export async function getFuzzTestTreeStates(seed: number, numberOfClients: numbe
 
 describe.only("Fuzz - save tree states history", () => {
 	it.only("with provided seed and number of clients", async () => {
-		const test = await getFuzzTestTreeStates(0, 2);
-		assert.equal(test, "ete")
+		await getFuzzTestTreeStates(0, 2);
 	});
 });

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzTestTreeStateHistory.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzTestTreeStateHistory.ts
@@ -1,0 +1,152 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	AsyncGenerator,
+	combineReducersAsync,
+	takeAsync,
+} from "@fluid-internal/stochastic-test-utils";
+import {
+	DDSFuzzModel,
+	DDSFuzzTestState,
+	DDSFuzzHarnessEvents,
+	Client,
+	getFullModel,
+} from "@fluid-internal/test-dds-utils";
+import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import {
+	defaultDDSFuzzSuiteOptions,
+	runTestForSeed,
+// eslint-disable-next-line import/no-internal-modules
+} from "@fluid-internal/test-dds-utils/dist/ddsFuzzHarness";
+import { SharedTreeTestFactory, toJsonableTree } from "../../utils";
+import { makeOpGenerator, EditGeneratorOpWeights, FuzzTestState } from "./fuzzEditGenerators";
+import {
+	applyFieldEdit,
+	applySynchronizationOp,
+	applyTransactionEdit,
+	applyUndoRedoEdit,
+} from "./fuzzEditReducers";
+import { onCreate } from "./fuzzUtils";
+import { Operation } from "./operationTypes";
+
+interface FuzzTestStateWithHistory extends FuzzTestState {
+	history?: Map<Client<SharedTreeTestFactory>, string[]>;
+}
+
+const fuzzReducerWithHistory = combineReducersAsync<Operation, FuzzTestStateWithHistory>({
+	edit: async (state, operation) => {
+		const { contents } = operation;
+		updateEmptyClientHistory(state)
+		switch (contents.type) {
+			case "fieldEdit": {
+				const tree = state.channel.view;
+				assert(tree !== undefined);
+				applyFieldEdit(tree, contents);
+				break;
+			}
+			default:
+				break;
+		}
+		updateStateHistory(state);
+		return state;
+	},
+	transaction: async (state, operation) => {
+		updateEmptyClientHistory(state)
+		const { contents } = operation;
+		const tree = state.channel;
+		applyTransactionEdit(tree.view, contents);
+		updateStateHistory(state);
+		return state;
+	},
+	undoRedo: async (state, operation) => {
+		updateEmptyClientHistory(state)
+		const { contents } = operation;
+		const tree = state.channel;
+		applyUndoRedoEdit(tree.view, contents);
+		updateStateHistory(state);
+		return state;
+	},
+	synchronizeTrees: async (state) => {
+		updateEmptyClientHistory(state)
+		applySynchronizationOp(state);
+		updateStateHistory(state);
+		return state;
+	},
+});
+
+function updateEmptyClientHistory(state: FuzzTestStateWithHistory){
+	if (state.history?.get(state.client) === undefined){
+		state.history?.set(state.client, [JSON.stringify(toJsonableTree(state.channel.view))])
+	}
+}
+
+function updateStateHistory(state: FuzzTestStateWithHistory) {
+	for (const client of state.clients) {
+		state.history?.get(client)?.push(JSON.stringify(toJsonableTree(client.channel.view)));
+	}
+}
+
+export async function getFuzzTestTreeStates(seed: number, numberOfClients: number) {
+	const composeVsIndividualWeights: Partial<EditGeneratorOpWeights> = {
+		insert: 1,
+		delete: 1,
+		start: 0,
+		commit: 0
+	};
+	const opsPerRun = 20;
+	const runsPerBatch = 1;
+
+	const generatorFactory = (): AsyncGenerator<Operation, FuzzTestStateWithHistory> =>
+		takeAsync(opsPerRun, makeOpGenerator(composeVsIndividualWeights));
+	const ddsModel: DDSFuzzModel<
+		SharedTreeTestFactory,
+		Operation,
+		DDSFuzzTestState<SharedTreeTestFactory>
+	> = {
+		workloadName: "SharedTree",
+		factory: new SharedTreeTestFactory(onCreate),
+		generatorFactory,
+		reducer: fuzzReducerWithHistory,
+		validateConsistency: () => {},
+	};
+	const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+	const treeStates: string[][] = [];
+	emitter.on("testStart", (initialState: FuzzTestStateWithHistory) => {
+		initialState.history = new Map<Client<SharedTreeTestFactory>, string[]>();
+		for (const client of initialState.clients) {
+			initialState.history?.set(client, [
+				JSON.stringify(toJsonableTree(client.channel.view)),
+			]);
+		}
+	});
+	emitter.on("testEnd", (finalState: FuzzTestStateWithHistory) => {
+		for (const client of finalState.clients) {
+			const clientHistory = finalState.history?.get(client);
+			assert(clientHistory !== undefined);
+			treeStates.push(clientHistory);
+		}
+	});
+	const providedOptions = {
+		defaultTestCount: runsPerBatch,
+		numberOfClients,
+		emitter,
+	};
+	const options = {
+		...defaultDDSFuzzSuiteOptions,
+		...providedOptions,
+	};
+	const model = getFullModel(ddsModel, options);
+	await runTestForSeed(model, options, seed);
+	return treeStates;
+}
+
+describe.only("Fuzz - save tree states history", () => {
+	it.only("with provided seed and number of clients", async () => {
+		const test = await getFuzzTestTreeStates(0, 2);
+		assert.equal(test, "ete")
+	});
+});

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1041,7 +1041,10 @@ export function createDDSFuzzSuite<
 	});
 }
 
-const getFullModel = <TChannelFactory extends IChannelFactory, TOperation extends BaseOperation>(
+export const getFullModel = <
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+>(
 	ddsModel: DDSFuzzModel<TChannelFactory, TOperation>,
 	options: DDSFuzzSuiteOptions,
 ): DDSFuzzModel<

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -18,4 +18,5 @@ export {
 	DDSFuzzHarnessEvents,
 	Synchronize,
 	replayTest,
+	getFullModel,
 } from "./ddsFuzzHarness";


### PR DESCRIPTION
## Description

This PR allows for visualizing the fuzz test tree states between each op.