### PR TITLE
Revert "Fix pipeline to publish @fluid-internal/client-utils package to ado build feed. (#17276)

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -39,10 +39,6 @@ parameters:
   type: string
   default:
 
-- name: isClientUtilsPackage
-  type: boolean
-  default: false
-
 jobs:
 - deployment: publish_${{ replace(parameters.environment, '-', '_') }}
   displayName: Publish ${{ parameters.environment }}
@@ -69,7 +65,6 @@ jobs:
               customEndPoint: ${{ parameters.customEndPoint }}
               official: ${{ parameters.official }}
               publishFlags: ${{ parameters.publishFlags }}
-              isClientUtilsPackage: ${{ parameters.isClientUtilsPackage }}
           - ${{ if eq(parameters.publishNonScopedPackages, true) }}:
             - template: include-publish-npm-package-steps.yml
               parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -27,36 +27,13 @@ parameters:
   type: string
   default:
 
-- name: isClientUtilsPackage
-  type: boolean
-  default: false
-
 steps:
 - task: Bash@3
   displayName: Generate .npmrc for ${{ parameters.artifactPath }}
   inputs:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
-    ${{ if eq(parameters.isClientUtilsPackage, true) }}:
-      script: |
-        echo Generating .npmrc for ${{ parameters.feedName }}
-        echo "@fluid-internal:registry=${{ parameters.feedName }}" >> ./.npmrc
-        echo "always-auth=true" >> ./.npmrc
-        cat .npmrc
-        echo Deleting @fluid-internal packages except fluid-internal-client-utils package
-        for packageName in $(ls fluid-internal-*.tgz | grep -v fluid-internal-client-utils-*.tgz)
-        do
-          rm -f $packageName
-        done
-        echo Deleting @fluid-example packages
-        rm -f fluid-example-*
-        echo Deleting @fluidframework packages
-        rm -f fluidframework-*
-        echo Deleting @fluid-experimental packages
-        rm -f fluid-experimental-*
-        echo Deleting @fluid-tools packages
-        rm -f fluid-tools-*
-    ${{ elseif eq(parameters.namespace, true) }}:
+    ${{ if eq(parameters.namespace, true) }}:
       ${{ if eq(parameters.official, false) }}:
         script: |
           echo Generating .npmrc for ${{ parameters.feedName }}
@@ -83,7 +60,7 @@ steps:
           done
           echo Deleting @fluid-example packages
           rm -f fluid-example-*
-    ${{ elseif eq(parameters.namespace, false) }}:
+    ${{ if eq(parameters.namespace, false) }}:
       script: |
         echo Generating .npmrc for ${{ parameters.feedName }}
         echo "registry=${{ parameters.feedName }}" >> ./.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -36,24 +36,6 @@ stages:
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
 
-- stage: publish_npm_internal_client_utils_package
-  dependsOn: build
-  displayName: Publish Client-Utils Internal Package
-  condition: and(succeeded(), eq(variables['testBuild'], false))
-  variables:
-  - group: ado-feeds
-  jobs:
-  - template: include-publish-npm-package-deployment.yml
-    parameters:
-      namespace: ${{ parameters.namespace }}
-      devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
-      feedName: $(ado-feeds-build) # Comes from the ado-feeds variable group
-      official: false
-      environment: package-build-feed
-      pool: ${{ parameters.pool }}
-      publishNonScopedPackages: false
-      isClientUtilsPackage: true
-
 - stage: publish_npm_internal
   dependsOn: build
   displayName: Publish Internal Packages


### PR DESCRIPTION
## Description

The change broke a lot of pipelines because all of them are trying to publish a package (@fluid-internal/client-utils) that only one of them actually produces. Reverting to keep CI healthy until we come up with an adjusted fix.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
