### PR TITLE
Data Object Examples Fixed

### DIFF
--- a/examples/data-objects/clicker/webpack.config.js
+++ b/examples/data-objects/clicker/webpack.config.js
@@ -5,6 +5,7 @@
 
 const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
+const webpack = require("webpack");
 const { merge } = require("webpack-merge");
 
 const pkg = require("./package.json");
@@ -46,6 +47,11 @@ module.exports = (env) => {
 					"Access-Control-Allow-Origin": "*",
 				},
 			},
+			plugins: [
+				new webpack.ProvidePlugin({
+					process: "process/browser",
+				}),
+			],
 			// This impacts which files are watched by the dev server (and likely by webpack if watch is true).
 			// This should be configurable under devServer.static.watch
 			// (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.

--- a/examples/data-objects/monaco/webpack.config.js
+++ b/examples/data-objects/monaco/webpack.config.js
@@ -6,6 +6,7 @@
 const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const { merge } = require("webpack-merge");
+const webpack = require("webpack");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 
 module.exports = (env) => {
@@ -98,6 +99,9 @@ module.exports = (env) => {
 			},
 			plugins: [
 				new MonacoWebpackPlugin(),
+				new webpack.ProvidePlugin({
+					process: "process/browser",
+				}),
 				// new BundleAnalyzerPlugin()
 			],
 		},

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -37,7 +37,7 @@ module.exports = {
 		"build:copy": [],
 		"build:genver": [],
 		"typetests:gen": ["^tsc", "build:genver"], // we may reexport type from dependent packages, needs to build them first.
-		"tsc": tscDependsOn,
+		"tsc": [...tscDependsOn, "webpack"],
 		"build:esnext": tscDependsOn,
 		"build:test": [...tscDependsOn, "typetests:gen", "tsc"],
 		"build:docs": [...tscDependsOn, "tsc"],

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -37,7 +37,7 @@ module.exports = {
 		"build:copy": [],
 		"build:genver": [],
 		"typetests:gen": ["^tsc", "build:genver"], // we may reexport type from dependent packages, needs to build them first.
-		"tsc": [...tscDependsOn, "webpack"],
+		"tsc": tscDependsOn,
 		"build:esnext": tscDependsOn,
 		"build:test": [...tscDependsOn, "typetests:gen", "tsc"],
 		"build:docs": [...tscDependsOn, "tsc"],

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -125,7 +125,10 @@
 					"webpack"
 				],
 				"script": false
-			}
+			},
+			"tsc": [
+				"webpack"
+			]
 		}
 	},
 	"typeValidation": {

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -36,7 +36,7 @@
 		"test:coverage": "c8 npm test",
 		"test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc",
+		"tsc": "tsc && webpack --color --config webpack.config.js",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
 		"webpack": "webpack --color --config webpack.config.js"

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -36,7 +36,7 @@
 		"test:coverage": "c8 npm test",
 		"test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc && webpack --color --config webpack.config.js",
+		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
 		"webpack": "webpack --color --config webpack.config.js"

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -127,6 +127,7 @@
 				"script": false
 			},
 			"tsc": [
+				"...",
 				"webpack"
 			]
 		}


### PR DESCRIPTION
## Description
When you build and run any of the examples under [FluidFramework/examples/data-objects](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects) with `pnpm run build:fast --nolint @fluid-example/{example-name}` you currently only see a blank page. From what I've seen, all these examples use webpack-fluid-loader and I believe this bug is due to fluid-loader.bundle.js file not being built.

This PR includes a potential fix for this bug and adds a necessary plugin to clicker and monaco [as seen in other examples](https://github.com/microsoft/FluidFramework/pull/17268). 

To recreate the bug and confirm the fix, follow the steps `Getting Started` steps under any of the [FluidFramework/examples/data-objects](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects) examples.

**Note**: The examples do run properly if you build the entire repo using `pnpm run build:fast --nolint`

## Reviewer Guidance

My main question is that I'm unsure if this is a 'hacky' fix or not -- I think the core issue might have to do with fluid-build since webpack-fluid-loader's webpack script is not executing when building these examples that depend on it. If this isn' the right fix I think updating the README say something like "build webpack-fluid-loader first before building these examples" would be good in the meantime.