### PR TITLE
Expose partialSynchronization in fuzz harness

### DIFF
--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -118,45 +118,50 @@ describe("Map fuzz tests", () => {
 		// Uncomment to replay a particular seed.
 		// replay: 0,
 		saveFailures: { directory: path.join(__dirname, "../../../src/test/mocha/results/map") },
+		validationStrategy: {
+			type: "partialSynchronization",
+			probability: 0.33,
+			clientProbability: 0.5,
+		},
 	});
 
-	createDDSFuzzSuite(
-		{ ...model, workloadName: "with reconnect" },
-		{
-			defaultTestCount: 100,
-			numberOfClients: 3,
-			clientJoinOptions: {
-				maxNumberOfClients: 6,
-				clientAddProbability: 0.1,
-			},
-			reconnectProbability: 0.1,
-			// Uncomment to replay a particular seed.
-			// replay: 0,
-			saveFailures: {
-				directory: path.join(__dirname, "../../../src/test/mocha/results/map-reconnect"),
-			},
-		},
-	);
+	// createDDSFuzzSuite(
+	// 	{ ...model, workloadName: "with reconnect" },
+	// 	{
+	// 		defaultTestCount: 100,
+	// 		numberOfClients: 3,
+	// 		clientJoinOptions: {
+	// 			maxNumberOfClients: 6,
+	// 			clientAddProbability: 0.1,
+	// 		},
+	// 		reconnectProbability: 0.1,
+	// 		// Uncomment to replay a particular seed.
+	// 		// replay: 0,
+	// 		saveFailures: {
+	// 			directory: path.join(__dirname, "../../../src/test/mocha/results/map-reconnect"),
+	// 		},
+	// 	},
+	// );
 
-	createDDSFuzzSuite(
-		{ ...model, workloadName: "with batches and rebasing" },
-		{
-			defaultTestCount: 100,
-			numberOfClients: 3,
-			clientJoinOptions: {
-				maxNumberOfClients: 6,
-				clientAddProbability: 0.1,
-			},
-			rebaseProbability: 0.2,
-			containerRuntimeOptions: {
-				flushMode: FlushMode.TurnBased,
-				enableGroupedBatching: true,
-			},
-			// Uncomment to replay a particular seed.
-			// replay: 0,
-			saveFailures: {
-				directory: path.join(__dirname, "../../../src/test/mocha/results/map-rebase"),
-			},
-		},
-	);
+	// createDDSFuzzSuite(
+	// 	{ ...model, workloadName: "with batches and rebasing" },
+	// 	{
+	// 		defaultTestCount: 100,
+	// 		numberOfClients: 3,
+	// 		clientJoinOptions: {
+	// 			maxNumberOfClients: 6,
+	// 			clientAddProbability: 0.1,
+	// 		},
+	// 		rebaseProbability: 0.2,
+	// 		containerRuntimeOptions: {
+	// 			flushMode: FlushMode.TurnBased,
+	// 			enableGroupedBatching: true,
+	// 		},
+	// 		// Uncomment to replay a particular seed.
+	// 		// replay: 0,
+	// 		saveFailures: {
+	// 			directory: path.join(__dirname, "../../../src/test/mocha/results/map-rebase"),
+	// 		},
+	// 	},
+	// );
 });

--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -118,50 +118,45 @@ describe("Map fuzz tests", () => {
 		// Uncomment to replay a particular seed.
 		// replay: 0,
 		saveFailures: { directory: path.join(__dirname, "../../../src/test/mocha/results/map") },
-		validationStrategy: {
-			type: "partialSynchronization",
-			probability: 0.33,
-			clientProbability: 0.5,
-		},
 	});
 
-	// createDDSFuzzSuite(
-	// 	{ ...model, workloadName: "with reconnect" },
-	// 	{
-	// 		defaultTestCount: 100,
-	// 		numberOfClients: 3,
-	// 		clientJoinOptions: {
-	// 			maxNumberOfClients: 6,
-	// 			clientAddProbability: 0.1,
-	// 		},
-	// 		reconnectProbability: 0.1,
-	// 		// Uncomment to replay a particular seed.
-	// 		// replay: 0,
-	// 		saveFailures: {
-	// 			directory: path.join(__dirname, "../../../src/test/mocha/results/map-reconnect"),
-	// 		},
-	// 	},
-	// );
+	createDDSFuzzSuite(
+		{ ...model, workloadName: "with reconnect" },
+		{
+			defaultTestCount: 100,
+			numberOfClients: 3,
+			clientJoinOptions: {
+				maxNumberOfClients: 6,
+				clientAddProbability: 0.1,
+			},
+			reconnectProbability: 0.1,
+			// Uncomment to replay a particular seed.
+			// replay: 0,
+			saveFailures: {
+				directory: path.join(__dirname, "../../../src/test/mocha/results/map-reconnect"),
+			},
+		},
+	);
 
-	// createDDSFuzzSuite(
-	// 	{ ...model, workloadName: "with batches and rebasing" },
-	// 	{
-	// 		defaultTestCount: 100,
-	// 		numberOfClients: 3,
-	// 		clientJoinOptions: {
-	// 			maxNumberOfClients: 6,
-	// 			clientAddProbability: 0.1,
-	// 		},
-	// 		rebaseProbability: 0.2,
-	// 		containerRuntimeOptions: {
-	// 			flushMode: FlushMode.TurnBased,
-	// 			enableGroupedBatching: true,
-	// 		},
-	// 		// Uncomment to replay a particular seed.
-	// 		// replay: 0,
-	// 		saveFailures: {
-	// 			directory: path.join(__dirname, "../../../src/test/mocha/results/map-rebase"),
-	// 		},
-	// 	},
-	// );
+	createDDSFuzzSuite(
+		{ ...model, workloadName: "with batches and rebasing" },
+		{
+			defaultTestCount: 100,
+			numberOfClients: 3,
+			clientJoinOptions: {
+				maxNumberOfClients: 6,
+				clientAddProbability: 0.1,
+			},
+			rebaseProbability: 0.2,
+			containerRuntimeOptions: {
+				flushMode: FlushMode.TurnBased,
+				enableGroupedBatching: true,
+			},
+			// Uncomment to replay a particular seed.
+			// replay: 0,
+			saveFailures: {
+				directory: path.join(__dirname, "../../../src/test/mocha/results/map-rebase"),
+			},
+		},
+	);
 });

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -86,6 +86,7 @@ export interface AddClient {
 
 export interface Synchronize {
 	type: "synchronize";
+	clients?: string[];
 }
 
 interface HasWorkloadName {
@@ -306,7 +307,8 @@ export interface DDSFuzzSuiteOptions {
 	 */
 	validationStrategy:
 		| { type: "random"; probability: number }
-		| { type: "fixedInterval"; interval: number };
+		| { type: "fixedInterval"; interval: number }
+		| { type: "partialSynchronization"; probability: number; clientProbability: number };
 	parseOperations: (serialized: string) => BaseOperation[];
 
 	/**
@@ -682,12 +684,42 @@ export function mixinSynchronization<
 				);
 			};
 			break;
+
+		case "partialSynchronization":
+			// passing 1 here causes infinite loops. passing close to 1 is wasteful
+			// as synchronization + eventual consistency validation should be idempotent.
+			// 0.5 is arbitrary but there's no reason anyone should want a probability near this.
+			assert(
+				validationStrategy.probability < 0.5,
+				"Use a lower synchronization probability.",
+			);
+			generatorFactory = (): Generator<TOperation | Synchronize, TState> => {
+				const baseGenerator = model.generatorFactory();
+				return async (state: TState): Promise<TOperation | Synchronize | typeof done> => {
+					if (!state.isDetached && state.random.bool(validationStrategy.probability)) {
+						const connectedClients = new Set(
+							state.clients
+								.filter((client) => client.containerRuntime.connected)
+								.filter(() =>
+									state.random.bool(validationStrategy.clientProbability),
+								)
+								.map((client) => client.containerRuntime.clientId),
+						);
+
+						return { type: "synchronize", clients: [...connectedClients] };
+					} else {
+						return baseGenerator(state);
+					}
+				};
+			};
+			break;
 		default:
 			unreachableCase(validationStrategy);
 	}
 
 	const isSynchronizeOp = (op: BaseOperation): op is Synchronize => op.type === "synchronize";
 	const reducer: Reducer<TOperation | Synchronize, TState> = async (state, operation) => {
+		// TODO: Only synchronize listed clients if specified
 		if (isSynchronizeOp(operation)) {
 			const connectedClients = state.clients.filter(
 				(client) => client.containerRuntime.connected,

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -308,6 +308,7 @@ export interface DDSFuzzSuiteOptions {
 	validationStrategy:
 		| { type: "random"; probability: number }
 		| { type: "fixedInterval"; interval: number }
+		// WIP: This validation strategy still currently synchronizes all clients.
 		| { type: "partialSynchronization"; probability: number; clientProbability: number };
 	parseOperations: (serialized: string) => BaseOperation[];
 
@@ -697,7 +698,7 @@ export function mixinSynchronization<
 				const baseGenerator = model.generatorFactory();
 				return async (state: TState): Promise<TOperation | Synchronize | typeof done> => {
 					if (!state.isDetached && state.random.bool(validationStrategy.probability)) {
-						const connectedClients = new Set(
+						const selectedClients = new Set(
 							state.clients
 								.filter((client) => client.containerRuntime.connected)
 								.filter(() =>
@@ -706,7 +707,7 @@ export function mixinSynchronization<
 								.map((client) => client.containerRuntime.clientId),
 						);
 
-						return { type: "synchronize", clients: [...connectedClients] };
+						return { type: "synchronize", clients: [...selectedClients] };
 					} else {
 						return baseGenerator(state);
 					}


### PR DESCRIPTION
## Description

Splitting #17062 into smaller chunks for a better review process. This change exposes `partialSynchronization` in the fuzz harness. As it stands, this functions the same as a normal synchronization op.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
