### PR TITLE
[GC stress] Revert the default test profile to mini

### DIFF
--- a/packages/test/test-service-load/src/test/mini.spec.ts
+++ b/packages/test/test-service-load/src/test/mini.spec.ts
@@ -11,7 +11,7 @@ const childArgs: string[] = [
 	"--driver",
 	"tinylicious",
 	"--profile",
-	"gc",
+	"mini",
 ];
 
 describe("stress test", () => {


### PR DESCRIPTION
Reverting the default test profile back to mini since the GC test is not run by default anymore.