### PR TITLE
Remove simulateReadConnectionUsingDelay which helped migrate to loading in read mode by default

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -152,7 +152,6 @@ export interface ITestContainerConfig {
     loaderProps?: Partial<ILoaderProps>;
     registry?: ChannelFactoryRegistry;
     runtimeOptions?: IContainerRuntimeOptions;
-    simulateReadConnectionUsingDelay?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -7,7 +7,6 @@ import {
 	IContainer,
 	IHostLoader,
 	IFluidCodeDetails,
-	LoaderHeader,
 	ILoader,
 } from "@fluidframework/container-definitions";
 import {
@@ -383,10 +382,10 @@ export class TestObjectProvider implements ITestObjectProvider {
 		return this.resolveContainer(loader, requestHeader);
 	}
 
-	private async resolveContainer(loader: ILoader, requestHeader?: IRequestHeader) {
+	private async resolveContainer(loader: ILoader, headers?: IRequestHeader) {
 		const container = await loader.resolve({
 			url: await this.driver.createContainerUrl(this.documentId),
-			headers: requestHeader,
+			headers,
 		});
 
 		return container;

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -112,9 +112,6 @@ export interface ITestContainerConfig {
 
 	/** Loader options for the loader used to create containers */
 	loaderProps?: Partial<ILoaderProps>;
-
-	/** Temporary flag: simulate read connection using delay connection, default is true */
-	simulateReadConnectionUsingDelay?: boolean;
 }
 
 export const createDocumentId = (): string => uuid();
@@ -386,40 +383,12 @@ export class TestObjectProvider implements ITestObjectProvider {
 		return this.resolveContainer(loader, requestHeader);
 	}
 
-	private async resolveContainer(
-		loader: ILoader,
-		requestHeader?: IRequestHeader,
-		delay: boolean = true,
-	) {
-		// Once AB#3889 is done to switch default connection mode to "read" on load, we don't need
-		// to load "delayed" across the board. Remove the following code.
-		const delayConnection =
-			delay &&
-			(requestHeader === undefined || requestHeader[LoaderHeader.reconnect] !== false);
-		const headers: IRequestHeader | undefined = delayConnection
-			? {
-					[LoaderHeader.loadMode]: { deltaConnection: "delayed" },
-					...requestHeader,
-			  }
-			: requestHeader;
-
+	private async resolveContainer(loader: ILoader, requestHeader?: IRequestHeader) {
 		const container = await loader.resolve({
 			url: await this.driver.createContainerUrl(this.documentId),
-			headers,
+			headers: requestHeader,
 		});
 
-		// Once AB#3889 is done to switch default connection mode to "read" on load, we don't need
-		// to load "delayed" across the board. Remove the following code.
-		if (delayConnection) {
-			// Older version may not have connect/disconnect. It was add in PR#9439, and available >= 0.59.1000
-			const maybeContainer = container as Partial<IContainer>;
-			if (maybeContainer.connect !== undefined) {
-				container.connect();
-			} else {
-				// back compat. Remove when we don't support < 0.59.1000
-				(container as any).resume();
-			}
-		}
 		return container;
 	}
 
@@ -473,11 +442,7 @@ export class TestObjectProvider implements ITestObjectProvider {
 	): Promise<IContainer> {
 		const loader = this.makeTestLoader(testContainerConfig);
 
-		const container = await this.resolveContainer(
-			loader,
-			requestHeader,
-			testContainerConfig?.simulateReadConnectionUsingDelay,
-		);
+		const container = await this.resolveContainer(loader, requestHeader);
 		await this.waitContainerToCatchUp(container);
 
 		return container;

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -383,12 +383,10 @@ export class TestObjectProvider implements ITestObjectProvider {
 	}
 
 	private async resolveContainer(loader: ILoader, headers?: IRequestHeader) {
-		const container = await loader.resolve({
+		return loader.resolve({
 			url: await this.driver.createContainerUrl(this.documentId),
 			headers,
 		});
-
-		return container;
 	}
 
 	/**


### PR DESCRIPTION
## Description

ADO:5500

The flag is no longer needed. Also, to work around the current default, one can use the `Fluid.Container.ForceWriteConnection` feature flag instead. [For example](https://github.com/microsoft/FluidFramework/blob/8826fbc97ab7e6fcdd7e2943b471efef963fc0a8/experimental/dds/tree/src/test/utilities/PendingLocalStateTests.ts#L176). 