### PR TITLE
test(api-markdown-documenter): Update test infra to refer to test assets in the src directory

### DIFF
--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -16,10 +16,8 @@
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build-and-test": "npm run build && npm run test",
-		"build:compile": "concurrently npm:tsc npm:build:copy",
-		"build:copy": "copyfiles \"src/**/test-data/**\" dist --up 1",
+		"build:compile": "npm run tsc",
 		"build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../_api-extractor-temp/",
-		"build:tsc": "tsc --pretty",
 		"ci:build:docs": "api-extractor run && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../_api-extractor-temp/",
 		"clean": "rimraf --glob '_api-extractor-temp' 'nyc' 'dist' '*.tsbuildinfo' '*.build.log'",
 		"eslint": "eslint src",

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -18,6 +18,7 @@
 		"build-and-test": "npm run build && npm run test",
 		"build:compile": "npm run tsc",
 		"build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../_api-extractor-temp/",
+		"build:tsc": "npm run tsc",
 		"ci:build:docs": "api-extractor run && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../_api-extractor-temp/",
 		"clean": "rimraf --glob '_api-extractor-temp' 'nyc' 'dist' '*.tsbuildinfo' '*.build.log'",
 		"eslint": "eslint src",

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -48,11 +48,23 @@ const defaultPartialConfig: Omit<ApiItemTransformationConfiguration, "apiModel">
 	uriRoot: ".",
 };
 
+// Relative to dist/api-item-transforms/test
+const testDataDirPath = Path.resolve(
+	__dirname,
+	"..",
+	"..",
+	"..",
+	"src",
+	"api-item-transforms",
+	"test",
+	"test-data",
+);
+
 /**
  * Generates an `ApiModel` from the API report file at the provided path.
  */
 function generateModel(testReportFileName: string): ApiModel {
-	const filePath = Path.resolve(__dirname, "test-data", testReportFileName);
+	const filePath = Path.resolve(testDataDirPath, testReportFileName);
 
 	const apiModel = new ApiModel();
 	apiModel.loadPackage(filePath);

--- a/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
@@ -22,9 +22,13 @@ const testTempDirPath = Path.resolve(__dirname, "test_temp");
 
 /**
  * Snapshot directory to which generated test data will be copied.
- * Relative to dist/test.
+ * Relative to dist/test
  */
 const snapshotsDirPath = Path.resolve(__dirname, "..", "..", "src", "test", "snapshots");
+
+// Relative to dist/test
+const testDataDirPath = Path.resolve(__dirname, "..", "..", "src", "test", "test-data");
+const testModelPaths = [Path.resolve(testDataDirPath, "simple-suite-test.json")];
 
 /**
  * Simple integration test that validates complete output from simple test package.
@@ -241,10 +245,5 @@ describe("api-markdown-documenter full-suite tests", () => {
 	});
 
 	// Run the test suite against a sample report
-	apiTestSuite(
-		"simple-suite-test",
-		// Relative to dist/test
-		[Path.resolve(__dirname, "test-data", "simple-suite-test.json")],
-		configs,
-	);
+	apiTestSuite("simple-suite-test", testModelPaths, configs);
 });


### PR DESCRIPTION
Updates the package's test infra to refer to test assets in `src` directory, rather than requiring the assets be copied into `dist` as a part of the build.