### PR TITLE
refactor(api-markdown-documenter): Don't include file extension in paths in Documentation Domain

### DIFF
--- a/.changeset/eight-shrimps-fail.md
+++ b/.changeset/eight-shrimps-fail.md
@@ -1,0 +1,13 @@
+---
+"@fluid-tools/api-markdown-documenter": minor
+---
+
+Don't include file extension in paths in Documentation Domain
+
+The Documentation Domain layer of the system is not intended to know anything about files on disk. It has a concept of abstract documentation hierarchy, which maps to file system structure, but that is as close as it gets.
+
+Previously, `DocumentNode` included a property called `filePath`, which included a hard-coded `.md` file extension. This has been removed; it is now the responsibility of consumers to append the appropriate file extension when writing rendered document contents to disk. `renderDocumentsAsMarkdown` now handled this, as the only code in the system that interacts with the file system.
+
+The `filePath` property has also been renamed to `documentPath` to help avoid confusion, and its docs have been updated call out the distinction.
+
+This PR also removes the `getFilePathForApiItem` utility function from the public API - consumers shouldn't need to use it, and it could cause confusion.

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
@@ -219,7 +219,7 @@ export class DocumentNode implements Parent<SectionNode>, DocumentNodeProps {
     constructor(props: DocumentNodeProps);
     readonly apiItemName: string;
     readonly children: SectionNode[];
-    readonly filePath: string;
+    readonly documentPath: string;
     readonly frontMatter?: string;
     readonly type = DocumentationNodeType.Document;
 }
@@ -228,7 +228,7 @@ export class DocumentNode implements Parent<SectionNode>, DocumentNodeProps {
 export interface DocumentNodeProps {
     readonly apiItemName: string;
     readonly children: SectionNode[];
-    readonly filePath: string;
+    readonly documentPath: string;
     readonly frontMatter?: string;
 }
 
@@ -257,9 +257,6 @@ export function getDeprecatedBlock(apiItem: ApiItem): DocSection | undefined;
 
 // @public
 export function getExampleBlocks(apiItem: ApiItem): DocSection[] | undefined;
-
-// @public
-export function getFilePathForApiItem(apiItem: ApiItem, config: Required<ApiItemTransformationConfiguration>): string;
 
 // @public
 export function getHeadingForApiItem(apiItem: ApiItem, config: Required<ApiItemTransformationConfiguration>, headingLevel?: number): Heading;

--- a/tools/api-markdown-documenter/src/RenderMarkdown.ts
+++ b/tools/api-markdown-documenter/src/RenderMarkdown.ts
@@ -69,7 +69,7 @@ export async function renderApiModelAsMarkdown(
  * Renders the provided documents using Markdown syntax, and writes each document to a file on disk.
  *
  * @param documents - The documents to render. Each will be rendered to its own file on disk per
- * {@link DocumentNode.filePath} (relative to the provided output directory).
+ * {@link DocumentNode.documentPath} (relative to the provided output directory).
  * @param renderConfig - A partial {@link MarkdownRenderConfiguration}.
  * @param fileSystemConfig - Configuration for writing document files to disk.
  * @param logger - Receiver of system log data. Default: {@link defaultConsoleLogger}.
@@ -95,7 +95,7 @@ export async function renderDocumentsAsMarkdown(
 				logger,
 			});
 
-			const filePath = Path.join(outputDirectoryPath, document.filePath);
+			const filePath = Path.join(outputDirectoryPath, `${document.documentPath}.md`);
 			await FileSystem.writeFileAsync(filePath, renderedDocument, {
 				convertLineEndings: newlineKind ?? NewlineKind.OsDefault,
 				ensureFolderExists: true,

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemUtilities.ts
@@ -251,8 +251,6 @@ export function getUnscopedPackageName(apiPackage: ApiPackage): string {
  *
  * @param apiItem - The API item for which we are generating a file path.
  * @param config - See {@link ApiItemTransformationConfiguration}.
- *
- * @public
  */
 export function getDocumentPathForApiItem(
 	apiItem: ApiItem,

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemUtilities.ts
@@ -207,7 +207,7 @@ function getLinkUrlForApiItem(
 	config: Required<ApiItemTransformationConfiguration>,
 ): string {
 	const uriBase = config.getUriBaseOverrideForItem(apiItem) ?? config.uriRoot;
-	let documentPath = getApiItemPath(apiItem, config, /* includeExtension: */ false).join("/");
+	let documentPath = getApiItemPath(apiItem, config).join("/");
 
 	// Omit "index" file name from path generated in links.
 	// This can be considered an optimization in most cases, but some documentation systems also special-case
@@ -240,9 +240,10 @@ export function getUnscopedPackageName(apiPackage: ApiPackage): string {
 }
 
 /**
- * Gets the file path for the specified API item.
+ * Gets the path to the document for the specified API item.
  *
  * @remarks
+ *
  * In the case of an item that does not get rendered to its own document, this will point to the document
  * of the ancestor item under which the provided item will be rendered.
  *
@@ -253,11 +254,11 @@ export function getUnscopedPackageName(apiPackage: ApiPackage): string {
  *
  * @public
  */
-export function getFilePathForApiItem(
+export function getDocumentPathForApiItem(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
 ): string {
-	const pathSegments = getApiItemPath(apiItem, config, true);
+	const pathSegments = getApiItemPath(apiItem, config);
 	return Path.join(...pathSegments);
 }
 
@@ -266,16 +267,14 @@ export function getFilePathForApiItem(
  *
  * @param apiItem - The API item for which we are generating a file path.
  * @param config - See {@link ApiItemTransformationConfiguration}.
- * @param includeExtension - Whether or not to include the `.md` file extension at the end of the path.
  */
 function getApiItemPath(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
-	includeExtension: boolean,
 ): string[] {
 	const targetDocumentItem = getFirstAncestorWithOwnDocument(apiItem, config.documentBoundaries);
 
-	const fileName = getFileNameForApiItem(apiItem, config, includeExtension);
+	const fileName = getDocumentNameForApiItem(apiItem, config);
 
 	// Filtered ancestry in ascending order
 	const documentAncestry = getAncestralHierarchy(targetDocumentItem, (hierarchyItem) =>
@@ -289,23 +288,22 @@ function getApiItemPath(
 }
 
 /**
- * Gets the file name for the specified API item.
+ * Gets the document name for the specified API item.
  *
  * @remarks
+ *
  * In the case of an item that does not get rendered to its own document, this will be the file name for the document
  * of the ancestor item under which the provided item will be rendered.
  *
  * Note: This is strictly the name of the file, not a path to that file.
- * To get the path, use {@link getFilePathForApiItem}.
+ * To get the path, use {@link getDocumentPathForApiItem}.
  *
  * @param apiItem - The API item for which we are generating a file path.
  * @param config - See {@link ApiItemTransformationConfiguration}.
- * @param includeExtension - Whether or not to include the `.md` file extension at the end of the file name.
  */
-function getFileNameForApiItem(
+function getDocumentNameForApiItem(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
-	includeExtension: boolean,
 ): string {
 	const targetDocumentItem = getFirstAncestorWithOwnDocument(apiItem, config.documentBoundaries);
 
@@ -319,11 +317,6 @@ function getFileNameForApiItem(
 		targetDocumentItem.kind !== ApiItemKind.Package
 	) {
 		unscopedFileName = `${unscopedFileName}-${targetDocumentItem.kind.toLocaleLowerCase()}`;
-	}
-
-	// Append file extension if requested
-	if (includeExtension) {
-		unscopedFileName = `${unscopedFileName}.md`;
 	}
 
 	// Walk parentage up until we reach the first ancestor which injects directory hierarchy.

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -22,7 +22,7 @@ import { apiItemToDocument, apiItemToSections } from "./TransformApiItem";
  * Which API members get their own documents and which get written to the contents of their parent is
  * determined by {@link DocumentationSuiteOptions.documentBoundaries}.
  *
- * The generated nodes' {@link DocumentNode.filePath}s are determined by the provided output path and the
+ * The generated nodes' {@link DocumentNode.documentPath}s are determined by the provided output path and the
  * following configuration properties:
  *
  * - {@link DocumentationSuiteOptions.documentBoundaries}

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -7,7 +7,7 @@ import { DocDeclarationReference } from "@microsoft/tsdoc";
 
 import { Link } from "../Link";
 import { DocumentNode, SectionNode } from "../documentation-domain";
-import { getFilePathForApiItem, getLinkForApiItem } from "./ApiItemUtilities";
+import { getDocumentPathForApiItem, getLinkForApiItem } from "./ApiItemUtilities";
 import { DocNodeTransformOptions } from "./DocNodeTransforms";
 import { ApiItemTransformationConfiguration } from "./configuration";
 import { wrapInSection } from "./helpers";
@@ -46,7 +46,7 @@ export function createDocument(
 	return new DocumentNode({
 		apiItemName: documentItem.displayName,
 		children: contents,
-		filePath: getFilePathForApiItem(documentItem, config),
+		documentPath: getDocumentPathForApiItem(documentItem, config),
 		frontMatter,
 	});
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/index.ts
@@ -17,7 +17,6 @@ export {
 	getDefaultValueBlock,
 	getDeprecatedBlock,
 	getExampleBlocks,
-	getFilePathForApiItem,
 	getHeadingForApiItem,
 	getLinkForApiItem,
 	getModifiers,

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -365,7 +365,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const expectedPackageDoc = new DocumentNode({
 			apiItemName: "test-package",
-			filePath: "test-package.md",
+			documentPath: "test-package",
 			children: [
 				new SectionNode(
 					[
@@ -403,7 +403,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const expectedEntryPointADoc = new DocumentNode({
 			apiItemName: "entry-point-a",
-			filePath: "test-package/entry-point-a-entrypoint.md",
+			documentPath: "test-package/entry-point-a-entrypoint",
 			children: [
 				new SectionNode(
 					[
@@ -487,7 +487,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const expectedEntryPointBDoc = new DocumentNode({
 			apiItemName: "entry-point-b",
-			filePath: "test-package/entry-point-b-entrypoint.md",
+			documentPath: "test-package/entry-point-b-entrypoint",
 			children: [
 				new SectionNode(
 					[

--- a/tools/api-markdown-documenter/src/documentation-domain/DocumentNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/DocumentNode.ts
@@ -27,8 +27,10 @@ export interface DocumentNodeProps {
 
 	/**
 	 * Path to which the resulting document should be saved.
+	 *
+	 * @remarks Does not include the file extension, as this domain has no concept of what kind of file will be produced.
 	 */
-	readonly filePath: string;
+	readonly documentPath: string;
 
 	/**
 	 * Optional document front-matter, to be appended above all other content.
@@ -63,9 +65,9 @@ export class DocumentNode implements UnistParent<SectionNode>, DocumentNodeProps
 	public readonly children: SectionNode[];
 
 	/**
-	 * {@inheritDoc DocumentNodeProps.filePath}
+	 * {@inheritDoc DocumentNodeProps.documentPath}
 	 */
-	public readonly filePath: string;
+	public readonly documentPath: string;
 
 	/**
 	 * {@inheritDoc DocumentNodeProps.frontMatter}
@@ -75,7 +77,7 @@ export class DocumentNode implements UnistParent<SectionNode>, DocumentNodeProps
 	public constructor(props: DocumentNodeProps) {
 		this.apiItemName = props.apiItemName;
 		this.children = props.children;
-		this.filePath = props.filePath;
+		this.documentPath = props.documentPath;
 		this.frontMatter = props.frontMatter;
 	}
 }

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -30,7 +30,6 @@ export {
 	getDefaultValueBlock,
 	getDeprecatedBlock,
 	getExampleBlocks,
-	getFilePathForApiItem,
 	getHeadingForApiItem,
 	getLinkForApiItem,
 	getModifiers,

--- a/tools/api-markdown-documenter/src/markdown-renderer/test/RenderDocument.test.ts
+++ b/tools/api-markdown-documenter/src/markdown-renderer/test/RenderDocument.test.ts
@@ -44,7 +44,7 @@ describe("Document rendering tests", () => {
 					HeadingNode.createFromPlainText("Sample Document"),
 				),
 			],
-			filePath: "./test.md",
+			documentPath: "./test.md",
 		});
 
 		const expected = [

--- a/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
@@ -142,12 +142,12 @@ function apiTestSuite(
 
 					const pathMap = new Map<string, DocumentNode>();
 					for (const document of documents) {
-						if (pathMap.has(document.filePath)) {
+						if (pathMap.has(document.documentPath)) {
 							expect.fail(
 								`Rendering generated multiple documents to be rendered to the same file path.`,
 							);
 						} else {
-							pathMap.set(document.filePath, document);
+							pathMap.set(document.documentPath, document);
 						}
 					}
 				});


### PR DESCRIPTION
The Documentation Domain layer of the system is not intended to know anything about files on disk. It has a concept of abstract documentation hierarchy, which maps to file system structure, but that is as close as it gets.

Previously, `DocumentNode` included a property called `filePath`, which included a hard-coded `.md` file extension. This has been removed; it is now the responsibility of consumers to append the appropriate file extension when writing rendered document contents to disk. `renderDocumentsAsMarkdown` now handled this, as the only code in the system that interacts with the file system.

The `filePath` property has also been renamed to `documentPath` to help avoid confusion, and its docs have been updated call out the distinction.

This PR also removes the `getFilePathForApiItem` utility function from the public API - consumers shouldn't need to use it, and it could cause confusion.

### Breaking Change

`filePath` was renamed to `documentPath` and `getFilePathForApiItem` was removed.