### PR TITLE
fix: Prevent ECONNRESET/socket-hang-up in t9s stress tests

### DIFF
--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -68,6 +68,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"@fluidframework/tool-utils": "workspace:~",
+		"agentkeepalive": "^4.5.0",
 		"axios": "^0.26.0",
 		"semver": "^7.5.3",
 		"uuid": "^9.0.0"

--- a/packages/test/test-drivers/src/factory.ts
+++ b/packages/test/test-drivers/src/factory.ts
@@ -27,52 +27,14 @@ export const DriverApi: DriverApiType = {
 	RouterliciousDriverApi,
 };
 
-let httpRequestPatched = false;
-function patchHttpRequestToForceKeepAlive() {
-	// Each TCP connection port has a delay to disallow it to be reused after close,
-	// and unit test make a lot of connection, which might cause port exhaustion.
-	// Patch http.request to force keep-alive.
-
-	if (httpRequestPatched) {
-		return;
-	}
-
-	httpRequestPatched = true;
-
-	// IMPORTANT: the Agent from agentkeepalive sets keep-alive to true by default and manages timeouts for active and
-	// inactive connections on the client side (default to 8s and 4s respectively). This should be coordinated with the
-	// corresponding timeout on the server's end. If the timeout on the client is higher than on the server, an inactive
-	// connection might be closed by the server but kept around on the client, and when something attempts to reuse it,
-	// our drivers will end up throwing an error like ECONNRESET or "socket hang up", indicating that "the other side of
-	// the connection closed it abruptly", which in this case isn't really abruptly, it's just that the client doesn't
-	// immediately react to the server closing the socket.
-	const httpAgent = new Agent();
-	const oldRequest = http.request;
-	http.request = ((url, options, callback) => {
-		// There are two variant of the API
-		// - http.request(options[, callback])
-		// - http.request(url[, options][, callback])
-		// See https://nodejs.org/dist/latest-v18.x/docs/api/http.html#httprequestoptions-callback
-
-		// decide which param is the actual options object and add agent to it.
-		let opts;
-		if (options !== undefined) {
-			opts = typeof options !== "function" ? options : url;
-		} else if (callback !== undefined) {
-			// eslint-disable-next-line no-param-reassign
-			options = {};
-			opts = options;
-		} else {
-			opts = url;
-		}
-		if (opts.agent === undefined) {
-			opts.agent = httpAgent;
-			opts.headers.Connection = ["keep-alive"];
-		}
-		// pass thru the param to the original function
-		return oldRequest(url, options, callback);
-	}) as any;
-}
+// IMPORTANT: the Agent from agentkeepalive sets keep-alive to true by default and manages timeouts for active and
+// inactive connections on the client side (default to 8s and 4s respectively). This should be coordinated with the
+// corresponding timeout on the server's end. If the timeout on the client is higher than on the server, an inactive
+// connection might be closed by the server but kept around on the client, and when something attempts to reuse it,
+// our drivers will end up throwing an error like ECONNRESET or "socket hang up", indicating that "the other side of
+// the connection closed it abruptly", which in this case isn't really abruptly, it's just that the client doesn't
+// immediately react to the server closing the socket.
+http.globalAgent = new Agent();
 
 export type CreateFromEnvConfigParam<T extends (config: any, ...args: any) => any> = T extends (
 	config: infer P,
@@ -99,16 +61,13 @@ export async function createFluidTestDriver(
 
 		case "t9s":
 		case "tinylicious":
-			patchHttpRequestToForceKeepAlive();
 			return new TinyliciousTestDriver(api.RouterliciousDriverApi);
 
 		case "r11s":
 		case "routerlicious":
-			patchHttpRequestToForceKeepAlive();
 			return RouterliciousTestDriver.createFromEnv(config?.r11s, api.RouterliciousDriverApi);
 
 		case "odsp":
-			patchHttpRequestToForceKeepAlive();
 			return OdspTestDriver.createFromEnv(config?.odsp, api.OdspDriverApi);
 
 		default:

--- a/packages/test/test-drivers/src/factory.ts
+++ b/packages/test/test-drivers/src/factory.ts
@@ -91,7 +91,7 @@ export async function createFluidTestDriver(
 
 		case "t9s":
 		case "tinylicious":
-			patchHttpRequestToForceKeepAlive();
+			// patchHttpRequestToForceKeepAlive();
 			return new TinyliciousTestDriver(api.RouterliciousDriverApi);
 
 		case "r11s":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9799,6 +9799,7 @@ importers:
       '@fluidframework/tool-utils': workspace:~
       '@microsoft/api-extractor': ^7.34.4
       '@types/node': ^16.18.38
+      agentkeepalive: ^4.5.0
       axios: ^0.26.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -9826,6 +9827,7 @@ importers:
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@fluidframework/tinylicious-driver': link:../../drivers/tinylicious-driver
       '@fluidframework/tool-utils': link:../../utils/tool-utils
+      agentkeepalive: 4.5.0
       axios: 0.26.1
       semver: 7.5.3
       uuid: 9.0.0
@@ -10091,7 +10093,7 @@ importers:
       commander: 5.1.0
       ps-node: 0.1.6
       start-server-and-test: 1.15.5
-      tinylicious: 1.0.0
+      tinylicious: link:../../../server/tinylicious
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
@@ -24487,6 +24489,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /agentkeepalive/4.5.0:
+    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      humanize-ms: 1.2.1
+
   /aggregate-error/3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -36088,7 +36096,7 @@ packages:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      agentkeepalive: 4.3.0
+      agentkeepalive: 4.5.0
       cacache: 16.1.3
       http-cache-semantics: 4.1.1
       http-proxy-agent: 5.0.0
@@ -36113,7 +36121,7 @@ packages:
     resolution: {integrity: sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      agentkeepalive: 4.3.0
+      agentkeepalive: 4.5.0
       cacache: 17.1.2
       http-cache-semantics: 4.1.1
       http-proxy-agent: 5.0.0
@@ -36136,7 +36144,7 @@ packages:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
     engines: {node: '>= 10'}
     dependencies:
-      agentkeepalive: 4.3.0
+      agentkeepalive: 4.5.0
       cacache: 15.3.0
       http-cache-semantics: 4.1.1
       http-proxy-agent: 4.0.1
@@ -43184,7 +43192,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.17.4
-      webpack: 5.88.1_webpack-cli@4.10.0
+      webpack: 5.88.1
     dev: true
 
   /terser/4.8.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10093,7 +10093,7 @@ importers:
       commander: 5.1.0
       ps-node: 0.1.6
       start-server-and-test: 1.15.5
-      tinylicious: link:../../../server/tinylicious
+      tinylicious: 1.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
@@ -16161,15 +16161,15 @@ packages:
     resolution: {integrity: sha512-wJoYsNy324cI5FI8N0KPUGq/hWFaEUwujAOdlrfBToZ1LSCFNY6CstZ0YR1ilASubHCariK6PfRIgM/ohfmlSw==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
@@ -16182,17 +16182,17 @@ packages:
       '@fluid-experimental/tree2': 2.0.0-internal.6.3.1
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
       '@fluidframework/cell': 2.0.0-internal.6.3.0
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/counter': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/map': 2.0.0-internal.6.3.0
       '@fluidframework/matrix': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/sequence': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16202,7 +16202,7 @@ packages:
     resolution: {integrity: sha512-J5BD1y3R0ZCjOphUlCkof6GHUMhju81T2mf9lfsM9yz+HoryS6d7dFr79gpDQ+VRgB5n2S97Wv6I7l65fc5iDQ==}
     dependencies:
       '@fluid-experimental/devtools-core': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/fluid-static': 2.0.0-internal.6.3.0
     transitivePeerDependencies:
       - debug
@@ -16496,11 +16496,11 @@ packages:
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
       '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
@@ -16508,7 +16508,7 @@ packages:
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
       '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/tool-utils': 2.0.0-internal.6.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -16522,9 +16522,9 @@ packages:
     resolution: {integrity: sha512-tAaOInpRr3ws0z478Lwwfk/FfQGD5Zf0Aw97TbiusxgBn+C9+w+zDSNGInrM1nIPMSh9gn5oS+NQo1dZ/4Cmag==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/odsp-driver': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
     transitivePeerDependencies:
@@ -16555,22 +16555,22 @@ packages:
   /@fluid-tools/webpack-fluid-loader/2.0.0-internal.6.3.0_nwcuyijzf6l5chuh7xhtrzgjly:
     resolution: {integrity: sha512-3PmcGriXPxH5R7IY204XBHbHXH5a695/eQCsDXOXBYEPaR4NitJjWpwjVnN8+/qEGnQY9mewYpJbM3c77MxZww==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/local-driver': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
       '@fluidframework/server-local-server': 1.0.1
       '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       '@fluidframework/test-runtime-utils': 2.0.0-internal.6.3.0
       '@fluidframework/tool-utils': 2.0.0-internal.6.3.0
       '@fluidframework/view-interfaces': 2.0.0-internal.6.3.0
@@ -16597,16 +16597,16 @@ packages:
     resolution: {integrity: sha512-SGO2uoQD5eXWxezrRvofIngk5IeY4Vf8i8UxLD4nPybT7VzCtPJCUD5n4j98GVZd+zlSRv+IYm8f00cIGVDRnQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/map': 2.0.0-internal.6.3.0
       '@fluidframework/register-collection': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       uuid: 9.0.0
     transitivePeerDependencies:
       - debug
@@ -16617,17 +16617,17 @@ packages:
     resolution: {integrity: sha512-9VF2sxInW8ReHcCRbBYz1Bbz7Kt3XUWEAVqdlDfBdbSwDmkPYTNh3cA1thjqVtWPSMrtTU2kCtt7ndm7RTa3EQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/map': 2.0.0-internal.6.3.0
       '@fluidframework/request-handler': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
       '@fluidframework/synthesize': 2.0.0-internal.6.3.0
       '@fluidframework/view-interfaces': 2.0.0-internal.6.3.0
       uuid: 9.0.0
@@ -16640,17 +16640,17 @@ packages:
     resolution: {integrity: sha512-9VF2sxInW8ReHcCRbBYz1Bbz7Kt3XUWEAVqdlDfBdbSwDmkPYTNh3cA1thjqVtWPSMrtTU2kCtt7ndm7RTa3EQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/map': 2.0.0-internal.6.3.0_debug@4.3.4
       '@fluidframework/request-handler': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/synthesize': 2.0.0-internal.6.3.0
       '@fluidframework/view-interfaces': 2.0.0-internal.6.3.0
       uuid: 9.0.0
@@ -16662,19 +16662,19 @@ packages:
   /@fluidframework/azure-client/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-1VacD24mJIG5fMN1GNxLHsjs3VaQzqBWoGXlnrn54gm6+9sg9/8p2G2VTnbkrXph+MoZQ7fmdrzcafoT8Getxg==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/fluid-static': 2.0.0-internal.6.3.0
       '@fluidframework/map': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
       '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       axios: 0.26.1
     transitivePeerDependencies:
       - bufferutil
@@ -17008,13 +17008,13 @@ packages:
   /@fluidframework/cell/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-qi/Sb1zJOZzUBb85HlPtdtzcHwcLEe2h/Po53CYX+jWGHHeChBKoFxAKijJtMuP3pqKLXavCXZSKqnXZtvD2FQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17037,8 +17037,8 @@ packages:
   /@fluidframework/container-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-E8cn8bxy7fn3XLT3eny09WrJ1RtLPlGYLTBG1ReQZjqn/Anz9XmwH+E/z1mnaetpEvSY9RPHa60cMfZWKQyO+A==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       events: 3.3.0
     dev: true
@@ -17056,15 +17056,15 @@ packages:
     resolution: {integrity: sha512-mZB1vAfXv2Gxmx3DfkVTfo0NHznGnuBhWdDMzvme5xaDTXGTfqdz4K5dECnh6mdOGjAgvJnTqVKvOlICwgTqdg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -17078,11 +17078,11 @@ packages:
   /@fluidframework/container-runtime-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-EW+bKhEff4mU3akr6CgH/OxV37AqVuGPeeyXUHXs26t2MF2lRB+vqRAdJzrYVnOFQNQOfx9zgnyQqwu+AaK0Gg==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
     dev: true
 
   /@fluidframework/container-runtime-definitions/2.0.0-internal.6.3.1:
@@ -17099,42 +17099,17 @@ packages:
     resolution: {integrity: sha512-vY9Fu8dRz88W4qnaZud1MEOHYW01eAajaoePaITsUHVSReVTFgEvCkkVnOorAf5fy7gkUQNZ4qUFQ28WmIW36w==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      sorted-btree: 1.8.1
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.6.3.0_debug@4.3.4:
-    resolution: {integrity: sha512-vY9Fu8dRz88W4qnaZud1MEOHYW01eAajaoePaITsUHVSReVTFgEvCkkVnOorAf5fy7gkUQNZ4qUFQ28WmIW36w==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -17170,14 +17145,39 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/container-runtime/2.0.0-internal.6.3.1_debug@4.3.4:
+    resolution: {integrity: sha512-3JcnYRZGFSmF/RdlzYP+qRSTezEqJ0hPBaHVdTc2dPXfegHz/dnMtJyrMVnIZS71Mg84/Z/hZNJp31cGb6FFQg==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      sorted-btree: 1.8.1
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
   /@fluidframework/container-utils/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-LAhGvw6WttlTgwFLE/Jr2GIwGN07meimpeebePBJtSEqLFBRKKI5X/+iLRmj8hTsnK3CM5hSbtFyVddRm6ThZw==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17209,13 +17209,13 @@ packages:
   /@fluidframework/counter/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-jMHvNJ7DsCdTcWx93s7k+9d7PEKLP/+gXOFJ7Amr7NFlMIZDDhxN1/mdKRxAudgdUc63a5hoJypRpXHy5YiARA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17225,17 +17225,17 @@ packages:
     resolution: {integrity: sha512-YpRwAlHyxno9Qqb0b27ewk+QKr2eE9LDzOdats5Dj8A0KIttVUDzz2Kg9yyFDHbT55XCwvcLyV0gqx1jWfiIPA==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/request-handler': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17244,10 +17244,10 @@ packages:
   /@fluidframework/datastore-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-JlTjFdcLw3p0Y2rGl7KW8J+SkBvVDkCjIOsTopB+SFem0hvKBLxpnbaLqeEzO/PQwtfBEWRgTLFf4iAmjNfF1Q==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
     dev: true
 
   /@fluidframework/datastore-definitions/2.0.0-internal.6.3.1:
@@ -17263,41 +17263,18 @@ packages:
     resolution: {integrity: sha512-1cffDavTBWMxEjCOnLXq/HAY9+wfHaa4cflcglEh3QVdrYqtbJRb07DkTHs9EAztMk3WfV9eEj/LA7UEovCZbg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
-      lodash: 4.17.21
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/datastore/2.0.0-internal.6.3.0_debug@4.3.4:
-    resolution: {integrity: sha512-1cffDavTBWMxEjCOnLXq/HAY9+wfHaa4cflcglEh3QVdrYqtbJRb07DkTHs9EAztMk3WfV9eEj/LA7UEovCZbg==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/protocol-base': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       lodash: 4.17.21
       uuid: 9.0.0
     transitivePeerDependencies:
@@ -17328,13 +17305,36 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/datastore/2.0.0-internal.6.3.1_debug@4.3.4:
+    resolution: {integrity: sha512-uimN9pvt/os3n1DxMr2drqqT9z3VYJ7fB8Msn+q10aCuZdyqBtkI3oJ36i8MCE62AwBFr+/ZgMtT1oNWj3yCwA==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/protocol-base': 1.0.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
+      lodash: 4.17.21
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
   /@fluidframework/dds-interceptions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-cH6zXeDhlKjOweVzDMPm0H8bvHYerUjtm/ByLJQbtEHyD3om2TyXtm2YoPpL6nDAMfk8VjmCorrlKzenGmSq5w==}
     dependencies:
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/map': 2.0.0-internal.6.3.0
       '@fluidframework/merge-tree': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/sequence': 2.0.0-internal.6.3.0
     transitivePeerDependencies:
       - debug
@@ -17345,8 +17345,8 @@ packages:
     resolution: {integrity: sha512-huIEhVkWxPT5JrkwTaCXGGqrI3ccHQBYHQpULNILWC3iYxAULJL0fESQzpaspTNJ3qyPYLwD6Q1tIC1AbDZGLg==}
     dependencies:
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/replay-driver': 2.0.0-internal.6.3.0
       jsonschema: 1.4.1
@@ -17359,12 +17359,12 @@ packages:
     resolution: {integrity: sha512-xGpB8wIMliYuILtgLzuf1Eb/c/aLI7Lz8870bcemAcghQot1yon/LHUgP46VuOXfbD7EMnJGpS+jCZFuSctqJg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17374,12 +17374,12 @@ packages:
     resolution: {integrity: sha512-xGpB8wIMliYuILtgLzuf1Eb/c/aLI7Lz8870bcemAcghQot1yon/LHUgP46VuOXfbD7EMnJGpS+jCZFuSctqJg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17388,7 +17388,7 @@ packages:
   /@fluidframework/driver-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-APq9/hes4OvQVzjjJ+z2geDmL4JqTG5+6WTExoLQkTfyz2AK6HKWBa99ZuLjHvAb6RqxTqylvI1DqZaPD7l1Mg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
@@ -17403,34 +17403,14 @@ packages:
     resolution: {integrity: sha512-Fh2/12GHSzVUUCCZnplHBtzsPLCv90JwsCil2uIUkZ83XfsXLNTnQrFVxwKY9Km5qPe0G6CMvfLg+e9mfVh3EQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/gitresources': 1.0.1
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       axios: 0.26.1
-      lz4js: 0.2.0
-      url: 0.11.1
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.6.3.0_debug@4.3.4:
-    resolution: {integrity: sha512-Fh2/12GHSzVUUCCZnplHBtzsPLCv90JwsCil2uIUkZ83XfsXLNTnQrFVxwKY9Km5qPe0G6CMvfLg+e9mfVh3EQ==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/gitresources': 1.0.1
-      '@fluidframework/protocol-base': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
-      axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
       url: 0.11.1
       uuid: 9.0.0
@@ -17459,13 +17439,33 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/driver-utils/2.0.0-internal.6.3.1_debug@4.3.4:
+    resolution: {integrity: sha512-lXVs+pwQxw2PsoIlMurT3nx3DGh6FcpPCyosJUQ6DDI0yl2ki5NUeS9PB3Zq1lwLfB9ko7cg3hxeqd3/fpbLDA==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/gitresources': 1.0.1
+      '@fluidframework/protocol-base': 1.0.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
+      axios: 0.26.1_debug@4.3.4
+      lz4js: 0.2.0
+      url: 0.11.1
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
   /@fluidframework/driver-web-cache/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-rfwZ7v8CWsllUUHURNE6+YUJl2otcrdmwqPQ9psEFI56DD4+lusBG1O9xOod/OzVymfo3sFiz8CFmZyozgZ2pg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -17527,10 +17527,10 @@ packages:
     resolution: {integrity: sha512-jOpgksCrevhIdg0pAsW2+8LSDAcOd14UvDrJCpB1AEbnK92gFUO3slitOqONGy+BOy0VDjiLan1wVq/AY7HA8w==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/replay-driver': 2.0.0-internal.6.3.0
     transitivePeerDependencies:
@@ -17543,13 +17543,13 @@ packages:
     hasBin: true
     dependencies:
       '@fluidframework/aqueduct': 2.0.0-internal.6.3.0
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/odsp-driver': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -17565,15 +17565,15 @@ packages:
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
       '@fluidframework/aqueduct': 2.0.0-internal.6.3.0
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/request-handler': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17588,12 +17588,12 @@ packages:
   /@fluidframework/ink/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-w3cEzpm+FVvY/duFe5Jgk11CoAgZt28O8RF1mE/HkYAJTWt+thCp0YB/Rz5BGFNvTSmhiOfGywBGfZz8dT+2nA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
       uuid: 9.0.0
     transitivePeerDependencies:
       - debug
@@ -17604,11 +17604,11 @@ packages:
     resolution: {integrity: sha512-XQr5QNLaGvO/Y2HEFLglKCpV8n0vO4N3BVQiViE6cpMypZTZLb0wy5W/HkJjq1OsFyFgIGwuUSTybjeu3kaVjg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/driver-base': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
@@ -17616,7 +17616,7 @@ packages:
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/server-services-core': 1.0.1
       '@fluidframework/server-test-utils': 1.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.1
@@ -17633,11 +17633,11 @@ packages:
     resolution: {integrity: sha512-XQr5QNLaGvO/Y2HEFLglKCpV8n0vO4N3BVQiViE6cpMypZTZLb0wy5W/HkJjq1OsFyFgIGwuUSTybjeu3kaVjg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/driver-base': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0_debug@4.3.4
@@ -17645,7 +17645,7 @@ packages:
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/server-services-core': 1.0.1
       '@fluidframework/server-test-utils': 1.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.1
@@ -17661,9 +17661,9 @@ packages:
   /@fluidframework/location-redirection-utils/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-QcI9Dh8hYG5AIoUcfkkrwjB1X9G17+u1x+tYPTvg8KjE7nHNu/BBw05AdF2OEQJ8MlN5kgR3AVtOwJhQBld/Xw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17672,15 +17672,15 @@ packages:
     resolution: {integrity: sha512-vguucbWQdaT/EaBHwf7cjAWq/rbdJcg+25bU/ZI71ra/fobu2eI7npqjQoKcBom37aYR0gUqVrodM/Hw4eEW0Q==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
@@ -17691,15 +17691,15 @@ packages:
     resolution: {integrity: sha512-vguucbWQdaT/EaBHwf7cjAWq/rbdJcg+25bU/ZI71ra/fobu2eI7npqjQoKcBom37aYR0gUqVrodM/Hw4eEW0Q==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
@@ -17710,16 +17710,16 @@ packages:
     resolution: {integrity: sha512-S9vrH2j1hRA2yl9WZ3gSt1IvdNxzN89A+mxsT7jmswpOFY1lCnQXkANSIDnlRGhj7Xubi/6LcNpjK2jz2Fcu3Q==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/merge-tree': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -17732,15 +17732,15 @@ packages:
     resolution: {integrity: sha512-IfmzRBl1190tvTEhlGTUlDOONtK2ylDHH+CT3aBJPpjzZo2lKsnLOU3dpCtFsIN2DyzICmYEwXRc22jdKozmCg==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17749,7 +17749,7 @@ packages:
   /@fluidframework/mocha-test-setup/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-49Eo0Op4gyn8KPjlUEyFTqPfwMyejDAYpea141Ic4voaLBOOPL/xnVFNvsb62PXj6rMPOsbWf8PBpuFeIE+paw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/test-driver-definitions': 2.0.0-internal.6.3.0
       mocha: 10.2.0
     dev: true
@@ -17758,12 +17758,12 @@ packages:
     resolution: {integrity: sha512-54qTGyDopAA/KrvyAHOKSyva2nOq2NFFD4wc7oqB65xP6+Be5v8pJhE3gkE62tGSWMK3QsoSdQ61d6QJCuGZLQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       node-fetch: 2.6.12
     transitivePeerDependencies:
       - debug
@@ -17775,12 +17775,12 @@ packages:
     resolution: {integrity: sha512-54qTGyDopAA/KrvyAHOKSyva2nOq2NFFD4wc7oqB65xP6+Be5v8pJhE3gkE62tGSWMK3QsoSdQ61d6QJCuGZLQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       node-fetch: 2.6.12
     transitivePeerDependencies:
       - debug
@@ -17791,24 +17791,24 @@ packages:
   /@fluidframework/odsp-driver-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-pYN7ouh1eGPLNVtmecx7VbIOy5RSEHoaDLgep7gA248w33siViAnq6da1+bmGEGG+Ceh19PTesF3L5QKmhmUIA==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
     dev: true
 
   /@fluidframework/odsp-driver/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-eRNbP9fU8reit0tcI2Y6W2keqmWfpK62Jqdn+74iuuUeYYt7tiY/LvlLYcHDBUV5Bf0iuGCNM8TbB9FP0aosuQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/driver-base': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/gitresources': 1.0.1
       '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       node-fetch: 2.6.12
       socket.io-client: 4.6.1
       uuid: 9.0.0
@@ -17823,8 +17823,8 @@ packages:
   /@fluidframework/odsp-urlresolver/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-oT3EuWW08MpuzLR0P01Wpr7ISJvQ+/o3Yiz0kyXRwCV1tq5CVI2/4FmM9+AbY7ZGjrUgj77U+oMowUFheUvl+g==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/odsp-driver': 2.0.0-internal.6.3.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.6.3.0
     transitivePeerDependencies:
@@ -17839,13 +17839,13 @@ packages:
     resolution: {integrity: sha512-PioqRa+SeGX/detDMM9ML2Jz13+ZO+5lo+uWW6jDE2Zo98y1hvI5zmusrRj/S68NClBFZ260qYg3ZoK2ShDyJQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
       uuid: 9.0.0
     transitivePeerDependencies:
       - debug
@@ -17877,13 +17877,13 @@ packages:
     resolution: {integrity: sha512-9tsDY7jbyyNkiM1PPnnb3q3CgTKJNoqx7VR4D7Q94Shb5+Ecp6Q6ILPAkhRvTYMM0dsZrddNRWOCqt00V9/Q8Q==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17893,12 +17893,12 @@ packages:
     resolution: {integrity: sha512-+v2JF2gBZbDYleUcn+Siyr8/m2VSA2IW31YHlfUmJTv09D/e123lZDlFf82TJ4+pS13AMr+ZJuhVOSb2up+g9w==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17907,11 +17907,11 @@ packages:
   /@fluidframework/request-handler/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-hNqHCQLzwBvJu79Syf0AgXpnGB/vMuNCgpSnzlps/T62QdVHqmtg5GQoWQHJcRByNWWu9UGeWvmOfVi/KTmSeQ==}
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17920,11 +17920,11 @@ packages:
   /@fluidframework/request-handler/2.0.0-internal.6.3.0_debug@4.3.4:
     resolution: {integrity: sha512-hNqHCQLzwBvJu79Syf0AgXpnGB/vMuNCgpSnzlps/T62QdVHqmtg5GQoWQHJcRByNWWu9UGeWvmOfVi/KTmSeQ==}
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17934,16 +17934,16 @@ packages:
     resolution: {integrity: sha512-wLkGzLSgQ0YrPcEZkUZgo7KNkkgAy0sdUpImxz4AkhuUOnVm2Vr1vDK8oASQpsEm8ZCKm79eo4rJkE0Y4PU53Q==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/driver-base': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/gitresources': 1.0.1
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
@@ -17961,16 +17961,16 @@ packages:
     resolution: {integrity: sha512-wLkGzLSgQ0YrPcEZkUZgo7KNkkgAy0sdUpImxz4AkhuUOnVm2Vr1vDK8oASQpsEm8ZCKm79eo4rJkE0Y4PU53Q==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/driver-base': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/gitresources': 1.0.1
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
@@ -17987,9 +17987,9 @@ packages:
   /@fluidframework/routerlicious-urlresolver/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-yc9aZ0BWvDYo2STOvNFEaIbmmR7MJHrqYGpT/fkQ6h5PF2iJ/rOzwhfQVf6b08+8SY7egw5YgieTMmlYbk5ZJQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       nconf: 0.12.0
       url: 0.11.1
@@ -17998,9 +17998,9 @@ packages:
   /@fluidframework/runtime-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-9GNZQh6Ishd46x2NsI8DIRGu68nxUBIYoa6J5ZvVYbVzAyTiOuqs+kwSzHIl4MRpHgl07rOYB/6ONCL2gbnOjA==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
     dev: true
 
@@ -18017,33 +18017,15 @@ packages:
     resolution: {integrity: sha512-OrRf7sUA5rzrGgGxRuGu9saps6rMeLJqUtDomMirqbWPvlKdcHB5CO2QKNdlK0zRSJ38i2X6DY6/5Vm1eicuUQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/runtime-utils/2.0.0-internal.6.3.0_debug@4.3.4:
-    resolution: {integrity: sha512-OrRf7sUA5rzrGgGxRuGu9saps6rMeLJqUtDomMirqbWPvlKdcHB5CO2QKNdlK0zRSJ38i2X6DY6/5Vm1eicuUQ==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18067,19 +18049,37 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/runtime-utils/2.0.0-internal.6.3.1_debug@4.3.4:
+    resolution: {integrity: sha512-Wjpwo+VaZ/9hbI2bL5EMbVbdL+AXcVNUYW2dmHvDqdDZeloqx7deiaGOtOae6MJD9tuLTm3eP6L6WCLAqwC5Vw==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
   /@fluidframework/sequence/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-M4WBuRGBIYuIxUCBVEupafAyLzKjwW1Uo4pMGjLcBX7qsO8XEJYATfKUGyc8WhG1s7DrvQGLixvsUNngqn5LdQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/merge-tree': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       uuid: 9.0.0
     transitivePeerDependencies:
       - debug
@@ -18465,36 +18465,16 @@ packages:
     resolution: {integrity: sha512-1vijG6eYL6pftYwUtjxw7kJlPHzoFsu3ypadI+MGXuyxwgJNtZfe1FkdoCM9beKiPhV5cd35njeuYLCVWSEzkQ==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/shared-object-base/2.0.0-internal.6.3.0_debug@4.3.4:
-    resolution: {integrity: sha512-1vijG6eYL6pftYwUtjxw7kJlPHzoFsu3ypadI+MGXuyxwgJNtZfe1FkdoCM9beKiPhV5cd35njeuYLCVWSEzkQ==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       uuid: 9.0.0
     transitivePeerDependencies:
       - debug
@@ -18521,15 +18501,35 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/shared-object-base/2.0.0-internal.6.3.1_debug@4.3.4:
+    resolution: {integrity: sha512-P7I7IfKOpMl44MN/YXqWEg/BNxd08fKrV4s8VXSLDdWkQ76gsUAVQ0/sdG9wYtEQC5aZDZa8lka8b9L3XKochg==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/core-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
   /@fluidframework/shared-summary-block/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-z24BhBb2+F5pF1/th4iYl4D/XHjCVkB74PwXyirPVmnopGR8KRd0Wm7bcmr71a+yE8xIstYi63XT3qOaeCE3Pg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18544,15 +18544,15 @@ packages:
   /@fluidframework/task-manager/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-wEu4en8AZbQWMnR+HJuZ1PLHvOVyxetihuTSXDTn/QwEdSfWik8HcfFhhZhCStj1COjJt8mBzeVdAAjMAXEIpw==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.6.3.1
       events: 3.3.0
     transitivePeerDependencies:
       - debug
@@ -18563,7 +18563,7 @@ packages:
     resolution: {integrity: sha512-LiqfGVcKTKyQK18YtGZ/lp9jqmX+2DhIW1RjbhqU8vd+OYlRzkX1tFqQb6kFy58NPyDWsogSUNSOKZXclWc2Aw==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       debug: 4.3.4
@@ -18590,8 +18590,8 @@ packages:
   /@fluidframework/test-driver-definitions/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-E8jTCpsLfl5Ehmd3f6puvvawlvwvSbgmyTRgmLYxVwM0J1ph7jT8/WlFzUG8W52ByR5ExKwRPbU3b/v4luLVSw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       uuid: 9.0.0
     dev: true
@@ -18600,17 +18600,17 @@ packages:
     resolution: {integrity: sha512-PdiwvWZPnejmE7MhvoMQt1fLmJR1/gbmGcs6lLHq29TiZarf5AblpjhyqnICSdgOBqM4xCrn7r7Tz6PZQP86nw==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -18627,17 +18627,17 @@ packages:
     resolution: {integrity: sha512-PdiwvWZPnejmE7MhvoMQt1fLmJR1/gbmGcs6lLHq29TiZarf5AblpjhyqnICSdgOBqM4xCrn7r7Tz6PZQP86nw==}
     dependencies:
       '@fluid-internal/client-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -18659,24 +18659,24 @@ packages:
     resolution: {integrity: sha512-3WVWwhNSTqxHnejKbpr/tEhN9uFVJ8p558O6gOBO6me5gQKwSuPiwEXQIl4uoqByNb5RqDJQ7Dl+TAkdRePG5A==}
     dependencies:
       '@fluidframework/aqueduct': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/container-runtime': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/datastore': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/datastore': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/local-driver': 2.0.0-internal.6.3.0_debug@4.3.4
       '@fluidframework/map': 2.0.0-internal.6.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/request-handler': 2.0.0-internal.6.3.0_debug@4.3.4
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.6.3.1
       '@fluidframework/test-driver-definitions': 2.0.0-internal.6.3.0
       '@fluidframework/test-runtime-utils': 2.0.0-internal.6.3.0_debug@4.3.4
       best-random: 1.0.3
@@ -18692,17 +18692,17 @@ packages:
   /@fluidframework/tinylicious-client/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-ZxqkCcx4P38T/MCgcurYrf5hYKqOF1GRYQnxHEc3yGMhH5O2//zdYzx2VmrdwGXROktDhZ5ChaWav6iwfuGcRA==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.6.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.6.3.1
       '@fluidframework/container-loader': 2.0.0-internal.6.3.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/fluid-static': 2.0.0-internal.6.3.0
       '@fluidframework/map': 2.0.0-internal.6.3.0
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.6.3.1
       '@fluidframework/tinylicious-driver': 2.0.0-internal.6.3.0
       uuid: 9.0.0
     transitivePeerDependencies:
@@ -18716,9 +18716,9 @@ packages:
   /@fluidframework/tinylicious-driver/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-wZyTTaPn4td3zFHz8MWRDY6aRjKP+Pa8Ps0bj5By2v+QnsyOpSQoUidr6yxHM+uqSC4+dURdqIOfxGY8qw77IA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.0
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.6.3.1
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/routerlicious-driver': 2.0.0-internal.6.3.0
       '@fluidframework/server-services-client': 1.0.1
@@ -18736,7 +18736,7 @@ packages:
     resolution: {integrity: sha512-ncPsI9jcFHp3yFXaWRiEoVDHqOSB6hGTQHSI+Ih/Q/JMTqs/Z+hjBi0ga63M5XdXmaEKJHWu8gjNYvMdjI/eDQ==}
     dependencies:
       '@fluidframework/core-utils': 2.0.0-internal.6.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.6.3.0_debug@4.3.4
+      '@fluidframework/driver-utils': 2.0.0-internal.6.3.1_debug@4.3.4
       '@fluidframework/odsp-doclib-utils': 2.0.0-internal.6.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.2.0
       async-mutex: 0.3.2
@@ -18764,7 +18764,7 @@ packages:
   /@fluidframework/view-adapters/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-E92ctXrf/S2jnpPqbj6cScP0l3aidI/QQyET/VyOTRZLsHDt59UV1nK/RKTpE6oH1b9kFkBw17j2fAHDhl7L8w==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
       '@fluidframework/view-interfaces': 2.0.0-internal.6.3.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -18773,7 +18773,7 @@ packages:
   /@fluidframework/view-interfaces/2.0.0-internal.6.3.0:
     resolution: {integrity: sha512-Nma5GC02ms1boy0DAugz08wx1AI2aovl7Kg8K9hOa7KsER2yHUtkBIeCTJwvOHHB5LWEvNuHzuX37CkARRefEA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.6.3.1
     dev: true
 
   /@fwouts/vite-tsconfig-paths/4.2.1_vxtpzrd3ijvkhh2fvnu2mlkwnm:

--- a/server/tinylicious/src/index.ts
+++ b/server/tinylicious/src/index.ts
@@ -18,9 +18,15 @@ import { TinyliciousRunnerFactory } from "./runnerFactory";
 
 // Tinylicious includes end points for the historian for the client. But even though we bundle all the
 // services in a monolithic process, it still uses sockets to communicate with the historian service.
-// For these calls, keep the TCP connection open so that they can be reused
+// For these calls, keep the TCP connection open so that they can be reused. Agent from agentkeepalive sets keep-alive
+// to true by default and uses 4s and 8s timeouts for inactive and active sockets respectively.
+// This should be coordinated with the corresponding timeout on the server's end (historian, in this case).
+// If the timeout on the client is higher than on the server, an inactive connection might be closed by the server but
+// kept around on the client, and when something attempts to reuse it, the client can see an error like ECONNRESET
+// or "socket hang up", indicating that "the other side of the connection closed it abruptly", which in this case isn't
+// really abruptly, it's just that the client doesn't immediately react to the server closing the socket.
 // TODO: Set this globally since the Historian use the global Axios default instance.  Make this encapsulated.
-Axios.defaults.httpAgent = new Agent({ keepAlive: true });
+Axios.defaults.httpAgent = new Agent();
 
 const configPath = path.join(__dirname, "../config.json");
 


### PR DESCRIPTION
## Description

Sets an explicit, lower-than-the-server, timeout for inactive sockets on the client side when using our test drivers. This fixes an issue we sometimes see in tinylicious stress tests, where the server might close a connection/socket due to inactivity, the client does not immediately react to that, and the next time something tries to reuse the socket it immediately encounters an error with message `read ECONNRESET` or `socket hang up`. Every time I saw this error it was the summarizer running into it; seems slightly suspicious, but for now I'll go with coincidence (maybe something about the way the summarizer works makes it more prone to running into this problem).

I tested by locally running stress tests against tinylicious always with the same seed (`0x18a9454f5ff`), the same custom profile shown below, and changing different bits of configuration on the client and the server. With any other change I made except this one, I could still consistently see `ECONNRESET` or `socket hang up` errors reported by the test runners after some time. With this change in place, I did not see them in 5+ successive stress test runs.

This is the profile I used for repeated local runs of stress tests (mostly wanted to remove all other potential sources of errors). After validating the change with this profile, I also validated with the default `ci` one and the errors didn't show up there either (where they also consistently reproduce without this change).

```json
"custom": {
	"opRatePerMin": 10,
	"signalsPerMin": 10,
	"progressIntervalMs": 15000,
	"numClients": 120,
	"totalSendCount": 10000,
	"totalSignalsSendCount": 10000,
	"blobSize": 256,
	"readWriteCycleMs": 30000
}
```

This also has an effect on the test drivers for r11s and odsp, but we haven't seen the same kind of errors when running tests against those servers. I'm not super confident that this would do anything to improve the issues we _do_ see for their stress/e2e tests (timeouts, NoJoinOps), but one can hope :) .

This PR also simplifies the configuration done in tinylicious (server) to achieve the same effect for its socket connections (as a client) to historian (since it was just using a default from `agentkeepalive`'s `Agent` class).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).