### PR TITLE
feat: Allow configuring the server lambdas from the t9s config file

### DIFF
--- a/server/tinylicious/config.json
+++ b/server/tinylicious/config.json
@@ -25,6 +25,8 @@
 		"restJsonSize": "50mb",
 		"maxNumberOfClientsPerDocument": 1000000
 	},
+	"deli": { },
+	"scribe": { },
 	"mongo": {
 		"endpoint": "mongodb://mongodb:27017",
 		"collectionNames": {

--- a/server/tinylicious/config.json
+++ b/server/tinylicious/config.json
@@ -25,8 +25,8 @@
 		"restJsonSize": "50mb",
 		"maxNumberOfClientsPerDocument": 1000000
 	},
-	"deli": { },
-	"scribe": { },
+	"deli": {},
+	"scribe": {},
 	"mongo": {
 		"endpoint": "mongodb://mongodb:27017",
 		"collectionNames": {

--- a/server/tinylicious/src/resourcesFactory.ts
+++ b/server/tinylicious/src/resourcesFactory.ts
@@ -74,6 +74,14 @@ export class TinyliciousResourcesFactory implements IResourcesFactory<Tinyliciou
 		const pubsub = new PubSubPublisher(io);
 		const webServerFactory = new WebServerFactory(io);
 
+		// This produces a static object with the merged settings from all the stores in the nconf Provider.
+		// It includes env variables that we probably don't need to pass to the LocalOrderManager, but small price to pay
+		// so we can apply configuration to the lambdas from the tinylicious config file.
+		// Note: using a Proxy doesn't work because this gets eventually lodash-merge()d with other objects, and that looks
+		// for the actual properties of an object, which won't trigger get() calls on the Proxy that we can forward to the
+		// nconf Provider.
+		const frozenConfig = config.get();
+
 		const orderManager = new LocalOrdererManager(
 			storage,
 			databaseManager,
@@ -82,7 +90,7 @@ export class TinyliciousResourcesFactory implements IResourcesFactory<Tinyliciou
 				return new Historian(url, false, false);
 			},
 			winston,
-			undefined /* serviceConfiguration */,
+			frozenConfig,
 			pubsub,
 		);
 


### PR DESCRIPTION
## Description

Makes it possible to configure the server lambdas from the tinylicious config file by freezing the settings present in the nconf Provider and passing that along. It also passes along configuration settings and env variables that the lambdas don't need, but won't use (since they do explicit `config.get("key")` calls for the values they want.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).