### PR TITLE
Revert "docs: remove rogue comment (#17322)"

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -236,7 +236,9 @@ export const OdspErrorTypes: {
     readonly incorrectServerResponse: "incorrectServerResponse";
     readonly fileOverwrittenInStorage: "fileOverwrittenInStorage";
     readonly deltaStreamConnectionForbidden: "deltaStreamConnectionForbidden";
-    readonly locationRedirection: "locationRedirection";
+    readonly locationRedirection: "locationRedirection"; /**
+    * SPO admin toggle: fluid service is not enabled.
+    */
     readonly fluidInvalidSchema: "fluidInvalidSchema";
     readonly fileIsLocked: "fileIsLocked";
     readonly genericError: "genericError";


### PR DESCRIPTION
This reverts commit 4a9d73f87c5185d3e8fca108c5e4e07ba5c929f7.

Pipeline [Build - Client bundle size artifacts](https://dev.azure.com/fluidframework/public/_build?definitionId=48) is happier with  the rogue comment.