### PR TITLE
[GC-stress] Add ability for test runners to abort and report failure

### DIFF
--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -178,6 +178,7 @@ async function orchestratorProcess(
 		driverType: testDriver.type,
 		driverEndpointName: testDriver.endpointName,
 		profile: args.profileName,
+		workLoadPath,
 		runId: undefined,
 	});
 

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -36,7 +36,7 @@ export type TestRunResult =
 	| {
 			/** Abort and fail the runner */
 			abort: true;
-			/** The errorCode that the runner exits with */
+			/** The errorCode that the runner exits with. Should be non-zero. */
 			errorCode: number;
 	  }
 	| {

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -29,6 +29,23 @@ export interface IDetachedTestRunner {
 	writeBlob(blobNumber: number): Promise<void>;
 }
 
+/**
+ * The result of running the test on a specific runner.
+ */
+export type TestRunResult =
+	| {
+			/** Abort and fail the runner */
+			abort: true;
+			/** The errorCode that the runner exits with */
+			errorCode: number;
+	  }
+	| {
+			/** The runner should not be aborted */
+			abort: false;
+			/** Whether the runner is done. If this is false, the runner reruns the test */
+			done: boolean;
+	  };
+
 export const ITestRunner: keyof IProvideTestRunner = "ITestRunner";
 export interface IProvideTestRunner {
 	readonly ITestRunner: ITestRunner;
@@ -38,7 +55,7 @@ export interface IProvideTestRunner {
  * called by the runner process and is the entry point into the test work load.
  */
 export interface ITestRunner extends IProvideTestRunner {
-	run(config: IRunConfig, reset: boolean): Promise<boolean>;
+	run(config: IRunConfig, reset: boolean): Promise<TestRunResult>;
 	getRuntime(): Promise<IFluidDataStoreRuntime>;
 	getDetachedRunner?(
 		config: Omit<IRunConfig, "runId" | "profileName">,

--- a/packages/test/test-service-load/src/workloads/default/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/workloads/default/loadTestDataStore.ts
@@ -13,7 +13,7 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { delay, assert } from "@fluidframework/core-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IDetachedTestRunner, IRunConfig, ITestRunner } from "../../testConfigFile";
+import { IDetachedTestRunner, IRunConfig, ITestRunner, TestRunResult } from "../../testConfigFile";
 import { LeaderElection } from "../../leaderElection";
 
 const taskManagerKey = "taskManager";
@@ -499,7 +499,7 @@ export class LoadTestDataStore extends DataObject implements ITestRunner {
 		);
 	}
 
-	public async run(config: IRunConfig, reset: boolean) {
+	public async run(config: IRunConfig, reset: boolean): Promise<TestRunResult> {
 		const dataModel = await LoadTestDataStoreModel.createRunnerInstance(
 			config,
 			reset,
@@ -536,7 +536,7 @@ export class LoadTestDataStore extends DataObject implements ITestRunner {
 				clearTimeout(timeout);
 			}
 		}
-		return runResult[0];
+		return { abort: false, done: runResult[0] };
 	}
 
 	async getRuntime() {

--- a/packages/test/test-service-load/src/workloads/summary/summaryDataStores.ts
+++ b/packages/test/test-service-load/src/workloads/summary/summaryDataStores.ts
@@ -19,7 +19,7 @@ import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { SharedCounter } from "@fluidframework/counter";
 import { SharedMap } from "@fluidframework/map";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
-import { IRunConfig, ITestRunner } from "../../testConfigFile";
+import { IRunConfig, ITestRunner, TestRunResult } from "../../testConfigFile";
 
 /**
  * The maximum number of leaf data objects that can be created.
@@ -418,9 +418,9 @@ export class RootDataObject extends BaseDataObject implements ITestRunner {
 		return this.runtime;
 	}
 
-	public async run(config: IRunConfig): Promise<boolean> {
+	public async run(config: IRunConfig): Promise<TestRunResult> {
 		if (this.running) {
-			return true;
+			return { abort: false, done: true };
 		}
 
 		this._nodeId = `client${config.runId + 1}`;
@@ -476,10 +476,10 @@ export class RootDataObject extends BaseDataObject implements ITestRunner {
 		}
 		this.stop();
 		const notDone = this.runtime.disposed || this.activityFailed;
-		return !notDone;
+		return { abort: false, done: !notDone };
 	}
 
-	public stop() {
+	private stop() {
 		this.running = false;
 		this.localChildDataObjects.forEach((dataObject: IActivityObject, id: string) => {
 			dataObject.stop();


### PR DESCRIPTION
Added support in the stress test infra for test runners to abort and report the failure. The failures would show up in the `Test` tab in ADO pipelines.
Here is how it works:
- `ITestRunner:run` function returns a `TestRunResult` object with the following type. If the test wants to report failure, it should set `abort: true` and provied an `errorCode` that is a non-zero number. This will result in this test runner reported as failed.
``` typescript
/**
 * The result of running the test on a specific runner.
 */
export type TestRunResult =
  | {
        /** Abort and fail the runner */
	abort: true;
	/** The errorCode that the runner exits with. Should be non-zero. */
	errorCode: number;
    }
  | {
	/** The runner should not be aborted */
	abort: false;
	/** Whether the runner is done. If this is false, the runner reruns the test */
	done: boolean;
    };
```
- An example usage of this is `RootDataObject` in `gcDataStores.ts` which returns a failure when certain events are logged.