### PR TITLE
docs: Improve documentation related to driver endpoint names

### DIFF
--- a/packages/test/test-drivers/README.md
+++ b/packages/test/test-drivers/README.md
@@ -22,3 +22,24 @@ before(function () {
 ```
 
 The `function` syntax must be used for `this.skip()` to be available, arrow function will not work.
+
+## Driver endpoint names
+
+Some drivers take a second bit of configuration besides the driver type, which is a specific "target environment",
+usually referred to as `<driverType>EndpointName`, e.g. `odspEndpointName` and `r11sEndpointName`.
+These are important to get right for the specific environment you're targetting, otherwise the test driver might
+configure things in a way that the target environment doesn't expect, and you could see weird and unexpected
+errors when running tests.
+
+Usually you'll pass these as extra flags when running tests. E.g., to run our e2e tests against a routerlicious instance
+running locally in docker per our dev setup for it, you'll want to run:
+
+```bash
+<base command to kick-off tests> --driver=r11s --r11sEndpointName=docker
+```
+
+E.g.
+
+```bash
+npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker
+```

--- a/packages/test/test-end-to-end-tests/README.md
+++ b/packages/test/test-end-to-end-tests/README.md
@@ -17,6 +17,28 @@ The tests under the `real-service-tests` dir target a live production service li
 These are run via `npm run test:realsvc:mocha`, and are included in the CI such that a test failure doesn't
 fail the pipeline - since a service outage or network hiccup could cause a failure when no code defect is present.
 
+### Enpdoint names
+
+When running tests against ODSP or R11s, be mindful of a second parameter/flag usually referred to as the "endpoint name".
+This should match the target environment you want to run against or the test driver might configure things in a way
+that the target environment doesn't expect, and you could see weird and unexpected errors when running tests.
+
+For ODSP, the possible endpoint names are `odsp` (for a tenant in the production ODSP environment) and `odsp-df`
+(for the dogfood environment).
+The default is `odsp`.
+For Routerlicious, they are `r11s` (for the internal cluster in Azure) and `docker` (when running routerlicious locally
+in docker with our development setup).
+The default is `r11s`.
+
+For example:
+
+```bash
+npm run test:realsvc:run -- --driver=odsp
+npm run test:realsvc:run -- --driver=odsp --odspEndpointName=odsp-df
+npm run test:realsvc:run -- --driver=r11s
+npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker
+```
+
 ## Trademark
 
 This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -42,6 +42,7 @@
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
 		"test:realsvc:odsp:report": "npm run test:realsvc:odsp --",
 		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s --use-openssl-ca",
+		"test:realsvc:r11s:docker": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker --timeout=20s",
 		"test:realsvc:routerlicious": "npm run test:realsvc:r11s",
 		"test:realsvc:routerlicious:report": "npm run test:realsvc:r11s --",
 		"test:realsvc:run": "mocha dist/test --config src/test/.mocharc.cjs --exclude dist/test/benchmark/**/* --verbose",


### PR DESCRIPTION
## Description

After a long session of spelunking and debugging code, I learned that in order for our e2e tests to run successfully against a local (docker) instance of routerlicious, we need to pass `--r11sEndpointName=docker` when running them, which doesn't seem to be documented anywhere. This tries to improve the situation around that a bit by adding some documentation in the e2e tests and test-drivers packages, and adding an npm script where the flag is passed explicitly, so someone can at least run into it by ctrl-F'ing in the repo or when looking at the other npm scripts to run e2e tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
