### PR TITLE
Revert "Temporarily enable debug logs for all runs of stress tests (#17246)"

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -30,11 +30,6 @@ variables:
 - name: testPackage
   value: "@fluid-internal/test-service-load"
   readonly: true
-# Temporarily enabling debug logs for all pipeline runs to be able to better troubleshoot when the odsp/odsp-df stages
-# time out and produce no output even though we know the tests did run.
-# TODO : remove this after troubleshooting.
-- name: system.debug
-  value: true
 
 lockBehavior: sequential
 stages:


### PR DESCRIPTION
## Description

This reverts commit 7a2063e1dbd1ab6b41cecba2b978614a231c1bd9.

We now have a few stress test runs that produced debug logs and where some stages timed out with no output, even though we know the tests ran successfully (e.g. [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=189980&view=results) and [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=189988&view=results)). So undoing the change that enabled debug logs for all runs of the pipeline.

I did not find anything in the debug logs that explained why the pipeline produced no output and timed out those stages.
## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
