### PR TITLE
tree2: Remove cyclic imports of schemaBuilder.ts

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -979,8 +979,6 @@ export { InternalEditableTreeTypes }
 
 declare namespace InternalTypedSchemaTypes {
     export {
-        RecursiveTreeSchemaSpecification,
-        RecursiveTreeSchema,
         ObjectToMap,
         WithDefault,
         Unbrand,
@@ -995,6 +993,8 @@ declare namespace InternalTypedSchemaTypes {
         MapSchemaSpecification,
         LeafSchemaSpecification,
         MapFieldSchema,
+        RecursiveTreeSchemaSpecification,
+        RecursiveTreeSchema,
         FlexList,
         FlexListToNonLazyArray,
         ConstantFlexListToNonLazyArray,

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -3,13 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
-	SchemaBuilder,
-	TypedSchemaCollection,
-	SchemaLibrary,
-	SchemaLibraryData,
-	SchemaLintConfiguration,
-} from "./schemaBuilder";
+export { SchemaBuilder, SchemaLibrary } from "./schemaBuilder";
 
 export {
 	TreeSchema,
@@ -26,6 +20,7 @@ export {
 	schemaIsLeaf,
 	schemaIsMap,
 	schemaIsStruct,
+	TypedSchemaCollection,
 } from "./typedTreeSchema";
 
 export { ViewSchema } from "./view";
@@ -34,6 +29,8 @@ export {
 	bannedFieldNames,
 	fieldApiPrefixes,
 	validateStructFieldName,
+	SchemaLibraryData,
+	SchemaLintConfiguration,
 } from "./buildViewSchemaCollection";
 
 // Below here are things that are used by the above, but not part of the desired API surface.

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/internal.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/internal.ts
@@ -4,7 +4,6 @@
  */
 
 // Used by public types, but not part of the desired API surface
-export { RecursiveTreeSchemaSpecification, RecursiveTreeSchema } from "./schemaBuilder";
 
 export { ObjectToMap, WithDefault, Unbrand, UnbrandList, ArrayToUnion } from "./typeUtils";
 
@@ -18,6 +17,8 @@ export {
 	MapSchemaSpecification,
 	LeafSchemaSpecification,
 	MapFieldSchema,
+	RecursiveTreeSchemaSpecification,
+	RecursiveTreeSchema,
 } from "./typedTreeSchema";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaBuilder.ts
@@ -4,44 +4,25 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { Adapters, TreeAdapter, TreeSchemaIdentifier, ValueSchema } from "../../core";
-import { requireAssignableTo, RestrictiveReadonlyRecord } from "../../util";
+import { Adapters, TreeSchemaIdentifier, ValueSchema } from "../../core";
+import { RestrictiveReadonlyRecord } from "../../util";
 import { FieldKindTypes, FieldKinds } from "../default-field-kinds";
-import { FullSchemaPolicy } from "../modular-schema";
-import { Sourced } from "./view";
-import { buildViewSchemaCollection } from "./buildViewSchemaCollection";
-import { AllowedTypes, TreeSchema, TreeSchemaSpecification, FieldSchema } from "./typedTreeSchema";
+import {
+	SchemaLibraryData,
+	SchemaLintConfiguration,
+	buildViewSchemaCollection,
+	schemaLintDefault,
+} from "./buildViewSchemaCollection";
+import {
+	AllowedTypes,
+	TreeSchema,
+	FieldSchema,
+	TypedSchemaCollection,
+	RecursiveTreeSchema,
+} from "./typedTreeSchema";
 import { FlexList } from "./flexList";
 
 // TODO: tests and examples for this file
-
-/**
- * Placeholder for to `TreeSchema` to use in constraints where `TreeSchema` is desired but using it causes
- * recursive types to fail to compile due to TypeScript limitations.
- *
- * Using `TreeSchema` instead in some key "extends" clauses cause recursive types to error with:
- * "'theSchema' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."
- *
- * TODO: how much more specific of a type can be provided without triggering the above error?
- * @alpha
- */
-export type RecursiveTreeSchema = unknown;
-
-/**
- * Placeholder for to `TreeSchemaSpecification` to use in constraints where `TreeSchemaSpecification` is desired but using it causes
- * recursive types to fail to compile due to TypeScript limitations.
- *
- * See `RecursiveTreeSchema`.
- *
- * TODO: how much more specific of a type can be provided without triggering the above error?
- * @alpha
- */
-export type RecursiveTreeSchemaSpecification = unknown;
-
-{
-	type _check1 = requireAssignableTo<TreeSchemaSpecification, RecursiveTreeSchemaSpecification>;
-	type _check2 = requireAssignableTo<TreeSchema, RecursiveTreeSchema>;
-}
 
 /**
  * Builds schema libraries, and the schema within them.
@@ -390,49 +371,6 @@ export class SchemaBuilder {
 }
 
 /**
- * Allows opting into and out of errors for some unusual schema patterns which are usually bugs.
- * @alpha
- */
-export interface SchemaLintConfiguration {
-	readonly rejectForbidden: boolean;
-	readonly rejectEmpty: boolean;
-}
-
-const schemaLintDefault: SchemaLintConfiguration = {
-	rejectForbidden: true,
-	rejectEmpty: true,
-};
-
-/**
- * Schema data collected by a single SchemaBuilder (does not include referenced libraries).
- * @alpha
- */
-export interface SchemaLibraryData {
-	readonly name: string;
-	readonly rootFieldSchema?: FieldSchema;
-	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
-	readonly adapters: Adapters;
-}
-
-/**
- * Schema data that can be be used to view a document.
- * Strongly typed over its rootFieldSchema.
- *
- * @remarks
- * This type is mainly used as a type constraint to mean that the code working with it requires strongly typed schema.
- * The actual type used will include detailed schema information for all the types in the collection.
- * This pattern is used to implement SchemaAware APIs.
- *
- * @alpha
- */
-export interface TypedSchemaCollection<T extends FieldSchema = FieldSchema> {
-	readonly rootFieldSchema: T;
-	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
-	readonly policy: FullSchemaPolicy;
-	readonly adapters: Adapters;
-}
-
-/**
  * Schema information collected by a SchemaBuilder, including referenced libraries.
  * Can be aggregated into other libraries by adding to their builders.
  * @alpha
@@ -442,16 +380,4 @@ export interface SchemaLibrary extends TypedSchemaCollection {
 	 * Schema data aggregated from a collection of libraries by a SchemaBuilder.
 	 */
 	readonly libraries: ReadonlySet<SchemaLibraryData>;
-}
-
-/**
- * Mutable adapter collection which records the associated factory.
- * See {@link Adapters}.
- */
-export interface SourcedAdapters {
-	readonly tree: (Sourced & TreeAdapter)[];
-}
-
-{
-	type _check = requireAssignableTo<SourcedAdapters, Adapters>;
 }

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -4,7 +4,14 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { EmptyKey, FieldKey, TreeSchemaIdentifier, TreeTypeSet, ValueSchema } from "../../core";
+import {
+	Adapters,
+	EmptyKey,
+	FieldKey,
+	TreeSchemaIdentifier,
+	TreeTypeSet,
+	ValueSchema,
+} from "../../core";
 import {
 	MakeNominal,
 	Assume,
@@ -12,11 +19,12 @@ import {
 	_InlineTrick,
 	FlattenKeys,
 	Named,
+	requireAssignableTo,
 } from "../../util";
 import { FieldKindTypes, FieldKinds } from "../default-field-kinds";
+import { FullSchemaPolicy } from "../modular-schema";
 import { LazyItem, normalizeFlexList } from "./flexList";
 import { ObjectToMap, WithDefault, objectToMapTyped } from "./typeUtils";
-import { RecursiveTreeSchemaSpecification } from "./schemaBuilder";
 
 // TODO: tests for this file
 
@@ -40,6 +48,34 @@ export type NormalizeStructFieldsInner<T extends Fields> = {
 export type NormalizeStructFields<T extends Fields | undefined> = NormalizeStructFieldsInner<
 	WithDefault<T, Record<string, never>>
 >;
+
+/**
+ * Placeholder for to `TreeSchema` to use in constraints where `TreeSchema` is desired but using it causes
+ * recursive types to fail to compile due to TypeScript limitations.
+ *
+ * Using `TreeSchema` instead in some key "extends" clauses cause recursive types to error with:
+ * "'theSchema' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."
+ *
+ * TODO: how much more specific of a type can be provided without triggering the above error?
+ * @alpha
+ */
+export type RecursiveTreeSchema = unknown;
+
+/**
+ * Placeholder for to `TreeSchemaSpecification` to use in constraints where `TreeSchemaSpecification` is desired but using it causes
+ * recursive types to fail to compile due to TypeScript limitations.
+ *
+ * See `RecursiveTreeSchema`.
+ *
+ * TODO: how much more specific of a type can be provided without triggering the above error?
+ * @alpha
+ */
+export type RecursiveTreeSchemaSpecification = unknown;
+
+{
+	type _check1 = requireAssignableTo<TreeSchemaSpecification, RecursiveTreeSchemaSpecification>;
+	type _check2 = requireAssignableTo<TreeSchema, RecursiveTreeSchema>;
+}
 
 /**
  * T must extend TreeSchemaSpecification.
@@ -294,4 +330,23 @@ export function allowedTypesToTypeSet(t: AllowedTypes): TreeTypeSet {
 	const list: readonly (() => TreeSchema)[] = normalizeFlexList(t);
 	const names = list.map((f) => f().name);
 	return new Set(names);
+}
+
+/**
+ * Schema data that can be be used to view a document.
+ * Strongly typed over its rootFieldSchema.
+ *
+ * @remarks
+ * This type is mainly used as a type constraint to mean that the code working with it requires strongly typed schema.
+ * The actual type used will include detailed schema information for all the types in the collection.
+ * This pattern is used to implement SchemaAware APIs.
+ *
+ * @alpha
+ */
+
+export interface TypedSchemaCollection<T extends FieldSchema = FieldSchema> {
+	readonly rootFieldSchema: T;
+	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
+	readonly policy: FullSchemaPolicy;
+	readonly adapters: Adapters;
 }

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/view.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/view.ts
@@ -15,7 +15,7 @@ import {
 	Compatibility,
 } from "../../core";
 import { FullSchemaPolicy, allowsRepoSuperset, isNeverTree } from "../modular-schema";
-import { TypedSchemaCollection } from "./schemaBuilder";
+import { TypedSchemaCollection } from "./typedTreeSchema";
 
 /**
  * A collection of View information for schema, including policy.


### PR DESCRIPTION
## Description

 Remove cyclic imports of schemaBuilder.ts

This is in preparation for moving schemaBuilder.ts out of the typedSchema folder to avoid users of typed schema depending on how those schema got created.
This will help with creating a new schema building API which can be migrated to from the current one, as well as making schemaBuilder able to link to editable tree for the canonical docs on the various field and node kinds without that introducing a cycle.

As this moves code between files, all file moves/renames are not done yet to ensure the review is not complicated by combining edits and file moves.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

