### PR TITLE
tree: Prevent edits to removed trees

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -36,6 +36,8 @@ import { TreeContext } from "./context";
  * Design and document iterator invalidation rules and ordering rules.
  * Providing a custom iterator type with place anchor semantics would be a good approach.
  *
+ * Editing operations are only valid on trees with the `TreeState.InDocument` `TreeState`.
+ *
  * @alpha
  */
 export interface Tree<TSchema = unknown> extends Iterable<Tree> {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -36,8 +36,6 @@ import { TreeContext } from "./context";
  * Design and document iterator invalidation rules and ordering rules.
  * Providing a custom iterator type with place anchor semantics would be a good approach.
  *
- * Editing operations are only valid on trees with the `TreeState.InDocument` `TreeState`.
- *
  * @alpha
  */
 export interface Tree<TSchema = unknown> extends Iterable<Tree> {
@@ -124,6 +122,8 @@ export interface TreeNode extends Tree<TreeSchema> {
  *
  * Fields are inherently part of their parent, and thus cannot be moved.
  * Instead their content can be moved, deleted or created.
+ *
+ * Editing operations are only valid on trees with the {@link TreeStatus#InDocument} `TreeStatus`.
  *
  * @remarks
  * Fields are used wherever an editable collection of nodes is required.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -230,8 +230,8 @@ export abstract class LazyField<TKind extends FieldKindTypes, TTypes extends All
 	}
 
 	/**
-	 * Throws iff the field is under a node whose tree status is not `TreeStatus.InDocument`.
-	 * Does not throw for the field that contains the document root.
+	 * Returns the path to this field to use for editing. Throws iff this path is not {@link TreeStatus#InDocument}.
+	 * This path is not valid to hold onto across edits: this must be recalled for each edit.
 	 */
 	public getFieldPathForEditing(): FieldUpPath {
 		assert(

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -17,6 +17,7 @@ import {
 	keyAsDetachedField,
 	rootField,
 	EmptyKey,
+	rootFieldKey,
 } from "../../core";
 import { FieldKind } from "../modular-schema";
 import { NewFieldContent, normalizeNewFieldContent } from "../contextuallyTyped";
@@ -228,6 +229,18 @@ export abstract class LazyField<TKind extends FieldKindTypes, TTypes extends All
 	public getFieldPath(): FieldUpPath {
 		return this[cursorSymbol].getFieldPath();
 	}
+
+	/**
+	 * Throws iff the field is under a node whose tree status is not `TreeStatus.InDocument`.
+	 * Does not throw for the field that contains the document root.
+	 */
+	public getFieldPathForEditing(): FieldUpPath {
+		assert(
+			this.key === rootFieldKey || this.parent?.treeStatus() === TreeStatus.InDocument,
+			"Field must be in the document to be edited",
+		);
+		return this.getFieldPath();
+	}
 }
 
 export class LazySequence<TTypes extends AllowedTypes>
@@ -246,7 +259,7 @@ export class LazySequence<TTypes extends AllowedTypes>
 	}
 
 	private sequenceEditor(): SequenceFieldEditBuilder {
-		const fieldPath = this[cursorSymbol].getFieldPath();
+		const fieldPath = this.getFieldPathForEditing();
 		const fieldEditor = this.context.editor.sequenceField(fieldPath);
 		return fieldEditor;
 	}
@@ -284,7 +297,7 @@ export class LazyValueField<TTypes extends AllowedTypes>
 	}
 
 	private valueFieldEditor(): ValueFieldEditBuilder {
-		const fieldPath = this[cursorSymbol].getFieldPath();
+		const fieldPath = this.getFieldPathForEditing();
 		const fieldEditor = this.context.editor.valueField(fieldPath);
 		return fieldEditor;
 	}
@@ -321,7 +334,7 @@ export class LazyOptionalField<TTypes extends AllowedTypes>
 	}
 
 	private optionalEditor(): OptionalFieldEditBuilder {
-		const fieldPath = this[cursorSymbol].getFieldPath();
+		const fieldPath = this.getFieldPathForEditing();
 		const fieldEditor = this.context.editor.optionalField(fieldPath);
 		return fieldEditor;
 	}

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -17,7 +17,6 @@ import {
 	keyAsDetachedField,
 	rootField,
 	EmptyKey,
-	rootFieldKey,
 } from "../../core";
 import { FieldKind } from "../modular-schema";
 import { NewFieldContent, normalizeNewFieldContent } from "../contextuallyTyped";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -236,8 +236,8 @@ export abstract class LazyField<TKind extends FieldKindTypes, TTypes extends All
 	 */
 	public getFieldPathForEditing(): FieldUpPath {
 		assert(
-			this.key === rootFieldKey || this.parent?.treeStatus() === TreeStatus.InDocument,
-			"Field must be in the document to be edited",
+			this.treeStatus() === TreeStatus.InDocument,
+			"Editing only allowed on fields with TreeStatus.InDocument status",
 		);
 		return this.getFieldPath();
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
@@ -1,0 +1,76 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { Any, SchemaBuilder } from "../../../feature-libraries";
+import { FieldAnchor, FieldKey, TreeNavigationResult, UpPath } from "../../../core";
+import { forestWithContent } from "../../utils";
+import { brand } from "../../../util";
+import {
+	LazyOptionalField,
+	LazySequence,
+	LazyValueField,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../feature-libraries/editable-tree-2/lazyField";
+import { getReadonlyContext } from "./utils";
+
+const detachedField: FieldKey = brand("detached");
+const detachedFieldAnchor = { parent: undefined, fieldKey: detachedField };
+
+describe("lazyField", () => {
+	it("Querying the path for editing throws for detached trees", () => {
+		const builder = new SchemaBuilder("lazyTree");
+		builder.struct("empty", {});
+		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(Any));
+		const forest = forestWithContent({ schema, initialTree: {} });
+		const context = getReadonlyContext(forest, schema);
+		const cursor = context.forest.allocateCursor();
+		assert.equal(
+			forest.tryMoveCursorToField({ fieldKey: detachedField, parent: undefined }, cursor),
+			TreeNavigationResult.Ok,
+		);
+		const parentNodePath: UpPath = {
+			parent: undefined,
+			parentField: detachedField,
+			parentIndex: 0,
+		};
+		const parentAnchor = forest.anchors.track(parentNodePath);
+		const nestedFieldAnchor: FieldAnchor = {
+			parent: parentAnchor,
+			fieldKey: brand("nested"),
+		};
+		const fields = [
+			new LazySequence(
+				context,
+				SchemaBuilder.fieldSequence(Any),
+				cursor,
+				detachedFieldAnchor,
+			),
+			new LazySequence(context, SchemaBuilder.fieldSequence(Any), cursor, nestedFieldAnchor),
+			new LazyOptionalField(
+				context,
+				SchemaBuilder.fieldOptional(Any),
+				cursor,
+				detachedFieldAnchor,
+			),
+			new LazyOptionalField(
+				context,
+				SchemaBuilder.fieldOptional(Any),
+				cursor,
+				nestedFieldAnchor,
+			),
+			new LazyValueField(context, SchemaBuilder.fieldValue(Any), cursor, detachedFieldAnchor),
+			new LazyValueField(context, SchemaBuilder.fieldValue(Any), cursor, nestedFieldAnchor),
+		];
+		cursor.free();
+		for (const field of fields) {
+			assert.throws(
+				() => field.getFieldPathForEditing(),
+				/only allowed on fields with TreeStatus.InDocument status/,
+			);
+		}
+	});
+});

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
@@ -15,11 +15,8 @@ import {
 } from "../../../feature-libraries/editable-tree-2/lazyTree";
 import {
 	Any,
-	DefaultEditBuilder,
 	PrimitiveValue,
 	SchemaBuilder,
-	TypedSchemaCollection,
-	createMockNodeKeyManager,
 	isPrimitiveValue,
 	jsonableTreeFromCursor,
 	singleMapTreeCursor,
@@ -35,14 +32,7 @@ import {
 } from "../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { Context } from "../../../feature-libraries/editable-tree-2/context";
-import {
-	FieldKey,
-	IEditableForest,
-	MapTree,
-	TreeNavigationResult,
-	TreeValue,
-	rootFieldKey,
-} from "../../../core";
+import { FieldKey, MapTree, TreeNavigationResult, TreeValue, rootFieldKey } from "../../../core";
 import { forestWithContent } from "../../utils";
 import { TreeContent } from "../../../shared-tree";
 import { RestrictiveReadonlyRecord, brand } from "../../../util";
@@ -57,12 +47,7 @@ import {
 import { visitIterableTree } from "../../../feature-libraries/editable-tree-2";
 import { testTrees, treeContentFromTestTree } from "../../testTrees";
 import { jsonSchema } from "../../../domains";
-
-function getReadonlyContext(forest: IEditableForest, schema: TypedSchemaCollection): Context {
-	// This will error if someone tries to call mutation methods on it
-	const dummyEditor = {} as unknown as DefaultEditBuilder;
-	return new Context(schema, forest, dummyEditor, createMockNodeKeyManager());
-}
+import { getReadonlyContext } from "./utils";
 
 function contextWithContentReadonly(content: TreeContent): Context {
 	const forest = forestWithContent(content);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	DefaultEditBuilder,
+	TypedSchemaCollection,
+	createMockNodeKeyManager,
+} from "../../../feature-libraries";
+// eslint-disable-next-line import/no-internal-modules
+import { Context } from "../../../feature-libraries/editable-tree-2/context";
+import { IEditableForest } from "../../../core";
+
+export function getReadonlyContext(
+	forest: IEditableForest,
+	schema: TypedSchemaCollection,
+): Context {
+	// This will error if someone tries to call mutation methods on it
+	const dummyEditor = {} as unknown as DefaultEditBuilder;
+	return new Context(schema, forest, dummyEditor, createMockNodeKeyManager());
+}


### PR DESCRIPTION
Adds a check to guard against editing of trees that are not in the document at the time the edit is crafted.