### PR TITLE
Some upcoming notices about logging types

### DIFF
--- a/.changeset/fancy-dancers-draw.md
+++ b/.changeset/fancy-dancers-draw.md
@@ -1,0 +1,15 @@
+---
+"@fluidframework/telemetry-utils": minor
+"@fluidframework/odsp-driver": minor
+"@fluidframework/runtime-definitions": minor
+---
+
+Upcoming: The type of the logger property/param in various APIs will be changing
+
+-   @fluidframework/runtime-definitions
+    -   `IFluidDataStoreRuntime.logger` will be re-typed as `ITelemetryBaseLogger`
+-   @fluidframework/odsp-driver
+    -   `protected OdspDocumentServiceFactoryCore.createDocumentServiceCore`'s parameter `odspLogger` will be re-typed as `ITelemetryLoggerExt`
+    -   `protected LocalOdspDocumentServiceFactory.createDocumentServiceCore`'s parameter `odspLogger` will be re-typed as `ITelemetryLoggerExt`
+
+Additionally, several of @fluidframework/telemetry-utils's exports are being marked as internal and should not be consumed outside of other FF packages.

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -51,7 +51,7 @@ export function createMultiSinkLogger(props: {
     tryInheritProperties?: true;
 }): ITelemetryLoggerExt;
 
-// @public
+// @internal
 export class DataCorruptionError extends LoggingError implements IErrorBase, IFluidErrorBase {
     constructor(message: string, props: ITelemetryBaseProperties);
     // (undocumented)
@@ -60,7 +60,7 @@ export class DataCorruptionError extends LoggingError implements IErrorBase, IFl
     readonly errorType: "dataCorruptionError";
 }
 
-// @public
+// @internal
 export class DataProcessingError extends LoggingError implements IErrorBase, IFluidErrorBase {
     // (undocumented)
     readonly canRetry = false;
@@ -82,7 +82,7 @@ export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> exten
 // @public (undocumented)
 export const eventNamespaceSeparator: ":";
 
-// @public
+// @internal
 export function extractLogSafeErrorProperties(error: unknown, sanitizeStack: boolean): {
     message: string;
     errorType?: string | undefined;
@@ -102,13 +102,13 @@ export const extractSafePropertiesFromMessage: (messageLike: Partial<Pick<ISeque
 // @public (undocumented)
 export function formatTick(tick: number): number;
 
-// @public
+// @internal
 export function generateErrorWithStack(): Error;
 
-// @public (undocumented)
+// @internal
 export function generateStack(): string | undefined;
 
-// @public
+// @internal
 export class GenericError extends LoggingError implements IGenericError, IFluidErrorBase {
     constructor(message: string, error?: any, props?: ITelemetryBaseProperties);
     // (undocumented)
@@ -117,7 +117,7 @@ export class GenericError extends LoggingError implements IGenericError, IFluidE
     readonly errorType: "genericError";
 }
 
-// @public
+// @internal
 export const getCircularReplacer: () => (key: string, value: unknown) => any;
 
 // @public
@@ -147,7 +147,7 @@ export interface IConfigProviderBase {
     getRawConfig(name: string): ConfigTypes;
 }
 
-// @public
+// @internal
 export interface IFluidErrorAnnotations {
     props?: ITelemetryBaseProperties;
 }
@@ -173,7 +173,7 @@ export interface IPerformanceEventMarkers {
     start?: true;
 }
 
-// @public
+// @internal
 export function isExternalError(error: unknown): boolean;
 
 // @public
@@ -254,7 +254,7 @@ export interface ITelemetryPropertiesExt {
 // @public (undocumented)
 export function loggerToMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L): MonitoringContext<L>;
 
-// @public
+// @internal
 export class LoggingError extends Error implements ILoggingError, Omit<IFluidErrorBase, "errorType"> {
     constructor(message: string, props?: ITelemetryBaseProperties, omitPropsFromLogging?: Set<string>);
     addTelemetryProperties(props: ITelemetryBaseProperties): void;
@@ -302,10 +302,10 @@ export interface MonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLo
     logger: L;
 }
 
-// @public
+// @internal
 export const NORMALIZED_ERROR_TYPE = "genericError";
 
-// @public
+// @internal
 export function normalizeError(error: unknown, annotations?: IFluidErrorAnnotations): IFluidErrorBase;
 
 // @public
@@ -415,17 +415,17 @@ export class ThresholdCounter {
     sendIfMultiple(eventName: string, value: number): void;
 }
 
-// @public
+// @internal
 export class UsageError extends LoggingError implements IUsageError, IFluidErrorBase {
     constructor(message: string, props?: ITelemetryBaseProperties);
     // (undocumented)
     readonly errorType: "usageError";
 }
 
-// @public
+// @internal
 export function wrapError<T extends LoggingError>(innerError: unknown, newErrorFn: (message: string) => T): T;
 
-// @public
+// @internal
 export function wrapErrorAndLog<T extends LoggingError>(innerError: unknown, newErrorFn: (message: string) => T, logger: ITelemetryLoggerExt): T;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/utils/telemetry-utils/src/error.ts
+++ b/packages/utils/telemetry-utils/src/error.ts
@@ -23,6 +23,8 @@ import { IFluidErrorBase } from "./fluidErrorBase";
 
 /**
  * Generic wrapper for an unrecognized/uncategorized error object
+ *
+ * @internal
  */
 export class GenericError extends LoggingError implements IGenericError, IFluidErrorBase {
 	readonly errorType = FluidErrorTypes.genericError;
@@ -43,6 +45,8 @@ export class GenericError extends LoggingError implements IGenericError, IFluidE
 
 /**
  * Error indicating an API is being used improperly resulting in an invalid operation.
+ *
+ * @internal
  */
 export class UsageError extends LoggingError implements IUsageError, IFluidErrorBase {
 	readonly errorType = FluidErrorTypes.usageError;
@@ -55,6 +59,8 @@ export class UsageError extends LoggingError implements IUsageError, IFluidError
 /**
  * DataCorruptionError indicates that we encountered definitive evidence that the data at rest
  * backing this container is corrupted, and this container would never be expected to load properly again
+ *
+ * @internal
  */
 export class DataCorruptionError extends LoggingError implements IErrorBase, IFluidErrorBase {
 	readonly errorType = FluidErrorTypes.dataCorruptionError;
@@ -73,6 +79,8 @@ export class DataCorruptionError extends LoggingError implements IErrorBase, IFl
  * The error will often originate in the dataStore or DDS implementation that is responding to incoming changes.
  * This differs from {@link DataCorruptionError} in that this may be a transient error that will not repro in another
  * client or session.
+ *
+ * @internal
  */
 export class DataProcessingError extends LoggingError implements IErrorBase, IFluidErrorBase {
 	/**

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -27,6 +27,8 @@ const isRegularObject = (value: unknown): boolean => {
 
 /**
  * Inspect the given error for common "safe" props and return them.
+ *
+ * @internal
  */
 export function extractLogSafeErrorProperties(
 	error: unknown,
@@ -95,6 +97,8 @@ function copyProps(
 
 /**
  * Metadata to annotate an error object when annotating or normalizing it
+ *
+ * @internal
  */
 export interface IFluidErrorAnnotations {
 	/**
@@ -121,6 +125,8 @@ function patchLegacyError(
  * @returns A valid Fluid Error with any provided annotations applied
  * @param error - The error to normalize
  * @param annotations - Annotations to apply to the normalized error
+ *
+ * @internal
  */
 export function normalizeError(
 	error: unknown,
@@ -190,6 +196,8 @@ let stackPopulatedOnCreation: boolean | undefined;
  * For such cases it's better to not read stack property right away, but rather delay it until / if it's needed
  * Some browsers will populate stack right away, others require throwing Error, so we do auto-detection on the fly.
  * @returns Error object that has stack populated.
+ *
+ * @internal
  */
 export function generateErrorWithStack(): Error {
 	const err = new Error("<<generated stack>>");
@@ -209,6 +217,12 @@ export function generateErrorWithStack(): Error {
 	}
 }
 
+/**
+ * Generate a stack at this callsite as if an error were thrown from here.
+ * @returns the callstack (does not throw)
+ *
+ * @internal
+ */
 export function generateStack(): string | undefined {
 	return generateErrorWithStack().stack;
 }
@@ -219,6 +233,8 @@ export function generateStack(): string | undefined {
  * @param innerError - An error from untrusted/unknown origins
  * @param newErrorFn - callback that will create a new error given the original error's message
  * @returns A new error object "wrapping" the given error
+ *
+ * @internal
  */
 export function wrapError<T extends LoggingError>(
 	innerError: unknown,
@@ -258,6 +274,8 @@ export function wrapError<T extends LoggingError>(
  * The same as wrapError, but also logs the innerError, including the wrapping error's instance ID.
  *
  * @typeParam T - The kind of wrapper error to create.
+ *
+ * @internal
  */
 export function wrapErrorAndLog<T extends LoggingError>(
 	innerError: unknown,
@@ -304,6 +322,8 @@ export function overwriteStack(error: IFluidErrorBase | LoggingError, stack: str
  * True for any error object that is an (optionally normalized) external error
  * False for any error we created and raised within the FF codebase via LoggingError base class,
  * or wrapped in a well-known error type
+ *
+ * @internal
  */
 export function isExternalError(error: unknown): boolean {
 	// LoggingErrors are an internal FF error type. However, an external error can be converted
@@ -357,6 +377,7 @@ function isTelemetryEventPropertyValue(x: unknown): x is TelemetryBaseEventPrope
 			return false;
 	}
 }
+
 /**
  * Walk an object's enumerable properties to find those fit for telemetry.
  */
@@ -389,6 +410,8 @@ function getValidTelemetryProps(obj: object, keysToOmit: Set<string>): ITelemetr
  * Avoids runtime errors with circular references.
  * Not ideal, as will cut values that are not necessarily circular references.
  * Could be improved by implementing Node's util.inspect() for browser (minus all the coloring code)
+ *
+ * @internal
  */
 // TODO: Use `unknown` instead (API breaking change)
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -412,6 +435,8 @@ export const getCircularReplacer = (): ((key: string, value: unknown) => any) =>
  * will be logged in accordance with their tag, if present.
  *
  * PLEASE take care to avoid setting sensitive data on this object without proper tagging!
+ *
+ * @internal
  */
 export class LoggingError
 	extends Error
@@ -494,8 +519,16 @@ export class LoggingError
 
 /**
  * The Error class used when normalizing an external error
+ *
+ * @internal
  */
 export const NORMALIZED_ERROR_TYPE = "genericError";
+
+/**
+ * Subclass of LoggingError returned by normalizeError
+ *
+ * @internal
+ */
 class NormalizedLoggingError extends LoggingError {
 	// errorType "genericError" is used as a default value throughout the code.
 	// Note that this matches ContainerErrorType/DriverErrorType's genericError


### PR DESCRIPTION
## Description

* Add an "Upcoming" changeset note to advertised planned changes to a few APIs using the deprecated `ITelemetryLogger` type.
* Mark a bunch of internal logging-related stuff as `@internal`

## Breaking Changes

No, but announces some that will be done after internal.7.0 releases (see [AB#5448](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5448))

## Reviewer Guidance

Question: Is there a defined procedure for transitioning an API from public to internal, in terms of announcing / annotating the deprecation for public consumption?
