### PR TITLE
server: add connectionTimeoutMs to all HTTP services

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -58,5 +58,10 @@ data:
             "maxRetriesPerRequest": "{{ .Values.gitrest.redis.maxRetriesPerRequest }}",
             "enableAutoPipelining": "{{ .Values.gitrest.redis.enableAutoPipelining }}",
             "enableOfflineQueue": "{{ .Values.gitrest.redis.enableOfflineQueue }}"
+        },
+        "system": {
+            "httpServer": {
+                "connectionTimeoutMs": {{ .Values.gitrest.system.httpServer.connectionTimeoutMs }}
+            }
         }
     }

--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -51,5 +51,10 @@ data:
         "restGitService": {
             "disableGitCache": {{ .Values.historian.restGitService.disableGitCache }}
         },
-        "storageUrl": "{{ .Values.historian.storageUrl }}"
+        "storageUrl": "{{ .Values.historian.storageUrl }}",
+        "system": {
+            "httpServer": {
+                "connectionTimeoutMs": {{ .Values.historian.system.httpServer.connectionTimeoutMs }}
+            }
+        }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -32,6 +32,9 @@ historian:
       createSummary: disabled
   restGitService:
     disableGitCache: false
+  system:
+    httpServer:
+      connectionTimeoutMs: 0
 
 gitrest:
   name: gitrest
@@ -64,6 +67,9 @@ gitrest:
     maxRetriesPerRequest: 20
     enableAutoPipelining: false
     enableOfflineQueue: true
+  system:
+    httpServer:
+      connectionTimeoutMs: 0
 
 gitssh:
   name: gitssh

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -29,7 +29,8 @@ export class GitrestResources implements core.IResources {
 		public readonly asyncLocalStorage?: AsyncLocalStorage<string>,
 		public readonly enableOptimizedInitialSummary?: boolean,
 	) {
-		this.webServerFactory = new services.BasicWebServerFactory();
+		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
+		this.webServerFactory = new services.BasicWebServerFactory(httpServerConfig);
 	}
 
 	public async dispose(): Promise<void> {

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -43,5 +43,10 @@
 		"maxRetriesPerRequest": 20,
 		"enableAutoPipelining": false,
 		"enableOfflineQueue": true
+	},
+	"system": {
+		"httpServer": {
+			"connectionTimeoutMs": 0
+		}
 	}
 }

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -29,7 +29,8 @@ export class HistorianResources implements core.IResources {
 		public revokedTokenChecker?: core.IRevokedTokenChecker,
 		public readonly denyList?: historianServices.IDenyList,
 	) {
-		this.webServerFactory = new services.BasicWebServerFactory();
+		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
+		this.webServerFactory = new services.BasicWebServerFactory(httpServerConfig);
 	}
 
 	public async dispose(): Promise<void> {

--- a/server/historian/packages/historian/config.json
+++ b/server/historian/packages/historian/config.json
@@ -87,5 +87,10 @@
 	"storageUrl": "",
 	"tokenRevocation": {
 		"enable": false
+	},
+	"system": {
+		"httpServer": {
+			"connectionTimeoutMs": 0
+		}
 	}
 }

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -164,7 +164,7 @@ data:
         },
         "system": {
             "httpServer": {
-                "connectionTimeout": {{ .Values.system.httpServer.connectionTimeout }}
+                "connectionTimeoutMs": {{ .Values.system.httpServer.connectionTimeoutMs }}
             },
             "topics": {
                 "send": "{{ .Values.kafka.topics.deltas }}"

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -107,7 +107,7 @@ zookeeper:
 
 system:
   httpServer:
-    connectionTimeout: 0
+    connectionTimeoutMs: 0
 
 usage:
   clientConnectivityCountingEnabled: false


### PR DESCRIPTION
## Description

`connectionTimeoutMs` config for setting Node.js internal timeouts was added a long time ago, but never plugged into Gitrest and Historian. This does that.
