### PR TITLE
tree2: Dedup SchemaBuilder Docs

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -176,6 +176,20 @@ export interface TreeField extends Tree<FieldSchema>, Iterable<TreeNode> {
  * A node that behaves like a `Map<FieldKey, Field>` for a specific `Field` type.
  * @alpha
  */
+
+/**
+ * A {@link TreeNode} that behaves like a `Map<FieldKey, Field>` for a specific `Field` type.
+ *
+ * @remarks
+ * Unlike TypeScript Map type, {@link MapNode.get} always provides a reference to any field looked up, even if its never been set.
+ *
+ * This means that, for example, a `MapNode` of {@link Sequence} fields will return an empty sequence when a previously unused key is looked up,
+ * and that sequence can be used to insert new items into the field.
+ * Additionally empty fields (those containing no nodes) are not distinguished from fields which do not exist.
+ * This differs from JavaScript Maps which have a subtle distinction between storing undefined as a value in the map and deleting an entry from the map.
+ *
+ * @alpha
+ */
 export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	/**
 	 * Get the field for `key`.
@@ -184,6 +198,9 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * @remarks
 	 * All fields under a map implicitly exist, so `get` can be called with any key and will always return a field.
 	 * Even if the field is empty, it will still be returned, and can be edited to insert content into the map.
+	 *
+	 * @privateRemarks
+	 * TODO: Consider changing the key type to `string` for easier use.
 	 */
 	get(key: FieldKey): TypedField<TSchema["mapFields"]>;
 
@@ -200,21 +217,36 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 }
 
 /**
- * A {@link TreeNode} that wraps a single field.
+ * A {@link TreeNode} that wraps a single {@link TreeField} (which is placed under the {@link EmptyKey}).
  *
  * @remarks
  * FieldNodes unbox to their content, so in schema aware APIs which do unboxing, the FieldNode itself will be skipped over.
- * Mainly useful when a field (such as a sequence) is desired in a location where nodes are required (like the member of a union or the child of another field).
+ * This layer of field nodes is then omitted when using schema-aware APIs which do unboxing.
+ * Other than this unboxing, a FieldNode is identical to a struct node with a single field using the {@link EmptyKey}.
  *
+ * There are several use-cases where it makes sense to use a field node.
+ * Here are a few:
+ * - When it's necessary to differentiate between an empty sequence, and no sequence.
+ * One case where this is needed is encoding Json.
+ * - When polymorphism over {@link FieldSchema} (and not just a union of {@link AllowedTypes}) is required.
+ * For example when encoding a schema for a type like
+ * `Foo[] | Bar[]`, `Foo | Foo[]` or `Optional<Foo> | Optional<Bar>` (Where `Optional` is the Optional field kind, not TypeScript's `Optional`).
+ * Since this schema system only allows `|` of {@link TreeSchema} (and only when declaring a {@link FieldSchema}), see {@link SchemaBuilder.field},
+ * these aggregate types are most simply expressed by creating fieldNodes for the terms like `Foo[]`, and `Optional<Foo>`.
+ * Note that these are distinct from types like `(Foo | Bar)[]` and `Optional<Foo | Bar>` which can be expressed as single fields without extra nodes.
+ * - When a distinct merge identity is desired for a field.
+ * For example, if the application wants to be able to have an optional node or a sequence which it can pass around, edit and observe changes to,
+ * in some cases (like when the content is moved to a different parent) this can be more flexible if a field node is introduced
+ * to create a separate logical entity (node) which wraps the field.
+ * This can even be useful with value fields to wrap terminal nodes if a stable merge
+ * - When a field (such as a {@link Sequence}) is desired in a location where {@link TreeNode}s are required
+ * (like the member of a union or the child of another {@link TreeField}).
+ * This can is typically just a different perspective on one of the above cases.
  * For example:
  * `Sequence<Foo> | Sequence<Bar>` or `OptionalField<Sequence<Foo>>` can't be expressed as simple fields
  * (unlike `Sequence<Foo | Bar>` or `OptionalField<Foo>` which can be done as simple fields).
  * Instead {@link FieldNode}s can be use to achieve something similar, more like:
  * `FieldNode<Sequence<Foo>> | FieldNode<Sequence<Bar>>` or `OptionalField<FieldNode<Sequence<Foo>>>`.
- *
- * This extra layer of field nodes is then omitted when using schema-aware APIs which do unboxing.
- *
- * Other than this unboxing, a FieldNode is identical to a struct node with a single field using the {@link EmptyKey}.
  *
  * @alpha
  */
@@ -238,11 +270,23 @@ export interface FieldNode<TSchema extends FieldNodeSchema> extends TreeNode {
 }
 
 /**
- * A node that behaves like struct, providing properties to access its fields.
+ * A {@link TreeNode} that behaves like struct, providing properties to access its fields.
+ *
+ * Struct nodes consist of a finite collection of fields, each with their own (distinct) key and {@link FieldSchema}.
  *
  * @remarks
  * Struct nodes require complex typing, and have been split into two parts for implementation purposes.
- * See {@link StructTyped} for the schema aware extensions to this.
+ * See {@link StructTyped} for the schema aware extensions to this that provide access to the fields.
+ *
+ * These "Structs" resemble (and are named after) "Structs" from a wide variety of programming languages
+ * (Including Algol 68, C, Go, Rust, C# etc.).
+ * Struct nodes also somewhat resemble JavaScript objects: this analogy is less precise (objects don't have a fixed schema for example),
+ * which is why "Struct" nodes are named after "Structs" instead.
+ *
+ * Another common name for this abstraction is [record](https://en.wikipedia.org/wiki/Record_(computer_science)).
+ * The name "Record" is avoided (in favor of Struct) here because it has less precise connotations for most TypeScript developers.
+ * For example, TypeScript has a built in `Record` type, but it requires all of the fields to have the same type,
+ * putting its semantics half way between this library's "Struct" schema and {@link MapNode}.
  *
  * @alpha
  */
@@ -269,7 +313,7 @@ export interface Leaf<TSchema extends LeafSchema> extends TreeNode {
 }
 
 /**
- * A node that behaves like struct, providing properties to access its fields.
+ * A {@link TreeNode} that behaves like struct, providing properties to access its fields.
  *
  * @alpha
  */
@@ -328,10 +372,20 @@ export type FlexibleNodeContent<TTypes extends AllowedTypes> = SchemaAware.Allow
 >;
 
 /**
- * Field that stores a sequence of children.
+ * {@link TreeField} that stores a sequence of children.
+ *
+ * Sequence fields can contain an ordered sequence any number of {@link TreeNode}s which must be of the {@link AllowedTypes} from the {@link FieldSchema}).
  *
  * @remarks
  * Allows for concurrent editing based on index, adjusting the locations of indexes as needed so they apply to the same logical place in the sequence when rebased and merged.
+ *
+ * Edits to sequence fields are anchored relative to their surroundings, so concurrent edits can result in the indexes of nodes and edits getting shifted.
+ * To hold onto locations in sequence across an edit, use anchors.
+ *
+ * @privateRemarks
+ * TODO:
+ * Add anchor API that can actually hold onto locations in a sequence.
+ * Currently only nodes can be held onto with anchors, and this does not replicate the behavior implemented for editing.
  * @alpha
  */
 export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
@@ -394,6 +448,13 @@ export interface RequiredField<TTypes extends AllowedTypes> extends TreeField {
  *
  * @remarks
  * Unboxes its content, so in schema aware APIs which do unboxing, the OptionalField itself will be skipped over and its content will be returned directly.
+ *
+ * @privateRemarks
+ * TODO: Document merge semitics
+ * TODO: Allow Optional fields to be used with last write wins OR first write wins merge resolution.
+ * TODO:
+ * Better centralize the documentation about what kinds of merge semantics are available for field kinds.
+ * Maybe link editor?
  * @alpha
  */
 export interface OptionalField<TTypes extends AllowedTypes> extends TreeField {

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
@@ -72,22 +72,9 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define (and add to this library) a {@link TreeSchema} for a struct node.
+	 * Define (and add to this library) a {@link TreeSchema} for a {@link Struct} node.
 	 *
 	 * The name must be unique among all TreeSchema in the the document schema.
-	 *
-	 * Struct nodes consist of a finite collection of fields, each with their own (distinct) key and {@link FieldSchema}.
-	 *
-	 * @remarks
-	 * These "Structs" resemble (and are named after) "Structs" from a wide variety of programming languages
-	 * (Including Algol 68, C, Go, Rust, C# etc.).
-	 * Struct nodes also somewhat resemble JavaScript objects: this analogy is less precise (objects don't have a fixed schema for example),
-	 * which is why "Struct" nodes are named after "Structs" instead.
-	 *
-	 * Another common name for this abstraction is [record](https://en.wikipedia.org/wiki/Record_(computer_science)).
-	 * The name "Record" is avoided (in favor of Struct) here because it has less precise connotations for most TypeScript developers.
-	 * For example, TypeScript has a built in `Record` type, but it requires all of the fields to have the same type,
-	 * putting its semantics half way between this library's "struct" schema and "map" schema.
 	 */
 	public struct<Name extends string, T extends RestrictiveReadonlyRecord<string, FieldSchema>>(
 		name: Name,
@@ -115,19 +102,7 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define (and add to this library) a {@link TreeSchema} for a map node.
-	 *
-	 * The name must be unique among all TreeSchema in the the document schema.
-	 *
-	 * Map nodes consist of a collection of fields, each with a unique key, but with the content of each following the same schema.
-	 * The schema permits any string to be used as a key.
-	 *
-	 * @remarks
-	 * These node resemble the TypeScript Map type, parameterized as `Map<string, fieldSchema>` with one important difference:
-	 * Unlike TypeScript Map type, Map nodes can always provide a reference to any field looked up, even if its never been set.
-	 * This means that, for example, a Map node of sequenceFields will return an empty sequence when a previously unused key is looked up, and that sequence can be used to insert new items into the field.
-	 * Additionally empty fields (those containing no nodes) are not distinguished from fields which do not exist.
-	 * This differs from JavaScript Maps which have a subtle distinction between storing undefined as a value in the map and deleting an entry from the map.
+	 * Define (and add to this library) a {@link TreeSchema} for a {@link MapNode}.
 	 */
 	public map<Name extends string, T extends FieldSchema>(
 		name: Name,
@@ -155,34 +130,11 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define (and add to this library) a {@link TreeSchema} for a field node.
-	 * Such nodes will be implicitly unwrapped to the field in some APIs.
+	 * Define (and add to this library) a {@link TreeSchema} for a {@link FieldNode}.
 	 *
 	 * The name must be unique among all TreeSchema in the the document schema.
 	 *
-	 * A field is a node with a single field which captures all its meaning.
-	 *
-	 * @remarks
-	 * Field nodes are mainly a shorthand for a struct with a single field.
-	 *
-	 * There are several use-cases where it makes sense to use a field node.
-	 * Here are a few:
-	 * - When it's necessary to differentiate between an empty sequence, and no sequence.
-	 * One case where this is needed is encoding Json.
-	 * - When polymorphism over file kinds is required.
-	 * For example when encoding a schema for a type like
-	 * `Foo[] | Bar[]`, `Foo | Foo[]` or `Optional<Foo> | Optional<Bar>` (Where `Optional` is our Optional field kind, not TypeScript's `Optional`).
-	 * Since this schema system only allows `|` of {@link TreeSchema} (and only when declaring a {@link FieldSchema}), see {@link SchemaBuilder.field},
-	 * these aggregate types are most simply expressed by creating fieldNodes for the terms like `Foo[]`, and `Optional<Foo>`.
-	 * Note that these are distinct from types like `(Foo | Bar)[]` and `Optional<Foo | Bar>` which can be expressed as single fields without extra nodes.
-	 * - When a distinct merge identity is desired for a field.
-	 * For example, if the application wants to be able to have an optional node or a sequence which it can pass around, edit and observe changes to,
-	 * in some cases (like when the content is moved to a different parent) this can be more flexible if a field node is introduced
-	 * to create a separate logical entity (node) which wraps the field.
-	 * This can even be useful with value fields to wrap terminal nodes if a stable merge identity is needed that survives editing the value (which is done by replacing the leaf node).
-	 *
-	 * Field nodes store their field under the {@link FieldKey} {@link EmptyKey}.
-	 *
+	 * @privateRemarks
 	 * TODO: Write and link document outlining field vs node data model and the separation of concerns related to that.
 	 * TODO: Maybe find a better name for this.
 	 */
@@ -234,13 +186,16 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define a schema for a field.
+	 * Define a {@link FieldSchema}.
 	 *
 	 * @param kind - The [kind](https://en.wikipedia.org/wiki/Kind_(type_theory)) of this field.
 	 * Determine the multiplicity, viewing and editing APIs as well as the merge resolution policy.
 	 * @param allowedTypes - What types of children are allowed in this field.
-	 * @returns a field which can be used as a struct field (see {@link SchemaBuilder.struct}),
-	 * a map field (see {@link SchemaBuilder.map}), or the root field (see {@link SchemaBuilder.intoDocumentSchema}).
+	 * @returns a {@link FieldSchema} which can be used as a struct field (see {@link SchemaBuilder.struct}),
+	 * a map field (see {@link SchemaBuilder.map}), a field node(see {@link SchemaBuilder.fieldNode}) or the root field (see {@link SchemaBuilder.intoDocumentSchema}).
+	 *
+	 * @privateRemarks
+	 * TODO: since this APi surface is using classes, maybe just have users do `new FieldSchema` instead?
 	 */
 	public static field<Kind extends FieldKindTypes, T extends AllowedTypes>(
 		kind: Kind,
@@ -250,16 +205,8 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define a schema for an optional field.
+	 * Define a schema for an {@link OptionalField}.
 	 * Shorthand or passing `FieldKinds.optional` to {@link SchemaBuilder.field}.
-	 *
-	 * Optional fields can be empty (undefined) or contain a single value of the allowed types.
-	 *
-	 * Optional fields can be used with last write wins OR first write wins merge resolution.
-	 * TODO: ensure the above is true and easy to do.
-	 * TODO:
-	 * Better centralize the documentation about what kinds of merge semantics are available for field kinds.
-	 * Maybe link editor?
 	 */
 	public static fieldOptional<T extends AllowedTypes>(
 		...allowedTypes: T
@@ -268,12 +215,13 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define a schema for a value field.
+	 * Define a schema for a {@link RequiredField}.
 	 * Shorthand or passing `FieldKinds.value` to {@link SchemaBuilder.field}.
 	 *
-	 * Value fields hold a single child.
-	 *
-	 * TODO: consider adding even shorter syntax where AllowedTypes can be used as a FieldSchema.
+	 * @privateRemarks
+	 * TODO: Consider adding even shorter syntax where:
+	 * - AllowedTypes can be used as a FieldSchema (Or SchemaBuilder takes a default field kind).
+	 * - A TreeSchema can be used as AllowedTypes in the non-polymorphic case.
 	 */
 	public static fieldValue<T extends AllowedTypes>(
 		...allowedTypes: T
@@ -282,15 +230,7 @@ export class SchemaBuilder {
 	}
 
 	/**
-	 * Define a schema for a sequence field.
-	 * Sequence fields can contain any number of value of the allowed types in an ordered sequence.
-	 *
-	 * Edits to sequence fields are anchored relative to their surroundings, so concurrent edits can result in the indexes of nodes and edits getting shifted.
-	 * To hold onto locations in sequence across an edit, use anchors.
-	 *
-	 * TODO:
-	 * Add anchor API that can actually hold onto locations in a sequence.
-	 * Currently only nodes can be held onto with anchors, and this does not replicate the behavior implemented for editing.
+	 * Define a schema for a {@link Sequence} field.
 	 */
 	public static fieldSequence<T extends AllowedTypes>(
 		...t: T

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -311,6 +311,12 @@ export class FieldSchema<Kind extends FieldKindTypes = FieldKindTypes, Types = A
 	public static readonly empty = new FieldSchema(FieldKinds.forbidden, []);
 
 	protected _typeCheck?: MakeNominal;
+
+	/**
+	 * @param kind - The [kind](https://en.wikipedia.org/wiki/Kind_(type_theory)) of this field.
+	 * Determine the multiplicity, viewing and editing APIs as well as the merge resolution policy.
+	 * @param allowedTypes - What types of tree nodes are allowed in this field.
+	 */
 	public constructor(public readonly kind: Kind, public readonly allowedTypes: Types) {}
 
 	public get types(): TreeTypeSet {


### PR DESCRIPTION
## Description

Move docs about field and node kinds specific stuff into the tree APi instead of the schema builder.
This will help with creating a new schema building API which can be migrated to from the current one.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
