### PR TITLE
Publish test logs when running azure e2e tests against tinylicious

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -335,11 +335,11 @@ jobs:
         condition: succeededOrFailed()
 
       # Publish tinylicious log for troubleshooting
-      - ${{ if contains(convertToJson(parameters.testCommand), 'tinylicious') }}:
+      - ${{ if or(contains(convertToJson(parameters.testCommand), 'tinylicious'), contains(convertToJson(parameters.testCommand), 't9s')) }}:
         - task: PublishPipelineArtifact@1
           displayName: Publish Artifact - Tinylicious Log
           inputs:
-            targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
+            targetPath: '${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/tinylicious.log'
             artifactName: 'tinyliciousLog'
             publishLocation: 'pipeline'
           condition: succeededOrFailed()

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -335,7 +335,7 @@ jobs:
         condition: succeededOrFailed()
 
       # Publish tinylicious log for troubleshooting
-      - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
+      - ${{ if contains(convertToJson(parameters.testCommand), 'tinylicious') }}:
         - task: PublishPipelineArtifact@1
           displayName: Publish Artifact - Tinylicious Log
           inputs:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -342,7 +342,7 @@ jobs:
             targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
             artifactName: 'tinyliciousLog'
             publishLocation: 'pipeline'
-          condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+          condition: succeededOrFailed()
           continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
       # Log Test Failures

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -334,6 +334,17 @@ jobs:
           mergeTestResults: false
         condition: succeededOrFailed()
 
+      # Publish tinylicious log for troubleshooting
+      - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Artifact - Tinylicious Log
+          inputs:
+            targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
+            artifactName: 'tinyliciousLog'
+            publishLocation: 'pipeline'
+          condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+          continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
+
       # Log Test Failures
       # - template: include-log-test-failures.yml
       #   parameters:

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -60,6 +60,6 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-            # Disable colorization for tinylicious logs (not useful when printing to a file)
-            logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
-            logger__morganFormat: tiny
+          # Disable colorization for tinylicious logs (not useful when printing to a file)
+          logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+          logger__morganFormat: tiny

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -46,10 +46,6 @@ stages:
           azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)
           azure__fluid__relay__service__endpoint: $(azure-fluid-relay-service-endpoint)
           azure__fluid__relay__service__key: $(azure-fluid-relay-service-key)
-          ${{ if contains(taskTestStep, 'tinylicious') }}:
-            # Disable colorization for tinylicious logs (not useful when printing to a file)
-            logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
-            logger__morganFormat: tiny
 
   - stage:
     displayName: e2e - azure client with azure local service
@@ -64,3 +60,6 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+            # Disable colorization for tinylicious logs (not useful when printing to a file)
+            logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+            logger__morganFormat: tiny

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -46,6 +46,10 @@ stages:
           azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)
           azure__fluid__relay__service__endpoint: $(azure-fluid-relay-service-endpoint)
           azure__fluid__relay__service__key: $(azure-fluid-relay-service-key)
+          ${{ if contains(taskTestStep, 'tinylicious') }}:
+            # Disable colorization for tinylicious logs (not useful when printing to a file)
+            logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+            logger__morganFormat: tiny
 
   - stage:
     displayName: e2e - azure client with azure local service

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -100,7 +100,6 @@ stages:
           # Disable colorization for tinylicious logs (not useful when printing to a file)
           logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
-        additionalSteps:
 
         # Publish the tinylicious log
         - task: PublishPipelineArtifact@1

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -101,16 +101,6 @@ stages:
           logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
 
-        # Publish the tinylicious log
-        - task: PublishPipelineArtifact@1
-          displayName: Publish Artifact - Tinylicious Log
-          inputs:
-            # NOTE: this depends on knowledge of what the template does and where it puts things.
-            # If the template changes its logic, we might need to adjust this path.
-            targetPath: '${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}/tinylicious.log'
-            artifactName: 'tinyliciousLog'
-            publishLocation: 'pipeline'
-
   # stress tests frs
   - stage: stress_tests_frs
     displayName: Stress tests - frs

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -66,16 +66,6 @@ stages:
           logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
 
-        # Publish the tinylicious log
-        - task: PublishPipelineArtifact@1
-          displayName: Publish Artifact - Tinylicious Log
-          inputs:
-            # NOTE: this depends on knowledge of what the template does and where it puts things.
-            # If the template changes its logic, we might need to adjust this path.
-            targetPath: '${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}/tinylicious.log'
-            artifactName: 'tinyliciousLog'
-            publishLocation: 'pipeline'
-
   # end-to-end tests routerlicious
   - stage: e2e_routerlicious
     displayName: e2e - routerlicious

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -65,7 +65,6 @@ stages:
           # Disable colorization for tinylicious logs (not useful when printing to a file)
           logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
-        additionalSteps:
 
         # Publish the tinylicious log
         - task: PublishPipelineArtifact@1


### PR DESCRIPTION
## Description

This PR modifies the azure e2e test pipeline to publish the tinylicious logs to help debugging. It also disables the text coloring to make the logs cleaner.

