### PR TITLE
Use tinylicious for azure e2e tests instead of azure-local-service

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -31,7 +31,7 @@
 		"postpack": "tar -cf ./azure-client.test-files.tar ./dist/test",
 		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
-		"start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
+		"start:tinylicious:test": "npx @fluidframework/azure-local-service > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
 		"test:realsvc": "npm run test:realsvc:tinylicious",
 		"test:realsvc:local:run": "mocha --recursive 'dist/test/**/*.spec.js' --exit --timeout 10000",
@@ -54,13 +54,13 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/server-services-client": "^1.0.1",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"axios": "^0.26.0",
-		"tinylicious": "^1.0.0"
+		"axios": "^0.26.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.6.3.0",
+		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/counter": "workspace:~",

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -31,7 +31,7 @@
 		"postpack": "tar -cf ./azure-client.test-files.tar ./dist/test",
 		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
-		"start:tinylicious:test": "npx @fluidframework/azure-local-service > tinylicious.log 2>&1",
+		"start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
 		"test:realsvc": "npm run test:realsvc:tinylicious",
 		"test:realsvc:local:run": "mocha --recursive 'dist/test/**/*.spec.js' --exit --timeout 10000",
@@ -54,13 +54,13 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/server-services-client": "^1.0.1",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"axios": "^0.26.0"
+		"axios": "^0.26.0",
+		"tinylicious": "^1.0.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.22.0",
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.6.3.0",
-		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/counter": "workspace:~",

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -23,7 +23,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --ignore-path ../../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../../.prettierignore",
-		"start:tinylicious:test": "PORT=7071 npx @fluidframework/azure-local-service > tinylicious.log 2>&1",
+		"start:tinylicious:test": "PORT=7071 tinylicious > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
 		"test:coverage": "c8 npm test",
 		"test:realsvc": "npm run test:realsvc:tinylicious",
@@ -80,7 +80,6 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.22.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,6 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.6.3.0
-      '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/container-definitions': workspace:~
@@ -105,6 +104,7 @@ importers:
       prettier: ~2.6.2
       rimraf: ^4.4.0
       start-server-and-test: ^1.11.7
+      tinylicious: ^1.0.0
       typescript: ~4.5.5
       uuid: ^9.0.0
     dependencies:
@@ -122,11 +122,11 @@ importers:
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
       axios: 0.26.1
+      tinylicious: 1.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.6.3.0
-      '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/counter': link:../../../packages/dds/counter
@@ -320,7 +320,6 @@ importers:
     specifiers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/container-definitions': workspace:~
@@ -381,7 +380,6 @@ importers:
       tinylicious: 1.0.0
       uuid: 9.0.0
     devDependencies:
-      '@fluidframework/azure-local-service': link:../../azure-local-service
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -17581,9 +17579,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/gitresources/1.0.0:
-    resolution: {integrity: sha512-j4yu9JM5kU3y+5XfPOu19Ak1vJZai+6tiqCAYeJeXaczfGRlWVdqWgl4Cc8LUdJ+JDPEKo9a54FaJG+Gpa/kwQ==}
-
   /@fluidframework/gitresources/1.0.1:
     resolution: {integrity: sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==}
 
@@ -17854,14 +17849,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/protocol-base/1.0.0:
-    resolution: {integrity: sha512-n/9NVKRDb0FVQtyLx0Z8VlcpdMf54IKXnSnZbHklUMHVC4Jehp9vrjgT0UOlEC032+i/CNteWXSVI4S1tqnMAQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      events: 3.3.0
-
   /@fluidframework/protocol-base/1.0.1:
     resolution: {integrity: sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==}
     dependencies:
@@ -18088,22 +18075,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas-driver/1.0.0:
-    resolution: {integrity: sha512-XGCYOOGb8SNO51gsgh+Ucu9v3IBcubCuAtLvDct0yMX72a4bS93oBUKvPmdJqE9NkW853BYkk2oWEStvIGfUMA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
-      assert: 2.0.0
-      async: 3.2.4
-      events: 3.3.0
-      lodash: 4.17.21
-      nconf: 0.12.0
-      serialize-error: 8.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   /@fluidframework/server-lambdas-driver/1.0.1:
     resolution: {integrity: sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==}
     dependencies:
@@ -18120,51 +18091,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/server-lambdas/1.0.0:
-    resolution: {integrity: sha512-agmr6BX9EWLJgeLZ7mFwXygEWFPN9Z8QETCM5jCIO5d+/Y5wYsTK+xGw4nIHpxaGBH3/JGvWmTPBDZS3dqR11A==}
+  /@fluidframework/server-lambdas/1.0.1:
+    resolution: {integrity: sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/gitresources': 1.0.1
       '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-lambdas-driver': 1.0.0
+      '@fluidframework/server-lambdas-driver': 1.0.1
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
+      '@fluidframework/server-services-telemetry': 1.0.1
       '@types/semver': 7.5.0
       assert: 2.0.0
       async: 3.2.4
       axios: 0.26.1
-      buffer: 6.0.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      nconf: 0.12.0
-      semver: 7.5.4
-      sha.js: 2.4.11
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  /@fluidframework/server-lambdas/1.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-agmr6BX9EWLJgeLZ7mFwXygEWFPN9Z8QETCM5jCIO5d+/Y5wYsTK+xGw4nIHpxaGBH3/JGvWmTPBDZS3dqR11A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 1.0.1
-      '@fluidframework/protocol-base': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-lambdas-driver': 1.0.0
-      '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
-      '@types/semver': 7.5.0
-      assert: 2.0.0
-      async: 3.2.4
-      axios: 0.26.1_debug@4.3.4
       buffer: 6.0.3
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -18207,26 +18149,6 @@ packages:
       - debug
       - supports-color
 
-  /@fluidframework/server-local-server/1.0.0:
-    resolution: {integrity: sha512-jMb4ciDz4mXXkYxZd9e4YSNa2wFZ40HRfgtxRxryxRVnvLPqiNEofqaSZBgoqH+whP8mBqDhGdEz7mAWZrBjZQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-lambdas': 1.0.0_debug@4.3.4
-      '@fluidframework/server-memory-orderer': 1.0.0
-      '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
-      '@fluidframework/server-test-utils': 1.0.1
-      debug: 4.3.4
-      events: 3.3.0
-      jsrsasign: 10.8.6
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   /@fluidframework/server-local-server/1.0.1:
     resolution: {integrity: sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==}
     dependencies:
@@ -18242,34 +18164,6 @@ packages:
       events: 3.3.0
       jsrsasign: 10.8.6
       uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  /@fluidframework/server-memory-orderer/1.0.0:
-    resolution: {integrity: sha512-P7OTd0v/NkvPjMP3kxMSsHecNwBvk+uIO4QF8s1ZeQ4E8i6HrJ0NryMIeJIwr5Rto+thsdv9xGORWRLoWnGBsA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/protocol-base': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-lambdas': 1.0.0_debug@4.3.4
-      '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
-      '@types/debug': 4.1.7
-      '@types/double-ended-queue': 2.1.2
-      '@types/lodash': 4.14.194
-      '@types/node': 16.18.40
-      '@types/ws': 6.0.4
-      assert: 2.0.0
-      debug: 4.3.4
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      sillyname: 0.1.0
-      uuid: 8.3.2
-      ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -18322,22 +18216,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/server-services-core/1.0.0:
-    resolution: {integrity: sha512-ieKRzPtE47Q3YTD/VQVp08GI0wzux9N1+PUfKQmwGORS2pSJb11YEp41Uq42injj8Iq9pRgO9li1pBKj26KkeQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
-      '@types/nconf': 0.10.3
-      '@types/node': 16.18.40
-      debug: 4.3.4
-      events: 3.3.0
-      nconf: 0.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   /@fluidframework/server-services-core/1.0.1:
     resolution: {integrity: sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==}
     dependencies:
@@ -18363,7 +18241,7 @@ packages:
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
+      '@fluidframework/server-services-telemetry': 1.0.1
       '@socket.io/redis-adapter': 7.2.0
       body-parser: 1.20.2
       debug: 4.3.4
@@ -18384,15 +18262,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@fluidframework/server-services-telemetry/1.0.0:
-    resolution: {integrity: sha512-sT4KvZSYCoxcf/nEgd6MXgvs5fcWq46x4uHnNcjKmzC51omrw5CjBYKYHyJPhFX0kXSlUIDsZRZBhDuEnSBcww==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      json-stringify-safe: 5.0.1
-      path-browserify: 1.0.1
-      serialize-error: 8.1.0
-      uuid: 8.3.2
-
   /@fluidframework/server-services-telemetry/1.0.1:
     resolution: {integrity: sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==}
     dependencies:
@@ -18408,7 +18277,7 @@ packages:
       '@fluidframework/protocol-definitions': 1.2.0
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
+      '@fluidframework/server-services-telemetry': 1.0.1
       debug: 4.3.4
       express: 4.18.2
       ioredis: 5.3.2
@@ -18422,25 +18291,6 @@ packages:
       uuid: 8.3.2
       winston: 3.8.2
       winston-transport: 4.5.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@fluidframework/server-test-utils/1.0.0:
-    resolution: {integrity: sha512-qS2CiyyOyN0iT+PS2OWwblTUau8Kj9uBRfH4s9Mpfo5ZNvNjOa6IIG5gAo1EvcK5U28Mb1KFLbmOocmynmKgRQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 1.0.1
-      '@fluidframework/protocol-base': 1.0.1
-      '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-core': 1.0.1
-      '@fluidframework/server-services-telemetry': 1.0.0
-      assert: 2.0.0
-      debug: 4.3.4
-      events: 3.3.0
-      lodash: 4.17.21
-      string-hash: 1.1.3
-      uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
 
@@ -24480,16 +24330,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /agentkeepalive/4.3.0:
-    resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      debug: 4.3.4
-      depd: 2.0.0
-      humanize-ms: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
 
   /agentkeepalive/4.5.0:
     resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
@@ -43324,19 +43164,19 @@ packages:
     hasBin: true
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 1.0.0
-      '@fluidframework/protocol-base': 1.0.0
+      '@fluidframework/gitresources': 1.0.1
+      '@fluidframework/protocol-base': 1.0.1
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/server-lambdas': 1.0.0
-      '@fluidframework/server-local-server': 1.0.0
-      '@fluidframework/server-memory-orderer': 1.0.0
+      '@fluidframework/server-lambdas': 1.0.1
+      '@fluidframework/server-local-server': 1.0.1
+      '@fluidframework/server-memory-orderer': 1.0.1
       '@fluidframework/server-services-client': 1.0.1
-      '@fluidframework/server-services-core': 1.0.0
+      '@fluidframework/server-services-core': 1.0.1
       '@fluidframework/server-services-shared': 1.0.0
-      '@fluidframework/server-services-telemetry': 1.0.0
+      '@fluidframework/server-services-telemetry': 1.0.1
       '@fluidframework/server-services-utils': 1.0.0
-      '@fluidframework/server-test-utils': 1.0.0
-      agentkeepalive: 4.3.0
+      '@fluidframework/server-test-utils': 1.0.1
+      agentkeepalive: 4.5.0
       axios: 0.26.1
       body-parser: 1.20.2
       charwise: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,7 @@ importers:
       '@fluid-tools/build-cli': ^0.22.0
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.6.3.0
+      '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.22.0
       '@fluidframework/container-definitions': workspace:~
@@ -104,7 +105,6 @@ importers:
       prettier: ~2.6.2
       rimraf: ^4.4.0
       start-server-and-test: ^1.11.7
-      tinylicious: ^1.0.0
       typescript: ~4.5.5
       uuid: ^9.0.0
     dependencies:
@@ -122,11 +122,11 @@ importers:
       '@fluidframework/server-services-client': 1.0.1
       '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
       axios: 0.26.1
-      tinylicious: 1.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.22.0_@types+node@16.18.38
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.6.3.0
+      '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.22.0_@types+node@16.18.38
       '@fluidframework/counter': link:../../../packages/dds/counter


### PR DESCRIPTION
## Description

This PR has azure e2e tests now use tinylicious instead of azure-local-service. This resolves an ongoing issue where the incorrect version of azure-local-service is being used in pipeline tests, causing them to fail.

[Example run passing with change (MSFT Internal)](https://dev.azure.com/fluidframework/internal/_build/results?buildId=191364&view=logs&j=5f8fe092-e504-55d5-bea6-4c19fb56d81e&t=3132203c-be3b-5f3e-4581-0d62126252e9)

[AB#5516](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5516)