### PR TITLE
tools(api-markdown-documenter): Enable `unicorn/prevent-abbreviations` eslint rule and fix violations

### DIFF
--- a/.changeset/slow-vans-help.md
+++ b/.changeset/slow-vans-help.md
@@ -1,0 +1,9 @@
+---
+"@fluid-tools/api-markdown-documenter": minor
+---
+
+Enable `unicorn/prevent-abbreviations` eslint rule
+
+Enabled rule to enhance developer accessibility. Rule details: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md
+
+Updated code to adhere to new rules. This resulted in a single API breaking change: renaming "transformDocNode" to "transformTsdocNode".

--- a/tools/api-markdown-documenter/.eslintrc.js
+++ b/tools/api-markdown-documenter/.eslintrc.js
@@ -26,8 +26,8 @@ module.exports = {
 			"error",
 			{
 				allowList: {
-					// Name comes from external library
-					DocNode: true,
+					// Industry-standard index variable name.
+					i: true,
 				},
 			},
 		],

--- a/tools/api-markdown-documenter/.eslintrc.js
+++ b/tools/api-markdown-documenter/.eslintrc.js
@@ -21,6 +21,17 @@ module.exports = {
 			},
 		],
 
+		// Useful for developer accessibility
+		"unicorn/prevent-abbreviations": [
+			"error",
+			{
+				allowList: {
+					// Name comes from external library
+					DocNode: true,
+				},
+			},
+		],
+
 		"unicorn/prefer-module": "off",
 		"unicorn/prefer-negative-index": "off",
 		"unicorn/no-array-push-push": "off",

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
@@ -216,7 +216,7 @@ export type DocumentBoundaries = ApiMemberKind[];
 
 // @public
 export class DocumentNode implements Parent<SectionNode>, DocumentNodeProps {
-    constructor(props: DocumentNodeProps);
+    constructor(properties: DocumentNodeProps);
     readonly apiItemName: string;
     readonly children: SectionNode[];
     readonly documentPath: string;
@@ -366,7 +366,7 @@ export interface Logger {
 }
 
 // @public
-export type LoggingFunction = (message: string | Error, ...args: unknown[]) => void;
+export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
 // @public
 export interface MarkdownRenderConfiguration extends ConfigurationBase {
@@ -553,7 +553,7 @@ export type TransformApiItemWithoutChildren<TApiItem extends ApiItem> = (apiItem
 export function transformApiModel(transformConfig: ApiItemTransformationConfiguration): DocumentNode[];
 
 // @public
-export function transformDocNode(docNode: DocNode, contextApiItem: ApiItem, config: Required<ApiItemTransformationConfiguration>): DocumentationNode | undefined;
+export function transformTsdocNode(node: DocNode, contextApiItem: ApiItem, config: Required<ApiItemTransformationConfiguration>): DocumentationNode | undefined;
 
 // @public
 export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {

--- a/tools/api-markdown-documenter/src/LoadModel.ts
+++ b/tools/api-markdown-documenter/src/LoadModel.ts
@@ -81,8 +81,11 @@ export async function loadModel(reportsDirectoryPath: string, logger?: Logger): 
  * @remarks Copied from `@microsoft/api-documenter` as a workaround for an `API-Extractor` limitation tracked by
  * this issue: {@link https://github.com/microsoft/rushstack/issues/2062}.
  */
+// "inheritDoc" is the name of the tag
+// eslint-disable-next-line unicorn/prevent-abbreviations
 function applyInheritDoc(apiItem: ApiItem, apiModel: ApiModel, logger?: Logger): void {
 	if (apiItem instanceof ApiDocumentedItem && apiItem.tsdocComment) {
+		// eslint-disable-next-line unicorn/prevent-abbreviations
 		const inheritDocTag: DocInheritDocTag | undefined = apiItem.tsdocComment.inheritDocTag;
 
 		if (inheritDocTag?.declarationReference !== undefined) {
@@ -103,7 +106,10 @@ function applyInheritDoc(apiItem: ApiItem, apiModel: ApiModel, logger?: Logger):
 				result.resolvedApiItem.tsdocComment &&
 				result.resolvedApiItem !== apiItem
 			) {
-				copyInheritedDocs(apiItem.tsdocComment, result.resolvedApiItem.tsdocComment);
+				copyInheritedDocumentation(
+					apiItem.tsdocComment,
+					result.resolvedApiItem.tsdocComment,
+				);
 			}
 		}
 	}
@@ -122,18 +128,18 @@ function applyInheritDoc(apiItem: ApiItem, apiModel: ApiModel, logger?: Logger):
  * @remarks Copied from `@microsoft/api-documenter` as a workaround for an `API-Extractor` limitation tracked by
  * this issue: {@link https://github.com/microsoft/rushstack/issues/2062}.
  */
-function copyInheritedDocs(targetDocComment: DocComment, sourceDocComment: DocComment): void {
-	targetDocComment.summarySection = sourceDocComment.summarySection;
-	targetDocComment.remarksBlock = sourceDocComment.remarksBlock;
+function copyInheritedDocumentation(targetComment: DocComment, sourceComment: DocComment): void {
+	targetComment.summarySection = sourceComment.summarySection;
+	targetComment.remarksBlock = sourceComment.remarksBlock;
 
-	targetDocComment.params.clear();
-	for (const param of sourceDocComment.params) {
-		targetDocComment.params.add(param);
+	targetComment.params.clear();
+	for (const parameter of sourceComment.params) {
+		targetComment.params.add(parameter);
 	}
-	for (const typeParam of sourceDocComment.typeParams) {
-		targetDocComment.typeParams.add(typeParam);
+	for (const typeParameter of sourceComment.typeParams) {
+		targetComment.typeParams.add(typeParameter);
 	}
-	targetDocComment.returnsBlock = sourceDocComment.returnsBlock;
+	targetComment.returnsBlock = sourceComment.returnsBlock;
 
-	targetDocComment.inheritDocTag = undefined;
+	targetComment.inheritDocTag = undefined;
 }

--- a/tools/api-markdown-documenter/src/Logging.ts
+++ b/tools/api-markdown-documenter/src/Logging.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
  *
  * @public
  */
-export type LoggingFunction = (message: string | Error, ...args: unknown[]) => void;
+export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
 /**
  * A logger for use with the system.
@@ -72,20 +72,20 @@ export const verboseConsoleLogger: Logger = {
 /**
  * Logs a warning message to the console in yellow, prefixed with "WARNING: ".
  */
-function logWarningToConsole(message: string | Error, ...args: unknown[]): void {
-	console.log(`${chalk.yellow(`WARNING`)}: ${message}`, ...args);
+function logWarningToConsole(message: string | Error, ...parameters: unknown[]): void {
+	console.log(`${chalk.yellow(`WARNING`)}: ${message}`, ...parameters);
 }
 
 /**
  * Logs an error message to the console in red, prefixed with "ERROR: ".
  */
-function logErrorToConsole(message: string | Error, ...args: unknown[]): void {
-	console.log(`${chalk.red(`ERROR`)}: ${message}`, ...args);
+function logErrorToConsole(message: string | Error, ...parameters: unknown[]): void {
+	console.log(`${chalk.red(`ERROR`)}: ${message}`, ...parameters);
 }
 
 /**
  * Logs a "success" message to the console in green, prefixed with "SUCCESS: ".
  */
-function logSuccessToConsole(message: string | Error, ...args: unknown[]): void {
-	console.log(`${chalk.green(`SUCCESS`)}: ${message}`, ...args);
+function logSuccessToConsole(message: string | Error, ...parameters: unknown[]): void {
+	console.log(`${chalk.green(`SUCCESS`)}: ${message}`, ...parameters);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -32,7 +32,7 @@ import {
 	SingleLineSpanNode,
 } from "../documentation-domain";
 import { ConfigurationBase } from "../ConfigurationBase";
-import { getDocNodeTransformationOptions } from "./Utilities";
+import { getTsdocNodeTransformationOptions } from "./Utilities";
 import { ApiItemTransformationConfiguration } from "./configuration";
 
 /**
@@ -54,19 +54,19 @@ import { ApiItemTransformationConfiguration } from "./configuration";
  *
  * @public
  */
-export function transformDocNode(
-	docNode: DocNode,
+export function transformTsdocNode(
+	node: DocNode,
 	contextApiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
 ): DocumentationNode | undefined {
-	const transformOptions = getDocNodeTransformationOptions(contextApiItem, config);
-	return _transformDocNode(docNode, transformOptions);
+	const transformOptions = getTsdocNodeTransformationOptions(contextApiItem, config);
+	return _transformTsdocNode(node, transformOptions);
 }
 
 /**
  * Options for {@link @microsoft/tsdoc#DocNode} transformations.
  */
-export interface DocNodeTransformOptions extends ConfigurationBase {
+export interface TsdocNodeTransformOptions extends ConfigurationBase {
 	/**
 	 * The API item with which the documentation node(s) are associated.
 	 */
@@ -94,29 +94,29 @@ export interface DocNodeTransformOptions extends ConfigurationBase {
  * @returns The transformed `DocNode`, if it was of a kind we support.
  * Else, an error will be logged, and `undefined` will be returned.
  */
-export function _transformDocNode(
+export function _transformTsdocNode(
 	node: DocNode,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): DocumentationNode | undefined {
 	switch (node.kind) {
 		case DocNodeKind.CodeSpan:
-			return transformDocCodeSpan(node as DocCodeSpan, options);
+			return transformTsdocCodeSpan(node as DocCodeSpan, options);
 		case DocNodeKind.EscapedText:
-			return transformDocEscapedText(node as DocEscapedText, options);
+			return transformTsdocEscapedText(node as DocEscapedText, options);
 		case DocNodeKind.FencedCode:
-			return transformDocFencedCode(node as DocFencedCode, options);
+			return transformTsdocFencedCode(node as DocFencedCode, options);
 		case DocNodeKind.HtmlStartTag:
-			return transformDocHtmlTag(node as DocHtmlStartTag, options);
+			return transformTsdocHtmlTag(node as DocHtmlStartTag, options);
 		case DocNodeKind.HtmlEndTag:
-			return transformDocHtmlTag(node as DocHtmlEndTag, options);
+			return transformTsdocHtmlTag(node as DocHtmlEndTag, options);
 		case DocNodeKind.LinkTag:
-			return transformDocLinkTag(node as DocLinkTag, options);
+			return transformTsdocLinkTag(node as DocLinkTag, options);
 		case DocNodeKind.Paragraph:
-			return transformDocParagraph(node as DocParagraph, options);
+			return transformTsdocParagraph(node as DocParagraph, options);
 		case DocNodeKind.PlainText:
-			return transformDocPlainText(node as DocPlainText, options);
+			return transformTsdocPlainText(node as DocPlainText, options);
 		case DocNodeKind.Section:
-			return transformDocSection(node as DocSection, options);
+			return transformTsdocSection(node as DocSection, options);
 		case DocNodeKind.SoftBreak:
 			return LineBreakNode.Singleton;
 		default:
@@ -128,9 +128,9 @@ export function _transformDocNode(
 /**
  * Converts a {@link @microsoft/tsdoc#DocCodeSpan} to a {@link CodeSpanNode}.
  */
-export function transformDocCodeSpan(
+export function transformTsdocCodeSpan(
 	node: DocCodeSpan,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): CodeSpanNode {
 	return CodeSpanNode.createFromPlainText(node.code.trim());
 }
@@ -138,9 +138,9 @@ export function transformDocCodeSpan(
 /**
  * Converts a {@link @microsoft/tsdoc#DocParagraph} to a {@link ParagraphNode}.
  */
-export function transformDocParagraph(
+export function transformTsdocParagraph(
 	node: DocParagraph,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): ParagraphNode {
 	return createParagraph(node.nodes, options);
 }
@@ -155,9 +155,9 @@ export function transformDocParagraph(
  * For that reason, their "section" concept gets mapped to a paragraph, rather than a section.
  * Consumers can wrap this in a section node as desired based on context.
  */
-export function transformDocSection(
+export function transformTsdocSection(
 	node: DocSection,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): ParagraphNode {
 	return createParagraph(node.nodes, options);
 }
@@ -165,9 +165,9 @@ export function transformDocSection(
 /**
  * Converts a {@link @microsoft/tsdoc#DocPlainText} to a {@link PlainTextNode}.
  */
-export function transformDocPlainText(
+export function transformTsdocPlainText(
 	node: DocPlainText,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): PlainTextNode {
 	return new PlainTextNode(node.text);
 }
@@ -175,9 +175,9 @@ export function transformDocPlainText(
 /**
  * Converts a {@link @microsoft/tsdoc#DocEscapedText} to a {@link PlainTextNode}.
  */
-export function transformDocEscapedText(
+export function transformTsdocEscapedText(
 	node: DocEscapedText,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): PlainTextNode {
 	return new PlainTextNode(node.encodedText, /* escaped: */ true);
 }
@@ -185,9 +185,9 @@ export function transformDocEscapedText(
 /**
  * Converts a {@link @microsoft/tsdoc#DocHtmlStartTag} | {@link @microsoft/tsdoc#DocHtmlEndTag} to a {@link PlainTextNode}.
  */
-export function transformDocHtmlTag(
+export function transformTsdocHtmlTag(
 	node: DocHtmlStartTag | DocHtmlEndTag,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): PlainTextNode {
 	return new PlainTextNode(node.emitAsHtml(), /* escaped: */ true);
 }
@@ -195,9 +195,9 @@ export function transformDocHtmlTag(
 /**
  * Converts a {@link @microsoft/tsdoc#DocPlainText} to a {@link PlainTextNode}.
  */
-export function transformDocFencedCode(
+export function transformTsdocFencedCode(
 	node: DocFencedCode,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): FencedCodeBlockNode {
 	return FencedCodeBlockNode.createFromPlainText(node.code.trim(), node.language);
 }
@@ -205,9 +205,9 @@ export function transformDocFencedCode(
 /**
  * Converts a {@link @microsoft/tsdoc#DocPlainText} to a {@link PlainTextNode}.
  */
-export function transformDocLinkTag(
+export function transformTsdocLinkTag(
 	input: DocLinkTag,
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): SingleLineDocumentationNode {
 	if (input.codeDestination !== undefined) {
 		const link = options.resolveApiReference(input.codeDestination);
@@ -251,7 +251,7 @@ export function transformDocLinkTag(
  */
 function createParagraph(
 	children: readonly DocNode[],
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): ParagraphNode {
 	// Note: transformChildren does some of its own cleanup on the initial transformed contents
 	let transformedChildren = transformChildren(children, options);
@@ -300,10 +300,10 @@ function createParagraph(
  */
 function transformChildren(
 	children: readonly DocNode[],
-	options: DocNodeTransformOptions,
+	options: TsdocNodeTransformOptions,
 ): DocumentationNode[] {
 	// Transform child items into Documentation domain
-	const transformedChildren = children.map((child) => _transformDocNode(child, options));
+	const transformedChildren = children.map((child) => _transformTsdocNode(child, options));
 
 	// Filter out `undefined` values resulting from transformation errors.
 	let filteredChildren = transformedChildren.filter(

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -8,7 +8,7 @@ import { DocDeclarationReference } from "@microsoft/tsdoc";
 import { Link } from "../Link";
 import { DocumentNode, SectionNode } from "../documentation-domain";
 import { getDocumentPathForApiItem, getLinkForApiItem } from "./ApiItemUtilities";
-import { DocNodeTransformOptions } from "./DocNodeTransforms";
+import { TsdocNodeTransformOptions } from "./TsdocNodeTransforms";
 import { ApiItemTransformationConfiguration } from "./configuration";
 import { wrapInSection } from "./helpers";
 
@@ -52,15 +52,15 @@ export function createDocument(
 }
 
 /**
- * Create {@link DocNodeTransformOptions} for the provided context API item and the system config.
+ * Create {@link TsdocNodeTransformOptions} for the provided context API item and the system config.
  *
- * @param contextApiItem - See {@link DocNodeTransformOptions.contextApiItem}.
+ * @param contextApiItem - See {@link TsdocNodeTransformOptions.contextApiItem}.
  * @param config - See {@link ApiItemTransformationConfiguration}.
  */
-export function getDocNodeTransformationOptions(
+export function getTsdocNodeTransformationOptions(
 	contextApiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
-): DocNodeTransformOptions {
+): TsdocNodeTransformOptions {
 	return {
 		contextApiItem,
 		resolveApiReference: (codeDestination): Link | undefined =>
@@ -72,7 +72,7 @@ export function getDocNodeTransformationOptions(
 /**
  * Resolves a symbolic link and creates a URL to the target.
  *
- * @param contextApiItem - See {@link DocNodeTransformOptions.contextApiItem}.
+ * @param contextApiItem - See {@link TsdocNodeTransformOptions.contextApiItem}.
  * @param codeDestination - The link reference target.
  * @param config - See {@link ApiItemTransformationConfiguration}.
  */

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -38,8 +38,8 @@ import {
 	getReleaseTag,
 	isDeprecated,
 } from "../ApiItemUtilities";
-import { transformDocSection } from "../DocNodeTransforms";
-import { getDocNodeTransformationOptions } from "../Utilities";
+import { transformTsdocSection } from "../TsdocNodeTransforms";
+import { getTsdocNodeTransformationOptions } from "../Utilities";
 import { ApiItemTransformationConfiguration } from "../configuration";
 import { createExcerptSpanWithHyperlinks } from "./Helpers";
 
@@ -533,11 +533,11 @@ export function createApiSummaryCell(
 	config: Required<ApiItemTransformationConfiguration>,
 ): TableBodyCellNode {
 	if (apiItem instanceof ApiDocumentedItem) {
-		const docNodeTransformOptions = getDocNodeTransformationOptions(apiItem, config);
+		const tsdocNodeTransformOptions = getTsdocNodeTransformationOptions(apiItem, config);
 		if (apiItem.tsdocComment !== undefined) {
-			const summaryComment = transformDocSection(
+			const summaryComment = transformTsdocSection(
 				apiItem.tsdocComment.summarySection,
-				docNodeTransformOptions,
+				tsdocNodeTransformOptions,
 			);
 			return new TableBodyCellNode(summaryComment.children);
 		}
@@ -617,7 +617,7 @@ export function createDefaultValueCell(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
 ): TableBodyCellNode {
-	const docNodeTransformOptions = getDocNodeTransformationOptions(apiItem, config);
+	const tsdocNodeTransformOptions = getTsdocNodeTransformationOptions(apiItem, config);
 
 	const defaultValueSection = getDefaultValueBlock(apiItem, config);
 
@@ -625,7 +625,7 @@ export function createDefaultValueCell(
 		return TableBodyCellNode.Empty;
 	}
 
-	const contents = transformDocSection(defaultValueSection, docNodeTransformOptions);
+	const contents = transformTsdocSection(defaultValueSection, tsdocNodeTransformOptions);
 
 	// Since we are sticking the contents into a table cell, we can remove the outer Paragraph node
 	// from the hierarchy to simplify things.
@@ -722,11 +722,11 @@ export function createParameterSummaryCell(
 		return TableBodyCellNode.Empty;
 	}
 
-	const docNodeTransformOptions = getDocNodeTransformationOptions(contextApiItem, config);
+	const tsdocNodeTransformOptions = getTsdocNodeTransformationOptions(contextApiItem, config);
 
-	const cellContent = transformDocSection(
+	const cellContent = transformTsdocSection(
 		apiParameter.tsdocParamBlock.content,
-		docNodeTransformOptions,
+		tsdocNodeTransformOptions,
 	);
 
 	// Since we are putting the contents into a table cell anyways, omit the Paragraph
@@ -752,11 +752,11 @@ export function createTypeParameterSummaryCell(
 		return TableBodyCellNode.Empty;
 	}
 
-	const docNodeTransformOptions = getDocNodeTransformationOptions(contextApiItem, config);
+	const tsdocNodeTransformOptions = getTsdocNodeTransformationOptions(contextApiItem, config);
 
-	const cellContent = transformDocSection(
+	const cellContent = transformTsdocSection(
 		apiTypeParameter.tsdocTypeParamBlock.content,
-		docNodeTransformOptions,
+		tsdocNodeTransformOptions,
 	);
 
 	// Since we are putting the contents into a table cell anyways, omit the Paragraph

--- a/tools/api-markdown-documenter/src/api-item-transforms/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/index.ts
@@ -42,6 +42,6 @@ export {
 	type TransformApiItemWithChildren,
 	type TransformApiItemWithoutChildren,
 } from "./configuration";
-export { transformDocNode } from "./DocNodeTransforms";
+export { transformTsdocNode } from "./TsdocNodeTransforms";
 export { apiItemToDocument, apiItemToSections } from "./TransformApiItem";
 export { transformApiModel } from "./TransformApiModel";

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -49,7 +49,7 @@ const defaultPartialConfig: Omit<ApiItemTransformationConfiguration, "apiModel">
 };
 
 // Relative to dist/api-item-transforms/test
-const testDataDirPath = Path.resolve(
+const testDataDirectoryPath = Path.resolve(
 	__dirname,
 	"..",
 	"..",
@@ -64,7 +64,7 @@ const testDataDirPath = Path.resolve(
  * Generates an `ApiModel` from the API report file at the provided path.
  */
 function generateModel(testReportFileName: string): ApiModel {
-	const filePath = Path.resolve(testDataDirPath, testReportFileName);
+	const filePath = Path.resolve(testDataDirectoryPath, testReportFileName);
 
 	const apiModel = new ApiModel();
 	apiModel.loadPackage(filePath);
@@ -375,7 +375,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		// The model-level doc in this case isn't particularly interesting, so we will skip evaluating it.
 
-		const expectedPackageDoc = new DocumentNode({
+		const expectedPackageDocument = new DocumentNode({
 			apiItemName: "test-package",
 			documentPath: "test-package",
 			children: [
@@ -411,9 +411,9 @@ describe("ApiItem to Documentation transformation tests", () => {
 				),
 			],
 		});
-		expect(documents[1]).to.deep.equal(expectedPackageDoc);
+		expect(documents[1]).to.deep.equal(expectedPackageDocument);
 
-		const expectedEntryPointADoc = new DocumentNode({
+		const expectedEntryPointADocument = new DocumentNode({
 			apiItemName: "entry-point-a",
 			documentPath: "test-package/entry-point-a-entrypoint",
 			children: [
@@ -495,9 +495,9 @@ describe("ApiItem to Documentation transformation tests", () => {
 				),
 			],
 		});
-		expect(documents[2]).to.deep.equal(expectedEntryPointADoc);
+		expect(documents[2]).to.deep.equal(expectedEntryPointADocument);
 
-		const expectedEntryPointBDoc = new DocumentNode({
+		const expectedEntryPointBDocument = new DocumentNode({
 			apiItemName: "entry-point-b",
 			documentPath: "test-package/entry-point-b-entrypoint",
 			children: [
@@ -575,6 +575,6 @@ describe("ApiItem to Documentation transformation tests", () => {
 				),
 			],
 		});
-		expect(documents[3]).to.deep.equal(expectedEntryPointBDoc);
+		expect(documents[3]).to.deep.equal(expectedEntryPointBDocument);
 	});
 });

--- a/tools/api-markdown-documenter/src/documentation-domain/DocumentNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/DocumentNode.ts
@@ -12,7 +12,7 @@ import { SectionNode } from "./SectionNode";
  *
  * @public
  */
-export interface DocumentNodeProps {
+export interface DocumentNodeProperties {
 	/**
 	 * Name of the API item from which this document node was generated.
 	 */
@@ -48,7 +48,7 @@ export interface DocumentNodeProps {
  *
  * @public
  */
-export class DocumentNode implements UnistParent<SectionNode>, DocumentNodeProps {
+export class DocumentNode implements UnistParent<SectionNode>, DocumentNodeProperties {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
@@ -74,10 +74,10 @@ export class DocumentNode implements UnistParent<SectionNode>, DocumentNodeProps
 	 */
 	public readonly frontMatter?: string;
 
-	public constructor(props: DocumentNodeProps) {
-		this.apiItemName = props.apiItemName;
-		this.children = props.children;
-		this.documentPath = props.documentPath;
-		this.frontMatter = props.frontMatter;
+	public constructor(properties: DocumentNodeProperties) {
+		this.apiItemName = properties.apiItemName;
+		this.children = properties.children;
+		this.documentPath = properties.documentPath;
+		this.frontMatter = properties.frontMatter;
 	}
 }

--- a/tools/api-markdown-documenter/src/documentation-domain/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/index.ts
@@ -16,7 +16,7 @@
 
 export { BlockQuoteNode } from "./BlockQuoteNode";
 export { CodeSpanNode } from "./CodeSpanNode";
-export { DocumentNode, DocumentNodeProps } from "./DocumentNode";
+export { DocumentNode, DocumentNodeProperties as DocumentNodeProps } from "./DocumentNode";
 export {
 	DocumentationNode,
 	DocumentationLiteralNode,

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -47,7 +47,7 @@ export {
 	type TransformApiItemWithChildren,
 	type TransformApiItemWithoutChildren,
 	transformApiModel,
-	transformDocNode,
+	transformTsdocNode,
 } from "./api-item-transforms";
 
 // We want to make sure the entirety of this domain is accessible.

--- a/tools/api-markdown-documenter/src/markdown-renderer/default-renderers/RenderTableRow.ts
+++ b/tools/api-markdown-documenter/src/markdown-renderer/default-renderers/RenderTableRow.ts
@@ -35,13 +35,13 @@ function renderTableRowWithMarkdownSyntax(
 ): void {
 	writer.ensureNewLine(); // Ensure line break before new row
 	writer.write("| ");
-	for (let i = 0; i < node.children.length; i++) {
-		const child = node.children[i];
+	for (let childIndex = 0; childIndex < node.children.length; childIndex++) {
+		const child = node.children[childIndex];
 		renderNode(child, writer, {
 			...context,
 			insideTable: true,
 		});
-		writer.write(i === node.children.length - 1 ? " |" : " | ");
+		writer.write(childIndex === node.children.length - 1 ? " |" : " | ");
 	}
 	writer.ensureNewLine(); // Ensure line break after row
 }

--- a/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
@@ -18,17 +18,17 @@ import { type MarkdownRenderConfiguration } from "../markdown-renderer";
 /**
  * Temp directory under which all tests that generate files will output their contents.
  */
-const testTempDirPath = Path.resolve(__dirname, "test_temp");
+const testTemporaryDirectoryPath = Path.resolve(__dirname, "test_temp");
 
 /**
  * Snapshot directory to which generated test data will be copied.
  * Relative to dist/test
  */
-const snapshotsDirPath = Path.resolve(__dirname, "..", "..", "src", "test", "snapshots");
+const snapshotsDirectoryPath = Path.resolve(__dirname, "..", "..", "src", "test", "snapshots");
 
 // Relative to dist/test
-const testDataDirPath = Path.resolve(__dirname, "..", "..", "src", "test", "test-data");
-const testModelPaths = [Path.resolve(testDataDirPath, "simple-suite-test.json")];
+const testDataDirectoryPath = Path.resolve(__dirname, "..", "..", "src", "test", "test-data");
+const testModelFilePaths = [Path.resolve(testDataDirectoryPath, "simple-suite-test.json")];
 
 /**
  * Simple integration test that validates complete output from simple test package.
@@ -42,8 +42,14 @@ async function snapshotTest(
 	transformConfig: ApiItemTransformationConfiguration,
 	renderConfig: MarkdownRenderConfiguration,
 ): Promise<void> {
-	const outputDirectoryPath = Path.resolve(testTempDirPath, relativeSnapshotDirectoryPath);
-	const snapshotDirectoryPath = Path.resolve(snapshotsDirPath, relativeSnapshotDirectoryPath);
+	const outputDirectoryPath = Path.resolve(
+		testTemporaryDirectoryPath,
+		relativeSnapshotDirectoryPath,
+	);
+	const snapshotDirectoryPath = Path.resolve(
+		snapshotsDirectoryPath,
+		relativeSnapshotDirectoryPath,
+	);
 
 	// Ensure the output temp and snapshots directories exists (will create an empty ones if they don't).
 	await FileSystem.ensureFolderAsync(outputDirectoryPath);
@@ -80,7 +86,7 @@ async function snapshotTest(
 /**
  * Input props for {@link apiTestSuite}.
  */
-interface ConfigTestProps {
+interface ConfigurationTestProperties {
 	/**
 	 * Name of the config to be used in naming of the test-suite
 	 */
@@ -107,16 +113,16 @@ interface ConfigTestProps {
  *
  * @param modelName - Name of the model for which the docs are being generated.
  * @param apiReportFilePaths - List of paths to package API report files to be loaded into the model.
- * @param configs - Configurations to test against.
+ * @param configurations - Configurations to test against.
  */
 function apiTestSuite(
 	modelName: string,
 	apiReportFilePaths: string[],
-	configs: ConfigTestProps[],
+	configurations: ConfigurationTestProperties[],
 ): Suite {
 	return describe(modelName, () => {
-		for (const configProps of configs) {
-			describe(configProps.configName, () => {
+		for (const configurationProperties of configurations) {
+			describe(configurationProperties.configName, () => {
 				/**
 				 * Complete transform config used in tests. Generated in `before` hook.
 				 */
@@ -134,11 +140,11 @@ function apiTestSuite(
 					}
 
 					transformConfig = {
-						...configProps.transformConfigLessApiModel,
+						...configurationProperties.transformConfigLessApiModel,
 						apiModel,
 					};
 
-					renderConfig = configProps.renderConfig;
+					renderConfig = configurationProperties.renderConfig;
 				});
 
 				it("Ensure no duplicate file paths", () => {
@@ -158,7 +164,7 @@ function apiTestSuite(
 
 				it("Snapshot test", async () => {
 					await snapshotTest(
-						Path.join(modelName, configProps.configName),
+						Path.join(modelName, configurationProperties.configName),
 						transformConfig,
 						renderConfig,
 					);
@@ -169,7 +175,7 @@ function apiTestSuite(
 }
 
 describe("api-markdown-documenter full-suite tests", () => {
-	const configs: ConfigTestProps[] = [
+	const configs: ConfigurationTestProperties[] = [
 		/**
 		 * Sample "default" configuration.
 		 */
@@ -237,13 +243,13 @@ describe("api-markdown-documenter full-suite tests", () => {
 
 	before(async () => {
 		// Ensure the output temp and snapshots directories exists (will create an empty ones if they don't).
-		await FileSystem.ensureFolderAsync(testTempDirPath);
-		await FileSystem.ensureFolderAsync(snapshotsDirPath);
+		await FileSystem.ensureFolderAsync(testTemporaryDirectoryPath);
+		await FileSystem.ensureFolderAsync(snapshotsDirectoryPath);
 
 		// Clear test temp dir before test run to make sure we are running from a clean state.
-		await FileSystem.ensureEmptyFolderAsync(testTempDirPath);
+		await FileSystem.ensureEmptyFolderAsync(testTemporaryDirectoryPath);
 	});
 
 	// Run the test suite against a sample report
-	apiTestSuite("simple-suite-test", testModelPaths, configs);
+	apiTestSuite("simple-suite-test", testModelFilePaths, configs);
 });


### PR DESCRIPTION
Sort of a proof of concept for #17329. Enables the rule and fixes violations.

Rule details: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md

### Breaking Change

Renames `transformDocNode` to `transformTsdocNode`.
