### PR TITLE
Bump default GC version in code to 3

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -6,7 +6,7 @@
 import { MonitoringContext, UsageError } from "@fluidframework/telemetry-utils";
 import { IContainerRuntimeMetadata } from "../summary";
 import {
-	currentGCVersion,
+	nextGCVersion,
 	defaultInactiveTimeoutMs,
 	defaultSessionExpiryDurationMs,
 	disableTombstoneKey,
@@ -15,7 +15,7 @@ import {
 	gcTestModeKey,
 	gcTombstoneGenerationOptionName,
 	GCVersion,
-	gcVersionUpgradeToV3Key,
+	gcVersionUpgradeToV4Key,
 	IGarbageCollectorConfigs,
 	IGCRuntimeOptions,
 	maxSnapshotCacheExpiryMs,
@@ -107,7 +107,7 @@ export function generateGCConfigs(
 
 	// If version upgrade is not enabled, fall back to the stable GC version.
 	const gcVersionInEffect =
-		mc.config.getBoolean(gcVersionUpgradeToV3Key) === true ? currentGCVersion : stableGCVersion;
+		mc.config.getBoolean(gcVersionUpgradeToV4Key) === true ? nextGCVersion : stableGCVersion;
 
 	// The GC version is up-to-date if the GC version in effect is at least equal to the GC version in base snapshot.
 	// If it is not up-to-date, there is a newer version of GC out there which is more reliable than this. So, GC

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -22,10 +22,10 @@ import {
 
 export type GCVersion = number;
 
-/** The stable version of garbage collection in production. */
-export const stableGCVersion: GCVersion = 2;
-/** The current version of garbage collection. */
-export const currentGCVersion: GCVersion = 3;
+/** The stable/default version of GC Data */
+export const stableGCVersion: GCVersion = 3;
+/** The next version of GC Data, to bump to in case we need to regenerate all GC Data across all files. */
+export const nextGCVersion: GCVersion = 4;
 
 /**
  * This undocumented GC Option (on ContainerRuntime Options) allows an app to disable enforcing GC on old documents by incrementing this value
@@ -60,7 +60,7 @@ export const throwOnTombstoneLoadKey = "Fluid.GarbageCollection.ThrowOnTombstone
 /** Config key to enable throwing an error when tombstone object is used (e.g. outgoing or incoming ops). */
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 /** Config key to enable GC version upgrade. */
-export const gcVersionUpgradeToV3Key = "Fluid.GarbageCollection.GCVersionUpgradeToV3";
+export const gcVersionUpgradeToV4Key = "Fluid.GarbageCollection.GCVersionUpgradeToV4";
 /** Config key to disable GC sweep for datastores. */
 export const disableDatastoreSweepKey = "Fluid.GarbageCollection.DisableDataStoreSweep";
 /** Config key to disable GC sweep for attachment blobs. */

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -5,7 +5,7 @@
 
 export { GarbageCollector } from "./garbageCollection";
 export {
-	nextGCVersion as currentGCVersion,
+	nextGCVersion,
 	defaultInactiveTimeoutMs,
 	defaultSessionExpiryDurationMs,
 	disableSweepLogKey,

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -5,7 +5,7 @@
 
 export { GarbageCollector } from "./garbageCollection";
 export {
-	currentGCVersion,
+	nextGCVersion as currentGCVersion,
 	defaultInactiveTimeoutMs,
 	defaultSessionExpiryDurationMs,
 	disableSweepLogKey,
@@ -15,7 +15,7 @@ export {
 	gcSweepGenerationOptionName,
 	GCFeatureMatrix,
 	GCVersion,
-	gcVersionUpgradeToV3Key,
+	gcVersionUpgradeToV4Key,
 	IGarbageCollectionRuntime,
 	IGarbageCollector,
 	IGarbageCollectorConfigs,

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -707,7 +707,7 @@ describe("Garbage Collection configurations", () => {
 			});
 
 			it("shouldRunGC should be false when gcVersionInEffect is older than gcVersionInBaseSnapshot", () => {
-				const gcVersionInBaseSnapshot = currentGCVersion + 1;
+				const gcVersionInBaseSnapshot = nextGCVersion + 1;
 				gc = createGcWithPrivateMembers({ gcFeature: gcVersionInBaseSnapshot });
 				assert.equal(gc.configs.gcEnabled, true, "PRECONDITION: gcEnabled set incorrectly");
 				assert.equal(gc.configs.shouldRunGC, false, "shouldRunGC should be false");

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -36,9 +36,9 @@ import {
 	runSweepKey,
 	defaultInactiveTimeoutMs,
 	gcTestModeKey,
-	currentGCVersion,
+	nextGCVersion,
 	stableGCVersion,
-	gcVersionUpgradeToV3Key,
+	gcVersionUpgradeToV4Key,
 	gcTombstoneGenerationOptionName,
 	gcSweepGenerationOptionName,
 	GCVersion,
@@ -257,8 +257,8 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than loaded from",
 			);
 		});
-		it("Metadata Roundtrip with GC version upgrade to v3 enabled", () => {
-			injectedSettings[gcVersionUpgradeToV3Key] = true;
+		it("Metadata Roundtrip with GC version upgrade to v4 enabled", () => {
+			injectedSettings[gcVersionUpgradeToV4Key] = true;
 			const inputMetadata: IGCMetadata = {
 				sweepEnabled: true, // ignored
 				gcFeature: 1,
@@ -271,7 +271,7 @@ describe("Garbage Collection configurations", () => {
 			const expectedOutputMetadata: IGCMetadata = {
 				...inputMetadata,
 				sweepEnabled: false, // Hardcoded, not used
-				gcFeature: currentGCVersion,
+				gcFeature: nextGCVersion,
 			};
 			assert.deepEqual(
 				outputMetadata,
@@ -279,8 +279,8 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than loaded from",
 			);
 		});
-		it("Metadata Roundtrip with GC version upgrade to v3 disabled", () => {
-			injectedSettings[gcVersionUpgradeToV3Key] = false;
+		it("Metadata Roundtrip with GC version upgrade to v4 disabled", () => {
+			injectedSettings[gcVersionUpgradeToV4Key] = false;
 			const inputMetadata: IGCMetadata = {
 				sweepEnabled: true, // ignored
 				gcFeature: 1,
@@ -425,11 +425,11 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than expected",
 			);
 		});
-		it("Metadata Roundtrip with GC version upgrade to v3 enabled", () => {
-			injectedSettings[gcVersionUpgradeToV3Key] = true;
+		it("Metadata Roundtrip with GC version upgrade to v4 enabled", () => {
+			injectedSettings[gcVersionUpgradeToV4Key] = true;
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
-				gcFeature: currentGCVersion,
+				gcFeature: nextGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
 				gcFeatureMatrix: undefined,

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { SummaryType } from "@fluidframework/protocol-definitions";
 import { gcDeletedBlobKey, gcTombstoneBlobKey } from "@fluidframework/runtime-definitions";
 import {
-	currentGCVersion,
+	nextGCVersion,
 	gcStateBlobKey,
 	GCSummaryStateTracker,
 	GCVersion,
@@ -191,8 +191,8 @@ describe("GCSummaryStateTracker tests", () => {
 				{
 					shouldRunGC: true,
 					tombstoneMode: true,
-					gcVersionInBaseSnapshot: currentGCVersion,
-					gcVersionInEffect: currentGCVersion,
+					gcVersionInBaseSnapshot: nextGCVersion,
+					gcVersionInEffect: nextGCVersion,
 				},
 				false /* wasGCRunInBaseSnapshot */,
 			);
@@ -319,8 +319,8 @@ describe("GCSummaryStateTracker tests", () => {
 			{
 				shouldRunGC: true,
 				tombstoneMode: true,
-				gcVersionInBaseSnapshot: currentGCVersion,
-				gcVersionInEffect: currentGCVersion,
+				gcVersionInBaseSnapshot: nextGCVersion,
+				gcVersionInEffect: nextGCVersion,
 			},
 			false /* wasGCRunInBaseSnapshot */,
 		);

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -168,9 +168,8 @@ export async function loadContainer(
 	const configProvider: IConfigProviderBase = {
 		getRawConfig: (name: string): ConfigTypes => settings[name],
 	};
-	// Enable GCVersionUpgradeToV3 feature. This is for the snapshot tests which are already using GC version 3
-	// but the default version was changed to 2. Once the default is 3, this will be removed.
-	settings["Fluid.GarbageCollection.GCVersionUpgradeToV3"] = true;
+	// This is to align with the snapshot tests which may upgrade GC Version before the default is changed.
+	settings["Fluid.GarbageCollection.GCVersionUpgradeToV4"] = false;
 
 	// Load the Fluid document while forcing summarizeProtocolTree option
 	const loader = new Loader({


### PR DESCRIPTION
## Description

The old version was 2, with an override for 3 available, and utilized by some internal early-adopters of GC to regenerate the GC Data, after some Summarizer fixes were made that were found to be corrupting the GC data.

Now 3 should be the default value, and if/when additional bugs are found that require regenerating the GC data for existing containers, we can bump the version to 4.

Fixes [AB#5439](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5439)