### PR TITLE
refactor(server): Cleanup rabbitmq references and deprecate rabbitmq-related code

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -134,8 +134,6 @@ services:
     image: "redis:alpine"
   mongodb:
     image: "mongo:3.4.3"
-  rabbitmq:
-    image: "rabbitmq:alpine"
 volumes:
   git:
     driver: local

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -161,9 +161,6 @@ services:
   mongodb:
     platform: linux/arm64/v8
     image: "mongo:4"
-  rabbitmq:
-    platform: linux/arm64
-    image: "rabbitmq:alpine"
 volumes:
   git:
     driver: local

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -97,8 +97,6 @@ services:
     image: "redis:alpine"
   mongodb:
     image: "mongo:4"
-  rabbitmq:
-    image: "rabbitmq:alpine"
 volumes:
   git:
     driver: local

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -122,8 +122,6 @@ services:
     image: "redis:alpine"
   mongodb:
     image: "mongo:4"
-  rabbitmq:
-    image: "rabbitmq:alpine"
 volumes:
   git:
     driver: local

--- a/server/routerlicious/kubernetes/README.md
+++ b/server/routerlicious/kubernetes/README.md
@@ -46,14 +46,15 @@ kubectl apply -f system/azure-unmanaged-premium.yaml
 
 #### Other base components
 
-You'll also need to have a Redis, MongoDB, Rabbitmq, and Historian instances running.
+You'll also need to have a Redis, MongoDB, and Historian instances running.
 
-We install MongoDB and Rabbitmq from the helm stable repository. We also configure MongoDB to use the managed-premium storage class in AKS.
+We install MongoDB from the helm stable repository.
+We also configure it to use the managed-premium storage class in AKS.
 
-In the following commands you can omit the optional key+value pairs to use the defaults defined in the Helm Chart. Also, replace the `<helm-release-name>` with the appropriate value.
+In the following commands you can omit the optional key+value pairs to use the defaults defined in the Helm Chart.
+Also, replace the `<helm-release-name>` with the appropriate value.
 
 `helm install --set persistence.storageClass=managed-premium,persistence.size=4094Gi,usePassword=false,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> <helm-release-name> bitnami/mongodb`
-`helm install --set rbac.create=false,auth.username=prague,auth.password=[password],persistence.enabled=true,persistence.size=16Gi,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> <helm-release-name> bitnami/rabbitmq`
 
 Redis, Kafka and Historian come from the `/server/charts` directory. You'll want to install each of them.
 
@@ -110,11 +111,9 @@ care of by Azure Kubernetes Service.
 -   Mongo - quoting-armadillo
 -   Redis - lumpy-condor
 -   Historian - terrific-otter
--   Rabbitmq - modest-poodle
 
 #### Prod
 
 -   Mongo - quieting-guppy
 -   Redis - winsome-wombat
 -   Historian - smelly-wolf
--   Rabbitmq - lumpy-worm

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -205,9 +205,6 @@ data:
             "checkpointTimeIntervalMsec": 1000,
             "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }}
         },
-        "rabbitmq": {
-            "connectionString": "{{ .Values.rabbitmq.connectionString }}"
-        },
         "riddler": {
             "port": 5000
         },

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -130,9 +130,6 @@ mongodb:
   permanentDeletionEnabled: false
   deletionIntervalMs: 3600000
 
-rabbitmq:
-  connectionString: ""
-
 redis:
   url: redis_url
   port: 6379

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -219,9 +219,6 @@
 		"checkpointBatchSize": 1,
 		"checkpointTimeIntervalMsec": 1000
 	},
-	"rabbitmq": {
-		"connectionString": "amqp://rabbitmq"
-	},
 	"redis": {
 		"host": "redis",
 		"port": 6379,

--- a/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
+++ b/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
@@ -1361,25 +1361,6 @@
 #   location = "/var/lib/puppet/state/last_run_summary.yaml"
 
 
-# # Read metrics from one or many RabbitMQ servers via the management API
-# [[inputs.rabbitmq]]
-#   # url = "http://localhost:15672"
-#   # name = "rmq-server-1" # optional tag
-#   # username = "guest"
-#   # password = "guest"
-#
-#   ## Optional SSL Config
-#   # ssl_ca = "/etc/telegraf/ca.pem"
-#   # ssl_cert = "/etc/telegraf/cert.pem"
-#   # ssl_key = "/etc/telegraf/key.pem"
-#   ## Use SSL but skip chain & host verification
-#   # insecure_skip_verify = false
-#
-#   ## A list of nodes to pull metrics about. If not specified, metrics for
-#   ## all nodes are gathered.
-#   # nodes = ["rabbit@node1", "rabbit@node2"]
-
-
 # # Read raindrops stats (raindrops - real-time stats for preforking Rack servers)
 # [[inputs.raindrops]]
 #   ## An array of raindrops middleware URI to gather stats.

--- a/server/routerlicious/packages/services-core/src/emptyTaskMessageSender.ts
+++ b/server/routerlicious/packages/services-core/src/emptyTaskMessageSender.ts
@@ -5,6 +5,10 @@
 
 import { ITaskMessage, ITaskMessageSender } from "./taskMessages";
 
+/**
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
+ */
 export class EmptyTaskMessageSender implements ITaskMessageSender {
 	public async initialize(): Promise<void> {
 		return;

--- a/server/routerlicious/packages/services-core/src/emptyTaskMessageSender.ts
+++ b/server/routerlicious/packages/services-core/src/emptyTaskMessageSender.ts
@@ -6,7 +6,7 @@
 import { ITaskMessage, ITaskMessageSender } from "./taskMessages";
 
 /**
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 export class EmptyTaskMessageSender implements ITaskMessageSender {

--- a/server/routerlicious/packages/services-core/src/taskMessages.ts
+++ b/server/routerlicious/packages/services-core/src/taskMessages.ts
@@ -6,7 +6,7 @@
 /**
  * Message for the task.
  *
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 export interface ITaskMessage {
@@ -47,7 +47,7 @@ export interface IAgentUploader {
 /**
  * Interface to implement the task sender.
  *
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 export interface ITaskMessageSender {
@@ -75,7 +75,7 @@ export interface ITaskMessageSender {
 /**
  * Interface to implement the task receiver.
  *
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 export interface ITaskMessageReceiver {

--- a/server/routerlicious/packages/services-core/src/taskMessages.ts
+++ b/server/routerlicious/packages/services-core/src/taskMessages.ts
@@ -5,6 +5,9 @@
 
 /**
  * Message for the task.
+ *
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
  */
 export interface ITaskMessage {
 	type: string;
@@ -43,6 +46,9 @@ export interface IAgentUploader {
 
 /**
  * Interface to implement the task sender.
+ *
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
  */
 export interface ITaskMessageSender {
 	/**
@@ -68,6 +74,9 @@ export interface ITaskMessageSender {
 
 /**
  * Interface to implement the task receiver.
+ *
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
  */
 export interface ITaskMessageReceiver {
 	/**

--- a/server/routerlicious/packages/services/src/messageReceiver.ts
+++ b/server/routerlicious/packages/services/src/messageReceiver.ts
@@ -9,6 +9,10 @@ import * as amqp from "amqplib";
 import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
+/**
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
+ */
 class RabbitmqReceiver implements ITaskMessageReceiver {
 	private readonly events = new EventEmitter();
 	private readonly rabbitmqConnectionString: string;
@@ -66,7 +70,12 @@ class RabbitmqReceiver implements ITaskMessageReceiver {
 	}
 }
 
-// Factory to switch between different message receiver.
+/**
+ * Factory to switch between different message receiver.
+ *
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
+ */
 export function createMessageReceiver(
 	rabbitmqConfig: any,
 	queueName: string,

--- a/server/routerlicious/packages/services/src/messageReceiver.ts
+++ b/server/routerlicious/packages/services/src/messageReceiver.ts
@@ -10,7 +10,7 @@ import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 /**
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 class RabbitmqReceiver implements ITaskMessageReceiver {
@@ -73,7 +73,7 @@ class RabbitmqReceiver implements ITaskMessageReceiver {
 /**
  * Factory to switch between different message receiver.
  *
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 export function createMessageReceiver(

--- a/server/routerlicious/packages/services/src/messageSender.ts
+++ b/server/routerlicious/packages/services/src/messageSender.ts
@@ -13,6 +13,10 @@ import * as amqp from "amqplib";
 import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
+/**
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
+ */
 class RabbitmqTaskSender implements ITaskMessageSender {
 	private readonly events = new EventEmitter();
 	private readonly rabbitmqConnectionString: string;
@@ -61,8 +65,13 @@ class RabbitmqTaskSender implements ITaskMessageSender {
 	}
 }
 
-// Factory to switch between specific message sender implementations. Returns a dummy implementation
-// if rabbitmq configs are not provided.
+/**
+ * Factory to switch between specific message sender implementations. Returns a dummy implementation
+ * if rabbitmq configs are not provided.
+ *
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
+ */
 export function createMessageSender(rabbitmqConfig: any, config: any): ITaskMessageSender {
 	// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
 	return rabbitmqConfig && rabbitmqConfig.connectionString

--- a/server/routerlicious/packages/services/src/messageSender.ts
+++ b/server/routerlicious/packages/services/src/messageSender.ts
@@ -14,7 +14,7 @@ import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 /**
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 class RabbitmqTaskSender implements ITaskMessageSender {
@@ -69,7 +69,7 @@ class RabbitmqTaskSender implements ITaskMessageSender {
  * Factory to switch between specific message sender implementations. Returns a dummy implementation
  * if rabbitmq configs are not provided.
  *
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 export function createMessageSender(rabbitmqConfig: any, config: any): ITaskMessageSender {

--- a/server/tinylicious/src/services/taskMessageSender.ts
+++ b/server/tinylicious/src/services/taskMessageSender.ts
@@ -6,7 +6,7 @@
 import { ITaskMessage, ITaskMessageSender } from "@fluidframework/server-services-core";
 
 /**
- * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
 

--- a/server/tinylicious/src/services/taskMessageSender.ts
+++ b/server/tinylicious/src/services/taskMessageSender.ts
@@ -5,6 +5,11 @@
 
 import { ITaskMessage, ITaskMessageSender } from "@fluidframework/server-services-core";
 
+/**
+ * @deprecated - This was functionality related to RabbitMq which is not used anymore,
+ * and will be removed in a future release.
+ */
+
 export class TaskMessageSender implements ITaskMessageSender {
 	public initialize(): Promise<void> {
 		throw new Error("Method not implemented.");

--- a/server/tinylicious/src/services/taskMessageSender.ts
+++ b/server/tinylicious/src/services/taskMessageSender.ts
@@ -9,7 +9,6 @@ import { ITaskMessage, ITaskMessageSender } from "@fluidframework/server-service
  * @deprecated This was functionality related to RabbitMq which is not used anymore,
  * and will be removed in a future release.
  */
-
 export class TaskMessageSender implements ITaskMessageSender {
 	public initialize(): Promise<void> {
 		throw new Error("Method not implemented.");


### PR DESCRIPTION
## Description

Cleans up references to RabbitMq in configuration files and deployment instructions, and deprecates code that was related to RabbitMq but isn't used anymore and will be removed in a future major release.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

@hedasilv @znewton @pradeepvairamani particularly interested in any feedback related to the deprecations. Based on usage in this repo, they seem correct, but you'd know better if any of that code was repurposed or is still used somehow in other contexts even if the base r11s implementation doesn't seem to use it. Based on what I understood, the whole flow of "task sending/receiving".