### PR TITLE
offline: fix stashed ops with no saved ops bug

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -856,9 +856,10 @@ export class ContainerRuntime
 		);
 
 		await runtime.blobManager.processStashedChanges();
-		// It's possible to have ops with a reference sequence number of 0. Op sequence numbers start
-		// at 1, so we won't see a replayed saved op with a sequence number of 0.
-		await runtime.pendingStateManager.applyStashedOpsAt(0);
+
+		// Apply stashed ops with a reference sequence number equal to the sequence number of the snapshot,
+		// or zero. This must be done before Container replays saved ops.
+		await runtime.pendingStateManager.applyStashedOpsAt(runtimeSequenceNumber ?? 0);
 
 		// Initialize the base state of the runtime before it's returned.
 		await runtime.initializeBaseState();

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1655,7 +1655,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 		// wait for summary
 		await new Promise<void>((resolve) =>
 			container1.on("op", (op) => {
-				if (op.type === "summarize") {
+				if (op.type === "summaryAck") {
 					resolve();
 				}
 			}),

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1653,11 +1653,13 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 
 	it("applies stashed ops with no saved ops", async function () {
 		// wait for summary
-		await new Promise<void>((resolve) => container1.on("op", (op) => {
-			if (op.type === "summarize") {
-				resolve();
-			}
-		}));
+		await new Promise<void>((resolve) =>
+			container1.on("op", (op) => {
+				if (op.type === "summarize") {
+					resolve();
+				}
+			}),
+		);
 
 		// avoid our join op being saved
 		const headers: IRequestHeader = { [LoaderHeader.loadMode]: { deltaConnection: "none" } };
@@ -1670,8 +1672,10 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 		assert(stashBlob);
 		const pendingState = JSON.parse(stashBlob);
 		// make sure the container loaded from summary and we have no saved ops
-		assert(pendingState.savedOps.length  === 0);
-		assert(pendingState.pendingRuntimeState.pending.pendingStates[0].referenceSequenceNumber > 0);
+		assert.strictEqual(pendingState.savedOps.length, 0);
+		assert(
+			pendingState.pendingRuntimeState.pending.pendingStates[0].referenceSequenceNumber > 0,
+		);
 
 		// load container with pending ops, which should resend the op not sent by previous container
 		const container2 = await loader.resolve({ url }, stashBlob);


### PR DESCRIPTION
A bug was discovered where stashed ops would not be applied if there were no saved sequenced ops in the stash blob, because stashed ops are applied as saved ops are replayed. More generally, ops with a reference sequence number equal to the base snapshot's sequence number are not applied at this sequence number, potentially causing problems even with saved ops.

This is fixed by applying stashed ops at the base snapshot sequence number during runtime initialization, similar to how stashed ops with a reference sequence number of zero are already handled.