### PR TITLE
improvement(eslint-config-fluid): Update test file pattern to better apply to our packages

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -370,7 +370,7 @@ module.exports = {
 		},
 		{
 			// Rules only for test files
-			files: ["*.spec.ts", "src/test/**"],
+			files: ["*.spec.ts", "*.test.ts", "**/test/**"],
 			rules: {
 				"@typescript-eslint/no-invalid-this": "off",
 				"@typescript-eslint/unbound-method": "off", // This rule has false positives in many of our test projects.


### PR DESCRIPTION
Our example packages frequently have their tests adjacent of the "src" directory, rather than directly under it. Some other packages organize their tests hierarchically alongside the code. 

Additionally, many packages use the `.test.ts` naming scheme, rather than `.spec.ts`.

This PR updates the eslint config pattern for test-code-specific rules to be more flexible and apply better to packages across the repo.