### PR TITLE
tree2: Add principals of new tree API to readme

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/README.md
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/README.md
@@ -52,23 +52,24 @@ There are four main usage modes for this API:
     Some control over these events is available via branching which provides snapshot isolation (among other things):
     this is done at a higher level than the tree API covered here but can be accessed via each tree entity's context property. (TODO: provide this access).
 
-To accommodate all of these at once in a single API surface, a few principals are followed in the API's design:
+To accommodate all of these at once in a single API surface, a few principles are followed in the API's design:
 
 -   Generic APIs suited for generic (non schema aware) tree readers form the base types of everything in the API.
     These provide access to all content of the tree in a uniform manner, including objects for every field and node.
     These are all traversable via iteration, and also can be walked along specific paths through the tree.
     This for example motivates the include of the optional `.value` on TreeNode.
--   Schema aware specializations of these types are provided which provide ergonomic access to optimized based on the specific kind of the node or field.
-    These APIs provide accessors which skip over levels of the tree (called "unboxing") that provide no additional information to a user that knows thew schema.
-    Since skipping over these layers is sometimes undesired (for example when needing to edit them), all APis which do this implicit "unboxing" have "boxed" alternatives that do not skip any layers of the tree.
-    An example of this is how structs provide properties for their fields that "unbox" some field kinds, like Required restoring the TreeNode in them instead of the field itself.
+-   Schema aware specializations of these types are provided which provide ergonomic access based on the specific kind of the node or field.
+    These APIs provide accessors which skip over (or "unbox") redundant layers of the tree - layers that provide no additional information to a user that knows the schema.
+    Since skipping over these layers is sometimes undesired (for example when needing to edit them), all APIs which do this implicit "unboxing" have "boxed" alternatives that do not skip any layers of the tree.
+    An example of this is how structs provide properties for their fields that "unbox" some field kinds.
+    For example, reading a Required field returns the content in the field instead of the field itself.
 -   A subset of the tree properties are picked to be enumerable own properties for use by generic JavaScript object handling code.
     This prefers the APIs which do implicit unboxing,
     and occasionally special purposes APIs added just for this use-case to ensure all content in the tree is reachable exactly once (for example `MapNode.asObject`).
-    This ensure operations like `assert.deepEqual` behave semantically correctly.
+    This ensures operations like `assert.deepEqual` behave semantically correctly.
     See Section below for details.
 -   Special attention is paid to defining what is and is not valid to hold onto across edits, and providing ways to check what edits happened.
-    For example `Tree.treeStatus` allow checking if the subtree is still part of the document and `TreeNode.on` allows subscribing to events.
+    For example `Tree.treeStatus` allows checking if the subtree is still part of the document and `TreeNode.on` allows subscribing to events.
 
 ## Javascript Object API: `enumerable` and `own` properties
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/README.md
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/README.md
@@ -46,11 +46,29 @@ There are four main usage modes for this API:
     This could be considered part of either reading API, but is being addressed separately here.
     APIs for receiving these changes take the form of registering callbacks for events.
     These events can be triggered by anything that impacts the content of the tree including local edits, remote edits, merges, rebasing local edits, transaction rollback, undo etc.
-    These can also be batched together, possibly eliminating intermediate states and reordering operations that don't impact eachother (like edits to different parts of the tree).
+    These can also be batched together, possibly eliminating intermediate states and reordering operations that don't impact each other (like edits to different parts of the tree).
     This means these event subscriptions should only be treated as changes to the content, and users of them should not attempt to ascribe meaning or providence to any particular event.
 
     Some control over these events is available via branching which provides snapshot isolation (among other things):
     this is done at a higher level than the tree API covered here but can be accessed via each tree entity's context property. (TODO: provide this access).
+
+To accommodate all of these at once in a single API surface, a few principals are followed in the API's design:
+
+-   Generic APIs suited for generic (non schema aware) tree readers form the base types of everything in the API.
+    These provide access to all content of the tree in a uniform manner, including objects for every field and node.
+    These are all traversable via iteration, and also can be walked along specific paths through the tree.
+    This for example motivates the include of the optional `.value` on TreeNode.
+-   Schema aware specializations of these types are provided which provide ergonomic access to optimized based on the specific kind of the node or field.
+    These APIs provide accessors which skip over levels of the tree (called "unboxing") that provide no additional information to a user that knows thew schema.
+    Since skipping over these layers is sometimes undesired (for example when needing to edit them), all APis which do this implicit "unboxing" have "boxed" alternatives that do not skip any layers of the tree.
+    An example of this is how structs provide properties for their fields that "unbox" some field kinds, like Required restoring the TreeNode in them instead of the field itself.
+-   A subset of the tree properties are picked to be enumerable own properties for use by generic JavaScript object handling code.
+    This prefers the APIs which do implicit unboxing,
+    and occasionally special purposes APIs added just for this use-case to ensure all content in the tree is reachable exactly once (for example `MapNode.asObject`).
+    This ensure operations like `assert.deepEqual` behave semantically correctly.
+    See Section below for details.
+-   Special attention is paid to defining what is and is not valid to hold onto across edits, and providing ways to check what edits happened.
+    For example `Tree.treeStatus` allow checking if the subtree is still part of the document and `TreeNode.on` allows subscribing to events.
 
 ## Javascript Object API: `enumerable` and `own` properties
 


### PR DESCRIPTION
## Description

Highlight principals of new tree API to readme, not just the use-cases that inspired them.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
