### PR TITLE
improvement(eslint-config-fluid): Disable consistent scoping rule in tests

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -370,7 +370,7 @@ module.exports = {
 		},
 		{
 			// Rules only for test files
-			files: ["*.spec.ts", "src/test/**"],
+			files: ["*.spec.ts", "*.test.ts", "**/test/**"],
 			rules: {
 				"@typescript-eslint/no-invalid-this": "off",
 				"@typescript-eslint/unbound-method": "off", // This rule has false positives in many of our test projects.

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1200,7 +1200,7 @@
             "error"
         ],
         "unicorn/consistent-function-scoping": [
-            "error"
+            "off"
         ],
         "unicorn/custom-error-definition": [
             "off"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -140,6 +140,14 @@ module.exports = {
 			},
 		},
 		{
+			// Rules for test code
+			files: ["*.spec.ts", "*.test.ts", "**/test/**"],
+			rules: {
+				// Does not work well with describe/it block scoping
+				"unicorn/consistent-function-scoping": "off",
+			},
+		},
+		{
 			// Rules only for type validation files
 			files: ["**/types/*validate*Previous*.ts"],
 			rules: {


### PR DESCRIPTION
Disables `unicorn/consistent-function-scoping` rule for tests, as it does not play well with describe/it blocks.