### PR TITLE
build(eslint-config-fluid): Remove settings for removed rules

### DIFF
--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -57,10 +57,8 @@ module.exports = {
 		"@typescript-eslint/dot-notation": "error",
 		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/func-call-spacing": "off",
-		"@typescript-eslint/interface-name-prefix": "off",
 		"@typescript-eslint/keyword-spacing": "off",
 		"@typescript-eslint/member-delimiter-style": "off",
-		"@typescript-eslint/no-duplicate-imports": "error",
 		"@typescript-eslint/no-dynamic-delete": "error",
 		"@typescript-eslint/no-empty-function": "off",
 		"@typescript-eslint/no-empty-interface": "error",
@@ -74,7 +72,6 @@ module.exports = {
 		"@typescript-eslint/no-magic-numbers": "off",
 		"@typescript-eslint/no-misused-new": "error",
 		"@typescript-eslint/no-non-null-assertion": "error",
-		"@typescript-eslint/no-parameter-properties": "off",
 		"@typescript-eslint/no-require-imports": "error",
 		"@typescript-eslint/no-shadow": [
 			"error",
@@ -214,7 +211,7 @@ module.exports = {
 		"no-control-regex": "error",
 		"no-debugger": "off",
 		"no-duplicate-case": "error",
-		"no-duplicate-imports": "off", // Superseded by @typescript-eslint/no-duplicate-imports
+		"no-duplicate-imports": "off", // Doesn't work with TypeScript
 		"no-empty": "off",
 		"no-eval": "error",
 		"no-extra-semi": "off", // Superseded by @typescript-eslint/no-extra-semi
@@ -270,7 +267,6 @@ module.exports = {
 		"one-var": ["error", "never"],
 		"padded-blocks": ["error", "never"],
 		"padding-line-between-statements": [
-			"off",
 			"error",
 			{
 				blankLine: "always",

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -87,7 +87,6 @@ module.exports = {
 		"@typescript-eslint/no-unnecessary-qualifier": "error",
 		"@typescript-eslint/no-unnecessary-type-arguments": "error",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
-		"@typescript-eslint/no-use-before-declare": "off",
 		"@typescript-eslint/no-var-requires": "error",
 		"@typescript-eslint/object-curly-spacing": "off",
 		"@typescript-eslint/prefer-for-of": "error",
@@ -170,7 +169,6 @@ module.exports = {
 		//            significant performance regression [node 14 x64].
 		"unicorn/no-for-loop": "off",
 		"unicorn/no-new-buffer": "error",
-		"unicorn/no-unsafe-regex": "error",
 
 		// eslint
 		"arrow-body-style": "off",
@@ -246,7 +244,6 @@ module.exports = {
 			},
 			"ForInStatement",
 		],
-		"no-return-await": "error",
 		"no-sequences": "error",
 		"no-shadow": "off", // Superseded by @typescript-eslint/no-shadow
 		"no-sparse-arrays": "error",
@@ -267,7 +264,7 @@ module.exports = {
 		"one-var": ["error", "never"],
 		"padded-blocks": ["error", "never"],
 		"padding-line-between-statements": [
-			"error",
+			"off",
 			{
 				blankLine: "always",
 				prev: "*",

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -148,7 +148,6 @@ module.exports = {
 			},
 		],
 		"unicorn/no-new-buffer": "error",
-		"unicorn/no-unsafe-regex": "error",
 		"unicorn/prefer-switch": "error",
 		"unicorn/prefer-ternary": "error",
 		"unicorn/prefer-type-error": "error",

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -168,7 +168,6 @@ module.exports = {
 		"@typescript-eslint/indent": "off",
 		"@typescript-eslint/member-ordering": "off",
 		"@typescript-eslint/no-explicit-any": "off",
-		"@typescript-eslint/no-parameter-properties": "off",
 		"@typescript-eslint/no-unused-vars": "off",
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/typedef": "off",

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -113,9 +113,6 @@
         "@typescript-eslint/indent": [
             "off"
         ],
-        "@typescript-eslint/interface-name-prefix": [
-            "off"
-        ],
         "@typescript-eslint/key-spacing": [
             "off"
         ],
@@ -162,9 +159,6 @@
             "error"
         ],
         "@typescript-eslint/no-duplicate-enum-values": [
-            "error"
-        ],
-        "@typescript-eslint/no-duplicate-imports": [
             "error"
         ],
         "@typescript-eslint/no-duplicate-type-constituents": [
@@ -229,9 +223,6 @@
         ],
         "@typescript-eslint/no-non-null-assertion": [
             "error"
-        ],
-        "@typescript-eslint/no-parameter-properties": [
-            "off"
         ],
         "@typescript-eslint/no-redundant-type-constituents": [
             "error"
@@ -1037,7 +1028,6 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "off",
             "error",
             {
                 "blankLine": "always",

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -282,9 +282,6 @@
         "@typescript-eslint/no-unused-vars": [
             "off"
         ],
-        "@typescript-eslint/no-use-before-declare": [
-            "off"
-        ],
         "@typescript-eslint/no-use-before-define": [
             "off"
         ],
@@ -899,9 +896,6 @@
             },
             "ForInStatement"
         ],
-        "no-return-await": [
-            "error"
-        ],
         "no-self-assign": [
             "error"
         ],
@@ -1028,7 +1022,7 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "error",
+            "off",
             {
                 "blankLine": "always",
                 "next": "return",
@@ -1341,9 +1335,6 @@
             "error"
         ],
         "unicorn/no-unreadable-iife": [
-            "error"
-        ],
-        "unicorn/no-unsafe-regex": [
             "error"
         ],
         "unicorn/no-unused-properties": [

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -106,9 +106,6 @@
         "@typescript-eslint/indent": [
             "off"
         ],
-        "@typescript-eslint/interface-name-prefix": [
-            "off"
-        ],
         "@typescript-eslint/key-spacing": [
             "off"
         ],
@@ -155,9 +152,6 @@
             "error"
         ],
         "@typescript-eslint/no-duplicate-enum-values": [
-            "error"
-        ],
-        "@typescript-eslint/no-duplicate-imports": [
             "error"
         ],
         "@typescript-eslint/no-duplicate-type-constituents": [
@@ -222,9 +216,6 @@
         ],
         "@typescript-eslint/no-non-null-assertion": [
             "error"
-        ],
-        "@typescript-eslint/no-parameter-properties": [
-            "off"
         ],
         "@typescript-eslint/no-redundant-type-constituents": [
             "error"
@@ -1013,7 +1004,6 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "off",
             "error",
             {
                 "blankLine": "always",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -275,9 +275,6 @@
         "@typescript-eslint/no-unused-vars": [
             "off"
         ],
-        "@typescript-eslint/no-use-before-declare": [
-            "off"
-        ],
         "@typescript-eslint/no-use-before-define": [
             "off"
         ],
@@ -875,9 +872,6 @@
             },
             "ForInStatement"
         ],
-        "no-return-await": [
-            "error"
-        ],
         "no-self-assign": [
             "error"
         ],
@@ -1004,7 +998,7 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "error",
+            "off",
             {
                 "blankLine": "always",
                 "next": "return",
@@ -1206,9 +1200,6 @@
             "off"
         ],
         "unicorn/no-new-buffer": [
-            "error"
-        ],
-        "unicorn/no-unsafe-regex": [
             "error"
         ],
         "unicorn/number-literal-case": [

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -115,9 +115,6 @@
         "@typescript-eslint/indent": [
             "off"
         ],
-        "@typescript-eslint/interface-name-prefix": [
-            "off"
-        ],
         "@typescript-eslint/key-spacing": [
             "off"
         ],
@@ -164,9 +161,6 @@
             "error"
         ],
         "@typescript-eslint/no-duplicate-enum-values": [
-            "error"
-        ],
-        "@typescript-eslint/no-duplicate-imports": [
             "error"
         ],
         "@typescript-eslint/no-duplicate-type-constituents": [
@@ -231,9 +225,6 @@
         ],
         "@typescript-eslint/no-non-null-assertion": [
             "error"
-        ],
-        "@typescript-eslint/no-parameter-properties": [
-            "off"
         ],
         "@typescript-eslint/no-redundant-type-constituents": [
             "error"
@@ -1039,7 +1030,6 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "off",
             "error",
             {
                 "blankLine": "always",

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -284,9 +284,6 @@
         "@typescript-eslint/no-unused-vars": [
             "off"
         ],
-        "@typescript-eslint/no-use-before-declare": [
-            "off"
-        ],
         "@typescript-eslint/no-use-before-define": [
             "off"
         ],
@@ -901,9 +898,6 @@
             },
             "ForInStatement"
         ],
-        "no-return-await": [
-            "error"
-        ],
         "no-self-assign": [
             "error"
         ],
@@ -1030,7 +1024,7 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "error",
+            "off",
             {
                 "blankLine": "always",
                 "next": "return",
@@ -1415,9 +1409,6 @@
             "error"
         ],
         "unicorn/no-unreadable-iife": [
-            "error"
-        ],
-        "unicorn/no-unsafe-regex": [
             "error"
         ],
         "unicorn/no-unused-properties": [

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -113,9 +113,6 @@
         "@typescript-eslint/indent": [
             "off"
         ],
-        "@typescript-eslint/interface-name-prefix": [
-            "off"
-        ],
         "@typescript-eslint/key-spacing": [
             "off"
         ],
@@ -162,9 +159,6 @@
             "error"
         ],
         "@typescript-eslint/no-duplicate-enum-values": [
-            "error"
-        ],
-        "@typescript-eslint/no-duplicate-imports": [
             "error"
         ],
         "@typescript-eslint/no-duplicate-type-constituents": [
@@ -229,9 +223,6 @@
         ],
         "@typescript-eslint/no-non-null-assertion": [
             "error"
-        ],
-        "@typescript-eslint/no-parameter-properties": [
-            "off"
         ],
         "@typescript-eslint/no-redundant-type-constituents": [
             "error"
@@ -1037,7 +1028,6 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "off",
             "error",
             {
                 "blankLine": "always",

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -282,9 +282,6 @@
         "@typescript-eslint/no-unused-vars": [
             "off"
         ],
-        "@typescript-eslint/no-use-before-declare": [
-            "off"
-        ],
         "@typescript-eslint/no-use-before-define": [
             "off"
         ],
@@ -899,9 +896,6 @@
             },
             "ForInStatement"
         ],
-        "no-return-await": [
-            "error"
-        ],
         "no-self-assign": [
             "error"
         ],
@@ -1028,7 +1022,7 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "error",
+            "off",
             {
                 "blankLine": "always",
                 "next": "return",
@@ -1341,9 +1335,6 @@
             "error"
         ],
         "unicorn/no-unreadable-iife": [
-            "error"
-        ],
-        "unicorn/no-unsafe-regex": [
             "error"
         ],
         "unicorn/no-unused-properties": [

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -132,9 +132,6 @@
         "@typescript-eslint/indent": [
             "off"
         ],
-        "@typescript-eslint/interface-name-prefix": [
-            "off"
-        ],
         "@typescript-eslint/key-spacing": [
             "off"
         ],
@@ -181,9 +178,6 @@
             "error"
         ],
         "@typescript-eslint/no-duplicate-enum-values": [
-            "error"
-        ],
-        "@typescript-eslint/no-duplicate-imports": [
             "error"
         ],
         "@typescript-eslint/no-duplicate-type-constituents": [
@@ -248,17 +242,6 @@
         ],
         "@typescript-eslint/no-non-null-assertion": [
             "error"
-        ],
-        "@typescript-eslint/no-parameter-properties": [
-            "warn",
-            {
-                "allows": [
-                    "private",
-                    "private readonly",
-                    "public readonly",
-                    "readonly"
-                ]
-            }
         ],
         "@typescript-eslint/no-redundant-type-constituents": [
             "error"
@@ -1091,7 +1074,6 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "off",
             "error",
             {
                 "blankLine": "always",

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -301,9 +301,6 @@
         "@typescript-eslint/no-unused-vars": [
             "off"
         ],
-        "@typescript-eslint/no-use-before-declare": [
-            "off"
-        ],
         "@typescript-eslint/no-use-before-define": [
             "off"
         ],
@@ -945,9 +942,6 @@
             },
             "ForInStatement"
         ],
-        "no-return-await": [
-            "error"
-        ],
         "no-self-assign": [
             "error"
         ],
@@ -1074,7 +1068,7 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "error",
+            "off",
             {
                 "blankLine": "always",
                 "next": "return",
@@ -1387,9 +1381,6 @@
             "error"
         ],
         "unicorn/no-unreadable-iife": [
-            "error"
-        ],
-        "unicorn/no-unsafe-regex": [
             "error"
         ],
         "unicorn/no-unused-properties": [

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -113,9 +113,6 @@
         "@typescript-eslint/indent": [
             "off"
         ],
-        "@typescript-eslint/interface-name-prefix": [
-            "off"
-        ],
         "@typescript-eslint/key-spacing": [
             "off"
         ],
@@ -162,9 +159,6 @@
             "error"
         ],
         "@typescript-eslint/no-duplicate-enum-values": [
-            "error"
-        ],
-        "@typescript-eslint/no-duplicate-imports": [
             "error"
         ],
         "@typescript-eslint/no-duplicate-type-constituents": [
@@ -229,9 +223,6 @@
         ],
         "@typescript-eslint/no-non-null-assertion": [
             "error"
-        ],
-        "@typescript-eslint/no-parameter-properties": [
-            "off"
         ],
         "@typescript-eslint/no-redundant-type-constituents": [
             "error"
@@ -1037,7 +1028,6 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "off",
             "error",
             {
                 "blankLine": "always",

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -282,9 +282,6 @@
         "@typescript-eslint/no-unused-vars": [
             "off"
         ],
-        "@typescript-eslint/no-use-before-declare": [
-            "off"
-        ],
         "@typescript-eslint/no-use-before-define": [
             "off"
         ],
@@ -899,9 +896,6 @@
             },
             "ForInStatement"
         ],
-        "no-return-await": [
-            "error"
-        ],
         "no-self-assign": [
             "error"
         ],
@@ -1028,7 +1022,7 @@
             "never"
         ],
         "padding-line-between-statements": [
-            "error",
+            "off",
             {
                 "blankLine": "always",
                 "next": "return",
@@ -1341,9 +1335,6 @@
             "error"
         ],
         "unicorn/no-unreadable-iife": [
-            "error"
-        ],
-        "unicorn/no-unsafe-regex": [
             "error"
         ],
         "unicorn/no-unused-properties": [

--- a/common/build/eslint-config-fluid/strict.js
+++ b/common/build/eslint-config-fluid/strict.js
@@ -70,15 +70,6 @@ module.exports = {
 					},
 				],
 
-				// Parameter properties can be confusing to those new to TypeScript as they are less explicit than other
-				// ways of declaring and initializing class members.
-				"@typescript-eslint/no-parameter-properties": [
-					"warn",
-					{
-						allows: ["private", "private readonly", "public readonly", "readonly"],
-					},
-				],
-
 				/**
 				 * Requires that type-only exports be done using `export type`. Being explicit allows the TypeScript
 				 * `isolatedModules` flag to be used, and isolated modules are needed to adopt modern build tools like swc.


### PR DESCRIPTION
The following rules were removed in typescript-eslint v6:

- @typescript-eslint/no-duplicate-imports
- @typescript-eslint/no-implicit-any-catch
- @typescript-eslint/no-parameter-properties
- @typescript-eslint/sort-type-union-intersection-members

This PR removes the settings overrides from our shared lint config, which is needed to prevent errors like "Definition for rule '@typescript-eslint/no-duplicate-imports' was not found"

I also noticed some rules that are deprecated, so I removed those entries as well.