### PR TITLE
PropertyDDS: fix packaging for `property-proxy`

### DIFF
--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -14,8 +14,9 @@
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
-		"dist",
-		"index.d.ts"
+		"dist/**/*",
+		"lib/**/*",
+		"dist/index.d.ts"
 	],
 	"scripts": {
 		"build": "fluid-build . --task build",


### PR DESCRIPTION
It turned out that `lib` build is missing for the `@fluid-experimental/property-proxy` package since of misconfiguration. This PR fixes the issue.