### PR TITLE
fix(shared-tree): Incorrect comparison in `LazyField.is`

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -118,7 +118,7 @@ export abstract class LazyField<TKind extends FieldKindTypes, TTypes extends All
 			"Narrowing must be done to a kind that exists in this context",
 		);
 
-		if (schema.kind !== schema.kind) {
+		if (schema.kind !== this.schema.kind) {
 			return false;
 		}
 		if (schema.types === undefined) {


### PR DESCRIPTION
Check was incorrectly comparing input schema kind to itself, rather than the field's schema.