### PR TITLE
Unregister events on connection close in odsp delta connection

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -129,27 +129,32 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
 		// Server sends this event when it wants to disconnect a particular client in which case the client id would
 		// be present or if it wants to disconnect all the clients. The server always closes the socket in case all
 		// clients needs to be disconnected. So fully remove the socket reference in this case.
-		socket.on("server_disconnect", (socketError: IOdspSocketError, clientId?: string) => {
-			// Treat all errors as recoverable, and rely on joinSession / reconnection flow to
-			// filter out retryable vs. non-retryable cases.
-			const error = errorObjectFromSocketError(socketError, "server_disconnect");
-			error.addTelemetryProperties({ disconnectClientId: clientId });
-			error.canRetry = true;
-
-			// see comment in disconnected() getter
-			// Setting it here to ensure socket reuse does not happen if new request to connect
-			// comes in from "disconnect" listener below, before we close socket.
-			this.isPendingInitialConnection = false;
-
-			if (clientId === undefined) {
-				// We could first raise "disconnect" event, but that may result in socket reuse due to
-				// new connection comming in. So, it's better to have more explicit flow to make it impossible.
-				this.closeSocket(error);
-			} else {
-				this.emit("disconnect", error, clientId);
-			}
-		});
+		socket.on("server_disconnect", this.serverDisconnectEventHandler);
 	}
+
+	private readonly serverDisconnectEventHandler = (
+		socketError: IOdspSocketError,
+		clientId?: string,
+	) => {
+		// Treat all errors as recoverable, and rely on joinSession / reconnection flow to
+		// filter out retryable vs. non-retryable cases.
+		const error = errorObjectFromSocketError(socketError, "server_disconnect");
+		error.addTelemetryProperties({ disconnectClientId: clientId });
+		error.canRetry = true;
+
+		// see comment in disconnected() getter
+		// Setting it here to ensure socket reuse does not happen if new request to connect
+		// comes in from "disconnect" listener below, before we close socket.
+		this.isPendingInitialConnection = false;
+
+		if (clientId === undefined) {
+			// We could first raise "disconnect" event, but that may result in socket reuse due to
+			// new connection comming in. So, it's better to have more explicit flow to make it impossible.
+			this.closeSocket(error);
+		} else {
+			this.emit("disconnect", error, clientId);
+		}
+	};
 
 	private clearTimer() {
 		if (this.delayDeleteTimeout !== undefined) {
@@ -163,6 +168,7 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
 			return;
 		}
 
+		this._socket.off("server_disconnect", this.serverDisconnectEventHandler);
 		this.clearTimer();
 
 		assert(
@@ -536,7 +542,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
 		this.socketReference!.on("disconnect", this.disconnectHandler);
 
-		this.socket.on("get_ops_response", (result: IGetOpsResponse) => {
+		this.addTrackedListener("get_ops_response", (result: IGetOpsResponse) => {
 			const messages = result.messages;
 			const data = this.getOpsMap.get(result.nonce);
 			// Due to socket multiplexing, this client may not have asked for any data
@@ -571,7 +577,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			}
 		});
 
-		this.socket.on("flush_ops_response", (result: IFlushOpsResponse) => {
+		this.addTrackedListener("flush_ops_response", (result: IFlushOpsResponse) => {
 			if (this.flushOpNonce === result.nonce) {
 				const seq = result.lastPersistedSequenceNumber;
 				let category: "generic" | "error" = "generic";

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuid } from "uuid";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IEvent } from "@fluidframework/core-interfaces";
 import { IAnyDriverError } from "@fluidframework/driver-definitions";
@@ -121,7 +122,7 @@ export class ClientSocketMock extends TypedEventEmitter<SocketMockEvents> {
 						{
 							const iConnected: IConnected = this.mockSocketConnectResponse
 								.connect_document.connectMessage ?? {
-								clientId: "clientId",
+								clientId: uuid(),
 								existing: true,
 								initialClients: [],
 								initialMessages: [],

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -116,8 +116,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Connect document success on connection", async () => {
 		socket = new ClientSocketMock();
-		const connection = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -127,8 +127,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		assert.strictEqual(connection.documentId, documentId, "document id should match");
 		assert(!connection.disposed, "connection should not be disposed");
 		assert(connection.existing, "doucment should already exist");
@@ -153,9 +153,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		let errorhappened = false;
 		let connection: OdspDocumentDeltaConnection | undefined;
 		try {
-			connection = await mockSocket(socket as unknown as Socket, async () => {
-				// eslint-disable-next-line no-return-await
-				return await OdspDocumentDeltaConnection.create(
+			connection = await mockSocket(socket as unknown as Socket, async () =>
+				OdspDocumentDeltaConnection.create(
 					tenantId,
 					documentId,
 					token,
@@ -165,8 +164,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 					60000,
 					epochTracker,
 					socketReferenceKeyPrefix,
-				);
-			});
+				),
+			);
 		} catch (err) {
 			errorhappened = true;
 			assert(isFluidError(err), "should be a Fluid error");
@@ -187,8 +186,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		});
 		let errorhappened = false;
 		try {
-			await mockSocket(socket as unknown as Socket, async () => {
-				return OdspDocumentDeltaConnection.create(
+			await mockSocket(socket as unknown as Socket, async () =>
+				OdspDocumentDeltaConnection.create(
 					tenantId,
 					documentId,
 					token,
@@ -198,8 +197,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 					60000,
 					epochTracker,
 					socketReferenceKeyPrefix,
-				);
-			});
+				),
+			);
 		} catch (err) {
 			errorhappened = true;
 			assert(isFluidError(err), "should be a Fluid error");
@@ -218,8 +217,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		});
 		let errorhappened = false;
 		try {
-			await mockSocket(socket as unknown as Socket, async () => {
-				return OdspDocumentDeltaConnection.create(
+			await mockSocket(socket as unknown as Socket, async () =>
+				OdspDocumentDeltaConnection.create(
 					tenantId,
 					documentId,
 					token,
@@ -229,8 +228,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 					60000,
 					epochTracker,
 					socketReferenceKeyPrefix,
-				);
-			});
+				),
+			);
 		} catch (err) {
 			errorhappened = true;
 			assert(isFluidError(err), "should be a Fluid error");
@@ -245,8 +244,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Connection object should handle server_disconnect event with clientId", async () => {
 		socket = new ClientSocketMock();
-		const connection = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -256,8 +255,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		let disconnectedEvent = false;
 		const errorToThrow = { message: "OdspSocketError", code: 400 };
 		let errorReceived;
@@ -282,8 +281,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Connection object should handle server_disconnect event without clientId", async () => {
 		socket = new ClientSocketMock();
-		const connection = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -293,8 +292,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		let disconnectedEvent = false;
 		let errorReceived;
 		const errorToThrow = { message: "OdspSocketError", code: 400 };
@@ -316,8 +315,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Connection object should handle disconnect event", async () => {
 		socket = new ClientSocketMock();
-		const connection = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -327,8 +326,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		let disconnectedEvent = false;
 		let errorReceived;
 		const errorToThrow = createOdspNetworkError("TestSocketError", 400);
@@ -353,8 +352,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Connection object should handle error event", async () => {
 		socket = new ClientSocketMock();
-		const connection = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -364,8 +363,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		let disconnectedEvent = false;
 		let errorReceived;
 		const errorToThrow = createOdspNetworkError("TestSocketError", 400);
@@ -386,8 +385,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Multiple connection objects should handle server_disconnect event without clientId", async () => {
 		socket = new ClientSocketMock();
-		const connection1 = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection1 = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -397,11 +396,11 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 
-		const connection2 = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection2 = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -411,8 +410,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		let disconnectedEvent1 = false;
 		let disconnectedEvent2 = false;
 		const errorToThrow = { message: "OdspSocketError", code: 400 };
@@ -433,8 +432,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 
 	it("Multiple connection objects should handle server_disconnect event with particular clientId", async () => {
 		socket = new ClientSocketMock();
-		const connection1 = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection1 = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -444,11 +443,11 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 
-		const connection2 = await mockSocket(socket as unknown as Socket, async () => {
-			return OdspDocumentDeltaConnection.create(
+		const connection2 = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
 				tenantId,
 				documentId,
 				token,
@@ -458,8 +457,8 @@ describe("OdspDocumentDeltaConnection tests", () => {
 				60000,
 				epochTracker,
 				socketReferenceKeyPrefix,
-			);
-		});
+			),
+		);
 		let disconnectedEvent1 = false;
 		let disconnectedEvent2 = false;
 		const errorToThrow = { message: "OdspSocketError", code: 400 };

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -66,6 +66,39 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		);
 	});
 
+	const checkListenerCount = (_socket: ClientSocketMock) => {
+		assert(
+			_socket.listenerCount("connect_error") === 0,
+			"no connect_error listener should exiist",
+		);
+		assert(
+			_socket.listenerCount("connect_document_error") === 0,
+			"no connect_document_error listener should exiist",
+		);
+		assert(
+			_socket.listenerCount("connect_timeout") === 0,
+			"no connect_timeout listener should exiist",
+		);
+		assert(
+			_socket.listenerCount("connect_document_success") === 0,
+			"no connect_document_success listener should exiist",
+		);
+		assert(
+			_socket.listenerCount("server_disconnect") === 0,
+			"no server_disconnect listener should exiist",
+		);
+		assert(
+			_socket.listenerCount("get_ops_response") === 0,
+			"no get_ops_response listener should exiist",
+		);
+		assert(
+			_socket.listenerCount("flush_ops_response") === 0,
+			"no flush_ops_response listener should exiist",
+		);
+		assert(_socket.listenerCount("error") === 0, "no error listener should exiist");
+		assert(_socket.listenerCount("disconnect") === 0, "no disconnect listener should exiist");
+	};
+
 	afterEach(async () => {
 		socket?.close();
 		await epochTracker.removeEntries().catch(() => {});
@@ -97,7 +130,6 @@ describe("OdspDocumentDeltaConnection tests", () => {
 			);
 		});
 		assert.strictEqual(connection.documentId, documentId, "document id should match");
-		assert.strictEqual(connection.details.clientId, "clientId", "client id should match");
 		assert(!connection.disposed, "connection should not be disposed");
 		assert(connection.existing, "doucment should already exist");
 		assert.strictEqual(connection.mode, "write", "connection should be write");
@@ -233,7 +265,7 @@ describe("OdspDocumentDeltaConnection tests", () => {
 			disconnectedEvent = true;
 			errorReceived = reason;
 		});
-		socket.sendServerDisconnectEvent(errorToThrow, "clientId");
+		socket.sendServerDisconnectEvent(errorToThrow, connection.clientId);
 
 		assert(disconnectedEvent, "disconnect event should happen");
 		assert(
@@ -242,9 +274,13 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		);
 		assert(errorReceived.errorType, DriverErrorTypes.genericNetworkError);
 		assert(socket?.connected, "socket should still be connected");
+		assert(
+			socket.listenerCount("server_disconnect") === 1,
+			"server_disconnect listener should still exiist",
+		);
 	});
 
-	it("Connection object should handle server_disconnect event without clientId handle disconnect event", async () => {
+	it("Connection object should handle server_disconnect event without clientId", async () => {
 		socket = new ClientSocketMock();
 		const connection = await mockSocket(socket as unknown as Socket, async () => {
 			return OdspDocumentDeltaConnection.create(
@@ -275,6 +311,7 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		);
 		assert(errorReceived.errorType, DriverErrorTypes.genericNetworkError);
 		assert(socket !== undefined && !socket.connected, "socket should be disconnected");
+		checkListenerCount(socket);
 	});
 
 	it("Connection object should handle disconnect event", async () => {
@@ -311,6 +348,7 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		assert(errorReceived.socketErrorType === details.context.type);
 		assert(errorReceived.socketCode === details.context.code);
 		assert(socket !== undefined && !socket.connected, "socket should be closed");
+		checkListenerCount(socket);
 	});
 
 	it("Connection object should handle error event", async () => {
@@ -343,5 +381,109 @@ describe("OdspDocumentDeltaConnection tests", () => {
 		);
 		assert(errorReceived.errorType, DriverErrorTypes.genericNetworkError);
 		assert(socket !== undefined && !socket.connected, "socket should be closed");
+		checkListenerCount(socket);
+	});
+
+	it("Multiple connection objects should handle server_disconnect event without clientId", async () => {
+		socket = new ClientSocketMock();
+		const connection1 = await mockSocket(socket as unknown as Socket, async () => {
+			return OdspDocumentDeltaConnection.create(
+				tenantId,
+				documentId,
+				token,
+				client,
+				webSocketUrl,
+				logger,
+				60000,
+				epochTracker,
+				socketReferenceKeyPrefix,
+			);
+		});
+
+		const connection2 = await mockSocket(socket as unknown as Socket, async () => {
+			return OdspDocumentDeltaConnection.create(
+				tenantId,
+				documentId,
+				token,
+				client,
+				webSocketUrl,
+				logger,
+				60000,
+				epochTracker,
+				socketReferenceKeyPrefix,
+			);
+		});
+		let disconnectedEvent1 = false;
+		let disconnectedEvent2 = false;
+		const errorToThrow = { message: "OdspSocketError", code: 400 };
+		connection1.on("disconnect", (reason: IAnyDriverError) => {
+			disconnectedEvent1 = true;
+		});
+		connection2.on("disconnect", (reason: IAnyDriverError) => {
+			disconnectedEvent2 = true;
+		});
+		socket.sendServerDisconnectEvent(errorToThrow);
+
+		assert(disconnectedEvent1, "disconnect event should happen on first object");
+		assert(disconnectedEvent2, "disconnect event should happen on second object");
+
+		assert(socket !== undefined && !socket.connected, "socket should be disconnected");
+		checkListenerCount(socket);
+	});
+
+	it("Multiple connection objects should handle server_disconnect event with particular clientId", async () => {
+		socket = new ClientSocketMock();
+		const connection1 = await mockSocket(socket as unknown as Socket, async () => {
+			return OdspDocumentDeltaConnection.create(
+				tenantId,
+				documentId,
+				token,
+				client,
+				webSocketUrl,
+				logger,
+				60000,
+				epochTracker,
+				socketReferenceKeyPrefix,
+			);
+		});
+
+		const connection2 = await mockSocket(socket as unknown as Socket, async () => {
+			return OdspDocumentDeltaConnection.create(
+				tenantId,
+				documentId,
+				token,
+				client,
+				webSocketUrl,
+				logger,
+				60000,
+				epochTracker,
+				socketReferenceKeyPrefix,
+			);
+		});
+		let disconnectedEvent1 = false;
+		let disconnectedEvent2 = false;
+		const errorToThrow = { message: "OdspSocketError", code: 400 };
+		connection1.on("disconnect", (reason: IAnyDriverError) => {
+			disconnectedEvent1 = true;
+		});
+		connection2.on("disconnect", (reason: IAnyDriverError) => {
+			disconnectedEvent2 = true;
+		});
+		socket.sendServerDisconnectEvent(errorToThrow, connection1.clientId);
+
+		assert(disconnectedEvent1, "disconnect event should happen on first object");
+		assert(!disconnectedEvent2, "disconnect event should not happen on second object");
+
+		assert(socket.connected, "socket should be connected");
+		assert(
+			socket.listenerCount("server_disconnect") === 1,
+			"server_disconnect listener should still exiist",
+		);
+		assert(socket.listenerCount("error") === 1, "1 error listener should exiist");
+		assert(socket.listenerCount("disconnect") === 1, "1 disconnect listener should exiist");
+		assert(
+			socket.listenerCount("get_ops_response") === 1,
+			"1 get_ops_response listener should exiist",
+		);
 	});
 });


### PR DESCRIPTION
## Description

Item link: https://dev.azure.com/fluidframework/internal/_workitems/edit/5056
We saw a transient memory leak in SocketReference in ODSP delta connection. It seems like we don't unregister some of the listeners on the socket and socketReference and also don't unregister the "socket_disconnect" listener on socket close which could cause issues as the socketReference object is shared between containers based on socketURl or tenantid/containerid.
Also added tests to tests some of these scenarios.