### PR TITLE
Refactor runnerHttpServerStop to services-shared

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -113,6 +113,10 @@ export class KafkaRunner implements IRunner {
 		this.stopped = true;
 		Lumberjack.info("KafkaRunner.stop starting.");
 		try {
+			this.runnerMetric.setProperties({
+				caller,
+			});
+
 			// Stop listening for new updates
 			await this.consumer.pause();
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -113,9 +113,7 @@ export class KafkaRunner implements IRunner {
 		this.stopped = true;
 		Lumberjack.info("KafkaRunner.stop starting.");
 		try {
-			this.runnerMetric.setProperties({
-				caller,
-			});
+			this.runnerMetric.setProperty("caller", caller);
 
 			// Stop listening for new updates
 			await this.consumer.pause();

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -63,6 +63,7 @@
 		"@fluidframework/server-services-ordering-kafkanode": "workspace:~",
 		"@fluidframework/server-services-ordering-rdkafka": "workspace:~",
 		"@fluidframework/server-services-ordering-zookeeper": "workspace:~",
+		"@fluidframework/server-services-shared": "workspace:~",
 		"@fluidframework/server-services-telemetry": "workspace:~",
 		"@fluidframework/server-services-utils": "workspace:~",
 		"body-parser": "^1.17.1",

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -28,7 +28,7 @@ import { createMetricClient } from "@fluidframework/server-services";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { LumberEventName, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { configureWebSocketServices } from "@fluidframework/server-lambdas";
-import { runnerHttpServerStop } from "../utils";
+import { runnerHttpServerStop } from "@fluidframework/server-services-shared";
 import * as app from "./app";
 import { IDocumentDeleteService } from "./services";
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -13,9 +13,9 @@ import {
 	ICollection,
 } from "@fluidframework/server-services-core";
 import { LumberEventName, Lumberjack } from "@fluidframework/server-services-telemetry";
+import { runnerHttpServerStop } from "@fluidframework/server-services-shared";
 import { Provider } from "nconf";
 import * as winston from "winston";
-import { runnerHttpServerStop } from "../utils";
 import * as app from "./app";
 import { ITenantDocument } from "./tenantManager";
 

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -8,4 +8,3 @@ export { createDocumentRouter, IPlugin } from "./documentRouter";
 export { catch404, handleError } from "./middleware";
 export { getIdFromRequest, getTenantIdFromRequest } from "./params";
 export { getSession } from "./sessionHelper";
-export { runnerHttpServerStop } from "./runnerHelper";

--- a/server/routerlicious/packages/services-shared/src/index.ts
+++ b/server/routerlicious/packages/services-shared/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from "./redisSocketIoAdapter";
 export { decodeHeader, RestLessServer } from "./restLessServer";
 export { run, runService } from "./runner";
+export { runnerHttpServerStop } from "./runnerUtils";
 export { DocumentStorage } from "./storage";
 export {
 	BasicWebServerFactory,

--- a/server/routerlicious/packages/services-shared/src/runnerUtils.ts
+++ b/server/routerlicious/packages/services-shared/src/runnerUtils.ts
@@ -18,6 +18,10 @@ export async function runnerHttpServerStop(
 	uncaughtException: any | undefined,
 ): Promise<void> {
 	try {
+		runnerMetric.setProperties({
+			caller,
+			runnerServerCloseTimeoutMs,
+		});
 		// Close the underlying server and then resolve the runner once closed
 		await promiseTimeout(runnerServerCloseTimeoutMs, server.close());
 		if (caller === "uncaughtException") {

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -540,6 +540,7 @@ importers:
       '@fluidframework/server-services-ordering-kafkanode': workspace:~
       '@fluidframework/server-services-ordering-rdkafka': workspace:~
       '@fluidframework/server-services-ordering-zookeeper': workspace:~
+      '@fluidframework/server-services-shared': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
       '@fluidframework/server-services-utils': workspace:~
       '@fluidframework/server-test-utils': workspace:~
@@ -600,6 +601,7 @@ importers:
       '@fluidframework/server-services-ordering-kafkanode': link:../services-ordering-kafkanode
       '@fluidframework/server-services-ordering-rdkafka': link:../services-ordering-rdkafka
       '@fluidframework/server-services-ordering-zookeeper': link:../services-ordering-zookeeper
+      '@fluidframework/server-services-shared': link:../services-shared
       '@fluidframework/server-services-telemetry': link:../services-telemetry
       '@fluidframework/server-services-utils': link:../services-utils
       body-parser: 1.20.2


### PR DESCRIPTION
## Description

- Moved runnerHttpServerStop utility method from routerlicious-base to services-shared so it can be used in gitrest/historian/objectstore runners.
- Added a few telemetry properties to runner metric.
