### PR TITLE
docs(tree2): Typos & such

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -54,7 +54,7 @@ export interface Tree<TSchema = unknown> extends Iterable<Tree> {
 	 * Gets the {@link TreeStatus} of this tree.
 	 *
 	 * @remarks
-	 * For non-root fields, this is the the status of the parent node, since fields do not have a separate lifetime.
+	 * For non-root fields, this is the status of the parent node, since fields do not have a separate lifetime.
 	 */
 	treeStatus(): TreeStatus;
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -108,7 +108,7 @@ export interface TreeNode extends Tree<TreeSchema> {
 
 	/**
 	 * Same as `this.schema.name`.
-	 * This is provided as a enumerable own property to aid with JavaScript object traversals of this data-structure.
+	 * This is provided as an enumerable own property to aid with JavaScript object traversals of this data-structure.
 	 * See [ReadMe](./README.md) for details.
 	 */
 	readonly type: TreeSchemaIdentifier;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -180,7 +180,7 @@ export interface TreeField extends Tree<FieldSchema>, Iterable<TreeNode> {
  * A {@link TreeNode} that behaves like a `Map<FieldKey, Field>` for a specific `Field` type.
  *
  * @remarks
- * Unlike TypeScript Map type, {@link MapNode.get} always provides a reference to any field looked up, even if its never been set.
+ * Unlike TypeScript Map type, {@link MapNode.get} always provides a reference to any field looked up, even if it has never been set.
  *
  * This means that, for example, a `MapNode` of {@link Sequence} fields will return an empty sequence when a previously unused key is looked up,
  * and that sequence can be used to insert new items into the field.

--- a/experimental/dds/tree2/src/feature-libraries/untypedTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/untypedTree.ts
@@ -286,7 +286,6 @@ export interface EditableTreeEvents {
 	 * Raised when a specific EditableTree node is changing.
 	 * This includes its fields.
 	 * @param upPath - the path corresponding to the location of the node being changed, upward.
-	 * @param value - the new value stored in the node.
 	 */
 	changing(upPath: UpPath): void;
 

--- a/experimental/dds/tree2/src/util/brand.ts
+++ b/experimental/dds/tree2/src/util/brand.ts
@@ -22,7 +22,7 @@ export type Brand<ValueType, Name extends string> = ValueType & BrandedType<Valu
 
 /**
  * Helper for {@link Brand}.
- * This is split out into its own as thats the only way to:
+ * This is split out into its own as that's the only way to:
  * - have doc comments for the field.
  * - make the field protected (so you don't accidentally try and read it).
  * - get nominal typing (so types produced without using this class can never be assignable to it).
@@ -31,7 +31,7 @@ export type Brand<ValueType, Name extends string> = ValueType & BrandedType<Valu
  * See {@link InternalTypes#MakeNominal} for some more details.
  *
  * Do not use this class with `instanceof`: this will always be false at runtime,
- * but the compiler may think its true in some cases.
+ * but the compiler may think it's true in some cases.
  *
  * @sealed
  * @alpha
@@ -59,7 +59,7 @@ export abstract class BrandedType<ValueType, Name extends string> {
  * however if we assume only code that produces these "opaque" handles does that conversion,
  * they can function like opaque handles.
  *
- * Recommenced usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
+ * Recommended usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
  * uses the type name instead of expanding it:
  * ```typescript
  * export interface MyType extends Opaque<Brand<string, "myPackage.MyType">>{}
@@ -131,7 +131,7 @@ export function brand<T extends Brand<any, string>>(
 }
 
 /**
- * Adds a type {@link Brand} to a value, returning it as a  {@link Opaque} handle.
+ * Adds a type {@link Brand} to a value, returning it as a {@link Opaque} handle.
  *
  * Only do this when specifically allowed by the requirements of the type being converted to.
  * @alpha

--- a/experimental/dds/tree2/src/util/typeCheck.ts
+++ b/experimental/dds/tree2/src/util/typeCheck.ts
@@ -5,7 +5,7 @@
 
 // Normally we would put tests in the test directory.
 // However in this case,
-// its important that the tests are run with the same compiler settings this library is being used with,
+// it's important that the tests are run with the same compiler settings this library is being used with,
 // since this library does not work for some configurations (ex: with strictNullChecks disabled).
 // Since the tests don't generate any JS: they only produce types,
 // importing them here gets us the validation of the compiler settings we want, with no JS size overhead.


### PR DESCRIPTION
## Description

Fixing typos and such. Removed one `@param - ` tag for a non-existent parameter on `EditableTreeEvents.changing`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
