### PR TITLE
TS5: Fix 'type-test-generator' to unblock bumping 'build-tools'

### DIFF
--- a/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
+++ b/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
@@ -25,10 +26,13 @@ type requireAssignableTo<_A extends B, B> = true;
  * This will strip some type branding information which ideally would be kept for stricter checking, but without it, const enums show up as breaking when unchanged.
  */
 export const typeOnly = `
+// See 'build-tools/src/type-test-generator/compatibility.ts' for more information.
 type TypeOnly<T> = T extends number
 	? number
 	: T extends string
 	? string
+	: T extends boolean | bigint | symbol
+	? T
 	: {
 			[P in keyof T]: TypeOnly<T[P]>;
 	  };
@@ -38,6 +42,8 @@ type TypeOnly<T> = T extends number
 	? number
 	: T extends string
 	? string
+	: T extends boolean | bigint | symbol
+	? T
 	: {
 			[P in keyof T]: TypeOnly<T[P]>;
 	  };
@@ -48,14 +54,12 @@ type TypeOnly<T> = T extends number
 
 // Non-Const enums
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test1 {
 	export enum A {
 		y = 0,
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test2 {
 	export enum A {
 		x = 0,
@@ -80,14 +84,12 @@ namespace Test2 {
 
 // Const enums
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test3 {
 	export const enum A {
 		y = 0,
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test4 {
 	export const enum A {
 		x = 0,
@@ -99,7 +101,6 @@ namespace Test4 {
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test5 {
 	export const enum A {
 		y = 0,
@@ -124,14 +125,12 @@ namespace Test5 {
 
 // Classes with protected members
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test6 {
 	export class Foo {
 		protected x!: number;
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Test7 {
 	export class Foo {
 		protected x!: number;
@@ -162,4 +161,37 @@ namespace Test7 {
 	type _check4 = requireAssignableTo<TypeOnly<Test6.Foo>, TypeOnly<Test7.Baz>>;
 	// but only in one direction:
 	type _check5 = requireAssignableTo<TypeOnly<Test7.Baz>, TypeOnly<Test6.Foo>>;
+}
+
+namespace Test_TypeOnly_Preserves_Primitives {
+	// Intersection ('&') with 'null' and 'undefined' results in 'never'.
+	// Just verify that the 'null' and 'undefined' values are preserved.
+	type _check_undefined1 = requireAssignableTo<TypeOnly<undefined>, undefined>;
+	type _check_undefined2 = requireAssignableTo<undefined, TypeOnly<undefined>>;
+
+	type _check_null1 = requireAssignableTo<TypeOnly<null>, null>;
+	type _check_null2 = requireAssignableTo<null, TypeOnly<null>>;
+
+	// Types that extend 'number' and 'string' are stripped to thier primitive types.
+	// (Nominal typing is erased.)
+	type brandedNumber = number & { brand: "Number" };
+	type _check_number1 = requireAssignableTo<TypeOnly<brandedNumber>, number>;
+	type _check_number2 = requireAssignableTo<number, TypeOnly<brandedNumber>>;
+
+	type brandedString = string & { brand: "String" };
+	type _check_string1 = requireAssignableTo<TypeOnly<brandedString>, string>;
+	type _check_string2 = requireAssignableTo<string, TypeOnly<brandedString>>;
+
+	// Other primitive types are preserved as-is.
+	type brandedBoolean = boolean & { brand: "Boolean" };
+	type _check_bool1 = requireAssignableTo<TypeOnly<brandedBoolean>, brandedBoolean>;
+	type _check_bool2 = requireAssignableTo<brandedBoolean, TypeOnly<brandedBoolean>>;
+
+	type brandedBigInt = bigint & { brand: "BigInt" };
+	type _check_bigint1 = requireAssignableTo<TypeOnly<brandedBigInt>, bigint>;
+	type _check_bigint2 = requireAssignableTo<brandedBigInt, TypeOnly<bigint>>;
+
+	type brandedSymbol = symbol & { brand: "Symbol" };
+	type _check_symbol1 = requireAssignableTo<TypeOnly<brandedSymbol>, symbol>;
+	type _check_symbol2 = requireAssignableTo<brandedSymbol, TypeOnly<symbol>>;
 }

--- a/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
+++ b/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
@@ -177,6 +177,7 @@ namespace Test_TypeOnly_Preserves_Primitives {
 	// (Nominal typing is erased.)
 	type brandedNumber = number & { brand: "Number" };
 	type _check_number1 = requireAssignableTo<TypeOnly<brandedNumber>, number>;
+   // Due to limitations of the current version of TypeOnly, brands on primitives are lost:
 	type _check_number2 = requireAssignableTo<number, TypeOnly<brandedNumber>>;
 
 	type brandedString = string & { brand: "String" };

--- a/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
+++ b/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
@@ -173,18 +173,31 @@ namespace Test_TypeOnly_Preserves_Primitives {
 	type _check_null1 = requireAssignableTo<TypeOnly<null>, null>;
 	type _check_null2 = requireAssignableTo<null, TypeOnly<null>>;
 
-	// Types that extend 'number' and 'string' are stripped to their primitive types.
-	// (Nominal typing is erased.)
+	// Due to limitations of the current version of TypeOnly, brands on number are lost,
+	// but the number type is preserved:
 	type brandedNumber = number & { brand: "Number" };
 	type _check_number1 = requireAssignableTo<TypeOnly<brandedNumber>, number>;
-   // Due to limitations of the current version of TypeOnly, brands on primitives are lost:
-	type _check_number2 = requireAssignableTo<number, TypeOnly<brandedNumber>>;
+	type _check_number2 = requireAssignableTo<brandedNumber, TypeOnly<brandedNumber>>;
 
+	// Due to limitations of the current version of TypeOnly, brands on string are lost,
+	// but the string type is preserved:
 	type brandedString = string & { brand: "String" };
 	type _check_string1 = requireAssignableTo<TypeOnly<brandedString>, string>;
-	type _check_string2 = requireAssignableTo<string, TypeOnly<brandedString>>;
+	type _check_string2 = requireAssignableTo<brandedString, TypeOnly<brandedString>>;
 
-	// Other primitive types are preserved as-is.
+	// Due to limitations of the current version of TypeOnly, brands on unions involving
+	// 'string' or 'number' are lost, but the 'string | number' type is preserved:
+	type brandedNumberOrString = (number | string) & { brand: "NumberOrString" };
+	type _check_number_or_string1 = requireAssignableTo<
+		TypeOnly<brandedNumberOrString>,
+		number | string
+	>;
+	type _check_number_or_string2 = requireAssignableTo<
+		brandedNumberOrString,
+		TypeOnly<brandedNumberOrString>
+	>;
+
+	// Other branded primitive types are preserved.
 	type brandedBoolean = boolean & { brand: "Boolean" };
 	type _check_bool1 = requireAssignableTo<TypeOnly<brandedBoolean>, brandedBoolean>;
 	type _check_bool2 = requireAssignableTo<brandedBoolean, TypeOnly<brandedBoolean>>;
@@ -196,4 +209,17 @@ namespace Test_TypeOnly_Preserves_Primitives {
 	type brandedSymbol = symbol & { brand: "Symbol" };
 	type _check_symbol1 = requireAssignableTo<TypeOnly<brandedSymbol>, symbol>;
 	type _check_symbol2 = requireAssignableTo<brandedSymbol, TypeOnly<symbol>>;
+
+	// Unions of primitive types are preserved.
+	type union = undefined | null | boolean | number | bigint | string | symbol;
+	type _check_union1 = requireAssignableTo<TypeOnly<union>, union>;
+	type _check_union2 = requireAssignableTo<union, TypeOnly<union>>;
+
+	// Branded unions of primitive types are preserved, except for string and number,
+	// which are stripped to just 'string | number'.
+	type brandedUnion = (undefined | null | boolean | bigint | symbol) & {
+		brand: "Union";
+	};
+	type _check_union3 = requireAssignableTo<TypeOnly<brandedUnion>, brandedUnion>;
+	type _check_union4 = requireAssignableTo<brandedUnion, TypeOnly<brandedUnion>>;
 }

--- a/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
+++ b/build-tools/packages/build-tools/src/type-test-generator/compatibility.ts
@@ -164,7 +164,8 @@ namespace Test7 {
 }
 
 namespace Test_TypeOnly_Preserves_Primitives {
-	// Intersection ('&') with 'null' and 'undefined' results in 'never'.
+	// The 'null' and 'undefined' values cannot be nominal typed (they are not
+	// valid enum values and intersection ('&') with 'null'/'undefined' -> 'never').
 	// Just verify that the 'null' and 'undefined' values are preserved.
 	type _check_undefined1 = requireAssignableTo<TypeOnly<undefined>, undefined>;
 	type _check_undefined2 = requireAssignableTo<undefined, TypeOnly<undefined>>;
@@ -172,7 +173,7 @@ namespace Test_TypeOnly_Preserves_Primitives {
 	type _check_null1 = requireAssignableTo<TypeOnly<null>, null>;
 	type _check_null2 = requireAssignableTo<null, TypeOnly<null>>;
 
-	// Types that extend 'number' and 'string' are stripped to thier primitive types.
+	// Types that extend 'number' and 'string' are stripped to their primitive types.
 	// (Nominal typing is erased.)
 	type brandedNumber = number & { brand: "Number" };
 	type _check_number1 = requireAssignableTo<TypeOnly<brandedNumber>, number>;


### PR DESCRIPTION
The current prelease version of 'type-test-generator' contains a change to TypeOnly<T> that strips nominal typing from strings and numbers.  While seemingly more permissive, this introduced 2 type test failures in '@fluidframework/file-driver'.

I believe the error message points to the _prototype_ of this ctor fn:
```ts
export const FileSnapshotWriterClassFactory = <TBase extends ReaderConstructor>(Base: TBase) =>
  class extends Base implements ISnapshotWriterStorage {
    ...
  }
```
And the symptoms indicate that a Boolean type is causing the TypeOnly comparison to fail, although the compiler does not indicate the specific field (it just reports that the 'prototype' field is not assignable.)

Further modifying TypeOnly<T> to preserve the original typing of other primitives (boolean, bigint, and symbol) fixes this issue.  The 'null' and 'undefined' values cannot be branded (intersection returns never) and do not require special treatment.

