### PR TITLE
improvement(eslint-config-fluid): Ignore generated files

### DIFF
--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -35,6 +35,13 @@ module.exports = {
 	},
 	plugins: ["unicorn"],
 	reportUnusedDisableDirectives: true,
+	ignorePatterns: [
+		// Don't lint generated files
+		"**/*.generated.*",
+
+		// Don't lint generated packageVersion files.
+		"**/packageVersion.ts",
+	],
 	rules: {
 		// Please keep entries alphabetized within a group
 

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -59,10 +59,6 @@ module.exports = {
 		"unicorn",
 	],
 	reportUnusedDisableDirectives: true,
-	ignorePatterns: [
-		// Don't lint generated packageVersion files.
-		"**/packageVersion.ts",
-	],
 	rules: {
 		/**
 		 * The @rushstack rules are documented in the package README:

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -10,6 +10,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "ignorePatterns": [
+        "**/*.generated.*",
         "**/packageVersion.ts"
     ],
     "parserOptions": {

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -10,6 +10,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "ignorePatterns": [
+        "**/*.generated.*",
         "**/packageVersion.ts"
     ],
     "parserOptions": {

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -10,6 +10,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "ignorePatterns": [
+        "**/*.generated.*",
         "**/packageVersion.ts"
     ],
     "parserOptions": {

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -10,6 +10,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "ignorePatterns": [
+        "**/*.generated.*",
         "**/packageVersion.ts"
     ],
     "parserOptions": {

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -10,6 +10,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "ignorePatterns": [
+        "**/*.generated.*",
         "**/packageVersion.ts"
     ],
     "parserOptions": {

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -10,6 +10,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "ignorePatterns": [
+        "**/*.generated.*",
         "**/packageVersion.ts"
     ],
     "parserOptions": {

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -179,13 +179,5 @@ module.exports = {
 				"unicorn/consistent-function-scoping": "off",
 			},
 		},
-		{
-			// Rules only for type validation files
-			files: ["**/types/*validate*Previous*.ts"],
-			rules: {
-				"@typescript-eslint/no-explicit-any": "off",
-				"@typescript-eslint/no-unsafe-argument": "off",
-			},
-		},
 	],
 };


### PR DESCRIPTION
There isn't really a need to lint generated file contents. Rather than disabling a subset of the rules for generated files, this change omits all `*.generated.*` files.