### PR TITLE
tree2: Update domains

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -24,17 +24,17 @@ export interface Adapters {
 }
 
 // @alpha
-const all: readonly [readonly [TreeSchema<"fluidframework.com.leaf.1.number", {
+const all: readonly [readonly [TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: ValueSchema.Number;
-}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+}>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: ValueSchema.Boolean;
-}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+}>, TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: ValueSchema.String;
-}>], TreeSchema<"fluidframework.com.leaf.1.number", {
+}>], TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: ValueSchema.Number;
-}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+}>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: ValueSchema.Boolean;
-}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+}>, TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: ValueSchema.String;
 }>];
 
@@ -211,7 +211,7 @@ export interface BindTree<T = BindTreeDefault> extends PathStep {
 export type BindTreeDefault = BindTree;
 
 // @alpha (undocumented)
-const boolean: TreeSchema<"fluidframework.com.leaf.1.boolean", {
+const boolean: TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: ValueSchema.Boolean;
 }>;
 
@@ -850,7 +850,7 @@ export function getPrimaryField(schema: TreeStoredSchema): {
 } | undefined;
 
 // @alpha (undocumented)
-const handle: TreeSchema<"fluidframework.com.leaf.1.handle", {
+const handle: TreeSchema<"com.fluidframework.leaf.handle", {
 leafValue: ValueSchema.FluidHandle;
 }>;
 
@@ -1244,11 +1244,11 @@ export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree;
 // @alpha (undocumented)
 export const jsonArray: TreeSchema<"Json.Array", {
 structFields: {
-"": FieldSchema<Sequence, [any, any, TreeSchema<"fluidframework.com.leaf.1.number", {
+"": FieldSchema<Sequence, [any, any, TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("../..").ValueSchema.Number;
-}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+}>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: import("../..").ValueSchema.Boolean;
-}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+}>, TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: import("../..").ValueSchema.String;
 }>, TreeSchema<"Json.Null", {
 structFields: {};
@@ -1257,7 +1257,7 @@ structFields: {};
 }>;
 
 // @alpha @deprecated (undocumented)
-export const jsonBoolean: TreeSchema<"fluidframework.com.leaf.1.boolean", {
+export const jsonBoolean: TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: import("../..").ValueSchema.Boolean;
 }>;
 
@@ -1280,7 +1280,7 @@ structFields: {};
 }>;
 
 // @alpha @deprecated (undocumented)
-export const jsonNumber: TreeSchema<"fluidframework.com.leaf.1.number", {
+export const jsonNumber: TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("../..").ValueSchema.Number;
 }>;
 
@@ -1288,21 +1288,21 @@ leafValue: import("../..").ValueSchema.Number;
 export const jsonObject: TreeSchema<"Json.Object", {
 mapFields: FieldSchema<Optional, [any, () => TreeSchema<"Json.Array", {
 structFields: {
-"": FieldSchema<Sequence, [any, any, TreeSchema<"fluidframework.com.leaf.1.number", {
+"": FieldSchema<Sequence, [any, any, TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("../..").ValueSchema.Number;
-}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+}>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: import("../..").ValueSchema.Boolean;
-}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+}>, TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: import("../..").ValueSchema.String;
 }>, TreeSchema<"Json.Null", {
 structFields: {};
 }>]>;
 };
-}>, TreeSchema<"fluidframework.com.leaf.1.number", {
+}>, TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("../..").ValueSchema.Number;
-}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+}>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: import("../..").ValueSchema.Boolean;
-}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+}>, TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: import("../..").ValueSchema.String;
 }>, TreeSchema<"Json.Null", {
 structFields: {};
@@ -1316,7 +1316,7 @@ export const jsonSchema: SchemaLibrary;
 const jsonSchema_2: SchemaLibrary;
 
 // @alpha @deprecated (undocumented)
-export const jsonString: TreeSchema<"fluidframework.com.leaf.1.string", {
+export const jsonString: TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: import("../..").ValueSchema.String;
 }>;
 
@@ -1597,7 +1597,7 @@ type NormalizeStructFieldsInner<T extends Fields> = {
 };
 
 // @alpha (undocumented)
-const number: TreeSchema<"fluidframework.com.leaf.1.number", {
+const number: TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: ValueSchema.Number;
 }>;
 
@@ -1685,11 +1685,11 @@ export function prefixFieldPath(prefix: PathRootPrefix | undefined, path: FieldU
 export function prefixPath(prefix: PathRootPrefix | undefined, path: UpPath | undefined): UpPath | undefined;
 
 // @alpha (undocumented)
-const primitives: readonly [TreeSchema<"fluidframework.com.leaf.1.number", {
+const primitives: readonly [TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: ValueSchema.Number;
-}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+}>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: ValueSchema.Boolean;
-}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+}>, TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: ValueSchema.String;
 }>];
 
@@ -1731,7 +1731,7 @@ export function recordDependency(dependent: ObservingDependent | undefined, depe
 const recursiveStruct: TreeSchema<"recursiveStruct", {
 structFields: {
 recursive: FieldSchema<Optional, [() => TreeSchema<"recursiveStruct", any>]>;
-number: FieldSchema<ValueFieldKind, [TreeSchema<"fluidframework.com.leaf.1.number", {
+number: FieldSchema<ValueFieldKind, [TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("..").ValueSchema.Number;
 }>]>;
 };
@@ -1741,7 +1741,7 @@ leafValue: import("..").ValueSchema.Number;
 const recursiveStruct2: TreeSchema<"recursiveStruct2", {
 structFields: {
 recursive: FieldSchema<Optional, [() => TreeSchema<"recursiveStruct2", any>]>;
-number: FieldSchema<ValueFieldKind, [TreeSchema<"fluidframework.com.leaf.1.number", {
+number: FieldSchema<ValueFieldKind, [TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("..").ValueSchema.Number;
 }>]>;
 };
@@ -2009,7 +2009,7 @@ export interface StoredSchemaRepository extends Dependee, ISubscribable<SchemaEv
 }
 
 // @alpha (undocumented)
-const string: TreeSchema<"fluidframework.com.leaf.1.string", {
+const string: TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: ValueSchema.String;
 }>;
 

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -24,6 +24,21 @@ export interface Adapters {
 }
 
 // @alpha
+const all: readonly [readonly [TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: ValueSchema.Number;
+}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: ValueSchema.Boolean;
+}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: ValueSchema.String;
+}>], TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: ValueSchema.Number;
+}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: ValueSchema.Boolean;
+}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: ValueSchema.String;
+}>];
+
+// @alpha
 export type AllowedTypes = [Any] | readonly LazyItem<TreeSchema>[];
 
 // @alpha
@@ -194,6 +209,11 @@ export interface BindTree<T = BindTreeDefault> extends PathStep {
 
 // @alpha
 export type BindTreeDefault = BindTree;
+
+// @alpha (undocumented)
+const boolean: TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: ValueSchema.Boolean;
+}>;
 
 // @alpha
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
@@ -830,6 +850,11 @@ export function getPrimaryField(schema: TreeStoredSchema): {
 } | undefined;
 
 // @alpha (undocumented)
+const handle: TreeSchema<"fluidframework.com.leaf.1.handle", {
+leafValue: ValueSchema.FluidHandle;
+}>;
+
+// @alpha (undocumented)
 export interface HasFieldChanges {
     // (undocumented)
     fieldChanges?: FieldChangeMap;
@@ -1219,21 +1244,21 @@ export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree;
 // @alpha (undocumented)
 export const jsonArray: TreeSchema<"Json.Array", {
 structFields: {
-"": FieldSchema<Sequence, [any, any, TreeSchema<"Json.Number", {
-leafValue: ValueSchema.Number;
-}>, TreeSchema<"Json.String", {
-leafValue: ValueSchema.String;
+"": FieldSchema<Sequence, [any, any, TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: import("../..").ValueSchema.Number;
+}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: import("../..").ValueSchema.Boolean;
+}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: import("../..").ValueSchema.String;
 }>, TreeSchema<"Json.Null", {
 structFields: {};
-}>, TreeSchema<"Json.Boolean", {
-leafValue: ValueSchema.Boolean;
 }>]>;
 };
 }>;
 
-// @alpha (undocumented)
-export const jsonBoolean: TreeSchema<"Json.Boolean", {
-leafValue: ValueSchema.Boolean;
+// @alpha @deprecated (undocumented)
+export const jsonBoolean: TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: import("../..").ValueSchema.Boolean;
 }>;
 
 // @alpha
@@ -1254,33 +1279,33 @@ export const jsonNull: TreeSchema<"Json.Null", {
 structFields: {};
 }>;
 
-// @alpha (undocumented)
-export const jsonNumber: TreeSchema<"Json.Number", {
-leafValue: ValueSchema.Number;
+// @alpha @deprecated (undocumented)
+export const jsonNumber: TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: import("../..").ValueSchema.Number;
 }>;
 
 // @alpha (undocumented)
 export const jsonObject: TreeSchema<"Json.Object", {
 mapFields: FieldSchema<Optional, [any, () => TreeSchema<"Json.Array", {
 structFields: {
-"": FieldSchema<Sequence, [any, any, TreeSchema<"Json.Number", {
-leafValue: ValueSchema.Number;
-}>, TreeSchema<"Json.String", {
-leafValue: ValueSchema.String;
+"": FieldSchema<Sequence, [any, any, TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: import("../..").ValueSchema.Number;
+}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: import("../..").ValueSchema.Boolean;
+}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: import("../..").ValueSchema.String;
 }>, TreeSchema<"Json.Null", {
 structFields: {};
-}>, TreeSchema<"Json.Boolean", {
-leafValue: ValueSchema.Boolean;
 }>]>;
 };
-}>, TreeSchema<"Json.Number", {
-leafValue: ValueSchema.Number;
-}>, TreeSchema<"Json.String", {
-leafValue: ValueSchema.String;
+}>, TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: import("../..").ValueSchema.Number;
+}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: import("../..").ValueSchema.Boolean;
+}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: import("../..").ValueSchema.String;
 }>, TreeSchema<"Json.Null", {
 structFields: {};
-}>, TreeSchema<"Json.Boolean", {
-leafValue: ValueSchema.Boolean;
 }>]>;
 }>;
 
@@ -1288,8 +1313,11 @@ leafValue: ValueSchema.Boolean;
 export const jsonSchema: SchemaLibrary;
 
 // @alpha (undocumented)
-export const jsonString: TreeSchema<"Json.String", {
-leafValue: ValueSchema.String;
+const jsonSchema_2: SchemaLibrary;
+
+// @alpha @deprecated (undocumented)
+export const jsonString: TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: import("../..").ValueSchema.String;
 }>;
 
 // @alpha
@@ -1308,6 +1336,19 @@ export interface Leaf<TSchema extends LeafSchema> extends TreeNode {
     readonly value: SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>;
 }
 
+declare namespace leaf {
+    export {
+        number,
+        boolean,
+        string,
+        handle,
+        primitives,
+        all,
+        library
+    }
+}
+export { leaf }
+
 // @alpha (undocumented)
 export type LeafSchema = TreeSchema & LeafSchemaSpecification;
 
@@ -1316,6 +1357,9 @@ interface LeafSchemaSpecification {
     // (undocumented)
     readonly leafValue: ValueSchema;
 }
+
+// @alpha (undocumented)
+const library: SchemaLibrary;
 
 // @alpha
 export enum LocalCommitSource {
@@ -1552,6 +1596,11 @@ type NormalizeStructFieldsInner<T extends Fields> = {
     [Property in keyof T]: NormalizeField<T[Property]>;
 };
 
+// @alpha (undocumented)
+const number: TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: ValueSchema.Number;
+}>;
+
 // @alpha
 type ObjectToMap<ObjectMap, MapKey extends number | string, MapValue> = ReadonlyMap<MapKey, MapValue> & {
     get<TKey extends keyof ObjectMap>(key: TKey): ObjectMap[TKey];
@@ -1636,6 +1685,15 @@ export function prefixFieldPath(prefix: PathRootPrefix | undefined, path: FieldU
 export function prefixPath(prefix: PathRootPrefix | undefined, path: UpPath | undefined): UpPath | undefined;
 
 // @alpha (undocumented)
+const primitives: readonly [TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: ValueSchema.Number;
+}>, TreeSchema<"fluidframework.com.leaf.1.boolean", {
+leafValue: ValueSchema.Boolean;
+}>, TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: ValueSchema.String;
+}>];
+
+// @alpha (undocumented)
 export type PrimitiveValue = string | boolean | number;
 
 // @alpha
@@ -1668,6 +1726,26 @@ export interface ReadonlyRepairDataStore<TTree = Delta.ProtoNode, TRevisionTag =
 
 // @alpha
 export function recordDependency(dependent: ObservingDependent | undefined, dependee: Dependee): void;
+
+// @alpha (undocumented)
+const recursiveStruct: TreeSchema<"recursiveStruct", {
+structFields: {
+recursive: FieldSchema<Optional, [() => TreeSchema<"recursiveStruct", any>]>;
+number: FieldSchema<ValueFieldKind, [TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: import("..").ValueSchema.Number;
+}>]>;
+};
+}>;
+
+// @alpha (undocumented)
+const recursiveStruct2: TreeSchema<"recursiveStruct2", {
+structFields: {
+recursive: FieldSchema<Optional, [() => TreeSchema<"recursiveStruct2", any>]>;
+number: FieldSchema<ValueFieldKind, [TreeSchema<"fluidframework.com.leaf.1.number", {
+leafValue: import("..").ValueSchema.Number;
+}>]>;
+};
+}>;
 
 // @alpha
 type RecursiveTreeSchema = unknown;
@@ -1930,6 +2008,11 @@ export interface StoredSchemaRepository extends Dependee, ISubscribable<SchemaEv
     update(newSchema: SchemaData): void;
 }
 
+// @alpha (undocumented)
+const string: TreeSchema<"fluidframework.com.leaf.1.string", {
+leafValue: ValueSchema.String;
+}>;
+
 // @alpha
 export interface Struct extends TreeNode {
     readonly localNodeKey?: LocalNodeKey;
@@ -1970,6 +2053,15 @@ export interface TaggedChange<TChangeset> {
     readonly revision: RevisionTag | undefined;
     readonly rollbackOf?: RevisionTag;
 }
+
+declare namespace testRecursiveDomain {
+    export {
+        recursiveStruct,
+        recursiveStruct2,
+        jsonSchema_2 as jsonSchema
+    }
+}
+export { testRecursiveDomain }
 
 // @alpha
 export type ToDelta = (child: NodeChangeset) => Delta.Modify;

--- a/experimental/dds/tree2/src/domains/index.ts
+++ b/experimental/dds/tree2/src/domains/index.ts
@@ -17,3 +17,9 @@ export {
 } from "./json";
 
 export { nodeKeyField, nodeKeySchema, nodeKeyTreeSchema } from "./nodeKey";
+
+import * as leaf from "./leafDomain";
+export { leaf };
+
+import * as testRecursiveDomain from "./testRecursiveDomain";
+export { testRecursiveDomain };

--- a/experimental/dds/tree2/src/domains/json/fence.json
+++ b/experimental/dds/tree2/src/domains/json/fence.json
@@ -1,5 +1,5 @@
 {
-	"tags": ["tree"],
+	"tags": ["domains-json"],
 	"exports": ["index"],
-	"imports": ["util", "core", "feature-libraries"]
+	"imports": ["util", "core", "feature-libraries", "domains"]
 }

--- a/experimental/dds/tree2/src/domains/json/jsonCursor.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonCursor.ts
@@ -14,14 +14,8 @@ import {
 } from "../../core";
 import { JsonCompatible } from "../../util";
 import { CursorAdapter, isPrimitiveValue, singleStackTreeCursor } from "../../feature-libraries";
-import {
-	jsonArray,
-	jsonBoolean,
-	jsonNull,
-	jsonNumber,
-	jsonObject,
-	jsonString,
-} from "./jsonDomainSchema";
+import * as leaf from "../leafDomain";
+import { jsonArray, jsonNull, jsonObject } from "./jsonDomainSchema";
 
 const adapter: CursorAdapter<JsonCompatible> = {
 	value: (node: JsonCompatible) =>
@@ -33,11 +27,11 @@ const adapter: CursorAdapter<JsonCompatible> = {
 
 		switch (type) {
 			case "number":
-				return jsonNumber.name;
+				return leaf.number.name;
 			case "string":
-				return jsonString.name;
+				return leaf.string.name;
 			case "boolean":
-				return jsonBoolean.name;
+				return leaf.boolean.name;
 			default:
 				if (node === null) {
 					return jsonNull.name;
@@ -112,9 +106,9 @@ export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
 	const type = reader.type;
 
 	switch (type) {
-		case jsonNumber.name:
-		case jsonBoolean.name:
-		case jsonString.name:
+		case leaf.number.name:
+		case leaf.boolean.name:
+		case leaf.string.name:
 			assert(isPrimitiveValue(reader.value), 0x41f /* expected a primitive value */);
 			return reader.value as JsonCompatible;
 		case jsonArray.name: {

--- a/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
@@ -4,20 +4,22 @@
  */
 
 import { AllowedTypes, FieldKinds, SchemaBuilder } from "../../feature-libraries";
-import { ValueSchema } from "../../core";
 import { requireAssignableTo } from "../../util";
+import * as leaf from "../leafDomain";
 
 const builder = new SchemaBuilder("Json Domain");
 
 /**
  * @alpha
+ * @deprecated Use leaf.number
  */
-export const jsonNumber = builder.leaf("Json.Number", ValueSchema.Number);
+export const jsonNumber = leaf.number;
 
 /**
  * @alpha
+ * @deprecated Use leaf.string
  */
-export const jsonString = builder.leaf("Json.String", ValueSchema.String);
+export const jsonString = leaf.string;
 
 /**
  * @alpha
@@ -26,10 +28,11 @@ export const jsonNull = builder.struct("Json.Null", {});
 
 /**
  * @alpha
+ * @deprecated Use leaf.boolean
  */
-export const jsonBoolean = builder.leaf("Json.Boolean", ValueSchema.Boolean);
+export const jsonBoolean = leaf.boolean;
 
-const jsonPrimitives = [jsonNumber, jsonString, jsonNull, jsonBoolean] as const;
+const jsonPrimitives = [...leaf.primitives, jsonNull] as const;
 
 /**
  * Types allowed as roots of Json content.

--- a/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
@@ -7,7 +7,7 @@ import { AllowedTypes, FieldKinds, SchemaBuilder } from "../../feature-libraries
 import { requireAssignableTo } from "../../util";
 import * as leaf from "../leafDomain";
 
-const builder = new SchemaBuilder("Json Domain");
+const builder = new SchemaBuilder("Json Domain", {}, leaf.library);
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SchemaBuilder } from "../feature-libraries";
+import { ValueSchema } from "../core";
+
+// https://en.wikipedia.org/wiki/Reverse_domain_name_notation
+const builder = new SchemaBuilder("Leaf");
+
+/**
+ * @alpha
+ */
+export const number = builder.leaf("fluidframework.com.leaf.1.number", ValueSchema.Number);
+/**
+ * @alpha
+ */
+export const boolean = builder.leaf("fluidframework.com.leaf.1.boolean", ValueSchema.Boolean);
+/**
+ * @alpha
+ */
+export const string = builder.leaf("fluidframework.com.leaf.1.string", ValueSchema.String);
+/**
+ * @alpha
+ */
+export const handle = builder.leaf("fluidframework.com.leaf.1.handle", ValueSchema.FluidHandle);
+
+/**
+ * @alpha
+ */
+export const primitives = [number, boolean, string] as const;
+
+/**
+ * Types allowed as roots of Json content.
+ * @alpha
+ */
+export const all = [primitives, ...primitives] as const;
+
+/**
+ * @alpha
+ */
+export const library = builder.intoLibrary();

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -7,26 +7,26 @@ import { SchemaBuilder } from "../feature-libraries";
 import { ValueSchema } from "../core";
 
 /**
- * Names in this domain follow https://en.wikipedia.org/wiki/Reverse_domain_name_notation, and are versioned.
+ * Names in this domain follow https://en.wikipedia.org/wiki/Reverse_domain_name_notation
  */
 const builder = new SchemaBuilder("Leaf");
 
 /**
  * @alpha
  */
-export const number = builder.leaf("fluidframework.com.leaf.1.number", ValueSchema.Number);
+export const number = builder.leaf("com.fluidframework.leaf.number", ValueSchema.Number);
 /**
  * @alpha
  */
-export const boolean = builder.leaf("fluidframework.com.leaf.1.boolean", ValueSchema.Boolean);
+export const boolean = builder.leaf("com.fluidframework.leaf.boolean", ValueSchema.Boolean);
 /**
  * @alpha
  */
-export const string = builder.leaf("fluidframework.com.leaf.1.string", ValueSchema.String);
+export const string = builder.leaf("com.fluidframework.leaf.string", ValueSchema.String);
 /**
  * @alpha
  */
-export const handle = builder.leaf("fluidframework.com.leaf.1.handle", ValueSchema.FluidHandle);
+export const handle = builder.leaf("com.fluidframework.leaf.handle", ValueSchema.FluidHandle);
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -6,7 +6,9 @@
 import { SchemaBuilder } from "../feature-libraries";
 import { ValueSchema } from "../core";
 
-// https://en.wikipedia.org/wiki/Reverse_domain_name_notation
+/**
+ * Names in this domain follow https://en.wikipedia.org/wiki/Reverse_domain_name_notation, and are versioned.
+ */
 const builder = new SchemaBuilder("Leaf");
 
 /**

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * This file exists and is package exported to aid in testing of exporting recursive types across package boundaries.
+ * Sometimes when TypeScript generates d.ts files, they type check significantly differently than the original source (One example of this: https://github.com/microsoft/TypeScript/issues/20979).
+ * Unfortunately our recursive schema types are an example of types that have this kind of issue: the d.ts files tend to get "any" instead of the recursive type reference.
+ * Currently we do not have tooling in place to test this in our test suite, and exporting these types here is a temporary crutch to aid in diagnosing this issue.
+ */
+
+import { AllowedTypes, FieldKinds, SchemaBuilder } from "../feature-libraries";
+import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../util";
+import * as leaf from "./leafDomain";
+
+const builder = new SchemaBuilder("Json Domain", {}, leaf.library);
+
+/**
+ * @alpha
+ */
+export const recursiveStruct = builder.structRecursive("recursiveStruct", {
+	recursive: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => recursiveStruct),
+	number: SchemaBuilder.fieldValue(leaf.number),
+});
+
+// Some related information in https://github.com/microsoft/TypeScript/issues/55758.
+function fixRecursiveReference<T extends AllowedTypes>(...types: T): void {}
+
+const recursiveReference = () => recursiveStruct2;
+fixRecursiveReference(recursiveReference);
+
+/**
+ * @alpha
+ */
+export const recursiveStruct2 = builder.struct("recursiveStruct2", {
+	recursive: SchemaBuilder.field(FieldKinds.optional, recursiveReference),
+	number: SchemaBuilder.fieldValue(leaf.number),
+});
+
+type _0 = requireFalse<isAny<typeof recursiveStruct2>>;
+type _1 = requireTrue<
+	areSafelyAssignable<
+		typeof recursiveStruct2,
+		ReturnType<typeof recursiveStruct2.structFieldsObject.recursive.allowedTypes[0]>
+	>
+>;
+/**
+ * @alpha
+ */
+export const jsonSchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -122,6 +122,8 @@ export {
 	jsonSchema,
 	nodeKeyField,
 	nodeKeySchema,
+	leaf,
+	testRecursiveDomain,
 } from "./domains";
 
 export {


### PR DESCRIPTION
## Description

Adds "leaf" domain providing default leaf types for each value type.

Updates the json domain to use these leaf types.

Adds a test domain for experimenting with cross package recursive types.
They do not work correctly, and this provides a simpler case to work on than the json domain.

## Breaking Changes

The type names for data in the Json schema have changed, which will break existing documents using it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

