### PR TITLE
fix(fluid-build): Pass env vars to child processes

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -230,6 +230,7 @@ export abstract class LeafTask extends Task {
 		return execAsync(this.command, {
 			cwd: this.node.pkg.directory,
 			env: {
+				...process.env,
 				PATH: `${path.join(this.node.pkg.directory, "node_modules", ".bin")}${
 					path.delimiter
 				}${process.env["PATH"]}`,


### PR DESCRIPTION
## Description

Make fluid-build pass env vars to child processes.

### Context 

Working on fluid-devtools we noticed that fluid-build doesn't seem to be passing environment variables to child processes when it runs tasks. `packages/tools/devtools/devtools-browser-extension` uses the [dotenv-webpack](https://github.com/mrsteele/dotenv-webpack) plugin to inline values of environment variables at bundle time. Doing something like `export MY_ENV_VAR=myValue; npm run webpack` works correctly, but `export MY_ENV_VAR=myValue; npm run build` does not (the plugin does not see the env var and ends up using a placeholder, like its docs say it will).

<img width="1022" alt="image" src="https://github.com/microsoft/FluidFramework/assets/716334/529e7a14-934a-4e83-9af7-36e17c75fd42">

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Confirmed locally that this makes the fluid-devtools scenario work.