### PR TITLE
Summarization: Wrap any errors thrown from mixed in summary handler as DataProcessingError

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1182,9 +1182,12 @@ export const mixinSummaryHandler = (
 
 		async summarize(...args: any[]) {
 			const summary = await super.summarize(...args);
+
+			// Any error coming from app-provided handler should be marked as DataProcessingError
 			const content = await handler(this).catch((e: unknown) => {
 				throw DataProcessingError.wrapIfUnrecognized(e, "mixinSummaryHandler");
 			});
+
 			if (content !== undefined) {
 				this.addBlob(summary, content.path, content.content);
 			}

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1182,7 +1182,9 @@ export const mixinSummaryHandler = (
 
 		async summarize(...args: any[]) {
 			const summary = await super.summarize(...args);
-			const content = await handler(this);
+			const content = await handler(this).catch((e: unknown) => {
+				throw DataProcessingError.wrapIfUnrecognized(e, "mixinSummaryHandler");
+			});
 			if (content !== undefined) {
 				this.addBlob(summary, content.path, content.content);
 			}

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1183,14 +1183,16 @@ export const mixinSummaryHandler = (
 		async summarize(...args: any[]) {
 			const summary = await super.summarize(...args);
 
-			// Any error coming from app-provided handler should be marked as DataProcessingError
-			const content = await handler(this).catch((e: unknown) => {
+			try {
+				const content = await handler(this);
+				if (content !== undefined) {
+					this.addBlob(summary, content.path, content.content);
+				}
+			} catch (e) {
+				// Any error coming from app-provided handler should be marked as DataProcessingError
 				throw DataProcessingError.wrapIfUnrecognized(e, "mixinSummaryHandler");
-			});
-
-			if (content !== undefined) {
-				this.addBlob(summary, content.path, content.content);
 			}
+
 			return summary;
 		}
 	} as typeof FluidDataStoreRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -715,17 +715,7 @@ describeNoCompat("Summarizer with local changes", (getTestObjectProvider) => {
 		},
 	);
 
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	itExpects.only(
+	itExpects(
 		"Errors thrown from mixinSummaryHandler are tagged as DataProcessingError",
 		[
 			{


### PR DESCRIPTION
## Description

When a consumer of FF uses `mixinSummaryHandler` to run additional code before summarization, they introduce risk to the Summarization system where that code could throw and cause summarization to fail.  These failures are completely outside the control of FF, but can be catastrophic for a container since persistent failure to summarize can lead to effective document corruption (e.g. ODSP blocks all changes once there are 10k unsummarized ops).

So we want to classify these errors as DataProcessingErrors with the codepath `mixinSummaryHandler` mentioned so we and our partners can have immediate insight when these errors arise.  Currently, a premier 1P partner is facing a large number of these errors and we are trying to clarify the telemetry signal to be more actionable.
 
Fixes [AB#5675](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5675)