### PR TITLE
Disable Service Summaries for Ephemeral Containers

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -835,11 +835,17 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				"Session metric already completed. Creating a new one.",
 				getLumberBaseProperties(this.documentId, this.tenantId),
 			);
+			const isEphemeralContainer: boolean =
+				this.sessionMetric?.properties.get("isEphemeralContainer") ?? false;
 			this.sessionMetric = createSessionMetric(
 				this.tenantId,
 				this.documentId,
 				LumberEventName.SessionResult,
 				this.serviceConfiguration,
+			);
+			this.sessionMetric?.setProperty(
+				CommonProperties.isEphemeralContainer,
+				isEphemeralContainer,
 			);
 		}
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -836,7 +836,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				getLumberBaseProperties(this.documentId, this.tenantId),
 			);
 			const isEphemeralContainer: boolean =
-				this.sessionMetric?.properties.get("isEphemeralContainer") ?? false;
+				this.sessionMetric?.properties.get(CommonProperties.isEphemeralContainer) ?? false;
 			this.sessionMetric = createSessionMetric(
 				this.tenantId,
 				this.documentId,

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -31,6 +31,7 @@ import {
 	LumberEventName,
 	Lumberjack,
 	getLumberBaseProperties,
+	CommonProperties,
 } from "@fluidframework/server-services-telemetry";
 import { NoOpLambda, createSessionMetric, isDocumentValid, isDocumentSessionValid } from "../utils";
 import { DeliLambda } from "./lambda";
@@ -126,6 +127,11 @@ export class DeliLambdaFactory
 					return new NoOpLambda(context);
 				}
 			}
+
+			sessionMetric?.setProperty(
+				CommonProperties.isEphemeralContainer,
+				document?.isEphemeralContainer ?? false,
+			);
 
 			gitManager = await this.tenantManager.getTenantGitManager(tenantId, documentId);
 		} catch (error) {

--- a/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
@@ -39,6 +39,7 @@ export interface ISummaryWriter {
 		lastSummaryHead: string | undefined,
 		checkpoint: IScribe,
 		pendingOps: ISequencedOperationMessage[],
+		isEphemeralContainer?: boolean,
 	): Promise<ISummaryWriteResponse>;
 
 	writeServiceSummary(
@@ -46,6 +47,7 @@ export interface ISummaryWriter {
 		currentProtocolHead: number,
 		checkpoint: IScribe,
 		pendingOps: ISequencedOperationMessage[],
+		isEphemeralContainer?: boolean,
 	): Promise<string | false>;
 
 	isExternal: boolean;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -36,6 +36,7 @@ import {
 	Lumber,
 	LumberEventName,
 	Lumberjack,
+	CommonProperties,
 } from "@fluidframework/server-services-telemetry";
 import Deque from "double-ended-queue";
 import * as _ from "lodash";
@@ -500,11 +501,17 @@ export class ScribeLambda implements IPartitionLambda {
 				"Scribe session metric already completed. Creating a new one.",
 				getLumberBaseProperties(this.documentId, this.tenantId),
 			);
+			const isEphemeralContainer: boolean =
+				this.scribeSessionMetric?.properties.get("isEphemeralContainer") ?? false;
 			this.scribeSessionMetric = createSessionMetric(
 				this.tenantId,
 				this.documentId,
 				LumberEventName.ScribeSessionResult,
 				this.serviceConfiguration,
+			);
+			this.scribeSessionMetric?.setProperty(
+				CommonProperties.isEphemeralContainer,
+				isEphemeralContainer,
 			);
 		}
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -112,6 +112,7 @@ export class ScribeLambda implements IPartitionLambda {
 		private readonly disableTransientTenantFiltering: boolean,
 		private readonly restartOnCheckpointFailure: boolean,
 		private readonly kafkaCheckpointOnReprocessingOp: boolean,
+		private readonly isEphemeralContainer: boolean,
 	) {
 		this.lastOffset = scribe.logOffset;
 		this.setStateFromCheckpoint(scribe);
@@ -351,6 +352,7 @@ export class ScribeLambda implements IPartitionLambda {
 
 					if (
 						this.serviceConfiguration.scribe.generateServiceSummary &&
+						!this.isEphemeralContainer &&
 						enableServiceSummaryForTenant
 					) {
 						const operation = value.operation as ISequencedDocumentAugmentedMessage;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -251,6 +251,7 @@ export class ScribeLambda implements IPartitionLambda {
 									this.lastClientSummaryHead,
 									scribeCheckpoint,
 									this.pendingCheckpointMessages.toArray(),
+									this.isEphemeralContainer,
 								);
 
 								// This block is only executed if the writer is not external. For an external writer,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -502,7 +502,8 @@ export class ScribeLambda implements IPartitionLambda {
 				getLumberBaseProperties(this.documentId, this.tenantId),
 			);
 			const isEphemeralContainer: boolean =
-				this.scribeSessionMetric?.properties.get("isEphemeralContainer") ?? false;
+				this.scribeSessionMetric?.properties.get(CommonProperties.isEphemeralContainer) ??
+				false;
 			this.scribeSessionMetric = createSessionMetric(
 				this.tenantId,
 				this.documentId,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -37,6 +37,7 @@ import {
 	getLumberBaseProperties,
 	LumberEventName,
 	Lumberjack,
+	CommonProperties,
 } from "@fluidframework/server-services-telemetry";
 import { NoOpLambda, createSessionMetric, isDocumentValid, isDocumentSessionValid } from "../utils";
 import { CheckpointManager } from "./checkpointManager";
@@ -156,6 +157,11 @@ export class ScribeLambdaFactory
 					return new NoOpLambda(context);
 				}
 			}
+
+			scribeSessionMetric?.setProperty(
+				CommonProperties.isEphemeralContainer,
+				document?.isEphemeralContainer ?? false,
+			);
 
 			gitManager = await this.tenantManager.getTenantGitManager(tenantId, documentId);
 			summaryReader = new SummaryReader(

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -315,6 +315,7 @@ export class ScribeLambdaFactory
 			this.disableTransientTenantFiltering,
 			this.restartOnCheckpointFailure,
 			this.kafkaCheckpointOnReprocessingOp,
+			document.isEphemeralContainer ?? false,
 		);
 
 		await this.sendLambdaStartResult(tenantId, documentId, {

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -398,6 +398,7 @@ export class LocalOrderer implements IOrderer {
 			true,
 			true,
 			true,
+			this.details.value.isEphemeralContainer,
 		);
 	}
 


### PR DESCRIPTION
## Description

> Title
> Also adds the isEphemeralContainer flag to the logs for a few logging metrics: ServiceSummary, ClientSummary, ScribeSessionResult, SessionResult

## Reviewer Guidance

> In making this PR, I chose not to add isEphemeralContainer as a parameter of the createSessionMetric function because in some places it is used in do not have access to isEphemeralContainer. In some of these cases, how I get around the issue is by calling this.metricName?.setProperty after creation once I have access to the flag (for example, getting the flag from a document that is later read).