### PR TITLE
Add reduce and boxedArray to tree sequence

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1861,12 +1861,18 @@ export interface Sequence2<TTypes extends AllowedTypes> extends TreeField {
     // (undocumented)
     [Symbol.iterator](): Iterator<TypedNodeUnion<TTypes>>;
     readonly asArray: readonly UnboxNodeUnion<TTypes>[];
+    readonly asBoxedArray: readonly TypedNodeUnion<TTypes>[];
     at(index: number): UnboxNodeUnion<TTypes>;
     boxedAt(index: number): TypedNodeUnion<TTypes>;
-    // (undocumented)
     readonly length: number;
     map<U>(callbackfn: (value: UnboxNodeUnion<TTypes>, index: number, array: this) => U): U[];
     mapBoxed<U>(callbackfn: (value: TypedNodeUnion<TTypes>, index: number, array: this) => U): U[];
+    reduce(callbackfn: (previousValue: UnboxNodeUnion<TTypes>, currentValue: UnboxNodeUnion<TTypes>, currentIndex: number, sequence: this) => UnboxNodeUnion<TTypes>, initialValue?: UnboxNodeUnion<TTypes>): UnboxNodeUnion<TTypes>;
+    // (undocumented)
+    reduce<U>(callbackfn: (previousValue: U, currentValue: UnboxNodeUnion<TTypes>, currentIndex: number, sequence: this) => UnboxNodeUnion<TTypes>, initialValue: U): U;
+    reduceBoxed(callbackfn: (previousValue: TypedNodeUnion<TTypes>, currentValue: TypedNodeUnion<TTypes>, currentIndex: number, sequence: this) => TypedNodeUnion<TTypes>, initialValue?: TypedNodeUnion<TTypes>): TypedNodeUnion<TTypes>;
+    // (undocumented)
+    reduceBoxed<U>(callbackfn: (previousValue: U, currentValue: TypedNodeUnion<TTypes>, currentIndex: number, sequence: this) => TypedNodeUnion<TTypes>, initialValue: U): U;
     // (undocumented)
     replaceRange(index: number, count: number, content: Iterable<FlexibleNodeContent<TTypes>>): void;
 }

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1867,12 +1867,12 @@ export interface Sequence2<TTypes extends AllowedTypes> extends TreeField {
     readonly length: number;
     map<U>(callbackfn: (value: UnboxNodeUnion<TTypes>, index: number, array: this) => U): U[];
     mapBoxed<U>(callbackfn: (value: TypedNodeUnion<TTypes>, index: number, array: this) => U): U[];
-    reduce(callbackfn: (previousValue: UnboxNodeUnion<TTypes>, currentValue: UnboxNodeUnion<TTypes>, currentIndex: number, sequence: this) => UnboxNodeUnion<TTypes>, initialValue?: UnboxNodeUnion<TTypes>): UnboxNodeUnion<TTypes>;
+    reduce(callbackfn: (previousValue: UnboxNodeUnion<TTypes>, currentValue: UnboxNodeUnion<TTypes>, currentIndex: number, sequence: this) => UnboxNodeUnion<TTypes> | Stop<UnboxNodeUnion<TTypes>>, initialValue?: UnboxNodeUnion<TTypes>): UnboxNodeUnion<TTypes>;
     // (undocumented)
-    reduce<U>(callbackfn: (previousValue: U, currentValue: UnboxNodeUnion<TTypes>, currentIndex: number, sequence: this) => UnboxNodeUnion<TTypes>, initialValue: U): U;
-    reduceBoxed(callbackfn: (previousValue: TypedNodeUnion<TTypes>, currentValue: TypedNodeUnion<TTypes>, currentIndex: number, sequence: this) => TypedNodeUnion<TTypes>, initialValue?: TypedNodeUnion<TTypes>): TypedNodeUnion<TTypes>;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: UnboxNodeUnion<TTypes>, currentIndex: number, sequence: this) => U | Stop<U>, initialValue: U): U;
+    reduceBoxed(callbackfn: (previousValue: TypedNodeUnion<TTypes>, currentValue: TypedNodeUnion<TTypes>, currentIndex: number, sequence: this) => TypedNodeUnion<TTypes> | Stop<TypedNodeUnion<TTypes>>, initialValue?: TypedNodeUnion<TTypes>): TypedNodeUnion<TTypes>;
     // (undocumented)
-    reduceBoxed<U>(callbackfn: (previousValue: U, currentValue: TypedNodeUnion<TTypes>, currentIndex: number, sequence: this) => TypedNodeUnion<TTypes>, initialValue: U): U;
+    reduceBoxed<U>(callbackfn: (previousValue: U, currentValue: TypedNodeUnion<TTypes>, currentIndex: number, sequence: this) => U | Stop<U>, initialValue: U): U;
     // (undocumented)
     replaceRange(index: number, count: number, content: Iterable<FlexibleNodeContent<TTypes>>): void;
 }
@@ -1930,6 +1930,13 @@ type Skip = number;
 
 // @alpha
 export type StableNodeKey = Brand<StableId, "Stable Node Key">;
+
+// @alpha
+export class Stop<T> {
+    constructor(value: T);
+    // (undocumented)
+    readonly value: T;
+}
 
 // @alpha
 export interface StoredSchemaRepository extends Dependee, ISubscribable<SchemaEvents>, SchemaData {

--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -83,6 +83,7 @@ export {
 	CursorMarker,
 	isCursor,
 	getDetachedFieldContainingPath,
+	Stop,
 } from "./tree";
 
 export {

--- a/experimental/dds/tree2/src/core/tree/cursor.ts
+++ b/experimental/dds/tree2/src/core/tree/cursor.ts
@@ -8,6 +8,9 @@ import { FieldKey } from "../schema-stored";
 import { FieldUpPath, UpPath } from "./pathTree";
 import { TreeType, Value } from "./types";
 
+export const Stop = Symbol("Stop");
+export type Stop = typeof Stop;
+
 /**
  * A symbol for marking an object as an {@link ITreeCursor}.
  *
@@ -341,16 +344,19 @@ export function mapCursorFields<T, TCursor extends ITreeCursor = ITreeCursor>(
 
 /**
  * @param cursor - cursor at a node whose fields will be visited.
- * @param f - For on each field.
+ * @param f - A function to run for each field.
+ * If `f` returns `Stop`, the iteration will end.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
  */
 export function forEachField<TCursor extends ITreeCursor = ITreeCursor>(
 	cursor: TCursor,
-	f: (cursor: TCursor) => void,
+	f: (cursor: TCursor) => void | Stop,
 ): void {
 	assert(cursor.mode === CursorLocationType.Nodes, 0x411 /* should be in nodes */);
 	for (let inField = cursor.firstField(); inField; inField = cursor.nextField()) {
-		f(cursor);
+		if (f(cursor) === Stop) {
+			return;
+		}
 	}
 }
 
@@ -374,16 +380,19 @@ export function mapCursorField<T, TCursor extends ITreeCursor = ITreeCursor>(
 
 /**
  * @param cursor - cursor at a field whose nodes will be visited.
- * @param f - For on each node.
+ * @param f - A function to run for each node.
+ * If `f` returns `Stop`, the iteration will end.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
  */
 export function forEachNode<TCursor extends ITreeCursor = ITreeCursor>(
 	cursor: TCursor,
-	f: (cursor: TCursor) => void,
+	f: (cursor: TCursor) => void | Stop,
 ): void {
 	assert(cursor.mode === CursorLocationType.Fields, 0x3bd /* should be in fields */);
 	for (let inNodes = cursor.firstNode(); inNodes; inNodes = cursor.nextNode()) {
-		f(cursor);
+		if (f(cursor) === Stop) {
+			return;
+		}
 	}
 }
 

--- a/experimental/dds/tree2/src/core/tree/cursor.ts
+++ b/experimental/dds/tree2/src/core/tree/cursor.ts
@@ -355,6 +355,7 @@ export function forEachField<TCursor extends ITreeCursor = ITreeCursor>(
 	assert(cursor.mode === CursorLocationType.Nodes, 0x411 /* should be in nodes */);
 	for (let inField = cursor.firstField(); inField; inField = cursor.nextField()) {
 		if (f(cursor) === Stop) {
+			cursor.exitField();
 			return;
 		}
 	}
@@ -391,6 +392,7 @@ export function forEachNode<TCursor extends ITreeCursor = ITreeCursor>(
 	assert(cursor.mode === CursorLocationType.Fields, 0x3bd /* should be in fields */);
 	for (let inNodes = cursor.firstNode(); inNodes; inNodes = cursor.nextNode()) {
 		if (f(cursor) === Stop) {
+			cursor.exitNode();
 			return;
 		}
 	}

--- a/experimental/dds/tree2/src/core/tree/index.ts
+++ b/experimental/dds/tree2/src/core/tree/index.ts
@@ -28,6 +28,7 @@ export {
 	inCursorNode,
 	CursorMarker,
 	isCursor,
+	Stop,
 } from "./cursor";
 export { ProtoNodes } from "./delta";
 export { getMapTreeField, MapTree } from "./mapTree";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -487,6 +487,63 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 	 */
 	mapBoxed<U>(callbackfn: (value: TypedNodeUnion<TTypes>, index: number, array: this) => U): U[];
 
+	/**
+	 * Calls the specified callback function for all the elements in the sequence.
+	 * The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+	 * @param callbackfn - A function that accepts up to four arguments.
+	 * The reduce method calls the callbackfn function one time for each element in the array.
+	 * @param initialValue - If present, it is passed to the first call to the callbackfn.
+	 * Otherwise, the first element in the sequence will be used as the initial accumulator value and skipped as currentValue.
+	 */
+	reduce(
+		callbackfn: (
+			previousValue: UnboxNodeUnion<TTypes>,
+			currentValue: UnboxNodeUnion<TTypes>,
+			currentIndex: number,
+			sequence: this,
+		) => UnboxNodeUnion<TTypes>,
+		initialValue?: UnboxNodeUnion<TTypes>,
+	): UnboxNodeUnion<TTypes>;
+	reduce<U>(
+		callbackfn: (
+			previousValue: U,
+			currentValue: UnboxNodeUnion<TTypes>,
+			currentIndex: number,
+			sequence: this,
+		) => UnboxNodeUnion<TTypes>,
+		initialValue: U,
+	): U;
+
+	/**
+	 * Calls the specified callback function for all the elements in the sequence.
+	 * The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+	 * @param callbackfn - A function that accepts up to four arguments.
+	 * The reduce method calls the callbackfn function one time for each element in the array.
+	 * @param initialValue - If present, it is passed to the first call to the callbackfn.
+	 * Otherwise, the first element in the sequence will be used as the initial accumulator value and skipped as currentValue.
+	 */
+	reduceBoxed(
+		callbackfn: (
+			previousValue: TypedNodeUnion<TTypes>,
+			currentValue: TypedNodeUnion<TTypes>,
+			currentIndex: number,
+			sequence: this,
+		) => TypedNodeUnion<TTypes>,
+		initialValue?: TypedNodeUnion<TTypes>,
+	): TypedNodeUnion<TTypes>;
+	reduceBoxed<U>(
+		callbackfn: (
+			previousValue: U,
+			currentValue: TypedNodeUnion<TTypes>,
+			currentIndex: number,
+			sequence: this,
+		) => TypedNodeUnion<TTypes>,
+		initialValue: U,
+	): U;
+
+	/**
+	 * The number of elements in this sequence.
+	 */
 	readonly length: number;
 
 	// TODO: more and/or better editing APIs. As is, this can't express moves.
@@ -499,13 +556,22 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 	[Symbol.iterator](): Iterator<TypedNodeUnion<TTypes>>;
 
 	/**
-	 * An enumerable own property which allows JavaScript object traversals to access {@link Sequence} content.
-	 * It is recommenced to NOT use this when possible (for performance and type safety reasons): instead use {@link Sequence#at} or iterate over nodes with `Symbol.iterator`.
-	 * See [ReadMe](./README.md) for details.
+	 * Provides a copy of this sequence's data as an array.
 	 *
+	 * @remarks
 	 * This array is not guaranteed to be kept up to date across edits and thus should not be held onto across edits.
+	 * This also serves as an enumerable own property which allows JavaScript object traversals to access {@link Sequence} content.
+	 * See [ReadMe](./README.md) for details.
 	 */
 	readonly asArray: readonly UnboxNodeUnion<TTypes>[];
+
+	/**
+	 * Provides a copy of this sequence's data as an array of nodes.
+	 *
+	 * @remarks
+	 * This array is not guaranteed to be kept up to date across edits and thus should not be held onto across edits.
+	 */
+	readonly asBoxedArray: readonly TypedNodeUnion<TTypes>[];
 }
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -569,7 +569,7 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 	 *
 	 * @remarks
 	 * This array is not guaranteed to be kept up to date across edits and thus should not be held onto across edits.
-	 * This also serves as an enumerable own property which allows JavaScript object traversals to access {@link Sequence} content.
+	 * This serves as an enumerable own property which allows JavaScript object traversals to access {@link Sequence} content.
 	 * See [ReadMe](./README.md) for details.
 	 */
 	readonly asArray: readonly UnboxNodeUnion<TTypes>[];

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -23,6 +23,15 @@ import { TreeStatus } from "../editable-tree";
 import { TreeContext } from "./context";
 
 /**
+ * An object returned during an iteration that indicates the iteration should stop after returning the wrapped value.
+ *
+ * @alpha
+ */
+export class Stop<T> {
+	public constructor(public readonly value: T) {}
+}
+
+/**
  * Part of a tree.
  * Iterates over children.
  *
@@ -490,8 +499,8 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 	/**
 	 * Calls the specified callback function for all the elements in the sequence.
 	 * The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn - A function that accepts up to four arguments.
-	 * The reduce method calls the callbackfn function one time for each element in the array.
+	 * @param callbackfn - An accumulation function to be called on each element.
+	 * The reduce method calls the callbackfn function one time for each element in the sequence, or until the callbackfn returns {@link Stop}.
 	 * @param initialValue - If present, it is passed to the first call to the callbackfn.
 	 * Otherwise, the first element in the sequence will be used as the initial accumulator value and skipped as currentValue.
 	 */
@@ -501,7 +510,7 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 			currentValue: UnboxNodeUnion<TTypes>,
 			currentIndex: number,
 			sequence: this,
-		) => UnboxNodeUnion<TTypes>,
+		) => UnboxNodeUnion<TTypes> | Stop<UnboxNodeUnion<TTypes>>,
 		initialValue?: UnboxNodeUnion<TTypes>,
 	): UnboxNodeUnion<TTypes>;
 	reduce<U>(
@@ -510,15 +519,15 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 			currentValue: UnboxNodeUnion<TTypes>,
 			currentIndex: number,
 			sequence: this,
-		) => UnboxNodeUnion<TTypes>,
+		) => U | Stop<U>,
 		initialValue: U,
 	): U;
 
 	/**
 	 * Calls the specified callback function for all the elements in the sequence.
 	 * The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn - A function that accepts up to four arguments.
-	 * The reduce method calls the callbackfn function one time for each element in the array.
+	 * @param callbackfn - An accumulation function to be called on each element.
+	 * The reduce method calls the callbackfn function one time for each element in the sequence, or until the callbackfn returns {@link Stop}.
 	 * @param initialValue - If present, it is passed to the first call to the callbackfn.
 	 * Otherwise, the first element in the sequence will be used as the initial accumulator value and skipped as currentValue.
 	 */
@@ -528,7 +537,7 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 			currentValue: TypedNodeUnion<TTypes>,
 			currentIndex: number,
 			sequence: this,
-		) => TypedNodeUnion<TTypes>,
+		) => TypedNodeUnion<TTypes> | Stop<TypedNodeUnion<TTypes>>,
 		initialValue?: TypedNodeUnion<TTypes>,
 	): TypedNodeUnion<TTypes>;
 	reduceBoxed<U>(
@@ -537,7 +546,7 @@ export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
 			currentValue: TypedNodeUnion<TTypes>,
 			currentIndex: number,
 			sequence: this,
-		) => TypedNodeUnion<TTypes>,
+		) => U | Stop<U>,
 		initialValue: U,
 	): U;
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
@@ -20,6 +20,7 @@ export {
 	StructTyped,
 	TypedNode,
 	TypedNodeUnion,
+	Stop,
 } from "./editableTreeTypes";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyTree.ts
@@ -298,7 +298,9 @@ export class LazyMap<TSchema extends MapSchema>
 
 	public get size(): number {
 		let fieldCount = 0;
-		forEachField(this[cursorSymbol], () => (fieldCount += 1));
+		forEachField(this[cursorSymbol], () => {
+			fieldCount += 1;
+		});
 		return fieldCount;
 	}
 

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -243,6 +243,7 @@ export {
 	TreeField,
 	TreeNode,
 	getTreeContext,
+	Stop,
 } from "./editable-tree-2";
 
 // Split into separate import and export for compatibility with API-Extractor.

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -288,6 +288,7 @@ export {
 	LeafSchema,
 	MapSchema,
 	StructSchema,
+	Stop,
 } from "./feature-libraries";
 
 export {


### PR DESCRIPTION
## Description

This adds the `reduce` and `reduceBoxed` method to editable tree `Sequence`, as well as a `toArrayBoxed` to match the spec.