### PR TITLE
Compression for initial summary enabled!

### DIFF
--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceFactoryCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceFactoryCompressionAdapter.ts
@@ -30,15 +30,7 @@ export class DocumentServiceFactoryCompressionAdapter extends DocumentServiceFac
 		clientIsSummarizer?: boolean,
 	): Promise<IDocumentService> {
 		if (createNewSummary !== undefined) {
-			// TODO : this is a hack to make sure that the initial summary is not compressed
-			// We must prevent the initial summary from being compressed because
-			// of the hack at packages/drivers/routerlicious-driver/src/createNewUtils.ts
-			// where the binary blob is converted to a string using UTF-8 encoding
-			// which is producing incorrect results for compressed data.
-			const configForInitial = {
-				...this._config,
-				minSizeToCompress: Number.POSITIVE_INFINITY,
-			};
+			const configForInitial = this._config;
 			const newAppSumary =
 				DocumentStorageServiceSummaryBlobCompressionAdapter.compressSummary(
 					createNewSummary.tree[".app"] as ISummaryTree,


### PR DESCRIPTION
The minor change to enable the compression summary for initial summaries.
@DLehenbauer @dstanesc @vladsud 