### PR TITLE
Fail explicitly when the node version cannot be used.

### DIFF
--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -20,6 +20,6 @@ steps:
       # Output installed node versions
       n ls
       # Use the specified node version
-      sudo n ${{ parameters.version }}
+      sudo n ${{ parameters.version }} || { echo "Failed to use the configured node version" ; exit 1; }
       # Output the node version
       echo "Using node $(node --version)"

--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -22,9 +22,11 @@ steps:
       # Use the specified node version
       sudo n ${{ parameters.version }}
       # Output the node version
-      version = $(node --version)
-      echo "Using node ${version}"
-      if [ $version != v${{ parameters.version }} ]; then
+      version=$(node --version)
+      if [ $version != v${{ parameters.version }} ];
+      then
         echo "Could not configure the required node version ${configuredVersion}";
         exit 1;
+      else
+        echo "Using node ${version}"
       fi

--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -20,6 +20,11 @@ steps:
       # Output installed node versions
       n ls
       # Use the specified node version
-      sudo n ${{ parameters.version }} || { echo "Failed to use the configured node version" ; exit 1; }
+      sudo n ${{ parameters.version }}
       # Output the node version
-      echo "Using node $(node --version)"
+      version = $(node --version)
+      echo "Using node ${version}"
+      if [ $version != v${{ parameters.version }} ]; then
+        echo "Could not configure the required node version ${configuredVersion}";
+        exit 1;
+      fi


### PR DESCRIPTION
## Description

ADO:5636

Currently, the script will fail silently and relies on subsequent tasks to error out when they don't find the proper node version installed.