### PR TITLE
tree2: Remove FieldKindTypes

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -24,13 +24,9 @@ export interface Adapters {
 }
 
 // @alpha
-const all: readonly [readonly [TreeSchema<"com.fluidframework.leaf.number", {
-leafValue: ValueSchema.Number;
-}>, TreeSchema<"com.fluidframework.leaf.boolean", {
-leafValue: ValueSchema.Boolean;
-}>, TreeSchema<"com.fluidframework.leaf.string", {
-leafValue: ValueSchema.String;
-}>], TreeSchema<"com.fluidframework.leaf.number", {
+const all: readonly [TreeSchema<"com.fluidframework.leaf.handle", {
+leafValue: ValueSchema.FluidHandle;
+}>, TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: ValueSchema.Number;
 }>, TreeSchema<"com.fluidframework.leaf.boolean", {
 leafValue: ValueSchema.Boolean;
@@ -685,9 +681,6 @@ export interface FieldKindSpecifier<T = FieldKindIdentifier> {
     identifier: T;
 }
 
-// @alpha (undocumented)
-export type FieldKindTypes = typeof FieldKinds[keyof typeof FieldKinds];
-
 // @alpha
 export interface FieldLocation {
     // (undocumented)
@@ -728,7 +721,7 @@ interface Fields {
 }
 
 // @alpha @sealed
-export class FieldSchema<Kind extends FieldKindTypes = FieldKindTypes, Types = AllowedTypes> {
+export class FieldSchema<Kind extends FieldKind = FieldKind, Types = AllowedTypes> {
     constructor(kind: Kind, allowedTypes: Types);
     // (undocumented)
     readonly allowedTypes: Types;
@@ -1312,9 +1305,6 @@ structFields: {};
 // @alpha (undocumented)
 export const jsonSchema: SchemaLibrary;
 
-// @alpha (undocumented)
-const jsonSchema_2: SchemaLibrary;
-
 // @alpha @deprecated (undocumented)
 export const jsonString: TreeSchema<"com.fluidframework.leaf.string", {
 leafValue: import("../..").ValueSchema.String;
@@ -1360,6 +1350,9 @@ interface LeafSchemaSpecification {
 
 // @alpha (undocumented)
 const library: SchemaLibrary;
+
+// @alpha (undocumented)
+const library_2: SchemaLibrary;
 
 // @alpha
 export enum LocalCommitSource {
@@ -1839,7 +1832,7 @@ export { SchemaAware }
 export class SchemaBuilder {
     constructor(name: string, lint?: Partial<SchemaLintConfiguration>, ...libraries: SchemaLibrary[]);
     addLibraries(...libraries: SchemaLibrary[]): void;
-    static field<Kind extends FieldKindTypes, T extends AllowedTypes>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
+    static field<Kind extends FieldKind, T extends AllowedTypes>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     fieldNode<Name extends string, T extends FieldSchema>(name: Name, t: T): TreeSchema<Name, {
         structFields: {
             [""]: T;
@@ -1851,10 +1844,10 @@ export class SchemaBuilder {
         };
     }>;
     static fieldOptional<T extends AllowedTypes>(...allowedTypes: T): FieldSchema<typeof FieldKinds.optional, T>;
-    static fieldRecursive<Kind extends FieldKindTypes, T extends FlexList<RecursiveTreeSchema>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
+    static fieldRecursive<Kind extends FieldKind, T extends FlexList<RecursiveTreeSchema>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     static fieldSequence<T extends AllowedTypes>(...t: T): FieldSchema<typeof FieldKinds.sequence, T>;
     static fieldValue<T extends AllowedTypes>(...allowedTypes: T): FieldSchema<typeof FieldKinds.value, T>;
-    intoDocumentSchema<Kind extends FieldKindTypes, Types extends AllowedTypes>(root: FieldSchema<Kind, Types>): TypedSchemaCollection<FieldSchema<Kind, Types>>;
+    intoDocumentSchema<Kind extends FieldKind, Types extends AllowedTypes>(root: FieldSchema<Kind, Types>): TypedSchemaCollection<FieldSchema<Kind, Types>>;
     intoLibrary(): SchemaLibrary;
     leaf<Name extends string, T extends ValueSchema>(name: Name, t: T): TreeSchema<Name, {
         leafValue: T;
@@ -2058,7 +2051,7 @@ declare namespace testRecursiveDomain {
     export {
         recursiveStruct,
         recursiveStruct2,
-        jsonSchema_2 as jsonSchema
+        library_2 as library
     }
 }
 export { testRecursiveDomain }
@@ -2236,7 +2229,7 @@ ApplyMultiplicity<TField["kind"]["multiplicity"], AllowedTypesToTypedTrees<Mode,
 ][_InlineTrick];
 
 // @alpha
-type TypedFieldInner<Kind extends FieldKindTypes, Types extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? Sequence2<Types> : Kind extends typeof FieldKinds.value ? RequiredField<Types> : Kind extends typeof FieldKinds.optional ? OptionalField<Types> : TreeField;
+type TypedFieldInner<Kind extends FieldKind, Types extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? Sequence2<Types> : Kind extends typeof FieldKinds.value ? RequiredField<Types> : Kind extends typeof FieldKinds.optional ? OptionalField<Types> : TreeField;
 
 // @alpha
 type TypedFields<Mode extends ApiMode, TFields extends undefined | {
@@ -2291,7 +2284,7 @@ export const typeSymbol: unique symbol;
 type UnboxField<TSchema extends FieldSchema> = UnboxFieldInner<TSchema["kind"], TSchema["allowedTypes"]>;
 
 // @alpha
-type UnboxFieldInner<Kind extends FieldKindTypes, TTypes extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? Sequence2<TTypes> : Kind extends typeof FieldKinds.value ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | undefined : unknown;
+type UnboxFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? Sequence2<TTypes> : Kind extends typeof FieldKinds.value ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | undefined : unknown;
 
 // @alpha
 type UnboxNode<TSchema extends TreeSchema> = TSchema extends LeafSchema ? SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["structFieldsObject"][""]> : TSchema extends StructSchema ? StructTyped<TSchema> : unknown;

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -10,7 +10,7 @@ import {
 	FieldSchema,
 	ValueSchema,
 	SchemaBuilder,
-	FieldKindTypes,
+	FieldKind,
 	Any,
 	TreeSchema,
 	LazyTreeSchema,
@@ -276,7 +276,7 @@ function buildPrimitiveSchema(
 	return treeSchema;
 }
 
-function buildFieldSchema<Kind extends FieldKindTypes = FieldKindTypes>(
+function buildFieldSchema<Kind extends FieldKind = FieldKind>(
 	builder: SchemaBuilder,
 	treeSchemaMap: Map<string, LazyTreeSchema>,
 	allChildrenByType: InheritingChildrenByType,
@@ -322,7 +322,7 @@ const builtinLibrary = builtinBuilder.intoLibrary();
  * the PropertyDDS schema inheritances / dependencies starting from
  * the root schema or built-in node property schemas.
  */
-export function convertPropertyToSharedTreeSchema<Kind extends FieldKindTypes = FieldKindTypes>(
+export function convertPropertyToSharedTreeSchema<Kind extends FieldKind = FieldKind>(
 	rootFieldKind: Kind,
 	allowedRootTypes: Any | ReadonlySet<string>,
 	extraTypes?: ReadonlySet<string>,

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -37,7 +37,7 @@ export const primitives = [number, boolean, string] as const;
  * Types allowed as roots of Json content.
  * @alpha
  */
-export const all = [primitives, ...primitives] as const;
+export const all = [handle, ...primitives] as const;
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -14,7 +14,7 @@ import { AllowedTypes, FieldKinds, SchemaBuilder } from "../feature-libraries";
 import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../util";
 import * as leaf from "./leafDomain";
 
-const builder = new SchemaBuilder("Json Domain", {}, leaf.library);
+const builder = new SchemaBuilder("Test Recursive Domain", {}, leaf.library);
 
 /**
  * @alpha
@@ -48,4 +48,4 @@ type _1 = requireTrue<
 /**
  * @alpha
  */
-export const jsonSchema = builder.intoLibrary();
+export const library = builder.intoLibrary();

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldKinds.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldKinds.ts
@@ -218,8 +218,3 @@ export const FieldKinds: {
 	readonly nodeKey: NodeKeyFieldKind;
 	readonly forbidden: Forbidden;
 } = { value, optional, sequence, nodeKey, forbidden };
-
-/**
- * @alpha
- */
-export type FieldKindTypes = typeof FieldKinds[keyof typeof FieldKinds];

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
@@ -10,7 +10,6 @@ export {
 	Sequence,
 	NodeKeyFieldKind,
 	Forbidden,
-	FieldKindTypes,
 	fieldKinds,
 } from "./defaultFieldKinds";
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -18,8 +18,9 @@ import {
 	StructSchema,
 } from "../typed-schema";
 import { EditableTreeEvents } from "../untypedTree";
-import { FieldKindTypes, FieldKinds } from "../default-field-kinds";
+import { FieldKinds } from "../default-field-kinds";
 import { TreeStatus } from "../editable-tree";
+import { FieldKind } from "../modular-schema";
 import { TreeContext } from "./context";
 
 /**
@@ -561,7 +562,7 @@ export type TypedField<TSchema extends FieldSchema> = TypedFieldInner<
  * @alpha
  */
 export type TypedFieldInner<
-	Kind extends FieldKindTypes,
+	Kind extends FieldKind,
 	Types extends AllowedTypes,
 > = Kind extends typeof FieldKinds.sequence
 	? Sequence<Types>
@@ -635,7 +636,7 @@ export type UnboxField<TSchema extends FieldSchema> = UnboxFieldInner<
  * @alpha
  */
 export type UnboxFieldInner<
-	Kind extends FieldKindTypes,
+	Kind extends FieldKind,
 	TTypes extends AllowedTypes,
 > = Kind extends typeof FieldKinds.sequence
 	? Sequence<TTypes>

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -21,7 +21,6 @@ import {
 import { FieldKind } from "../modular-schema";
 import { NewFieldContent, normalizeNewFieldContent } from "../contextuallyTyped";
 import {
-	FieldKindTypes,
 	FieldKinds,
 	OptionalFieldEditBuilder,
 	SequenceFieldEditBuilder,
@@ -93,7 +92,7 @@ export function makeField(
  * A Proxy target, which together with a `fieldProxyHandler` implements a basic access to
  * the nodes of {@link EditableField} by means of the cursors.
  */
-export abstract class LazyField<TKind extends FieldKindTypes, TTypes extends AllowedTypes>
+export abstract class LazyField<TKind extends FieldKind, TTypes extends AllowedTypes>
 	extends LazyEntity<FieldSchema<TKind, TTypes>, FieldAnchor>
 	implements TreeField
 {
@@ -406,7 +405,7 @@ function unboxedTree<TSchema extends TreeSchema>(
  */
 function unboxedUnion<TTypes extends AllowedTypes>(
 	context: Context,
-	schema: FieldSchema<FieldKindTypes, TTypes>,
+	schema: FieldSchema<FieldKind, TTypes>,
 	cursor: ITreeSubscriptionCursor,
 ): UnboxNodeUnion<TTypes> {
 	const type = oneFromSet(schema.types);

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -194,7 +194,6 @@ export {
 	Sequence,
 	NodeKeyFieldKind,
 	Forbidden,
-	FieldKindTypes,
 	DefaultChangeset,
 	DefaultChangeFamily,
 	DefaultEditBuilder,

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/core-utils";
 import { Adapters, TreeSchemaIdentifier, ValueSchema } from "../core";
 import { RestrictiveReadonlyRecord } from "../util";
-import { FieldKindTypes, FieldKinds } from "./default-field-kinds";
+import { FieldKinds } from "./default-field-kinds";
 import {
 	SchemaLibraryData,
 	SchemaLintConfiguration,
@@ -19,6 +19,7 @@ import {
 	RecursiveTreeSchema,
 	FlexList,
 } from "./typed-schema";
+import { FieldKind } from "./modular-schema";
 
 // TODO: tests and examples for this file
 
@@ -197,7 +198,7 @@ export class SchemaBuilder {
 	 * @privateRemarks
 	 * TODO: since this APi surface is using classes, maybe just have users do `new FieldSchema` instead?
 	 */
-	public static field<Kind extends FieldKindTypes, T extends AllowedTypes>(
+	public static field<Kind extends FieldKind, T extends AllowedTypes>(
 		kind: Kind,
 		...allowedTypes: T
 	): FieldSchema<Kind, T> {
@@ -249,7 +250,7 @@ export class SchemaBuilder {
 	 * TODO: Try and find a way to provide a more specific type without triggering the above error.
 	 */
 	public static fieldRecursive<
-		Kind extends FieldKindTypes,
+		Kind extends FieldKind,
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
 		T extends FlexList<RecursiveTreeSchema>,
 	>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T> {
@@ -286,7 +287,7 @@ export class SchemaBuilder {
 	 *
 	 * May only be called once after adding content to builder is complete.
 	 */
-	public intoDocumentSchema<Kind extends FieldKindTypes, Types extends AllowedTypes>(
+	public intoDocumentSchema<Kind extends FieldKind, Types extends AllowedTypes>(
 		root: FieldSchema<Kind, Types>,
 	): TypedSchemaCollection<FieldSchema<Kind, Types>> {
 		this.finalize();

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
@@ -5,9 +5,9 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { Adapters, TreeAdapter, TreeSchemaIdentifier } from "../../core";
-import { FullSchemaPolicy } from "../modular-schema";
+import { FieldKind, FullSchemaPolicy } from "../modular-schema";
 import { capitalize, fail, requireAssignableTo } from "../../util";
-import { defaultSchemaPolicy, FieldKinds, FieldKindTypes } from "../default-field-kinds";
+import { defaultSchemaPolicy, FieldKinds } from "../default-field-kinds";
 import {
 	FieldSchema,
 	TreeSchema,
@@ -190,7 +190,7 @@ export function validateViewSchemaCollection(
 				() => `Map fields of "${identifier}" schema from library "${tree.builder.name}"`,
 				errors,
 			);
-			if ((tree.mapFields.kind as FieldKindTypes) === FieldKinds.value) {
+			if ((tree.mapFields.kind as FieldKind) === FieldKinds.value) {
 				errors.push(
 					`Map fields of "${identifier}" schema from library "${tree.builder.name}" has kind "value". This is invalid since it requires all possible field keys to have a value under them.`,
 				);

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -21,8 +21,8 @@ import {
 	Named,
 	requireAssignableTo,
 } from "../../util";
-import { FieldKindTypes, FieldKinds } from "../default-field-kinds";
-import { FullSchemaPolicy } from "../modular-schema";
+import { FieldKinds } from "../default-field-kinds";
+import { FieldKind, FullSchemaPolicy } from "../modular-schema";
 import { LazyItem, normalizeFlexList } from "./flexList";
 import { ObjectToMap, WithDefault, objectToMapTyped } from "./typeUtils";
 
@@ -304,7 +304,7 @@ export type TreeSchemaSpecification = [
  * This can include policy for how to use this schema for "view" purposes, and well as how to expose editing APIs.
  * @sealed @alpha
  */
-export class FieldSchema<Kind extends FieldKindTypes = FieldKindTypes, Types = AllowedTypes> {
+export class FieldSchema<Kind extends FieldKind = FieldKind, Types = AllowedTypes> {
 	/**
 	 * Schema for a field which must always be empty.
 	 */

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -207,7 +207,6 @@ export {
 	UnwrappedUntypedTree,
 	UntypedTreeOrPrimitive,
 	SchemaBuilder,
-	FieldKindTypes,
 	AllowedTypes,
 	TreeSchema,
 	BrandedFieldKind,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -17,7 +17,7 @@ import {
 	typeNameSymbol,
 	getPrimaryField,
 	SchemaBuilder,
-	FieldKindTypes,
+	FieldKind,
 	UnwrappedEditableField,
 	setField,
 	EditableTree,
@@ -46,7 +46,7 @@ const otherFieldKey: FieldKey = brand("foo2");
 
 const rootSchemaName: TreeSchemaIdentifier = brand("Test");
 
-function getTestSchema<Kind extends FieldKindTypes>(fieldKind: Kind) {
+function getTestSchema<Kind extends FieldKind>(fieldKind: Kind) {
 	const builder = new SchemaBuilder("getTestSchema", {}, personSchemaLibrary);
 	const rootNodeSchema = builder.struct("Test", {
 		foo: SchemaBuilder.field(fieldKind, stringSchema),


### PR DESCRIPTION
## Description

`FieldKindTypes` is a union of the currently default supported implementations of `FieldKind`.
This change replaces use of it with `FieldKind`, which makes the code a bit more conventional, but also more generic in that it will will work with future FieldKinds as well as eventual legacy kinds for back compat more simply.

Also cleans up a few typos in the domains files.


## Breaking Changes

`FieldKindTypes` has been removed. Usages of it should be replaced with `FieldKind` and handle cases where the kind is an unexpected type.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

