### PR TITLE
tree2: Add some tree type tests

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
@@ -21,10 +21,19 @@ import {
 	TypedNode,
 	TreeField,
 	RequiredField,
+	TreeNode,
+	TypedNodeUnion,
+	UnboxNodeUnion,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/editable-tree-2/editableTreeTypes";
 import { jsonSequenceRootSchema } from "../../utils";
-import { isAssignableTo, requireAssignableTo, requireFalse, requireTrue } from "../../../util";
+import {
+	areSafelyAssignable,
+	isAssignableTo,
+	requireAssignableTo,
+	requireFalse,
+	requireTrue,
+} from "../../../util";
 import { EmptyKey } from "../../../core";
 import {
 	FieldKinds,
@@ -170,5 +179,134 @@ describe("editableTreeTypes", () => {
 		type _2 = requireFalse<isAssignableTo<typeof basicStruct, FieldNodeSchema>>;
 		type _3 = requireFalse<isAssignableTo<typeof basicStruct, MapSchema>>;
 		type _4 = requireTrue<isAssignableTo<typeof basicStruct, StructSchema>>;
+	}
+
+	function nominalTyping(): void {
+		const builder2 = new SchemaBuilder("test");
+		const emptyStruct1 = builder2.struct("empty1", {});
+		const emptyStruct2 = builder2.struct("empty2", {});
+
+		// Schema for types which only different in name are distinguished
+		{
+			type _1 = requireFalse<isAssignableTo<typeof emptyStruct1, typeof emptyStruct2>>;
+			type _2 = requireFalse<isAssignableTo<typeof emptyStruct2, typeof emptyStruct1>>;
+		}
+		type Empty1 = TypedNode<typeof emptyStruct1>;
+		type Empty2 = TypedNode<typeof emptyStruct2>;
+
+		// Schema for TypedNode which only different in name are distinguished
+		{
+			// TODO: Fis this. Might be fixed when moving to class based schema builder. Otherwise add strongly typed named to nodes.
+			// @ts-expect-error TODO: fix this and remove expected error.
+			type _1 = requireFalse<isAssignableTo<Empty1, Empty2>>;
+			// @ts-expect-error TODO: fix this and remove expected error.
+			type _2 = requireFalse<isAssignableTo<Empty2, Empty1>>;
+		}
+	}
+
+	type Basic1 = TypedNode<typeof basicStruct>;
+	type Basic2 = TypedNode<typeof basicFieldNode>;
+	{
+		type _1 = requireFalse<isAssignableTo<Basic1, Basic2>>;
+		type _2 = requireFalse<isAssignableTo<Basic2, Basic1>>;
+	}
+
+	// Basic unit test for TreeNode.is type narrowing.
+	function nodeIs(node: TreeNode): void {
+		if (node.is(basicStruct)) {
+			type _1 = requireAssignableTo<typeof node, Basic1>;
+		}
+		if (node.is(basicFieldNode)) {
+			type _1 = requireAssignableTo<typeof node, Basic2>;
+		}
+	}
+
+	// TypedNodeUnion
+	{
+		// Any
+		{
+			type _1 = requireTrue<areSafelyAssignable<TypedNodeUnion<[Any]>, TreeNode>>;
+		}
+
+		// Direct
+		{
+			type UnionBasic1 = TypedNodeUnion<[typeof basicStruct]>;
+			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, Basic1>>;
+		}
+		// Lazy
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<TypedNodeUnion<[() => typeof basicStruct]>, Basic1>
+			>;
+		}
+		// Union
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<
+					TypedNodeUnion<[typeof basicStruct, typeof basicFieldNode]>,
+					Basic1 | Basic2
+				>
+			>;
+		}
+		// Recursive
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<TypedNodeUnion<[typeof recursiveStruct]>, Recursive>
+			>;
+		}
+		// Recursive Lazy
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<TypedNodeUnion<[() => typeof recursiveStruct]>, Recursive>
+			>;
+		}
+	}
+
+	// UnboxNodeUnion
+	{
+		// Any
+		{
+			type _1 = requireTrue<areSafelyAssignable<UnboxNodeUnion<[Any]>, TreeNode>>;
+		}
+
+		// Direct
+		{
+			type UnionBasic1 = UnboxNodeUnion<[typeof basicStruct]>;
+			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, Basic1>>;
+		}
+		// Lazy
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<[() => typeof basicStruct]>, Basic1>
+			>;
+		}
+		// Union
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<
+					UnboxNodeUnion<[typeof basicStruct, typeof basicFieldNode]>,
+					Basic1 | Basic2
+				>
+			>;
+		}
+		// Unboxed FieldNode
+		{
+			type UnboxedFieldNode = UnboxNodeUnion<[typeof basicFieldNode]>;
+			// TODO: areSafelyAssignable doesn't seem to work in this case. Revisit this once on TS 5 and TypeCheck is updated for it.
+			type _1 = requireAssignableTo<UnboxedFieldNode, TreeNode | undefined>;
+			type _2 = requireAssignableTo<TreeNode | undefined, UnboxedFieldNode>;
+		}
+		// Recursive
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<[typeof recursiveStruct]>, Recursive>
+			>;
+		}
+		// Recursive Lazy
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<[() => typeof recursiveStruct]>, Recursive>
+			>;
+		}
 	}
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
@@ -204,20 +204,21 @@ describe("editableTreeTypes", () => {
 		}
 	}
 
-	type Basic1 = TypedNode<typeof basicStruct>;
-	type Basic2 = TypedNode<typeof basicFieldNode>;
+	// Two different simple node types to compare and test with.
+	type BasicStruct = TypedNode<typeof basicStruct>;
+	type BasicFieldNode = TypedNode<typeof basicFieldNode>;
 	{
-		type _1 = requireFalse<isAssignableTo<Basic1, Basic2>>;
-		type _2 = requireFalse<isAssignableTo<Basic2, Basic1>>;
+		type _1 = requireFalse<isAssignableTo<BasicStruct, BasicFieldNode>>;
+		type _2 = requireFalse<isAssignableTo<BasicFieldNode, BasicStruct>>;
 	}
 
 	// Basic unit test for TreeNode.is type narrowing.
 	function nodeIs(node: TreeNode): void {
 		if (node.is(basicStruct)) {
-			type _1 = requireAssignableTo<typeof node, Basic1>;
+			type _1 = requireAssignableTo<typeof node, BasicStruct>;
 		}
 		if (node.is(basicFieldNode)) {
-			type _1 = requireAssignableTo<typeof node, Basic2>;
+			type _1 = requireAssignableTo<typeof node, BasicFieldNode>;
 		}
 	}
 
@@ -231,12 +232,12 @@ describe("editableTreeTypes", () => {
 		// Direct
 		{
 			type UnionBasic1 = TypedNodeUnion<[typeof basicStruct]>;
-			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, Basic1>>;
+			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, BasicStruct>>;
 		}
 		// Lazy
 		{
 			type _1 = requireTrue<
-				areSafelyAssignable<TypedNodeUnion<[() => typeof basicStruct]>, Basic1>
+				areSafelyAssignable<TypedNodeUnion<[() => typeof basicStruct]>, BasicStruct>
 			>;
 		}
 		// Union
@@ -244,7 +245,7 @@ describe("editableTreeTypes", () => {
 			type _1 = requireTrue<
 				areSafelyAssignable<
 					TypedNodeUnion<[typeof basicStruct, typeof basicFieldNode]>,
-					Basic1 | Basic2
+					BasicStruct | BasicFieldNode
 				>
 			>;
 		}
@@ -272,12 +273,12 @@ describe("editableTreeTypes", () => {
 		// Direct
 		{
 			type UnionBasic1 = UnboxNodeUnion<[typeof basicStruct]>;
-			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, Basic1>>;
+			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, BasicStruct>>;
 		}
 		// Lazy
 		{
 			type _1 = requireTrue<
-				areSafelyAssignable<UnboxNodeUnion<[() => typeof basicStruct]>, Basic1>
+				areSafelyAssignable<UnboxNodeUnion<[() => typeof basicStruct]>, BasicStruct>
 			>;
 		}
 		// Union
@@ -285,7 +286,7 @@ describe("editableTreeTypes", () => {
 			type _1 = requireTrue<
 				areSafelyAssignable<
 					UnboxNodeUnion<[typeof basicStruct, typeof basicFieldNode]>,
-					Basic1 | Basic2
+					BasicStruct | BasicFieldNode
 				>
 			>;
 		}

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
@@ -196,7 +196,7 @@ describe("editableTreeTypes", () => {
 
 		// Schema for TypedNode which only different in name are distinguished
 		{
-			// TODO: Fis this. Might be fixed when moving to class based schema builder. Otherwise add strongly typed named to nodes.
+			// TODO: Fix this. Might be fixed when moving to class based schema builder. Otherwise add strongly typed named to nodes.
 			// @ts-expect-error TODO: fix this and remove expected error.
 			type _1 = requireFalse<isAssignableTo<Empty1, Empty2>>;
 			// @ts-expect-error TODO: fix this and remove expected error.


### PR DESCRIPTION
## Description

Adds some more coverage of type for the new tree API.

This found that schema types are not type checking nominally currently: a TODO and test for this is included.

Otherwise, everything seems to be working as expected.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

