### PR TITLE
fix(devtools): Exclude unnecessary files from code coverage analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,9 @@
 			"**/dist/test/**/*.js",
 			"experimental/examples/**",
 			"experimental/PropertyDDS/examples/**",
-			"**/*.bundle.js"
+			"**/*.bundle.js",
+			"packages/tools/devtools/devtools-browser-extension/dist/e2e-tests/**",
+			"packages/tools/devtools/devtools-browser-extension/dist/bundle/**"
 		],
 		"exclude-after-remap": false,
 		"extension": [

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -49,7 +49,9 @@
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.ts",
-			"dist/tsc/test/**/*.js"
+			"dist/tsc/test/**/*.js",
+			"dist/e2e-tests/**",
+			"dist/bundle/**"
 		],
 		"exclude-after-remap": false,
 		"include": [

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -26,7 +26,7 @@
 		"good-fences": "gf",
 		"lint": "npm run prettier && npm run good-fences && npm run eslint",
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
-		"mocha": "mocha dist/**/*.test.js --exit",
+		"mocha": "mocha dist/tsc/test/**/*.test.js --exit",
 		"prettier": "prettier --check . --ignore-path ../../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../../.prettierignore",
 		"rebuild": "npm run clean && npm run build",
@@ -49,12 +49,12 @@
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.ts",
-			"dist/test/**/*.js"
+			"dist/tsc/test/**/*.js"
 		],
 		"exclude-after-remap": false,
 		"include": [
 			"src/**/*.ts",
-			"dist/**/*.js"
+			"dist/tsc/**/*.js"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [


### PR DESCRIPTION
## Description

`npm run test:coverage` time duration bump from ~1m20s to ~3m30s. Example pipeline run: https://dev.azure.com/fluidframework/internal/_build/results?buildId=134923&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=38623822-d55d-5839-9078-a2164c1dcf41
 Example error:
~~~
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/background/BackgroundScript.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/background/Logging.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/Constants.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/index.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/Messages.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/src/messaging/Utilities.ts' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/bootstrap' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/compat get default export' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/define property getters' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/ensure chunk' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/get javascript chunk filename' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/global' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/hasOwnProperty shorthand' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/jsonp chunk loading' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/load script' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/make namespace object' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/node module decorator' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger-chrome-extension/webpack/runtime/publicPath' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/AudienceMetadata.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/Container.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/FluidClientDebugger.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/index.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/Registry.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/messaging/Constants.js' does not exist (any more).
2023-03-02T02:15:42: File '/mnt/vss/_work/1/s/packages/tools/client-debugger/client-debugger-chrome-extension/dist/background/@***-tools/client-debugger/dist/messaging/index.js' does not exist (any more).

~~~
Remove unnecessary file from test coverage path.
AB#[4602](https://dev.azure.com/fluidframework/internal/_workitems/edit/4602)

## Sample
https://dev.azure.com/fluidframework/internal/_build/results?buildId=193342&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=38623822-d55d-5839-9078-a2164c1dcf41