### PR TITLE
change log level to verbose for riddler caching

### DIFF
--- a/server/historian/packages/historian-base/src/services/riddlerService.ts
+++ b/server/historian/packages/historian-base/src/services/riddlerService.ts
@@ -8,7 +8,6 @@ import { ITenantConfig, ITenantConfigManager } from "@fluidframework/server-serv
 import { getCorrelationId } from "@fluidframework/server-services-utils";
 import { BasicRestWrapper, RestWrapper } from "@fluidframework/server-services-client";
 import * as uuid from "uuid";
-import * as winston from "winston";
 import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { getRequestErrorTranslator, getTokenLifetimeInSec } from "../utils";
 import { ITenantService } from "./definitions";
@@ -61,13 +60,11 @@ export class RiddlerService implements ITenantService, ITenantConfigManager {
 	): Promise<ITenantConfig> {
 		const lumberProperties = { [BaseTelemetryProperties.tenantId]: tenantId };
 		const cachedDetail = await this.cache.get(tenantId).catch((error) => {
-			winston.error(`Error fetching tenant details from cache`, error);
 			Lumberjack.error(`Error fetching tenant details from cache`, lumberProperties, error);
 			return undefined;
 		});
 		if (cachedDetail) {
-			winston.info(`Resolving tenant details from cache`);
-			Lumberjack.info(`Resolving tenant details from cache`, lumberProperties);
+			Lumberjack.verbose(`Resolving tenant details from cache`, lumberProperties);
 			return JSON.parse(cachedDetail) as ITenantConfig;
 		}
 		const tenantUrl = `/api/tenants/${tenantId}`;
@@ -75,7 +72,6 @@ export class RiddlerService implements ITenantService, ITenantConfigManager {
 			.get<ITenantConfig>(tenantUrl, { includeDisabledTenant })
 			.catch(getRequestErrorTranslator(tenantUrl, "GET", lumberProperties));
 		this.cache.set(tenantId, JSON.stringify(details)).catch((error) => {
-			winston.error(`Error caching tenant details to redis`, error);
 			Lumberjack.error(`Error caching tenant details to redis`, lumberProperties, error);
 		});
 		return details;
@@ -99,14 +95,12 @@ export class RiddlerService implements ITenantService, ITenantConfigManager {
 	): Promise<void> {
 		const lumberProperties = { [BaseTelemetryProperties.tenantId]: tenantId };
 		const cachedToken = await this.cache.exists(token).catch((error) => {
-			winston.error(`Error fetching token from cache`, error);
 			Lumberjack.error(`Error fetching token from cache`, lumberProperties, error);
 			return false;
 		});
 
 		if (cachedToken) {
-			winston.info(`Resolving token from cache`);
-			Lumberjack.info(`Resolving token from cache`, lumberProperties);
+			Lumberjack.verbose(`Resolving token from cache`, lumberProperties);
 			return;
 		}
 
@@ -123,7 +117,6 @@ export class RiddlerService implements ITenantService, ITenantConfigManager {
 			tokenLifetimeInSec = Math.round(tokenLifetimeInSec - (tokenLifetimeInSec * 5) / 100);
 		}
 		this.cache.set(token, "", tokenLifetimeInSec).catch((error) => {
-			winston.error(`Error caching token to redis`, error);
 			Lumberjack.error(`Error caching token to redis`, lumberProperties, error);
 		});
 	}

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -198,7 +198,7 @@ export async function verifyToken(
 			});
 
 			if (cachedToken) {
-				Lumberjack.info("Token cache hit", logProperties);
+				Lumberjack.verbose("Token cache hit", logProperties);
 				if (options.ensureSingleUseToken) {
 					throw new NetworkError(403, "Access token has already been used.");
 				}
@@ -210,7 +210,7 @@ export async function verifyToken(
 
 		// Update token cache
 		if ((options.enableTokenCache || options.ensureSingleUseToken) && options.tokenCache) {
-			Lumberjack.info("Token cache miss", logProperties);
+			Lumberjack.verbose("Token cache miss", logProperties);
 			const tokenCacheKey = token;
 			options.tokenCache
 				.set(


### PR DESCRIPTION
## Description
We are sending `Token cache miss` logs ~8M per hour, and `Token cache hit` logs ~0.8M per hour, `Resolving tenant details from cache` ~5M per hour, `Resolving token from cache` ~3.5M per hour in FRS. Though they were introduced to provide detailed logging when we introduced token caching, we almost don't look into these logs. So to reduce noise and relieve resources, changing these logs to `verbose` level instead of `info`.