### PR TITLE
build(docs): Add optional title for @throws section in docs

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -457,13 +457,14 @@ export function createRemarksSection(
  *
  * @param apiItem - The API item whose `@throws` documentation will be rendered.
  * @param config - See {@link ApiItemTransformationConfiguration}.
+ * @param headingText - The text to use for the heading in the throws section. Defaults to "Throws".
  *
  * @returns The doc section if the API item had any `@throws` comments, otherwise `undefined`.
  */
 export function createThrowsSection(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
-	title: string = "Throws",
+	headingText: string = "Throws",
 ): SectionNode | undefined {
 	const throwsBlocks = getThrowsBlocks(apiItem);
 	if (throwsBlocks === undefined || throwsBlocks.length === 0) {
@@ -477,7 +478,7 @@ export function createThrowsSection(
 	);
 
 	return wrapInSection(paragraphs, {
-		title,
+		title: headingText,
 		id: `${getQualifiedApiItemName(apiItem)}-throws`,
 	});
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -463,6 +463,7 @@ export function createRemarksSection(
 export function createThrowsSection(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
+	title: string = "Throws",
 ): SectionNode | undefined {
 	const throwsBlocks = getThrowsBlocks(apiItem);
 	if (throwsBlocks === undefined || throwsBlocks.length === 0) {
@@ -476,7 +477,7 @@ export function createThrowsSection(
 	);
 
 	return wrapInSection(paragraphs, {
-		title: "Throws",
+		title,
 		id: `${getQualifiedApiItemName(apiItem)}-throws`,
 	});
 }


### PR DESCRIPTION
The api-markdownd-documenter package exposes a utility function called `createThrowsSection` (in Helpers.ts), which generates the section contents describing all `@throws` comments on an API item. Currently, the heading text "Throws" is hard-coded for that section. For FF.com, we wish to use "Error Handling", instead of "Throws".

To accomplish this, we will need to update the createThrowsSection function to accept an optional parameter for the heading text.

Later (after a new version has been published and consumed in the website build), we can specify "Error Handling" as the value for this function call.