### PR TITLE
build(docs): Add optional title for @examples section in docs

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -527,13 +527,14 @@ export function createDeprecationNoticeSection(
  *
  * @param apiItem - The API item whose `@example` documentation will be rendered.
  * @param config - See {@link ApiItemTransformationConfiguration}.
+ * @param headingText - The text to use for the heading in the examples section. Defaults to "Examples".
  *
  * @returns The doc section if the API item had any `@example` comment blocks, otherwise `undefined`.
  */
 export function createExamplesSection(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
-	title: string = "Examples",
+	headingText: string = "Examples",
 ): SectionNode | undefined {
 	const exampleBlocks = getExampleBlocks(apiItem);
 
@@ -555,7 +556,7 @@ export function createExamplesSection(
 	}
 
 	return wrapInSection(exampleSections, {
-		title,
+		title: headingText,
 		id: `${getQualifiedApiItemName(apiItem)}-examples`,
 	});
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -533,6 +533,7 @@ export function createDeprecationNoticeSection(
 export function createExamplesSection(
 	apiItem: ApiItem,
 	config: Required<ApiItemTransformationConfiguration>,
+	title: string = "Examples",
 ): SectionNode | undefined {
 	const exampleBlocks = getExampleBlocks(apiItem);
 
@@ -554,7 +555,7 @@ export function createExamplesSection(
 	}
 
 	return wrapInSection(exampleSections, {
-		title: "Examples",
+		title,
 		id: `${getQualifiedApiItemName(apiItem)}-examples`,
 	});
 }


### PR DESCRIPTION
The api-markdownd-documenter package exposes a utility function called `createExamplesSection` (in Helpers.ts), which generates the section contents describing all `@example` comments on an API item. Currently, the heading text "Examples" is hard-coded for that section. For FF.com, we wish to use "Usage", instead of "Examples".

To accomplish this, we will need to update the createExamplesSection function to accept an optional parameter for the heading text.

Later (after a new version has been published and consumed in the website build), we can specify "Usage" as the value for this function call.