### PR TITLE
(generate:buildVersion): Include alpha and beta releases

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -15,8 +15,8 @@ This command is used to compute the version number of Fluid packages. The releas
 
 ```
 USAGE
-  $ flub generate buildVersion --build <value> [-v | --quiet] [--testBuild <value>] [--release release|prerelease|none]
-    [--patch <value>] [--base <value>] [--tag <value>] [-i <value>]
+  $ flub generate buildVersion --build <value> [-v | --quiet] [--testBuild <value>] [--release
+    release|prerelease|alpha|beta|none] [--patch <value>] [--base <value>] [--tag <value>] [-i <value>]
 
 FLAGS
   -i, --includeInternalVersions=<value>  Include Fluid internal versions.
@@ -25,7 +25,7 @@ FLAGS
   --build=<value>                        (required) The CI build number.
   --patch=<value>                        Indicates the build is a patch build.
   --release=<option>                     Indicates the build is a release build.
-                                         <options: release|prerelease|none>
+                                         <options: release|prerelease|alpha|beta|none>
   --tag=<value>                          The tag name to use.
   --testBuild=<value>                    Indicates the build is a test build.
 

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -34,7 +34,7 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 		}),
 		release: Flags.string({
 			description: "Indicates the build is a release build.",
-			options: ["release", "prerelease", "none"],
+			options: ["release", "prerelease", "alpha", "beta", "none"],
 			env: "VERSION_RELEASE",
 		}),
 		patch: Flags.string({


### PR DESCRIPTION
Include alpha/beta as part of the release flag for releasing alpha/beta packages

[AB#5572](https://dev.azure.com/fluidframework/internal/_workitems/edit/5572)