### PR TITLE
Ensure stress test clients don't try to catch up immediately

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -152,23 +152,34 @@ function* factoryPermutations<T extends IDocumentServiceFactory>(create: () => T
 		// Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
 		// At the same time we want to test newly created factory.
 		let documentServiceFactory: T = factoryReused;
-		let headers: IRequestHeader = {};
+		let headers: IRequestHeader = { deltaConnection: "none" };
 		switch (counter % 5) {
 			default:
 			case 0:
 				documentServiceFactory = create();
 				break;
 			case 1:
-				headers = { [LoaderHeader.loadMode]: { opsBeforeReturn: "cached" } };
+				headers = {
+					[LoaderHeader.loadMode]: { opsBeforeReturn: "cached", deltaConnection: "none" },
+				};
 				break;
 			case 2:
-				headers = { [LoaderHeader.loadMode]: { opsBeforeReturn: "all" } };
+				headers = {
+					[LoaderHeader.loadMode]: {
+						opsBeforeReturn: "cached",
+						deltaConnection: "delayed",
+					},
+				};
 				break;
 			case 3:
-				headers = { [LoaderHeader.loadMode]: { deltaConnection: "none" } };
+				headers = {
+					[LoaderHeader.loadMode]: { opsBeforeReturn: "all", deltaConnection: "none" },
+				};
 				break;
 			case 4:
-				headers = { [LoaderHeader.loadMode]: { deltaConnection: "delayed" } };
+				headers = {
+					[LoaderHeader.loadMode]: { opsBeforeReturn: "all", deltaConnection: "delayed" },
+				};
 				break;
 		}
 		yield { documentServiceFactory, headers };


### PR DESCRIPTION
## Description

Related to ADO:5524, this should help reduce the `NoJoinOp` incident rate.

Tested in a private branch, these are the error counts:


Data_branch | Data_hostName | runId | errors | min_min_Event_Time
-- | -- | -- | -- | --
refs/heads/test/andreiiacob | @fluid-internal/test-service-load | 193774-routerlicious-frsCanary-ci_frs | 4 | 2023-09-26 18:03:48.0860000
refs/heads/test/andreiiacob | @fluid-internal/test-service-load | 193774-routerlicious-frs-ci_frs | 1 | 2023-09-26 18:03:47.1280000
refs/heads/test/andreiiacob | @fluid-internal/test-service-load | 193774-odsp-odsp-df-ci | 1 | 2023-09-26 18:03:45.2450000
refs/heads/test/andreiiacob | @fluid-internal/test-service-load | 193774-tinylicious-local-ci | 4 | 2023-09-26 18:03:38.8330000
refs/heads/test/andreiiacob | @fluid-internal/test-service-load | 193774-odsp-odsp-ci | 1 | 2023-09-26 18:03:35.5200000

Out of which only 2 `NoJoinOp`  events:

Data_error | Data_errorType | Data_message | runId | count_
-- | -- | -- | -- | --
NoJoinOp |   |   | 193774-tinylicious-local-ci | 2
ReceivedJoinOp |   |   | 193774-tinylicious-local-ci | 2
