### PR TITLE
docs(shared-tree): Fix a couple of links

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -131,7 +131,7 @@ export interface TreeNode extends Tree<TreeSchema> {
  * 1. To hold the children of non-leaf {@link TreeNode}s.
  * 2. As the root of a {@link Tree}.
  *
- * Down-casting (via {@link TreeField#is}) is required to access Schema-Aware APIs, including editing.
+ * Down-casting (via {@link TreeField.is}) is required to access Schema-Aware APIs, including editing.
  * All content in the tree is accessible without down-casting, but if the schema is known,
  * the schema aware API may be more ergonomic.
  *

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -313,7 +313,7 @@ export class FieldSchema<Kind extends FieldKind = FieldKind, Types = AllowedType
 	protected _typeCheck?: MakeNominal;
 
 	/**
-	 * @param kind - The [kind](https://en.wikipedia.org/wiki/Kind_(type_theory)) of this field.
+	 * @param kind - The {@link https://en.wikipedia.org/wiki/Kind_(type_theory) | kind} of this field.
 	 * Determine the multiplicity, viewing and editing APIs as well as the merge resolution policy.
 	 * @param allowedTypes - What types of tree nodes are allowed in this field.
 	 */


### PR DESCRIPTION
Fix a couple of comment links to adhere to [@link guidelines](https://api-extractor.com/pages/tsdoc/tag_link/) (also see [declaration reference docs](https://api-extractor.com/pages/tsdoc/declaration_references/)).