### PR TITLE
refactor(tree2): Use helper function to verify assert messages

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 
+import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { Any, SchemaBuilder } from "../../../feature-libraries";
 import { FieldKey, TreeNavigationResult } from "../../../core";
 import { forestWithContent } from "../../utils";
@@ -53,15 +54,27 @@ describe("lazyField", () => {
 		cursor.free();
 		assert.throws(
 			() => sequenceField.replaceRange(0, 1, []),
-			/only allowed on fields with TreeStatus.InDocument status/,
+			(e: Error) =>
+				validateAssertionError(
+					e,
+					/only allowed on fields with TreeStatus.InDocument status/,
+				),
 		);
 		assert.throws(
 			() => optionalField.setContent(undefined),
-			/only allowed on fields with TreeStatus.InDocument status/,
+			(e: Error) =>
+				validateAssertionError(
+					e,
+					/only allowed on fields with TreeStatus.InDocument status/,
+				),
 		);
 		assert.throws(
 			() => valueField.setContent({}),
-			/only allowed on fields with TreeStatus.InDocument status/,
+			(e: Error) =>
+				validateAssertionError(
+					e,
+					/only allowed on fields with TreeStatus.InDocument status/,
+				),
 		);
 	});
 });


### PR DESCRIPTION
Without using this helper function, the tests will fail once the asserts being tested are tagged, because the tagging changes the message that gets logged. The helper function ensures that the tests work regardless of tagging.