### PR TITLE
Move some deli props to service configuration

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -133,7 +133,8 @@ export class CheckpointContext {
 		const isLocal =
 			globalCheckpointOnly === true
 				? false
-				: localCheckpointEnabled && checkpoint.reason !== CheckpointReason.NoClients;
+				: localCheckpointEnabled === true &&
+				  checkpoint.reason !== CheckpointReason.NoClients;
 
 		if (checkpoint.clear) {
 			updateP = this.checkpointManager.deleteCheckpoint(checkpoint, isLocal);

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -19,7 +19,7 @@ export class CheckpointContext {
 		private readonly id: string,
 		private readonly checkpointManager: IDeliCheckpointManager,
 		private readonly context: IContext,
-		private readonly checkpointService: ICheckpointService,
+		private readonly checkpointService: ICheckpointService | undefined,
 	) {}
 
 	/**
@@ -127,7 +127,7 @@ export class CheckpointContext {
 
 		let updateP: Promise<void>;
 
-		const localCheckpointEnabled = this.checkpointService.localCheckpointEnabled;
+		const localCheckpointEnabled = this.checkpointService?.localCheckpointEnabled;
 
 		// determine if checkpoint is local
 		const isLocal =

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -266,7 +266,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
 	private noActiveClients: boolean;
 
-	private globalCheckpointOnly;
+	private globalCheckpointOnly: boolean = false;
 
 	private closed: boolean = false;
 
@@ -292,9 +292,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		private readonly serviceConfiguration: IServiceConfiguration,
 		private sessionMetric: Lumber<LumberEventName.SessionResult> | undefined,
 		private readonly sessionStartMetric: Lumber<LumberEventName.StartSessionResult> | undefined,
-		private readonly checkpointService: ICheckpointService,
-		private readonly restartOnCheckpointFailure: boolean,
-		private readonly kafkaCheckpointOnReprocessingOp: boolean,
+		private readonly checkpointService: ICheckpointService | undefined,
 		private readonly sequencedSignalClients: Map<string, ISequencedSignalClient> = new Map(),
 	) {
 		super();
@@ -438,16 +436,16 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			try {
 				if (
 					this.checkpointInfo.currentKafkaCheckpointMessage &&
-					this.kafkaCheckpointOnReprocessingOp
+					this.serviceConfiguration.deli.kafkaCheckpointOnReprocessingOp
 				) {
 					this.context.checkpoint(
 						this.checkpointInfo.currentKafkaCheckpointMessage,
-						this.restartOnCheckpointFailure,
+						this.serviceConfiguration.deli.restartOnCheckpointFailure,
 					);
 				}
 				reprocessOpsMetric.setProperty(
 					"kafkaCheckpointOnReprocessingOp",
-					this.kafkaCheckpointOnReprocessingOp,
+					this.serviceConfiguration.deli.kafkaCheckpointOnReprocessingOp,
 				);
 				reprocessOpsMetric.success(`Successfully reprocessed repeating ops.`);
 			} catch (error) {
@@ -1973,7 +1971,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				this.checkpointContext
 					.checkpoint(
 						checkpointParams,
-						this.restartOnCheckpointFailure,
+						this.serviceConfiguration.deli.restartOnCheckpointFailure,
 						globalCheckpointOnly,
 					)
 					.catch((error) => {

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -66,8 +66,6 @@ export class DeliLambdaFactory
 		private readonly signalProducer: IProducer | undefined,
 		private readonly reverseProducer: IProducer,
 		private readonly serviceConfiguration: IServiceConfiguration,
-		private readonly restartOnCheckpointFailure: boolean,
-		private readonly kafkaCheckpointOnReprocessingOp: boolean,
 	) {
 		super();
 	}
@@ -223,8 +221,6 @@ export class DeliLambdaFactory
 			sessionMetric,
 			sessionStartMetric,
 			this.checkpointService,
-			this.restartOnCheckpointFailure,
-			this.kafkaCheckpointOnReprocessingOp,
 		);
 
 		deliLambda.on("close", (closeType) => {

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -166,8 +166,6 @@ describe("Routerlicious", () => {
 					undefined,
 					testReverseProducer,
 					DefaultServiceConfiguration,
-					true,
-					true,
 				);
 				lambda = await factory.create(
 					{ documentId: testId, tenantId: testTenantId },
@@ -193,8 +191,6 @@ describe("Routerlicious", () => {
 							enableWriteClientSignals: true,
 						},
 					},
-					true,
-					true,
 				);
 				lambdaWithSignals = await factoryWithSignals.create(
 					{ documentId: testId, tenantId: testTenantId },
@@ -217,8 +213,6 @@ describe("Routerlicious", () => {
 							maintainBatches: true,
 						},
 					},
-					true,
-					true,
 				);
 				lambdaWithBatching = await factoryWithBatching.create(
 					{ documentId: testId, tenantId: testTenantId },

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -292,8 +292,6 @@ export class LocalOrderer implements IOrderer {
 					undefined,
 					undefined,
 					checkpointService,
-					true,
-					true,
 				);
 			},
 		);

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -150,6 +150,11 @@ export async function deliCreate(
 		...core.DefaultServiceConfiguration,
 		externalOrdererUrl,
 		enforceDiscoveryFlow,
+		deli: {
+			...core.DefaultServiceConfiguration.deli,
+			restartOnCheckpointFailure,
+			kafkaCheckpointOnReprocessingOp,
+		},
 	};
 
 	const checkpointService = new core.CheckpointService(
@@ -168,8 +173,6 @@ export async function deliCreate(
 		undefined,
 		reverseProducer,
 		serviceConfiguration,
-		restartOnCheckpointFailure,
-		kafkaCheckpointOnReprocessingOp,
 	);
 }
 

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -102,6 +102,23 @@
 			},
 			"ClassDeclaration_MongoDocumentRepository": {
 				"forwardCompat": false
+			},
+			"VariableDeclaration_DefaultServiceConfiguration": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IServerConfiguration": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IServiceConfiguration": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IDeliServerConfiguration": {
+				"forwardCompat": false,
+				"backCompat": true
+			},
+			"InterfaceDeclaration_IOrdererConnection": {
+				"forwardCompat": false,
+				"backCompat": true
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -58,6 +58,12 @@ export interface IDeliServerConfiguration {
 
 	// enables marking leave ops with a flag when they were the last client
 	enableLeaveOpNoClientServerMetadata: boolean;
+
+	// enables restarting the process when deli fails to checkpoint
+	restartOnCheckpointFailure: boolean;
+
+	// enables kafka checkpoints when reprocessing messages
+	kafkaCheckpointOnReprocessingOp: boolean;
 }
 
 export interface ICheckpointHeuristicsServerConfiguration {
@@ -218,6 +224,8 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 		skipSummarizeAugmentationForSingleCommmit: false,
 		disableNoClientMessage: false,
 		enableLeaveOpNoClientServerMetadata: false,
+		restartOnCheckpointFailure: true,
+		kafkaCheckpointOnReprocessingOp: true,
 	},
 	broadcaster: {
 		includeEventInMessageBatchName: false,

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -167,6 +167,7 @@ declare function get_old_VariableDeclaration_DefaultServiceConfiguration():
 declare function use_current_VariableDeclaration_DefaultServiceConfiguration(
     use: TypeOnly<typeof current.DefaultServiceConfiguration>);
 use_current_VariableDeclaration_DefaultServiceConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_old_VariableDeclaration_DefaultServiceConfiguration());
 
 /*
@@ -648,6 +649,7 @@ declare function get_old_InterfaceDeclaration_IDeliServerConfiguration():
 declare function use_current_InterfaceDeclaration_IDeliServerConfiguration(
     use: TypeOnly<current.IDeliServerConfiguration>);
 use_current_InterfaceDeclaration_IDeliServerConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDeliServerConfiguration());
 
 /*
@@ -1202,6 +1204,7 @@ declare function get_old_InterfaceDeclaration_IOrdererConnection():
 declare function use_current_InterfaceDeclaration_IOrdererConnection(
     use: TypeOnly<current.IOrdererConnection>);
 use_current_InterfaceDeclaration_IOrdererConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IOrdererConnection());
 
 /*
@@ -1854,6 +1857,7 @@ declare function get_old_InterfaceDeclaration_IServerConfiguration():
 declare function use_current_InterfaceDeclaration_IServerConfiguration(
     use: TypeOnly<current.IServerConfiguration>);
 use_current_InterfaceDeclaration_IServerConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IServerConfiguration());
 
 /*
@@ -1878,6 +1882,7 @@ declare function get_old_InterfaceDeclaration_IServiceConfiguration():
 declare function use_current_InterfaceDeclaration_IServiceConfiguration(
     use: TypeOnly<current.IServiceConfiguration>);
 use_current_InterfaceDeclaration_IServiceConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IServiceConfiguration());
 
 /*


### PR DESCRIPTION
- Move `kafkaCheckpointOnReprocessingOp` and `kafkaCheckpointOnReprocessingOp` into service configuration. The lambda constructor already has too many arguments so we shouldn't add more booleans to it. These also fit into what service configuration was meant to store.
- Fix typing / initialization of `globalCheckpointOnly`
- Allow `checkpointService` to be undefined