### PR TITLE
improvement(api-markdown-documenter): Re-export `ReleaseTag` as complete enum, not just type signature

### DIFF
--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -114,11 +114,11 @@ export {
 // #region Convenience re-exports
 
 // Convenience re-exports
-export type {
-	ApiItem,
-	ApiItemKind,
-	ApiModel,
-	ApiPackage,
+export {
+	type ApiItem,
+	type ApiItemKind,
+	type ApiModel,
+	type ApiPackage,
 	ReleaseTag,
 } from "@microsoft/api-extractor-model";
 export { NewlineKind } from "@rushstack/node-core-library";


### PR DESCRIPTION
Allows consumers to actually use the enum flags.