### PR TITLE
Scribe uncaught exceptions2

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -67,8 +67,9 @@ export class CheckpointManager {
 
 		// Finally begin checkpointing the offsets.
 		this.checkpointing = true;
-		const commitP = this.consumer.commitCheckpoint(this.id, queuedMessage);
-		return commitP
+
+		return this.consumer
+			.commitCheckpoint(this.id, queuedMessage)
 			.then(() => {
 				this.commitedCheckpoint = queuedMessage;
 				this.checkpointing = false;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -612,17 +612,19 @@ export class ScribeLambda implements IPartitionLambda {
 			return;
 		}
 		let databaseCheckpointFailed = false;
-		this.pendingP = clearCache
-			? this.checkpointManager.delete(this.protocolHead, true)
-			: this.writeCheckpoint(checkpoint).catch((error) => {
-					databaseCheckpointFailed = true;
-					Lumberjack.error(
-						`Error writing database checkpoint.`,
-						getLumberBaseProperties(this.documentId, this.tenantId),
-						error,
-					);
-			  });
-		this.pendingP
+
+		this.pendingP = (
+			clearCache
+				? this.checkpointManager.delete(this.protocolHead, true)
+				: this.writeCheckpoint(checkpoint).catch((error) => {
+						databaseCheckpointFailed = true;
+						Lumberjack.error(
+							`Error writing database checkpoint.`,
+							getLumberBaseProperties(this.documentId, this.tenantId),
+							error,
+						);
+				  })
+		)
 			.then(() => {
 				this.pendingP = undefined;
 				if (!skipKafkaCheckpoint && !databaseCheckpointFailed) {


### PR DESCRIPTION
This updates more promises to immediately set `.catch()` and `.then()`  based on the changes in this original pull request: [https://github.com/microsoft/FluidFramework/pull/16365](https://github.com/microsoft/FluidFramework/pull/16365 )