### PR TITLE
Fix DeltaManager logging

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -368,7 +368,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		assert(this.connectionManager.connected, 0x238 /* "called only in connected state" */);
 
 		const pendingSorted = this.pending.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
-		this.logger.sendErrorEvent({
+		this.logger.sendTelemetryEvent({
 			...event,
 			// This directly tells us if fetching ops is in flight, and thus likely the reason of
 			// stalled op processing


### PR DESCRIPTION
## Description

Tangential to ADO:5524

Regardless of the event category provided to the `logConnectionIssue` function, it will _always_ send the event as an error. This goes against the intention of calls such as https://github.com/microsoft/FluidFramework/blob/441964ed717b0cc03a23d19bdb0fa4b9b4d98871/packages/loader/container-loader/src/connectionStateHandler.ts#L415 -> https://github.com/microsoft/FluidFramework/blob/441964ed717b0cc03a23d19bdb0fa4b9b4d98871/packages/loader/container-loader/src/container.ts#L875
