### PR TITLE
fix(ci): Add attempt number to the tinylicious log artifact name

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -279,7 +279,7 @@ stages:
               buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
               tagName: ${{ parameters.tagName }}
               interdependencyRange: ${{ parameters.interdependencyRange }}
-  
+
         # Build
         - ${{ if ne(parameters.taskBuild, 'false') }}:
           - task: Npm@1
@@ -383,7 +383,7 @@ stages:
               displayName: Publish Artifact - Tinylicious Log
               inputs:
                 targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
-                artifactName: 'tinyliciousLog'
+                artifactName: 'tinyliciousLog_attempt-$(System.JobAttempt)'
                 publishLocation: 'pipeline'
               condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
               continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -340,7 +340,7 @@ jobs:
           displayName: Publish Artifact - Tinylicious Log
           inputs:
             targetPath: '${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/tinylicious.log'
-            artifactName: 'tinyliciousLog'
+            artifactName: 'tinyliciousLog_attempt-$(System.JobAttempt)'
             publishLocation: 'pipeline'
           condition: succeededOrFailed()
           continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -149,8 +149,8 @@ jobs:
               condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
         # Verify if the tinylicious log exists
         - task: Bash@3
-          displayName: Validate Tinylicious Log 
-          inputs: 
+          displayName: Validate Tinylicious Log
+          inputs:
             targetType: 'inline'
             workingDirectory: ${{ parameters.buildDirectory }}
             script: |
@@ -162,7 +162,7 @@ jobs:
           displayName: Publish Artifact - Tinylicious Log
           inputs:
             targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
-            artifactName: 'tinyliciousLog_${{ parameters.stageName }}'
+            artifactName: 'tinyliciousLog_${{ parameters.stageName }}_attempt-$(System.JobAttempt)'
             publishLocation: 'pipeline'
           condition: and(failed(), eq(variables['logExists'], 'true'), contains('${{ taskTestStep }}', 'tinylicious'))
           continueOnError: true


### PR DESCRIPTION
## Description

Sometimes we'll re-run a failed job in a pipeline, and the second attempt will fail to upload the tinylicious log because the first attempt already uploaded an artifact with the same name. This adds the attempt number to the artifact name to avoid this problem.

[Here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=194606&view=artifacts&pathAsName=false&type=publishedArtifacts) (msft internal) is a test run showing the effect of this PR (with an additional change to make the pipeline fail on attempt 1, so this could be tested).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
