### PR TITLE
Break down socket connect into smaller pieces

### DIFF
--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -4,6 +4,10 @@
 
 ## Contents
 
+-   [3.0.0 Breaking Changes](#300-breaking-changes)
+
+    -   [An invalid JWT token will now return a 401 error instead of a 500](#an-invalid-jwt-token-will-now-return-a-401-error-instead-of-a-500)
+
 -   [1.0.0 Breaking Changes](#100-breaking-changes)
 
     -   [getLatestKeyVersion function added to ISecretManager](#getlatestkeyversion-function-added-to-isecretmanager)
@@ -36,6 +40,13 @@
     -   [@fluidframework/server-services-client@0.1020](#fluidframeworkserver-services-client01020)
 
 -   [0.1019 and earlier Breaking Changes](#01019-and-earlier-breaking-changes)
+
+## 3.0.0 Breaking Changes
+
+### An invalid JWT token will now return a 401 error instead of a 500
+
+When we auth request JWT token, previous we would fail directly for the invalid/malformtted JWT token and don't do any handling and return 500. Now it is returning a 401 with Invalid token information
+
 
 ## 1.0.0 Breaking Changes
 

--- a/server/routerlicious/packages/services-client/src/auth.ts
+++ b/server/routerlicious/packages/services-client/src/auth.ts
@@ -23,7 +23,12 @@ export function validateTokenClaims(
 		throw new NetworkError(403, `Token must be a string. Received: ${typeof token}`);
 	}
 
-	const claims = jwtDecode<ITokenClaims>(token);
+	let claims: ITokenClaims;
+	try {
+		claims = jwtDecode<ITokenClaims>(token);
+	} catch {
+		throw new NetworkError(401, "Invalid token");
+	}
 
 	if (!claims || claims.documentId !== documentId || claims.tenantId !== tenantId) {
 		throw new NetworkError(

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -322,7 +322,7 @@ export function validateTokenScopeClaims(expectedScopes: string): RequestHandler
 		try {
 			claims = decode(token) as ITokenClaims;
 		} catch {
-			throw new NetworkError(401, "Invalid token");
+			return respondWithNetworkError(response, new NetworkError(401, "Invalid token."));
 		}
 
 		if (!claims) {

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -318,7 +318,13 @@ export function validateTokenScopeClaims(expectedScopes: string): RequestHandler
 			);
 		}
 
-		const claims = decode(token) as ITokenClaims;
+		let claims: ITokenClaims;
+		try {
+			claims = decode(token) as ITokenClaims;
+		} catch {
+			throw new NetworkError(401, "Invalid token");
+		}
+
 		if (!claims) {
 			return respondWithNetworkError(
 				response,


### PR DESCRIPTION
Socket connect flow is very hard to follow and read. This PR do followings:
1. Introduced `ConnectDocumentStage` enum to indicate different of stages, which will be used for reliability reporting.
2. Break the long connect method into smaller functions, so that code is easier to scan/read.
3. Moved version check step to the first step instead of last few steps. 

Need to load diff for the large diff view