### PR TITLE
[main>6.3] ci: publish packages to feeds based on settings

### DIFF
--- a/build-tools/packages/build-cli/docs/list.md
+++ b/build-tools/packages/build-cli/docs/list.md
@@ -12,7 +12,7 @@ List packages in a release group in topological order.
 ```
 USAGE
   $ flub list -g client|server|azure|build-tools|gitrest|historian [-v | --quiet] [--json] [--private]
-    [--scope <value> | --skipScope <value>] [--tarball]
+    [--scope <value> | --skipScope <value>] [--feed official|internal|internal-test] [--tarball]
 
 FLAGS
   -g, --releaseGroup=<option>  (required) Name of a release group.
@@ -24,15 +24,18 @@ LOGGING FLAGS
   -v, --verbose  Enable verbose logging.
   --quiet        Disable all logging.
 
-GLOBAL FLAGS
-  --json  Format output as json.
-
 PACKAGE FILTER FLAGS
+  --feed=<option>         Filter the resulting packages to those that should be published to a particular npm feed. Use
+                          'official' for public npm.
+                          <options: official|internal|internal-test>
   --[no-]private          Only include private packages. Use --no-private to exclude private packages instead.
   --scope=<value>...      Package scopes to filter to. If provided, only packages whose scope matches the flag will be
                           included. Cannot be used with --skipScope.
   --skipScope=<value>...  Package scopes to filter out. If provided, packages whose scope matches the flag will be
                           excluded. Cannot be used with --scope.
+
+GLOBAL FLAGS
+  --json  Format output as json.
 
 DESCRIPTION
   List packages in a release group in topological order.

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -36,7 +36,7 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 /**
  * Whether the package is known to be a publicly published package for general use.
  */
-function packageMustPublishToNPM(name: string, config: PackageNamePolicyConfig): boolean {
+export function packageMustPublishToNPM(name: string, config: PackageNamePolicyConfig): boolean {
 	const mustPublish = config.mustPublish.npm;
 
 	if (mustPublish === undefined) {
@@ -60,7 +60,7 @@ function packageMustPublishToNPM(name: string, config: PackageNamePolicyConfig):
  * Note that packages published to NPM will also be published internally, however.
  * This should be a minimal set required for legacy compat of internal partners or internal CI requirements.
  */
-function packageMustPublishToInternalFeedOnly(
+export function packageMustPublishToInternalFeedOnly(
 	name: string,
 	config: PackageNamePolicyConfig,
 ): boolean {
@@ -86,7 +86,10 @@ function packageMustPublishToInternalFeedOnly(
  * Whether the package has the option to publicly publish if it chooses.
  * For example, an experimental package may choose to remain unpublished until it's ready for customers to try it out.
  */
-function packageMayChooseToPublishToNPM(name: string, config: PackageNamePolicyConfig): boolean {
+export function packageMayChooseToPublishToNPM(
+	name: string,
+	config: PackageNamePolicyConfig,
+): boolean {
 	const mayPublish = config.mayPublish.npm;
 
 	if (mayPublish === undefined) {
@@ -108,7 +111,7 @@ function packageMayChooseToPublishToNPM(name: string, config: PackageNamePolicyC
 /**
  * Whether the package has the option to publish to an internal feed if it chooses.
  */
-function packageMayChooseToPublishToInternalFeedOnly(
+export function packageMayChooseToPublishToInternalFeedOnly(
 	name: string,
 	config: PackageNamePolicyConfig,
 ): boolean {
@@ -134,7 +137,7 @@ function packageMayChooseToPublishToInternalFeedOnly(
  * If we haven't explicitly OK'd the package scope to publish in one of the categories above, it must be marked
  * private to prevent publishing.
  */
-function packageMustBePrivate(name: string, root: string): boolean {
+export function packageMustBePrivate(name: string, root: string): boolean {
 	const config = getFluidBuildConfig(root).policy?.packageNames;
 
 	if (config === undefined) {
@@ -153,7 +156,7 @@ function packageMustBePrivate(name: string, root: string): boolean {
 /**
  * If we know a package needs to publish somewhere, then it must not be marked private to allow publishing.
  */
-function packageMustNotBePrivate(name: string, root: string): boolean {
+export function packageMustNotBePrivate(name: string, root: string): boolean {
 	const config = getFluidBuildConfig(root).policy?.packageNames;
 
 	if (config === undefined) {

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -170,7 +170,12 @@ module.exports = {
 
 			mustPublish: {
 				// These packages will always be published to npm.
-				npm: ["@fluidframework", "fluid-framework", "tinylicious"],
+				npm: [
+					"@fluidframework",
+					"fluid-framework",
+					"tinylicious",
+					"@fluid-internal/client-utils",
+				],
 				// A list of packages known to be an internally published package but not to npm. Note that packages published
 				// to npm will also be published internally, however. This should be a minimal set required for legacy compat of
 				// internal partners or internal CI requirements.

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -26,6 +26,11 @@ if [ -f ".releaseGroup" ]; then
   # This saves a list of the packages in the working directory in topological order to a temporary file.
   # Each package name is modified to match the packed tar files.
   flub list --no-private --releaseGroup $RELEASE_GROUP --tarball > $STAGING_PATH/pack/packagePublishOrder.txt
+
+  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed official > $STAGING_PATH/pack/packagePublishOrder-official.txt
+  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed internal > $STAGING_PATH/pack/packagePublishOrder-internal.txt
+  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed internal-test > $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
+
 else
   $PACKAGE_MANAGER pack && mv -t $STAGING_PATH/pack/scoped/ ./*.tgz
 fi

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -7,8 +7,8 @@ parameters:
 - name: namespace
   type: boolean
 
-- name: official
-  type: boolean
+- name: feedKind
+  type: string
 
 - name: feedName
   type: string
@@ -63,7 +63,7 @@ jobs:
               devFeedName: ${{ parameters.devFeedName }}
               feedName: ${{ parameters.feedName }}
               customEndPoint: ${{ parameters.customEndPoint }}
-              official: ${{ parameters.official }}
+              feedKind: ${{ parameters.feedKind }}
               publishFlags: ${{ parameters.publishFlags }}
           - ${{ if eq(parameters.publishNonScopedPackages, true) }}:
             - template: include-publish-npm-package-steps.yml
@@ -72,7 +72,7 @@ jobs:
                 artifactPath: non-scoped
                 devFeedName: ${{ parameters.devFeedName }}
                 feedName: ${{ parameters.feedName }}
-                official: ${{ parameters.official }}
+                feedKind: ${{ parameters.feedKind }}
                 customEndPoint: ${{ parameters.customEndPoint }}
                 publishFlags: ${{ parameters.publishFlags }}
           - template: include-git-tag-steps.yml

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -13,7 +13,7 @@ parameters:
 - name: devFeedName
   type: string
 
-- name: official
+- name: feedKind
   type: string
 
 - name: artifactPath
@@ -34,7 +34,7 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     ${{ if eq(parameters.namespace, true) }}:
-      ${{ if eq(parameters.official, false) }}:
+      ${{ if ne(parameters.feedKind, 'official') }}:
         script: |
           echo Generating .npmrc for ${{ parameters.feedName }}
           echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
@@ -44,7 +44,7 @@ steps:
           echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
-      ${{ if eq(parameters.official, true) }}:
+      ${{ if eq(parameters.feedKind, 'official') }}:
         script: |
           echo Generating .npmrc for ${{ parameters.feedName }}
           echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
@@ -53,13 +53,6 @@ steps:
           echo "@fluid-internal:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
-          echo Deleting @fluid-internal packages except fluid-internal-client-utils package
-          for packageName in $(ls fluid-internal-*.tgz | grep -v fluid-internal-client-utils-*.tgz)
-          do
-            rm -f $packageName
-          done
-          echo Deleting @fluid-example packages
-          rm -f fluid-example-*
     ${{ if eq(parameters.namespace, false) }}:
       script: |
         echo Generating .npmrc for ${{ parameters.feedName }}
@@ -88,8 +81,8 @@ steps:
       echo Tag: $tag
       cp .npmrc ~/.npmrc
       maximumRetryIfNetworkError=3
-      if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
-        packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
+      if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder-${{ parameters.feedKind }}.txt ]]; then
+        packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder-${{ parameters.feedKind }}.txt)
         sorted=true
       else
         packages=*.tgz
@@ -146,7 +139,7 @@ steps:
 
               if [[ $release == "release" && $feedId == "build" ]]; then
                 packageVersion=$(grep -oP 'npm notice version:\s+\K[^\s]+' publish_log)
-                
+
                 if [ "${{ parameters.artifactPath }}" == "scoped" ]; then
                   scopes=("fluidframework" "fluid-tools" "fluid-internal" "fluid-experimental")
                   for scope in "${scopes[@]}"; do
@@ -172,9 +165,9 @@ steps:
                       }' \
                       "$feedPromotionUrl"
                   )
-                
+
                 curlExitStatus=$?
-                
+
                 if echo "$response" | grep -q '"success":"false"'; then
                   reason="${response#*\"reason\":\"}"
                   reason="${reason%%\"*}"
@@ -186,7 +179,7 @@ steps:
                   exit 1
                 fi
               fi
-              
+
               rm publish_log
               break
             fi

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -31,7 +31,7 @@ stages:
       namespace: ${{ parameters.namespace }}
       devFeedName: $(ado-feeds-test) # Comes from the ado-feeds variable group
       feedName: $(ado-feeds-test) # Comes from the ado-feeds variable group
-      official: false
+      feedKind: internal-test
       environment: test-package-build-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
@@ -48,7 +48,7 @@ stages:
       namespace: ${{ parameters.namespace }}
       devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
       feedName: $(ado-feeds-build) # Comes from the ado-feeds variable group
-      official: false
+      feedKind: internal
       environment: package-build-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
@@ -67,7 +67,7 @@ stages:
       # using the `dev` registry is safe.
       devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
       feedName: https://registry.npmjs.org
-      official: true
+      feedKind: official
       environment: package-npmjs-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}


### PR DESCRIPTION
Port of https://github.com/microsoft/FluidFramework/pull/17477 to the 6.3 release branch.

This PR unifies the logic that decides what feeds a given package can be
published to and uses that logic in the CI pipeline to determine what
packages to publish to a feed.

It does this by creating a file with a list of packages. One file is
created for each of the feed kinds - official, internal, and
internal-test. These files are then used in the bash script that
publishes the packages. Only packages listed in the files are published,
so this effectively filters out packages that shouldn't be published to
a particular feed, including examples and most fluid-internal packages.

Since the policy-check logic is used to determine whether a package
should be published, as we update that policy, the publishing pipeline
should benefit from those changes and "just work."