### PR TITLE
[bump] test-tools: 0.2.0 => 1.0.0 (major)

### DIFF
--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-tools",
-	"version": "0.2.0",
+	"version": "1.0.0",
 	"description": "Fluid test tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped test-tools from 0.2.0 to 1.0.0. Pre 1.0 versions are difficult to reason about because the semver rules are different, so this will address that. Plus we were using our "simple" version scheme which just appends the build number to the version number, which is confusing. After this change the package will be a "standard semver" package.
 
Commands used:

```
pnpm flub bump test-tools -t major
```