### PR TITLE
ci(test-tools): Don't use buildNumberInPatch param

### DIFF
--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -76,4 +76,3 @@ extends:
     taskLint: false
     taskTest:
     - test
-    buildNumberInPatch: true


### PR DESCRIPTION
We're switching to standard semver for this package.