### PR TITLE
build(client): Update deps on test-tools client release group

### DIFF
--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -62,7 +62,7 @@
 		"@fluidframework/local-driver": "workspace:~",
 		"@fluidframework/server-local-server": "^2.0.1",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -54,7 +54,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -71,7 +71,7 @@
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",
 		"@types/react": "^17.0.44",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -56,7 +56,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -50,7 +50,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -68,7 +68,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/cors": "^2.8.4",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/express": "^4.11.0",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@octokit/core": "^4.0.5",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/build-tools": "^0.24.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-tools": "^0.2.158186",
+		"@fluidframework/test-tools": "^1.0.195075",
 		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/jsrsasign": "^8.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@microsoft/api-documenter': ^7.21.6
       '@microsoft/api-extractor': ^7.37.0
       '@octokit/core': ^4.0.5
@@ -46,7 +46,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@microsoft/api-documenter': 7.22.5
       '@microsoft/api-extractor': 7.37.0
       '@octokit/core': 4.2.0
@@ -234,7 +234,7 @@ importers:
       '@fluidframework/server-local-server': ^2.0.1
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -287,7 +287,7 @@ importers:
       '@fluidframework/local-driver': link:../../../packages/drivers/local-driver
       '@fluidframework/server-local-server': 2.0.1
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -308,7 +308,7 @@ importers:
       rimraf: 4.4.1
       start-server-and-test: 1.15.5
       tinylicious: 2.0.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -492,7 +492,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -531,7 +531,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -547,7 +547,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -569,7 +569,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/test-utils': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -619,7 +619,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -638,7 +638,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -658,7 +658,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -704,7 +704,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -721,7 +721,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -751,7 +751,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/view-adapters': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -822,7 +822,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -870,7 +870,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/tinylicious-client': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -912,7 +912,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -927,7 +927,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -951,7 +951,7 @@ importers:
       '@fluidframework/request-handler': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/task-manager': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -995,7 +995,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1012,7 +1012,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -1033,7 +1033,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1071,7 +1071,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1087,7 +1087,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -1108,7 +1108,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/view-interfaces': workspace:~
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
@@ -1146,7 +1146,7 @@ importers:
       '@fluidframework/build-tools': 0.24.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/mocha': 9.1.1
       '@types/node': 16.18.38
       '@types/react': 17.0.52
@@ -1177,7 +1177,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1218,7 +1218,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1234,7 +1234,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       typescript-formatter: 7.2.2_typescript@5.1.6
@@ -1257,7 +1257,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1298,7 +1298,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1314,7 +1314,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -1336,7 +1336,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1375,7 +1375,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1391,7 +1391,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -1560,7 +1560,7 @@ importers:
       rimraf: 4.4.1
       start-server-and-test: 1.15.5
       tinylicious: 2.0.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       tslib: 1.14.1
       typescript: 5.1.6
@@ -1579,7 +1579,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/ink': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1618,7 +1618,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1658,7 +1658,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/task-manager': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/test-utils': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -1696,7 +1696,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -1713,7 +1713,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -1809,7 +1809,7 @@ importers:
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -1845,7 +1845,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1861,7 +1861,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -1880,7 +1880,7 @@ importers:
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@rushstack/eslint-config': ^2.5.1
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -1917,7 +1917,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@rushstack/eslint-config': 2.6.2_qvtltsyn3reahc7lgycismcfiq
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -1934,7 +1934,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2024,7 +2024,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2056,7 +2056,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2070,7 +2070,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2086,7 +2086,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2122,7 +2122,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2141,7 +2141,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2167,7 +2167,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/request-handler': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/view-adapters': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -2215,7 +2215,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2234,7 +2234,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2251,7 +2251,7 @@ importers:
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2281,7 +2281,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2295,7 +2295,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2352,7 +2352,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2387,7 +2387,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2406,7 +2406,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2421,7 +2421,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2456,7 +2456,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2475,7 +2475,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2490,7 +2490,7 @@ importers:
       '@fluidframework/build-common': ^2.0.0
       '@fluidframework/build-tools': ^0.24.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2525,7 +2525,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2544,7 +2544,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -2678,7 +2678,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/undo-redo': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -2743,7 +2743,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2916,8 +2916,8 @@ importers:
       c8: 7.13.0
       cross-env: 7.0.3
       eslint: 8.6.0
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
-      eslint-plugin-import: 2.25.4_av4jjatakjabmml5z5flrwsy3e
+      eslint-import-resolver-typescript: 3.5.5_lzq2knpwsp5cvefgpb4ykfeff4
+      eslint-plugin-import: 2.25.4_htojv7osgecekql5s5yswrjo4e
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
@@ -3006,7 +3006,7 @@ importers:
       '@fluidframework/map': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/test-utils': workspace:~
       '@fluidframework/view-adapters': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -3053,7 +3053,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -3174,8 +3174,8 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.83.0
       eslint: 8.6.0
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
-      eslint-plugin-import: 2.25.4_av4jjatakjabmml5z5flrwsy3e
+      eslint-import-resolver-typescript: 3.5.5_lzq2knpwsp5cvefgpb4ykfeff4
+      eslint-plugin-import: 2.25.4_htojv7osgecekql5s5yswrjo4e
       esm-loader-css: 1.0.4
       file-loader: 3.0.1_webpack@5.83.0
       html-loader: 3.1.2_webpack@5.83.0
@@ -3224,7 +3224,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/task-manager': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/cors': ^2.8.4
       '@types/expect-puppeteer': 2.2.1
@@ -3316,7 +3316,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/cors': 2.8.13
       '@types/expect-puppeteer': 2.2.1
       '@types/express': 4.17.17
@@ -3334,7 +3334,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.6.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
-      eslint-plugin-import: 2.25.4_eslint@8.6.0
+      eslint-plugin-import: 2.25.4_4pij4nvnkqnncanfc5qjphoilq
       eslint-plugin-jsdoc: 39.3.25_eslint@8.6.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@8.6.0
       eslint-plugin-react: 7.28.0_eslint@8.6.0
@@ -3354,7 +3354,7 @@ importers:
       stream-http: 3.2.0
       supertest: 3.4.2
       tinylicious: 2.0.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -3516,7 +3516,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -3562,7 +3562,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3579,7 +3579,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -3612,7 +3612,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/task-manager': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -3683,7 +3683,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3697,7 +3697,7 @@ importers:
       css-loader: 1.0.1_webpack@5.83.0
       eslint: 8.6.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
-      eslint-plugin-import: 2.25.4_eslint@8.6.0
+      eslint-plugin-import: 2.25.4_4pij4nvnkqnncanfc5qjphoilq
       eslint-plugin-jsdoc: 39.3.25_eslint@8.6.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@8.6.0
       eslint-plugin-react: 7.28.0_eslint@8.6.0
@@ -3712,7 +3712,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -3745,7 +3745,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/task-manager': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -3816,7 +3816,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3830,7 +3830,7 @@ importers:
       css-loader: 1.0.1_webpack@5.83.0
       eslint: 8.6.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
-      eslint-plugin-import: 2.25.4_eslint@8.6.0
+      eslint-plugin-import: 2.25.4_4pij4nvnkqnncanfc5qjphoilq
       eslint-plugin-jsdoc: 39.3.25_eslint@8.6.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@8.6.0
       eslint-plugin-react: 7.28.0_eslint@8.6.0
@@ -3845,7 +3845,7 @@ importers:
       puppeteer: 17.1.3
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.83.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -3867,7 +3867,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/map': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/view-adapters': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -3914,7 +3914,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3932,7 +3932,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -3951,7 +3951,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3990,7 +3990,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -4007,7 +4007,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -4026,7 +4026,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -4073,7 +4073,7 @@ importers:
       '@fluidframework/build-common': 2.0.0
       '@fluidframework/build-tools': 0.24.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -4092,7 +4092,7 @@ importers:
       process: 0.11.10
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -5051,7 +5051,7 @@ importers:
       jest-junit: 10.0.0
       prettier: 2.6.2
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       typescript: 5.1.6
 
   experimental/PropertyDDS/services/property-query-service:
@@ -5928,7 +5928,7 @@ importers:
       rewire: 5.0.0
       rimraf: 4.4.1
       sinon: 7.5.0
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-node: 10.9.1_df7afiotem46v675cpaych2n3q
       typescript: 5.1.6
 
@@ -7746,7 +7746,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/routerlicious-driver': workspace:~
-      '@fluidframework/test-tools': ^0.2.158186
+      '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.0.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/jsrsasign': ^8.0.8
@@ -7776,7 +7776,7 @@ importers:
       '@fluidframework/build-tools': 0.24.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-tools': 0.2.158186
+      '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.7.0.0
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
       '@types/jsrsasign': 8.0.13
@@ -9923,8 +9923,8 @@ importers:
       '@types/uuid': 9.0.2
       c8: 7.13.0
       eslint: 8.6.0
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
-      eslint-plugin-import: 2.25.4_av4jjatakjabmml5z5flrwsy3e
+      eslint-import-resolver-typescript: 3.5.5_lzq2knpwsp5cvefgpb4ykfeff4
+      eslint-plugin-import: 2.25.4_htojv7osgecekql5s5yswrjo4e
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
@@ -10260,8 +10260,8 @@ importers:
       c8: 7.13.0
       cross-env: 7.0.3
       eslint: 8.6.0
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
-      eslint-plugin-import: 2.25.4_av4jjatakjabmml5z5flrwsy3e
+      eslint-import-resolver-typescript: 3.5.5_lzq2knpwsp5cvefgpb4ykfeff4
+      eslint-plugin-import: 2.25.4_htojv7osgecekql5s5yswrjo4e
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
@@ -10477,7 +10477,7 @@ importers:
       sinon: 7.5.0
       sinon-chrome: 3.0.1
       start-server-and-test: 1.15.5
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -10699,7 +10699,7 @@ importers:
       prettier: 2.6.2
       puppeteer: 17.1.3
       rimraf: 4.4.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       ts-loader: 9.4.2_2g4z7xhl5j2hjnjlc6adf2vq2m
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
@@ -10840,7 +10840,7 @@ importers:
       prop-types: 15.8.1
       rimraf: 4.4.1
       simple-git: 3.19.1
-      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-jest: 29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4
       typescript: 5.1.6
       vite: 4.4.9_@types+node@16.18.40
 
@@ -15218,7 +15218,7 @@ packages:
       '@fluentui/utilities': 8.13.13_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/react-icons/2.0.201_react@17.0.2:
@@ -18293,8 +18293,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-tools/0.2.158186:
-    resolution: {integrity: sha512-PwO7X/Kg46befSo28mSuef95/fQUmfOFWmoY1FdWAMz+6srX4o/8B4KVaKQ/3nmFD5a/PQHYHqyzAxWiFZYpfQ==}
+  /@fluidframework/test-tools/1.0.195075:
+    resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
     dev: true
 
@@ -24172,8 +24172,10 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.12.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -27809,7 +27811,7 @@ packages:
       memfs-or-file-map-to-github-branch: 1.2.1
       micromatch: 4.0.5
       node-cleanup: 2.1.2
-      node-fetch: 2.6.11
+      node-fetch: 2.7.0
       override-require: 1.1.1
       p-limit: 2.3.0
       parse-diff: 0.7.1
@@ -29134,7 +29136,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.5_wwrwxdavgu4hzdoqb37x5rvvke:
+  /eslint-import-resolver-typescript/3.5.5_lzq2knpwsp5cvefgpb4ykfeff4:
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -29144,8 +29146,8 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.6.0
-      eslint-module-utils: 2.8.0_av4jjatakjabmml5z5flrwsy3e
-      eslint-plugin-import: 2.25.4_av4jjatakjabmml5z5flrwsy3e
+      eslint-module-utils: 2.8.0_htojv7osgecekql5s5yswrjo4e
+      eslint-plugin-import: 2.25.4_htojv7osgecekql5s5yswrjo4e
       get-tsconfig: 4.6.2
       globby: 13.1.4
       is-core-module: 2.12.1
@@ -29158,7 +29160,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.8.0_2wwsys6gbnsdc4a7jaa5rcv4nq:
+  /eslint-module-utils/2.8.0_htojv7osgecekql5s5yswrjo4e:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -29179,66 +29181,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.55.0_qvtltsyn3reahc7lgycismcfiq
       debug: 3.2.7
       eslint: 8.6.0
-      eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils/2.8.0_ajv3vlqzjpoxbu6hdlpgvuycsm:
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      debug: 3.2.7
-      eslint: 8.6.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils/2.8.0_av4jjatakjabmml5z5flrwsy3e:
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      debug: 3.2.7
-      eslint: 8.6.0
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
+      eslint-import-resolver-typescript: 3.5.5_lzq2knpwsp5cvefgpb4ykfeff4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29268,7 +29214,7 @@ packages:
       debug: 3.2.7
       eslint: 8.6.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5_wwrwxdavgu4hzdoqb37x5rvvke
+      eslint-import-resolver-typescript: 3.5.5_lzq2knpwsp5cvefgpb4ykfeff4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29367,66 +29313,6 @@ packages:
       eslint: 8.6.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0_nd5yjn7vp7rjhzbqd7k4s2bww4
-      has: 1.0.3
-      is-core-module: 2.12.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.2
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import/2.25.4_av4jjatakjabmml5z5flrwsy3e:
-    resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.6.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0_ajv3vlqzjpoxbu6hdlpgvuycsm
-      has: 1.0.3
-      is-core-module: 2.12.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.2
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import/2.25.4_eslint@8.6.0:
-    resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.6.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0_2wwsys6gbnsdc4a7jaa5rcv4nq
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -30396,7 +30282,7 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.3.0
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.12.0
       fast-deep-equal: 3.1.3
       fast-uri: 2.2.0
       rfdc: 1.3.0
@@ -41379,7 +41265,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.12.0
       ajv-keywords: 5.1.0_ajv@8.12.0
 
   /scoped-regex/2.1.0:
@@ -43543,7 +43429,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest/29.1.1_bd7t4cpe6hueih24owb27fpuam:
+  /ts-jest/29.1.1_tndnqa5xo6u3ff2xboqc6b3zs4:
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -43564,6 +43450,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.22.10
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.6.2_@types+node@16.18.38


### PR DESCRIPTION
Updated the following:

  client (release group)

Dependencies on @fluidframework/test-tools updated:

  @fluidframework/test-tools: ^1.0.195075

Command used:

```shell
flub bump deps test-tools -t greatest
```