### PR TITLE
Add repair data regression

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -38,10 +38,10 @@ import {
 } from "../../feature-libraries";
 import { brand } from "../../util";
 import { ISubscribable } from "../../events";
-import { TestSharedTreeCore } from "./utils";
 import { SharedTreeTestFactory } from "../utils";
-import { ISharedTree, InitializeAndSchematizeConfiguration } from "../../shared-tree";
+import { InitializeAndSchematizeConfiguration } from "../../shared-tree";
 import { leaf } from "../../domains";
+import { TestSharedTreeCore } from "./utils";
 
 describe("SharedTreeCore", () => {
 	describe("emits", () => {

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -312,12 +312,14 @@ describe("SharedTreeCore", () => {
 		assert.equal(getTrunkLength(tree), 1);
 	});
 
-	it.skip("Regression 0x4a6", async () => {
+	// This test triggers 0x4a6 at the time of writing, as rebasing tree2's final edit over tree1's final edit
+	// didn't properly track state related to the detached node the edit affects.
+	// When unskipping this test, it may be desirable to add assertions verifying the final state of the two trees.
+	it.skip("Regression test for 0x4a6", async () => {
 		const containerRuntimeFactory = new MockContainerRuntimeFactory();
 		const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
 		const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-		const onCreate = (tree: ISharedTree) => {};
-		const factory = new SharedTreeTestFactory(onCreate);
+		const factory = new SharedTreeTestFactory(() => {});
 
 		containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 		containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);


### PR DESCRIPTION
## Description

Adds a skipped regression test for a series of valid edits which can trigger 0x4a6.

This issue was found by modifying some of the fuzz test logic to more authentically handle different field kinds. (See #17560)