### PR TITLE
refactor(azure): Enable no-abbreviations eslint rule and fix violations

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -28,7 +28,7 @@ export class AzureAudience extends ServiceAudience<AzureMember> implements IAzur
 
 // @public
 export class AzureClient {
-    constructor(props: AzureClientProps);
+    constructor(properties: AzureClientProps);
     copyContainer(id: string, containerSchema: ContainerSchema, version?: AzureContainerVersion): Promise<{
         container: IFluidContainer;
         services: AzureContainerServices;

--- a/azure/packages/azure-client/.eslintrc.js
+++ b/azure/packages/azure-client/.eslintrc.js
@@ -5,8 +5,32 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
-	plugins: ["eslint-plugin-jsdoc"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
+	rules: {
+		// Useful for developer accessibility
+		"unicorn/prevent-abbreviations": [
+			"error",
+			{
+				allowList: {
+					// Industry-standard index variable name.
+					i: true,
+
+					// Existing export - renaming would be a breaking change.
+					// Leaving this alone for now, but this can be reconsidered in the future.
+					AzureClientProps: true,
+				},
+			},
+		],
+	},
+	overrides: [
+		{
+			// Overrides for type-tests
+			files: ["src/test/types/*"],
+			rules: {
+				"unicorn/prevent-abbreviations": "off",
+			},
+		},
+	],
 };

--- a/azure/packages/azure-client/.eslintrc.js
+++ b/azure/packages/azure-client/.eslintrc.js
@@ -16,11 +16,12 @@ module.exports = {
 				allowList: {
 					// Industry-standard index variable name.
 					i: true,
-
-					// Existing export - renaming would be a breaking change.
-					// Leaving this alone for now, but this can be reconsidered in the future.
-					AzureClientProps: true,
 				},
+				ignore: [
+					// "props" has become something of an industry standard abbreviation for "properties".
+					// Allow names to include "props" / "Props".
+					"[pP]rops",
+				],
 			},
 		],
 	},

--- a/azure/packages/azure-client/.eslintrc.js
+++ b/azure/packages/azure-client/.eslintrc.js
@@ -13,10 +13,15 @@ module.exports = {
 		"unicorn/prevent-abbreviations": [
 			"error",
 			{
+				// Exact variable name checks.
+				// See: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md#allowlist
 				allowList: {
 					// Industry-standard index variable name.
 					i: true,
 				},
+
+				// RegEx-based exclusions
+				// See: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md#ignore
 				ignore: [
 					// "props" has become something of an industry standard abbreviation for "properties".
 					// Allow names to include "props" / "Props".

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -41,9 +41,9 @@ import { isAzureRemoteConnectionConfig } from "./utils";
  * Strongly typed id for connecting to a local Azure Fluid Relay.
  */
 const LOCAL_MODE_TENANT_ID = "local";
-const getTenantId = (connectionProps: AzureConnectionConfig): string => {
-	return isAzureRemoteConnectionConfig(connectionProps)
-		? connectionProps.tenantId
+const getTenantId = (connectionProperties: AzureConnectionConfig): string => {
+	return isAzureRemoteConnectionConfig(connectionProperties)
+		? connectionProperties.tenantId
 		: LOCAL_MODE_TENANT_ID;
 };
 
@@ -60,26 +60,26 @@ export class AzureClient {
 
 	/**
 	 * Creates a new client instance using configuration parameters.
-	 * @param props - Properties for initializing a new AzureClient instance
+	 * @param properties - Properties for initializing a new AzureClient instance
 	 */
-	public constructor(private readonly props: AzureClientProps) {
+	public constructor(private readonly properties: AzureClientProps) {
 		// remove trailing slash from URL if any
-		props.connection.endpoint = props.connection.endpoint.replace(/\/$/, "");
+		properties.connection.endpoint = properties.connection.endpoint.replace(/\/$/, "");
 		this.urlResolver = new AzureUrlResolver();
 		// The local service implementation differs from the Azure Fluid Relay in blob
 		// storage format. Azure Fluid Relay supports whole summary upload. Local currently does not.
-		const isRemoteConnection = isAzureRemoteConnectionConfig(this.props.connection);
+		const isRemoteConnection = isAzureRemoteConnectionConfig(this.properties.connection);
 		const origDocumentServiceFactory: IDocumentServiceFactory =
-			new RouterliciousDocumentServiceFactory(this.props.connection.tokenProvider, {
+			new RouterliciousDocumentServiceFactory(this.properties.connection.tokenProvider, {
 				enableWholeSummaryUpload: isRemoteConnection,
 				enableDiscovery: isRemoteConnection,
 			});
 
 		this.documentServiceFactory = applyStorageCompression(
 			origDocumentServiceFactory,
-			props.summaryCompression,
+			properties.summaryCompression,
 		);
-		this.configProvider = props.configProvider;
+		this.configProvider = properties.configProvider;
 	}
 
 	/**
@@ -98,7 +98,10 @@ export class AzureClient {
 			config: {},
 		});
 
-		const fluidContainer = await this.createFluidContainer(container, this.props.connection);
+		const fluidContainer = await this.createFluidContainer(
+			container,
+			this.properties.connection,
+		);
 		const services = this.getContainerServices(container);
 		return { container: fluidContainer, services };
 	}
@@ -120,9 +123,12 @@ export class AzureClient {
 		services: AzureContainerServices;
 	}> {
 		const loader = this.createLoader(containerSchema);
-		const url = new URL(this.props.connection.endpoint);
-		url.searchParams.append("storage", encodeURIComponent(this.props.connection.endpoint));
-		url.searchParams.append("tenantId", encodeURIComponent(getTenantId(this.props.connection)));
+		const url = new URL(this.properties.connection.endpoint);
+		url.searchParams.append("storage", encodeURIComponent(this.properties.connection.endpoint));
+		url.searchParams.append(
+			"tenantId",
+			encodeURIComponent(getTenantId(this.properties.connection)),
+		);
 		url.searchParams.append("containerId", encodeURIComponent(id));
 		const sourceContainer = await loader.resolve({ url: url.href });
 
@@ -143,7 +149,10 @@ export class AzureClient {
 
 		const container = await loader.rehydrateDetachedContainerFromSnapshot(JSON.stringify(tree));
 
-		const fluidContainer = await this.createFluidContainer(container, this.props.connection);
+		const fluidContainer = await this.createFluidContainer(
+			container,
+			this.properties.connection,
+		);
 		const services = this.getContainerServices(container);
 		return { container: fluidContainer, services };
 	}
@@ -162,9 +171,12 @@ export class AzureClient {
 		services: AzureContainerServices;
 	}> {
 		const loader = this.createLoader(containerSchema);
-		const url = new URL(this.props.connection.endpoint);
-		url.searchParams.append("storage", encodeURIComponent(this.props.connection.endpoint));
-		url.searchParams.append("tenantId", encodeURIComponent(getTenantId(this.props.connection)));
+		const url = new URL(this.properties.connection.endpoint);
+		url.searchParams.append("storage", encodeURIComponent(this.properties.connection.endpoint));
+		url.searchParams.append(
+			"tenantId",
+			encodeURIComponent(getTenantId(this.properties.connection)),
+		);
 		url.searchParams.append("containerId", encodeURIComponent(id));
 		const container = await loader.resolve({ url: url.href });
 		// eslint-disable-next-line import/no-deprecated
@@ -185,9 +197,12 @@ export class AzureClient {
 		id: string,
 		options?: AzureGetVersionsOptions,
 	): Promise<AzureContainerVersion[]> {
-		const url = new URL(this.props.connection.endpoint);
-		url.searchParams.append("storage", encodeURIComponent(this.props.connection.endpoint));
-		url.searchParams.append("tenantId", encodeURIComponent(getTenantId(this.props.connection)));
+		const url = new URL(this.properties.connection.endpoint);
+		url.searchParams.append("storage", encodeURIComponent(this.properties.connection.endpoint));
+		url.searchParams.append(
+			"tenantId",
+			encodeURIComponent(getTenantId(this.properties.connection)),
+		);
 		url.searchParams.append("containerId", encodeURIComponent(id));
 
 		const resolvedUrl = await this.urlResolver.resolve({ url: url.href });
@@ -238,7 +253,7 @@ export class AzureClient {
 			urlResolver: this.urlResolver,
 			documentServiceFactory: this.documentServiceFactory,
 			codeLoader,
-			logger: this.props.logger,
+			logger: this.properties.logger,
 			options: { client },
 			configProvider: this.configProvider,
 		});

--- a/azure/packages/azure-client/src/AzureUrlResolver.ts
+++ b/azure/packages/azure-client/src/AzureUrlResolver.ts
@@ -71,18 +71,18 @@ function decodeAzureUrl(urlString: string): {
 } {
 	const url = new URL(urlString);
 	const ordererUrl = url.origin;
-	const searchParams = url.searchParams;
-	const storageUrl = searchParams.get("storage");
+	const searchParameters = url.searchParams;
+	const storageUrl = searchParameters.get("storage");
 	if (storageUrl === null) {
 		throw new Error("Azure URL did not contain a storage URL");
 	}
-	const tenantId = searchParams.get("tenantId");
+	const tenantId = searchParameters.get("tenantId");
 	if (tenantId === null) {
 		throw new Error("Azure URL did not contain a tenant ID");
 	}
 	const storageUrlDecoded = decodeURIComponent(storageUrl);
 	const tenantIdDecoded = decodeURIComponent(tenantId);
-	const containerId = searchParams.get("containerId");
+	const containerId = searchParameters.get("containerId");
 	const containerIdDecoded = containerId === null ? undefined : decodeURIComponent(containerId);
 	return {
 		ordererUrl,

--- a/azure/packages/azure-client/src/test/AzureClient.spec.ts
+++ b/azure/packages/azure-client/src/test/AzureClient.spec.ts
@@ -18,7 +18,7 @@ import { AzureClient } from "../AzureClient";
 import { type AzureLocalConnectionConfig } from "../interfaces";
 
 function createAzureClient(scopes?: ScopeType[]): AzureClient {
-	const connectionProps: AzureLocalConnectionConfig = {
+	const connectionProperties: AzureLocalConnectionConfig = {
 		tokenProvider: new InsecureTokenProvider(
 			"fooBar",
 			{
@@ -30,7 +30,7 @@ function createAzureClient(scopes?: ScopeType[]): AzureClient {
 		endpoint: "http://localhost:7070",
 		type: "local",
 	};
-	return new AzureClient({ connection: connectionProps });
+	return new AzureClient({ connection: connectionProperties });
 }
 
 const connectionModeOf = (container: IFluidContainer): ConnectionMode =>
@@ -166,22 +166,22 @@ describe("AzureClient", () => {
 	 * Expected behavior: an error should be thrown when trying to get a non-existent container.
 	 */
 	it("cannot load improperly created container (cannot load a non-existent container)", async () => {
-		const consoleErrorFn = console.error;
+		const consoleErrorFunction = console.error;
 		console.error = (): void => {};
 		const containerAndServicesP = client.getContainer("containerConfig", schema);
 
-		const errorFn = (error: Error): boolean => {
+		const errorFunction = (error: Error): boolean => {
 			assert.notStrictEqual(error.message, undefined, "Azure Client error is undefined");
 			return true;
 		};
 
 		await assert.rejects(
 			containerAndServicesP,
-			errorFn,
+			errorFunction,
 			"Azure Client can load a non-existent container",
 		);
 		// eslint-disable-next-line require-atomic-updates
-		console.error = consoleErrorFn;
+		console.error = consoleErrorFunction;
 	});
 
 	/**

--- a/azure/packages/azure-local-service/.eslintrc.js
+++ b/azure/packages/azure-local-service/.eslintrc.js
@@ -5,8 +5,28 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
-	plugins: ["eslint-plugin-jsdoc"],
 	parserOptions: {
 		project: ["./tsconfig.json"],
 	},
+	rules: {
+		// Useful for developer accessibility
+		"unicorn/prevent-abbreviations": [
+			"error",
+			{
+				allowList: {
+					// Industry-standard index variable name.
+					i: true,
+				},
+			},
+		],
+	},
+	overrides: [
+		{
+			// Overrides for type-tests
+			files: ["src/test/types/*"],
+			rules: {
+				"unicorn/prevent-abbreviations": "off",
+			},
+		},
+	],
 };

--- a/azure/packages/azure-service-utils/.eslintrc.js
+++ b/azure/packages/azure-service-utils/.eslintrc.js
@@ -5,12 +5,31 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
-	plugins: ["eslint-plugin-jsdoc"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
 		"import/no-unassigned-import": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
+
+		// Useful for developer accessibility
+		"unicorn/prevent-abbreviations": [
+			"error",
+			{
+				allowList: {
+					// Industry-standard index variable name.
+					i: true,
+				},
+			},
+		],
 	},
+	overrides: [
+		{
+			// Overrides for type-tests
+			files: ["src/test/types/*"],
+			rules: {
+				"unicorn/prevent-abbreviations": "off",
+			},
+		},
+	],
 };

--- a/azure/packages/azure-service-utils/src/generateToken.ts
+++ b/azure/packages/azure-service-utils/src/generateToken.ts
@@ -55,6 +55,8 @@ export function generateToken(
 	documentId?: string,
 	user?: IUser,
 	lifetime: number = 60 * 60,
+	// Naming intended to match `ITokenClaims.ver`
+	// eslint-disable-next-line unicorn/prevent-abbreviations
 	ver: string = "1.0",
 ): string {
 	let userClaim = user ?? generateUser();
@@ -64,10 +66,9 @@ export function generateToken(
 
 	// Current time in seconds
 	const now = Math.round(Date.now() / 1000);
-	const docId = documentId ?? "";
 
 	const claims: ITokenClaims & { jti: string } = {
-		documentId: docId,
+		documentId: documentId ?? "",
 		scopes,
 		tenantId,
 		user: userClaim,


### PR DESCRIPTION
Abbreviations present an accessibility concern for new developers on the team, and developers whose native language is not American English. This PR enables the [unicorn/prevent-abbreviations](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md) rule for the Azure packages, and fixes violations where it would not introduce API-breaking changes.

This PR can be considered a prototype, as I would personally like to see this rule enabled globally across the repo to make our code more accessible both for developers on the team and our customers.