### PR TITLE
TS5: Bump 'prettier' for 'build-tools'

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -79,7 +79,7 @@
 		"cz-conventional-changelog": "^3.3.0",
 		"cz-customizable": "^7.0.0",
 		"inquirer": "^8.2.5",
-		"prettier": "~2.6.2",
+		"prettier": "~3.0.3",
 		"rimraf": "^4.4.1",
 		"run-script-os": "^1.1.6",
 		"syncpack": "^9.8.6",

--- a/build-tools/packages/build-cli/api-report/build-cli.api.md
+++ b/build-tools/packages/build-cli/api-report/build-cli.api.md
@@ -10,7 +10,7 @@ import { run } from '@oclif/core';
 export const knownReleaseGroups: readonly ["build-tools", "client", "server", "gitrest", "historian"];
 
 // @internal
-export type ReleaseGroup = typeof knownReleaseGroups[number] | string;
+export type ReleaseGroup = (typeof knownReleaseGroups)[number] | string;
 
 // @internal
 export type ReleasePackage = string;

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -97,7 +97,7 @@
 		"node-fetch": "^2.6.9",
 		"npm-check-updates": "^16.10.15",
 		"oclif": "^3.9.1",
-		"prettier": "~2.6.2",
+		"prettier": "~3.0.3",
 		"prompts": "^2.4.2",
 		"read-pkg-up": "^7.0.1",
 		"semver": "^7.5.4",

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -17,7 +17,7 @@ import { CommandLogger } from "./logging";
  * A type representing all the flags of the base commands and subclasses.
  */
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<
-	typeof BaseCommand["baseFlags"] & T["flags"]
+	(typeof BaseCommand)["baseFlags"] & T["flags"]
 >;
 export type Args<T extends typeof Command> = Interfaces.InferredArgs<T["args"]>;
 

--- a/build-tools/packages/build-cli/src/commands/generate/changeset.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changeset.ts
@@ -306,7 +306,7 @@ async function createChangesetFile(
 	const changesetContent = await createChangesetContent(packages, body);
 	await writeFile(
 		changesetPath,
-		prettier(changesetContent, { proseWrap: "never", parser: "markdown" }),
+		await prettier(changesetContent, { proseWrap: "never", parser: "markdown" }),
 	);
 	return changesetPath;
 }

--- a/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
@@ -89,7 +89,10 @@ export default class GenerateUpcomingCommand extends BaseCommand<typeof Generate
 		const contents = `${header}\n\n${intro}\n\n${body}`;
 		const outputPath = path.join(context.repo.resolvedRoot, flags.out);
 		this.info(`Writing output file: ${outputPath}`);
-		await writeFile(outputPath, prettier(contents, { proseWrap: "never", parser: "markdown" }));
+		await writeFile(
+			outputPath,
+			await prettier(contents, { proseWrap: "never", parser: "markdown" }),
+		);
 
 		return contents;
 	}

--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -561,7 +561,7 @@ export async function setVersion(
 		prettierConfig.filepath = lernaPath;
 	}
 	lernaJson.version = translatedVersion.version;
-	const output = prettier(
+	const output = await prettier(
 		JSON.stringify(lernaJson),
 		prettierConfig === null ? undefined : prettierConfig,
 	);

--- a/build-tools/packages/build-cli/src/releaseGroups.ts
+++ b/build-tools/packages/build-cli/src/releaseGroups.ts
@@ -33,7 +33,7 @@ export const knownReleaseGroups = [
  *
  * @internal
  */
-export type ReleaseGroup = typeof knownReleaseGroups[number] | string;
+export type ReleaseGroup = (typeof knownReleaseGroups)[number] | string;
 
 /**
  * A type guard used to determine if a string is a ReleaseGroup.

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -87,7 +87,7 @@
 		"concurrently": "^8.2.1",
 		"eslint": "~8.6.0",
 		"mocha": "^10.2.0",
-		"prettier": "~2.6.2"
+		"prettier": "~3.0.3"
 	},
 	"engines": {
 		"node": ">=14.17.0"

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -263,7 +263,10 @@ export class FluidRepo {
 
 	public readonly packages: Packages;
 
-	constructor(public readonly resolvedRoot: string, log: Logger = defaultLogger) {
+	constructor(
+		public readonly resolvedRoot: string,
+		log: Logger = defaultLogger,
+	) {
 		const packageManifest = getFluidBuildConfig(resolvedRoot);
 
 		// Expand to full IFluidRepoPackage and full path

--- a/build-tools/packages/build-tools/src/common/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/common/gitRepo.ts
@@ -8,7 +8,10 @@ import { Logger } from "./logging";
 import { exec, execNoError } from "./utils";
 
 export class GitRepo {
-	constructor(public readonly resolvedRoot: string, protected readonly log?: Logger) {}
+	constructor(
+		public readonly resolvedRoot: string,
+		protected readonly log?: Logger,
+	) {}
 
 	private async getRemotes() {
 		const result = await this.exec(`remote -v`, `getting remotes`);

--- a/build-tools/packages/build-tools/src/common/versionBag.ts
+++ b/build-tools/packages/build-tools/src/common/versionBag.ts
@@ -102,9 +102,9 @@ export class ReferenceVersionBag extends VersionBag {
 				const existingReference = this.referenceData.get(entryName);
 				const message = `Inconsistent dependency to ${pkg.name}\n  ${version.padStart(
 					10,
-				)} in ${newReference}\n  ${existing.padStart(10)} in ${
-					existingReference?.reference
-				}`;
+				)} in ${newReference}\n  ${existing.padStart(
+					10,
+				)} in ${existingReference?.reference}`;
 				if (
 					existingReference?.reference &&
 					this.publishedPackage.has(existingReference.reference) &&

--- a/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
@@ -43,7 +43,10 @@ export class NpmDepChecker {
 		["@angular/compiler", "@angular/platform-browser-dynamic"],
 	]);
 
-	constructor(private readonly pkg: Package, private readonly checkFiles: string[]) {
+	constructor(
+		private readonly pkg: Package,
+		private readonly checkFiles: string[],
+	) {
 		if (checkFiles.length !== 0) {
 			for (const name of Object.keys(pkg.packageJson.dependencies!)) {
 				if (this.ignored.indexOf(name) !== -1) {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/webpackTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/webpackTask.ts
@@ -32,9 +32,8 @@ export class WebpackTask extends LeafWithDoneFileTask {
 			const srcGlob = toPosixPath(this.node.pkg.directory) + "/src/**/*.*";
 			const srcFiles = await globFn(srcGlob);
 			for (const srcFile of srcFiles) {
-				content.sources[srcFile] = await this.node.buildContext.fileHashCache.getFileHash(
-					srcFile,
-				);
+				content.sources[srcFile] =
+					await this.node.buildContext.fileHashCache.getFileHash(srcFile);
 			}
 
 			for (const dep of this.allDependentTasks) {

--- a/build-tools/packages/build-tools/src/layerCheck/layerGraph.ts
+++ b/build-tools/packages/build-tools/src/layerCheck/layerGraph.ts
@@ -139,7 +139,10 @@ type LayerDependencyNode = { node: LayerNode; orderedChildren: LayerNode[] };
 class GroupNode extends BaseNode {
 	public layerNodes: LayerNode[] = [];
 
-	constructor(name: string, private readonly groupInfo: ILayerGroupInfo) {
+	constructor(
+		name: string,
+		private readonly groupInfo: ILayerGroupInfo,
+	) {
 		super(name);
 	}
 
@@ -187,7 +190,10 @@ class PackageNode extends BaseNode {
 	private _indirectDependencies: Set<PackageNode> | undefined;
 	private _level: number | undefined;
 
-	constructor(name: string, public readonly layerNode: LayerNode) {
+	constructor(
+		name: string,
+		public readonly layerNode: LayerNode,
+	) {
 		super(name);
 	}
 

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -51,7 +51,7 @@
 		"eslint-plugin-import": "~2.25.4",
 		"eslint-plugin-unicorn": "~40.0.0",
 		"eslint-plugin-unused-imports": "~2.0.0",
-		"prettier": "~2.6.2",
+		"prettier": "~3.0.3",
 		"rimraf": "^4.4.1"
 	}
 }

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -63,7 +63,7 @@
 		"eslint-config-oclif": "^4.0.0",
 		"eslint-config-oclif-typescript": "^1.0.3",
 		"eslint-config-prettier": "~8.5.0",
-		"prettier": "~2.6.2",
+		"prettier": "~3.0.3",
 		"rimraf": "^4.4.1",
 		"ts-node": "^10.9.1",
 		"tslib": "^2.6.0",

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -78,7 +78,7 @@ export function isVersionScheme(scheme: string): scheme is VersionScheme;
 export function isWorkspaceRange(r: any): r is WorkspaceRange;
 
 // @public
-export type RangeOperator = typeof RangeOperators[number];
+export type RangeOperator = (typeof RangeOperators)[number];
 
 // @public
 export const RangeOperators: readonly ["^", "~", ""];
@@ -114,7 +114,7 @@ export type VersionChangeTypeExtended = VersionBumpTypeExtended | semver.SemVer;
 export type VersionScheme = "semver" | "internal" | "internalPrerelease" | "virtualPatch";
 
 // @public
-export type WorkspaceRange = typeof WorkspaceRanges[number];
+export type WorkspaceRange = (typeof WorkspaceRanges)[number];
 
 // @public
 export const WorkspaceRanges: readonly ["workspace:*", "workspace:^", "workspace:~"];

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -100,7 +100,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.29.4",
 		"oclif": "^3.9.1",
-		"prettier": "~2.6.2",
+		"prettier": "~3.0.3",
 		"rimraf": "^4.4.1",
 		"ts-node": "^10.9.1",
 		"tslib": "^2.6.0",

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -28,7 +28,7 @@ export const RangeOperators = ["^", "~", ""] as const;
  * @remarks
  * We intentionally only include the operators we use, not everything considered valid in the semver spec.
  */
-export type RangeOperator = typeof RangeOperators[number];
+export type RangeOperator = (typeof RangeOperators)[number];
 
 /**
  * A typeguard to check if a variable is a {@link RangeOperator}.
@@ -58,7 +58,7 @@ export const WorkspaceRanges = ["workspace:*", "workspace:^", "workspace:~"] as 
  * We intentionally only include the ranges we use, not everything considered valid by workspace-protocol-aware tools
  * like yarn and pnpm.
  */
-export type WorkspaceRange = typeof WorkspaceRanges[number];
+export type WorkspaceRange = (typeof WorkspaceRanges)[number];
 
 /**
  * A typeguard to check if a variable is a {@link WorkspaceRange}.

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       cz-conventional-changelog: ^3.3.0
       cz-customizable: ^7.0.0
       inquirer: ^8.2.5
-      prettier: ~2.6.2
+      prettier: ~3.0.3
       rimraf: ^4.4.1
       run-script-os: ^1.1.6
       syncpack: ^9.8.6
@@ -47,7 +47,7 @@ importers:
       cz-conventional-changelog: 3.3.0
       cz-customizable: 7.0.0
       inquirer: 8.2.5
-      prettier: 2.6.2
+      prettier: 3.0.3
       rimraf: 4.4.1
       run-script-os: 1.1.6
       syncpack: 9.8.6
@@ -115,7 +115,7 @@ importers:
       node-fetch: ^2.6.9
       npm-check-updates: ^16.10.15
       oclif: ^3.9.1
-      prettier: ~2.6.2
+      prettier: ~3.0.3
       prompts: ^2.4.2
       read-pkg-up: ^7.0.1
       rimraf: ^4.4.1
@@ -160,7 +160,7 @@ importers:
       node-fetch: 2.6.9
       npm-check-updates: 16.10.15
       oclif: 3.9.1_vliugzio5c6rxk3co27b7rq74a
-      prettier: 2.6.2
+      prettier: 3.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
       semver: 7.5.4
@@ -250,7 +250,7 @@ importers:
       lodash.merge: ^4.6.2
       minimatch: ^7.4.6
       mocha: ^10.2.0
-      prettier: ~2.6.2
+      prettier: ~3.0.3
       replace-in-file: ^6.3.5
       rimraf: ^4.4.1
       semver: ^7.5.4
@@ -311,7 +311,7 @@ importers:
       concurrently: 8.2.1
       eslint: 8.6.0
       mocha: 10.2.0
-      prettier: 2.6.2
+      prettier: 3.0.3
 
   packages/bundle-size-tools:
     specifiers:
@@ -332,7 +332,7 @@ importers:
       jszip: ^3.10.1
       msgpack-lite: ^0.1.26
       pako: ^2.1.0
-      prettier: ~2.6.2
+      prettier: ~3.0.3
       rimraf: ^4.4.1
       typescript: ~5.1.6
       webpack: ^5.88.1
@@ -357,7 +357,7 @@ importers:
       eslint-plugin-import: 2.25.4_eslint@8.6.0
       eslint-plugin-unicorn: 40.0.0_eslint@8.6.0
       eslint-plugin-unused-imports: 2.0.0_eslint@8.6.0
-      prettier: 2.6.2
+      prettier: 3.0.3
       rimraf: 4.4.1
 
   packages/readme-command:
@@ -382,7 +382,7 @@ importers:
       eslint-config-oclif-typescript: ^1.0.3
       eslint-config-prettier: ~8.5.0
       oclif: ^3.9.1
-      prettier: ~2.6.2
+      prettier: ~3.0.3
       rimraf: ^4.4.1
       semver: ^7.5.4
       ts-node: ^10.9.1
@@ -411,7 +411,7 @@ importers:
       eslint-config-oclif: 4.0.0_eslint@8.6.0
       eslint-config-oclif-typescript: 1.0.3_qvtltsyn3reahc7lgycismcfiq
       eslint-config-prettier: 8.5.0_eslint@8.6.0
-      prettier: 2.6.2
+      prettier: 3.0.3
       rimraf: 4.4.1
       ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
       tslib: 2.6.0
@@ -449,7 +449,7 @@ importers:
       mocha-multi-reporters: ^1.5.1
       moment: ^2.29.4
       oclif: ^3.9.1
-      prettier: ~2.6.2
+      prettier: ~3.0.3
       rimraf: ^4.4.1
       semver: ^7.5.4
       table: ^6.8.1
@@ -490,7 +490,7 @@ importers:
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
       oclif: 3.9.1_vliugzio5c6rxk3co27b7rq74a
-      prettier: 2.6.2
+      prettier: 3.0.3
       rimraf: 4.4.1
       ts-node: 10.9.1_vliugzio5c6rxk3co27b7rq74a
       tslib: 2.6.0
@@ -863,8 +863,8 @@ packages:
       - '@swc/wasm'
     dev: true
 
-  /@commitlint/load/17.7.1:
-    resolution: {integrity: sha512-S/QSOjE1ztdogYj61p6n3UbkUvweR17FQ0zDbNtoTLc+Hz7vvfS7ehoTMQ27hPSjVBpp7SzEcOQu081RLjKHJQ==}
+  /@commitlint/load/17.7.2:
+    resolution: {integrity: sha512-XA7WTnsjHZ4YH6ZYsrnxgLdXzriwMMq+utZUET6spbOEEIPBCDLdOQXS26P+v3TTO4hUHOEhzUquaBv3jbBixw==}
     engines: {node: '>=v14'}
     requiresBuild: true
     dependencies:
@@ -872,15 +872,15 @@ packages:
       '@commitlint/execute-rule': 17.4.0
       '@commitlint/resolve-extends': 17.6.7
       '@commitlint/types': 17.4.4
-      '@types/node': 20.4.7
+      '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.2.0
-      cosmiconfig-typescript-loader: 4.2.0_mrt2wnih5zjrgf7emf6zukdxaq
+      cosmiconfig-typescript-loader: 4.2.0_2i75q7fwhwfiv6j6cyvrfuvxre
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1_dvq55o6ihfzbtkatyu52wpt2ee
+      ts-node: 10.9.1_nlfdnzsudxdzt42qyp5hqbr53u
       typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
@@ -2502,8 +2502,8 @@ packages:
   /@types/node/15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
 
-  /@types/node/20.4.7:
-    resolution: {integrity: sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==}
+  /@types/node/20.5.1:
+    resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
     optional: true
 
@@ -4217,7 +4217,7 @@ packages:
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader/4.2.0_mrt2wnih5zjrgf7emf6zukdxaq:
+  /cosmiconfig-typescript-loader/4.2.0_2i75q7fwhwfiv6j6cyvrfuvxre:
     resolution: {integrity: sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -4229,9 +4229,9 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.4.7
+      '@types/node': 20.5.1
       cosmiconfig: 8.2.0
-      ts-node: 10.9.1_dvq55o6ihfzbtkatyu52wpt2ee
+      ts-node: 10.9.1_nlfdnzsudxdzt42qyp5hqbr53u
       typescript: 5.1.6
     dev: true
     optional: true
@@ -4319,7 +4319,7 @@ packages:
       longest: 2.0.1
       word-wrap: 1.2.3
     optionalDependencies:
-      '@commitlint/load': 17.7.1
+      '@commitlint/load': 17.7.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8783,6 +8783,12 @@ packages:
     resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: true
+
+  /prettier/3.0.3:
+    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   /pretty-bytes/5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -10135,7 +10141,7 @@ packages:
       '@ts-morph/common': 0.18.1
       code-block-writer: 11.0.3
 
-  /ts-node/10.9.1_dvq55o6ihfzbtkatyu52wpt2ee:
+  /ts-node/10.9.1_nlfdnzsudxdzt42qyp5hqbr53u:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10156,7 +10162,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 20.4.7
+      '@types/node': 20.5.1
       acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
Fix syntax error when using explicit variance annotations. (TS5 support begins at prettier@^2.8.5.)