### PR TITLE
fix(build-cli): Add missing await

### DIFF
--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -561,7 +561,7 @@ export async function setVersion(
 		prettierConfig.filepath = lernaPath;
 	}
 	lernaJson.version = translatedVersion.version;
-	const output = prettier(
+	const output = await prettier(
 		JSON.stringify(lernaJson),
 		prettierConfig === null ? undefined : prettierConfig,
 	);


### PR DESCRIPTION
A missing `await` when calling prettier starts throwing a compile error when bumping to the latest version. This should address the CI failures in #17567 and #17559.