### PR TITLE
fix (bump-deps): Add warning when bumping server packages

### DIFF
--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -163,7 +163,7 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand> {
 
 			if (flags.updateType !== "patch" && flags.updateType !== "minor") {
 				this.warning(
-					"Ensure the client release notes indicate that server dependencies have been bumped to a new major version.",
+					"Ensure the client release notes indicate that server dependencies have been bumped to a new major version and link the release notes.",
 				);
 			}
 		}

--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -138,25 +138,33 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand> {
 
 		const branchName = await context.gitRepo.getCurrentBranchName();
 
-		if (args.package_or_release_group === MonoRepoKind.Server && branchName !== "next") {
-			const { confirmed } = await prompts({
-				type: "confirm",
-				name: "confirmed",
-				message: `Server releases should be consumed in the ${chalk.bold(
-					"next",
-				)} branch only. The current branch is ${branchName}. Are you sure you want to continue?`,
-				initial: false,
-				onState: (state: any) => {
-					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-					if (state.aborted) {
-						process.nextTick(() => this.exit(0));
-					}
-				},
-			});
+		if (args.package_or_release_group === MonoRepoKind.Server) {
+			if (branchName !== "next") {
+				const { confirmed } = await prompts({
+					type: "confirm",
+					name: "confirmed",
+					message: `Server releases should be consumed in the ${chalk.bold(
+						"next",
+					)} branch only. The current branch is ${branchName}. Are you sure you want to continue?`,
+					initial: false,
+					onState: (state: any) => {
+						// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+						if (state.aborted) {
+							process.nextTick(() => this.exit(0));
+						}
+					},
+				});
 
-			if (confirmed !== true) {
-				this.info("Cancelled");
-				this.exit(0);
+				if (confirmed !== true) {
+					this.info("Cancelled");
+					this.exit(0);
+				}
+			}
+
+			if (flags.updateType !== "patch" && flags.updateType !== "minor") {
+				this.warning(
+					"Ensure the client release notes indicate that server dependencies have been bumped to a new major version.",
+				);
 			}
 		}
 


### PR DESCRIPTION
## Description

We should alert our customers when we bump our server dependencies so they can also bump any server package dependencies in their applications as well. This PR adds a warning message when running `bump deps server` for a major server release.

[AB#5457](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5457)