### PR TITLE
fix (ci): Allow server releases to be published on GitHub

### DIFF
--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -102,7 +102,7 @@ jobs:
 
       # Only creates GH releases for client and build-tools releases.
       - name: Create GH release
-        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'build-tools'
+        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'build-tools' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'server'
         uses: ncipollo/release-action@eb05307dcee34deaad054e98128088a30d7980dc # ratchet:ncipollo/release-action@main
         with:
           # Allow updates to existing releases.


### PR DESCRIPTION
## Description

This PR re-enables server releases being published on the [GitHub releases page](https://github.com/microsoft/FluidFramework/releases).

[AB#5457](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5457)