### PR TITLE
Unify and Fix Handling of Test Content

### DIFF
--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -77,7 +77,8 @@
 		"@fluidframework/replay-driver": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/server-local-server": "^2.0.1",
-		"@fluidframework/test-utils": "workspace:~"
+		"@fluidframework/test-utils": "workspace:~",
+		"mocha": "^10.2.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.24.0",
@@ -90,7 +91,6 @@
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.6.0",
-		"mocha": "^10.2.0",
 		"mocha-json-output-reporter": "^2.0.1",
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -12,22 +12,23 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { pkgVersion } from "./packageVersion";
 import { validateSnapshots } from "./validateSnapshots";
 import { getMetadata, writeMetadataFile } from "./metadata";
+import { getTestContent } from "./testContent";
 
 // Determine relative file locations
 function getFileLocations(): [string, string] {
 	// Correct if executing from working directory of package root
-	const origTestCollateralPath = "content/snapshotTestContent";
-	let testCollateralPath = origTestCollateralPath;
+	const testCollateral = getTestContent("snapshotTestContent");
 	let workerPath = "./dist/replayWorker.js";
-	if (fs.existsSync(testCollateralPath)) {
-		assert(fs.existsSync(workerPath), `Cannot find worker js file: ${workerPath}`);
-		return [testCollateralPath, workerPath];
+	if (fs.existsSync(workerPath) && testCollateral.exists) {
+		return [testCollateral.path, workerPath];
 	}
 	// Relative to this generated js file being executed
-	testCollateralPath = nodePath.join(__dirname, "..", testCollateralPath);
 	workerPath = nodePath.join(__dirname, "..", workerPath);
-	assert(fs.existsSync(workerPath), `Cannot find worker js file: ${workerPath}`);
-	return [testCollateralPath, workerPath];
+	assert(
+		fs.existsSync(workerPath) && testCollateral.exists,
+		`Cannot find worker js or test content file: ${workerPath}, ${testCollateral.path}`,
+	);
+	return [testCollateral.path, workerPath];
 }
 const [fileLocation, workerLocation] = getFileLocations();
 
@@ -146,8 +147,6 @@ export async function processOneNode(args: IWorkerArgs) {
 export async function processContent(mode: Mode, concurrently = true) {
 	const limiter = new ConcurrencyLimiter(numberOfThreads);
 
-	ensureTestCollateralPath();
-
 	for (const node of fs.readdirSync(fileLocation, { withFileTypes: true })) {
 		if (!node.isDirectory()) {
 			continue;
@@ -209,10 +208,6 @@ export async function processContent(mode: Mode, concurrently = true) {
 	}
 
 	return limiter.waitAll();
-}
-
-export function testCollateralExists() {
-	return fs.existsSync(fileLocation);
 }
 
 /**
@@ -462,16 +457,4 @@ function cleanFailedSnapshots(dir: string) {
 	}
 
 	fs.rmdirSync(failedSnapshotsDir);
-}
-
-let collateralPathValidated: boolean;
-
-/**
- * Validates that the required external files exist.
- */
-function ensureTestCollateralPath() {
-	if (!collateralPathValidated) {
-		assert(fs.existsSync(fileLocation), `Cannot find test collateral path: ${fileLocation}`);
-		collateralPathValidated = true;
-	}
 }

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -25,7 +25,7 @@ function getFileLocations(): [string, string] {
 	// Relative to this generated js file being executed
 	workerPath = nodePath.join(__dirname, "..", workerPath);
 	assert(
-		fs.existsSync(workerPath) && testCollateral.exists,
+		fs.existsSync(workerPath),
 		`Cannot find worker js or test content file: ${workerPath}, ${testCollateral.path}`,
 	);
 	return [testCollateral.path, workerPath];

--- a/packages/test/snapshots/src/test/replay.spec.ts
+++ b/packages/test/snapshots/src/test/replay.spec.ts
@@ -3,21 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { Mode, processContent, testCollateralExists } from "../replayMultipleFiles";
+import { Mode, processContent } from "../replayMultipleFiles";
+import { getTestContent, skipOrFailIfTestContentMissing } from "../testContent";
 
 describe("Snapshots", function () {
 	this.timeout(300000);
 
-	let collateralExists = false;
-
-	before(() => {
-		collateralExists = testCollateralExists();
-	});
+	const contentLocation = getTestContent("snapshotTestContent");
 
 	beforeEach(function () {
-		if (!collateralExists) {
-			this.skip();
-		}
+		skipOrFailIfTestContentMissing(this, contentLocation);
 	});
 
 	it("Stress Test", async () => {

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -24,28 +24,28 @@ import { ConsensusRegisterCollection } from "@fluidframework/register-collection
 import { ConsensusQueue, ConsensusOrderedCollection } from "@fluidframework/ordered-collection";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
+import { getTestContent, skipOrFailIfTestContentMissing } from "../testContent";
 
 describe(`Container Serialization Backwards Compatibility`, () => {
 	const loaderContainerTracker = new LoaderContainerTracker();
-	let filename: string;
-	const contentFolder = "content/serializedContainerTestContent";
+	const contentFolder = getTestContent("serializedContainerTestContent");
 
 	// Ideally we would have each test call this.skip() but in this case they're created dynamically
 	// based on the contents of the folder which might or might not exist, so this is the alternative
 	// I came up with.
-	if (!fs.existsSync(contentFolder)) {
-		it(`Skipping dynamic tests in this suite - test collateral folder (${contentFolder}) doesn't exist`, function () {
-			this.skip();
+	if (!contentFolder.exists) {
+		it(`dynamic tests in this suite - test collateral folder (${contentFolder.path}) doesn't exist`, function () {
+			skipOrFailIfTestContentMissing(this, contentFolder);
 		});
 		return;
 	}
 
-	for (filename of recurseFiles(contentFolder)) {
-		tests();
+	for (const filename of recurseFiles(contentFolder.path)) {
+		tests(filename);
 	}
 
-	function tests(): void {
-		const filenameShort = filename.slice(contentFolder.length + 1);
+	function tests(filename: string): void {
+		const filenameShort = filename.slice(contentFolder.path.length + 1);
 		it(`Rehydrate container from ${filenameShort} and check contents before attach`, async () => {
 			const snapshotTree = fs.readFileSync(filename, "utf8");
 

--- a/packages/test/snapshots/src/testContent.ts
+++ b/packages/test/snapshots/src/testContent.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import fs from "fs";
+import nodePath from "path";
+import * as Mocha from "mocha";
+
+export interface TestContent {
+	exists: boolean;
+	path: string;
+}
+
+// Determine relative file locations
+export function getTestContent(subPath?: string): TestContent {
+	let path = nodePath.join("content", subPath);
+	if (fs.existsSync(path)) {
+		return {
+			exists: true,
+			path,
+		};
+	}
+	// Relative to this generated js file being executed
+	path = nodePath.join(__dirname, "..", path);
+	if (fs.existsSync(path)) {
+		return {
+			exists: true,
+			path,
+		};
+	}
+	return {
+		exists: false,
+		path,
+	};
+}
+
+export function skipOrFailIfTestContentMissing(test: Mocha.Context, content: TestContent): void {
+	if (!content.exists) {
+		// environment variable details here: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+		if (process.env.TF_BUILD === "true") {
+			throw new Error(
+				`Running in automation and test content does not exist: ${content.path}`,
+			);
+		}
+		test.skip();
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9593,6 +9593,7 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
       '@fluidframework/server-local-server': 2.0.1
       '@fluidframework/test-utils': link:../test-utils
+      mocha: 10.2.0
     devDependencies:
       '@fluid-tools/build-cli': 0.24.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.0
@@ -9604,7 +9605,6 @@ importers:
       c8: 7.13.0
       cross-env: 7.0.3
       eslint: 8.6.0
-      mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4


### PR DESCRIPTION
The serialization tests were incorrectly creating the path for the text content, and not running locally. this change unifies how we create paths for test content, and will fail if the test content doesn't exist in automation.