### PR TITLE
Update logs for KafkaRunner and producer's error handlers

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -166,6 +166,7 @@ export class DocumentPartition {
 			restart: false,
 			tenantId: this.tenantId,
 			documentId: this.documentId,
+			errorLabel: "documentPartition:markAsCorrupt",
 		});
 		if (message) {
 			this.context.checkpoint(message);

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -53,6 +53,10 @@ export class PartitionManager extends EventEmitter {
 		if (listenForConsumerErrors) {
 			this.consumer.on("error", (error, errorData: IContextErrorData) => {
 				if (this.stopped) {
+					Lumberjack.info(
+						"Consumer.onError: PartitionManager already stopped, not emitting error again",
+						{ error, ...errorData },
+					);
 					return;
 				}
 
@@ -217,6 +221,10 @@ export class PartitionManager extends EventEmitter {
 			// Listen for error events to know when the partition has stopped processing due to an error
 			newPartition.on("error", (error, errorData: IContextErrorData) => {
 				if (this.stopped) {
+					Lumberjack.info(
+						"Partition.onError: PartitionManager already stopped, not emitting error again",
+						{ error, ...errorData },
+					);
 					return;
 				}
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -72,7 +72,7 @@ export class KafkaRunner implements IRunner {
 
 			this.runnerMetric.setProperties(lumberProperties);
 
-			if (errorData.errorLabel) {
+			if (errorData?.errorLabel) {
 				this.runnerMetric.setProperty("errorLabel", errorData.errorLabel);
 			}
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -72,6 +72,10 @@ export class KafkaRunner implements IRunner {
 
 			this.runnerMetric.setProperties(lumberProperties);
 
+			if (errorData.errorLabel) {
+				this.runnerMetric.setProperty("errorLabel", errorData.errorLabel);
+			}
+
 			if (errorData && !errorData.restart) {
 				const errorMsg =
 					"KafkaRunner encountered an error that is not configured to trigger restart";

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -52,6 +52,13 @@ export interface IContextErrorData {
 
 	tenantId?: string;
 	documentId?: string;
+
+	/**
+	 * For KafkaRunner logging purposes.
+	 * Since KafkaRunner metric logs all the errors, this will indicate how the error was handled
+	 * eg: doc corruption error / rdkafkaConsumer error, so that we can filter accordingly
+	 */
+	errorLabel?: string;
 }
 
 export interface IContext {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -163,7 +163,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		consumer.on("connection.failure", async (error) => {
 			await this.close(true);
 
-			this.error(error);
+			this.error(error, { restart: false, errorLabel: "rdkafkaConsumer:connection.failure" });
 
 			this.connect();
 		});
@@ -182,7 +182,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 						err.code === this.kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
 
 				if (!shouldRetryCommit) {
-					this.error(err);
+					this.error(err, {
+						restart: false,
+						errorLabel: "rdkafkaConsumer:offset.commit",
+					});
 				}
 			}
 
@@ -209,7 +212,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 						this.emit("checkpoint", offset.partition, offset.offset);
 					}
 				} else {
-					this.error(new Error(`Unknown commit for partition ${offset.partition}`));
+					this.error(new Error(`Unknown commit for partition ${offset.partition}`), {
+						restart: false,
+						errorLabel: "rdkakfaConsumer:offset.commit",
+					});
 				}
 			}
 		});
@@ -282,21 +288,21 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 					}
 				} catch (ex) {
 					this.isRebalancing = false;
-					this.error(ex);
+					this.error(ex, { restart: false, errorLabel: "rdkafkaConsumer:rebalance" });
 				} finally {
 					this.pendingMessages.clear();
 				}
 			} else {
-				this.error(err);
+				this.error(err, { restart: false, errorLabel: "rdkafkaConsumer:rebalance" });
 			}
 		});
 
 		consumer.on("rebalance.error", (error) => {
-			this.error(error);
+			this.error(error, { restart: false, errorLabel: "rdkafkaConsumer:rebalance.error" });
 		});
 
 		consumer.on("event.error", (error) => {
-			this.error(error);
+			this.error(error, { restart: false, errorLabel: "rdkafkaConsumer:event.error" });
 		});
 
 		consumer.on("event.throttle", (event) => {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -150,15 +150,28 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 		 */
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		producer.on("connection.failure", async (error) => {
-			await this.close(true);
-
-			this.error(error);
+			try {
+				await this.close(true);
+				this.error(error, {
+					restart: false,
+					errorLabel: "rdkafkaProducer:connection.failure",
+				});
+			} catch (err) {
+				Lumberjack.error(
+					"Error encountered when handling producer connection.failure",
+					undefined,
+					err,
+				);
+			}
 
 			this.connect();
 		});
 
 		producer.on("event.error", (error) => {
-			this.handleError(producer, error).catch((handleErrorError) => {
+			this.handleError(producer, error, {
+				restart: false,
+				errorLabel: "rdkafkaProducer:event.error",
+			}).catch((handleErrorError) => {
 				Lumberjack.error(
 					"Error encountered when handling producer event.error",
 					undefined,
@@ -366,6 +379,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 							restart: true,
 							tenantId: boxcar.tenantId,
 							documentId: boxcar.documentId,
+							errorLabel: "rdkafkaProducer:producer.produce",
 						}).catch((error) => {
 							Lumberjack.error(
 								"Error encountered when handling producer error in sendBoxcar()",
@@ -400,6 +414,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 				restart: true,
 				tenantId: boxcar.tenantId,
 				documentId: boxcar.documentId,
+				errorLabel: "rdkafkaProducer:sendBoxcar",
 			}).catch((error) => {
 				Lumberjack.error(
 					"Error encountered when handling producer error in sendBoxcar() catch block",

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -156,6 +156,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 					restart: false,
 					errorLabel: "rdkafkaProducer:connection.failure",
 				});
+				this.connect();
 			} catch (err) {
 				Lumberjack.error(
 					"Error encountered when handling producer connection.failure",
@@ -163,8 +164,6 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 					err,
 				);
 			}
-
-			this.connect();
 		});
 
 		producer.on("event.error", (error) => {

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -44,6 +44,11 @@ export function createProducer(
 
 		producer.on("error", (error, errorData: IContextErrorData) => {
 			if (errorData?.restart) {
+				Lumberjack.error(
+					"Kafka Producer emitted an error that is configured to restart the process.",
+					{ errorLabel: errorData.errorLabel },
+					error,
+				);
 				throw new Error(error);
 			} else {
 				winston.error(
@@ -52,7 +57,7 @@ export function createProducer(
 				winston.error(inspect(error));
 				Lumberjack.error(
 					"Kafka Producer emitted an error that is not configured to restart the process.",
-					undefined,
+					{ errorLabel: errorData.errorLabel },
 					error,
 				);
 			}

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -46,7 +46,7 @@ export function createProducer(
 			if (errorData?.restart) {
 				Lumberjack.error(
 					"Kafka Producer emitted an error that is configured to restart the process.",
-					{ errorLabel: errorData.errorLabel },
+					{ errorLabel: errorData?.errorLabel },
 					error,
 				);
 				throw new Error(error);
@@ -57,7 +57,7 @@ export function createProducer(
 				winston.error(inspect(error));
 				Lumberjack.error(
 					"Kafka Producer emitted an error that is not configured to restart the process.",
-					{ errorLabel: errorData.errorLabel },
+					{ errorLabel: errorData?.errorLabel },
 					error,
 				);
 			}


### PR DESCRIPTION
## Description

1. The KafkaRunner metric logs often contain exceptions that might be bubbled up from the doc corruption flow or the restart flow. Adding a property in those logs to identify such exceptions so that we can filter them and understand the impact of remaining exceptions. Similarly updated the logs for Kafka producer's error handler.

2. Adding some logs in partitionManager to debug an issue where restart might be triggered from more than one flow.

## Reviewer Guidance

Using `errorLabel` as the new property name to indicate which flow the error is coming from. Open to suggestions for a better name.