### PR TITLE
Porting #17401 (Make `forceReadonly` work) to release/v2int/6.1

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -425,21 +425,7 @@ export class ConnectionManager implements IConnectionManager {
 	}
 
 	/**
-	 * Sends signal to runtime (and data stores) to be read-only.
-	 * Hosts may have read only views, indicating to data stores that no edits are allowed.
-	 * This is independent from this._readonlyPermissions (permissions) and this.connectionMode
-	 * (server can return "write" mode even when asked for "read")
-	 * Leveraging same "readonly" event as runtime & data stores should behave the same in such case
-	 * as in read-only permissions.
-	 * But this.active can be used by some DDSes to figure out if ops can be sent
-	 * (for example, read-only view still participates in code proposals / upgrades decisions)
-	 *
-	 * Forcing Readonly does not prevent DDS from generating ops. It is up to user code to honour
-	 * the readonly flag. If ops are generated, they will accumulate locally and not be sent. If
-	 * there are pending in the outbound queue, it will stop sending until force readonly is
-	 * cleared.
-	 *
-	 * @param readonly - set or clear force readonly.
+	 * {@inheritDoc Container.forceReadonly}
 	 */
 	public forceReadonly(readonly: boolean) {
 		if (readonly !== this._forceReadonly) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -613,7 +613,21 @@ export class Container
 	}
 
 	/**
-	 * Tracks host requiring read-only mode.
+	 * Sends signal to runtime (and data stores) to be read-only.
+	 * Hosts may have read only views, indicating to data stores that no edits are allowed.
+	 * This is independent from this._readonlyPermissions (permissions) and this.connectionMode
+	 * (server can return "write" mode even when asked for "read")
+	 * Leveraging same "readonly" event as runtime & data stores should behave the same in such case
+	 * as in read-only permissions.
+	 * But this.active can be used by some DDSes to figure out if ops can be sent
+	 * (for example, read-only view still participates in code proposals / upgrades decisions)
+	 *
+	 * Forcing Readonly does not prevent DDS from generating ops. It is up to user code to honour
+	 * the readonly flag. If ops are generated, they will accumulate locally and not be sent. If
+	 * there are pending in the outbound queue, it will stop sending until force readonly is
+	 * cleared.
+	 *
+	 * @param readonly - set or clear force readonly.
 	 */
 	public forceReadonly(readonly: boolean) {
 		this._deltaManager.connectionManager.forceReadonly(readonly);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1568,35 +1568,6 @@ export class ContainerRuntime
 			}
 		}
 
-		this.deltaManager.on("readonly", (readonly: boolean) => {
-			// we accumulate ops while being in read-only state.
-			// once user gets write permissions and we have active connection, flush all pending ops.
-			// Note that the inner (non-proxy) delta manager is needed here to get the readonly information.
-			assert(
-				readonly === this.innerDeltaManager.readOnlyInfo.readonly,
-				0x124 /* "inconsistent readonly property/event state" */,
-			);
-
-			// We need to be very careful with when we (re)send pending ops, to ensure that we only send ops
-			// when we either never send an op, or attempted to send it but we know for sure it was not
-			// sequenced by server and will never be sequenced (i.e. was lost)
-			// For loss of connection, we wait for our own "join" op and use it a a barrier to know all the
-			// ops that made it from previous connection, before switching clientId and raising "connected" event
-			// But with read-only permissions, if we transition between read-only and r/w states while on same
-			// connection, then we have no good signal to tell us when it's safe to send ops we accumulated while
-			// being in read-only state.
-			// For that reason, we support getting to read-only state only when disconnected. This ensures that we
-			// can rely on same safety mechanism and resend ops only when we establish new connection.
-			// This is applicable for read-only permissions (event is raised before connection is properly registered),
-			// but it's an extra requirement for Container.forceReadonly() API
-			assert(
-				!readonly || !this.connected,
-				0x125 /* "Unsafe to transition to read-only state!" */,
-			);
-
-			this.replayPendingStates();
-		});
-
 		// logging hardware telemetry
 		logger.sendTelemetryEvent({
 			eventName: "DeviceSpec",

--- a/packages/test/test-end-to-end-tests/src/test/loadModes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loadModes.spec.ts
@@ -22,10 +22,15 @@ import {
 	createDocumentId,
 	LoaderContainerTracker,
 	ITestObjectProvider,
+	DataObjectFactoryType,
+	ITestContainerConfig,
+	ITestFluidObject,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-internal/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ContainerRuntime, ISummarizer, Summarizer } from "@fluidframework/container-runtime";
+import { SharedMap } from "@fluidframework/map";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
 const counterKey = "count";
 
@@ -353,6 +358,45 @@ describeNoCompat("LoadModes", (getTestObjectProvider) => {
 			container2.deltaManager.lastSequenceNumber,
 			"container2 should still be at the specified sequence number",
 		);
+	});
+
+	it("forceReadonly works", async () => {
+		const mapId = "mapKey";
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry: [[mapId, SharedMap.getFactory()]],
+		};
+		const created = await provider.makeTestContainer(testContainerConfig);
+		const do1 = await requestFluidObject<ITestFluidObject>(created, "default");
+		const map1 = await do1.getSharedObject<SharedMap>(mapId);
+
+		const headers: IRequestHeader = {
+			[LoaderHeader.cache]: false,
+			[LoaderHeader.loadMode]: { deltaConnection: "delayed" },
+		};
+
+		const loader = provider.makeTestLoader(testContainerConfig);
+		const loaded = await loader.resolve({
+			url: await provider.driver.createContainerUrl(provider.documentId),
+			headers,
+		});
+		const do2 = await requestFluidObject<ITestFluidObject>(loaded, "default");
+		loaded.connect();
+		loaded.forceReadonly?.(true);
+		const map2 = await do2.getSharedObject<SharedMap>(mapId);
+		map2.set("key1", "1");
+		map2.set("key2", "2");
+		await provider.ensureSynchronized();
+
+		// The container is in read-only mode, its changes haven't been sent
+		assert.strictEqual(map1.get("key1"), undefined);
+		assert.strictEqual(map1.get("key2"), undefined);
+
+		// The container's read-only mode is cleared, so the pending ops must be sent
+		loaded.forceReadonly?.(false);
+		await provider.ensureSynchronized();
+		assert.strictEqual(map1.get("key1"), "1");
+		assert.strictEqual(map1.get("key2"), "2");
 	});
 
 	describe("Expected error cases", () => {


### PR DESCRIPTION
## Description
Porting #17401 (Make `forceReadonly` work) to release/v2int/6.1 

`forceReadonly` does not work as expected. Doing something like:

```
container.forceReadonly?.(true);
containerMap.set("key1", "1");
containerMap.set("key2", "2");
loaded.forceReadonly?.(false);
<<synchronize>>
```

will cause assert `0x173`, as clearing the readonly flag will not trigger a new connection but will call the readonly event handler on the deltamanager, which calls replayPendingStates without a new connection.

We have noticed thousands of hits in our telemetry about this..

The root cause is the redudant `readonly` event handler in the container runtime, causing the pendig state manager to be called twice. We're already doing that when the connection state changes.

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

> A concise description of the changes (bug or feature) and their impact/motivation.
> If this description is short enough to be used as the title, delete this section and just use the title.

> For bug fixes, also include specifics of how to reproduce it / confirm it is fixed.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

## Breaking Changes

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
> If there are no breaking changes, delete this section.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
