### PR TITLE
tree2: Update inventory sample to new API

### DIFF
--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -25,10 +25,10 @@ const factory = new TypedTreeFactory({
 				name: "nut",
 				quantity: 0,
 			},
-			// {
-			// 	name: "bolt",
-			// 	quantity: 0,
-			// },
+			{
+				name: "bolt",
+				quantity: 0,
+			},
 		],
 	},
 	allowedSchemaModifications: AllowedUpdateType.None,

--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -4,31 +4,58 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { ISharedTree, SharedTreeFactory } from "@fluid-experimental/tree2";
+import {
+	AllowedUpdateType,
+	ForestType,
+	TypedTreeChannel,
+	TypedTreeFactory,
+	typeboxValidator,
+} from "@fluid-experimental/tree2";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { InventoryField, inventoryField, schema } from "./schema";
 
 const treeKey = "tree";
 
-export class InventoryList extends DataObject {
-	private _tree: ISharedTree | undefined;
+const factory = new TypedTreeFactory({
+	jsonValidator: typeboxValidator,
+	forest: ForestType.Reference,
+	initialTree: {
+		parts: [
+			{
+				name: "nut",
+				quantity: 0,
+			},
+			// {
+			// 	name: "bolt",
+			// 	quantity: 0,
+			// },
+		],
+	},
+	allowedSchemaModifications: AllowedUpdateType.None,
+	schema,
+	subtype: "InventoryList",
+});
 
-	public get tree(): ISharedTree {
+export class InventoryList extends DataObject {
+	private _tree: TypedTreeChannel<typeof inventoryField> | undefined;
+
+	public get tree(): InventoryField {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this._tree!;
+		return this._tree!.root;
 	}
 
 	protected async initializingFirstTime() {
-		this._tree = this.runtime.createChannel(
-			undefined,
-			new SharedTreeFactory().type,
-		) as ISharedTree;
-
-		this.root.set(treeKey, this.tree.handle);
+		this._tree = this.runtime.createChannel(undefined, factory.type) as TypedTreeChannel<
+			typeof inventoryField
+		>;
+		this.root.set(treeKey, this._tree.handle);
 	}
 
 	protected async initializingFromExisting() {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this._tree = await this.root.get<IFluidHandle<ISharedTree>>(treeKey)!.get();
+		this._tree = await this.root
+			.get<IFluidHandle<TypedTreeChannel<typeof inventoryField>>>(treeKey)!
+			.get();
 	}
 
 	protected async hasInitialized() {}
@@ -37,6 +64,6 @@ export class InventoryList extends DataObject {
 export const InventoryListFactory = new DataObjectFactory(
 	"@fluid-experimental/inventory-list",
 	InventoryList,
-	[new SharedTreeFactory()],
+	[factory],
 	{},
 );

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -3,24 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKinds, SchemaAware, SchemaBuilder, ValueSchema } from "@fluid-experimental/tree2";
+import { FieldKinds, SchemaBuilder, TypedField, TypedNode, leaf } from "@fluid-experimental/tree2";
 
-const builder = new SchemaBuilder("inventory app");
-export const float64 = builder.leaf("number", ValueSchema.Number);
-export const string = builder.leaf("string", ValueSchema.String);
+const builder = new SchemaBuilder("inventory app", {}, leaf.library);
 
 export const part = builder.struct("Contoso:Part-1.0.0", {
-	name: SchemaBuilder.field(FieldKinds.value, string),
-	quantity: SchemaBuilder.field(FieldKinds.value, float64),
+	name: SchemaBuilder.field(FieldKinds.value, leaf.string),
+	quantity: SchemaBuilder.field(FieldKinds.value, leaf.number),
 });
 
 export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	parts: SchemaBuilder.field(FieldKinds.sequence, part),
 });
 
-export const rootField = SchemaBuilder.field(FieldKinds.value, inventory);
-export type RootField = SchemaAware.TypedField<typeof rootField>;
+export const inventoryField = SchemaBuilder.field(FieldKinds.value, inventory);
+export type InventoryField = TypedField<typeof inventoryField>;
 
-export const schema = builder.intoDocumentSchema(rootField);
+export const schema = builder.intoDocumentSchema(inventoryField);
 
-export type Inventory = SchemaAware.TypedNode<typeof inventory>;
+export type Inventory = TypedNode<typeof inventory>;

--- a/examples/data-objects/inventory-app/src/view/counter.tsx
+++ b/examples/data-objects/inventory-app/src/view/counter.tsx
@@ -3,32 +3,35 @@
  * Licensed under the MIT License.
  */
 
+import { useTreeContext } from "@fluid-experimental/tree-react-api";
+import { SchemaBuilder, TypedField, leaf } from "@fluid-experimental/tree2";
 import * as React from "react";
+
+const schema = SchemaBuilder.fieldValue(leaf.number);
 
 export interface ICounterProps {
 	title: string;
-	count: number;
-	onIncrement: () => void;
-	onDecrement: () => void;
+	count: TypedField<typeof schema>;
 }
 
 /**
  * Counter implementation
  */
-export const Counter = ({
-	title,
-	count,
-	onIncrement,
-	onDecrement,
-}: ICounterProps): React.ReactElement => (
-	<div className="counter">
-		<h2>{title}</h2>
-		<div className="counter_spinner">
-			<button onClick={onDecrement} disabled={!(count > 0)}>
-				-
-			</button>
-			<span className="counter_value">{count}</span>
-			<button onClick={onIncrement}>+</button>
+export const Counter = ({ title, count }: ICounterProps): React.ReactElement => {
+	useTreeContext(count.context);
+	return (
+		<div className="counter">
+			<h2>{title}</h2>
+			<div className="counter_spinner">
+				<button
+					onClick={() => count.setContent(count.content - 1)}
+					disabled={!(count.content > 0)}
+				>
+					-
+				</button>
+				<span className="counter_value">{count.content}</span>
+				<button onClick={() => count.setContent(count.content + 1)}>+</button>
+			</div>
 		</div>
-	</div>
-);
+	);
+};

--- a/examples/data-objects/inventory-app/src/view/inventoryList.tsx
+++ b/examples/data-objects/inventory-app/src/view/inventoryList.tsx
@@ -4,44 +4,20 @@
  */
 
 import * as React from "react";
-import { AllowedUpdateType, ISharedTree } from "@fluid-experimental/tree2";
-import { useTree } from "@fluid-experimental/tree-react-api";
-import { Inventory, RootField, schema } from "../schema";
+import { useTreeContext } from "@fluid-experimental/tree-react-api";
+import { Inventory, InventoryField } from "../schema";
 import { Counter } from "./counter";
 
-const schemaPolicy = {
-	schema,
-	initialTree: {
-		parts: [
-			{
-				name: "nut",
-				quantity: 0,
-			},
-			{
-				name: "bolt",
-				quantity: 0,
-			},
-		],
-	},
-	allowedSchemaModifications: AllowedUpdateType.None,
-};
-
-export const MainView: React.FC<{ tree: ISharedTree }> = ({ tree }) => {
-	const root: RootField = useTree(tree.view, schemaPolicy);
-	// TODO: value fields like `root` which always contain exactly one value should have a nicer API for accessing that child, like `.child`.
-	const inventory: Inventory = root[0];
+export const MainView: React.FC<{ tree: InventoryField }> = ({ tree }) => {
+	// TODO: offer an API to subscribe to invalidation from a field to avoid depending on the whole document here.
+	useTreeContext(tree.context);
+	const inventory: Inventory = tree.content;
 
 	const counters: JSX.Element[] = [];
 
 	for (const part of inventory.parts) {
 		counters.push(
-			<Counter
-				key={part.name}
-				title={part.name}
-				count={part.quantity}
-				onDecrement={() => part.quantity--}
-				onIncrement={() => part.quantity++}
-			></Counter>,
+			<Counter key={part.name} title={part.name} count={part.boxedQuantity}></Counter>,
 		);
 	}
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -692,14 +692,6 @@ export interface OptionalField<TTypes extends AllowedTypes> extends TreeField {
 // #region Typed
 
 /**
- * The strongly typed {@link Tree} API for a given schema.
- * @alpha
- */
-export type Typed<TSchema extends FieldSchema | TreeSchema> = TSchema extends FieldSchema
-	? TypedField<TSchema>
-	: TypedNode<Assume<TSchema, TreeSchema>>;
-
-/**
  * Schema aware specialization of {@link TreeField}.
  * @alpha
  */

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -692,6 +692,14 @@ export interface OptionalField<TTypes extends AllowedTypes> extends TreeField {
 // #region Typed
 
 /**
+ * The strongly typed {@link Tree} API for a given schema.
+ * @alpha
+ */
+export type Typed<TSchema extends FieldSchema | TreeSchema> = TSchema extends FieldSchema
+	? TypedField<TSchema>
+	: TypedNode<Assume<TSchema, TreeSchema>>;
+
+/**
  * Schema aware specialization of {@link TreeField}.
  * @alpha
  */

--- a/experimental/framework/tree-react-api/src/index.ts
+++ b/experimental/framework/tree-react-api/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { useTree } from "./useTree";
+export { useTree, useSubtree, useTreeContext } from "./useTree";

--- a/experimental/framework/tree-react-api/src/useTree.ts
+++ b/experimental/framework/tree-react-api/src/useTree.ts
@@ -52,13 +52,13 @@ export function useTree<TRoot extends FieldSchema>(
 export function useTreeContext(document: TreeContext): void {
 	// This proof-of-concept implementation allocates a state variable this is modified
 	// when the tree changes to trigger re-render.
-	const [invalidations, setInvalidations] = React.useState(0);
+	const [, setInvalidations] = React.useState(0);
 
 	// Register for tree deltas when the component mounts
 	React.useEffect(() => {
 		// Returns the cleanup function to be invoked when the component unmounts.
 		return document.on("afterChange", () => {
-			setInvalidations(invalidations + 1);
+			setInvalidations((invalidations) => invalidations + 1);
 		});
 	}, [document]);
 }
@@ -70,15 +70,15 @@ export function useTreeContext(document: TreeContext): void {
 export function useSubtree(tree: TreeNode): void {
 	// This proof-of-concept implementation allocates a state variable this is modified
 	// when the tree changes to trigger re-render.
-	const [invalidations, setInvalidations] = React.useState(0);
+	const [, setInvalidations] = React.useState(0);
 
 	// Register for tree deltas when the component mounts
 	React.useEffect(() => {
 		// Returns the cleanup function to be invoked when the component unmounts.
 		return tree.on("subtreeChanging", () => {
-			setInvalidations(invalidations + 1);
+			setInvalidations((invalidations) => invalidations + 1);
 		});
-	}, [tree, setInvalidations, invalidations]);
+	}, [tree, setInvalidations]);
 }
 
 // TODO: schematize component which shows error (with proper invalidation), or passes tree to sub componet.

--- a/experimental/framework/tree-react-api/src/useTree.ts
+++ b/experimental/framework/tree-react-api/src/useTree.ts
@@ -4,6 +4,8 @@
  */
 
 import {
+	TreeContext,
+	TreeNode,
 	FieldSchema,
 	ISharedTreeView,
 	InitializeAndSchematizeConfiguration,
@@ -19,6 +21,8 @@ import React from "react";
  * Use deep clone if saving a copy for comparison.
  *
  * Not currently compatible with 'React.memo'.
+ *
+ * @deprecated Prefer using the new TypedTree entry point and tree types, and the hooks for them, {@link useTreeContext} and {@link useSubtree}.
  */
 export function useTree<TRoot extends FieldSchema>(
 	tree: ISharedTreeView,
@@ -41,3 +45,40 @@ export function useTree<TRoot extends FieldSchema>(
 
 	return typedTree.context.root as unknown as SchemaAware.TypedField<TRoot>;
 }
+
+/**
+ * React Hook to trigger invalidation of the current component if anything in the document changes.
+ */
+export function useTreeContext(document: TreeContext): void {
+	// This proof-of-concept implementation allocates a state variable this is modified
+	// when the tree changes to trigger re-render.
+	const [invalidations, setInvalidations] = React.useState(0);
+
+	// Register for tree deltas when the component mounts
+	React.useEffect(() => {
+		// Returns the cleanup function to be invoked when the component unmounts.
+		return document.on("afterChange", () => {
+			setInvalidations(invalidations + 1);
+		});
+	}, [document]);
+}
+
+/**
+ * React Hook to trigger invalidation of the current component if anything in the provided subtree changes.
+ * This does NOT include if this subtree is moved into a different parent!
+ */
+export function useSubtree(tree: TreeNode): void {
+	// This proof-of-concept implementation allocates a state variable this is modified
+	// when the tree changes to trigger re-render.
+	const [invalidations, setInvalidations] = React.useState(0);
+
+	// Register for tree deltas when the component mounts
+	React.useEffect(() => {
+		// Returns the cleanup function to be invoked when the component unmounts.
+		return tree.on("subtreeChanging", () => {
+			setInvalidations(invalidations + 1);
+		});
+	}, [tree, setInvalidations, invalidations]);
+}
+
+// TODO: schematize component which shows error (with proper invalidation), or passes tree to sub componet.


### PR DESCRIPTION
## Description

Update inventory sample to:
1. Use the new leaf domain for its leaf types.
2. Use the new TypeTree factory entry point and new editable tree API.
3. Pass the count fields to the counter component so they can have self contained editing logic.
4. Attempt to use a more general/functional react hook to handle invalidation in a more composable way. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Known issue: invalidation doesn't work on the counter. After the first increment, following ones get applied, and the events get send and the setState call occurs, but the counter component (whose state was set) does not rerun.
