### PR TITLE
build(docs): update throws and examples sections to new titles

### DIFF
--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -84,7 +84,7 @@ function layoutContent(apiItem, itemSpecificContent, config) {
 	}
 
 	// Render examples (if any)
-	const renderedExamples = LayoutUtilities.createExamplesSection(apiItem, config);
+	const renderedExamples = LayoutUtilities.createExamplesSection(apiItem, config, "Usage");
 	if (renderedExamples !== undefined) {
 		sections.push(renderedExamples);
 	}
@@ -96,7 +96,7 @@ function layoutContent(apiItem, itemSpecificContent, config) {
 	}
 
 	// Render @throws content (if any)
-	const renderedThrows = LayoutUtilities.createThrowsSection(apiItem, config);
+	const renderedThrows = LayoutUtilities.createThrowsSection(apiItem, config, "Error Handling");
 	if (renderedThrows !== undefined) {
 		sections.push(renderedThrows);
 	}

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -17,6 +17,9 @@ const {
 
 const { AlertNode } = require("./alert-node");
 
+const customExamplesSectionTitle = "Usage";
+const customThrowsSectionTitle = "Error Handling";
+
 /**
  * Default content layout for all API items.
  *
@@ -84,7 +87,7 @@ function layoutContent(apiItem, itemSpecificContent, config) {
 	}
 
 	// Render examples (if any)
-	const renderedExamples = LayoutUtilities.createExamplesSection(apiItem, config, "Usage");
+	const renderedExamples = LayoutUtilities.createExamplesSection(apiItem, config, customExamplesSectionTitle);
 	if (renderedExamples !== undefined) {
 		sections.push(renderedExamples);
 	}
@@ -96,7 +99,7 @@ function layoutContent(apiItem, itemSpecificContent, config) {
 	}
 
 	// Render @throws content (if any)
-	const renderedThrows = LayoutUtilities.createThrowsSection(apiItem, config, "Error Handling");
+	const renderedThrows = LayoutUtilities.createThrowsSection(apiItem, config, customThrowsSectionTitle);
 	if (renderedThrows !== undefined) {
 		sections.push(renderedThrows);
 	}

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,7 +39,7 @@
 		"start": "hugo server"
 	},
 	"dependencies": {
-		"@fluid-tools/api-markdown-documenter": "^0.8.3",
+		"@fluid-tools/api-markdown-documenter": "^0.9.0",
 		"@fluid-tools/markdown-magic": "file:../tools/markdown-magic",
 		"@fluidframework/build-common": "^2.0.0",
 		"@microsoft/api-extractor-model": "^7.27.3",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   .:
     specifiers:
-      '@fluid-tools/api-markdown-documenter': ^0.8.3
+      '@fluid-tools/api-markdown-documenter': ^0.9.0
       '@fluid-tools/markdown-magic': file:../tools/markdown-magic
       '@fluidframework/build-common': ^2.0.0
       '@microsoft/api-extractor-model': ^7.27.3
@@ -38,7 +38,7 @@ importers:
       rimraf: ^5.0.1
       start-server-and-test: ^2.0.0
     dependencies:
-      '@fluid-tools/api-markdown-documenter': 0.8.3
+      '@fluid-tools/api-markdown-documenter': 0.9.0
       '@fluid-tools/markdown-magic': file:../tools/markdown-magic_bfrwj6ys6wock6p526xv5vf35u
       '@fluidframework/build-common': 2.0.0
       '@microsoft/api-extractor-model': 7.27.3
@@ -148,8 +148,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@fluid-tools/api-markdown-documenter/0.8.3:
-    resolution: {integrity: sha512-rGmb3VJxaP7vVJoVZw21jLlj9WpC6wW9x271Rp4WvQQYaxD/a8XSLNyNwJ5P8O6IOe4tPTJEc5xRrA/svqGS/A==}
+  /@fluid-tools/api-markdown-documenter/0.9.0:
+    resolution: {integrity: sha512-u0CQq9x+Lq3g5ADwGLx/nOP1Rg2Wl6PQcqnYA+D1D3o8NjqrE8MR3kk/8XJ72cnOC5st3PglE5vIo9P00Iw9/Q==}
     dependencies:
       '@microsoft/api-documenter': 7.22.33
       '@microsoft/api-extractor-model': 7.28.0


### PR DESCRIPTION
Consume the updated `api-markdown-documenter` package to allow custom titles for the `@example` and `@throws` sections.

1. The `api-markdown-documenter` package has utility functions `createExamplesSection` and `createThrowsSection` in `Helpers.ts` which was updated to include a optional headingTitle param in v0.9.0. These functions generate sections that describe the `@example` and `@throws` comments on an API item, respectively.
   
2. At present, the headings "Examples" and "Throws" are hard-coded for these sections. For FF.com, we aim to use custom titles "Usage" for the `@example` section and "Error Handling" for the `@throws` section.
   
3. Adjustments on FF.com:
   - The default title in the examples section should be changed from "Examples" to "Usage".
   - The default title in the throws section should be changed from "Throws" to "Error Handling".

![image](https://github.com/microsoft/FluidFramework/assets/107130183/08b1bee0-5340-4c97-8239-36aab7f04372)
![image](https://github.com/microsoft/FluidFramework/assets/107130183/f61299bb-8c6b-4b66-950f-f7c46076bded)


[AB#5581](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5581)