### PR TITLE
docs(fluid-build): README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,17 @@ Run the following to build the client packages:
 
 ```shell
 pnpm install
-npm run build:fast
+npm run build
 ```
 
+You can use the experimental worker mode to get faster build time as well: `npm run build:fast`
+
 See also: [Contributing](#Contributing)
+
+## Build in VSCode
+
+To build Fluid Framework within VSCode, open the Fluid Framework repo folder as a work space and use Ctrl-Shift-B
+to activate the build task. It is the same as running `npm run build` on the command line.
 
 ## NodeJs Installation
 

--- a/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { getFluidBuildConfig } from "./fluidUtils";
 import { PackageJson } from "./npmPackage";
 
 /**
@@ -17,13 +16,13 @@ export type TaskDependencies = string[];
 export interface TaskConfig {
 	/**
 	 * Task dependencies as a plain string array.
-	 * The string can specify dependencies:
+	 * The strings specify dependencies for the task
 	 * - "<name>": another task within the package
 	 * - "^<name>": all the task with the name in dependent packages.
 	 *
-	 * When task definition is augmented in the package.json itself the dependencies can be:
+	 * When task definition is augmented in the package.json itself, the dependencies can also be:
 	 * - "<package>#<name>": specific dependent package's task
-	 * - "...": expand to the dependencies in global fluidBuild config
+	 * - "...": expand to the dependencies in global fluidBuild config (default is override)
 	 */
 	dependsOn: TaskDependencies;
 	/**
@@ -31,22 +30,22 @@ export interface TaskConfig {
 	 * in the config file, or the task's config is just a plain string array.
 	 *
 	 * If true, the task will match with the script it the package.json and invoke
-	 * the command once all the dependencies are satisfied.
+	 * the command once all the task's dependencies are satisfied.
 	 *
-	 * If false, the task will only trigger the dependencies. It can be used to define
-	 * group of task for the command line.
+	 * If false, the task will only trigger the dependencies (and not look for the script in package.json).
+	 * It can be used as an alias to a group of tasks.
 	 */
 	script: boolean;
 	/**
-	 * Tasks that this task needs to run before (example clean)
+	 * Tasks that needs to run before the current task (example clean)
 	 * - "<name>": another task within the package
 	 * - "*": any other task within the package
 	 *
-	 * When task definition is augmented in the package.json itself the dependencies can be:
-	 * - "...": expand to the "before in the global fluidBuild config
+	 * When task definition is augmented in the package.json itself, the dependencies can also be:
+	 * - "...": expand to the "before" in the global fluidBuild config
 	 *
-	 * Note that this will affect ordering if the task is already scheduled. It won't
-	 * get the tasks to be scheduled if it isn't already
+	 * Note that this will only affect ordering if matched task is already scheduled. It won't
+	 * get the matched tasks to be scheduled if it isn't already
 	 */
 	before: TaskDependencies;
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -71,22 +71,22 @@ function printUsage() {
 Usage: fluid-build <options> [(<package regexp>|<path>) ...]
     [<package regexp> ...] Regexp to match the package name (default: all packages)
 Options:
-       --all            Operate on all packages/monorepo (default: client monorepo). See also "--server".
-    -c --clean          Same as running build script 'clean' on matched packages (all if package regexp is not specified)
-    -d --dep            Apply actions (clean/force/rebuild) to matched packages and their dependent packages
-       --fix            Auto fix warning from package check if possible
-    -f --force          Force build and ignore dependency check on matched packages (all if package regexp is not specified)
-    -? --help           Print this message
-       --install        Run npm install for all packages/monorepo. This skips a package if node_modules already exists: it can not be used to update in response to changes to the package.json.
-    -r --rebuild        Clean and build on matched packages (all if package regexp is not specified)
-       --reinstall      Same as --uninstall --install.
-	-g --releaseGroup   Release group to operate on
-       --root <path>    Root directory of the Fluid repo (default: env _FLUID_ROOT_)
-	-t --task <name>    target to execute (default:build)
-       --symlink        Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
-       --symlink:full   Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-       --uninstall      Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
-       --vscode         Output error message to work with default problem matcher in vscode
+     --all            Operate on all packages/monorepo (default: client monorepo). See also "-g" or "--releaseGroup".
+  -c --clean          Same as running build script 'clean' on matched packages (all if package regexp is not specified)
+  -d --dep            Apply actions (clean/force/rebuild) to matched packages and their dependent packages
+     --fix            Auto fix warning from package check if possible
+  -f --force          Force build and ignore dependency check on matched packages (all if package regexp is not specified)
+  -? --help           Print this message
+     --install        Run npm install for all packages/monorepo. This skips a package if node_modules already exists: it can not be used to update in response to changes to the package.json.
+  -r --rebuild        Clean and build on matched packages (all if package regexp is not specified)
+     --reinstall      Same as --uninstall --install.
+  -g --releaseGroup   Release group to operate on
+     --root <path>    Root directory of the Fluid repo (default: env _FLUID_ROOT_)
+  -t --task <name>    target to execute (default:build)
+     --symlink        Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
+     --symlink:full   Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
+     --uninstall      Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --vscode         Output error message to work with default problem matcher in vscode
 ${commonOptionString}
 `,
 	);


### PR DESCRIPTION
Update `fluid-build`'s README.md:
- Removing legacy information
- Add more examples for task and package selection
- Describe the task and dependency definition system
- Update how incremental is detected.
- Describe experimental worker mode
- Describe where to fine the specification for release groups.

Also:
- Update spacing on command line help
- Update some comment to make it easier to read.
