### PR TITLE
Don't ignore mock createBlob errors in blob manager tests

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -582,8 +582,8 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 				.then(async () => this.uploadBlob(localId, entry.blob));
 			return entry.uploadP;
 		} else {
+			this.deletePendingBlob(localId);
 			entry.handleP.reject(error);
-			throw error;
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -223,6 +223,7 @@ export class MockRuntime
 		await new Promise<void>((resolve) => setTimeout(resolve, delay));
 		this.connected = true;
 		this.emit("connected", "client ID");
+		await this.processStashed();
 		const ops = this.ops;
 		this.ops = [];
 		ops.forEach((op) => this.blobManager.reSubmit(op.metadata));

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -760,6 +760,7 @@ describe("BlobManager", () => {
 				// finish op
 				await Promise.all([p1, p2]);
 			} catch (error: any) {
+				assert.strictEqual(error.message, "uploadBlob aborted");
 				assert.ok(error.uploadTime);
 				assert.strictEqual(error.acked, false);
 			}
@@ -785,6 +786,7 @@ describe("BlobManager", () => {
 				ac.abort();
 				await handleP;
 			} catch (error: any) {
+				assert.strictEqual(error.message, "uploadBlob aborted");
 				assert.ok(error.uploadTime);
 				assert.strictEqual(error.acked, false);
 			}

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -181,7 +181,7 @@ export class MockRuntime
 			this.processBlobsP.reject(new Error("fake error"));
 		}
 		this.processBlobsP = new Deferred<void>();
-		await Promise.allSettled(blobPs).catch(()=>{});
+		await Promise.allSettled(blobPs).catch(() => {});
 	}
 
 	public async processHandles() {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -689,7 +689,6 @@ describe("BlobManager", () => {
 			assert.strictEqual(runtime.unprocessedBlobs.size, 1);
 			try {
 				await runtime.processBlobs(false);
-				await handleP;
 				assert.fail("Should not succeed");
 			} catch (error: any) {
 				assert.strictEqual(error.message, "fake error");
@@ -711,7 +710,6 @@ describe("BlobManager", () => {
 			ac.abort();
 			try {
 				await runtime.processBlobs();
-				await handleP;
 				assert.fail("Should not succeed");
 			} catch (error: any) {
 				assert.strictEqual(
@@ -821,7 +819,6 @@ describe("BlobManager", () => {
 
 			const blobContents = IsoBuffer.from(content, "utf8");
 			const handleP = runtime.createBlob(blobContents);
-			await runtime.processBlobs();
 			await runtime.processAll();
 
 			const blobHandle = await handleP;
@@ -848,7 +845,6 @@ describe("BlobManager", () => {
 			const blob2Contents = IsoBuffer.from("blob2", "utf8");
 			const handle1P = runtime.createBlob(blob1Contents);
 			const handle2P = runtime.createBlob(blob2Contents);
-			await runtime.processBlobs();
 			await runtime.processAll();
 
 			const blob1Handle = await handle1P;

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -181,10 +181,7 @@ export class MockRuntime
 			this.processBlobsP.reject(new Error("fake error"));
 		}
 		this.processBlobsP = new Deferred<void>();
-		for (const blobP of blobPs) {
-			// allow uploadBlob to finish their then/catch statements
-			await blobP.then().catch(() => {});
-		}
+		await Promise.allSettled(blobPs).catch(()=>{});
 	}
 
 	public async processHandles() {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -450,8 +450,7 @@ describe("BlobManager", () => {
 		try {
 			await handleP;
 			assert.fail("should fail");
-		}
-		catch (error: any) {
+		} catch (error: any) {
 			assert.strictEqual(error.message, "fake error");
 		}
 		await assert.rejects(handleP);

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -181,7 +181,11 @@ export class MockRuntime
 			this.processBlobsP.reject(new Error("fake error"));
 		}
 		this.processBlobsP = new Deferred<void>();
-		await Promise.all(blobPs).catch(() => {});
+		for (const blobP of blobPs) {
+			// allow uploadBlob to finish their then/catch statements
+			await blobP.then().catch(() => {});
+		}
+		// await Promise.allSettled(blobPs).catch(() => {});
 	}
 
 	public async processHandles() {
@@ -691,6 +695,7 @@ describe("BlobManager", () => {
 			await runtime.processBlobs(false);
 			try {
 				await handleP;
+				assert.fail("Should not succeed");
 			} catch (error: any) {
 				assert.strictEqual(error.message, "uploadBlob aborted");
 			}
@@ -756,6 +761,7 @@ describe("BlobManager", () => {
 			try {
 				// finish op
 				await handleP;
+				assert.fail("Should not succeed");
 			} catch (error: any) {
 				assert.strictEqual(error.message, "uploadBlob aborted");
 				assert.ok(error.uploadTime);
@@ -781,6 +787,7 @@ describe("BlobManager", () => {
 				runtime.disconnect();
 				ac.abort();
 				await handleP;
+				assert.fail("Should not succeed");
 			} catch (error: any) {
 				assert.strictEqual(error.message, "uploadBlob aborted");
 				assert.ok(error.uploadTime);

--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -42,7 +42,6 @@ describe("getPendingLocalState", () => {
 
 		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
 		await runtime2.attach();
-		await runtime2.processStashed();
 		await runtime2.connect();
 		await runtime2.processAll();
 
@@ -73,7 +72,6 @@ describe("getPendingLocalState", () => {
 
 		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
 		await runtime2.attach();
-		await runtime2.processStashed();
 		await runtime2.connect();
 		await runtime2.processAll();
 
@@ -104,7 +102,6 @@ describe("getPendingLocalState", () => {
 
 		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
 		await runtime2.attach();
-		await runtime2.processStashed();
 		await runtime2.connect();
 		await runtime2.processAll();
 
@@ -139,7 +136,6 @@ describe("getPendingLocalState", () => {
 
 		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
 		await runtime2.attach();
-		await runtime2.processStashed();
 		await runtime2.connect();
 		await runtime2.processAll();
 


### PR DESCRIPTION
Our mock createBlob was swallowing errors throw by itself. It hid a couple of issues in the current tests so I improved abort tests, ensuring only the statement that is expected to throw gets inside a try block and making sure the error message is the one we expect. It also hid some errors in getPendingBlobs tests caused by a recent change where now the stashed blob process is done while connecting for the first time. 