### PR TITLE
tree2: Rename "Value" Multiplicity and FieldKind

### DIFF
--- a/.changeset/tame-steaks-own.md
+++ b/.changeset/tame-steaks-own.md
@@ -1,0 +1,10 @@
+---
+"@fluid-experimental/devtools-core": minor
+"@fluid-experimental/property-shared-tree-interop": minor
+"@fluid-experimental/tree-react-api": minor
+"@fluid-experimental/tree2": minor
+---
+
+Rename "Value" Multiplicity and FieldKind
+
+`Multiplicity.Value` has been renamed to `Multiplicity.Single` and `FieldKinds.value` has been renamed to `FieldKinds.required`.

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -586,7 +586,7 @@ export type FieldKindIdentifier = Brand<string, "tree.FieldKindIdentifier">;
 
 // @alpha
 export const FieldKinds: {
-    readonly required: ValueFieldKind;
+    readonly required: Required_2;
     readonly optional: Optional;
     readonly sequence: Sequence;
     readonly nodeKey: NodeKeyFieldKind;
@@ -1548,7 +1548,7 @@ export function recordDependency(dependent: ObservingDependent | undefined, depe
 const recursiveStruct: TreeSchema<"recursiveStruct", {
 structFields: {
 recursive: FieldSchema<Optional, [() => TreeSchema<"recursiveStruct", any>]>;
-number: FieldSchema<ValueFieldKind, [TreeSchema<"com.fluidframework.leaf.number", {
+number: FieldSchema<Required_2, [TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("..").ValueSchema.Number;
 }>]>;
 };
@@ -1558,7 +1558,7 @@ leafValue: import("..").ValueSchema.Number;
 const recursiveStruct2: TreeSchema<"recursiveStruct2", {
 structFields: {
 recursive: FieldSchema<Optional, [() => TreeSchema<"recursiveStruct2", any>]>;
-number: FieldSchema<ValueFieldKind, [TreeSchema<"com.fluidframework.leaf.number", {
+number: FieldSchema<Required_2, [TreeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("..").ValueSchema.Number;
 }>]>;
 };
@@ -1572,6 +1572,11 @@ type RecursiveTreeSchemaSpecification = unknown;
 
 // @alpha
 type _RecursiveTrick = never;
+
+// @alpha (undocumented)
+interface Required_2 extends FieldKind<"Value", Multiplicity.Single> {
+}
+export { Required_2 as Required }
 
 // @alpha
 export interface RequiredField<TTypes extends AllowedTypes> extends TreeField {
@@ -2206,7 +2211,7 @@ export type UntypedTreeOrPrimitive<TContext = UntypedTreeContext> = UntypedTree<
 interface UntypedValueField<TContext = UntypedTreeContext, TChild = UntypedTree<TContext>, TUnwrappedChild = UnwrappedUntypedTree<TContext>, TNewContent = ContextuallyTypedNodeData> extends UntypedField<TContext, TChild, UntypedTree<TContext>, TUnwrappedChild> {
     readonly content: TChild;
     readonly fieldSchema: FieldStoredSchema & {
-        readonly kind: ValueFieldKind;
+        readonly kind: Required_2;
     };
     setContent(newContent: ITreeCursor | TNewContent): void;
 }
@@ -2239,10 +2244,6 @@ export type Value = undefined | TreeValue;
 // @alpha (undocumented)
 export interface ValueFieldEditBuilder {
     set(newContent: ITreeCursor): void;
-}
-
-// @alpha (undocumented)
-export interface ValueFieldKind extends FieldKind<"Value", Multiplicity.Single> {
 }
 
 // @alpha

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -125,7 +125,7 @@ type ApplyMultiplicity<TMultiplicity extends Multiplicity, TypedChild, Mode exte
     [Multiplicity.Forbidden]: undefined;
     [Multiplicity.Optional]: Mode extends ApiMode.Editable ? EditableOptionalField<TypedChild> : undefined | TypedChild;
     [Multiplicity.Sequence]: Mode extends ApiMode.Editable | ApiMode.EditableUnwrapped ? EditableSequenceField<TypedChild> : TypedChild[];
-    [Multiplicity.Value]: Mode extends ApiMode.Editable ? EditableValueField<TypedChild> : TypedChild;
+    [Multiplicity.Single]: Mode extends ApiMode.Editable ? EditableValueField<TypedChild> : TypedChild;
 }[TMultiplicity];
 
 // @alpha
@@ -586,7 +586,7 @@ export type FieldKindIdentifier = Brand<string, "tree.FieldKindIdentifier">;
 
 // @alpha
 export const FieldKinds: {
-    readonly value: ValueFieldKind;
+    readonly required: ValueFieldKind;
     readonly optional: Optional;
     readonly sequence: Sequence;
     readonly nodeKey: NodeKeyFieldKind;
@@ -1342,7 +1342,7 @@ export enum Multiplicity {
     Forbidden = 3,
     Optional = 1,
     Sequence = 2,
-    Value = 0
+    Single = 0
 }
 
 // @alpha
@@ -1393,7 +1393,7 @@ export const nodeKeyField: {
 export const nodeKeyFieldKey = "__n_id__";
 
 // @alpha (undocumented)
-export interface NodeKeyFieldKind extends FieldKind<"NodeKey", Multiplicity.Value> {
+export interface NodeKeyFieldKind extends FieldKind<"NodeKey", Multiplicity.Single> {
 }
 
 // @alpha
@@ -1643,8 +1643,8 @@ export class SchemaBuilder {
     }>;
     static fieldOptional<T extends AllowedTypes>(...allowedTypes: T): FieldSchema<typeof FieldKinds.optional, T>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<RecursiveTreeSchema>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
+    static fieldRequired<T extends AllowedTypes>(...allowedTypes: T): FieldSchema<typeof FieldKinds.required, T>;
     static fieldSequence<T extends AllowedTypes>(...t: T): FieldSchema<typeof FieldKinds.sequence, T>;
-    static fieldValue<T extends AllowedTypes>(...allowedTypes: T): FieldSchema<typeof FieldKinds.value, T>;
     intoDocumentSchema<Kind extends FieldKind, Types extends AllowedTypes>(root: FieldSchema<Kind, Types>): TypedSchemaCollection<FieldSchema<Kind, Types>>;
     intoLibrary(): SchemaLibrary;
     leaf<Name extends string, T extends ValueSchema>(name: Name, t: T): TreeSchema<Name, {
@@ -2027,7 +2027,7 @@ ApplyMultiplicity<TField["kind"]["multiplicity"], AllowedTypesToTypedTrees<Mode,
 ][_InlineTrick];
 
 // @alpha
-type TypedFieldInner<Kind extends FieldKind, Types extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? Sequence2<Types> : Kind extends typeof FieldKinds.value ? RequiredField<Types> : Kind extends typeof FieldKinds.optional ? OptionalField<Types> : TreeField;
+type TypedFieldInner<Kind extends FieldKind, Types extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? Sequence2<Types> : Kind extends typeof FieldKinds.required ? RequiredField<Types> : Kind extends typeof FieldKinds.optional ? OptionalField<Types> : TreeField;
 
 // @alpha
 type TypedFields<Mode extends ApiMode, TFields extends undefined | {
@@ -2105,7 +2105,7 @@ export const typeSymbol: unique symbol;
 type UnboxField<TSchema extends FieldSchema, Emptiness extends "maybeEmpty" | "notEmpty" = "maybeEmpty"> = UnboxFieldInner<TSchema["kind"], TSchema["allowedTypes"], Emptiness>;
 
 // @alpha
-type UnboxFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? Sequence2<TTypes> : Kind extends typeof FieldKinds.value ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined) : unknown;
+type UnboxFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? Sequence2<TTypes> : Kind extends typeof FieldKinds.required ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined) : unknown;
 
 // @alpha
 type UnboxNode<TSchema extends TreeSchema> = TSchema extends LeafSchema ? SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["structFieldsObject"][""]> : TSchema extends StructSchema ? StructTyped<TSchema> : unknown;
@@ -2242,7 +2242,7 @@ export interface ValueFieldEditBuilder {
 }
 
 // @alpha (undocumented)
-export interface ValueFieldKind extends FieldKind<"Value", Multiplicity.Value> {
+export interface ValueFieldKind extends FieldKind<"Value", Multiplicity.Single> {
 }
 
 // @alpha

--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
@@ -12,16 +12,16 @@ export const stringSchema = builder.leaf("string", ValueSchema.String);
 export const numberSchema = builder.leaf("number", ValueSchema.Number);
 
 export const bubbleSchema = builder.struct("BubbleBenchAppStateBubble-1.0.0", {
-	x: SchemaBuilder.fieldValue(numberSchema),
-	y: SchemaBuilder.fieldValue(numberSchema),
-	r: SchemaBuilder.fieldValue(numberSchema),
-	vx: SchemaBuilder.fieldValue(numberSchema),
-	vy: SchemaBuilder.fieldValue(numberSchema),
+	x: SchemaBuilder.fieldRequired(numberSchema),
+	y: SchemaBuilder.fieldRequired(numberSchema),
+	r: SchemaBuilder.fieldRequired(numberSchema),
+	vx: SchemaBuilder.fieldRequired(numberSchema),
+	vy: SchemaBuilder.fieldRequired(numberSchema),
 });
 
 export const clientSchema = builder.struct("BubbleBenchAppStateClient-1.0.0", {
-	clientId: SchemaBuilder.fieldValue(stringSchema),
-	color: SchemaBuilder.fieldValue(stringSchema),
+	clientId: SchemaBuilder.fieldRequired(stringSchema),
+	color: SchemaBuilder.fieldRequired(stringSchema),
 	bubbles: SchemaBuilder.fieldSequence(bubbleSchema),
 });
 

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -8,15 +8,15 @@ import { FieldKinds, SchemaBuilder, TypedField, TypedNode, leaf } from "@fluid-e
 const builder = new SchemaBuilder("inventory app", {}, leaf.library);
 
 export const part = builder.struct("Contoso:Part-1.0.0", {
-	name: SchemaBuilder.field(FieldKinds.value, leaf.string),
-	quantity: SchemaBuilder.field(FieldKinds.value, leaf.number),
+	name: SchemaBuilder.field(FieldKinds.required, leaf.string),
+	quantity: SchemaBuilder.field(FieldKinds.required, leaf.number),
 });
 
 export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	parts: SchemaBuilder.field(FieldKinds.sequence, part),
 });
 
-export const inventoryField = SchemaBuilder.field(FieldKinds.value, inventory);
+export const inventoryField = SchemaBuilder.field(FieldKinds.required, inventory);
 export type InventoryField = TypedField<typeof inventoryField>;
 
 export const schema = builder.intoDocumentSchema(inventoryField);

--- a/examples/data-objects/inventory-app/src/view/counter.tsx
+++ b/examples/data-objects/inventory-app/src/view/counter.tsx
@@ -7,7 +7,7 @@ import { useTreeContext } from "@fluid-experimental/tree-react-api";
 import { SchemaBuilder, TypedField, leaf } from "@fluid-experimental/tree2";
 import * as React from "react";
 
-const schema = SchemaBuilder.fieldValue(leaf.number);
+const schema = SchemaBuilder.fieldRequired(leaf.number);
 
 export interface ICounterProps {
 	title: string;

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -134,7 +134,7 @@ function buildTreeSchema(
 					!fields.has(nodePropertyField),
 					0x712 /* name collision for nodePropertyField */,
 				);
-				fields.set(nodePropertyField, SchemaBuilder.fieldValue(nodePropertySchema));
+				fields.set(nodePropertyField, SchemaBuilder.fieldRequired(nodePropertySchema));
 			}
 			const fieldsObject = mapToObject(fields);
 			cache.treeSchema = builder.struct(typeid, fieldsObject);
@@ -240,7 +240,7 @@ function buildLocalFields(
 						builder,
 						treeSchemaMap,
 						allChildrenByType,
-						property.optional ? FieldKinds.optional : FieldKinds.value,
+						property.optional ? FieldKinds.optional : FieldKinds.required,
 						currentTypeid,
 					),
 				);

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/schemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/schemaConverter.spec.ts
@@ -65,7 +65,7 @@ describe("schema converter", () => {
 						const idFieldSchema =
 							propertySchema.structFields.get(brand("guid")) ??
 							fail("expected field");
-						assert.deepEqual(idFieldSchema.kind, FieldKinds.value);
+						assert.deepEqual(idFieldSchema.kind, FieldKinds.required);
 						assert.deepEqual(
 							[...(idFieldSchema.types ?? fail("expected types"))],
 							["String"],
@@ -85,7 +85,7 @@ describe("schema converter", () => {
 							const idFieldSchema =
 								propertySchema.structFields.get(brand("guid")) ??
 								fail("expected field");
-							assert.deepEqual(idFieldSchema.kind, FieldKinds.value);
+							assert.deepEqual(idFieldSchema.kind, FieldKinds.required);
 							assert.deepEqual(
 								[...(idFieldSchema.types ?? fail("expected types"))],
 								["String"],
@@ -94,7 +94,7 @@ describe("schema converter", () => {
 								const toFieldSchema =
 									propertySchema.structFields.get(brand("to")) ??
 									fail("expected field");
-								assert.deepEqual(toFieldSchema.kind, FieldKinds.value);
+								assert.deepEqual(toFieldSchema.kind, FieldKinds.required);
 								assert.deepEqual(
 									[...(toFieldSchema.types ?? fail("expected types"))],
 									["Reference"],

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -21,7 +21,7 @@ const builder = new SchemaBuilder("Test Recursive Domain", {}, leaf.library);
  */
 export const recursiveStruct = builder.structRecursive("recursiveStruct", {
 	recursive: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => recursiveStruct),
-	number: SchemaBuilder.fieldValue(leaf.number),
+	number: SchemaBuilder.fieldRequired(leaf.number),
 });
 
 // Some related information in https://github.com/microsoft/TypeScript/issues/55758.
@@ -35,7 +35,7 @@ fixRecursiveReference(recursiveReference);
  */
 export const recursiveStruct2 = builder.struct("recursiveStruct2", {
 	recursive: SchemaBuilder.field(FieldKinds.optional, recursiveReference),
-	number: SchemaBuilder.fieldValue(leaf.number),
+	number: SchemaBuilder.fieldRequired(leaf.number),
 });
 
 type _0 = requireFalse<isAny<typeof recursiveStruct2>>;

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -250,7 +250,7 @@ export function tryShapeFromFieldSchema(
 	shapes: Map<TreeSchemaIdentifier, ShapeInfo>,
 ): FieldShape | undefined {
 	const kind = policy.fieldKinds.get(type.kind.identifier) ?? fail("missing FieldKind");
-	if (kind.multiplicity !== Multiplicity.Value) {
+	if (kind.multiplicity !== Multiplicity.Single) {
 		return undefined;
 	}
 	if (type.types?.size !== 1) {

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
@@ -69,7 +69,7 @@ export function fieldShaper(
 	const type = oneFromSet(field.types);
 	const nodeEncoder = type !== undefined ? treeHandler.shapeFromTree(type) : anyNodeEncoder;
 	// eslint-disable-next-line unicorn/prefer-ternary
-	if (kind.multiplicity === Multiplicity.Value) {
+	if (kind.multiplicity === Multiplicity.Single) {
 		return asFieldEncoder(nodeEncoder);
 	} else {
 		return cache.nestedArray(nodeEncoder);

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -574,7 +574,7 @@ function setFieldForKey(
 ): void {
 	const requiredFieldSchema = getFieldSchema(key, schema);
 	const multiplicity = getFieldKind(requiredFieldSchema).multiplicity;
-	if (multiplicity === Multiplicity.Value && context.fieldSource !== undefined) {
+	if (multiplicity === Multiplicity.Single && context.fieldSource !== undefined) {
 		const fieldGenerator = context.fieldSource(key, requiredFieldSchema);
 		if (fieldGenerator !== undefined) {
 			const children = fieldGenerator();
@@ -621,7 +621,7 @@ export function applyFieldTypesFromContext(
 		return children;
 	}
 	assert(
-		multiplicity === Multiplicity.Value || multiplicity === Multiplicity.Optional,
+		multiplicity === Multiplicity.Single || multiplicity === Multiplicity.Optional,
 		0x4da /* single value provided for an unsupported field */,
 	);
 	return [applyTypesFromContext(context, field.types, data)];

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultChangeFamily.ts
@@ -20,7 +20,7 @@ import {
 	FieldChangeset,
 	ModularChangeset,
 } from "../modular-schema";
-import { fieldKinds, optional, sequence, value as valueFieldKind } from "./defaultFieldKinds";
+import { fieldKinds, optional, sequence, required as valueFieldKind } from "./defaultFieldKinds";
 
 export type DefaultChangeset = ModularChangeset;
 

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldKinds.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultFieldKinds.ts
@@ -74,18 +74,18 @@ export const valueChangeHandler: FieldChangeHandler<OptionalChangeset, ValueFiel
 	editor: valueFieldEditor,
 };
 
-const valueIdentifier = "Value";
+const requiredIdentifier = "Value";
 
 /**
  * Exactly one item.
  */
-export const value = new FieldKindWithEditor(
-	valueIdentifier,
-	Multiplicity.Value,
+export const required = new FieldKindWithEditor(
+	requiredIdentifier,
+	Multiplicity.Single,
 	valueChangeHandler,
 	(types, other) =>
 		(other.kind.identifier === sequence.identifier ||
-			other.kind.identifier === valueIdentifier ||
+			other.kind.identifier === requiredIdentifier ||
 			other.kind.identifier === optional.identifier ||
 			other.kind.identifier === nodeKey.identifier) &&
 		allowsTreeSchemaIdentifierSuperset(types, other.types),
@@ -115,11 +115,11 @@ const nodeKeyIdentifier = "NodeKey";
  */
 export const nodeKey = new FieldKindWithEditor(
 	nodeKeyIdentifier,
-	Multiplicity.Value,
+	Multiplicity.Single,
 	noChangeHandler,
 	(types, other) =>
 		(other.kind.identifier === sequence.identifier ||
-			other.kind.identifier === valueIdentifier ||
+			other.kind.identifier === requiredIdentifier ||
 			other.kind.identifier === optional.identifier ||
 			other.kind.identifier === nodeKeyIdentifier) &&
 		allowsTreeSchemaIdentifierSuperset(types, other.types),
@@ -159,7 +159,7 @@ export const forbidden = new FieldKindWithEditor(
 	Multiplicity.Forbidden,
 	noChangeHandler,
 	// All multiplicities other than Value support empty.
-	(types, other) => fieldKinds.get(other.kind.identifier)?.multiplicity !== Multiplicity.Value,
+	(types, other) => fieldKinds.get(other.kind.identifier)?.multiplicity !== Multiplicity.Single,
 	new Set(),
 );
 
@@ -167,18 +167,18 @@ export const forbidden = new FieldKindWithEditor(
  * Default field kinds by identifier
  */
 export const fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor> = new Map(
-	[value, optional, sequence, nodeKey, forbidden].map((s) => [s.identifier, s]),
+	[required, optional, sequence, nodeKey, forbidden].map((s) => [s.identifier, s]),
 );
 
 // Create named Aliases for nicer intellisense.
 
-// TODO: Find a way to make docs like {@inheritDoc value} work in vscode.
+// TODO: Find a way to make docs like {@inheritDoc required} work in vscode.
 // TODO: ensure thy work in generated docs.
 // TODO: add these comments to the rest of the cases below.
 /**
  * @alpha
  */
-export interface ValueFieldKind extends FieldKind<"Value", Multiplicity.Value> {}
+export interface Required extends FieldKind<"Value", Multiplicity.Single> {}
 /**
  * @alpha
  */
@@ -190,7 +190,7 @@ export interface Sequence extends FieldKind<"Sequence", Multiplicity.Sequence> {
 /**
  * @alpha
  */
-export interface NodeKeyFieldKind extends FieldKind<"NodeKey", Multiplicity.Value> {}
+export interface NodeKeyFieldKind extends FieldKind<"NodeKey", Multiplicity.Single> {}
 /**
  * @alpha
  */
@@ -203,9 +203,9 @@ export interface Forbidden
  */
 export const FieldKinds: {
 	// TODO: inheritDoc for these somehow
-	readonly value: ValueFieldKind;
+	readonly required: Required;
 	readonly optional: Optional;
 	readonly sequence: Sequence;
 	readonly nodeKey: NodeKeyFieldKind;
 	readonly forbidden: Forbidden;
-} = { value, optional, sequence, nodeKey, forbidden };
+} = { required, optional, sequence, nodeKey, forbidden };

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
@@ -5,7 +5,7 @@
 
 export {
 	FieldKinds,
-	ValueFieldKind,
+	Required as ValueFieldKind,
 	Optional,
 	Sequence,
 	NodeKeyFieldKind,

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/index.ts
@@ -5,7 +5,7 @@
 
 export {
 	FieldKinds,
-	Required as ValueFieldKind,
+	Required,
 	Optional,
 	Sequence,
 	NodeKeyFieldKind,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -711,7 +711,7 @@ export type TypedFieldInner<
 	Types extends AllowedTypes,
 > = Kind extends typeof FieldKinds.sequence
 	? Sequence<Types>
-	: Kind extends typeof FieldKinds.value
+	: Kind extends typeof FieldKinds.required
 	? RequiredField<Types>
 	: Kind extends typeof FieldKinds.optional
 	? OptionalField<Types>
@@ -787,7 +787,7 @@ export type UnboxFieldInner<
 	Emptiness extends "maybeEmpty" | "notEmpty",
 > = Kind extends typeof FieldKinds.sequence
 	? Sequence<TTypes>
-	: Kind extends typeof FieldKinds.value
+	: Kind extends typeof FieldKinds.required
 	? UnboxNodeUnion<TTypes>
 	: Kind extends typeof FieldKinds.optional
 	? UnboxNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined)

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -373,12 +373,12 @@ export class LazySequence<TTypes extends AllowedTypes>
 }
 
 export class LazyValueField<TTypes extends AllowedTypes>
-	extends LazyField<typeof FieldKinds.value, TTypes>
+	extends LazyField<typeof FieldKinds.required, TTypes>
 	implements RequiredField<TTypes>
 {
 	public constructor(
 		context: Context,
-		schema: FieldSchema<typeof FieldKinds.value, TTypes>,
+		schema: FieldSchema<typeof FieldKinds.required, TTypes>,
 		cursor: ITreeSubscriptionCursor,
 		fieldAnchor: FieldAnchor,
 	) {
@@ -466,7 +466,7 @@ const builderList: [FieldKind, Builder][] = [
 	[FieldKinds.nodeKey, LazyOptionalField], // TODO
 	[FieldKinds.optional, LazyOptionalField],
 	[FieldKinds.sequence, LazySequence],
-	[FieldKinds.value, LazyValueField],
+	[FieldKinds.required, LazyValueField],
 ];
 
 const kindToClass: ReadonlyMap<FieldKind, Builder> = new Map(builderList);

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/unboxed.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/unboxed.ts
@@ -74,7 +74,7 @@ export function unboxedField<TSchema extends FieldSchema>(
 	cursor: ITreeSubscriptionCursor,
 ): UnboxField<TSchema> {
 	const kind = schema.kind;
-	if (kind === FieldKinds.value) {
+	if (kind === FieldKinds.required) {
 		return inCursorNode(cursor, 0, (innerCursor) =>
 			unboxedUnion(context, schema, innerCursor),
 		) as UnboxField<TSchema>;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -237,7 +237,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 	 */
 	private valueFieldEditor(): ValueFieldEditBuilder {
 		assert(
-			this.kind === FieldKinds.value,
+			this.kind === FieldKinds.required,
 			0x6bb /* Field kind must be a value to edit as a value. */,
 		);
 		const fieldPath = this.cursor.getFieldPath();
@@ -253,7 +253,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 				}
 				return this.getNode(0);
 			}
-			case Multiplicity.Value: {
+			case Multiplicity.Single: {
 				return this.getNode(0);
 			}
 			case Multiplicity.Forbidden: {
@@ -280,7 +280,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 				fieldEditor.set(content.length === 0 ? undefined : content[0], this.length === 0);
 				break;
 			}
-			case FieldKinds.value: {
+			case FieldKinds.required: {
 				const fieldEditor = this.valueFieldEditor();
 				assert(
 					content.length === 1,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -189,7 +189,7 @@ export {
 
 export {
 	FieldKinds,
-	ValueFieldKind,
+	Required,
 	Optional,
 	Sequence,
 	NodeKeyFieldKind,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/comparison.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/comparison.ts
@@ -189,7 +189,7 @@ export function isNeverFieldRecursive(
 ): boolean {
 	if (
 		(policy.fieldKinds.get(field.kind.identifier) ?? fail("missing field kind"))
-			.multiplicity === Multiplicity.Value &&
+			.multiplicity === Multiplicity.Single &&
 		field.types !== undefined
 	) {
 		for (const type of field.types) {
@@ -249,7 +249,7 @@ export function isNeverTreeRecursive(
 			(
 				policy.fieldKinds.get(normalizeField(tree.mapFields).kind.identifier) ??
 				fail("missing field kind")
-			).multiplicity === Multiplicity.Value
+			).multiplicity === Multiplicity.Single
 		) {
 			return true;
 		}

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldKind.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldKind.ts
@@ -153,7 +153,7 @@ export enum Multiplicity {
 	/**
 	 * Exactly one item.
 	 */
-	Value,
+	Single,
 	/**
 	 * 0 or 1 items.
 	 */

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/partlyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/partlyTyped.ts
@@ -5,7 +5,7 @@
 
 import { FieldStoredSchema, ITreeCursor } from "../../core";
 import { ContextuallyTypedNodeData, NewFieldContent } from "../contextuallyTyped";
-import { Optional, Sequence, ValueFieldKind } from "../default-field-kinds";
+import { Optional, Sequence, Required } from "../default-field-kinds";
 import {
 	UntypedField,
 	UntypedTree,
@@ -97,7 +97,7 @@ export interface UntypedValueField<
 	 * The `FieldStoredSchema` of this field.
 	 */
 	readonly fieldSchema: FieldStoredSchema & {
-		readonly kind: ValueFieldKind;
+		readonly kind: Required;
 	};
 
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -182,7 +182,7 @@ export type ApplyMultiplicity<
 	[Multiplicity.Sequence]: Mode extends ApiMode.Editable | ApiMode.EditableUnwrapped
 		? EditableSequenceField<TypedChild>
 		: TypedChild[];
-	[Multiplicity.Value]: Mode extends ApiMode.Editable
+	[Multiplicity.Single]: Mode extends ApiMode.Editable
 		? EditableValueField<TypedChild>
 		: TypedChild;
 }[TMultiplicity];

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
@@ -217,17 +217,17 @@ export class SchemaBuilder {
 
 	/**
 	 * Define a schema for a {@link RequiredField}.
-	 * Shorthand or passing `FieldKinds.value` to {@link SchemaBuilder.field}.
+	 * Shorthand or passing `FieldKinds.required` to {@link SchemaBuilder.field}.
 	 *
 	 * @privateRemarks
 	 * TODO: Consider adding even shorter syntax where:
 	 * - AllowedTypes can be used as a FieldSchema (Or SchemaBuilder takes a default field kind).
 	 * - A TreeSchema can be used as AllowedTypes in the non-polymorphic case.
 	 */
-	public static fieldValue<T extends AllowedTypes>(
+	public static fieldRequired<T extends AllowedTypes>(
 		...allowedTypes: T
-	): FieldSchema<typeof FieldKinds.value, T> {
-		return SchemaBuilder.field(FieldKinds.value, ...allowedTypes);
+	): FieldSchema<typeof FieldKinds.required, T> {
+		return SchemaBuilder.field(FieldKinds.required, ...allowedTypes);
 	}
 
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
@@ -190,7 +190,7 @@ export function validateViewSchemaCollection(
 				() => `Map fields of "${identifier}" schema from library "${tree.builder.name}"`,
 				errors,
 			);
-			if ((tree.mapFields.kind as FieldKind) === FieldKinds.value) {
+			if ((tree.mapFields.kind as FieldKind) === FieldKinds.required) {
 				errors.push(
 					`Map fields of "${identifier}" schema from library "${tree.builder.name}" has kind "value". This is invalid since it requires all possible field keys to have a value under them.`,
 				);

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -182,7 +182,7 @@ export {
 	SchemaBuilder,
 	AllowedTypes,
 	TreeSchema,
-	ValueFieldKind,
+	Required,
 	Optional,
 	Sequence,
 	NodeKeyFieldKind,

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -57,7 +57,7 @@ export function initializeContent(
 		// These kinds are known to tolerate empty, so use the schema as is:
 		incrementalSchemaUpdate = schema;
 	} else {
-		assert(rootKind === FieldKinds.value.identifier, 0x5c8 /* Unexpected kind */);
+		assert(rootKind === FieldKinds.required.identifier, 0x5c8 /* Unexpected kind */);
 		// Replace value kind with optional kind in root field schema:
 		incrementalSchemaUpdate = {
 			treeSchema: schema.treeSchema,

--- a/experimental/dds/tree2/src/test/counterFieldKind.ts
+++ b/experimental/dds/tree2/src/test/counterFieldKind.ts
@@ -99,7 +99,7 @@ export const counterHandle: FieldChangeHandler<number> = {
  */
 export const counter = new FieldKindWithEditor(
 	"Counter",
-	Multiplicity.Value,
+	Multiplicity.Single,
 	counterHandle,
 	(types, other) => other.kind.identifier === "Counter",
 	new Set(),

--- a/experimental/dds/tree2/src/test/cursorTestSuite.ts
+++ b/experimental/dds/tree2/src/test/cursorTestSuite.ts
@@ -39,7 +39,7 @@ const emptySchema3 = schemaBuilder.struct("Empty Struct 3", {});
 export const mapSchema = schemaBuilder.map("Map", SchemaBuilder.fieldSequence(Any));
 // Struct with fixed shape
 export const structSchema = schemaBuilder.struct("struct", {
-	child: SchemaBuilder.fieldValue(leafNumber),
+	child: SchemaBuilder.fieldRequired(leafNumber),
 });
 
 export const testTreeSchema = schemaBuilder.intoDocumentSchema(SchemaBuilder.fieldSequence(Any));

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -46,7 +46,7 @@ import { polygonTree, testData } from "./uniformChunkTestData";
 const builder = new SchemaBuilder("chunkTree");
 const leaf = builder.leaf("leaf", ValueSchema.Number);
 const empty = builder.struct("empty", {});
-const valueField = SchemaBuilder.fieldValue(leaf);
+const valueField = SchemaBuilder.fieldRequired(leaf);
 const structValue = builder.struct("structValue", { x: valueField });
 const optionalField = SchemaBuilder.fieldOptional(leaf);
 const structOptional = builder.struct("structOptional", { x: optionalField });

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncoding.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncoding.spec.ts
@@ -72,7 +72,7 @@ describe("schemaBasedEncoding", () => {
 						return onlyTypeShape;
 					},
 				},
-				SchemaBuilder.fieldValue(minimal),
+				SchemaBuilder.fieldRequired(minimal),
 				cache,
 			);
 			// This is expected since this case should be optimized to just encode the inner shape.
@@ -98,7 +98,7 @@ describe("schemaBasedEncoding", () => {
 						return onlyTypeShape;
 					},
 				},
-				SchemaBuilder.fieldValue(minimal, numeric),
+				SchemaBuilder.fieldRequired(minimal, numeric),
 				cache,
 			);
 			// There are multiple choices about how this case should be optimized, but the current implementation does this:

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -115,7 +115,7 @@ describe("ContextuallyTyped", () => {
 			const builder = new SchemaBuilder("cursorFromContextualData");
 			const generatedSchema = builder.leaf("generated", ValueSchema.String);
 			const nodeSchema = builder.struct("node", {
-				foo: SchemaBuilder.fieldValue(generatedSchema),
+				foo: SchemaBuilder.fieldRequired(generatedSchema),
 			});
 
 			const nodeSchemaData = builder.intoDocumentSchema(
@@ -149,7 +149,7 @@ describe("ContextuallyTyped", () => {
 			const generatedSchema = builder.leaf("generated", ValueSchema.String);
 
 			const nodeSchema = builder.structRecursive("node", {
-				foo: SchemaBuilder.fieldValue(generatedSchema),
+				foo: SchemaBuilder.fieldRequired(generatedSchema),
 				child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => nodeSchema),
 			});
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
@@ -87,8 +87,8 @@ describe("editableTreeTypes", () => {
 		/**
 		 * Test doc comment.
 		 */
-		leaf: SchemaBuilder.fieldValue(jsonNumber),
-		polymorphic: SchemaBuilder.fieldValue(jsonNumber, jsonString),
+		leaf: SchemaBuilder.fieldRequired(jsonNumber),
+		polymorphic: SchemaBuilder.fieldRequired(jsonNumber, jsonString),
 		optionalLeaf: SchemaBuilder.fieldOptional(jsonNumber),
 		optionalObject: SchemaBuilder.fieldOptional(jsonObject),
 		sequence: SchemaBuilder.fieldSequence(jsonNumber),
@@ -103,7 +103,7 @@ describe("editableTreeTypes", () => {
 		/**
 		 * Data field.
 		 */
-		x: SchemaBuilder.fieldValue(jsonNumber),
+		x: SchemaBuilder.fieldRequired(jsonNumber),
 	});
 	type Recursive = TypedNode<typeof recursiveStruct>;
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
@@ -76,7 +76,7 @@ describe("LazyField", () => {
 		);
 		const valueField = new LazyValueField(
 			context,
-			SchemaBuilder.fieldValue(Any),
+			SchemaBuilder.fieldRequired(Any),
 			cursor,
 			detachedFieldAnchor,
 		);
@@ -136,7 +136,7 @@ describe("LazyOptionalField", () => {
 			const builder = new SchemaBuilder("test");
 			const booleanLeafSchema = builder.leaf("bool", ValueSchema.Boolean);
 			const recursiveStructSchema = builder.structRecursive("recursiveStruct", {
-				flag: SchemaBuilder.fieldValue(booleanLeafSchema),
+				flag: SchemaBuilder.fieldRequired(booleanLeafSchema),
 				child: SchemaBuilder.fieldRecursive(
 					FieldKinds.optional,
 					() => recursiveStructSchema,
@@ -162,10 +162,10 @@ describe("LazyOptionalField", () => {
 			// Negative cases
 			assert(!field.is(SchemaBuilder.fieldOptional()));
 			assert(!field.is(SchemaBuilder.fieldOptional(booleanLeafSchema)));
-			assert(!field.is(SchemaBuilder.fieldValue(Any)));
+			assert(!field.is(SchemaBuilder.fieldRequired(Any)));
 			assert(!field.is(SchemaBuilder.fieldSequence(Any)));
 			assert(
-				!field.is(SchemaBuilder.fieldRecursive(FieldKinds.value, recursiveStructSchema)),
+				!field.is(SchemaBuilder.fieldRecursive(FieldKinds.required, recursiveStructSchema)),
 			);
 		});
 
@@ -176,7 +176,7 @@ describe("LazyOptionalField", () => {
 			const booleanLeafSchema = builder.leaf("bool", ValueSchema.Boolean);
 			const numberLeafSchema = builder.leaf("number", ValueSchema.Number);
 			const recursiveStructSchema = builder.structRecursive("recursiveStruct", {
-				flag: SchemaBuilder.fieldValue(booleanLeafSchema),
+				flag: SchemaBuilder.fieldRequired(booleanLeafSchema),
 				child: SchemaBuilder.fieldRecursive(
 					FieldKinds.optional,
 					() => recursiveStructSchema,
@@ -200,14 +200,14 @@ describe("LazyOptionalField", () => {
 			assert(field.is(SchemaBuilder.fieldOptional(booleanLeafSchema)));
 
 			// Negative cases
-			assert(!field.is(SchemaBuilder.fieldValue(Any)));
-			assert(!field.is(SchemaBuilder.fieldValue(booleanLeafSchema)));
-			assert(!field.is(SchemaBuilder.fieldValue(numberLeafSchema)));
+			assert(!field.is(SchemaBuilder.fieldRequired(Any)));
+			assert(!field.is(SchemaBuilder.fieldRequired(booleanLeafSchema)));
+			assert(!field.is(SchemaBuilder.fieldRequired(numberLeafSchema)));
 			assert(!field.is(SchemaBuilder.fieldSequence(Any)));
 			assert(!field.is(SchemaBuilder.fieldSequence(booleanLeafSchema)));
 			assert(!field.is(SchemaBuilder.fieldSequence(numberLeafSchema)));
 			assert(
-				!field.is(SchemaBuilder.fieldRecursive(FieldKinds.value, recursiveStructSchema)),
+				!field.is(SchemaBuilder.fieldRecursive(FieldKinds.required, recursiveStructSchema)),
 			);
 		});
 
@@ -218,11 +218,11 @@ describe("LazyOptionalField", () => {
 			const booleanLeafSchema = builder.leaf("bool", ValueSchema.Boolean);
 			const numberLeafSchema = builder.leaf("number", ValueSchema.Number);
 			const structLeafSchema = builder.struct("struct", {
-				foo: SchemaBuilder.fieldValue(booleanLeafSchema),
+				foo: SchemaBuilder.fieldRequired(booleanLeafSchema),
 				bar: SchemaBuilder.fieldOptional(numberLeafSchema),
 			});
 			const recursiveStructSchema = builder.structRecursive("recursiveStruct", {
-				flag: SchemaBuilder.fieldValue(booleanLeafSchema),
+				flag: SchemaBuilder.fieldRequired(booleanLeafSchema),
 				child: SchemaBuilder.fieldRecursive(
 					FieldKinds.optional,
 					() => recursiveStructSchema,
@@ -246,14 +246,14 @@ describe("LazyOptionalField", () => {
 			assert(field.is(SchemaBuilder.fieldOptional(structLeafSchema)));
 
 			// Negative cases
-			assert(!field.is(SchemaBuilder.fieldValue(Any)));
-			assert(!field.is(SchemaBuilder.fieldValue(structLeafSchema)));
-			assert(!field.is(SchemaBuilder.fieldValue(booleanLeafSchema)));
+			assert(!field.is(SchemaBuilder.fieldRequired(Any)));
+			assert(!field.is(SchemaBuilder.fieldRequired(structLeafSchema)));
+			assert(!field.is(SchemaBuilder.fieldRequired(booleanLeafSchema)));
 			assert(!field.is(SchemaBuilder.fieldSequence(Any)));
 			assert(!field.is(SchemaBuilder.fieldSequence(structLeafSchema)));
 			assert(!field.is(SchemaBuilder.fieldSequence(booleanLeafSchema)));
 			assert(
-				!field.is(SchemaBuilder.fieldRecursive(FieldKinds.value, recursiveStructSchema)),
+				!field.is(SchemaBuilder.fieldRecursive(FieldKinds.required, recursiveStructSchema)),
 			);
 		});
 
@@ -339,7 +339,7 @@ describe("LazyOptionalField", () => {
 		const booleanLeafSchema = builder.leaf("bool", ValueSchema.Boolean);
 		const numberLeafSchema = builder.leaf("number", ValueSchema.Number);
 		const leafSchema = builder.struct("struct", {
-			foo: SchemaBuilder.fieldValue(booleanLeafSchema),
+			foo: SchemaBuilder.fieldRequired(booleanLeafSchema),
 			bar: SchemaBuilder.fieldOptional(numberLeafSchema),
 		});
 		const rootSchema = SchemaBuilder.fieldOptional(leafSchema);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
@@ -95,7 +95,7 @@ describe("unboxedField", () => {
 	it("Value field (struct)", () => {
 		const builder = new SchemaBuilder("test", undefined, leafDomain.library);
 		const structSchema = builder.structRecursive("struct", {
-			name: SchemaBuilder.fieldValue(leafDomain.string),
+			name: SchemaBuilder.fieldRequired(leafDomain.string),
 			child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => structSchema),
 		});
 		const fieldSchema = SchemaBuilder.fieldOptional(structSchema);
@@ -156,7 +156,7 @@ describe("unboxedField", () => {
 describe("unboxedTree", () => {
 	it("Leaf", () => {
 		const builder = new SchemaBuilder("test", undefined, leafDomain.library);
-		const rootSchema = SchemaBuilder.fieldValue(leafDomain.string);
+		const rootSchema = SchemaBuilder.fieldRequired(leafDomain.string);
 		const schema = builder.intoDocumentSchema(rootSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
@@ -192,7 +192,7 @@ describe("unboxedTree", () => {
 	it("Struct", () => {
 		const builder = new SchemaBuilder("test", undefined, leafDomain.library);
 		const structSchema = builder.structRecursive("struct", {
-			name: SchemaBuilder.fieldValue(leafDomain.string),
+			name: SchemaBuilder.fieldRequired(leafDomain.string),
 			child: SchemaBuilder.fieldRecursive(FieldKinds.optional, () => structSchema),
 		});
 		const rootSchema = SchemaBuilder.fieldOptional(structSchema);
@@ -235,7 +235,7 @@ describe("unboxedUnion", () => {
 
 	it("Single type", () => {
 		const builder = new SchemaBuilder("test", undefined, leafDomain.library);
-		const fieldSchema = SchemaBuilder.fieldValue(leafDomain.boolean);
+		const fieldSchema = SchemaBuilder.fieldRequired(leafDomain.boolean);
 		const schema = builder.intoDocumentSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -589,7 +589,7 @@ describe("editable-tree: editing", () => {
 
 		it("as value field", () => {
 			const view = viewWithContent({
-				schema: getTestSchema(FieldKinds.value),
+				schema: getTestSchema(FieldKinds.required),
 				initialTree: { foo: "initial", foo2: "" },
 			});
 			const root = view.root;

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.identifier.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.identifier.spec.ts
@@ -22,14 +22,14 @@ const builder = new SchemaBuilder("EditableTree Node Keys", {}, nodeKeySchema);
 const stringSchema = builder.leaf("string", ValueSchema.String);
 const childNodeSchema = builder.struct("ChildNode", {
 	...nodeKeyField,
-	name: SchemaBuilder.fieldValue(stringSchema),
+	name: SchemaBuilder.fieldRequired(stringSchema),
 });
 
 const parentNodeSchema = builder.struct("ParentNode", {
 	...nodeKeyField,
 	children: SchemaBuilder.fieldSequence(childNodeSchema),
 });
-const rootField = SchemaBuilder.fieldValue(parentNodeSchema);
+const rootField = SchemaBuilder.fieldRequired(parentNodeSchema);
 const schema = builder.intoDocumentSchema(rootField);
 
 // TODO: this can probably be removed once daesun's stuff goes in

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -286,7 +286,7 @@ describe("editable-tree: read-only", () => {
 
 		const emptyOptional = buildTestTree(
 			{},
-			SchemaBuilder.field(FieldKinds.value, optionalChildSchema),
+			SchemaBuilder.field(FieldKinds.required, optionalChildSchema),
 		).unwrappedRoot;
 		assert(isEditableTree(emptyOptional));
 		// Check empty field does not show up:
@@ -296,7 +296,7 @@ describe("editable-tree: read-only", () => {
 			{
 				child: { [typeNameSymbol]: int32Schema.name, [valueSymbol]: 1 },
 			},
-			SchemaBuilder.field(FieldKinds.value, optionalChildSchema),
+			SchemaBuilder.field(FieldKinds.required, optionalChildSchema),
 		).unwrappedRoot;
 		assert(isEditableTree(fullOptional));
 		// Check full field does show up:
@@ -306,7 +306,7 @@ describe("editable-tree: read-only", () => {
 			{
 				[valueSymbol]: 1,
 			},
-			SchemaBuilder.field(FieldKinds.value, float64Schema),
+			SchemaBuilder.field(FieldKinds.required, float64Schema),
 		).root.content;
 		assert(isEditableTree(hasValue));
 		// Value does show up when not empty:
@@ -346,7 +346,7 @@ describe("editable-tree: read-only", () => {
 	});
 
 	it("value roots are unwrapped", () => {
-		const schemaData = buildTestSchema(SchemaBuilder.fieldValue(optionalChildSchema));
+		const schemaData = buildTestSchema(SchemaBuilder.fieldRequired(optionalChildSchema));
 		const forest = setupForest(schemaData, {});
 		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert(isEditableTree(context.unwrappedRoot));
@@ -375,7 +375,7 @@ describe("editable-tree: read-only", () => {
 	});
 
 	it("primitives are unwrapped at root", () => {
-		const rootSchema = SchemaBuilder.field(FieldKinds.value, int32Schema);
+		const rootSchema = SchemaBuilder.field(FieldKinds.required, int32Schema);
 		const schemaData = buildTestSchema(rootSchema);
 		const forest = setupForest(schemaData, 1);
 		const context = getReadonlyEditableTreeContext(forest, schemaData);
@@ -387,9 +387,9 @@ describe("editable-tree: read-only", () => {
 	it("primitives under node are unwrapped, but may be accessed without unwrapping", () => {
 		const builder = new SchemaBuilder("test", {}, personSchemaLibrary);
 		const parentSchema = builder.struct("parent", {
-			child: SchemaBuilder.field(FieldKinds.value, stringSchema),
+			child: SchemaBuilder.field(FieldKinds.required, stringSchema),
 		});
-		const rootSchema = SchemaBuilder.field(FieldKinds.value, parentSchema);
+		const rootSchema = SchemaBuilder.field(FieldKinds.required, parentSchema);
 		const schemaData = builder.intoDocumentSchema(rootSchema);
 		const forest = setupForest(schemaData, { child: "x" });
 		const context = getReadonlyEditableTreeContext(forest, schemaData);
@@ -404,7 +404,7 @@ describe("editable-tree: read-only", () => {
 	});
 
 	it("array nodes get unwrapped", () => {
-		const rootSchema = SchemaBuilder.field(FieldKinds.value, phonesSchema);
+		const rootSchema = SchemaBuilder.field(FieldKinds.required, phonesSchema);
 		assert(getPrimaryField(phonesSchema) !== undefined);
 		const schemaData = buildTestSchema(rootSchema);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -51,8 +51,8 @@ export const simplePhonesSchema = builder.struct("Test:SimplePhones-1.0.0", {
 });
 
 export const complexPhoneSchema = builder.struct("Test:Phone-1.0.0", {
-	number: SchemaBuilder.field(FieldKinds.value, stringSchema),
-	prefix: SchemaBuilder.field(FieldKinds.value, stringSchema),
+	number: SchemaBuilder.field(FieldKinds.required, stringSchema),
+	prefix: SchemaBuilder.field(FieldKinds.required, stringSchema),
 	extraPhones: SchemaBuilder.field(FieldKinds.optional, simplePhonesSchema),
 });
 
@@ -68,7 +68,7 @@ export const phonesSchema = builder.fieldNode(
 );
 
 export const addressSchema = builder.struct("Test:Address-1.0.0", {
-	zip: SchemaBuilder.field(FieldKinds.value, stringSchema, int32Schema),
+	zip: SchemaBuilder.field(FieldKinds.required, stringSchema, int32Schema),
 	street: SchemaBuilder.field(FieldKinds.optional, stringSchema),
 	city: SchemaBuilder.field(FieldKinds.optional, stringSchema),
 	country: SchemaBuilder.field(FieldKinds.optional, stringSchema),
@@ -82,7 +82,7 @@ export const mapStringSchema = builder.map(
 );
 
 export const personSchema = builder.struct("Test:Person-1.0.0", {
-	name: SchemaBuilder.field(FieldKinds.value, stringSchema),
+	name: SchemaBuilder.field(FieldKinds.required, stringSchema),
 	age: SchemaBuilder.field(FieldKinds.optional, int32Schema),
 	adult: SchemaBuilder.field(FieldKinds.optional, boolSchema),
 	salary: SchemaBuilder.field(FieldKinds.optional, float64Schema, int32Schema, stringSchema),

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/utilities.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/utilities.spec.ts
@@ -44,7 +44,7 @@ describe("editable-tree utilities", () => {
 			schema,
 		};
 
-		const rootSchema = SchemaBuilder.field(FieldKinds.value, arraySchema);
+		const rootSchema = SchemaBuilder.field(FieldKinds.required, arraySchema);
 		const fullSchemaData = buildTestSchema(rootSchema);
 		const primary = getPrimaryField(arraySchema);
 		assert(primary !== undefined);

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -94,7 +94,7 @@ export const valueHandler: FieldChangeHandler<ValueChangeset> = {
 
 export const valueField = new FieldKindWithEditor(
 	"Value",
-	Multiplicity.Value,
+	Multiplicity.Single,
 	valueHandler,
 	(a, b) => false,
 	new Set(),

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -55,7 +55,7 @@ describe("Schema Comparison", () => {
 	/**
 	 * FieldStoredSchema which is impossible for any data to be in schema with.
 	 */
-	const neverField = fieldSchema(FieldKinds.value, []);
+	const neverField = fieldSchema(FieldKinds.required, []);
 
 	/**
 	 * TreeStoredSchema which is impossible for any data to be in schema with.
@@ -86,11 +86,11 @@ describe("Schema Comparison", () => {
 
 	const valueLocalFieldTree = namedTreeSchema({
 		name: "valueLocalFieldTree",
-		structFields: { x: fieldSchema(FieldKinds.value, [emptyTree.name]) },
+		structFields: { x: fieldSchema(FieldKinds.required, [emptyTree.name]) },
 	});
 
-	const valueAnyField = fieldSchema(FieldKinds.value);
-	const valueEmptyTreeField = fieldSchema(FieldKinds.value, [emptyTree.name]);
+	const valueAnyField = fieldSchema(FieldKinds.required);
+	const valueEmptyTreeField = fieldSchema(FieldKinds.required, [emptyTree.name]);
 	const optionalAnyField = fieldSchema(FieldKinds.optional);
 	const optionalEmptyTreeField = fieldSchema(FieldKinds.optional, [emptyTree.name]);
 
@@ -109,7 +109,7 @@ describe("Schema Comparison", () => {
 		const repo = new InMemoryStoredSchemaRepository();
 		assert(isNeverField(defaultSchemaPolicy, repo, neverField));
 		updateTreeSchema(repo, brand("never"), neverTree);
-		const neverField2: FieldStoredSchema = fieldSchema(FieldKinds.value, [brand("never")]);
+		const neverField2: FieldStoredSchema = fieldSchema(FieldKinds.required, [brand("never")]);
 		assert(isNeverField(defaultSchemaPolicy, repo, neverField2));
 		assert.equal(isNeverField(defaultSchemaPolicy, repo, storedEmptyFieldSchema), false);
 		assert.equal(isNeverField(defaultSchemaPolicy, repo, anyField), false);
@@ -119,7 +119,7 @@ describe("Schema Comparison", () => {
 			isNeverField(
 				defaultSchemaPolicy,
 				repo,
-				fieldSchema(FieldKinds.value, [brand("empty")]),
+				fieldSchema(FieldKinds.required, [brand("empty")]),
 			),
 			false,
 		);
@@ -165,7 +165,7 @@ describe("Schema Comparison", () => {
 
 	it("isNeverTreeRecursive", () => {
 		const repo = new InMemoryStoredSchemaRepository();
-		const recursiveField = fieldSchema(FieldKinds.value, [brand("recursive")]);
+		const recursiveField = fieldSchema(FieldKinds.required, [brand("recursive")]);
 		const recursiveType = treeSchema({
 			mapFields: recursiveField,
 		});
@@ -175,7 +175,10 @@ describe("Schema Comparison", () => {
 
 	it("isNeverTreeRecursive non-never", () => {
 		const repo = new InMemoryStoredSchemaRepository();
-		const recursiveField = fieldSchema(FieldKinds.value, [brand("recursive"), emptyTree.name]);
+		const recursiveField = fieldSchema(FieldKinds.required, [
+			brand("recursive"),
+			emptyTree.name,
+		]);
 		const recursiveType = treeSchema({
 			mapFields: recursiveField,
 		});
@@ -236,7 +239,7 @@ describe("Schema Comparison", () => {
 		const repo = new InMemoryStoredSchemaRepository();
 		updateTreeSchema(repo, brand("never"), neverTree);
 		updateTreeSchema(repo, emptyTree.name, emptyTree);
-		const neverField2: FieldStoredSchema = fieldSchema(FieldKinds.value, [brand("never")]);
+		const neverField2: FieldStoredSchema = fieldSchema(FieldKinds.required, [brand("never")]);
 		const compare = (a: FieldStoredSchema, b: FieldStoredSchema): boolean =>
 			allowsFieldSuperset(defaultSchemaPolicy, repo, a, b);
 		testOrder(compare, [

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -73,7 +73,7 @@ const singleNodeHandler: FieldChangeHandler<NodeChangeset> = {
 
 const singleNodeField = new FieldKindWithEditor(
 	"SingleNode",
-	Multiplicity.Value,
+	Multiplicity.Single,
 	singleNodeHandler,
 	(a, b) => false,
 	new Set(),
@@ -733,7 +733,7 @@ describe("ModularChangeFamily", () => {
 		} as unknown as FieldChangeHandler<RevisionTag[]>;
 		const field = new FieldKindWithEditor(
 			"ChecksRevIndexing",
-			Multiplicity.Value,
+			Multiplicity.Single,
 			handler,
 			(a, b) => false,
 			new Set(),

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -100,8 +100,8 @@ describe("Schema Evolution Examples", () => {
 	});
 
 	const point = contentTypesBuilder.struct(pointIdentifier, {
-		x: SchemaBuilder.field(FieldKinds.value, number),
-		y: SchemaBuilder.field(FieldKinds.value, number),
+		x: SchemaBuilder.field(FieldKinds.required, number),
+		y: SchemaBuilder.field(FieldKinds.required, number),
 	});
 
 	const defaultContentLibrary = contentTypesBuilder.intoLibrary();
@@ -114,14 +114,14 @@ describe("Schema Evolution Examples", () => {
 
 	// A type that can be used to position items without an inherent position within the canvas.
 	const positionedCanvasItem = containersBuilder.struct(positionedCanvasItemIdentifier, {
-		position: SchemaBuilder.field(FieldKinds.value, point),
-		content: SchemaBuilder.field(FieldKinds.value, text),
+		position: SchemaBuilder.field(FieldKinds.required, point),
+		content: SchemaBuilder.field(FieldKinds.required, text),
 	});
 	const canvas = containersBuilder.struct(canvasIdentifier, {
 		items: SchemaBuilder.field(FieldKinds.sequence, positionedCanvasItem),
 	});
 
-	const root: FieldSchema = SchemaBuilder.field(FieldKinds.value, canvas);
+	const root: FieldSchema = SchemaBuilder.field(FieldKinds.required, canvas);
 
 	const tolerantRoot = SchemaBuilder.field(FieldKinds.optional, canvas);
 
@@ -257,14 +257,14 @@ describe("Schema Evolution Examples", () => {
 				"0d8da0ca-b3ba-4025-93a3-b8f181379e3b",
 			);
 			const counter = builderWithCounter.struct(counterIdentifier, {
-				count: SchemaBuilder.field(FieldKinds.value, number),
+				count: SchemaBuilder.field(FieldKinds.required, number),
 			});
 			// Lets allow counters inside positionedCanvasItem, instead of just text:
 			const positionedCanvasItem2 = builderWithCounter.struct(
 				positionedCanvasItemIdentifier,
 				{
-					position: SchemaBuilder.field(FieldKinds.value, point),
-					content: SchemaBuilder.field(FieldKinds.value, text, counter),
+					position: SchemaBuilder.field(FieldKinds.required, point),
+					content: SchemaBuilder.field(FieldKinds.required, text, counter),
 				},
 			);
 			// And canvas is still the same storage wise, but its view schema references the updated positionedCanvasItem2:
@@ -402,7 +402,7 @@ describe("Schema Evolution Examples", () => {
 	// 			() => formattedText,
 	// 			codePoint,
 	// 		),
-	// 		size: SchemaBuilder.field(FieldKinds.value, number),
+	// 		size: SchemaBuilder.field(FieldKinds.required, number),
 	// 	});
 
 	// 	// We are also updating positionedCanvasItem to accept the new type.
@@ -413,9 +413,9 @@ describe("Schema Evolution Examples", () => {
 	// 	// as no version of the app need both view schema at the same time
 	// 	// (except for some approaches for staging roll-outs which are not covered here).
 	// 	const positionedCanvasItemNew = builder.struct(positionedCanvasItemIdentifier, {
-	// 		position: SchemaBuilder.field(FieldKinds.value, point),
+	// 		position: SchemaBuilder.field(FieldKinds.required, point),
 	// 		// Note that we are specifically excluding the old text here
-	// 		content: SchemaBuilder.field(FieldKinds.value, formattedText),
+	// 		content: SchemaBuilder.field(FieldKinds.required, formattedText),
 	// 	});
 	// 	// And canvas is still the same storage wise, but its view schema references the updated positionedCanvasItem2:
 	// 	const canvas2 = builder.struct(canvasIdentifier, {
@@ -423,7 +423,7 @@ describe("Schema Evolution Examples", () => {
 	// 	});
 
 	// 	const viewCollection: SchemaCollection = builder.intoDocumentSchema(
-	// 		SchemaBuilder.fieldValue(canvas2),
+	// 		SchemaBuilder.fieldRequired(canvas2),
 	// 	);
 
 	// 	const textAdapter: TreeAdapter = { input: textIdentifier, output: formattedTextIdentifier };
@@ -475,9 +475,9 @@ describe("Schema Evolution Examples", () => {
 	// 		// TODO: add an automated way to determine that this is the needed upgrade (some way to union schema?).
 	// 		const positionedCanvasItemTolerant = treeSchema({
 	// 			structFields: {
-	// 				position: fieldSchema(FieldKinds.value, [pointIdentifier]),
+	// 				position: fieldSchema(FieldKinds.required, [pointIdentifier]),
 	// 				// Note that we are specifically supporting both formats here.
-	// 				content: fieldSchema(FieldKinds.value, [
+	// 				content: fieldSchema(FieldKinds.required, [
 	// 					formattedTextIdentifier,
 	// 					textIdentifier,
 	// 				]),

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -48,7 +48,7 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 
 {
 	// Aliases for conciseness
-	const { optional, value, sequence } = FieldKinds;
+	const { optional, required, sequence } = FieldKinds;
 
 	// Example Schema:
 	const builder = new SchemaBuilder("Schema Aware tests");
@@ -58,14 +58,14 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 
 	// Check the various ways to refer to child types produce the same results
 	{
-		const numberField1 = SchemaBuilder.field(value, numberSchema);
-		const numberField2 = SchemaBuilder.fieldValue(numberSchema);
-		const numberField3 = SchemaBuilder.fieldRecursive(value, numberSchema);
+		const numberField1 = SchemaBuilder.field(required, numberSchema);
+		const numberField2 = SchemaBuilder.fieldRequired(numberSchema);
+		const numberField3 = SchemaBuilder.fieldRecursive(required, numberSchema);
 		type check1_ = requireAssignableTo<typeof numberField1, typeof numberField2>;
 		type check2_ = requireAssignableTo<typeof numberField2, typeof numberField3>;
 		type check3_ = requireAssignableTo<typeof numberField3, typeof numberField1>;
 
-		const numberFieldLazy = SchemaBuilder.field(value, () => numberSchema);
+		const numberFieldLazy = SchemaBuilder.field(required, () => numberSchema);
 		type NonLazy = InternalTypedSchemaTypes.FlexListToNonLazyArray<
 			typeof numberFieldLazy.allowedTypes
 		>;
@@ -75,14 +75,14 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 	// Simple object
 	{
 		const simpleObject = builder.struct("simple", {
-			x: SchemaBuilder.fieldValue(numberSchema),
+			x: SchemaBuilder.fieldRequired(numberSchema),
 		});
 	}
 
 	const ballSchema = builder.struct("ball", {
 		// Test schema objects in as well as lazy functions
-		x: SchemaBuilder.fieldValue(numberSchema),
-		y: SchemaBuilder.fieldValue(() => numberSchema),
+		x: SchemaBuilder.fieldRequired(numberSchema),
+		y: SchemaBuilder.fieldRequired(() => numberSchema),
 		size: SchemaBuilder.fieldOptional(numberSchema),
 	});
 
@@ -213,7 +213,7 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 		const builder2 = new SchemaBuilder("Schema Aware polymorphic");
 		const bool = builder2.leaf("bool", ValueSchema.Boolean);
 		const str = builder2.leaf("str", ValueSchema.String);
-		const parentField = SchemaBuilder.fieldValue(str, bool);
+		const parentField = SchemaBuilder.fieldRequired(str, bool);
 		const parent = builder2.struct("parent", { child: parentField });
 
 		type FlexBool =
@@ -459,7 +459,7 @@ describe("SchemaAware Editing", () => {
 			children: SchemaBuilder.fieldSequence(stringSchema),
 		});
 		const schema = builder.intoDocumentSchema(
-			SchemaBuilder.field(FieldKinds.value, rootNodeSchema),
+			SchemaBuilder.field(FieldKinds.required, rootNodeSchema),
 		);
 		const view = createSharedTreeView().schematize({
 			schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAwareSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAwareSimple.ts
@@ -79,7 +79,7 @@ export type ApplyMultiplicity<TMultiplicity extends Multiplicity, TypedChild> = 
 	[Multiplicity.Forbidden]: undefined;
 	[Multiplicity.Optional]: undefined | TypedChild;
 	[Multiplicity.Sequence]: TypedChild[];
-	[Multiplicity.Value]: TypedChild;
+	[Multiplicity.Single]: TypedChild;
 }[TMultiplicity];
 
 // TODO: add strong typed `getNode`.

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -27,7 +27,7 @@ export const listTaskSchema = builder.structRecursive("ListTask", {
 	type _check = requireAssignableTo<typeof listTaskSchema, TreeSchema>;
 }
 
-export const rootFieldSchema = SchemaBuilder.fieldValue(stringTaskSchema, listTaskSchema);
+export const rootFieldSchema = SchemaBuilder.fieldRequired(stringTaskSchema, listTaskSchema);
 
 export const appSchemaData = builder.intoDocumentSchema(rootFieldSchema);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -11,8 +11,8 @@ const builder = new SchemaBuilder("Simple Schema");
 export const numberSchema = builder.leaf("number", ValueSchema.Number);
 
 export const pointSchema = builder.struct("point", {
-	x: SchemaBuilder.fieldValue(numberSchema),
-	y: SchemaBuilder.fieldValue(numberSchema),
+	x: SchemaBuilder.fieldRequired(numberSchema),
+	y: SchemaBuilder.fieldRequired(numberSchema),
 });
 
 export const appSchemaData = builder.intoDocumentSchema(SchemaBuilder.fieldSequence(pointSchema));

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
@@ -13,8 +13,8 @@ const numberSchema = builder.leaf("number", ValueSchema.Number);
 
 // Declare struct
 const ballSchema = builder.struct("Ball", {
-	x: SchemaBuilder.fieldValue(numberSchema),
-	y: SchemaBuilder.fieldValue(numberSchema),
+	x: SchemaBuilder.fieldRequired(numberSchema),
+	y: SchemaBuilder.fieldRequired(numberSchema),
 });
 
 // We can inspect the schema.

--- a/experimental/dds/tree2/src/test/scalableTestTrees.ts
+++ b/experimental/dds/tree2/src/test/scalableTestTrees.ts
@@ -30,7 +30,7 @@ const deepBuilder = new SchemaBuilder("sharedTree.bench: deep", {}, jsonSchema);
 
 // Test data in "deep" mode: a linked list with a number at the end.
 const linkedListSchema = deepBuilder.structRecursive("linkedList", {
-	foo: SchemaBuilder.fieldRecursive(FieldKinds.value, () => linkedListSchema, jsonNumber),
+	foo: SchemaBuilder.fieldRecursive(FieldKinds.required, () => linkedListSchema, jsonNumber),
 });
 
 const wideBuilder = new SchemaBuilder("sharedTree.bench: wide", {}, jsonSchema);
@@ -40,11 +40,11 @@ export const wideRootSchema = wideBuilder.struct("WideRoot", {
 });
 
 export const wideSchema = wideBuilder.intoDocumentSchema(
-	SchemaBuilder.field(FieldKinds.value, wideRootSchema),
+	SchemaBuilder.field(FieldKinds.required, wideRootSchema),
 );
 
 export const deepSchema = deepBuilder.intoDocumentSchema(
-	SchemaBuilder.field(FieldKinds.value, linkedListSchema, jsonNumber),
+	SchemaBuilder.field(FieldKinds.required, linkedListSchema, jsonNumber),
 );
 
 /**

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -37,7 +37,7 @@ export const initialTreeState: JsonableTree = {
 	},
 };
 
-const rootFieldSchema = fieldSchema(FieldKinds.value);
+const rootFieldSchema = fieldSchema(FieldKinds.required);
 const rootNodeSchema = namedTreeSchema({
 	name: "TestValue",
 	mapFields: fieldSchema(FieldKinds.sequence),

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -36,13 +36,13 @@ const builder = new SchemaBuilder("opSize");
 
 const stringSchema = builder.leaf("String", ValueSchema.String);
 const childSchema = builder.struct("Test:Opsize-Bench-Child", {
-	data: SchemaBuilder.fieldValue(stringSchema),
+	data: SchemaBuilder.fieldRequired(stringSchema),
 });
 const parentSchema = builder.struct("Test:Opsize-Bench-Root", {
 	children: SchemaBuilder.fieldSequence(childSchema),
 });
 
-const rootSchema = SchemaBuilder.fieldValue(parentSchema);
+const rootSchema = SchemaBuilder.fieldRequired(parentSchema);
 
 const fullSchemaData = builder.intoDocumentSchema(rootSchema);
 

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -37,7 +37,7 @@ const schemaGeneralized = builderGeneralized.intoDocumentSchema(SchemaBuilder.fi
 
 const builderValue = new SchemaBuilder("Schematize Tree Tests");
 const root2 = builderValue.leaf("root", ValueSchema.Number);
-const schemaValueRoot = builderValue.intoDocumentSchema(SchemaBuilder.fieldValue(Any));
+const schemaValueRoot = builderValue.intoDocumentSchema(SchemaBuilder.fieldRequired(Any));
 
 const emptySchema = new SchemaBuilder("Empty", {
 	rejectEmpty: false,
@@ -111,7 +111,7 @@ describe("schematizeTree", () => {
 
 					assert.deepEqual(
 						log,
-						content.schema.rootFieldSchema.kind === FieldKinds.value
+						content.schema.rootFieldSchema.kind === FieldKinds.required
 							? ["schema", "content", "schema"]
 							: ["schema", "content"],
 					);

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -105,7 +105,7 @@ describe("SharedTree", () => {
 	it("editable-tree-2-end-to-end", () => {
 		const builder = new SchemaBuilder("e2e");
 		const numberSchema = builder.leaf("number", ValueSchema.Number);
-		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldValue(numberSchema));
+		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldRequired(numberSchema));
 		const factory = new SharedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,
@@ -945,7 +945,7 @@ describe("SharedTree", () => {
 		const builder = new SchemaBuilder("Events test schema");
 		const numberSchema = builder.leaf("number", ValueSchema.Number);
 		const treeSchema = builder.struct("root", {
-			x: SchemaBuilder.fieldValue(numberSchema),
+			x: SchemaBuilder.fieldRequired(numberSchema),
 		});
 		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldOptional(Any));
 
@@ -1767,7 +1767,7 @@ describe("SharedTree", () => {
 		it("Anchor Stability fails when root node is deleted", async () => {
 			const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
 
-			const rootFieldSchema = SchemaBuilder.fieldValue(Any);
+			const rootFieldSchema = SchemaBuilder.fieldRequired(Any);
 			const testSchemaBuilder = new SchemaBuilder("testSchema");
 			const numberSchema = testSchemaBuilder.leaf("Number", ValueSchema.Number);
 			const rootNodeSchema = testSchemaBuilder.structRecursive("Node", {

--- a/experimental/dds/tree2/src/test/testTrees.ts
+++ b/experimental/dds/tree2/src/test/testTrees.ts
@@ -39,7 +39,7 @@ function testTree<T extends TreeSchema>(
 	rootNode: T,
 	data: SchemaAware.AllowedTypesToTypedTrees<SchemaAware.ApiMode.Flexible, [T]>,
 ): TestTree {
-	const fieldSchema = SchemaBuilder.fieldValue(rootNode);
+	const fieldSchema = SchemaBuilder.fieldRequired(rootNode);
 	return testField(name, schemaData, fieldSchema, data);
 }
 
@@ -94,28 +94,28 @@ export const minimal = builder.struct("minimal", {});
 export const numeric = builder.leaf("numeric", ValueSchema.Number);
 export const bool = builder.leaf("bool", ValueSchema.Boolean);
 export const hasMinimalValueField = builder.struct("hasMinimalValueField", {
-	field: SchemaBuilder.fieldValue(minimal),
+	field: SchemaBuilder.fieldRequired(minimal),
 });
 export const hasNumericValueField = builder.struct("hasNumericValueField", {
-	field: SchemaBuilder.fieldValue(numeric),
+	field: SchemaBuilder.fieldRequired(numeric),
 });
 export const hasPolymorphicValueField = builder.struct("hasPolymorphicValueField", {
-	field: SchemaBuilder.fieldValue(numeric, minimal),
+	field: SchemaBuilder.fieldRequired(numeric, minimal),
 });
 export const hasAnyValueField = builder.struct("hasAnyValueField", {
-	field: SchemaBuilder.fieldValue(Any),
+	field: SchemaBuilder.fieldRequired(Any),
 });
 export const hasOptionalField = builder.struct("hasOptionalField", {
 	field: SchemaBuilder.fieldOptional(numeric),
 });
 export const allTheFields = builder.struct("allTheFields", {
 	optional: SchemaBuilder.fieldOptional(numeric),
-	valueField: SchemaBuilder.fieldValue(numeric),
+	valueField: SchemaBuilder.fieldRequired(numeric),
 	sequence: SchemaBuilder.fieldSequence(numeric),
 });
 export const anyFields = builder.struct("anyFields", {
 	optional: SchemaBuilder.fieldOptional(Any),
-	valueField: SchemaBuilder.fieldValue(Any),
+	valueField: SchemaBuilder.fieldRequired(Any),
 	sequence: SchemaBuilder.fieldSequence(Any),
 });
 

--- a/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
@@ -14,7 +14,7 @@ describe("TypedTree", () => {
 	it("editable-tree-2-end-to-end", () => {
 		const builder = new SchemaBuilder("e2e");
 		const numberSchema = builder.leaf("number", ValueSchema.Number);
-		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldValue(numberSchema));
+		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldRequired(numberSchema));
 		const factory = new TypedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,

--- a/experimental/framework/tree-react-api/src/test/schema.ts
+++ b/experimental/framework/tree-react-api/src/test/schema.ts
@@ -3,18 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKinds, SchemaAware, SchemaBuilder, ValueSchema } from "@fluid-experimental/tree2";
+import { FieldKinds, SchemaBuilder, TypedField, leaf } from "@fluid-experimental/tree2";
 
-const builder = new SchemaBuilder("tree-react-api");
-export const float64 = builder.leaf("number", ValueSchema.Number);
+const builder = new SchemaBuilder("tree-react-api", {}, leaf.library);
 
 export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
-	nuts: SchemaBuilder.field(FieldKinds.value, float64),
-	bolts: SchemaBuilder.field(FieldKinds.value, float64),
+	nuts: SchemaBuilder.field(FieldKinds.required, leaf.number),
+	bolts: SchemaBuilder.field(FieldKinds.required, leaf.number),
 });
 
-export const rootField = SchemaBuilder.field(FieldKinds.value, inventory);
+export const inventoryField = SchemaBuilder.field(FieldKinds.required, inventory);
 
-export const schema = builder.intoDocumentSchema(rootField);
+export const schema = builder.intoDocumentSchema(inventoryField);
 
-export type Inventory = SchemaAware.TypedNode<typeof inventory>;
+export type Inventory = TypedField<typeof schema.rootFieldSchema>;

--- a/experimental/framework/tree-react-api/src/test/useTree.spec.ts
+++ b/experimental/framework/tree-react-api/src/test/useTree.spec.ts
@@ -6,22 +6,32 @@
 import { strict as assert } from "assert";
 import {
 	AllowedUpdateType,
-	ISharedTreeView,
-	SchemaAware,
-	SharedTreeFactory,
+	ForestType,
+	TypedTreeFactory,
+	typeboxValidator,
 } from "@fluid-experimental/tree2";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import React from "react";
 import { SinonSandbox, createSandbox } from "sinon";
-import { useTree } from "..";
-import { rootField, schema } from "./schema";
+import { useTreeContext } from "..";
+import { Inventory, schema } from "./schema";
 
 // TODO: why do failing tests in this suite not cause CI to fail?
 describe("useTree()", () => {
-	function createLocalTree(id: string): ISharedTreeView {
-		const factory = new SharedTreeFactory();
+	function createLocalTree(id: string): Inventory {
+		const factory = new TypedTreeFactory({
+			jsonValidator: typeboxValidator,
+			forest: ForestType.Reference,
+			initialTree: {
+				nuts: 0,
+				bolts: 0,
+			},
+			allowedSchemaModifications: AllowedUpdateType.None,
+			schema,
+			subtype: "InventoryList",
+		});
 		const tree = factory.create(new MockFluidDataStoreRuntime(), id);
-		return tree.view;
+		return tree.root;
 	}
 
 	// Mock 'React.setState()'
@@ -60,15 +70,11 @@ describe("useTree()", () => {
 
 	it("works", () => {
 		const tree = createLocalTree("tree");
-		const root: SchemaAware.TypedField<typeof rootField> = useTree(tree, {
-			schema,
-			initialTree: {
-				nuts: 0,
-				bolts: 0,
-			},
-			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
+		useTreeContext(tree.context);
+		assert.deepEqual(JSON.parse(JSON.stringify(tree.content)), {
+			nuts: 0,
+			bolts: 0,
+			type: "Contoso:Inventory-1.0.0",
 		});
-
-		assert.deepEqual(JSON.parse(JSON.stringify(root[0])), { nuts: 0, bolts: 0 });
 	});
 });

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -413,21 +413,21 @@ describe("DefaultVisualizers unit tests", () => {
 		const handleSchema = builder.leaf("handle-property", ValueSchema.FluidHandle);
 
 		const leafSchema = builder.struct("leaf-item", {
-			leafField: SchemaBuilder.fieldValue(booleanSchema, handleSchema, stringSchema),
+			leafField: SchemaBuilder.fieldRequired(booleanSchema, handleSchema, stringSchema),
 		});
 
 		const childSchema = builder.struct("child-item", {
-			childField: SchemaBuilder.fieldValue(stringSchema, booleanSchema),
+			childField: SchemaBuilder.fieldRequired(stringSchema, booleanSchema),
 			childData: SchemaBuilder.fieldOptional(leafSchema),
 		});
 
 		const rootNodeSchema = builder.struct("root-item", {
 			childrenOne: SchemaBuilder.fieldSequence(childSchema),
-			childrenTwo: SchemaBuilder.fieldValue(numberSchema),
+			childrenTwo: SchemaBuilder.fieldRequired(numberSchema),
 		});
 
 		const schema = builder.intoDocumentSchema(
-			SchemaBuilder.field(FieldKinds.value, rootNodeSchema),
+			SchemaBuilder.field(FieldKinds.required, rootNodeSchema),
 		);
 
 		sharedTree.schematize({

--- a/packages/tools/devtools/devtools-example/src/FluidObject.ts
+++ b/packages/tools/devtools/devtools-example/src/FluidObject.ts
@@ -11,7 +11,6 @@ import { SharedMatrix } from "@fluidframework/matrix";
 import { type SharedObjectClass } from "@fluidframework/fluid-static";
 import {
 	AllowedUpdateType,
-	FieldKinds,
 	type ISharedTree,
 	SchemaBuilder,
 	ValueSchema,
@@ -225,22 +224,20 @@ export class AppData extends DataObject {
 		const handleSchema = builder.leaf("handle-property", ValueSchema.FluidHandle);
 
 		const leafSchema = builder.struct("leaf-item", {
-			leafField: SchemaBuilder.fieldValue(stringSchema, booleanSchema, handleSchema),
+			leafField: SchemaBuilder.fieldRequired(stringSchema, booleanSchema, handleSchema),
 		});
 
 		const childSchema = builder.struct("child-item", {
-			childField: SchemaBuilder.fieldValue(stringSchema, booleanSchema),
+			childField: SchemaBuilder.fieldRequired(stringSchema, booleanSchema),
 			childData: SchemaBuilder.fieldOptional(leafSchema),
 		});
 
 		const rootNodeSchema = builder.struct("root-item", {
 			childrenOne: SchemaBuilder.fieldSequence(childSchema),
-			childrenTwo: SchemaBuilder.fieldValue(numberSchema),
+			childrenTwo: SchemaBuilder.fieldRequired(numberSchema),
 		});
 
-		const schema = builder.intoDocumentSchema(
-			SchemaBuilder.field(FieldKinds.value, rootNodeSchema),
-		);
+		const schema = builder.intoDocumentSchema(SchemaBuilder.fieldRequired(rootNodeSchema));
 
 		sharedTree.schematize({
 			schema,


### PR DESCRIPTION
## Description

Rename "Value" Multiplicity and FieldKind, and modernize schema for test in tree-react-api.

## Breaking Changes

`Multiplicity.Value` has been renamed to `Multiplicity.Single` and `FieldKinds.value` has been renamed to `FieldKinds.required`.

This does not break cross version collaboration or persisted schema since the field kind (including its identifier) is not change: this is an API break only.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
