### PR TITLE
tree2: Move TreeStatus from editable-tree to editable-tree-2

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -19,7 +19,6 @@ import {
 } from "../typed-schema";
 import { EditableTreeEvents } from "../untypedTree";
 import { FieldKinds } from "../default-field-kinds";
-import { TreeStatus } from "../editable-tree";
 import { FieldKind } from "../modular-schema";
 import { TreeContext } from "./context";
 
@@ -71,6 +70,27 @@ export interface Tree<TSchema = unknown> {
 	 * No mutations to the current view of the shared tree are permitted during iteration.
 	 */
 	[boxedIterator](): IterableIterator<Tree>;
+}
+
+/**
+ * Status of the tree that a particular node in {@link EditableTree} and {@link UntypedTree} belongs to.
+ * @alpha
+ */
+export enum TreeStatus {
+	/**
+	 * Is parented under the root field.
+	 */
+	InDocument = 0,
+
+	/**
+	 * Is not parented under the root field, but can be added back to the original document tree.
+	 */
+	Removed = 1,
+
+	/**
+	 * Is removed and cannot be added back to the original document tree.
+	 */
+	Deleted = 2,
 }
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
@@ -22,6 +22,7 @@ export {
 	TypedNodeUnion,
 	boxedIterator,
 	CheckTypesOverlap,
+	TreeStatus,
 } from "./editableTreeTypes";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyEntity.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyEntity.ts
@@ -9,10 +9,9 @@ import {
 	ITreeSubscriptionCursor,
 	ITreeSubscriptionCursorState,
 } from "../../core";
-import { TreeStatus } from "../editable-tree";
 import { fail, disposeSymbol, IDisposable } from "../../util";
 import { Context } from "./context";
-import { Tree, boxedIterator } from "./editableTreeTypes";
+import { Tree, TreeStatus, boxedIterator } from "./editableTreeTypes";
 
 /**
  * Declare an enumerable own property on `T` under the key `key` using the implementation of one on `from`.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -33,7 +33,7 @@ import {
 	fail,
 } from "../../util";
 import { AllowedTypes, FieldSchema } from "../typed-schema";
-import { TreeStatus, treeStatusFromPath } from "../editable-tree";
+import { treeStatusFromPath } from "../editable-tree";
 import { Context } from "./context";
 import {
 	FlexibleNodeContent,
@@ -47,6 +47,7 @@ import {
 	RequiredField,
 	boxedIterator,
 	CheckTypesOverlap,
+	TreeStatus,
 } from "./editableTreeTypes";
 import { makeTree } from "./lazyTree";
 import {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyTree.ts
@@ -35,7 +35,7 @@ import {
 	StructSchema,
 	Any,
 } from "../typed-schema";
-import { TreeStatus, treeStatusFromPath } from "../editable-tree";
+import { treeStatusFromPath } from "../editable-tree";
 import { EditableTreeEvents } from "../untypedTree";
 import { FieldKinds } from "../default-field-kinds";
 import { Context } from "./context";
@@ -51,6 +51,7 @@ import {
 	TreeField,
 	TreeNode,
 	boxedIterator,
+	TreeStatus,
 } from "./editableTreeTypes";
 import { makeField } from "./lazyField";
 import {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -38,6 +38,7 @@ import {
 	ValueFieldEditBuilder,
 } from "../default-field-kinds";
 import { assertValidIndex, fail, assertNonNegativeSafeInteger } from "../../util";
+import { TreeStatus } from "../editable-tree-2";
 import {
 	AdaptingProxyHandler,
 	adaptWithProxy,
@@ -50,7 +51,6 @@ import { ProxyContext } from "./editableTreeContext";
 import {
 	EditableField,
 	EditableTree,
-	TreeStatus,
 	UnwrappedEditableField,
 	UnwrappedEditableTree,
 	proxyTargetSymbol,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -41,6 +41,7 @@ import {
 	contextSymbol,
 	treeStatus,
 } from "../untypedTree";
+import { TreeStatus } from "../editable-tree-2";
 import {
 	AdaptingProxyHandler,
 	adaptWithProxy,
@@ -55,7 +56,6 @@ import {
 	proxyTargetSymbol,
 	localNodeKeySymbol,
 	setField,
-	TreeStatus,
 } from "./editableTreeTypes";
 import { makeField, unwrappedField } from "./editableField";
 import { ProxyTarget } from "./ProxyTarget";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeTypes.ts
@@ -35,27 +35,6 @@ export const localNodeKeySymbol: unique symbol = Symbol("editable-tree:localNode
 export const setField: unique symbol = Symbol("editable-tree:setField()");
 
 /**
- * Status of the tree that a particular node in {@link EditableTree} and {@link UntypedTree} belongs to.
- * @alpha
- */
-export enum TreeStatus {
-	/**
-	 * Is parented under the root field.
-	 */
-	InDocument = 0,
-
-	/**
-	 * Is not parented under the root field, but can be added back to the original document tree.
-	 */
-	Removed = 1,
-
-	/**
-	 * Is removed and cannot be added back to the original document tree.
-	 */
-	Deleted = 2,
-}
-
-/**
  * A tree which can be traversed and edited.
  *
  * When iterating, only visits non-empty fields.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/index.ts
@@ -13,7 +13,6 @@ export {
 	areCursors,
 	localNodeKeySymbol,
 	setField,
-	TreeStatus,
 } from "./editableTreeTypes";
 
 export { isEditableField } from "./editableField";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/utilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/utilities.ts
@@ -17,7 +17,8 @@ import { valueSymbol } from "../contextuallyTyped";
 import { FieldKinds } from "../default-field-kinds";
 import { StableNodeKey } from "../node-key";
 import { getField } from "../untypedTree";
-import { EditableTree, TreeStatus } from "./editableTreeTypes";
+import { TreeStatus } from "../editable-tree-2";
+import { EditableTree } from "./editableTreeTypes";
 
 /**
  * @returns true iff `schema` trees should default to being viewed as just their value when possible.

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -53,7 +53,6 @@ export {
 	comparePipeline,
 	compileSyntaxTree,
 	setField,
-	TreeStatus,
 } from "./editable-tree";
 
 export {
@@ -244,6 +243,7 @@ export {
 	getTreeContext,
 	boxedIterator,
 	CheckTypesOverlap,
+	TreeStatus,
 } from "./editable-tree-2";
 
 // Split into separate import and export for compatibility with API-Extractor.

--- a/experimental/dds/tree2/src/feature-libraries/untypedTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/untypedTree.ts
@@ -17,7 +17,7 @@ import {
 import { ISubscribable } from "../events";
 import { Named } from "../util";
 import { PrimitiveValue, MarkedArrayLike, typeNameSymbol, valueSymbol } from "./contextuallyTyped";
-import { TreeStatus } from "./editable-tree";
+import { TreeStatus } from "./editable-tree-2";
 
 /**
  * This file provides an API for working with trees which is type safe even when schema is not known.


### PR DESCRIPTION
## Description

Move TreeStatus from editable-tree to editable-tree-2 so the old API is not depended on by the new one.

This is one of many steps toward being able to remove the old editable-tree API.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
