### PR TITLE
Session timeout logs

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -714,6 +714,12 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
 		if (this.serviceConfiguration.enableLumberjack) {
 			this.logSessionEndMetrics(closeType);
+			if (!this.globalCheckpointOnly && closeType === LambdaCloseType.ActivityTimeout) {
+				Lumberjack.info(
+					`Closing due to ActivityTimeout before NoClient op`,
+					getLumberBaseProperties(this.documentId, this.tenantId),
+				);
+			}
 		}
 	}
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -714,7 +714,11 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
 		if (this.serviceConfiguration.enableLumberjack) {
 			this.logSessionEndMetrics(closeType);
-			if (!this.globalCheckpointOnly && closeType === LambdaCloseType.ActivityTimeout) {
+			if (
+				this.checkpointService?.localCheckpointEnabled &&
+				!this.globalCheckpointOnly &&
+				closeType === LambdaCloseType.ActivityTimeout
+			) {
 				Lumberjack.info(
 					`Closing due to ActivityTimeout before NoClient op`,
 					getLumberBaseProperties(this.documentId, this.tenantId),


### PR DESCRIPTION
Add logs to check if deli is closing due to inactivity without receiving a NoClient op