### PR TITLE
add generic fuzz test minimization

### DIFF
--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -226,10 +226,9 @@ const baseModel: Omit<
 	minimizationTransforms: [
 		(op) => {
 			if (op.type !== "addText") {
-				return op;
+				return;
 			}
 			op.content = op.content.slice(1);
-			return op;
 		},
 		(op) => {
 			switch (op.type) {
@@ -250,16 +249,14 @@ const baseModel: Omit<
 				default:
 					break;
 			}
-			return op;
 		},
 		(op) => {
 			if (op.type !== "removeRange" && op.type !== "addInterval") {
-				return op;
+				return;
 			}
 			if (op.end > 0) {
 				op.end -= 1;
 			}
-			return op;
 		},
 	],
 };

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -223,6 +223,45 @@ const baseModel: Omit<
 		makeReducer(),
 	validateConsistency: assertEquivalentSharedStrings,
 	factory: new IntervalCollectionFuzzFactory(),
+	minimizationTransforms: [
+		(op) => {
+			if (op.type !== "addText") {
+				return op;
+			}
+			op.content = op.content.slice(1);
+			return op;
+		},
+		(op) => {
+			switch (op.type) {
+				case "addText":
+					if (op.index > 0) {
+						op.index -= 1;
+					}
+					break;
+				case "removeRange":
+				case "addInterval":
+					if (op.start > 0) {
+						op.start -= 1;
+					}
+					if (op.end > 0) {
+						op.end -= 1;
+					}
+					break;
+				default:
+					break;
+			}
+			return op;
+		},
+		(op) => {
+			if (op.type !== "removeRange" && op.type !== "addInterval") {
+				return op;
+			}
+			if (op.end > 0) {
+				op.end -= 1;
+			}
+			return op;
+		},
+	],
 };
 
 const defaultFuzzOptions: Partial<DDSFuzzSuiteOptions> = {

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -999,10 +999,12 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 ): void {
 	const itFn = options.only.has(seed) ? it.only : options.skip.has(seed) ? it.skip : it;
 	itFn(`seed ${seed}`, async () => {
+		// don't write to files or do minimization in CI
+		const inCi = !!process.env.TF_BUILD;
 		try {
-			await runTestForSeed(model, options, seed, saveInfo);
+			await runTestForSeed(model, options, seed, inCi ? undefined : saveInfo);
 		} catch (error) {
-			if (!saveInfo) {
+			if (!saveInfo || inCi) {
 				throw error;
 			}
 

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -21,6 +21,7 @@ import {
 	performFuzzActionsAsync as performFuzzActions,
 	AsyncReducer as Reducer,
 	SaveInfo,
+	saveOpsToFile,
 } from "@fluid-internal/stochastic-test-utils";
 import {
 	MockFluidDataStoreRuntime,
@@ -32,6 +33,7 @@ import {
 import { IChannelFactory, IChannelServices } from "@fluidframework/datastore-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { unreachableCase } from "@fluidframework/core-utils";
+import { FuzzTestMinimizer, MinimizationTransform } from "./minification";
 
 export interface Client<TChannelFactory extends IChannelFactory> {
 	channel: ReturnType<TChannelFactory["create"]>;
@@ -195,6 +197,8 @@ export interface DDSFuzzModel<
 		channelA: ReturnType<TChannelFactory["create"]>,
 		channelB: ReturnType<TChannelFactory["create"]>,
 	) => void;
+
+	minimizationTransforms?: MinimizationTransform<TOperation>[];
 }
 
 export interface DDSFuzzHarnessEvents {
@@ -435,6 +439,10 @@ export function mixinNewClient<
 		};
 	};
 
+	const minimizationTransforms = model.minimizationTransforms as
+		| MinimizationTransform<TOperation | AddClient>[]
+		| undefined;
+
 	const reducer: Reducer<TOperation | AddClient, TState> = async (state, op) => {
 		if (isClientAddOp(op)) {
 			const newClient = await loadClient(
@@ -452,6 +460,7 @@ export function mixinNewClient<
 
 	return {
 		...model,
+		minimizationTransforms,
 		generatorFactory,
 		reducer,
 	};
@@ -487,6 +496,10 @@ export function mixinReconnect<
 		};
 	};
 
+	const minimizationTransforms = model.minimizationTransforms as
+		| MinimizationTransform<TOperation | ChangeConnectionState>[]
+		| undefined;
+
 	const reducer: Reducer<TOperation | ChangeConnectionState, TState> = async (
 		state,
 		operation,
@@ -502,6 +515,7 @@ export function mixinReconnect<
 	};
 	return {
 		...model,
+		minimizationTransforms,
 		generatorFactory,
 		reducer,
 	};
@@ -538,6 +552,10 @@ export function mixinAttach<
 			return baseGenerator(state);
 		};
 	};
+
+	const minimizationTransforms = model.minimizationTransforms as
+		| MinimizationTransform<TOperation | Attach>[]
+		| undefined;
 
 	const reducer: Reducer<TOperation | Attach, TState> = async (state, operation) => {
 		if (operation.type === "attach") {
@@ -581,6 +599,7 @@ export function mixinAttach<
 	};
 	return {
 		...model,
+		minimizationTransforms,
 		generatorFactory,
 		reducer,
 	};
@@ -617,6 +636,10 @@ export function mixinRebase<
 		};
 	};
 
+	const minimizationTransforms = model.minimizationTransforms as
+		| MinimizationTransform<TOperation | TriggerRebase>[]
+		| undefined;
+
 	const reducer: Reducer<TOperation | TriggerRebase, TState> = async (state, operation) => {
 		if (operation.type === "rebase") {
 			assert(
@@ -631,6 +654,7 @@ export function mixinRebase<
 	};
 	return {
 		...model,
+		minimizationTransforms,
 		generatorFactory,
 		reducer,
 	};
@@ -651,6 +675,7 @@ export function mixinSynchronization<
 ): DDSFuzzModel<TChannelFactory, TOperation | Synchronize, TState> {
 	const { validationStrategy } = options;
 	let generatorFactory: () => Generator<TOperation | Synchronize, TState>;
+	// const minimizationTransforms = model.minimizationTransforms as MinimizationTransform<TOperation | Synchronize>[] | undefined;
 	switch (validationStrategy.type) {
 		case "random": {
 			// passing 1 here causes infinite loops. passing close to 1 is wasteful
@@ -721,6 +746,10 @@ export function mixinSynchronization<
 		}
 	}
 
+	const minimizationTransforms = model.minimizationTransforms as
+		| MinimizationTransform<TOperation | Synchronize>[]
+		| undefined;
+
 	const isSynchronizeOp = (op: BaseOperation): op is Synchronize => op.type === "synchronize";
 	const reducer: Reducer<TOperation | Synchronize, TState> = async (state, operation) => {
 		// TODO: Only synchronize listed clients if specified
@@ -751,6 +780,7 @@ export function mixinSynchronization<
 	};
 	return {
 		...model,
+		minimizationTransforms,
 		generatorFactory,
 		reducer,
 	};
@@ -969,7 +999,24 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 ): void {
 	const itFn = options.only.has(seed) ? it.only : options.skip.has(seed) ? it.skip : it;
 	itFn(`seed ${seed}`, async () => {
-		await runTestForSeed(model, options, seed, saveInfo);
+		try {
+			await runTestForSeed(model, options, seed, saveInfo);
+		} catch (error) {
+			if (!saveInfo) {
+				throw error;
+			}
+
+			const operations = JSON.parse(
+				readFileSync(saveInfo.filepath).toString(),
+			) as TOperation[];
+			const minimizer = new FuzzTestMinimizer(model, options, operations, seed, saveInfo, 50);
+
+			const minimized = await minimizer.minimize();
+
+			await saveOpsToFile(saveInfo.filepath, minimized);
+
+			throw error;
+		}
 	});
 }
 

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -675,7 +675,7 @@ export function mixinSynchronization<
 ): DDSFuzzModel<TChannelFactory, TOperation | Synchronize, TState> {
 	const { validationStrategy } = options;
 	let generatorFactory: () => Generator<TOperation | Synchronize, TState>;
-	// const minimizationTransforms = model.minimizationTransforms as MinimizationTransform<TOperation | Synchronize>[] | undefined;
+
 	switch (validationStrategy.type) {
 		case "random": {
 			// passing 1 here causes infinite loops. passing close to 1 is wasteful

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -198,6 +198,13 @@ export interface DDSFuzzModel<
 		channelB: ReturnType<TChannelFactory["create"]>,
 	) => void;
 
+	/**
+	 * An array of transforms used during fuzz test minimization to reduce test
+	 * cases. See {@link MinimizationTransform} for additional context.
+	 *
+	 * If no transforms are supplied, minimization will still occur, but the
+	 * contents of the operations will remain unchanged.
+	 */
 	minimizationTransforms?: MinimizationTransform<TOperation>[];
 }
 

--- a/packages/dds/test-dds-utils/src/minification.ts
+++ b/packages/dds/test-dds-utils/src/minification.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { SaveInfo, makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { BaseOperation, DDSFuzzModel, DDSFuzzSuiteOptions, replayTest } from "./ddsFuzzHarness";
@@ -51,9 +56,6 @@ export class FuzzTestMinimizer<
 		return this.operations;
 	}
 
-	/**
-	 * Remove any superfluous ops
-	 */
 	private async tryDeleteEachOp(): Promise<void> {
 		let idx = this.operations.length - 1;
 

--- a/packages/dds/test-dds-utils/src/minification.ts
+++ b/packages/dds/test-dds-utils/src/minification.ts
@@ -1,0 +1,177 @@
+import { SaveInfo, makeRandom } from "@fluid-internal/stochastic-test-utils";
+import { IChannelFactory } from "@fluidframework/datastore-definitions";
+import { BaseOperation, DDSFuzzModel, DDSFuzzSuiteOptions, replayTest } from "./ddsFuzzHarness";
+
+export type MinimizationTransform<TOperation extends BaseOperation> = (
+	op: TOperation,
+) => TOperation;
+
+export class FuzzTestMinimizer<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+> {
+	private initialErrorMessage: string | undefined;
+	private readonly transforms: MinimizationTransform<TOperation>[];
+	private readonly random = makeRandom();
+
+	constructor(
+		readonly ddsModel: DDSFuzzModel<TChannelFactory, TOperation>,
+		readonly providedOptions: Partial<DDSFuzzSuiteOptions>,
+		readonly operations: TOperation[],
+		readonly seed: number,
+		readonly saveInfo: SaveInfo,
+		readonly numIterations: number = 1000,
+	) {
+		this.transforms = ddsModel.minimizationTransforms ?? [];
+	}
+
+	async minimize(): Promise<TOperation[]> {
+		const firstError = await this.assertFails();
+
+		if (!firstError) {
+			throw new Error("test case doesn't fail.");
+		}
+
+		await this.tryDeleteEachOp();
+
+		if (this.transforms.length === 0) {
+			return this.operations;
+		}
+
+		for (let i = 0; i < this.numIterations; i += 1) {
+			await this.applyRandomTransform();
+			// some minimizations can only occur if two or more ops are modified
+			// at the same time
+			await this.applyNRandomTransforms(2);
+			await this.applyNRandomTransforms(3);
+		}
+
+		await this.tryDeleteEachOp();
+
+		return this.operations;
+	}
+
+	/**
+	 * Remove any superfluous ops
+	 */
+	private async tryDeleteEachOp(): Promise<void> {
+		let idx = this.operations.length - 1;
+
+		while (idx > 0) {
+			const deletedOp = this.operations.splice(idx, 1)[0];
+
+			if (!(await this.assertFails())) {
+				this.operations.splice(idx, 0, deletedOp);
+			}
+
+			idx -= 1;
+		}
+	}
+
+	private async applyRandomTransform(): Promise<void> {
+		const transform = this.random.pick(this.transforms);
+
+		if (!transform) {
+			throw new Error("no transforms passed");
+		}
+
+		const opIdx = this.random.integer(0, this.operations.length - 1);
+
+		await this.applyTransform(transform, opIdx);
+	}
+
+	private async applyNRandomTransforms(n: number): Promise<void> {
+		if (n > this.operations.length) {
+			return;
+		}
+
+		// select `n` random transforms. duplicates are allowed.
+		const transforms = Array.from({ length: n })
+			.fill(undefined)
+			.map(() => this.random.pick(this.transforms));
+
+		// select `n` random operations without duplicates
+		let operationIdxs = [...Array.from({ length: n }).keys()];
+		this.random.shuffle(operationIdxs);
+		operationIdxs = operationIdxs.slice(0, n);
+
+		if (transforms.length !== operationIdxs.length) {
+			throw new Error(
+				`mismatch in number of operations and transforms: ${transforms.length} vs ${operationIdxs.length}`,
+			);
+		}
+
+		const originalOperations: [TOperation, number][] = [];
+
+		for (let i = 0; i < transforms.length; i++) {
+			const transform = transforms[i];
+			const op = this.operations[operationIdxs[i]];
+
+			originalOperations.push([
+				JSON.parse(JSON.stringify(op)) as TOperation,
+				operationIdxs[i],
+			]);
+
+			transform(op);
+		}
+
+		if (!(await this.assertFails())) {
+			for (const [op, idx] of originalOperations) {
+				this.operations[idx] = op;
+			}
+		}
+	}
+
+	private async applyTransform(
+		transform: MinimizationTransform<TOperation>,
+		opIdx: number,
+	): Promise<void> {
+		if (opIdx >= this.operations.length) {
+			throw new Error("invalid op index. this indicates a bug in minimization.");
+		}
+
+		const op = this.operations[opIdx];
+
+		// deep clone the op as transforms may modify by reference
+		const originalOp = JSON.parse(JSON.stringify(op)) as TOperation;
+
+		transform(op);
+
+		if (!(await this.assertFails())) {
+			this.operations[opIdx] = originalOp;
+		}
+	}
+
+	/**
+	 * Returns whether or not the test still fails with the same error message.
+	 *
+	 * We use the simple heuristic of verifying the error message is the same
+	 * to avoid dealing with transforms that would result in invalid ops
+	 */
+	private async assertFails(): Promise<boolean> {
+		try {
+			await replayTest(
+				this.ddsModel,
+				this.seed,
+				this.operations,
+				{
+					saveOnFailure: false,
+					filepath: this.saveInfo?.filepath,
+				},
+				this.providedOptions,
+			);
+			return false;
+		} catch (error: unknown) {
+			if (!error || !(error instanceof Error)) {
+				return false;
+			}
+
+			if (this.initialErrorMessage === undefined) {
+				this.initialErrorMessage = error.message;
+				return true;
+			}
+
+			return error.message === this.initialErrorMessage;
+		}
+	}
+}

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -415,6 +415,7 @@ describe("DDS Fuzz Harness", () => {
 					reducer: async ({ client }) => {
 						reducerSelectionCounts.increment(client.channel.id);
 					},
+					minimizationTransforms: [],
 				},
 				options,
 			);

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -862,15 +862,34 @@ describe("DDS Fuzz Harness", () => {
 				);
 			});
 
-			it("causes failure files to be written to disk", () => {
-				assert(fs.existsSync(path.join(jsonDir, "0.json")));
-				assert(fs.existsSync(path.join(jsonDir, "1.json")));
-				const contents: unknown = JSON.parse(
-					// eslint-disable-next-line unicorn/prefer-json-parse-buffer
-					fs.readFileSync(path.join(jsonDir, "0.json"), { encoding: "utf8" }),
-				);
-				assert.deepEqual(contents, [{ type: "attach" }, { clientId: "B", type: "noop" }]);
-			});
+			const inCi = !!process.env.TF_BUILD;
+			if (inCi) {
+				it("doesn't cause failure files to be written to disk", () => {
+					const file0Exists = fs.existsSync(path.join(jsonDir, "0.json"));
+					const file1Exists = fs.existsSync(path.join(jsonDir, "1.json"));
+
+					// we don't write files in CI to avoid superfluous computation
+					assert(!file0Exists, "expected file0 to not be written in CI");
+					assert(!file1Exists, "expected file0 to not be written in CI");
+				});
+			} else {
+				it("causes failure files to be written to disk", () => {
+					const file0Exists = fs.existsSync(path.join(jsonDir, "0.json"));
+					const file1Exists = fs.existsSync(path.join(jsonDir, "1.json"));
+
+					assert(file0Exists);
+					assert(file1Exists);
+
+					const contents: unknown = JSON.parse(
+						// eslint-disable-next-line unicorn/prefer-json-parse-buffer
+						fs.readFileSync(path.join(jsonDir, "0.json"), { encoding: "utf8" }),
+					);
+					assert.deepEqual(contents, [
+						{ type: "attach" },
+						{ clientId: "B", type: "noop" },
+					]);
+				});
+			}
 		});
 
 		describe("replay", () => {

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/replay.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/replay.ts
@@ -29,6 +29,7 @@ const model: DDSFuzzModel<SharedNothingFactory, Operation> = {
 		// current spec for `replay`: it avoids running other fuzz test seeds/configurations.
 		currentIndex++;
 	},
+	minimizationTransforms: [],
 };
 
 createDDSFuzzSuite(model, {

--- a/packages/dds/test-dds-utils/src/test/sharedNothing.ts
+++ b/packages/dds/test-dds-utils/src/test/sharedNothing.ts
@@ -115,4 +115,5 @@ export const baseModel: DDSFuzzModel<SharedNothingFactory, Operation | ChangeCon
 	generatorFactory: () => noopGenerator,
 	reducer: async (state, op) => {},
 	validateConsistency: () => {},
+	minimizationTransforms: [],
 };

--- a/packages/test/stochastic-test-utils/src/index.ts
+++ b/packages/test/stochastic-test-utils/src/index.ts
@@ -31,7 +31,7 @@ export {
 	takeAsync,
 } from "./generators";
 export { PerformanceWordMarkovChain, SpaceEfficientWordMarkovChain } from "./markovChain";
-export { performFuzzActions, performFuzzActionsAsync } from "./performActions";
+export { performFuzzActions, performFuzzActionsAsync, saveOpsToFile } from "./performActions";
 export { makeRandom } from "./random";
 export {
 	AcceptanceCondition,

--- a/packages/test/stochastic-test-utils/src/performActions.ts
+++ b/packages/test/stochastic-test-utils/src/performActions.ts
@@ -131,7 +131,7 @@ export async function performFuzzActionsAsync<
  * @param filepath - path to the file
  * @param operations - operations to save in the file
  */
-async function saveOpsToFile(filepath: string, operations: { type: string | number }[]) {
+export async function saveOpsToFile(filepath: string, operations: { type: string | number }[]) {
 	await fs.mkdir(path.dirname(filepath), { recursive: true });
 	await fs.writeFile(filepath, JSON.stringify(operations, undefined, 4));
 }


### PR DESCRIPTION
Run basic fuzz test minimization on all failing fuzz tests. 

This change more tightly couples fuzz test minimization to the actual fuzz test running itself, as now that we have more options it becomes necessary to update the minimization tool to also use those same options (e.g. `containerRuntimeOptions` must be the same as the original test run for minimization to be able to reproduce the failure).

The current implementation is a scaled down version of the current implementation in `sequence`. It gets maybe 90% of the way there for all test cases by running the deletion rule and ~50 random transforms. This is sufficient to remove the majority of the noise, but the particulars like the length of the created string may still be sub-optimal. Since this runs on every failure, I wanted for the minimization here to be less expensive.

For minifying tests to be used as unit or regression tests, I usually run a couple thousand iterations of applying a transform as many times as possible to each operation, somewhat skirting the pass ordering problem -- since we have so few ops we can afford to run everything in a for loop a bunch of times. To solve the case in which we want to minimize a test case for a unit test, I want to add an option similar to `skip` that lets one specify particular seeds to minimize fully.

That said, I think this serves as a sufficient baseline change that can be built on, and also makes it easier for me to apply local changes that I need to make some things work.