### PR TITLE
fix (ci): Specify the release group for root package.json changeset script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"build:gendocs": "copyfiles server/routerlicious/_api-extractor-temp/** ./_api-extractor-temp/doc-models/ -f -V && cd docs && npm run build",
 		"bundle-analysis:collect": "npm run webpack:profile && flub generate bundleStats",
 		"bundle-analysis:run": "flub run bundleStats --dangerfile build-tools/packages/build-cli/lib/lib/dangerfile.js",
-		"changeset": "flub changeset add",
+		"changeset": "flub changeset add --releaseGroup client",
 		"check:versions": "flub check buildVersion -g client --path .",
 		"ci:build": "fluid-build --task ci:build",
 		"ci:test:jest": "npm run test:jest:report",


### PR DESCRIPTION
## Description

This PR adds the `--releaseGroup client` flag to the root package.json changeset script.