### PR TITLE
Replace map node field keys with strings

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1257,14 +1257,14 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<UnboxField<TSchema["mapFields"], "notEmpty">>;
     readonly asObject: {
-        readonly [P in FieldKey]?: UnboxField<TSchema["mapFields"]>;
+        readonly [P in string]?: UnboxField<TSchema["mapFields"]>;
     };
-    entries(): IterableIterator<[FieldKey, UnboxField<TSchema["mapFields"]>]>;
-    forEach(callbackFn: (value: UnboxField<TSchema["mapFields"]>, key: FieldKey, map: MapNode<TSchema>) => void, thisArg?: any): void;
-    get(key: FieldKey): UnboxField<TSchema["mapFields"]>;
-    getBoxed(key: FieldKey): TypedField<TSchema["mapFields"]>;
-    has(key: FieldKey): boolean;
-    keys(): IterableIterator<FieldKey>;
+    entries(): IterableIterator<[string, UnboxField<TSchema["mapFields"]>]>;
+    forEach(callbackFn: (value: UnboxField<TSchema["mapFields"]>, key: string, map: MapNode<TSchema>) => void, thisArg?: any): void;
+    get(key: string): UnboxField<TSchema["mapFields"]>;
+    getBoxed(key: string): TypedField<TSchema["mapFields"]>;
+    has(key: string): boolean;
+    keys(): IterableIterator<string>;
     readonly size: number;
     values(): IterableIterator<UnboxField<TSchema["mapFields"]>>;
 }

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1257,14 +1257,14 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<UnboxField<TSchema["mapFields"], "notEmpty">>;
     readonly asObject: {
-        readonly [P in string]?: UnboxField<TSchema["mapFields"]>;
+        readonly [P in FieldKey]?: UnboxField<TSchema["mapFields"]>;
     };
-    entries(): IterableIterator<[string, UnboxField<TSchema["mapFields"]>]>;
-    forEach(callbackFn: (value: UnboxField<TSchema["mapFields"]>, key: string, map: MapNode<TSchema>) => void, thisArg?: any): void;
+    entries(): IterableIterator<[FieldKey, UnboxField<TSchema["mapFields"]>]>;
+    forEach(callbackFn: (value: UnboxField<TSchema["mapFields"]>, key: FieldKey, map: MapNode<TSchema>) => void, thisArg?: any): void;
     get(key: string): UnboxField<TSchema["mapFields"]>;
     getBoxed(key: string): TypedField<TSchema["mapFields"]>;
     has(key: string): boolean;
-    keys(): IterableIterator<string>;
+    keys(): IterableIterator<FieldKey>;
     readonly size: number;
     values(): IterableIterator<UnboxField<TSchema["mapFields"]>>;
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -206,12 +206,7 @@ export interface TreeField extends Tree<FieldSchema> {
 // #region Node Kinds
 
 /**
- * A node that behaves like a `Map<FieldKey, Field>` for a specific `Field` type.
- * @alpha
- */
-
-/**
- * A {@link TreeNode} that behaves like a `Map<FieldKey, Field>` for a specific `Field` type.
+ * A {@link TreeNode} that behaves like a `Map<string, Field>` for a specific `Field` type.
  *
  * @remarks
  * Unlike TypeScript Map type, {@link MapNode.get} always provides a reference to any field looked up, even if it has never been set.
@@ -238,20 +233,14 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 *
 	 * @remarks
 	 * All fields under a map implicitly exist, but `has` will only return true if there are one or more nodes present in the given field.
-	 *
-	 * @privateRemarks
-	 * TODO: Consider changing the key type to `string` for easier use.
 	 */
-	has(key: FieldKey): boolean;
+	has(key: string): boolean;
 
 	/**
 	 * Get the value associated with `key`.
 	 * @param key - which map entry to look up.
-	 *
-	 * @privateRemarks
-	 * TODO: Consider changing the key type to `string` for easier use.
 	 */
-	get(key: FieldKey): UnboxField<TSchema["mapFields"]>;
+	get(key: string): UnboxField<TSchema["mapFields"]>;
 
 	/**
 	 * Get the field for `key`.
@@ -260,11 +249,8 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * @remarks
 	 * All fields under a map implicitly exist, so `get` can be called with any key and will always return a field.
 	 * Even if the field is empty, it will still be returned, and can be edited to insert content into the map.
-	 *
-	 * @privateRemarks
-	 * TODO: Consider changing the key type to `string` for easier use.
 	 */
-	getBoxed(key: FieldKey): TypedField<TSchema["mapFields"]>;
+	getBoxed(key: string): TypedField<TSchema["mapFields"]>;
 
 	/**
 	 * Returns an iterable of keys in the map.
@@ -272,7 +258,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * @remarks
 	 * All fields under a map implicitly exist, but `keys` will yield only the keys of fields which contain one or more nodes.
 	 */
-	keys(): IterableIterator<FieldKey>;
+	keys(): IterableIterator<string>;
 
 	/**
 	 * Returns an iterable of values in the map.
@@ -288,7 +274,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * @remarks
 	 * All fields under a map implicitly exist, but `entries` will yield only the entries whose fields contain one or more nodes.
 	 */
-	entries(): IterableIterator<[FieldKey, UnboxField<TSchema["mapFields"]>]>;
+	entries(): IterableIterator<[string, UnboxField<TSchema["mapFields"]>]>;
 
 	/**
 	 * Executes a provided function once per each key/value pair in the map.
@@ -301,14 +287,14 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	forEach(
 		callbackFn: (
 			value: UnboxField<TSchema["mapFields"]>,
-			key: FieldKey,
+			key: string,
 			map: MapNode<TSchema>,
 		) => void,
 		thisArg?: any,
 	): void;
 
 	// TODO: Add `set` method when FieldKind provides a setter (and derive the type from it).
-	// set(key: FieldKey, content: FlexibleFieldContent<TSchema["mapFields"]>): void;
+	// set(key: string, content: FlexibleFieldContent<TSchema["mapFields"]>): void;
 
 	/**
 	 * Iterate through all fields in the map.
@@ -329,7 +315,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * This object is not guaranteed to be kept up to date across edits and thus should not be held onto across edits.
 	 */
 	readonly asObject: {
-		readonly [P in FieldKey]?: UnboxField<TSchema["mapFields"]>;
+		readonly [P in string]?: UnboxField<TSchema["mapFields"]>;
 	};
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -258,7 +258,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * @remarks
 	 * All fields under a map implicitly exist, but `keys` will yield only the keys of fields which contain one or more nodes.
 	 */
-	keys(): IterableIterator<string>;
+	keys(): IterableIterator<FieldKey>;
 
 	/**
 	 * Returns an iterable of values in the map.
@@ -274,7 +274,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * @remarks
 	 * All fields under a map implicitly exist, but `entries` will yield only the entries whose fields contain one or more nodes.
 	 */
-	entries(): IterableIterator<[string, UnboxField<TSchema["mapFields"]>]>;
+	entries(): IterableIterator<[FieldKey, UnboxField<TSchema["mapFields"]>]>;
 
 	/**
 	 * Executes a provided function once per each key/value pair in the map.
@@ -287,7 +287,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	forEach(
 		callbackFn: (
 			value: UnboxField<TSchema["mapFields"]>,
-			key: string,
+			key: FieldKey,
 			map: MapNode<TSchema>,
 		) => void,
 		thisArg?: any,
@@ -315,7 +315,7 @@ export interface MapNode<TSchema extends MapSchema> extends TreeNode {
 	 * This object is not guaranteed to be kept up to date across edits and thus should not be held onto across edits.
 	 */
 	readonly asObject: {
-		readonly [P in string]?: UnboxField<TSchema["mapFields"]>;
+		readonly [P in FieldKey]?: UnboxField<TSchema["mapFields"]>;
 	};
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
@@ -28,7 +28,6 @@ import {
 	unboxedUnion,
 } from "../../../feature-libraries/editable-tree-2/unboxed";
 import { type TreeContent } from "../../../shared-tree";
-import { brand } from "../../../util";
 import { contextWithContentReadonly } from "./utils";
 
 const rootFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: rootFieldKey };
@@ -185,8 +184,8 @@ describe("unboxedTree", () => {
 
 		const unboxed = unboxedTree(context, mapSchema, cursor);
 		assert.equal(unboxed.size, 2);
-		assert.equal(unboxed.get(brand("foo")), "Hello");
-		assert.equal(unboxed.get(brand("bar")), "world");
+		assert.equal(unboxed.get("foo"), "Hello");
+		assert.equal(unboxed.get("bar"), "world");
 	});
 
 	it("Struct", () => {


### PR DESCRIPTION
## Description

Use simple strings as keys in map nodes so that users don't have to brand their keys.
