### PR TITLE
ci: Label server PRs with API changes as changeset-required

### DIFF
--- a/.github/actions-labeler.yml
+++ b/.github/actions-labeler.yml
@@ -85,3 +85,7 @@ documentation:
 # flag changes to public APIs so they can be reviewed to see if they're breaking
 "public api change":
   - "**/api-report/**"
+
+# Require changesets for server public API changes
+"changeset-required":
+  - "**/routerlicious/api-report/**"


### PR DESCRIPTION
By labeling PRs that change the public server API, which is only two packages, we can encourage folks to add changesets for these changes. Note that adding the label doesn't REQUIRE someone add a changeset. They can still merge without one. It's a strong suggestion, not a requirement.