### PR TITLE
bump mongodb to 4.17.1 to remove the flood warning logs

### DIFF
--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -67,7 +67,7 @@
 		"events": "^3.1.0",
 		"ioredis": "^5.2.3",
 		"lru-cache": "^6.0.0",
-		"mongodb": "4.17.0",
+		"mongodb": "4.17.1",
 		"nconf": "^0.12.0",
 		"socket.io": "^4.5.3",
 		"telegrafjs": "^0.1.3",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -701,7 +701,7 @@ importers:
       ioredis-mock: ^8.2.3
       lru-cache: ^6.0.0
       mocha: ^10.2.0
-      mongodb: 4.17.0
+      mongodb: 4.17.1
       nconf: ^0.12.0
       prettier: ~3.0.3
       redis-commands: ^1.7.0
@@ -729,7 +729,7 @@ importers:
       events: 3.3.0
       ioredis: 5.3.2
       lru-cache: 6.0.0
-      mongodb: 4.17.0
+      mongodb: 4.17.1
       nconf: 0.12.0
       socket.io: 4.6.2
       telegrafjs: 0.1.3
@@ -12299,6 +12299,21 @@ packages:
       '@mongodb-js/saslprep': 1.1.0
     transitivePeerDependencies:
       - aws-crt
+    dev: true
+
+  /mongodb/4.17.1:
+    resolution: {integrity: sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==}
+    engines: {node: '>=12.9.0'}
+    dependencies:
+      bson: 4.7.2
+      mongodb-connection-string-url: 2.6.0
+      socks: 2.7.1
+    optionalDependencies:
+      '@aws-sdk/credential-providers': 3.354.0
+      '@mongodb-js/saslprep': 1.1.0
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
 
   /morgan/1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}


### PR DESCRIPTION
4.17.0 didn't import `saslprep` properly and caused a lot warning. Upgrade to 4.17.1 which fixes this issue