### PR TITLE
Fix FluidDataStoreRuntime.load method

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -113,12 +113,11 @@ export class FluidDataStoreRuntime
 		sharedObjectRegistry: ISharedObjectRegistry,
 		existing: boolean,
 	): FluidDataStoreRuntime {
-		return new FluidDataStoreRuntime(
-			context,
-			sharedObjectRegistry,
-			existing,
-			async (dataStoreRuntime) => dataStoreRuntime.entryPoint,
-		);
+		return new FluidDataStoreRuntime(context, sharedObjectRegistry, existing, () => {
+			throw new UsageError(
+				"FluidDataStoreRuntime.load is deprecated and should no longer be used",
+			);
+		});
 	}
 
 	/**


### PR DESCRIPTION
`FluidDataStoreRuntime.load` is deprecated, so it should throw on `provideEntryPoint` like the deprecated `ContainerRuntime.load` method also does.