### PR TITLE
[main > 7.0] ci: Centralize feed publishing and unify style

### DIFF
--- a/build-tools/packages/build-cli/docs/list.md
+++ b/build-tools/packages/build-cli/docs/list.md
@@ -11,8 +11,9 @@ List packages in a release group in topological order.
 
 ```
 USAGE
-  $ flub list -g client|server|azure|build-tools|gitrest|historian [-v | --quiet] [--json] [--private]
-    [--scope <value> | --skipScope <value>] [--feed official|internal|internal-test] [--tarball]
+  $ flub list -g client|server|azure|build-tools|gitrest|historian [-v | --quiet] [--json] [--feed
+    public|internal-build|internal-test|internal-dev|official|internal] [--private] [--scope <value> | --skipScope
+    <value>] [--tarball]
 
 FLAGS
   -g, --releaseGroup=<option>  (required) Name of a release group.
@@ -26,8 +27,9 @@ LOGGING FLAGS
 
 PACKAGE FILTER FLAGS
   --feed=<option>         Filter the resulting packages to those that should be published to a particular npm feed. Use
-                          'official' for public npm.
-                          <options: official|internal|internal-test>
+                          'public' for public npm. The 'official' and 'internal' values are deprecated and should not be
+                          used.
+                          <options: public|internal-build|internal-test|internal-dev|official|internal>
   --[no-]private          Only include private packages. Use --no-private to exclude private packages instead.
   --scope=<value>...      Package scopes to filter to. If provided, only packages whose scope matches the flag will be
                           included. Cannot be used with --skipScope.

--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -9,12 +9,13 @@ import { filterPackages, parsePackageFilterFlags } from "../filter";
 import { filterFlags, releaseGroupFlag } from "../flags";
 import { PnpmListEntry, pnpmList } from "../pnpm";
 import {
-	packageMayChooseToPublishToInternalFeedOnly,
-	packageMayChooseToPublishToNPM,
-	packageMustPublishToInternalFeedOnly,
-	packageMustPublishToNPM,
+	type Feed,
+	isFeed,
+	packagePublishesToFeed,
+	feeds,
 	// eslint-disable-next-line import/no-internal-modules -- the policy-related stuff will eventually be moved into this package
 } from "@fluidframework/build-tools/dist/repoPolicyCheck/handlers/npmPackages";
+import { Package, PackageNamePolicyConfig } from "@fluidframework/build-tools";
 
 interface ListItem extends PnpmListEntry {
 	tarball?: string;
@@ -33,14 +34,27 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 
 	static flags = {
 		releaseGroup: releaseGroupFlag({ required: true }),
-		...filterFlags,
-		feed: Flags.string({
+		feed: Flags.custom<Feed | undefined>({
 			description:
-				"Filter the resulting packages to those that should be published to a particular npm feed. Use 'official' for public npm.",
-			options: ["official", "internal", "internal-test"],
+				"Filter the resulting packages to those that should be published to a particular npm feed. Use 'public' for public npm. The 'official' and 'internal' values are deprecated and should not be used.",
+			options: [...feeds, "official", "internal"],
 			helpGroup: "PACKAGE FILTER",
 			required: false,
-		}),
+			parse: async (str: string) => {
+				if (isFeed(str)) {
+					return str;
+				}
+				// Handle back-compat values
+				if (str === "official") {
+					return "public";
+				}
+
+				if (str === "internal") {
+					return "internal-build";
+				}
+			},
+		})(),
+		...filterFlags,
 		tarball: Flags.boolean({
 			description:
 				"Return packed tarball names (without extension) instead of package names. @-signs will be removed from the name, and slashes are replaced with dashes.",
@@ -68,28 +82,12 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 					this.error(`No fluid-build package name policy config found.`);
 				}
 
-				const official =
-					packageMustPublishToNPM(item.name, config) ||
-					packageMayChooseToPublishToNPM(item.name, config);
-
-				const internal =
-					packageMustPublishToInternalFeedOnly(item.name, config) ||
-					packageMayChooseToPublishToInternalFeedOnly(item.name, config);
-
-				switch (this.flags.feed) {
-					case "official": {
-						return official;
-					}
-
-					case "internal":
-					case "internal-test": {
-						return official || internal;
-					}
-
-					default: {
-						return true;
-					}
+				if (this.flags.feed === undefined) {
+					return true;
 				}
+
+				const result = packagePublishesToFeed(item.name, config, this.flags.feed);
+				return result;
 			})
 			.map((item) => {
 				// pnpm returns absolute paths, but repo relative is more useful
@@ -109,4 +107,32 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 
 		return filtered;
 	}
+}
+
+/**
+ * Calculates the packages that should be published to a feed and returns a map of Feed to the packages that should be
+ * published there.
+ */
+export function FeedsForPackages(
+	packages: Package[],
+	config: PackageNamePolicyConfig,
+): Map<Feed, Package[]> {
+	const mapping = new Map<Feed, Package[]>();
+	for (const pkg of packages) {
+		for (const feed of feeds) {
+			let pkgList = mapping.get(feed);
+			if (pkgList === undefined) {
+				pkgList = [];
+			}
+
+			if (!mapping.has(feed)) {
+				mapping.set(feed, []);
+			}
+
+			if (packagePublishesToFeed(pkg.name, config, feed)) {
+				mapping.get(feed)?.push(pkg);
+			}
+		}
+	}
+	return mapping;
 }

--- a/build-tools/packages/build-cli/test/commands/list.test.ts
+++ b/build-tools/packages/build-cli/test/commands/list.test.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { expect } from "chai";
+import { Context, GitRepo, getResolvedFluidRoot } from "@fluidframework/build-tools";
+import { FeedsForPackages } from "../../src/commands/list";
+
+describe("feeds", async () => {
+	const resolvedRoot = await getResolvedFluidRoot();
+	const gitRepo = new GitRepo(resolvedRoot);
+	const branch = await gitRepo.getCurrentBranchName();
+
+	const context = new Context(gitRepo, "microsoft/FluidFramework", branch);
+	const config = context.rootFluidBuildConfig?.policy?.packageNames!;
+	const packages = FeedsForPackages(context.packages, config);
+
+	it("dev and build feed are mutually exclusive", () => {
+		const dev = packages.get("internal-dev")?.map((p) => p.name);
+		const build = packages.get("internal-build")?.map((p) => p.name);
+
+		const hasDupes = build?.some((name) => {
+			return dev?.includes(name);
+		});
+
+		expect(hasDupes).to.be.false;
+	});
+});

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -25,10 +25,9 @@ if [ -f ".releaseGroup" ]; then
 
   # This saves a list of the packages in the working directory in topological order to a temporary file.
   # Each package name is modified to match the packed tar files.
-  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball > $STAGING_PATH/pack/packagePublishOrder.txt
-
-  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed official > $STAGING_PATH/pack/packagePublishOrder-official.txt
-  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed internal > $STAGING_PATH/pack/packagePublishOrder-internal.txt
+  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed public > $STAGING_PATH/pack/packagePublishOrder-public.txt
+  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed internal-build > $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
+  flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed internal-dev > $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
   flub list --no-private --releaseGroup $RELEASE_GROUP --tarball --feed internal-test > $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
 
 else

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -10,10 +10,7 @@ parameters:
 - name: feedKind
   type: string
 
-- name: feedName
-  type: string
-
-- name: devFeedName
+- name: feedUrl
   type: string
 
 - name: environment
@@ -60,8 +57,7 @@ jobs:
             parameters:
               namespace: ${{ parameters.namespace }}
               artifactPath: scoped
-              devFeedName: ${{ parameters.devFeedName }}
-              feedName: ${{ parameters.feedName }}
+              feedUrl: ${{ parameters.feedUrl }}
               customEndPoint: ${{ parameters.customEndPoint }}
               feedKind: ${{ parameters.feedKind }}
               publishFlags: ${{ parameters.publishFlags }}
@@ -70,8 +66,7 @@ jobs:
               parameters:
                 namespace: false
                 artifactPath: non-scoped
-                devFeedName: ${{ parameters.devFeedName }}
-                feedName: ${{ parameters.feedName }}
+                feedUrl: ${{ parameters.feedUrl }}
                 feedKind: ${{ parameters.feedKind }}
                 customEndPoint: ${{ parameters.customEndPoint }}
                 publishFlags: ${{ parameters.publishFlags }}

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -7,10 +7,7 @@ parameters:
 - name: namespace
   type: boolean
 
-- name: feedName
-  type: string
-
-- name: devFeedName
+- name: feedUrl
   type: string
 
 - name: feedKind
@@ -34,29 +31,32 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     ${{ if eq(parameters.namespace, true) }}:
-      ${{ if ne(parameters.feedKind, 'official') }}:
+      ${{ if ne(parameters.feedKind, 'public') }}:
         script: |
-          echo Generating .npmrc for ${{ parameters.feedName }}
-          echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-example:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-internal:registry=${{ parameters.devFeedName }}" >> ./.npmrc
-          echo "@fluid-experimental:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
+          echo Generating .npmrc for ${{ parameters.feedUrl }}
+          echo "@fluidframework:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-example:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-internal:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-private:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-experimental:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-tools:registry=${{ parameters.feedUrl }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
-      ${{ if eq(parameters.feedKind, 'official') }}:
+      ${{ if eq(parameters.feedKind, 'public') }}:
+        # The official feed excludes @fluid-example and @fluid-private. While earlier steps should also exclude these
+        # packages, excluding those scopes here is an additional defense.
         script: |
-          echo Generating .npmrc for ${{ parameters.feedName }}
-          echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-experimental:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-internal:registry=${{ parameters.feedName }}" >> ./.npmrc
+          echo Generating .npmrc for ${{ parameters.feedUrl }}
+          echo "@fluidframework:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-experimental:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-tools:registry=${{ parameters.feedUrl }}" >> ./.npmrc
+          echo "@fluid-internal:registry=${{ parameters.feedUrl }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
     ${{ if eq(parameters.namespace, false) }}:
       script: |
-        echo Generating .npmrc for ${{ parameters.feedName }}
-        echo "registry=${{ parameters.feedName }}" >> ./.npmrc
+        echo Generating .npmrc for ${{ parameters.feedUrl }}
+        echo "registry=${{ parameters.feedUrl }}" >> ./.npmrc
         echo "always-auth=true" >> ./.npmrc
         cat .npmrc
 - task: npmAuthenticate@0
@@ -149,7 +149,7 @@ steps:
                   done
                 fi
 
-                baseURL="${${{ parameters.feedName }}%/registry/}"
+                baseURL="${${{ parameters.feedUrl }}%/registry/}"
                 feedPromotionUrl="${baseURL/_packaging/_apis/packaging/feeds}"
 
                 response=$(curl -f -s -X PATCH \

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -52,6 +52,7 @@ stages:
       namespace: ${{ parameters.namespace }}
       feedUrl: $(ado-feeds-build) # Comes from the ado-feeds variable group
       feedKind: internal-build
+      # Environment should match the condition for publish_npm_internal_dev
       environment: package-build-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
@@ -69,7 +70,8 @@ stages:
       namespace: ${{ parameters.namespace }}
       feedUrl: $(ado-feeds-dev) # Comes from the ado-feeds variable group
       feedKind: internal-dev
-      environment: test-package-build-feed
+      # Environment should match the condition for publish_npm_internal_build
+      environment: package-build-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
 

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -19,9 +19,11 @@ parameters:
   default: Small
 
 stages:
+
+# This stage only runs for test-branch builds
 - stage: publish_npm_internal_test
   dependsOn: build
-  displayName: Publish Internal Test Packages
+  displayName: Publish internal test feed
   condition: and(succeeded(), eq(variables['testBuild'], true))
   variables:
   - group: ado-feeds
@@ -29,16 +31,18 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: $(ado-feeds-test) # Comes from the ado-feeds variable group
-      feedName: $(ado-feeds-test) # Comes from the ado-feeds variable group
+      feedUrl: $(ado-feeds-test) # Comes from the ado-feeds variable group
       feedKind: internal-test
       environment: test-package-build-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
 
-- stage: publish_npm_internal
+# This stage and the following stage both run for non-test builds. The build feed is equivalent to the public npmjs.org
+# feed except it contains builds for every main- or next-branch build.
+- stage: publish_npm_internal_build
   dependsOn: build
-  displayName: Publish Internal Packages
+  displayName: Publish to internal build feed
+  # This condition should match the condition for publish_npm_internal_dev
   condition: and(succeeded(), eq(variables['testBuild'], false))
   variables:
   - group: ado-feeds
@@ -46,16 +50,32 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
-      feedName: $(ado-feeds-build) # Comes from the ado-feeds variable group
-      feedKind: internal
+      feedUrl: $(ado-feeds-build) # Comes from the ado-feeds variable group
+      feedKind: internal-build
       environment: package-build-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
 
-- stage: publish_npm_official
+- stage: publish_npm_internal_dev
   dependsOn: build
-  displayName: Publish Official Packages
+  displayName: Publish to internal dev feed
+  # This condition should match the condition for publish_npm_internal_build
+  condition: and(succeeded(), eq(variables['testBuild'], false))
+  variables:
+  - group: ado-feeds
+  jobs:
+  - template: include-publish-npm-package-deployment.yml
+    parameters:
+      namespace: ${{ parameters.namespace }}
+      feedUrl: $(ado-feeds-dev) # Comes from the ado-feeds variable group
+      feedKind: internal-dev
+      environment: test-package-build-feed
+      pool: ${{ parameters.pool }}
+      publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}
+
+- stage: publish_npm_public
+  dependsOn: build
+  displayName: Publish to public npmjs.org
   condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
   variables:
   - group: ado-feeds
@@ -63,11 +83,8 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      # internal/example packages are deleted for official releases, but in case something goes wrong with that,
-      # using the `dev` registry is safe.
-      devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
-      feedName: https://registry.npmjs.org
-      feedKind: official
+      feedUrl: https://registry.npmjs.org
+      feedKind: public
       environment: package-npmjs-feed
       pool: ${{ parameters.pool }}
       publishNonScopedPackages: ${{ parameters.publishNonScopedPackages }}


### PR DESCRIPTION
Cherry-pick pipeline fixes in https://github.com/microsoft/FluidFramework/pull/17608 and https://github.com/microsoft/FluidFramework/pull/17625 to the 7.0 release branch.