### PR TITLE
Reduce the number of cache reads and writes in OpsCache

### DIFF
--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -119,7 +119,7 @@ async function runTestNoTimer(
 	cache.addOps(mockData);
 
 	const writes = mockCache.writeCount;
-	assert.equal(writes, initialWritesExpected);
+	assert.equal(writes, initialWritesExpected, "initialWrites should match");
 
 	// Validate that writing same ops is not going to change anything
 	cache.addOps(mockData);
@@ -134,7 +134,11 @@ async function runTestNoTimer(
 	// ensure adding same ops and flushing again is doing nothing
 	cache.addOps(mockData);
 	cache.flushOps();
-	assert.equal(mockCache.opsWritten, totalOpsWritten ?? mockData.length);
+	assert.equal(
+		mockCache.opsWritten,
+		totalOpsWritten ?? mockData.length,
+		"ops written does not match",
+	);
 	logger.assertMatchNone([{ category: "error" }]);
 }
 
@@ -241,6 +245,47 @@ describe("OpsCache", () => {
 			},
 			1,
 			2,
+		);
+	});
+
+	it("Epmty ops at beginning and end of batch should cause the batch to not be cached", async () => {
+		await runTest(
+			5,
+			100,
+			[
+				{ sequenceNumber: 101, data: "101" },
+				{ sequenceNumber: 102, data: "102" },
+				{ sequenceNumber: 103, data: "103" },
+			],
+			{},
+			0,
+			0,
+			0,
+		);
+	});
+
+	it("Epmty ops at just the beginning should still cause the batch to be cached", async () => {
+		await runTest(
+			5,
+			100,
+			[
+				{ sequenceNumber: 101, data: "101" },
+				{ sequenceNumber: 102, data: "102" },
+				{ sequenceNumber: 103, data: "103" },
+				{ sequenceNumber: 104, data: "104" },
+			],
+			{
+				"5_20": [
+					undefined,
+					{ sequenceNumber: 101, data: "101" },
+					{ sequenceNumber: 102, data: "102" },
+					{ sequenceNumber: 103, data: "103" },
+					{ sequenceNumber: 104, data: "104" },
+				],
+			},
+			1,
+			1,
+			4,
 		);
 	});
 


### PR DESCRIPTION
## Description

ADO task link: https://dev.azure.com/fluidframework/internal/_workitems/edit/5556

Reduce cache reads by bailing out early if we don't get any ops from the current batch.

Reduce the number of cache write by not flushing out an empty batch or a batch which has empty slots at both start and end as this will mostly not satisfy the need during read.