### PR TITLE
Add scopes to Alfred-Historian token

### DIFF
--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { ScopeType } from "@fluidframework/protocol-definitions";
 import {
 	GitManager,
 	Historian,
@@ -109,7 +110,11 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 		};
 		const getDefaultHeaders = () => {
 			const credentials: ICredentials = {
-				password: generateToken(tenantId, documentId, key, null),
+				password: generateToken(tenantId, documentId, key, [
+					ScopeType.DocWrite,
+					ScopeType.DocRead,
+					ScopeType.SummaryWrite,
+				]),
 				user: tenantId,
 			};
 			const headers: RawAxiosRequestHeaders = {


### PR DESCRIPTION
## Description

#17522 began enforcing the same JWT token claims requirements for Historian as are in Alfred. However, Alfred explicitly sets `claims.scopes` to `null`, which causes Historian to complain during document creation and summary writes.

Instead of going back to allowing `null` scopes, I'm fixing forward by adding scopes to service-generated tokens.
