### PR TITLE
build: Update dependencies on `@fluidframework/build-common` to `2.0.1`

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.0.0",
 		"@fluidframework/azure-local-service": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/counter": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.0.0",
 		"@fluidframework/azure-local-service": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/counter": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -36,7 +36,7 @@
 		"tinylicious": "^2.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -36,7 +36,7 @@
 		"tinylicious": "^2.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -43,7 +43,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -43,7 +43,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@fluid-experimental/devtools": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@fluid-experimental/devtools": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -80,7 +80,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/mocha": "^9.1.1",

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -80,7 +80,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/mocha": "^9.1.1",

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -88,7 +88,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/js-yaml": "^4.0.5",

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -88,7 +88,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/js-yaml": "^4.0.5",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -71,7 +71,7 @@
 		"@commitlint/config-conventional": "^17.6.6",
 		"@commitlint/cz-commitlint": "^17.5.0",
 		"@fluid-tools/build-cli": "~0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "~0.25.0",
 		"@microsoft/api-documenter": "^7.22.24",
 		"@microsoft/api-extractor": "^7.36.1",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -71,7 +71,7 @@
 		"@commitlint/config-conventional": "^17.6.6",
 		"@commitlint/cz-commitlint": "^17.5.0",
 		"@fluid-tools/build-cli": "~0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "~0.25.0",
 		"@microsoft/api-documenter": "^7.22.24",
 		"@microsoft/api-extractor": "^7.36.1",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -111,7 +111,7 @@
 	},
 	"devDependencies": {
 		"@fluid-private/readme-command": "workspace:*",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@types/async": "^3.2.20",
 		"@types/chai": "^4.3.5",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -111,7 +111,7 @@
 	},
 	"devDependencies": {
 		"@fluid-private/readme-command": "workspace:*",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@types/async": "^3.2.20",
 		"@types/chai": "^4.3.5",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -70,7 +70,7 @@
 		"yaml": "^2.3.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@types/async": "^3.2.20",
 		"@types/fs-extra": "^8.1.2",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -70,7 +70,7 @@
 		"yaml": "^2.3.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@types/async": "^3.2.20",
 		"@types/fs-extra": "^8.1.2",

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -38,7 +38,7 @@
 		"webpack": "^5.88.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@types/msgpack-lite": "^0.1.8",

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -38,7 +38,7 @@
 		"webpack": "^5.88.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@types/msgpack-lite": "^0.1.8",

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -48,7 +48,7 @@
 		"semver": "^7.5.4"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@types/chai": "^4.3.5",
 		"@types/chai-arrays": "^2.0.0",

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -48,7 +48,7 @@
 		"semver": "^7.5.4"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@types/chai": "^4.3.5",
 		"@types/chai-arrays": "^2.0.0",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-private/readme-command": "workspace:*",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@oclif/test": "^2.3.27",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-private/readme-command": "workspace:*",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@oclif/test": "^2.3.27",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@commitlint/config-conventional': ^17.6.6
       '@commitlint/cz-commitlint': ^17.5.0
       '@fluid-tools/build-cli': ~0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ~0.25.0
       '@microsoft/api-documenter': ^7.22.24
       '@microsoft/api-extractor': ^7.36.1
@@ -59,7 +59,7 @@ importers:
     specifiers:
       '@fluid-private/readme-command': workspace:*
       '@fluid-tools/version-tools': workspace:*
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': workspace:*
       '@fluidframework/bundle-size-tools': workspace:*
       '@fluidframework/eslint-config-fluid': ^2.1.0
@@ -213,7 +213,7 @@ importers:
   packages/build-tools:
     specifiers:
       '@fluid-tools/version-tools': workspace:*
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/bundle-size-tools': workspace:*
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@manypkg/get-packages': ^2.2.0
@@ -317,7 +317,7 @@ importers:
 
   packages/bundle-size-tools:
     specifiers:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@microsoft/api-extractor': ^7.36.1
       '@types/msgpack-lite': ^0.1.8
@@ -364,7 +364,7 @@ importers:
 
   packages/readme-command:
     specifiers:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@oclif/core': ^2.8.11
       '@oclif/plugin-help': ^5.2.11
@@ -422,7 +422,7 @@ importers:
   packages/version-tools:
     specifiers:
       '@fluid-private/readme-command': workspace:*
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@microsoft/api-extractor': ^7.36.1
       '@oclif/core': ^2.8.11

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@commitlint/config-conventional': ^17.6.6
       '@commitlint/cz-commitlint': ^17.5.0
       '@fluid-tools/build-cli': ~0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ~0.25.0
       '@microsoft/api-documenter': ^7.22.24
       '@microsoft/api-extractor': ^7.36.1
@@ -36,7 +36,7 @@ importers:
       '@commitlint/config-conventional': 17.6.6
       '@commitlint/cz-commitlint': 17.5.0_i4x6owxztfhigiiqlxwntt4k24
       '@fluid-tools/build-cli': 0.25.0_typescript@5.1.6
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@microsoft/api-documenter': 7.22.24
       '@microsoft/api-extractor': 7.36.1
@@ -59,7 +59,7 @@ importers:
     specifiers:
       '@fluid-private/readme-command': workspace:*
       '@fluid-tools/version-tools': workspace:*
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': workspace:*
       '@fluidframework/bundle-size-tools': workspace:*
       '@fluidframework/eslint-config-fluid': ^2.1.0
@@ -176,7 +176,7 @@ importers:
       type-fest: 2.19.0
     devDependencies:
       '@fluid-private/readme-command': link:../readme-command
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@types/async': 3.2.20
       '@types/chai': 4.3.5
@@ -213,7 +213,7 @@ importers:
   packages/build-tools:
     specifiers:
       '@fluid-tools/version-tools': workspace:*
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/bundle-size-tools': workspace:*
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@manypkg/get-packages': ^2.2.0
@@ -296,7 +296,7 @@ importers:
       typescript: 5.1.6
       yaml: 2.3.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@types/async': 3.2.20
       '@types/fs-extra': 8.1.2
@@ -317,7 +317,7 @@ importers:
 
   packages/bundle-size-tools:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@microsoft/api-extractor': ^7.36.1
       '@types/msgpack-lite': ^0.1.8
@@ -346,7 +346,7 @@ importers:
       typescript: 5.1.6
       webpack: 5.88.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
       '@types/msgpack-lite': 0.1.8
@@ -364,7 +364,7 @@ importers:
 
   packages/readme-command:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@oclif/core': ^2.8.11
       '@oclif/plugin-help': ^5.2.11
@@ -398,7 +398,7 @@ importers:
       oclif: 3.9.1_vliugzio5c6rxk3co27b7rq74a
       semver: 7.5.4
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@types/chai': 4.3.5
       '@types/chai-arrays': 2.0.0
@@ -422,7 +422,7 @@ importers:
   packages/version-tools:
     specifiers:
       '@fluid-private/readme-command': workspace:*
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@microsoft/api-extractor': ^7.36.1
       '@oclif/core': ^2.8.11
@@ -470,7 +470,7 @@ importers:
       table: 6.8.1
     devDependencies:
       '@fluid-private/readme-command': link:../readme-command
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.1.0_qvtltsyn3reahc7lgycismcfiq
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
       '@oclif/test': 2.3.27_vliugzio5c6rxk3co27b7rq74a
@@ -865,8 +865,8 @@ packages:
       - '@swc/wasm'
     dev: true
 
-  /@commitlint/load/17.7.1:
-    resolution: {integrity: sha512-S/QSOjE1ztdogYj61p6n3UbkUvweR17FQ0zDbNtoTLc+Hz7vvfS7ehoTMQ27hPSjVBpp7SzEcOQu081RLjKHJQ==}
+  /@commitlint/load/17.7.2:
+    resolution: {integrity: sha512-XA7WTnsjHZ4YH6ZYsrnxgLdXzriwMMq+utZUET6spbOEEIPBCDLdOQXS26P+v3TTO4hUHOEhzUquaBv3jbBixw==}
     engines: {node: '>=v14'}
     requiresBuild: true
     dependencies:
@@ -874,15 +874,15 @@ packages:
       '@commitlint/execute-rule': 17.4.0
       '@commitlint/resolve-extends': 17.6.7
       '@commitlint/types': 17.4.4
-      '@types/node': 20.4.7
+      '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.2.0
-      cosmiconfig-typescript-loader: 4.2.0_mrt2wnih5zjrgf7emf6zukdxaq
+      cosmiconfig-typescript-loader: 4.2.0_2i75q7fwhwfiv6j6cyvrfuvxre
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1_dvq55o6ihfzbtkatyu52wpt2ee
+      ts-node: 10.9.1_nlfdnzsudxdzt42qyp5hqbr53u
       typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
@@ -1097,8 +1097,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -2497,8 +2497,8 @@ packages:
   /@types/node/15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
 
-  /@types/node/20.4.7:
-    resolution: {integrity: sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==}
+  /@types/node/20.5.1:
+    resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
     optional: true
 
@@ -4211,7 +4211,7 @@ packages:
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader/4.2.0_mrt2wnih5zjrgf7emf6zukdxaq:
+  /cosmiconfig-typescript-loader/4.2.0_2i75q7fwhwfiv6j6cyvrfuvxre:
     resolution: {integrity: sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -4223,9 +4223,9 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.4.7
+      '@types/node': 20.5.1
       cosmiconfig: 8.2.0
-      ts-node: 10.9.1_dvq55o6ihfzbtkatyu52wpt2ee
+      ts-node: 10.9.1_nlfdnzsudxdzt42qyp5hqbr53u
       typescript: 5.1.6
     dev: true
     optional: true
@@ -4313,7 +4313,7 @@ packages:
       longest: 2.0.1
       word-wrap: 1.2.3
     optionalDependencies:
-      '@commitlint/load': 17.7.1
+      '@commitlint/load': 17.7.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -10120,7 +10120,7 @@ packages:
       '@ts-morph/common': 0.18.1
       code-block-writer: 11.0.3
 
-  /ts-node/10.9.1_dvq55o6ihfzbtkatyu52wpt2ee:
+  /ts-node/10.9.1_nlfdnzsudxdzt42qyp5hqbr53u:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10141,7 +10141,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 20.4.7
+      '@types/node': 20.5.1
       acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -43,7 +43,7 @@
 		"eslint-plugin-unused-imports": "~3.0.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.49.0",
 		"prettier": "~3.0.3",

--- a/common/build/eslint-config-fluid/pnpm-lock.yaml
+++ b/common/build/eslint-config-fluid/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@rushstack/eslint-patch': ~1.4.0
       '@rushstack/eslint-plugin': ~0.13.0
       '@rushstack/eslint-plugin-security': ~0.7.0
@@ -42,7 +42,7 @@ importers:
       eslint-plugin-unicorn: 48.0.1_eslint@8.49.0
       eslint-plugin-unused-imports: 3.0.0_xmpxy5vxwoyu2njpjt6m3zinx4
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       concurrently: 8.2.1
       eslint: 8.49.0
       prettier: 3.0.3
@@ -126,8 +126,8 @@ packages:
     resolution: {integrity: sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -37,10 +37,9 @@
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub generate typetests --prepare --dir ."
 	},
-	"dependencies": {},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@0.20.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/common/lib/common-definitions/pnpm-lock.yaml
+++ b/common/lib/common-definitions/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions-previous': npm:@fluidframework/common-definitions@0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -21,7 +21,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_vy4ah4eawmaxtqslmps6irc47e
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/common-definitions-previous': /@fluidframework/common-definitions/0.20.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -264,8 +264,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -85,7 +85,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",

--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions': ^1.0.0
       '@fluidframework/common-utils-previous': npm:@fluidframework/common-utils@1.0.0
@@ -58,7 +58,7 @@ importers:
       sha.js: 2.4.11
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_vy4ah4eawmaxtqslmps6irc47e
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/common-utils-previous': /@fluidframework/common-utils/1.0.0
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -632,8 +632,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -3935,7 +3935,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr/1.1.4:
@@ -6110,8 +6110,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -7674,7 +7674,7 @@ packages:
       sane: 4.1.0
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@2.0.0",

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -24,7 +24,7 @@ importers:
       '@fluidframework/common-definitions': 1.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/2.0.0
@@ -267,8 +267,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -66,7 +66,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -66,7 +66,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -51,7 +51,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -51,7 +51,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/express": "^4.11.0",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/express": "^4.11.0",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -53,7 +53,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -53,7 +53,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/codemirror": "5.60.7",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/codemirror": "5.60.7",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/react": "^17.0.44",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/react": "^17.0.44",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -66,7 +66,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -66,7 +66,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -59,7 +59,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/events": "^3.0.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -59,7 +59,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/events": "^3.0.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-version-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-version-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -92,7 +92,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-version-utils": "workspace:~",
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -92,7 +92,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-version-utils": "workspace:~",
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -82,7 +82,7 @@
 		"valid-url": "^1.0.9"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -82,7 +82,7 @@
 		"valid-url": "^1.0.9"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@cerner/duplicate-package-checker-webpack-plugin": "^2.3.0",
 		"@fluid-tools/version-tools": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/bundle-size-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@cerner/duplicate-package-checker-webpack-plugin": "^2.3.0",
 		"@fluid-tools/version-tools": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/bundle-size-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -76,7 +76,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -76,7 +76,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -78,7 +78,7 @@
 		"react-virtualized-auto-sizer": "^1.0.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -78,7 +78,7 @@
 		"react-virtualized-auto-sizer": "^1.0.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -29,7 +29,7 @@
 		"tsc": "tsc"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -29,7 +29,7 @@
 		"tsc": "tsc"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -78,7 +78,7 @@
 		"@babel/plugin-proposal-decorators": "^7.20.4",
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.2.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -78,7 +78,7 @@
 		"@babel/plugin-proposal-decorators": "^7.20.4",
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.2.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -70,7 +70,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/lodash": "^4.14.118",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -70,7 +70,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/lodash": "^4.14.118",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -65,7 +65,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -65,7 +65,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@fluid-experimental/property-common": "workspace:~",
 		"@fluid-internal/test-drivers": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@fluid-experimental/property-common": "workspace:~",
 		"@fluid-internal/test-drivers": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -65,7 +65,7 @@
 		"@fluid-experimental/property-properties": "workspace:~",
 		"@fluid-experimental/property-proxy": "workspace:~",
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@storybook/addon-actions": "^6.4.22",
 		"@storybook/addon-essentials": "^6.4.22",

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -65,7 +65,7 @@
 		"@fluid-experimental/property-properties": "workspace:~",
 		"@fluid-experimental/property-proxy": "workspace:~",
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@storybook/addon-actions": "^6.4.22",
 		"@storybook/addon-essentials": "^6.4.22",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -71,7 +71,7 @@
 		"underscore": "^1.13.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -71,7 +71,7 @@
 		"underscore": "^1.13.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -44,7 +44,7 @@
 		"@babel/core": "^7.13.0",
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.2.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -44,7 +44,7 @@
 		"@babel/core": "^7.13.0",
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.2.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
@@ -38,7 +38,7 @@
 		"@fluidframework/core-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
@@ -38,7 +38,7 @@
 		"@fluidframework/core-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@types/jest": "29.5.3",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -78,7 +78,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -78,7 +78,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -70,7 +70,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -70,7 +70,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -59,7 +59,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-drivers": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -59,7 +59,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-drivers": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -85,7 +85,7 @@
 		"@fluid-internal/test-drivers": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -85,7 +85,7 @@
 		"@fluid-internal/test-drivers": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -62,7 +62,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -62,7 +62,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -67,7 +67,7 @@
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -67,7 +67,7 @@
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"@changesets/cli": "^2.26.1",
 		"@fluid-private/changelog-generator-wrapper": "file:tools/changelog-generator-wrapper",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"@changesets/cli": "^2.26.1",
 		"@fluid-private/changelog-generator-wrapper": "file:tools/changelog-generator-wrapper",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -64,7 +64,7 @@
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.47.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -64,7 +64,7 @@
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.47.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -71,7 +71,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -71,7 +71,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.0.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.0.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -80,7 +80,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.0.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -80,7 +80,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.0.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -80,7 +80,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.0.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -80,7 +80,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.0.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -81,7 +81,7 @@
 		"@fluid-internal/test-pairwise-generator": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.0.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -81,7 +81,7 @@
 		"@fluid-internal/test-pairwise-generator": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.0.0",

--- a/packages/dds/migration-shim/package.json
+++ b/packages/dds/migration-shim/package.json
@@ -73,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/migration-shim/package.json
+++ b/packages/dds/migration-shim/package.json
@@ -73,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -73,7 +73,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -73,7 +73,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -69,7 +69,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -69,7 +69,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -72,7 +72,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -72,7 +72,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -86,7 +86,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -86,7 +86,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -75,7 +75,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -75,7 +75,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.0.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.0.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.0.0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.0.0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.0.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.0.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.0.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -79,7 +79,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -79,7 +79,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -83,7 +83,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -83,7 +83,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -75,7 +75,7 @@
 	"devDependencies": {
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -75,7 +75,7 @@
 	"devDependencies": {
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -42,7 +42,7 @@
 		"@microsoft/applicationinsights-web": "^2.8.11"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -42,7 +42,7 @@
 		"@microsoft/applicationinsights-web": "^2.8.11"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -73,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.0.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -73,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.0.0",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -63,7 +63,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -63,7 +63,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/datastore": "workspace:~",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/datastore": "workspace:~",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.0.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.0.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.0.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -75,7 +75,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -75,7 +75,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.0.0",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.0.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"eslint": "~8.50.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"eslint": "~8.50.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -84,7 +84,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -84,7 +84,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.0.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.0.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.0.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -72,7 +72,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -72,7 +72,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -56,7 +56,7 @@
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-internal/test-pairwise-generator": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/cell": "workspace:~",
 		"@fluidframework/container-definitions": "workspace:~",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -56,7 +56,7 @@
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-internal/test-pairwise-generator": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/cell": "workspace:~",
 		"@fluidframework/container-definitions": "workspace:~",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.0.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.0.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.48.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.48.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -37,7 +37,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -37,7 +37,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.0.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.0.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -75,7 +75,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -75,7 +75,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -125,7 +125,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -125,7 +125,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -105,7 +105,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -105,7 +105,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -84,7 +84,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -84,7 +84,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -86,7 +86,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -86,7 +86,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -83,7 +83,7 @@
 		"@fluid-example/example-utils": "workspace:~",
 		"@fluid-experimental/react-inputs": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -83,7 +83,7 @@
 		"@fluid-example/example-utils": "workspace:~",
 		"@fluid-experimental/react-inputs": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.0.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.0.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -70,7 +70,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -70,7 +70,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -64,7 +64,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -64,7 +64,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.0.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.0.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -48,7 +48,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -48,7 +48,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.0.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.0.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -64,7 +64,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -64,7 +64,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.0.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -74,7 +74,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -74,7 +74,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "2.0.1",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,16 @@
 lockfileVersion: 5.4
 
+overrides:
+  '@microsoft/api-extractor>typescript': ~5.1.6
+  '@types/node': ^16.18.38
+  node-fetch: ^2.6.9
+  good-fences>nodegit: npm:empty-npm-package@1.0.0
+  qs: ^6.11.0
+  simplemde>codemirror: ^5.65.11
+  simplemde>marked: ^4.3.0
+  '@fluidframework/build-tools>npm-package-json-lint@^6.0.0': ~6.3.0
+  '@oclif/core': ~2.4.0
+
 importers:
 
   .:
@@ -7,7 +18,7 @@ importers:
       '@changesets/cli': ^2.26.1
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -62,7 +73,7 @@ importers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.0.0
       '@fluidframework/azure-local-service': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -139,7 +150,7 @@ importers:
 
   azure/packages/azure-local-service:
     specifiers:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@microsoft/api-extractor': ^7.37.0
@@ -170,7 +181,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -207,7 +218,7 @@ importers:
     specifiers:
       '@fluid-experimental/devtools': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -304,7 +315,7 @@ importers:
     specifiers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -383,7 +394,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -467,7 +478,7 @@ importers:
       '@fluid-experimental/attributor': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -545,7 +556,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -635,7 +646,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -726,7 +737,7 @@ importers:
       '@fluid-example/prosemirror': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -846,7 +857,7 @@ importers:
       '@fluid-experimental/data-objects': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -925,7 +936,7 @@ importers:
       '@fluid-experimental/oldest-client-observer': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -1010,7 +1021,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1084,7 +1095,7 @@ importers:
       '@fluid-experimental/tree': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1154,7 +1165,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1234,7 +1245,7 @@ importers:
       '@fluid-experimental/sharejs-json1': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1313,7 +1324,7 @@ importers:
       '@fluid-experimental/tree': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1387,7 +1398,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1458,7 +1469,7 @@ importers:
     specifiers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/app-insights-logger': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1558,7 +1569,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1635,7 +1646,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/counter': workspace:~
@@ -1709,7 +1720,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -1789,7 +1800,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -1860,7 +1871,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1931,7 +1942,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -2001,7 +2012,7 @@ importers:
       '@fluid-example/multiview-coordinate-model': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -2065,7 +2076,7 @@ importers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-example/multiview-slider-coordinate-view': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2142,7 +2153,7 @@ importers:
       '@fluid-example/multiview-triangle-view': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -2229,7 +2240,7 @@ importers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -2288,7 +2299,7 @@ importers:
   examples/data-objects/multiview/interface:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@types/expect-puppeteer': 2.2.1
@@ -2331,7 +2342,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2400,7 +2411,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2469,7 +2480,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2538,7 +2549,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2645,7 +2656,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2760,7 +2771,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2839,7 +2850,7 @@ importers:
       '@fluid-internal/test-version-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -2914,7 +2925,7 @@ importers:
       '@fluid-example/table-document': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -2980,7 +2991,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -3068,7 +3079,7 @@ importers:
       '@fluid-internal/test-version-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -3187,7 +3198,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3336,7 +3347,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/version-tools': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/bundle-size-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
@@ -3399,7 +3410,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3473,7 +3484,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3562,7 +3573,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3683,7 +3694,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3814,7 +3825,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3901,7 +3912,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -3976,7 +3987,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -4068,7 +4079,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4201,7 +4212,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4330,7 +4341,7 @@ importers:
 
   experimental/PropertyDDS/examples/schemas:
     specifiers:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -4355,7 +4366,7 @@ importers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-dds': workspace:~
       '@fluid-experimental/property-properties': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
@@ -4436,7 +4447,7 @@ importers:
   experimental/PropertyDDS/packages/property-changeset:
     specifiers:
       '@fluid-experimental/property-common': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/lodash': ^4.14.118
@@ -4496,7 +4507,7 @@ importers:
 
   experimental/PropertyDDS/packages/property-common:
     specifiers:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -4577,7 +4588,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-drivers': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4680,7 +4691,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@hig/fonts': ^1.0.2
       '@material-ui/core': 4.12.4
@@ -4816,7 +4827,7 @@ importers:
     specifiers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-common': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/mocha': ^9.1.1
@@ -4878,7 +4889,7 @@ importers:
       '@babel/preset-env': ^7.2.0
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-properties': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@types/jest': 29.5.3
@@ -4976,7 +4987,7 @@ importers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/tree2': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -5149,7 +5160,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5220,7 +5231,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5283,7 +5294,7 @@ importers:
     specifiers:
       '@fluid-experimental/ot': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -5344,7 +5355,7 @@ importers:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5409,7 +5420,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-drivers': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -5512,7 +5523,7 @@ importers:
       '@fluid-internal/test-drivers': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -5612,7 +5623,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5656,7 +5667,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -5699,7 +5710,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -5741,7 +5752,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -5796,7 +5807,7 @@ importers:
   packages/common/client-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5891,7 +5902,7 @@ importers:
   packages/common/container-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.0.0
       '@fluidframework/core-interfaces': workspace:~
@@ -5930,7 +5941,7 @@ importers:
   packages/common/core-interfaces:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -5959,7 +5970,7 @@ importers:
     specifiers:
       '@fluid-tools/benchmark': ^0.47.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -6008,7 +6019,7 @@ importers:
   packages/common/driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.0.0
@@ -6040,7 +6051,7 @@ importers:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.0.0
       '@fluidframework/core-interfaces': workspace:~
@@ -6102,7 +6113,7 @@ importers:
   packages/dds/counter:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6163,7 +6174,7 @@ importers:
   packages/dds/ink:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6226,7 +6237,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6302,7 +6313,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6392,7 +6403,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -6468,7 +6479,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6530,7 +6541,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6595,7 +6606,7 @@ importers:
   packages/dds/pact-map:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6662,7 +6673,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6729,7 +6740,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6809,7 +6820,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -6885,7 +6896,7 @@ importers:
   packages/dds/shared-summary-block:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6950,7 +6961,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -7023,7 +7034,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -7076,7 +7087,7 @@ importers:
   packages/drivers/debugger:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.0.0
@@ -7118,7 +7129,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7178,7 +7189,7 @@ importers:
   packages/drivers/driver-web-cache:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7224,7 +7235,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7268,7 +7279,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7318,7 +7329,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7405,7 +7416,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7485,7 +7496,7 @@ importers:
   packages/drivers/odsp-driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -7518,7 +7529,7 @@ importers:
   packages/drivers/odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -7566,7 +7577,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7613,7 +7624,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7703,7 +7714,7 @@ importers:
   packages/drivers/routerlicious-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7758,7 +7769,7 @@ importers:
   packages/drivers/tinylicious-driver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -7817,7 +7828,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -7870,7 +7881,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -7947,7 +7958,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8021,7 +8032,7 @@ importers:
 
   packages/framework/client-logger/app-insights-logger:
     specifiers:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8070,7 +8081,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8122,7 +8133,7 @@ importers:
   packages/framework/dds-interceptions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.0.0
@@ -8183,7 +8194,7 @@ importers:
   packages/framework/fluid-framework:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8224,7 +8235,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8295,7 +8306,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8336,7 +8347,7 @@ importers:
   packages/framework/request-handler:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8397,7 +8408,7 @@ importers:
   packages/framework/synthesize:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -8449,7 +8460,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8519,7 +8530,7 @@ importers:
   packages/framework/undo-redo:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -8582,7 +8593,7 @@ importers:
   packages/framework/view-adapters:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8621,7 +8632,7 @@ importers:
   packages/framework/view-interfaces:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8656,7 +8667,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.0.0
@@ -8742,7 +8753,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -8814,7 +8825,7 @@ importers:
   packages/loader/location-redirection-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8870,7 +8881,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -8903,7 +8914,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -8993,7 +9004,7 @@ importers:
   packages/runtime/container-runtime-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.0.0
@@ -9031,7 +9042,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9105,7 +9116,7 @@ importers:
   packages/runtime/datastore-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9140,7 +9151,7 @@ importers:
   packages/runtime/runtime-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9178,7 +9189,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -9247,7 +9258,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9328,7 +9339,7 @@ importers:
     specifiers:
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -9393,7 +9404,7 @@ importers:
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9512,7 +9523,7 @@ importers:
   packages/test/mocha-test-setup:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9553,7 +9564,7 @@ importers:
       '@fluid-experimental/sequence-deprecated': workspace:~
       '@fluid-internal/replay-tool': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9634,7 +9645,7 @@ importers:
   packages/test/stochastic-test-utils:
     specifiers:
       '@fluid-tools/benchmark': ^0.48.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9683,7 +9694,7 @@ importers:
   packages/test/test-app-insights-logger:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9712,7 +9723,7 @@ importers:
   packages/test/test-driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -9748,7 +9759,7 @@ importers:
     specifiers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -9827,7 +9838,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/agent-scheduler': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9959,7 +9970,7 @@ importers:
   packages/test/test-pairwise-generator:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -10001,7 +10012,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10084,7 +10095,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10189,7 +10200,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/version-tools': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10303,7 +10314,7 @@ importers:
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.0.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -10366,7 +10377,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10512,7 +10523,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10605,7 +10616,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10738,7 +10749,7 @@ importers:
       '@fluentui/react-icons': ^2.0.201
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-internal/client-utils': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10873,7 +10884,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.0.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -10928,7 +10939,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10991,7 +11002,7 @@ importers:
     specifiers:
       '@fluid-experimental/sequence-deprecated': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -11076,7 +11087,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -11185,7 +11196,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -11248,7 +11259,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -11314,7 +11325,7 @@ importers:
   packages/utils/tool-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-utils': workspace:~
@@ -11375,35 +11386,6 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       typescript: 5.1.6
-
-  tools/telemetry-generator:
-    specifiers:
-      '@fluidframework/build-common': ^2.0.1
-      '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-driver-definitions': '>=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0'
-      '@oclif/core': ^1.12.0
-      '@types/node': ^14.18.0
-      applicationinsights: ^2.4.1
-      concurrently: ^8.2.1
-      eslint: ~8.6.0
-      prettier: ~3.0.3
-      rimraf: ^2.6.2
-      typescript: ~4.5.5
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.1.4.9
-      '@oclif/core': 1.26.2
-      applicationinsights: 2.9.0
-    devDependencies:
-      '@fluidframework/build-common': 2.0.1
-      '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@types/node': 14.18.63
-      concurrently: 8.2.1
-      eslint: 8.6.0
-      prettier: 3.0.3
-      rimraf: 2.7.1
-      typescript: 4.5.5
 
 packages:
 
@@ -11497,20 +11479,6 @@ packages:
       '@opentelemetry/api': 1.4.1
       '@opentelemetry/core': 1.13.0_@opentelemetry+api@1.4.1
       '@opentelemetry/instrumentation': 0.35.1_@opentelemetry+api@1.4.1
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@azure/opentelemetry-instrumentation-azure-sdk/1.0.0-beta.5:
-    resolution: {integrity: sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@azure/core-tracing': 1.0.1
-      '@azure/logger': 1.0.4
-      '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
-      '@opentelemetry/instrumentation': 0.41.2_@opentelemetry+api@1.6.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -14528,15 +14496,6 @@ packages:
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
     dev: false
 
-  /@es-joy/jsdoccomment/0.33.4:
-    resolution: {integrity: sha512-02XyYuvR/Gn+3BT6idHVNQ4SSQlA1X1FeEfeKm2ypv8ANB6Lt9KRFZ2S7y5xjwR+EPQ/Rzb0XFaD+xKyqe4ALw==}
-    engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
-    dependencies:
-      comment-parser: 1.3.1
-      esquery: 1.5.0
-      jsdoc-type-pratt-parser: 3.1.0
-    dev: true
-
   /@es-joy/jsdoccomment/0.40.1:
     resolution: {integrity: sha512-YORCdZSusAlBrFpZ77pJjc5r1bQs5caPWtAu+WWmiSo+8XaUzseapVrfAtiRFbQWnrBxxLLEwF6f6ZG/UgCQCg==}
     engines: {node: '>=16'}
@@ -14754,36 +14713,9 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/eslint-utils/4.4.0_eslint@8.6.0:
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.6.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
   /@eslint-community/regexpp/4.9.1:
     resolution: {integrity: sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/eslintrc/1.4.1:
-    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.6.1
-      globals: 13.23.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@eslint/eslintrc/2.1.2:
@@ -14831,14 +14763,14 @@ packages:
     resolution: {integrity: sha512-q3zaKmH79+gO5t0EwR2ghSVbJqP3nnNNXx3o/rp+v6LKVZaxRZYMWgw2ESR2gF8rI7TWSeKkGVfBime2mVbDoQ==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/dom-utilities/2.2.11:
     resolution: {integrity: sha512-2tXfg7/9PXu9nfU72/P3o3waHEFEQtHUfQbVexUaYqNNAxMj6sOfsqpUx4vd5nPgO+grSWrl+spqlLN2yej51w==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/font-icons-mdl2/8.5.17_q5o373oqrklnndq2vhekyuzhxi:
@@ -14847,7 +14779,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@fluentui/style-utilities': 8.9.17_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
-      tslib: 2.6.0
+      tslib: 2.6.2
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -14865,13 +14797,13 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/keyboard-key/0.4.11:
     resolution: {integrity: sha512-TVB/EloWado9AVp1niChgcdDOQAHGP5B30Dinmtfe7zi8OnstwPoxwFP6dHJDdpLQ6ZEUTaEHViSzvewl7Chag==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/keyboard-keys/9.0.3:
@@ -14884,14 +14816,14 @@ packages:
     resolution: {integrity: sha512-vIiFv7WtXTPz0Sx6h1NpzqrwDN7yef7aQwqFl46yov72BodiAQMTazBl2A/z76IanBPklJmaTquFT9Uydlp/Dg==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/merge-styles/8.5.12:
     resolution: {integrity: sha512-ZnUo0YuMP7AYi68dkknFqVxopIAgbrUnqR/MZlemmRvBYyy1SMj1WQeHcoiLFA8mF8YKn7B+jxQgJbN2bfcrRw==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/priority-overflow/9.1.4:
@@ -15280,7 +15212,7 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/react-hooks/8.6.24_q5o373oqrklnndq2vhekyuzhxi:
@@ -16075,7 +16007,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/react/8.109.4_74b3ggvk3akyhuq4eydyx3fqim:
@@ -16109,13 +16041,13 @@ packages:
   /@fluentui/set-version/8.2.11:
     resolution: {integrity: sha512-UI03tysau/adBO1a3q4uFZWQ3lfkiFcAWIFng4k5odWcCokfCm5IxA0urKqj5W5JRYdyoBUaq8QbcNGkFB4dCw==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/set-version/8.2.9:
     resolution: {integrity: sha512-fpWo4DLt8K4spNip2YhNZlGnSKIa5F9hL/wQBE0EPei6+HEeRO2slXfHohOO5v1lIkfLPcpAh/Lzs2iuxzw/lw==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/style-utilities/8.9.10_q5o373oqrklnndq2vhekyuzhxi:
@@ -16126,7 +16058,7 @@ packages:
       '@fluentui/theme': 2.6.35_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@microsoft/load-themed-styles': 1.10.295
-      tslib: 2.6.0
+      tslib: 2.6.2
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -16140,7 +16072,7 @@ packages:
       '@fluentui/theme': 2.6.35_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@microsoft/load-themed-styles': 1.10.295
-      tslib: 2.6.0
+      tslib: 2.6.2
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -16157,7 +16089,7 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/theme/2.6.35_q5o373oqrklnndq2vhekyuzhxi:
@@ -16171,7 +16103,7 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/tokens/1.0.0-alpha.8:
@@ -16191,7 +16123,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluentui/utilities/8.13.18_q5o373oqrklnndq2vhekyuzhxi:
@@ -16205,7 +16137,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: false
 
   /@fluid-experimental/attributable-map/2.0.0-internal.7.0.0:
@@ -16695,7 +16627,7 @@ packages:
       isomorphic-fetch: 3.0.0
       nconf: 0.12.0
       sillyname: 0.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
       webpack-dev-server: 4.6.0_nwcuyijzf6l5chuh7xhtrzgjly
     transitivePeerDependencies:
       - '@types/express'
@@ -16722,7 +16654,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16745,7 +16677,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/synthesize': 2.0.0-internal.7.0.0
       '@fluidframework/view-interfaces': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16768,7 +16700,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/synthesize': 2.0.0-internal.7.0.0
       '@fluidframework/view-interfaces': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16804,7 +16736,7 @@ packages:
     dependencies:
       '@fluidframework/protocol-definitions': 3.0.0
       jsrsasign: 10.8.6
-      uuid: 9.0.0
+      uuid: 9.0.1
     dev: true
 
   /@fluidframework/build-common/2.0.1:
@@ -17188,10 +17120,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/common-definitions/0.20.1:
-    resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
-    dev: false
-
   /@fluidframework/common-definitions/1.0.0:
     resolution: {integrity: sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ==}
 
@@ -17231,8 +17159,8 @@ packages:
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lodash: 4.17.21
-      url: 0.11.0
-      uuid: 9.0.0
+      url: 0.11.3
+      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17266,7 +17194,7 @@ packages:
       events: 3.3.0
       lz4js: 0.2.0
       sorted-btree: 1.8.1
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17291,15 +17219,11 @@ packages:
       events: 3.3.0
       lz4js: 0.2.0
       sorted-btree: 1.8.1
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
-
-  /@fluidframework/core-interfaces/2.0.0-internal.1.4.9:
-    resolution: {integrity: sha512-b9oZpYNSmQjhSaW/za/XQ23d8aDRvhf6XkilUI9GcOBRCFLc2o2FYg7RLs23GGkjFIi3jvqe7UdeYkZfHR60Rg==}
-    dev: false
 
   /@fluidframework/core-interfaces/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA==}
@@ -17368,7 +17292,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       lodash: 4.17.21
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17389,7 +17313,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       lodash: 4.17.21
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17452,14 +17376,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.1.4.9:
-    resolution: {integrity: sha512-N10hoaUbaWfQkoJWPhl3gmlkQTqBFiBf9VZIwGbw/NLHVH2Xh8Tl66+91vU85r0U45unq8UCSVGSkGIXxTUu9A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.1.4.9
-      '@fluidframework/protocol-definitions': 1.2.0
-    dev: false
-
   /@fluidframework/driver-definitions/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==}
     dependencies:
@@ -17480,8 +17396,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       axios: 0.26.1
       lz4js: 0.2.0
-      url: 0.11.0
-      uuid: 9.0.0
+      url: 0.11.3
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17500,8 +17416,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
-      url: 0.11.0
-      uuid: 9.0.0
+      url: 0.11.3
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17517,32 +17433,6 @@ packages:
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@fluidframework/eslint-config-fluid/2.1.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-pdQQpFB0UJcZxUpe/zgN+TUJzZw1Kvrnrvbn8HgZZ5KFDHgJYxs+k9ZCJopgOYjomhbHsJSmlsuIESiF/YeEOg==}
-    dependencies:
-      '@rushstack/eslint-patch': 1.1.4
-      '@rushstack/eslint-plugin': 0.8.6_kufnqfq7tb5rpdawkdb6g5smma
-      '@rushstack/eslint-plugin-security': 0.2.6_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/eslint-plugin': 5.55.0_36lylnhpq2p3xhpusv76l3z5qu
-      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      eslint-config-prettier: 8.5.0_eslint@8.6.0
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
-      eslint-plugin-import: 2.25.4_4pij4nvnkqnncanfc5qjphoilq
-      eslint-plugin-jsdoc: 39.3.25_eslint@8.6.0
-      eslint-plugin-promise: 6.0.1_eslint@8.6.0
-      eslint-plugin-react: 7.28.0_eslint@8.6.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.6.0
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-unicorn: 40.0.0_eslint@8.6.0
-      eslint-plugin-unused-imports: 2.0.0_mk3lxcfeigio6zzden7bbdcose
-    transitivePeerDependencies:
-      - eslint
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-      - typescript
     dev: true
 
   /@fluidframework/eslint-config-fluid/3.0.0_loebgezstcsvd2poh2d55fifke:
@@ -17665,7 +17555,7 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/shared-object-base': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17690,8 +17580,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       events: 3.3.0
       jsrsasign: 10.8.6
-      url: 0.11.0
-      uuid: 9.0.0
+      url: 0.11.3
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17719,8 +17609,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       events: 3.3.0
       jsrsasign: 10.8.6
-      url: 0.11.0
-      uuid: 9.0.0
+      url: 0.11.3
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17836,7 +17726,7 @@ packages:
       '@fluidframework/driver-utils': 2.0.0-internal.7.0.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      node-fetch: 2.6.11
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
       - encoding
@@ -17853,7 +17743,7 @@ packages:
       '@fluidframework/driver-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      node-fetch: 2.6.11
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
       - encoding
@@ -17880,9 +17770,9 @@ packages:
       '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      node-fetch: 2.6.11
+      node-fetch: 2.7.0
       socket.io-client: 4.6.1
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17917,7 +17807,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/shared-object-base': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17930,12 +17820,6 @@ packages:
       '@fluidframework/gitresources': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
-
-  /@fluidframework/protocol-definitions/1.2.0:
-    resolution: {integrity: sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-    dev: false
 
   /@fluidframework/protocol-definitions/3.0.0:
     resolution: {integrity: sha512-FUIw5B5aTVJ831zAvsNUzKGFCkPoswmUeeYfZtVlq2wRpO2Ffm28TYhbkrAGFOtCd0BiByJDho6Oo+iZbNBgUA==}
@@ -18017,7 +17901,7 @@ packages:
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
       url-parse: 1.5.10
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18044,7 +17928,7 @@ packages:
       json-stringify-safe: 5.0.1
       socket.io-client: 4.6.1
       url-parse: 1.5.10
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18061,7 +17945,7 @@ packages:
       '@fluidframework/driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/protocol-definitions': 3.0.0
       nconf: 0.12.0
-      url: 0.11.0
+      url: 0.11.3
     dev: true
 
   /@fluidframework/runtime-definitions/2.0.0-internal.7.0.0:
@@ -18122,7 +18006,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/shared-object-base': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18380,7 +18264,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18400,7 +18284,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18453,20 +18337,10 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       debug: 4.3.4
       events: 3.3.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@fluidframework/test-driver-definitions/2.0.0-internal.1.4.9:
-    resolution: {integrity: sha512-xg+BmeB0Qo8z2l/RV33GG5gEWpPryeDERVB4s7kIC3gSDKFRxaoGZjHMptWnC8+FjFTYREXW6/VkP+vjydHPZA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.1.4.9
-      '@fluidframework/driver-definitions': 2.0.0-internal.1.4.9
-      '@fluidframework/protocol-definitions': 1.2.0
-      uuid: 8.3.2
-    dev: false
 
   /@fluidframework/test-driver-definitions/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-IubdjrhM5Rtx9cYk4g9WQliIflkIrgQC800m6o12giUvm8ocnwl5klNkqC6WYLgwfBWP3vhQrPluFD4X2pKaFw==}
@@ -18474,7 +18348,7 @@ packages:
       '@fluidframework/core-interfaces': 2.0.0-internal.7.0.0
       '@fluidframework/driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/protocol-definitions': 3.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     dev: true
 
   /@fluidframework/test-runtime-utils/2.0.0-internal.7.0.0:
@@ -18495,7 +18369,7 @@ packages:
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18522,7 +18396,7 @@ packages:
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18562,7 +18436,7 @@ packages:
       '@fluidframework/test-runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -18585,7 +18459,7 @@ packages:
       '@fluidframework/routerlicious-driver': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/tinylicious-driver': 2.0.0-internal.7.0.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18604,7 +18478,7 @@ packages:
       '@fluidframework/routerlicious-driver': 2.0.0-internal.7.0.0
       '@fluidframework/server-services-client': 2.0.1
       jsrsasign: 10.8.6
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18707,7 +18581,7 @@ packages:
     dependencies:
       '@griffel/core': 1.14.1
       react: 17.0.2
-      tslib: 2.5.0
+      tslib: 2.6.2
     dev: false
 
   /@griffel/style-types/1.0.1:
@@ -18762,17 +18636,6 @@ packages:
 
   /@humanwhocodes/config-array/0.11.11:
     resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@humanwhocodes/config-array/0.9.5:
-    resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -20153,40 +20016,6 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/core/1.26.2:
-    resolution: {integrity: sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@oclif/linewrap': 1.0.0
-      '@oclif/screen': 3.0.7
-      ansi-escapes: 4.3.2
-      ansi-styles: 4.3.0
-      cardinal: 2.1.1
-      chalk: 4.1.2
-      clean-stack: 3.0.1
-      cli-progress: 3.12.0
-      debug: 4.3.4_supports-color@8.1.1
-      ejs: 3.1.9
-      fs-extra: 9.1.0
-      get-package-type: 0.1.0
-      globby: 11.1.0
-      hyperlinker: 1.0.0
-      indent-string: 4.0.0
-      is-wsl: 2.2.0
-      js-yaml: 3.14.1
-      natural-orderby: 2.0.3
-      object-treeify: 1.1.33
-      password-prompt: 1.1.3
-      semver: 7.5.4
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      supports-color: 8.1.1
-      supports-hyperlinks: 2.3.0
-      tslib: 2.6.2
-      widest-line: 3.1.0
-      wrap-ansi: 7.0.0
-    dev: false
-
   /@oclif/core/2.4.0:
     resolution: {integrity: sha512-wWUnOOfQQty0k1Cstm/iWW6pbG0mHzU7rcUtab2Sni9kjBPCcy6ENTgpsWbb/WdITopqtXmvpYII2fgcjKdzUA==}
     engines: {node: '>=14.0.0'}
@@ -20219,10 +20048,6 @@ packages:
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
-
-  /@oclif/linewrap/1.0.0:
-    resolution: {integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==}
-    dev: false
 
   /@oclif/plugin-autocomplete/2.3.8:
     resolution: {integrity: sha512-cmRPss9OQxz8sRoaw5C/4t/Da7eBEIDJWKRsuzUSQBcPJCN3kTgjp24VTjPHT3j86197s/qkjCRct+3P0IGArg==}
@@ -20288,11 +20113,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@oclif/screen/3.0.7:
-    resolution: {integrity: sha512-jQBPHcMh5rcIPKdqA6xlzioLOmkaVnjg2MVyjMzBKV8hDhLWNSiZqx7NAWXpP70v2LFvGdVoV8BSbK9iID3eHg==}
-    engines: {node: '>=12.0.0'}
-    dev: false
 
   /@oclif/test/2.3.28:
     resolution: {integrity: sha512-Eee3efwfHHdgZIwOUGFEe8p4d8YEWFYKHoAezxdXzXVOtV4L9r7Oq6KH8dXGBy8yjYDleydwn0PqoZGhFeLxYQ==}
@@ -20495,7 +20315,7 @@ packages:
       '@octokit/request-error': 2.1.0
       '@octokit/types': 6.41.0
       is-plain-object: 5.0.0
-      node-fetch: 2.6.11
+      node-fetch: 2.7.0
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
@@ -20627,11 +20447,6 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@opentelemetry/api/1.6.0:
-    resolution: {integrity: sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==}
-    engines: {node: '>=8.0.0'}
-    dev: false
-
   /@opentelemetry/core/1.13.0_@opentelemetry+api@1.4.1:
     resolution: {integrity: sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==}
     engines: {node: '>=14'}
@@ -20642,16 +20457,6 @@ packages:
       '@opentelemetry/semantic-conventions': 1.13.0
     dev: false
 
-  /@opentelemetry/core/1.17.1_@opentelemetry+api@1.6.0:
-    resolution: {integrity: sha512-I6LrZvl1FF97FQXPR0iieWQmKnGxYtMbWA1GrAXnLUR+B1Hn2m8KqQNEIlZAucyv00GBgpWkpllmULmZfG8P3g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.7.0'
-    dependencies:
-      '@opentelemetry/api': 1.6.0
-      '@opentelemetry/semantic-conventions': 1.17.1
-    dev: false
-
   /@opentelemetry/instrumentation/0.35.1_@opentelemetry+api@1.4.1:
     resolution: {integrity: sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==}
     engines: {node: '>=14'}
@@ -20660,22 +20465,6 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.4.1
       require-in-the-middle: 5.2.0
-      semver: 7.5.4
-      shimmer: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@opentelemetry/instrumentation/0.41.2_@opentelemetry+api@1.6.0:
-    resolution: {integrity: sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-    dependencies:
-      '@opentelemetry/api': 1.6.0
-      '@types/shimmer': 1.0.3
-      import-in-the-middle: 1.4.2
-      require-in-the-middle: 7.2.0
       semver: 7.5.4
       shimmer: 1.2.1
     transitivePeerDependencies:
@@ -20693,17 +20482,6 @@ packages:
       '@opentelemetry/semantic-conventions': 1.13.0
     dev: false
 
-  /@opentelemetry/resources/1.17.1_@opentelemetry+api@1.6.0:
-    resolution: {integrity: sha512-M2e5emqg5I7qRKqlzKx0ROkcPyF8PbcSaWEdsm72od9txP7Z/Pl8PDYOyu80xWvbHAWk5mDxOF6v3vNdifzclA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.7.0'
-    dependencies:
-      '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
-      '@opentelemetry/semantic-conventions': 1.17.1
-    dev: false
-
   /@opentelemetry/sdk-trace-base/1.13.0_@opentelemetry+api@1.4.1:
     resolution: {integrity: sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==}
     engines: {node: '>=14'}
@@ -20716,25 +20494,8 @@ packages:
       '@opentelemetry/semantic-conventions': 1.13.0
     dev: false
 
-  /@opentelemetry/sdk-trace-base/1.17.1_@opentelemetry+api@1.6.0:
-    resolution: {integrity: sha512-pfSJJSjZj5jkCJUQZicSpzN8Iz9UKMryPWikZRGObPnJo6cUSoKkjZh6BM3j+D47G4olMBN+YZKYqkFM1L6zNA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.7.0'
-    dependencies:
-      '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
-      '@opentelemetry/resources': 1.17.1_@opentelemetry+api@1.6.0
-      '@opentelemetry/semantic-conventions': 1.17.1
-    dev: false
-
   /@opentelemetry/semantic-conventions/1.13.0:
     resolution: {integrity: sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==}
-    engines: {node: '>=14'}
-    dev: false
-
-  /@opentelemetry/semantic-conventions/1.17.1:
-    resolution: {integrity: sha512-xbR2U+2YjauIuo42qmE8XyJK6dYeRMLJuOlUP5SO4auET4VtOHOzgkRVOq+Ik18N+Xf3YPcqJs9dZMiDddz1eQ==}
     engines: {node: '>=14'}
     dev: false
 
@@ -21071,10 +20832,6 @@ packages:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-patch/1.1.4:
-    resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
-    dev: true
-
   /@rushstack/eslint-patch/1.4.0:
     resolution: {integrity: sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg==}
     dev: true
@@ -21091,19 +20848,6 @@ packages:
       '@rushstack/tree-pattern': 0.3.1
       '@typescript-eslint/experimental-utils': 5.59.11_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin-security/0.2.6_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.3
-      '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
-      eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21130,19 +20874,6 @@ packages:
       '@rushstack/tree-pattern': 0.3.1
       '@typescript-eslint/experimental-utils': 5.59.11_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin/0.8.6_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.3
-      '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
-      eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21241,10 +20972,6 @@ packages:
     dependencies:
       resolve: 1.22.6
       strip-json-comments: 3.1.1
-    dev: true
-
-  /@rushstack/tree-pattern/0.2.3:
-    resolution: {integrity: sha512-8KWZxzn6XKuy3iKRSAd2CHXSXneRlGCmH9h/qM7jYQDekp+U18oUzub5xqOqHS2PLUC+torOMYZxgAIO/fF86A==}
     dev: true
 
   /@rushstack/tree-pattern/0.3.1:
@@ -23370,10 +23097,6 @@ packages:
       form-data: 3.0.1
     dev: true
 
-  /@types/node/14.18.63:
-    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
-    dev: true
-
   /@types/node/16.18.38:
     resolution: {integrity: sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==}
     dev: true
@@ -23508,10 +23231,6 @@ packages:
   /@types/semver/7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
 
-  /@types/semver/7.5.3:
-    resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
-    dev: true
-
   /@types/send/0.17.1:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
@@ -23536,10 +23255,6 @@ packages:
       '@types/glob': 7.2.0
       '@types/node': 16.18.53
     dev: true
-
-  /@types/shimmer/1.0.3:
-    resolution: {integrity: sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA==}
-    dev: false
 
   /@types/simplemde/1.11.8:
     resolution: {integrity: sha512-NF3MJ1jdP5nJB5DH2HNmGQK61mRr6Rxoe+EWboxR0XBrIS95/PgHuP+Ry6rCJ63DMMX70OKxvJ4bCP4IIvLhPg==}
@@ -23688,34 +23403,6 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.55.0_36lylnhpq2p3xhpusv76l3z5qu:
-    resolution: {integrity: sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/type-utils': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@typescript-eslint/utils': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      debug: 4.3.4
-      eslint: 8.6.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/5.59.11_5x5zj3ed4pfrlx677mwttmrwaa:
     resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23786,44 +23473,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.6.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.13
-      '@typescript-eslint/scope-manager': 5.6.0
-      '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.5
-      eslint: 8.6.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/parser/5.55.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0_typescript@4.5.5
-      debug: 4.3.4
-      eslint: 8.6.0
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/5.59.11_loebgezstcsvd2poh2d55fifke:
     resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23865,14 +23514,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.55.0:
-    resolution: {integrity: sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/visitor-keys': 5.55.0
-    dev: true
-
   /@typescript-eslint/scope-manager/5.59.11:
     resolution: {integrity: sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23889,40 +23530,12 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/scope-manager/5.6.0:
-    resolution: {integrity: sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/visitor-keys': 5.6.0
-    dev: true
-
   /@typescript-eslint/scope-manager/6.7.4:
     resolution: {integrity: sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.7.4
       '@typescript-eslint/visitor-keys': 6.7.4
-    dev: true
-
-  /@typescript-eslint/type-utils/5.55.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.55.0_typescript@4.5.5
-      '@typescript-eslint/utils': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      debug: 4.3.4
-      eslint: 8.6.0
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/type-utils/5.59.11_loebgezstcsvd2poh2d55fifke:
@@ -23965,11 +23578,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.55.0:
-    resolution: {integrity: sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /@typescript-eslint/types/5.59.11:
     resolution: {integrity: sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23980,35 +23588,9 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/types/5.6.0:
-    resolution: {integrity: sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /@typescript-eslint/types/6.7.4:
     resolution: {integrity: sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree/5.55.0_typescript@4.5.5:
-    resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/visitor-keys': 5.55.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree/5.59.11_typescript@5.1.6:
@@ -24053,27 +23635,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.5:
-    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/visitor-keys': 5.6.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/6.7.4_typescript@5.1.6:
     resolution: {integrity: sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -24093,26 +23654,6 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/utils/5.55.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.6.0
-      '@types/json-schema': 7.0.13
-      '@types/semver': 7.5.3
-      '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0_typescript@4.5.5
-      eslint: 8.6.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils/5.59.11_loebgezstcsvd2poh2d55fifke:
@@ -24174,14 +23715,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.55.0:
-    resolution: {integrity: sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.55.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
   /@typescript-eslint/visitor-keys/5.59.11:
     resolution: {integrity: sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -24195,14 +23728,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.59.6
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
-  /@typescript-eslint/visitor-keys/5.6.0:
-    resolution: {integrity: sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.6.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -24584,6 +24109,7 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.10.0
+    dev: true
 
   /acorn-import-assertions/1.9.0_acorn@8.8.2:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
@@ -24939,32 +24465,6 @@ packages:
       - supports-color
     dev: false
 
-  /applicationinsights/2.9.0:
-    resolution: {integrity: sha512-W90WNjtvZ10GUInpkyNM0xBGe2qRYChHhdb44SE5KU7hXtCZLxs3IZjWw1gJINQem0qGAgtZlxrVvKPj5SlTbQ==}
-    engines: {node: '>=8.0.0'}
-    peerDependencies:
-      applicationinsights-native-metrics: '*'
-    peerDependenciesMeta:
-      applicationinsights-native-metrics:
-        optional: true
-    dependencies:
-      '@azure/core-auth': 1.5.0
-      '@azure/core-rest-pipeline': 1.10.1
-      '@azure/core-util': 1.2.0
-      '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.5
-      '@microsoft/applicationinsights-web-snippet': 1.0.1
-      '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
-      '@opentelemetry/sdk-trace-base': 1.17.1_@opentelemetry+api@1.6.0
-      '@opentelemetry/semantic-conventions': 1.17.1
-      cls-hooked: 4.2.2
-      continuation-local-storage: 3.2.1
-      diagnostic-channel: 1.1.1
-      diagnostic-channel-publishers: 1.0.7_diagnostic-channel@1.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /aproba/1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
     dev: true
@@ -25087,17 +24587,6 @@ packages:
       is-string: 1.0.7
     dev: true
 
-  /array-includes/3.1.7:
-    resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
-      get-intrinsic: 1.2.1
-      is-string: 1.0.7
-    dev: true
-
   /array-to-sentence/1.1.0:
     resolution: {integrity: sha512-YkwkMmPA2+GSGvXj1s9NZ6cc2LBtR+uSeWTy2IGi5MR1Wag4DdrcjTxA/YV/Fw+qKlBeXomneZgThEbm/wvZbw==}
     dev: false
@@ -25155,16 +24644,6 @@ packages:
       es-shim-unscopables: 1.0.0
     dev: true
 
-  /array.prototype.flat/1.3.2:
-    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
-      es-shim-unscopables: 1.0.0
-    dev: true
-
   /array.prototype.flatmap/1.3.1:
     resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
     engines: {node: '>= 0.4'}
@@ -25172,16 +24651,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.21.2
-      es-shim-unscopables: 1.0.0
-    dev: true
-
-  /array.prototype.flatmap/1.3.2:
-    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -27016,11 +26485,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ci-info/3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-    dev: true
-
   /cipher-base/1.0.4:
     resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
     dependencies:
@@ -27034,6 +26498,7 @@ packages:
 
   /cjs-module-lexer/1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+    dev: true
 
   /class-utils/0.3.6:
     resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
@@ -27512,11 +26977,6 @@ packages:
 
   /commandpost/1.4.0:
     resolution: {integrity: sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==}
-    dev: true
-
-  /comment-parser/1.3.1:
-    resolution: {integrity: sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==}
-    engines: {node: '>= 12.0.0'}
     dev: true
 
   /comment-parser/1.4.0:
@@ -28913,24 +28373,10 @@ packages:
       diagnostic-channel: 1.1.0
     dev: false
 
-  /diagnostic-channel-publishers/1.0.7_diagnostic-channel@1.1.1:
-    resolution: {integrity: sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==}
-    peerDependencies:
-      diagnostic-channel: '*'
-    dependencies:
-      diagnostic-channel: 1.1.1
-    dev: false
-
   /diagnostic-channel/1.1.0:
     resolution: {integrity: sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==}
     dependencies:
       semver: 5.7.2
-    dev: false
-
-  /diagnostic-channel/1.1.1:
-    resolution: {integrity: sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==}
-    dependencies:
-      semver: 7.5.4
     dev: false
 
   /diff-sequences/29.4.3:
@@ -29395,14 +28841,6 @@ packages:
       ansi-colors: 4.1.3
     dev: true
 
-  /enquirer/2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      ansi-colors: 4.1.3
-      strip-ansi: 6.0.1
-    dev: true
-
   /entities/1.1.2:
     resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
     dev: true
@@ -29786,15 +29224,6 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier/8.5.0_eslint@8.6.0:
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.6.0
-    dev: true
-
   /eslint-config-prettier/9.0.0_eslint@8.50.0:
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
@@ -29806,16 +29235,6 @@ packages:
 
   /eslint-import-resolver-node/0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
-    dependencies:
-      debug: 3.2.7
-      is-core-module: 2.13.0
-      resolve: 1.22.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-import-resolver-node/0.3.9:
-    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
       debug: 3.2.7
       is-core-module: 2.13.0
@@ -29872,35 +29291,6 @@ packages:
       eslint: 8.50.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.6.1_mc36sq7crv2v5vtlozlclqwu5e
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils/2.8.0_efyktxylcfmcbkqa5c3pglhkk4:
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      debug: 3.2.7
-      eslint: 8.6.0
-      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -30066,17 +29456,6 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-eslint-comments/3.2.0_eslint@8.6.0:
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      escape-string-regexp: 1.0.5
-      eslint: 8.6.0
-      ignore: 5.2.4
-    dev: true
-
   /eslint-plugin-filenames/1.3.2_eslint@8.50.0:
     resolution: {integrity: sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==}
     peerDependencies:
@@ -30087,37 +29466,6 @@ packages:
       lodash.kebabcase: 4.1.1
       lodash.snakecase: 4.1.1
       lodash.upperfirst: 4.3.1
-    dev: true
-
-  /eslint-plugin-import/2.25.4_4pij4nvnkqnncanfc5qjphoilq:
-    resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
-      array-includes: 3.1.7
-      array.prototype.flat: 1.3.2
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.6.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0_efyktxylcfmcbkqa5c3pglhkk4
-      has: 1.0.4
-      is-core-module: 2.13.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.7
-      resolve: 1.22.6
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-import/2.28.1_4nytrgfpfmroylhx7ogxfohaye:
@@ -30299,24 +29647,6 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jsdoc/39.3.25_eslint@8.6.0:
-    resolution: {integrity: sha512-7JiFOOaipz7Z7lNQ9sMJ6cdvclmVUwNYtFWGS3a0k0uEFcdZPPD64WOfENuyNHpl86C0AKIEPgOpZby5kd+pew==}
-    engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dependencies:
-      '@es-joy/jsdoccomment': 0.33.4
-      comment-parser: 1.3.1
-      debug: 4.3.4
-      escape-string-regexp: 4.0.0
-      eslint: 8.6.0
-      esquery: 1.5.0
-      semver: 7.5.4
-      spdx-expression-parse: 3.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-plugin-jsdoc/46.8.2_eslint@8.50.0:
     resolution: {integrity: sha512-5TSnD018f3tUJNne4s4gDWQflbsgOycIKEUBoCLn6XtBMgNHxQFmV8vVxUtiPxAQq8lrX85OaSG/2gnctxw9uQ==}
     engines: {node: '>=16'}
@@ -30377,15 +29707,6 @@ packages:
       eslint: 8.50.0
     dev: true
 
-  /eslint-plugin-promise/6.0.1_eslint@8.6.0:
-    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dependencies:
-      eslint: 8.6.0
-    dev: true
-
   /eslint-plugin-promise/6.1.1_eslint@8.50.0:
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -30402,15 +29723,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.50.0
-    dev: true
-
-  /eslint-plugin-react-hooks/4.6.0_eslint@8.6.0:
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.6.0
     dev: true
 
   /eslint-plugin-react/7.27.1_eslint@8.50.0:
@@ -30434,29 +29746,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.8
-    dev: true
-
-  /eslint-plugin-react/7.28.0_eslint@8.6.0:
-    resolution: {integrity: sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      doctrine: 2.1.0
-      eslint: 8.6.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      object.hasown: 1.1.3
-      object.values: 1.1.7
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.4
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.10
     dev: true
 
   /eslint-plugin-react/7.33.2_eslint@8.50.0:
@@ -30491,29 +29780,6 @@ packages:
       '@microsoft/tsdoc-config': 0.16.2
     dev: true
 
-  /eslint-plugin-unicorn/40.0.0_eslint@8.6.0:
-    resolution: {integrity: sha512-5GRXISfBk8jMmYk1eeNDw8zSRnWTxBjWkzx2Prre6E2/yLu2twozZ3EomLWCBu9nWms/ZE361BItyMQwfnG1qA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      eslint: '>=7.32.0'
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      ci-info: 3.9.0
-      clean-regexp: 1.0.0
-      eslint: 8.6.0
-      eslint-utils: 3.0.0_eslint@8.6.0
-      esquery: 1.5.0
-      indent-string: 4.0.0
-      is-builtin-module: 3.2.1
-      lodash: 4.17.21
-      pluralize: 8.0.0
-      read-pkg-up: 7.0.1
-      regexp-tree: 0.1.27
-      safe-regex: 2.1.1
-      semver: 7.5.4
-      strip-indent: 3.0.0
-    dev: true
-
   /eslint-plugin-unicorn/48.0.1_eslint@8.50.0:
     resolution: {integrity: sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==}
     engines: {node: '>=16'}
@@ -30536,21 +29802,6 @@ packages:
       regjsparser: 0.10.0
       semver: 7.5.4
       strip-indent: 3.0.0
-    dev: true
-
-  /eslint-plugin-unused-imports/2.0.0_mk3lxcfeigio6zzden7bbdcose:
-    resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^8.0.0
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.55.0_36lylnhpq2p3xhpusv76l3z5qu
-      eslint: 8.6.0
-      eslint-rule-composer: 0.3.0
     dev: true
 
   /eslint-plugin-unused-imports/3.0.0_eslint@8.50.0:
@@ -30622,16 +29873,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       eslint-visitor-keys: 1.3.0
-    dev: true
-
-  /eslint-utils/3.0.0_eslint@8.6.0:
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.6.0
-      eslint-visitor-keys: 2.1.0
     dev: true
 
   /eslint-visitor-keys/1.3.0:
@@ -30737,53 +29978,6 @@ packages:
       optionator: 0.9.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint/8.6.0:
-    resolution: {integrity: sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.9.5
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      enquirer: 2.4.1
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-utils: 3.0.0_eslint@8.6.0
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 6.0.2
-      globals: 13.23.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      progress: 2.0.3
-      regexpp: 3.2.0
-      semver: 7.5.4
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-      v8-compile-cache: 2.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -32442,13 +31636,6 @@ packages:
       type-fest: 0.20.2
     dev: true
 
-  /globals/13.23.0:
-    resolution: {integrity: sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.20.2
-    dev: true
-
   /globals/9.18.0:
     resolution: {integrity: sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==}
     engines: {node: '>=0.10.0'}
@@ -33524,15 +32711,6 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  /import-in-the-middle/1.4.2:
-    resolution: {integrity: sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==}
-    dependencies:
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0_acorn@8.10.0
-      cjs-module-lexer: 1.2.3
-      module-details-from-path: 1.0.3
-    dev: false
 
   /import-lazy/2.1.0:
     resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==}
@@ -35723,11 +34901,6 @@ packages:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
     dev: true
 
-  /jsdoc-type-pratt-parser/3.1.0:
-    resolution: {integrity: sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==}
-    engines: {node: '>=12.0.0'}
-    dev: true
-
   /jsdoc-type-pratt-parser/4.0.0:
     resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
     engines: {node: '>=12.0.0'}
@@ -36149,16 +35322,6 @@ packages:
       object.assign: 4.1.4
     dev: true
 
-  /jsx-ast-utils/3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
-    engines: {node: '>=4.0'}
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.flat: 1.3.2
-      object.assign: 4.1.4
-      object.values: 1.1.7
-    dev: true
-
   /jszip/3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
     dependencies:
@@ -36287,7 +35450,7 @@ packages:
     dependencies:
       abort-controller: 3.0.0
       ky: 0.12.0
-      node-fetch: 2.6.11
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -38740,15 +37903,6 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
-  /object.entries/1.1.7:
-    resolution: {integrity: sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
-    dev: true
-
   /object.fromentries/2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
     engines: {node: '>= 0.4'}
@@ -38756,15 +37910,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.21.2
-    dev: true
-
-  /object.fromentries/2.0.7:
-    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
     dev: true
 
   /object.getownpropertydescriptors/2.1.6:
@@ -38794,13 +37939,6 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
-  /object.hasown/1.1.3:
-    resolution: {integrity: sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==}
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
-    dev: true
-
   /object.pick/1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
@@ -38815,15 +37953,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.21.2
-    dev: true
-
-  /object.values/1.1.7:
-    resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
     dev: true
 
   /objectorarray/1.0.5:
@@ -39485,13 +38614,6 @@ packages:
     dependencies:
       ansi-escapes: 3.2.0
       cross-spawn: 6.0.5
-
-  /password-prompt/1.1.3:
-    resolution: {integrity: sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==}
-    dependencies:
-      ansi-escapes: 4.3.2
-      cross-spawn: 7.0.3
-    dev: false
 
   /path-browserify/0.0.1:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
@@ -41848,17 +40970,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /require-in-the-middle/7.2.0:
-    resolution: {integrity: sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      debug: 4.3.4
-      module-details-from-path: 1.0.3
-      resolve: 1.22.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /require-main-filename/1.0.1:
     resolution: {integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==}
     dev: true
@@ -42223,12 +41334,6 @@ packages:
     resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
     dependencies:
       ret: 0.1.15
-    dev: true
-
-  /safe-regex/2.1.1:
-    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
-    dependencies:
-      regexp-tree: 0.1.27
     dev: true
 
   /safe-stable-stringify/2.4.3:
@@ -43490,20 +42595,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
-
-  /string.prototype.matchall/4.0.10:
-    resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
-      es-abstract: 1.22.2
-      get-intrinsic: 1.2.1
-      has-symbols: 1.0.3
-      internal-slot: 1.0.5
-      regexp.prototype.flags: 1.5.1
-      set-function-name: 2.0.1
-      side-channel: 1.0.4
     dev: true
 
   /string.prototype.matchall/4.0.8:
@@ -44803,16 +43894,6 @@ packages:
   /tslib/2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils/3.21.0_typescript@4.5.5:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.5.5
-    dev: true
-
   /tsutils/3.21.0_typescript@5.1.6:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -45694,10 +44775,6 @@ packages:
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
-    dev: true
-
-  /v8-compile-cache/2.4.0:
-    resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
     dev: true
 
   /v8-to-istanbul/9.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       '@changesets/cli': ^2.26.1
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -44,7 +44,7 @@ importers:
       '@changesets/cli': 2.26.1
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -73,7 +73,7 @@ importers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.0.0
       '@fluidframework/azure-local-service': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -127,7 +127,7 @@ importers:
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.0.0
       '@fluidframework/azure-local-service': link:../azure-local-service
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/counter': link:../../../packages/dds/counter
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -150,7 +150,7 @@ importers:
 
   azure/packages/azure-local-service:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@microsoft/api-extractor': ^7.37.0
@@ -165,7 +165,7 @@ importers:
     dependencies:
       tinylicious: 2.0.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0
@@ -181,7 +181,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -202,7 +202,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
       '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0
@@ -218,7 +218,7 @@ importers:
     specifiers:
       '@fluid-experimental/devtools': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -273,7 +273,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-experimental/devtools': link:../../../packages/tools/devtools/devtools
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
@@ -315,7 +315,7 @@ importers:
     specifiers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -375,7 +375,7 @@ importers:
       tinylicious: 2.0.1
       uuid: 9.0.0
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/mocha': 9.1.1
@@ -394,7 +394,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -456,7 +456,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/js-yaml': 4.0.5
@@ -478,7 +478,7 @@ importers:
       '@fluid-experimental/attributor': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -523,7 +523,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -556,7 +556,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -611,7 +611,7 @@ importers:
       style-loader: 1.3.0_webpack@5.83.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -646,7 +646,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -696,7 +696,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -737,7 +737,7 @@ importers:
       '@fluid-example/prosemirror': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -814,7 +814,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -857,7 +857,7 @@ importers:
       '@fluid-experimental/data-objects': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -904,7 +904,7 @@ importers:
       process: 0.11.10
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -936,7 +936,7 @@ importers:
       '@fluid-experimental/oldest-client-observer': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -987,7 +987,7 @@ importers:
       style-loader: 1.3.0_webpack@5.83.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1021,7 +1021,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1063,7 +1063,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1095,7 +1095,7 @@ importers:
       '@fluid-experimental/tree': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1137,7 +1137,7 @@ importers:
       use-resize-observer: 7.1.0_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
@@ -1165,7 +1165,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1210,7 +1210,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1245,7 +1245,7 @@ importers:
       '@fluid-experimental/sharejs-json1': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1290,7 +1290,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1324,7 +1324,7 @@ importers:
       '@fluid-experimental/tree': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1367,7 +1367,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1398,7 +1398,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1442,7 +1442,7 @@ importers:
       webpack-dev-server: 4.6.0_nwcuyijzf6l5chuh7xhtrzgjly
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/express': 4.17.17
@@ -1469,7 +1469,7 @@ importers:
     specifiers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/app-insights-logger': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1528,7 +1528,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
@@ -1569,7 +1569,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1610,7 +1610,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1646,7 +1646,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/counter': workspace:~
@@ -1688,7 +1688,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1720,7 +1720,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -1776,7 +1776,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/codemirror': 5.60.7
@@ -1800,7 +1800,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -1837,7 +1837,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1871,7 +1871,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1909,7 +1909,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1942,7 +1942,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1983,7 +1983,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/react': 17.0.52
@@ -2012,7 +2012,7 @@ importers:
       '@fluid-example/multiview-coordinate-model': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -2046,7 +2046,7 @@ importers:
       '@fluidframework/map': link:../../../../packages/dds/map
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2076,7 +2076,7 @@ importers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-example/multiview-slider-coordinate-view': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2112,7 +2112,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2153,7 +2153,7 @@ importers:
       '@fluid-example/multiview-triangle-view': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -2205,7 +2205,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2240,7 +2240,7 @@ importers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -2271,7 +2271,7 @@ importers:
       '@fluidframework/map': link:../../../../packages/dds/map
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2299,7 +2299,7 @@ importers:
   examples/data-objects/multiview/interface:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@types/expect-puppeteer': 2.2.1
@@ -2319,7 +2319,7 @@ importers:
       webpack-merge: ^5.8.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/expect-puppeteer': 2.2.1
@@ -2342,7 +2342,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2377,7 +2377,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2411,7 +2411,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2446,7 +2446,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2480,7 +2480,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2515,7 +2515,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2549,7 +2549,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2628,7 +2628,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.38
@@ -2656,7 +2656,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2734,7 +2734,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2771,7 +2771,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2826,7 +2826,7 @@ importers:
       simplemde: 1.11.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/events': 3.0.0
@@ -2850,7 +2850,7 @@ importers:
       '@fluid-internal/test-version-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -2896,7 +2896,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-version-utils': link:../../../packages/test/test-version-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -2925,7 +2925,7 @@ importers:
       '@fluid-example/table-document': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -2966,7 +2966,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.38
@@ -2991,7 +2991,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -3043,7 +3043,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3079,7 +3079,7 @@ importers:
       '@fluid-internal/test-version-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -3151,7 +3151,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-version-utils': link:../../../packages/test/test-version-utils
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -3198,7 +3198,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3299,7 +3299,7 @@ importers:
       uuid: 9.0.0
       valid-url: 1.0.9
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3347,7 +3347,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/version-tools': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/bundle-size-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
@@ -3386,7 +3386,7 @@ importers:
     devDependencies:
       '@cerner/duplicate-package-checker-webpack-plugin': 2.3.0_webpack@5.83.0
       '@fluid-tools/version-tools': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/bundle-size-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -3410,7 +3410,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3467,7 +3467,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -3484,7 +3484,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3538,7 +3538,7 @@ importers:
       style-loader: 1.3.0_webpack@5.83.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3573,7 +3573,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3653,7 +3653,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3694,7 +3694,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3780,7 +3780,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3825,7 +3825,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3878,7 +3878,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3912,7 +3912,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -3954,7 +3954,7 @@ importers:
       style-loader: 1.3.0_webpack@5.83.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3987,7 +3987,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -4037,7 +4037,7 @@ importers:
       vue: 2.6.14
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -4079,7 +4079,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4172,7 +4172,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -4212,7 +4212,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4310,7 +4310,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       react-virtualized-auto-sizer: 1.0.7_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -4341,14 +4341,14 @@ importers:
 
   experimental/PropertyDDS/examples/schemas:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       eslint: ~8.50.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
       typescript: ~5.1.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       eslint: 8.50.0
       prettier: 3.0.3
@@ -4366,7 +4366,7 @@ importers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-dds': workspace:~
       '@fluid-experimental/property-properties': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
@@ -4412,7 +4412,7 @@ importers:
       '@babel/plugin-proposal-decorators': 7.21.0_@babel+core@7.21.8
       '@babel/plugin-transform-runtime': 7.21.4_@babel+core@7.21.8
       '@babel/preset-env': 7.21.5_@babel+core@7.21.8
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../../packages/test/test-utils
@@ -4447,7 +4447,7 @@ importers:
   experimental/PropertyDDS/packages/property-changeset:
     specifiers:
       '@fluid-experimental/property-common': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/lodash': ^4.14.118
@@ -4484,7 +4484,7 @@ importers:
       semver: 7.5.3
       traverse: 0.6.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/lodash': 4.14.194
@@ -4507,7 +4507,7 @@ importers:
 
   experimental/PropertyDDS/packages/property-common:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -4552,7 +4552,7 @@ importers:
       semver: 7.5.3
       traverse: 0.6.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
@@ -4588,7 +4588,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-drivers': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4653,7 +4653,7 @@ importers:
     devDependencies:
       '@fluid-experimental/property-common': link:../property-common
       '@fluid-internal/test-drivers': link:../../../../packages/test/test-drivers
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/container-loader': link:../../../../packages/loader/container-loader
       '@fluidframework/driver-definitions': link:../../../../packages/common/driver-definitions
@@ -4691,7 +4691,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@hig/fonts': ^1.0.2
       '@material-ui/core': 4.12.4
@@ -4776,7 +4776,7 @@ importers:
       '@fluid-experimental/property-properties': link:../property-properties
       '@fluid-experimental/property-proxy': link:../property-proxy
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@storybook/addon-actions': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-essentials': 6.5.16_kht5apfbr7lobbt7tjefh3nlcq
@@ -4827,7 +4827,7 @@ importers:
     specifiers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-common': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/mocha': ^9.1.1
@@ -4863,7 +4863,7 @@ importers:
       traverse: 0.6.6
       underscore: 1.13.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/mocha': 9.1.1
@@ -4889,7 +4889,7 @@ importers:
       '@babel/preset-env': ^7.2.0
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-properties': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@types/jest': 29.5.3
@@ -4912,7 +4912,7 @@ importers:
       '@babel/core': 7.21.8
       '@babel/plugin-transform-runtime': 7.21.4_@babel+core@7.21.8
       '@babel/preset-env': 7.21.5_@babel+core@7.21.8
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/jest': 29.5.3
@@ -4987,7 +4987,7 @@ importers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/tree2': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -5007,7 +5007,7 @@ importers:
       '@fluid-experimental/tree2': link:../../../dds/tree2
       '@fluidframework/core-utils': link:../../../../packages/common/core-utils
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@types/jest': 29.5.3
@@ -5160,7 +5160,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5206,7 +5206,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5231,7 +5231,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5268,7 +5268,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../../packages/dds/shared-object-base
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../../packages/dds/test-dds-utils
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
@@ -5294,7 +5294,7 @@ importers:
     specifiers:
       '@fluid-experimental/ot': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -5329,7 +5329,7 @@ importers:
       ot-json1: 1.0.2
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../../../packages/dds/test-dds-utils
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../../packages/test/mocha-test-setup
@@ -5355,7 +5355,7 @@ importers:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5392,7 +5392,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5420,7 +5420,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-drivers': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -5483,7 +5483,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-internal/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/container-runtime': link:../../../packages/runtime/container-runtime
@@ -5523,7 +5523,7 @@ importers:
       '@fluid-internal/test-drivers': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -5586,7 +5586,7 @@ importers:
       '@fluid-internal/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
@@ -5623,7 +5623,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5651,7 +5651,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -5667,7 +5667,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -5694,7 +5694,7 @@ importers:
       '@fluidframework/shared-summary-block': link:../../../packages/dds/shared-summary-block
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5710,7 +5710,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -5735,7 +5735,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -5752,7 +5752,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -5782,7 +5782,7 @@ importers:
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5807,7 +5807,7 @@ importers:
   packages/common/client-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5862,7 +5862,7 @@ importers:
       sha.js: 2.4.11
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.40
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.40
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -5902,7 +5902,7 @@ importers:
   packages/common/container-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.0.0
       '@fluidframework/core-interfaces': workspace:~
@@ -5925,7 +5925,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -5941,7 +5941,7 @@ importers:
   packages/common/core-interfaces:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -5954,7 +5954,7 @@ importers:
       typescript: ~5.1.6
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -5970,7 +5970,7 @@ importers:
     specifiers:
       '@fluid-tools/benchmark': ^0.47.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -5994,7 +5994,7 @@ importers:
     devDependencies:
       '@fluid-tools/benchmark': 0.47.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6019,7 +6019,7 @@ importers:
   packages/common/driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.0.0
@@ -6036,7 +6036,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6051,7 +6051,7 @@ importers:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.0.0
       '@fluidframework/core-interfaces': workspace:~
@@ -6089,7 +6089,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6113,7 +6113,7 @@ importers:
   packages/dds/counter:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6150,7 +6150,7 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6174,7 +6174,7 @@ importers:
   packages/dds/ink:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6210,7 +6210,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.0.0
@@ -6237,7 +6237,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6285,7 +6285,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.0.0
@@ -6313,7 +6313,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6370,7 +6370,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.0.0
@@ -6403,7 +6403,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -6450,7 +6450,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.0.0
@@ -6479,7 +6479,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6516,7 +6516,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.53
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.53
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6541,7 +6541,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6582,7 +6582,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6606,7 +6606,7 @@ importers:
   packages/dds/pact-map:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6646,7 +6646,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6673,7 +6673,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6712,7 +6712,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6740,7 +6740,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6791,7 +6791,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6820,7 +6820,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -6869,7 +6869,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6896,7 +6896,7 @@ importers:
   packages/dds/shared-summary-block:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6933,7 +6933,7 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6961,7 +6961,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -7007,7 +7007,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7034,7 +7034,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -7066,7 +7066,7 @@ importers:
       mocha: 10.2.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7087,7 +7087,7 @@ importers:
   packages/drivers/debugger:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.0.0
@@ -7113,7 +7113,7 @@ importers:
       jsonschema: 1.4.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7129,7 +7129,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7165,7 +7165,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7189,7 +7189,7 @@ importers:
   packages/drivers/driver-web-cache:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7216,7 +7216,7 @@ importers:
       idb: 6.1.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7235,7 +7235,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7262,7 +7262,7 @@ importers:
       '@fluidframework/replay-driver': link:../replay-driver
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.0.0
@@ -7279,7 +7279,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7309,7 +7309,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7329,7 +7329,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7389,7 +7389,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.0.0
@@ -7416,7 +7416,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7469,7 +7469,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7496,7 +7496,7 @@ importers:
   packages/drivers/odsp-driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -7513,7 +7513,7 @@ importers:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.0.0
@@ -7529,7 +7529,7 @@ importers:
   packages/drivers/odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -7556,7 +7556,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7577,7 +7577,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7606,7 +7606,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.0.0
@@ -7624,7 +7624,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7684,7 +7684,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7714,7 +7714,7 @@ importers:
   packages/drivers/routerlicious-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7747,7 +7747,7 @@ importers:
       url: 0.11.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7769,7 +7769,7 @@ importers:
   packages/drivers/tinylicious-driver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -7804,7 +7804,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7828,7 +7828,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -7865,7 +7865,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
       '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -7881,7 +7881,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -7933,7 +7933,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
       '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7958,7 +7958,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8007,7 +8007,7 @@ importers:
     devDependencies:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8032,7 +8032,7 @@ importers:
 
   packages/framework/client-logger/app-insights-logger:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8057,7 +8057,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@microsoft/applicationinsights-web': 2.8.13_tslib@1.14.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.37.0
@@ -8081,7 +8081,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8118,7 +8118,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../dds/shared-object-base
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8133,7 +8133,7 @@ importers:
   packages/framework/dds-interceptions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.0.0
@@ -8168,7 +8168,7 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8194,7 +8194,7 @@ importers:
   packages/framework/fluid-framework:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8219,7 +8219,7 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -8235,7 +8235,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8279,7 +8279,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.0.0
@@ -8306,7 +8306,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8331,7 +8331,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../dds/test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8347,7 +8347,7 @@ importers:
   packages/framework/request-handler:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8382,7 +8382,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8408,7 +8408,7 @@ importers:
   packages/framework/synthesize:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -8434,7 +8434,7 @@ importers:
       '@fluidframework/core-utils': link:../../common/core-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/datastore': link:../../runtime/datastore
@@ -8460,7 +8460,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8508,7 +8508,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
       '@fluidframework/aqueduct': link:../aqueduct
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
@@ -8530,7 +8530,7 @@ importers:
   packages/framework/undo-redo:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -8566,7 +8566,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8593,7 +8593,7 @@ importers:
   packages/framework/view-adapters:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8616,7 +8616,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.0.0
@@ -8632,7 +8632,7 @@ importers:
   packages/framework/view-interfaces:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8649,7 +8649,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.0.0
@@ -8667,7 +8667,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.0.0
@@ -8724,7 +8724,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-loader-utils': link:../test-loader-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8753,7 +8753,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -8800,7 +8800,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8825,7 +8825,7 @@ importers:
   packages/loader/location-redirection-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8856,7 +8856,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.0.0
@@ -8881,7 +8881,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -8900,7 +8900,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
@@ -8914,7 +8914,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -8976,7 +8976,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9004,7 +9004,7 @@ importers:
   packages/runtime/container-runtime-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.0.0
@@ -9027,7 +9027,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9042,7 +9042,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9091,7 +9091,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9116,7 +9116,7 @@ importers:
   packages/runtime/datastore-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9137,7 +9137,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.0.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9151,7 +9151,7 @@ importers:
   packages/runtime/runtime-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9173,7 +9173,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.0.0
@@ -9189,7 +9189,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -9232,7 +9232,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -9258,7 +9258,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9313,7 +9313,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -9339,7 +9339,7 @@ importers:
     specifiers:
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -9371,7 +9371,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-loader-utils': link:../../loader/test-loader-utils
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/container-loader': link:../../loader/container-loader
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
@@ -9404,7 +9404,7 @@ importers:
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9464,7 +9464,7 @@ importers:
       '@fluid-internal/test-loader-utils': link:../../loader/test-loader-utils
       '@fluid-internal/test-pairwise-generator': link:../test-pairwise-generator
       '@fluidframework/aqueduct': link:../../framework/aqueduct
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/cell': link:../../dds/cell
       '@fluidframework/container-definitions': link:../../common/container-definitions
@@ -9523,7 +9523,7 @@ importers:
   packages/test/mocha-test-setup:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9546,7 +9546,7 @@ importers:
       source-map-support: 0.5.21
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.0.0
@@ -9564,7 +9564,7 @@ importers:
       '@fluid-experimental/sequence-deprecated': workspace:~
       '@fluid-internal/replay-tool': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9626,7 +9626,7 @@ importers:
       mocha: 10.2.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -9645,7 +9645,7 @@ importers:
   packages/test/stochastic-test-utils:
     specifiers:
       '@fluid-tools/benchmark': ^0.48.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9671,7 +9671,7 @@ importers:
       best-random: 1.0.3
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -9694,7 +9694,7 @@ importers:
   packages/test/test-app-insights-logger:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9711,7 +9711,7 @@ importers:
       applicationinsights: 2.6.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.38
@@ -9723,7 +9723,7 @@ importers:
   packages/test/test-driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -9744,7 +9744,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.0.0
@@ -9759,7 +9759,7 @@ importers:
     specifiers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -9814,7 +9814,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -9838,7 +9838,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/agent-scheduler': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9948,7 +9948,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@types/mocha': 9.1.1
@@ -9970,7 +9970,7 @@ importers:
   packages/test/test-pairwise-generator:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -9989,7 +9989,7 @@ importers:
       random-js: 1.0.8
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10012,7 +10012,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10077,7 +10077,7 @@ importers:
       tinylicious: 2.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10095,7 +10095,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10168,7 +10168,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10200,7 +10200,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/version-tools': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10282,7 +10282,7 @@ importers:
       semver: 7.5.3
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10314,7 +10314,7 @@ importers:
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.0.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -10345,7 +10345,7 @@ importers:
     devDependencies:
       '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.0.0
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
@@ -10377,7 +10377,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10458,7 +10458,7 @@ importers:
       '@fluid-example/example-utils': link:../../../../examples/utils/example-utils
       '@fluid-experimental/react-inputs': link:../../../../experimental/framework/react-inputs
       '@fluidframework/aqueduct': link:../../../framework/aqueduct
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/container-definitions': link:../../../common/container-definitions
       '@fluidframework/container-loader': link:../../../loader/container-loader
@@ -10523,7 +10523,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10578,7 +10578,7 @@ importers:
     devDependencies:
       '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.0.0
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/driver-definitions': link:../../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -10616,7 +10616,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10704,7 +10704,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       scheduler: 0.20.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_atz6un26dygc5sbqeq4zzkgzji
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../../test/test-utils
@@ -10749,7 +10749,7 @@ importers:
       '@fluentui/react-icons': ^2.0.201
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-internal/client-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10829,7 +10829,7 @@ importers:
       recharts: 2.7.2_oxfzelaz5ynxsop2v2nu2h2m64
       scheduler: 0.20.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.40
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
@@ -10884,7 +10884,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.0.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -10926,7 +10926,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
       '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.0.0
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.38
@@ -10939,7 +10939,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10979,7 +10979,7 @@ importers:
       yargs: 13.2.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.0.0
@@ -11002,7 +11002,7 @@ importers:
     specifiers:
       '@fluid-experimental/sequence-deprecated': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -11071,7 +11071,7 @@ importers:
       json-stable-stringify: 1.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.37.0_@types+node@16.18.38
@@ -11087,7 +11087,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.0.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -11167,7 +11167,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.0.0_nwcuyijzf6l5chuh7xhtrzgjly
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_2wska3rv6ra5ajbmktsvyxwga4
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11196,7 +11196,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -11234,7 +11234,7 @@ importers:
       node-fetch: 2.6.11
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11259,7 +11259,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -11298,7 +11298,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11325,7 +11325,7 @@ importers:
   packages/utils/tool-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-utils': workspace:~
@@ -11365,7 +11365,7 @@ importers:
       proper-lockfile: 4.1.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.38
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -14747,14 +14747,14 @@ packages:
     resolution: {integrity: sha512-q3zaKmH79+gO5t0EwR2ghSVbJqP3nnNNXx3o/rp+v6LKVZaxRZYMWgw2ESR2gF8rI7TWSeKkGVfBime2mVbDoQ==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/dom-utilities/2.2.11:
     resolution: {integrity: sha512-2tXfg7/9PXu9nfU72/P3o3waHEFEQtHUfQbVexUaYqNNAxMj6sOfsqpUx4vd5nPgO+grSWrl+spqlLN2yej51w==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/font-icons-mdl2/8.5.17_q5o373oqrklnndq2vhekyuzhxi:
@@ -14763,7 +14763,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@fluentui/style-utilities': 8.9.17_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
-      tslib: 2.6.2
+      tslib: 2.6.0
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -14781,13 +14781,13 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/keyboard-key/0.4.11:
     resolution: {integrity: sha512-TVB/EloWado9AVp1niChgcdDOQAHGP5B30Dinmtfe7zi8OnstwPoxwFP6dHJDdpLQ6ZEUTaEHViSzvewl7Chag==}
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/keyboard-keys/9.0.3:
@@ -14800,14 +14800,14 @@ packages:
     resolution: {integrity: sha512-vIiFv7WtXTPz0Sx6h1NpzqrwDN7yef7aQwqFl46yov72BodiAQMTazBl2A/z76IanBPklJmaTquFT9Uydlp/Dg==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/merge-styles/8.5.12:
     resolution: {integrity: sha512-ZnUo0YuMP7AYi68dkknFqVxopIAgbrUnqR/MZlemmRvBYyy1SMj1WQeHcoiLFA8mF8YKn7B+jxQgJbN2bfcrRw==}
     dependencies:
       '@fluentui/set-version': 8.2.11
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/priority-overflow/9.1.4:
@@ -15196,7 +15196,7 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/react-hooks/8.6.24_q5o373oqrklnndq2vhekyuzhxi:
@@ -15991,7 +15991,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/react/8.109.4_74b3ggvk3akyhuq4eydyx3fqim:
@@ -16025,13 +16025,13 @@ packages:
   /@fluentui/set-version/8.2.11:
     resolution: {integrity: sha512-UI03tysau/adBO1a3q4uFZWQ3lfkiFcAWIFng4k5odWcCokfCm5IxA0urKqj5W5JRYdyoBUaq8QbcNGkFB4dCw==}
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/set-version/8.2.9:
     resolution: {integrity: sha512-fpWo4DLt8K4spNip2YhNZlGnSKIa5F9hL/wQBE0EPei6+HEeRO2slXfHohOO5v1lIkfLPcpAh/Lzs2iuxzw/lw==}
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/style-utilities/8.9.10_q5o373oqrklnndq2vhekyuzhxi:
@@ -16042,7 +16042,7 @@ packages:
       '@fluentui/theme': 2.6.35_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@microsoft/load-themed-styles': 1.10.295
-      tslib: 2.6.2
+      tslib: 2.6.0
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -16056,7 +16056,7 @@ packages:
       '@fluentui/theme': 2.6.35_q5o373oqrklnndq2vhekyuzhxi
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@microsoft/load-themed-styles': 1.10.295
-      tslib: 2.6.2
+      tslib: 2.6.0
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -16073,7 +16073,7 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/theme/2.6.35_q5o373oqrklnndq2vhekyuzhxi:
@@ -16087,7 +16087,7 @@ packages:
       '@fluentui/utilities': 8.13.18_q5o373oqrklnndq2vhekyuzhxi
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/tokens/1.0.0-alpha.8:
@@ -16107,7 +16107,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluentui/utilities/8.13.18_q5o373oqrklnndq2vhekyuzhxi:
@@ -16121,7 +16121,7 @@ packages:
       '@fluentui/set-version': 8.2.11
       '@types/react': 17.0.52
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.6.0
     dev: false
 
   /@fluid-experimental/attributable-map/2.0.0-internal.7.0.0:
@@ -16611,7 +16611,7 @@ packages:
       isomorphic-fetch: 3.0.0
       nconf: 0.12.0
       sillyname: 0.1.0
-      uuid: 9.0.1
+      uuid: 9.0.0
       webpack-dev-server: 4.6.0_nwcuyijzf6l5chuh7xhtrzgjly
     transitivePeerDependencies:
       - '@types/express'
@@ -16638,7 +16638,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16661,7 +16661,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/synthesize': 2.0.0-internal.7.0.0
       '@fluidframework/view-interfaces': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16684,7 +16684,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/synthesize': 2.0.0-internal.7.0.0
       '@fluidframework/view-interfaces': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16720,11 +16720,11 @@ packages:
     dependencies:
       '@fluidframework/protocol-definitions': 3.0.0
       jsrsasign: 10.8.6
-      uuid: 9.0.1
+      uuid: 9.0.0
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -17143,8 +17143,8 @@ packages:
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lodash: 4.17.21
-      url: 0.11.3
-      uuid: 9.0.1
+      url: 0.11.0
+      uuid: 9.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17178,7 +17178,7 @@ packages:
       events: 3.3.0
       lz4js: 0.2.0
       sorted-btree: 1.8.1
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17203,7 +17203,7 @@ packages:
       events: 3.3.0
       lz4js: 0.2.0
       sorted-btree: 1.8.1
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17276,7 +17276,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       lodash: 4.17.21
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17297,7 +17297,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       lodash: 4.17.21
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17380,8 +17380,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       axios: 0.26.1
       lz4js: 0.2.0
-      url: 0.11.3
-      uuid: 9.0.1
+      url: 0.11.0
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17400,8 +17400,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
-      url: 0.11.3
-      uuid: 9.0.1
+      url: 0.11.0
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17539,7 +17539,7 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/shared-object-base': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17564,8 +17564,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       events: 3.3.0
       jsrsasign: 10.8.6
-      url: 0.11.3
-      uuid: 9.0.1
+      url: 0.11.0
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17593,8 +17593,8 @@ packages:
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
       events: 3.3.0
       jsrsasign: 10.8.6
-      url: 0.11.3
-      uuid: 9.0.1
+      url: 0.11.0
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17710,7 +17710,7 @@ packages:
       '@fluidframework/driver-utils': 2.0.0-internal.7.0.0
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      node-fetch: 2.7.0
+      node-fetch: 2.6.11
     transitivePeerDependencies:
       - debug
       - encoding
@@ -17727,7 +17727,7 @@ packages:
       '@fluidframework/driver-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      node-fetch: 2.7.0
+      node-fetch: 2.6.11
     transitivePeerDependencies:
       - debug
       - encoding
@@ -17754,9 +17754,9 @@ packages:
       '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      node-fetch: 2.7.0
-      socket.io-client: 4.7.2
-      uuid: 9.0.1
+      node-fetch: 2.6.11
+      socket.io-client: 4.6.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17791,7 +17791,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/shared-object-base': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17881,11 +17881,11 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      cross-fetch: 3.1.8
+      cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
-      socket.io-client: 4.7.2
+      socket.io-client: 4.6.1
       url-parse: 1.5.10
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17908,11 +17908,11 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      cross-fetch: 3.1.8
+      cross-fetch: 3.1.6
       json-stringify-safe: 5.0.1
-      socket.io-client: 4.7.2
+      socket.io-client: 4.6.1
       url-parse: 1.5.10
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17929,7 +17929,7 @@ packages:
       '@fluidframework/driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/protocol-definitions': 3.0.0
       nconf: 0.12.0
-      url: 0.11.3
+      url: 0.11.0
     dev: true
 
   /@fluidframework/runtime-definitions/2.0.0-internal.7.0.0:
@@ -17990,7 +17990,7 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/shared-object-base': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18248,7 +18248,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18268,7 +18268,7 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       '@fluidframework/telemetry-utils': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18321,7 +18321,7 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       debug: 4.3.4
       events: 3.3.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18332,7 +18332,7 @@ packages:
       '@fluidframework/core-interfaces': 2.0.0-internal.7.0.0
       '@fluidframework/driver-definitions': 2.0.0-internal.7.0.0
       '@fluidframework/protocol-definitions': 3.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     dev: true
 
   /@fluidframework/test-runtime-utils/2.0.0-internal.7.0.0:
@@ -18353,7 +18353,7 @@ packages:
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18380,7 +18380,7 @@ packages:
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18420,7 +18420,7 @@ packages:
       '@fluidframework/test-runtime-utils': 2.0.0-internal.7.0.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -18443,7 +18443,7 @@ packages:
       '@fluidframework/routerlicious-driver': 2.0.0-internal.7.0.0
       '@fluidframework/runtime-utils': 2.0.0-internal.7.0.0
       '@fluidframework/tinylicious-driver': 2.0.0-internal.7.0.0
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18462,7 +18462,7 @@ packages:
       '@fluidframework/routerlicious-driver': 2.0.0-internal.7.0.0
       '@fluidframework/server-services-client': 2.0.1
       jsrsasign: 10.8.6
-      uuid: 9.0.1
+      uuid: 9.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18565,7 +18565,7 @@ packages:
     dependencies:
       '@griffel/core': 1.14.1
       react: 17.0.2
-      tslib: 2.6.2
+      tslib: 2.5.0
     dev: false
 
   /@griffel/style-types/1.0.1:
@@ -20299,7 +20299,7 @@ packages:
       '@octokit/request-error': 2.1.0
       '@octokit/types': 6.41.0
       is-plain-object: 5.0.0
-      node-fetch: 2.7.0
+      node-fetch: 2.6.11
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
@@ -24942,7 +24942,7 @@ packages:
   /axios/0.21.4_debug@4.3.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: true
@@ -24980,7 +24980,7 @@ packages:
   /axios/0.27.2_debug@4.3.4:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -27407,15 +27407,6 @@ packages:
       node-fetch: 2.6.11
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /cross-fetch/3.1.8:
-    resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
 
   /cross-spawn/5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -28780,28 +28771,9 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /engine.io-client/6.5.2:
-    resolution: {integrity: sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==}
-    dependencies:
-      '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4
-      engine.io-parser: 5.2.1
-      ws: 8.11.0
-      xmlhttprequest-ssl: 2.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /engine.io-parser/5.0.7:
     resolution: {integrity: sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==}
     engines: {node: '>=10.0.0'}
-
-  /engine.io-parser/5.2.1:
-    resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
-    engines: {node: '>=10.0.0'}
-    dev: true
 
   /engine.io/6.4.2:
     resolution: {integrity: sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==}
@@ -35438,7 +35410,7 @@ packages:
     dependencies:
       abort-controller: 3.0.0
       ky: 0.12.0
-      node-fetch: 2.7.0
+      node-fetch: 2.6.11
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -41991,20 +41963,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  /socket.io-client/4.7.2:
-    resolution: {integrity: sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4
-      engine.io-client: 6.5.2
-      socket.io-parser: 4.2.4
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /socket.io-parser/4.2.2:
     resolution: {integrity: sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,5 @@
 lockfileVersion: 5.4
 
-overrides:
-  '@microsoft/api-extractor>typescript': ~5.1.6
-  '@types/node': ^16.18.38
-  node-fetch: ^2.6.9
-  good-fences>nodegit: npm:empty-npm-package@1.0.0
-  qs: ^6.11.0
-  simplemde>codemirror: ^5.65.11
-  simplemde>marked: ^4.3.0
-  '@fluidframework/build-tools>npm-package-json-lint@^6.0.0': ~6.3.0
-  '@oclif/core': ~2.4.0
-
 importers:
 
   .:
@@ -11387,6 +11376,35 @@ importers:
       rimraf: 4.4.1
       typescript: 5.1.6
 
+  tools/telemetry-generator:
+    specifiers:
+      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/common-definitions': ^0.20.1
+      '@fluidframework/eslint-config-fluid': ^2.0.0
+      '@fluidframework/test-driver-definitions': '>=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0'
+      '@oclif/core': ^1.12.0
+      '@types/node': ^14.18.0
+      applicationinsights: ^2.4.1
+      concurrently: ^8.2.1
+      eslint: ~8.6.0
+      prettier: ~3.0.3
+      rimraf: ^2.6.2
+      typescript: ~4.5.5
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.1.4.9
+      '@oclif/core': 1.26.2
+      applicationinsights: 2.9.0
+    devDependencies:
+      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@types/node': 14.18.63
+      concurrently: 8.2.1
+      eslint: 8.6.0
+      prettier: 3.0.3
+      rimraf: 2.7.1
+      typescript: 4.5.5
+
 packages:
 
   /@aashutoshrathi/word-wrap/1.2.6:
@@ -11421,12 +11439,21 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@azure/core-auth/1.5.0:
+    resolution: {integrity: sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-util': 1.2.0
+      tslib: 2.6.2
+    dev: false
+
   /@azure/core-rest-pipeline/1.10.1:
     resolution: {integrity: sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.4.0
+      '@azure/core-auth': 1.5.0
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.2.0
       '@azure/logger': 1.0.4
@@ -11470,6 +11497,20 @@ packages:
       '@opentelemetry/api': 1.4.1
       '@opentelemetry/core': 1.13.0_@opentelemetry+api@1.4.1
       '@opentelemetry/instrumentation': 0.35.1_@opentelemetry+api@1.4.1
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@azure/opentelemetry-instrumentation-azure-sdk/1.0.0-beta.5:
+    resolution: {integrity: sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@azure/core-tracing': 1.0.1
+      '@azure/logger': 1.0.4
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
+      '@opentelemetry/instrumentation': 0.41.2_@opentelemetry+api@1.6.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -14079,6 +14120,13 @@ packages:
     dependencies:
       regenerator-runtime: 0.14.0
 
+  /@babel/runtime/7.23.1:
+    resolution: {integrity: sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: true
+
   /@babel/template/7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
@@ -14480,6 +14528,15 @@ packages:
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
     dev: false
 
+  /@es-joy/jsdoccomment/0.33.4:
+    resolution: {integrity: sha512-02XyYuvR/Gn+3BT6idHVNQ4SSQlA1X1FeEfeKm2ypv8ANB6Lt9KRFZ2S7y5xjwR+EPQ/Rzb0XFaD+xKyqe4ALw==}
+    engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
+    dependencies:
+      comment-parser: 1.3.1
+      esquery: 1.5.0
+      jsdoc-type-pratt-parser: 3.1.0
+    dev: true
+
   /@es-joy/jsdoccomment/0.40.1:
     resolution: {integrity: sha512-YORCdZSusAlBrFpZ77pJjc5r1bQs5caPWtAu+WWmiSo+8XaUzseapVrfAtiRFbQWnrBxxLLEwF6f6ZG/UgCQCg==}
     engines: {node: '>=16'}
@@ -14697,9 +14754,36 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /@eslint-community/eslint-utils/4.4.0_eslint@8.6.0:
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.6.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
   /@eslint-community/regexpp/4.9.1:
     resolution: {integrity: sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/eslintrc/1.4.1:
+    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 9.6.1
+      globals: 13.23.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@eslint/eslintrc/2.1.2:
@@ -17104,6 +17188,10 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/common-definitions/0.20.1:
+    resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
+    dev: false
+
   /@fluidframework/common-definitions/1.0.0:
     resolution: {integrity: sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ==}
 
@@ -17208,6 +17296,10 @@ packages:
       - debug
       - supports-color
     dev: true
+
+  /@fluidframework/core-interfaces/2.0.0-internal.1.4.9:
+    resolution: {integrity: sha512-b9oZpYNSmQjhSaW/za/XQ23d8aDRvhf6XkilUI9GcOBRCFLc2o2FYg7RLs23GGkjFIi3jvqe7UdeYkZfHR60Rg==}
+    dev: false
 
   /@fluidframework/core-interfaces/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA==}
@@ -17360,6 +17452,14 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/driver-definitions/2.0.0-internal.1.4.9:
+    resolution: {integrity: sha512-N10hoaUbaWfQkoJWPhl3gmlkQTqBFiBf9VZIwGbw/NLHVH2Xh8Tl66+91vU85r0U45unq8UCSVGSkGIXxTUu9A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.1.4.9
+      '@fluidframework/protocol-definitions': 1.2.0
+    dev: false
+
   /@fluidframework/driver-definitions/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==}
     dependencies:
@@ -17417,6 +17517,32 @@ packages:
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@fluidframework/eslint-config-fluid/2.1.0_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-pdQQpFB0UJcZxUpe/zgN+TUJzZw1Kvrnrvbn8HgZZ5KFDHgJYxs+k9ZCJopgOYjomhbHsJSmlsuIESiF/YeEOg==}
+    dependencies:
+      '@rushstack/eslint-patch': 1.1.4
+      '@rushstack/eslint-plugin': 0.8.6_kufnqfq7tb5rpdawkdb6g5smma
+      '@rushstack/eslint-plugin-security': 0.2.6_kufnqfq7tb5rpdawkdb6g5smma
+      '@typescript-eslint/eslint-plugin': 5.55.0_36lylnhpq2p3xhpusv76l3z5qu
+      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      eslint-config-prettier: 8.5.0_eslint@8.6.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.6.0
+      eslint-plugin-import: 2.25.4_4pij4nvnkqnncanfc5qjphoilq
+      eslint-plugin-jsdoc: 39.3.25_eslint@8.6.0
+      eslint-plugin-promise: 6.0.1_eslint@8.6.0
+      eslint-plugin-react: 7.28.0_eslint@8.6.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.6.0
+      eslint-plugin-tsdoc: 0.2.17
+      eslint-plugin-unicorn: 40.0.0_eslint@8.6.0
+      eslint-plugin-unused-imports: 2.0.0_mk3lxcfeigio6zzden7bbdcose
+    transitivePeerDependencies:
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
     dev: true
 
   /@fluidframework/eslint-config-fluid/3.0.0_loebgezstcsvd2poh2d55fifke:
@@ -17804,6 +17930,12 @@ packages:
       '@fluidframework/gitresources': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
+
+  /@fluidframework/protocol-definitions/1.2.0:
+    resolution: {integrity: sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+    dev: false
 
   /@fluidframework/protocol-definitions/3.0.0:
     resolution: {integrity: sha512-FUIw5B5aTVJ831zAvsNUzKGFCkPoswmUeeYfZtVlq2wRpO2Ffm28TYhbkrAGFOtCd0BiByJDho6Oo+iZbNBgUA==}
@@ -18326,6 +18458,16 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/test-driver-definitions/2.0.0-internal.1.4.9:
+    resolution: {integrity: sha512-xg+BmeB0Qo8z2l/RV33GG5gEWpPryeDERVB4s7kIC3gSDKFRxaoGZjHMptWnC8+FjFTYREXW6/VkP+vjydHPZA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.1.4.9
+      '@fluidframework/driver-definitions': 2.0.0-internal.1.4.9
+      '@fluidframework/protocol-definitions': 1.2.0
+      uuid: 8.3.2
+    dev: false
+
   /@fluidframework/test-driver-definitions/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-IubdjrhM5Rtx9cYk4g9WQliIflkIrgQC800m6o12giUvm8ocnwl5klNkqC6WYLgwfBWP3vhQrPluFD4X2pKaFw==}
     dependencies:
@@ -18620,6 +18762,17 @@ packages:
 
   /@humanwhocodes/config-array/0.11.11:
     resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.3.4
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/config-array/0.9.5:
+    resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -20000,6 +20153,40 @@ packages:
       - supports-color
     dev: true
 
+  /@oclif/core/1.26.2:
+    resolution: {integrity: sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@oclif/linewrap': 1.0.0
+      '@oclif/screen': 3.0.7
+      ansi-escapes: 4.3.2
+      ansi-styles: 4.3.0
+      cardinal: 2.1.1
+      chalk: 4.1.2
+      clean-stack: 3.0.1
+      cli-progress: 3.12.0
+      debug: 4.3.4_supports-color@8.1.1
+      ejs: 3.1.9
+      fs-extra: 9.1.0
+      get-package-type: 0.1.0
+      globby: 11.1.0
+      hyperlinker: 1.0.0
+      indent-string: 4.0.0
+      is-wsl: 2.2.0
+      js-yaml: 3.14.1
+      natural-orderby: 2.0.3
+      object-treeify: 1.1.33
+      password-prompt: 1.1.3
+      semver: 7.5.4
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      supports-color: 8.1.1
+      supports-hyperlinks: 2.3.0
+      tslib: 2.6.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
+    dev: false
+
   /@oclif/core/2.4.0:
     resolution: {integrity: sha512-wWUnOOfQQty0k1Cstm/iWW6pbG0mHzU7rcUtab2Sni9kjBPCcy6ENTgpsWbb/WdITopqtXmvpYII2fgcjKdzUA==}
     engines: {node: '>=14.0.0'}
@@ -20032,6 +20219,10 @@ packages:
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
+
+  /@oclif/linewrap/1.0.0:
+    resolution: {integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==}
+    dev: false
 
   /@oclif/plugin-autocomplete/2.3.8:
     resolution: {integrity: sha512-cmRPss9OQxz8sRoaw5C/4t/Da7eBEIDJWKRsuzUSQBcPJCN3kTgjp24VTjPHT3j86197s/qkjCRct+3P0IGArg==}
@@ -20097,6 +20288,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@oclif/screen/3.0.7:
+    resolution: {integrity: sha512-jQBPHcMh5rcIPKdqA6xlzioLOmkaVnjg2MVyjMzBKV8hDhLWNSiZqx7NAWXpP70v2LFvGdVoV8BSbK9iID3eHg==}
+    engines: {node: '>=12.0.0'}
+    dev: false
 
   /@oclif/test/2.3.28:
     resolution: {integrity: sha512-Eee3efwfHHdgZIwOUGFEe8p4d8YEWFYKHoAezxdXzXVOtV4L9r7Oq6KH8dXGBy8yjYDleydwn0PqoZGhFeLxYQ==}
@@ -20431,6 +20627,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
+  /@opentelemetry/api/1.6.0:
+    resolution: {integrity: sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
   /@opentelemetry/core/1.13.0_@opentelemetry+api@1.4.1:
     resolution: {integrity: sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==}
     engines: {node: '>=14'}
@@ -20441,6 +20642,16 @@ packages:
       '@opentelemetry/semantic-conventions': 1.13.0
     dev: false
 
+  /@opentelemetry/core/1.17.1_@opentelemetry+api@1.6.0:
+    resolution: {integrity: sha512-I6LrZvl1FF97FQXPR0iieWQmKnGxYtMbWA1GrAXnLUR+B1Hn2m8KqQNEIlZAucyv00GBgpWkpllmULmZfG8P3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/semantic-conventions': 1.17.1
+    dev: false
+
   /@opentelemetry/instrumentation/0.35.1_@opentelemetry+api@1.4.1:
     resolution: {integrity: sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==}
     engines: {node: '>=14'}
@@ -20449,6 +20660,22 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.4.1
       require-in-the-middle: 5.2.0
+      semver: 7.5.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation/0.41.2_@opentelemetry+api@1.6.0:
+    resolution: {integrity: sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@types/shimmer': 1.0.3
+      import-in-the-middle: 1.4.2
+      require-in-the-middle: 7.2.0
       semver: 7.5.4
       shimmer: 1.2.1
     transitivePeerDependencies:
@@ -20466,6 +20693,17 @@ packages:
       '@opentelemetry/semantic-conventions': 1.13.0
     dev: false
 
+  /@opentelemetry/resources/1.17.1_@opentelemetry+api@1.6.0:
+    resolution: {integrity: sha512-M2e5emqg5I7qRKqlzKx0ROkcPyF8PbcSaWEdsm72od9txP7Z/Pl8PDYOyu80xWvbHAWk5mDxOF6v3vNdifzclA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
+      '@opentelemetry/semantic-conventions': 1.17.1
+    dev: false
+
   /@opentelemetry/sdk-trace-base/1.13.0_@opentelemetry+api@1.4.1:
     resolution: {integrity: sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==}
     engines: {node: '>=14'}
@@ -20478,8 +20716,25 @@ packages:
       '@opentelemetry/semantic-conventions': 1.13.0
     dev: false
 
+  /@opentelemetry/sdk-trace-base/1.17.1_@opentelemetry+api@1.6.0:
+    resolution: {integrity: sha512-pfSJJSjZj5jkCJUQZicSpzN8Iz9UKMryPWikZRGObPnJo6cUSoKkjZh6BM3j+D47G4olMBN+YZKYqkFM1L6zNA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+    dependencies:
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
+      '@opentelemetry/resources': 1.17.1_@opentelemetry+api@1.6.0
+      '@opentelemetry/semantic-conventions': 1.17.1
+    dev: false
+
   /@opentelemetry/semantic-conventions/1.13.0:
     resolution: {integrity: sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /@opentelemetry/semantic-conventions/1.17.1:
+    resolution: {integrity: sha512-xbR2U+2YjauIuo42qmE8XyJK6dYeRMLJuOlUP5SO4auET4VtOHOzgkRVOq+Ik18N+Xf3YPcqJs9dZMiDddz1eQ==}
     engines: {node: '>=14'}
     dev: false
 
@@ -20816,6 +21071,10 @@ packages:
       - supports-color
     dev: true
 
+  /@rushstack/eslint-patch/1.1.4:
+    resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
+    dev: true
+
   /@rushstack/eslint-patch/1.4.0:
     resolution: {integrity: sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg==}
     dev: true
@@ -20832,6 +21091,19 @@ packages:
       '@rushstack/tree-pattern': 0.3.1
       '@typescript-eslint/experimental-utils': 5.59.11_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin-security/0.2.6_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.3
+      '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
+      eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20858,6 +21130,19 @@ packages:
       '@rushstack/tree-pattern': 0.3.1
       '@typescript-eslint/experimental-utils': 5.59.11_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin/0.8.6_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.3
+      '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
+      eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20956,6 +21241,10 @@ packages:
     dependencies:
       resolve: 1.22.6
       strip-json-comments: 3.1.1
+    dev: true
+
+  /@rushstack/tree-pattern/0.2.3:
+    resolution: {integrity: sha512-8KWZxzn6XKuy3iKRSAd2CHXSXneRlGCmH9h/qM7jYQDekp+U18oUzub5xqOqHS2PLUC+torOMYZxgAIO/fF86A==}
     dev: true
 
   /@rushstack/tree-pattern/0.3.1:
@@ -23081,6 +23370,10 @@ packages:
       form-data: 3.0.1
     dev: true
 
+  /@types/node/14.18.63:
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
+    dev: true
+
   /@types/node/16.18.38:
     resolution: {integrity: sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==}
     dev: true
@@ -23091,8 +23384,8 @@ packages:
   /@types/node/16.18.53:
     resolution: {integrity: sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==}
 
-  /@types/normalize-package-data/2.4.1:
-    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
+  /@types/normalize-package-data/2.4.2:
+    resolution: {integrity: sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==}
     dev: true
 
   /@types/npmlog/4.1.4:
@@ -23215,6 +23508,10 @@ packages:
   /@types/semver/7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
 
+  /@types/semver/7.5.3:
+    resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
+    dev: true
+
   /@types/send/0.17.1:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
@@ -23239,6 +23536,10 @@ packages:
       '@types/glob': 7.2.0
       '@types/node': 16.18.53
     dev: true
+
+  /@types/shimmer/1.0.3:
+    resolution: {integrity: sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA==}
+    dev: false
 
   /@types/simplemde/1.11.8:
     resolution: {integrity: sha512-NF3MJ1jdP5nJB5DH2HNmGQK61mRr6Rxoe+EWboxR0XBrIS95/PgHuP+Ry6rCJ63DMMX70OKxvJ4bCP4IIvLhPg==}
@@ -23387,6 +23688,34 @@ packages:
     dev: true
     optional: true
 
+  /@typescript-eslint/eslint-plugin/5.55.0_36lylnhpq2p3xhpusv76l3z5qu:
+    resolution: {integrity: sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.9.1
+      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@typescript-eslint/scope-manager': 5.55.0
+      '@typescript-eslint/type-utils': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@typescript-eslint/utils': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      debug: 4.3.4
+      eslint: 8.6.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin/5.59.11_5x5zj3ed4pfrlx677mwttmrwaa:
     resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23457,6 +23786,44 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.6.0_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.13
+      '@typescript-eslint/scope-manager': 5.6.0
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.5
+      eslint: 8.6.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/parser/5.55.0_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.55.0
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/typescript-estree': 5.55.0_typescript@4.5.5
+      debug: 4.3.4
+      eslint: 8.6.0
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser/5.59.11_loebgezstcsvd2poh2d55fifke:
     resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23498,6 +23865,14 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/scope-manager/5.55.0:
+    resolution: {integrity: sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/visitor-keys': 5.55.0
+    dev: true
+
   /@typescript-eslint/scope-manager/5.59.11:
     resolution: {integrity: sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23514,12 +23889,40 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
+  /@typescript-eslint/scope-manager/5.6.0:
+    resolution: {integrity: sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/visitor-keys': 5.6.0
+    dev: true
+
   /@typescript-eslint/scope-manager/6.7.4:
     resolution: {integrity: sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.7.4
       '@typescript-eslint/visitor-keys': 6.7.4
+    dev: true
+
+  /@typescript-eslint/type-utils/5.55.0_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.55.0_typescript@4.5.5
+      '@typescript-eslint/utils': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      debug: 4.3.4
+      eslint: 8.6.0
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@typescript-eslint/type-utils/5.59.11_loebgezstcsvd2poh2d55fifke:
@@ -23562,6 +23965,11 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/types/5.55.0:
+    resolution: {integrity: sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /@typescript-eslint/types/5.59.11:
     resolution: {integrity: sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23572,9 +23980,35 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@typescript-eslint/types/5.6.0:
+    resolution: {integrity: sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /@typescript-eslint/types/6.7.4:
     resolution: {integrity: sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.55.0_typescript@4.5.5:
+    resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/visitor-keys': 5.55.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree/5.59.11_typescript@5.1.6:
@@ -23619,6 +24053,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.5:
+    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/visitor-keys': 5.6.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/6.7.4_typescript@5.1.6:
     resolution: {integrity: sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -23638,6 +24093,26 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.55.0_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.6.0
+      '@types/json-schema': 7.0.13
+      '@types/semver': 7.5.3
+      '@typescript-eslint/scope-manager': 5.55.0
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/typescript-estree': 5.55.0_typescript@4.5.5
+      eslint: 8.6.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /@typescript-eslint/utils/5.59.11_loebgezstcsvd2poh2d55fifke:
@@ -23699,6 +24174,14 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/visitor-keys/5.55.0:
+    resolution: {integrity: sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.55.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.59.11:
     resolution: {integrity: sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23712,6 +24195,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.59.6
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.6.0:
+    resolution: {integrity: sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -24093,7 +24584,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.10.0
-    dev: true
 
   /acorn-import-assertions/1.9.0_acorn@8.8.2:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
@@ -24449,6 +24939,32 @@ packages:
       - supports-color
     dev: false
 
+  /applicationinsights/2.9.0:
+    resolution: {integrity: sha512-W90WNjtvZ10GUInpkyNM0xBGe2qRYChHhdb44SE5KU7hXtCZLxs3IZjWw1gJINQem0qGAgtZlxrVvKPj5SlTbQ==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      applicationinsights-native-metrics: '*'
+    peerDependenciesMeta:
+      applicationinsights-native-metrics:
+        optional: true
+    dependencies:
+      '@azure/core-auth': 1.5.0
+      '@azure/core-rest-pipeline': 1.10.1
+      '@azure/core-util': 1.2.0
+      '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.5
+      '@microsoft/applicationinsights-web-snippet': 1.0.1
+      '@opentelemetry/api': 1.6.0
+      '@opentelemetry/core': 1.17.1_@opentelemetry+api@1.6.0
+      '@opentelemetry/sdk-trace-base': 1.17.1_@opentelemetry+api@1.6.0
+      '@opentelemetry/semantic-conventions': 1.17.1
+      cls-hooked: 4.2.2
+      continuation-local-storage: 3.2.1
+      diagnostic-channel: 1.1.1
+      diagnostic-channel-publishers: 1.0.7_diagnostic-channel@1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /aproba/1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
     dev: true
@@ -24571,6 +25087,17 @@ packages:
       is-string: 1.0.7
     dev: true
 
+  /array-includes/3.1.7:
+    resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
+      get-intrinsic: 1.2.1
+      is-string: 1.0.7
+    dev: true
+
   /array-to-sentence/1.1.0:
     resolution: {integrity: sha512-YkwkMmPA2+GSGvXj1s9NZ6cc2LBtR+uSeWTy2IGi5MR1Wag4DdrcjTxA/YV/Fw+qKlBeXomneZgThEbm/wvZbw==}
     dev: false
@@ -24628,6 +25155,16 @@ packages:
       es-shim-unscopables: 1.0.0
     dev: true
 
+  /array.prototype.flat/1.3.2:
+    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
+      es-shim-unscopables: 1.0.0
+    dev: true
+
   /array.prototype.flatmap/1.3.1:
     resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
     engines: {node: '>= 0.4'}
@@ -24635,6 +25172,16 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.21.2
+      es-shim-unscopables: 1.0.0
+    dev: true
+
+  /array.prototype.flatmap/1.3.2:
+    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -24676,7 +25223,7 @@ packages:
     dependencies:
       array-buffer-byte-length: 1.0.0
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.22.2
       get-intrinsic: 1.2.1
       is-array-buffer: 3.0.2
@@ -26469,6 +27016,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /ci-info/3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /cipher-base/1.0.4:
     resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
     dependencies:
@@ -26482,7 +27034,6 @@ packages:
 
   /cjs-module-lexer/1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
-    dev: true
 
   /class-utils/0.3.6:
     resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
@@ -26750,7 +27301,7 @@ packages:
     dependencies:
       async-hook-jl: 1.7.6
       emitter-listener: 1.1.2
-      semver: 5.7.1
+      semver: 5.7.2
     dev: false
 
   /clsx/1.2.1:
@@ -26961,6 +27512,11 @@ packages:
 
   /commandpost/1.4.0:
     resolution: {integrity: sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==}
+    dev: true
+
+  /comment-parser/1.3.1:
+    resolution: {integrity: sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==}
+    engines: {node: '>= 12.0.0'}
     dev: true
 
   /comment-parser/1.4.0:
@@ -27923,7 +28479,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.1
     dev: true
 
   /dateformat/3.0.3:
@@ -28357,10 +28913,24 @@ packages:
       diagnostic-channel: 1.1.0
     dev: false
 
+  /diagnostic-channel-publishers/1.0.7_diagnostic-channel@1.1.1:
+    resolution: {integrity: sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==}
+    peerDependencies:
+      diagnostic-channel: '*'
+    dependencies:
+      diagnostic-channel: 1.1.1
+    dev: false
+
   /diagnostic-channel/1.1.0:
     resolution: {integrity: sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==}
     dependencies:
       semver: 5.7.2
+    dev: false
+
+  /diagnostic-channel/1.1.1:
+    resolution: {integrity: sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==}
+    dependencies:
+      semver: 7.5.4
     dev: false
 
   /diff-sequences/29.4.3:
@@ -28678,7 +29248,7 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
     dependencies:
-      jake: 10.8.6
+      jake: 10.8.7
 
   /electron-to-chromium/1.4.527:
     resolution: {integrity: sha512-EafxEiEDzk2aLrdbtVczylHflHdHkNrpGNHIgDyA63sUQLQVS2ayj2hPw3RsVB42qkwURH+T2OxV7kGPUuYszA==}
@@ -28823,6 +29393,14 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.3
+    dev: true
+
+  /enquirer/2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
     dev: true
 
   /entities/1.1.2:
@@ -28975,7 +29553,7 @@ packages:
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
-      has: 1.0.3
+      has: 1.0.4
       has-property-descriptors: 1.0.0
       has-proto: 1.0.1
       has-symbols: 1.0.3
@@ -29054,14 +29632,14 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.1
-      has: 1.0.3
+      has: 1.0.4
       has-tostringtag: 1.0.0
     dev: true
 
   /es-shim-unscopables/1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
     dependencies:
-      has: 1.0.3
+      has: 1.0.4
     dev: true
 
   /es-to-primitive/1.2.1:
@@ -29208,6 +29786,15 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /eslint-config-prettier/8.5.0_eslint@8.6.0:
+    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.6.0
+    dev: true
+
   /eslint-config-prettier/9.0.0_eslint@8.50.0:
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
@@ -29219,6 +29806,16 @@ packages:
 
   /eslint-import-resolver-node/0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.13.0
+      resolve: 1.22.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-import-resolver-node/0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
       debug: 3.2.7
       is-core-module: 2.13.0
@@ -29275,6 +29872,35 @@ packages:
       eslint: 8.50.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.6.1_mc36sq7crv2v5vtlozlclqwu5e
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils/2.8.0_efyktxylcfmcbkqa5c3pglhkk4:
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      debug: 3.2.7
+      eslint: 8.6.0
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29440,6 +30066,17 @@ packages:
       ignore: 5.2.4
     dev: true
 
+  /eslint-plugin-eslint-comments/3.2.0_eslint@8.6.0:
+    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
+    engines: {node: '>=6.5.0'}
+    peerDependencies:
+      eslint: '>=4.19.1'
+    dependencies:
+      escape-string-regexp: 1.0.5
+      eslint: 8.6.0
+      ignore: 5.2.4
+    dev: true
+
   /eslint-plugin-filenames/1.3.2_eslint@8.50.0:
     resolution: {integrity: sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==}
     peerDependencies:
@@ -29450,6 +30087,37 @@ packages:
       lodash.kebabcase: 4.1.1
       lodash.snakecase: 4.1.1
       lodash.upperfirst: 4.3.1
+    dev: true
+
+  /eslint-plugin-import/2.25.4_4pij4nvnkqnncanfc5qjphoilq:
+    resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.55.0_kufnqfq7tb5rpdawkdb6g5smma
+      array-includes: 3.1.7
+      array.prototype.flat: 1.3.2
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint: 8.6.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.0_efyktxylcfmcbkqa5c3pglhkk4
+      has: 1.0.4
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.7
+      resolve: 1.22.6
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-import/2.28.1_4nytrgfpfmroylhx7ogxfohaye:
@@ -29631,6 +30299,24 @@ packages:
       - typescript
     dev: true
 
+  /eslint-plugin-jsdoc/39.3.25_eslint@8.6.0:
+    resolution: {integrity: sha512-7JiFOOaipz7Z7lNQ9sMJ6cdvclmVUwNYtFWGS3a0k0uEFcdZPPD64WOfENuyNHpl86C0AKIEPgOpZby5kd+pew==}
+    engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@es-joy/jsdoccomment': 0.33.4
+      comment-parser: 1.3.1
+      debug: 4.3.4
+      escape-string-regexp: 4.0.0
+      eslint: 8.6.0
+      esquery: 1.5.0
+      semver: 7.5.4
+      spdx-expression-parse: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-jsdoc/46.8.2_eslint@8.50.0:
     resolution: {integrity: sha512-5TSnD018f3tUJNne4s4gDWQflbsgOycIKEUBoCLn6XtBMgNHxQFmV8vVxUtiPxAQq8lrX85OaSG/2gnctxw9uQ==}
     engines: {node: '>=16'}
@@ -29691,6 +30377,15 @@ packages:
       eslint: 8.50.0
     dev: true
 
+  /eslint-plugin-promise/6.0.1_eslint@8.6.0:
+    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.6.0
+    dev: true
+
   /eslint-plugin-promise/6.1.1_eslint@8.50.0:
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -29707,6 +30402,15 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.50.0
+    dev: true
+
+  /eslint-plugin-react-hooks/4.6.0_eslint@8.6.0:
+    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.6.0
     dev: true
 
   /eslint-plugin-react/7.27.1_eslint@8.50.0:
@@ -29730,6 +30434,29 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.8
+    dev: true
+
+  /eslint-plugin-react/7.28.0_eslint@8.6.0:
+    resolution: {integrity: sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.flatmap: 1.3.2
+      doctrine: 2.1.0
+      eslint: 8.6.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.7
+      object.fromentries: 2.0.7
+      object.hasown: 1.1.3
+      object.values: 1.1.7
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.4
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.10
     dev: true
 
   /eslint-plugin-react/7.33.2_eslint@8.50.0:
@@ -29764,6 +30491,29 @@ packages:
       '@microsoft/tsdoc-config': 0.16.2
     dev: true
 
+  /eslint-plugin-unicorn/40.0.0_eslint@8.6.0:
+    resolution: {integrity: sha512-5GRXISfBk8jMmYk1eeNDw8zSRnWTxBjWkzx2Prre6E2/yLu2twozZ3EomLWCBu9nWms/ZE361BItyMQwfnG1qA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      eslint: '>=7.32.0'
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.20
+      ci-info: 3.9.0
+      clean-regexp: 1.0.0
+      eslint: 8.6.0
+      eslint-utils: 3.0.0_eslint@8.6.0
+      esquery: 1.5.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.1
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      read-pkg-up: 7.0.1
+      regexp-tree: 0.1.27
+      safe-regex: 2.1.1
+      semver: 7.5.4
+      strip-indent: 3.0.0
+    dev: true
+
   /eslint-plugin-unicorn/48.0.1_eslint@8.50.0:
     resolution: {integrity: sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==}
     engines: {node: '>=16'}
@@ -29786,6 +30536,21 @@ packages:
       regjsparser: 0.10.0
       semver: 7.5.4
       strip-indent: 3.0.0
+    dev: true
+
+  /eslint-plugin-unused-imports/2.0.0_mk3lxcfeigio6zzden7bbdcose:
+    resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.55.0_36lylnhpq2p3xhpusv76l3z5qu
+      eslint: 8.6.0
+      eslint-rule-composer: 0.3.0
     dev: true
 
   /eslint-plugin-unused-imports/3.0.0_eslint@8.50.0:
@@ -29857,6 +30622,16 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       eslint-visitor-keys: 1.3.0
+    dev: true
+
+  /eslint-utils/3.0.0_eslint@8.6.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 8.6.0
+      eslint-visitor-keys: 2.1.0
     dev: true
 
   /eslint-visitor-keys/1.3.0:
@@ -29962,6 +30737,53 @@ packages:
       optionator: 0.9.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint/8.6.0:
+    resolution: {integrity: sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint/eslintrc': 1.4.1
+      '@humanwhocodes/config-array': 0.9.5
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      enquirer: 2.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-utils: 3.0.0_eslint@8.6.0
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 6.0.2
+      globals: 13.23.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.5.4
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -30581,7 +31403,7 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 3.0.4
+      flat-cache: 3.1.1
     dev: true
 
   /file-loader/3.0.1_webpack@5.83.0:
@@ -30803,6 +31625,15 @@ packages:
       rimraf: 3.0.2
     dev: true
 
+  /flat-cache/3.1.1:
+    resolution: {integrity: sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      flatted: 3.2.9
+      keyv: 4.5.4
+      rimraf: 3.0.2
+    dev: true
+
   /flat/5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
@@ -30824,6 +31655,10 @@ packages:
 
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+    dev: true
+
+  /flatted/3.2.9:
+    resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
   /flexbuffer/0.0.6:
@@ -31236,7 +32071,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.22.2
       functions-have-names: 1.2.3
     dev: true
@@ -31297,7 +32132,7 @@ packages:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
       function-bind: 1.1.1
-      has: 1.0.3
+      has: 1.0.4
       has-proto: 1.0.1
       has-symbols: 1.0.3
 
@@ -31602,6 +32437,13 @@ packages:
 
   /globals/13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.20.2
+    dev: true
+
+  /globals/13.23.0:
+    resolution: {integrity: sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -31964,6 +32806,11 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: true
+
+  /has/1.0.4:
+    resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
+    engines: {node: '>= 0.4.0'}
 
   /hash-base/3.1.0:
     resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
@@ -32678,6 +33525,15 @@ packages:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  /import-in-the-middle/1.4.2:
+    resolution: {integrity: sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==}
+    dependencies:
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0_acorn@8.10.0
+      cjs-module-lexer: 1.2.3
+      module-details-from-path: 1.0.3
+    dev: false
+
   /import-lazy/2.1.0:
     resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==}
     engines: {node: '>=4'}
@@ -32830,7 +33686,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.1
-      has: 1.0.3
+      has: 1.0.4
       side-channel: 1.0.4
     dev: true
 
@@ -32972,7 +33828,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
     dev: true
 
   /is-arrayish/0.2.1:
@@ -33058,7 +33914,7 @@ packages:
   /is-core-module/2.13.0:
     resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
     dependencies:
-      has: 1.0.3
+      has: 1.0.4
 
   /is-data-descriptor/0.1.4:
     resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==}
@@ -33696,8 +34552,8 @@ packages:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
-  /jake/10.8.6:
-    resolution: {integrity: sha512-G43Ub9IYEFfu72sua6rzooi8V8Gz2lkfk48rW20vEWCGizeaEPlKB1Kh8JIA84yQbiAEfqlPmSpGgCKKxH3rDA==}
+  /jake/10.8.7:
+    resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -34867,6 +35723,11 @@ packages:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
     dev: true
 
+  /jsdoc-type-pratt-parser/3.1.0:
+    resolution: {integrity: sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
   /jsdoc-type-pratt-parser/4.0.0:
     resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
     engines: {node: '>=12.0.0'}
@@ -35288,6 +36149,16 @@ packages:
       object.assign: 4.1.4
     dev: true
 
+  /jsx-ast-utils/3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.flat: 1.3.2
+      object.assign: 4.1.4
+      object.values: 1.1.7
+    dev: true
+
   /jszip/3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
     dependencies:
@@ -35344,6 +36215,12 @@ packages:
 
   /keyv/4.5.2:
     resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
+
+  /keyv/4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
     dev: true
@@ -37849,7 +38726,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: true
@@ -37863,6 +38740,15 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
+  /object.entries/1.1.7:
+    resolution: {integrity: sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
+    dev: true
+
   /object.fromentries/2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
     engines: {node: '>= 0.4'}
@@ -37870,6 +38756,15 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.21.2
+    dev: true
+
+  /object.fromentries/2.0.7:
+    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: true
 
   /object.getownpropertydescriptors/2.1.6:
@@ -37899,6 +38794,13 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
+  /object.hasown/1.1.3:
+    resolution: {integrity: sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==}
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
+    dev: true
+
   /object.pick/1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
@@ -37913,6 +38815,15 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.21.2
+    dev: true
+
+  /object.values/1.1.7:
+    resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: true
 
   /objectorarray/1.0.5:
@@ -38574,6 +39485,13 @@ packages:
     dependencies:
       ansi-escapes: 3.2.0
       cross-spawn: 6.0.5
+
+  /password-prompt/1.1.3:
+    resolution: {integrity: sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==}
+    dependencies:
+      ansi-escapes: 4.3.2
+      cross-spawn: 7.0.3
+    dev: false
 
   /path-browserify/0.0.1:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
@@ -40382,7 +41300,7 @@ packages:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
     dependencies:
-      '@types/normalize-package-data': 2.4.1
+      '@types/normalize-package-data': 2.4.2
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
@@ -40650,7 +41568,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       set-function-name: 2.0.1
     dev: true
 
@@ -40929,6 +41847,17 @@ packages:
       resolve: 1.22.6
     transitivePeerDependencies:
       - supports-color
+
+  /require-in-the-middle/7.2.0:
+    resolution: {integrity: sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      debug: 4.3.4
+      module-details-from-path: 1.0.3
+      resolve: 1.22.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /require-main-filename/1.0.1:
     resolution: {integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==}
@@ -41296,6 +42225,12 @@ packages:
       ret: 0.1.15
     dev: true
 
+  /safe-regex/2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+    dependencies:
+      regexp-tree: 0.1.27
+    dev: true
+
   /safe-stable-stringify/2.4.3:
     resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
@@ -41499,6 +42434,7 @@ packages:
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
+    dev: true
 
   /semver/5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -42200,7 +43136,7 @@ packages:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.16
     dev: true
 
   /spdx-exceptions/2.3.0:
@@ -42211,11 +43147,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.16
     dev: true
 
-  /spdx-license-ids/3.0.13:
-    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+  /spdx-license-ids/3.0.16:
+    resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
     dev: true
 
   /spdy-transport/3.0.0:
@@ -42556,6 +43492,20 @@ packages:
       strip-ansi: 7.1.0
     dev: true
 
+  /string.prototype.matchall/4.0.10:
+    resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
+      get-intrinsic: 1.2.1
+      has-symbols: 1.0.3
+      internal-slot: 1.0.5
+      regexp.prototype.flags: 1.5.1
+      set-function-name: 2.0.1
+      side-channel: 1.0.4
+    dev: true
+
   /string.prototype.matchall/4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
@@ -42601,7 +43551,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.22.2
     dev: true
 
@@ -42617,7 +43567,7 @@ packages:
     resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.22.2
     dev: true
 
@@ -42633,7 +43583,7 @@ packages:
     resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.22.2
     dev: true
 
@@ -43853,6 +44803,16 @@ packages:
   /tslib/2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  /tsutils/3.21.0_typescript@4.5.5:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.5.5
+    dev: true
+
   /tsutils/3.21.0_typescript@5.1.6:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -44027,7 +44987,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
     dev: true
 
   /typed-rest-client/1.8.9:
@@ -44734,6 +45694,10 @@ packages:
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
+    dev: true
+
+  /v8-compile-cache/2.4.0:
+    resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
     dev: true
 
   /v8-to-istanbul/9.1.0:

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@rushstack/eslint-config": "^2.6.1",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -78,7 +78,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@rushstack/eslint-config": "^2.6.1",
 		"@types/async": "^3.2.9",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -41,7 +41,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@rushstack/eslint-config": "^2.6.1",
 		"@types/async": "^3.2.9",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@rushstack/eslint-config': ^2.6.1
@@ -39,7 +39,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_ymnhzceeoeqwo36456pbfebzye
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.7
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@rushstack/eslint-config': 2.6.2_4rqwsplhh2ekz63wktwk7d7ht4
@@ -69,7 +69,7 @@ importers:
 
   packages/gitrest:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitrest-base': workspace:~
       '@fluidframework/server-services-shared': ^3.0.0-192517
@@ -117,7 +117,7 @@ importers:
       uuid: 3.4.0
       winston: 3.8.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@rushstack/eslint-config': 2.6.2_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/async': 3.2.16
@@ -140,7 +140,7 @@ importers:
 
   packages/gitrest-base:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^3.0.0-192517
@@ -220,7 +220,7 @@ importers:
       uuid: 3.4.0
       winston: 3.8.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@rushstack/eslint-config': 2.6.2_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/async': 3.2.16
@@ -451,8 +451,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -4536,7 +4536,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr/1.1.4:
@@ -6611,8 +6611,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@rushstack/eslint-config": "^2.6.1",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -75,7 +75,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-test-utils": "^3.0.0-192517",
 		"@rushstack/eslint-config": "^2.6.1",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@rushstack/eslint-config': ^2.6.1
@@ -41,7 +41,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@rushstack/eslint-config': 2.6.2_4rqwsplhh2ekz63wktwk7d7ht4
@@ -153,7 +153,7 @@ importers:
 
   packages/historian-base:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^3.0.0-192517
@@ -231,7 +231,7 @@ importers:
       uuid: 3.4.0
       winston: 3.8.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-test-utils': 3.0.0-192517
       '@rushstack/eslint-config': 2.6.2_4rqwsplhh2ekz63wktwk7d7ht4
@@ -281,7 +281,7 @@ packages:
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
       tslib: 1.14.1
     dev: false
     optional: true
@@ -300,7 +300,7 @@ packages:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
       '@aws-sdk/util-locate-window': 3.310.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
@@ -311,7 +311,7 @@ packages:
     resolution: {integrity: sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
       tslib: 1.14.1
     dev: false
     optional: true
@@ -326,714 +326,431 @@ packages:
   /@aws-crypto/util/3.0.0:
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
     dependencies:
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
     dev: false
     optional: true
 
-  /@aws-sdk/abort-controller/3.357.0:
-    resolution: {integrity: sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/client-cognito-identity/3.358.0:
-    resolution: {integrity: sha512-rXm9I3e89fA/RgYz3gtAAEYkkeSXZzNstivfQgKVGocIgxlMDcH6EdprENtqVQX5th7zwF67opgUGHKrnhCn7Q==}
+  /@aws-sdk/client-cognito-identity/3.427.0:
+    resolution: {integrity: sha512-9brRaNnl6haE7R3R43A5CSNw0k1YtB3xjuArbMg/p6NDUpvRSRgOVNWu2R02Yjh/j2ZuaLOCPLuCipb+PHQPKQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.358.0
-      '@aws-sdk/config-resolver': 3.357.0
-      '@aws-sdk/credential-provider-node': 3.358.0
-      '@aws-sdk/fetch-http-handler': 3.357.0
-      '@aws-sdk/hash-node': 3.357.0
-      '@aws-sdk/invalid-dependency': 3.357.0
-      '@aws-sdk/middleware-content-length': 3.357.0
-      '@aws-sdk/middleware-endpoint': 3.357.0
-      '@aws-sdk/middleware-host-header': 3.357.0
-      '@aws-sdk/middleware-logger': 3.357.0
-      '@aws-sdk/middleware-recursion-detection': 3.357.0
-      '@aws-sdk/middleware-retry': 3.357.0
-      '@aws-sdk/middleware-serde': 3.357.0
-      '@aws-sdk/middleware-signing': 3.357.0
-      '@aws-sdk/middleware-stack': 3.357.0
-      '@aws-sdk/middleware-user-agent': 3.357.0
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/node-http-handler': 3.357.0
-      '@aws-sdk/smithy-client': 3.358.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/url-parser': 3.357.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.358.0
-      '@aws-sdk/util-defaults-mode-node': 3.358.0
-      '@aws-sdk/util-endpoints': 3.357.0
-      '@aws-sdk/util-retry': 3.357.0
-      '@aws-sdk/util-user-agent-browser': 3.357.0
-      '@aws-sdk/util-user-agent-node': 3.357.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
+      '@aws-sdk/client-sts': 3.427.0
+      '@aws-sdk/credential-provider-node': 3.427.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-signing': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/region-config-resolver': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/client-sso-oidc/3.358.0:
-    resolution: {integrity: sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==}
+  /@aws-sdk/client-sso/3.427.0:
+    resolution: {integrity: sha512-sFVFEmsQ1rmgYO1SgrOTxE/MTKpeE4hpOkm1WqhLQK7Ij136vXpjCxjH1JYZiHiUzO1wr9t4ex4dlB5J3VS/Xg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.357.0
-      '@aws-sdk/fetch-http-handler': 3.357.0
-      '@aws-sdk/hash-node': 3.357.0
-      '@aws-sdk/invalid-dependency': 3.357.0
-      '@aws-sdk/middleware-content-length': 3.357.0
-      '@aws-sdk/middleware-endpoint': 3.357.0
-      '@aws-sdk/middleware-host-header': 3.357.0
-      '@aws-sdk/middleware-logger': 3.357.0
-      '@aws-sdk/middleware-recursion-detection': 3.357.0
-      '@aws-sdk/middleware-retry': 3.357.0
-      '@aws-sdk/middleware-serde': 3.357.0
-      '@aws-sdk/middleware-stack': 3.357.0
-      '@aws-sdk/middleware-user-agent': 3.357.0
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/node-http-handler': 3.357.0
-      '@aws-sdk/smithy-client': 3.358.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/url-parser': 3.357.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.358.0
-      '@aws-sdk/util-defaults-mode-node': 3.358.0
-      '@aws-sdk/util-endpoints': 3.357.0
-      '@aws-sdk/util-retry': 3.357.0
-      '@aws-sdk/util-user-agent-browser': 3.357.0
-      '@aws-sdk/util-user-agent-node': 3.357.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/region-config-resolver': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/client-sso/3.358.0:
-    resolution: {integrity: sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==}
+  /@aws-sdk/client-sts/3.427.0:
+    resolution: {integrity: sha512-le2wLJKILyWuRfPz2HbyaNtu5kEki+ojUkTqCU6FPDRrqUvEkaaCBH9Awo/2AtrCfRkiobop8RuTTj6cAnpiJg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.357.0
-      '@aws-sdk/fetch-http-handler': 3.357.0
-      '@aws-sdk/hash-node': 3.357.0
-      '@aws-sdk/invalid-dependency': 3.357.0
-      '@aws-sdk/middleware-content-length': 3.357.0
-      '@aws-sdk/middleware-endpoint': 3.357.0
-      '@aws-sdk/middleware-host-header': 3.357.0
-      '@aws-sdk/middleware-logger': 3.357.0
-      '@aws-sdk/middleware-recursion-detection': 3.357.0
-      '@aws-sdk/middleware-retry': 3.357.0
-      '@aws-sdk/middleware-serde': 3.357.0
-      '@aws-sdk/middleware-stack': 3.357.0
-      '@aws-sdk/middleware-user-agent': 3.357.0
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/node-http-handler': 3.357.0
-      '@aws-sdk/smithy-client': 3.358.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/url-parser': 3.357.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.358.0
-      '@aws-sdk/util-defaults-mode-node': 3.358.0
-      '@aws-sdk/util-endpoints': 3.357.0
-      '@aws-sdk/util-retry': 3.357.0
-      '@aws-sdk/util-user-agent-browser': 3.357.0
-      '@aws-sdk/util-user-agent-node': 3.357.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
+      '@aws-sdk/credential-provider-node': 3.427.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-sdk-sts': 3.425.0
+      '@aws-sdk/middleware-signing': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/region-config-resolver': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
+      fast-xml-parser: 4.2.5
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/client-sts/3.358.0:
-    resolution: {integrity: sha512-lBtle7UMBXXxp9LHcmNDwsQZoz1B0sE4F6F63sTv+U4fT/Uo8m0AcxUE0WFxAP687w8rg7dSqxJCbMCKrfVQPA==}
+  /@aws-sdk/credential-provider-cognito-identity/3.427.0:
+    resolution: {integrity: sha512-BQNzNrMJlBAfXhYNdAUqaVASpT9Aho5swj7glZKxx4Uds1w5Pih2e14JWgnl8XgUWAZ36pchTrV1aA4JT7N8vw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.357.0
-      '@aws-sdk/credential-provider-node': 3.358.0
-      '@aws-sdk/fetch-http-handler': 3.357.0
-      '@aws-sdk/hash-node': 3.357.0
-      '@aws-sdk/invalid-dependency': 3.357.0
-      '@aws-sdk/middleware-content-length': 3.357.0
-      '@aws-sdk/middleware-endpoint': 3.357.0
-      '@aws-sdk/middleware-host-header': 3.357.0
-      '@aws-sdk/middleware-logger': 3.357.0
-      '@aws-sdk/middleware-recursion-detection': 3.357.0
-      '@aws-sdk/middleware-retry': 3.357.0
-      '@aws-sdk/middleware-sdk-sts': 3.357.0
-      '@aws-sdk/middleware-serde': 3.357.0
-      '@aws-sdk/middleware-signing': 3.357.0
-      '@aws-sdk/middleware-stack': 3.357.0
-      '@aws-sdk/middleware-user-agent': 3.357.0
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/node-http-handler': 3.357.0
-      '@aws-sdk/smithy-client': 3.358.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/url-parser': 3.357.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.358.0
-      '@aws-sdk/util-defaults-mode-node': 3.358.0
-      '@aws-sdk/util-endpoints': 3.357.0
-      '@aws-sdk/util-retry': 3.357.0
-      '@aws-sdk/util-user-agent-browser': 3.357.0
-      '@aws-sdk/util-user-agent-node': 3.357.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
-      fast-xml-parser: 4.2.4
+      '@aws-sdk/client-cognito-identity': 3.427.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/config-resolver/3.357.0:
-    resolution: {integrity: sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==}
+  /@aws-sdk/credential-provider-env/3.425.0:
+    resolution: {integrity: sha512-J20etnLvMKXRVi5FK4F8yOCNm2RTaQn5psQTGdDEPWJNGxohcSpzzls8U2KcMyUJ+vItlrThr4qwgpHG3i/N0w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-config-provider': 3.310.0
-      '@aws-sdk/util-middleware': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-cognito-identity/3.358.0:
-    resolution: {integrity: sha512-x2GIuzbk1BYIQcGevc8PoQsVn9UQDnpX2UzptrdQMBI4UdG3LwH17pQnQGGvwrMcLTnCEQpbistB4+WgIZAaqg==}
+  /@aws-sdk/credential-provider-http/3.425.0:
+    resolution: {integrity: sha512-aP9nkoVWf+OlNMecrUqe4+RuQrX13nucVbty0HTvuwfwJJj0T6ByWZzle+fo1D+5OxvJmtzTflBWt6jUERdHWA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.358.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-    optional: true
-
-  /@aws-sdk/credential-provider-env/3.357.0:
-    resolution: {integrity: sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/property-provider': 2.0.12
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-imds/3.357.0:
-    resolution: {integrity: sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==}
+  /@aws-sdk/credential-provider-ini/3.427.0:
+    resolution: {integrity: sha512-NmH1cO/w98CKMltYec3IrJIIco19wRjATFNiw83c+FGXZ+InJwReqBnruxIOmKTx2KDzd6fwU1HOewS7UjaaaQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/url-parser': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/credential-provider-ini/3.358.0:
-    resolution: {integrity: sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.357.0
-      '@aws-sdk/credential-provider-imds': 3.357.0
-      '@aws-sdk/credential-provider-process': 3.357.0
-      '@aws-sdk/credential-provider-sso': 3.358.0
-      '@aws-sdk/credential-provider-web-identity': 3.357.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/shared-ini-file-loader': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/credential-provider-env': 3.425.0
+      '@aws-sdk/credential-provider-process': 3.425.0
+      '@aws-sdk/credential-provider-sso': 3.427.0
+      '@aws-sdk/credential-provider-web-identity': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-node/3.358.0:
-    resolution: {integrity: sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==}
+  /@aws-sdk/credential-provider-node/3.427.0:
+    resolution: {integrity: sha512-wYYbQ57nKL8OfgRbl8k6uXcdnYml+p3LSSfDUAuUEp1HKlQ8lOXFJ3BdLr5qrk7LhpyppSRnWBmh2c3kWa7ANQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.357.0
-      '@aws-sdk/credential-provider-imds': 3.357.0
-      '@aws-sdk/credential-provider-ini': 3.358.0
-      '@aws-sdk/credential-provider-process': 3.357.0
-      '@aws-sdk/credential-provider-sso': 3.358.0
-      '@aws-sdk/credential-provider-web-identity': 3.357.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/shared-ini-file-loader': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/credential-provider-env': 3.425.0
+      '@aws-sdk/credential-provider-ini': 3.427.0
+      '@aws-sdk/credential-provider-process': 3.425.0
+      '@aws-sdk/credential-provider-sso': 3.427.0
+      '@aws-sdk/credential-provider-web-identity': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-process/3.357.0:
-    resolution: {integrity: sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==}
+  /@aws-sdk/credential-provider-process/3.425.0:
+    resolution: {integrity: sha512-YY6tkLdvtb1Fgofp3b1UWO+5vwS14LJ/smGmuGpSba0V7gFJRdcrJ9bcb9vVgAGuMdjzRJ+bUKlLLtqXkaykEw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/shared-ini-file-loader': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-sso/3.358.0:
-    resolution: {integrity: sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==}
+  /@aws-sdk/credential-provider-sso/3.427.0:
+    resolution: {integrity: sha512-c+tXyS/i49erHs4bAp6vKNYeYlyQ0VNMBgoco0LCn1rL0REtHbfhWMnqDLF6c2n3yIWDOTrQu0D73Idnpy16eA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sso': 3.358.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/shared-ini-file-loader': 3.357.0
-      '@aws-sdk/token-providers': 3.358.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/client-sso': 3.427.0
+      '@aws-sdk/token-providers': 3.427.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/credential-provider-web-identity/3.357.0:
-    resolution: {integrity: sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==}
+  /@aws-sdk/credential-provider-web-identity/3.425.0:
+    resolution: {integrity: sha512-/0R65TgRzL01JU3SzloivWNwdkbIhr06uY/F5pBHf/DynQqaspKNfdHn6AiozgSVDfwRHFjKBTUy6wvf3QFkuA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/credential-providers/3.358.0:
-    resolution: {integrity: sha512-qJQZ6dXAOLxPYnODGoj92IIrXhCRY9pWeRnnwNdEOFiVj+UdEslDE8qZoAiY9pSGQfkZYguR3UC2rtd0SgGLEw==}
+  /@aws-sdk/credential-providers/3.427.0:
+    resolution: {integrity: sha512-rKKohSHju462vo+uQnPjcEZPBAfAMgGH6K1XyyCNpuOC0yYLkG87PYpvAQeb8riTrkHPX0dYUHuTHZ6zQgMGjA==}
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.358.0
-      '@aws-sdk/client-sso': 3.358.0
-      '@aws-sdk/client-sts': 3.358.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.358.0
-      '@aws-sdk/credential-provider-env': 3.357.0
-      '@aws-sdk/credential-provider-imds': 3.357.0
-      '@aws-sdk/credential-provider-ini': 3.358.0
-      '@aws-sdk/credential-provider-node': 3.358.0
-      '@aws-sdk/credential-provider-process': 3.357.0
-      '@aws-sdk/credential-provider-sso': 3.358.0
-      '@aws-sdk/credential-provider-web-identity': 3.357.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/client-cognito-identity': 3.427.0
+      '@aws-sdk/client-sso': 3.427.0
+      '@aws-sdk/client-sts': 3.427.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.427.0
+      '@aws-sdk/credential-provider-env': 3.425.0
+      '@aws-sdk/credential-provider-http': 3.425.0
+      '@aws-sdk/credential-provider-ini': 3.427.0
+      '@aws-sdk/credential-provider-node': 3.427.0
+      '@aws-sdk/credential-provider-process': 3.425.0
+      '@aws-sdk/credential-provider-sso': 3.427.0
+      '@aws-sdk/credential-provider-web-identity': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/eventstream-codec/3.357.0:
-    resolution: {integrity: sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==}
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-hex-encoding': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/fetch-http-handler/3.357.0:
-    resolution: {integrity: sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/querystring-builder': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-base64': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/hash-node/3.357.0:
-    resolution: {integrity: sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==}
+  /@aws-sdk/middleware-host-header/3.425.0:
+    resolution: {integrity: sha512-E5Gt41LObQ+cr8QnLthwsH3MtVSNXy1AKJMowDr85h0vzqA/FHUkgHyOGntgozzjXT5M0MaSRYxS0xwTR5D4Ew==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-buffer-from': 3.310.0
-      '@aws-sdk/util-utf8': 3.310.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/invalid-dependency/3.357.0:
-    resolution: {integrity: sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==}
+  /@aws-sdk/middleware-logger/3.425.0:
+    resolution: {integrity: sha512-INE9XWRXx2f4a/r2vOU0tAmgctVp7nEaEasemNtVBYhqbKLZvr9ndLBSgKGgJ8LIcXAoISipaMuFiqIGkFsm7A==}
+    engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/is-array-buffer/3.310.0:
-    resolution: {integrity: sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==}
+  /@aws-sdk/middleware-recursion-detection/3.425.0:
+    resolution: {integrity: sha512-77gnzJ5b91bgD75L/ugpOyerx6lR3oyS4080X1YI58EzdyBMkDrHM4FbMcY2RynETi3lwXCFzLRyZjWXY1mRlw==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      '@aws-sdk/types': 3.425.0
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/middleware-content-length/3.357.0:
-    resolution: {integrity: sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==}
+  /@aws-sdk/middleware-sdk-sts/3.425.0:
+    resolution: {integrity: sha512-JFojrg76oKAoBknnr9EL5N2aJ1mRCtBqXoZYST58GSx8uYdFQ89qS65VNQ8JviBXzsrCNAn4vDhZ5Ch5E6TxGQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/middleware-signing': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/middleware-endpoint/3.357.0:
-    resolution: {integrity: sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==}
+  /@aws-sdk/middleware-signing/3.425.0:
+    resolution: {integrity: sha512-ZpOfgJHk7ovQ0sSwg3tU4NxFOnz53lJlkJRf7S+wxQALHM0P2MJ6LYBrZaFMVsKiJxNIdZBXD6jclgHg72ZW6Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/middleware-serde': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/url-parser': 3.357.0
-      '@aws-sdk/util-middleware': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/signature-v4': 2.0.11
+      '@smithy/types': 2.3.5
+      '@smithy/util-middleware': 2.0.4
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/middleware-host-header/3.357.0:
-    resolution: {integrity: sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==}
+  /@aws-sdk/middleware-user-agent/3.427.0:
+    resolution: {integrity: sha512-y9HxYsNvnA3KqDl8w1jHeCwz4P9CuBEtu/G+KYffLeAMBsMZmh4SIkFFCO9wE/dyYg6+yo07rYcnnIfy7WA0bw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/middleware-logger/3.357.0:
-    resolution: {integrity: sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==}
+  /@aws-sdk/region-config-resolver/3.425.0:
+    resolution: {integrity: sha512-u7uv/iUOapIJdRgRkO3wnpYsUgV6ponsZJQgVg/8L+n+Vo5PQL5gAcIuAOwcYSKQPFaeK+KbmByI4SyOK203Vw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.357.0
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
+      '@smithy/util-config-provider': 2.0.0
+      '@smithy/util-middleware': 2.0.4
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/middleware-recursion-detection/3.357.0:
-    resolution: {integrity: sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==}
+  /@aws-sdk/token-providers/3.427.0:
+    resolution: {integrity: sha512-4E5E+4p8lJ69PBY400dJXF06LUHYx5lkKzBEsYqWWhoZcoftrvi24ltIhUDoGVLkrLcTHZIWSdFAWSos4hXqeg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/middleware-retry/3.357.0:
-    resolution: {integrity: sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/service-error-classification': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-middleware': 3.357.0
-      '@aws-sdk/util-retry': 3.357.0
-      tslib: 2.6.0
-      uuid: 8.3.2
-    dev: false
-    optional: true
-
-  /@aws-sdk/middleware-sdk-sts/3.357.0:
-    resolution: {integrity: sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-signing': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/middleware-serde/3.357.0:
-    resolution: {integrity: sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/middleware-signing/3.357.0:
-    resolution: {integrity: sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/signature-v4': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-middleware': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/middleware-stack/3.357.0:
-    resolution: {integrity: sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/middleware-user-agent/3.357.0:
-    resolution: {integrity: sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-endpoints': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/node-config-provider/3.357.0:
-    resolution: {integrity: sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/shared-ini-file-loader': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/node-http-handler/3.357.0:
-    resolution: {integrity: sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/abort-controller': 3.357.0
-      '@aws-sdk/protocol-http': 3.357.0
-      '@aws-sdk/querystring-builder': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/property-provider/3.357.0:
-    resolution: {integrity: sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/protocol-http/3.357.0:
-    resolution: {integrity: sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/querystring-builder/3.357.0:
-    resolution: {integrity: sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-uri-escape': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/querystring-parser/3.357.0:
-    resolution: {integrity: sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/service-error-classification/3.357.0:
-    resolution: {integrity: sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==}
-    engines: {node: '>=14.0.0'}
-    dev: false
-    optional: true
-
-  /@aws-sdk/shared-ini-file-loader/3.357.0:
-    resolution: {integrity: sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/signature-v4/3.357.0:
-    resolution: {integrity: sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/eventstream-codec': 3.357.0
-      '@aws-sdk/is-array-buffer': 3.310.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-hex-encoding': 3.310.0
-      '@aws-sdk/util-middleware': 3.357.0
-      '@aws-sdk/util-uri-escape': 3.310.0
-      '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/smithy-client/3.358.0:
-    resolution: {integrity: sha512-oqctxWb9yAqCh4ENwUkt9MC01l5uKoy+QCiSUUhQ76k7R3lyGOge9ycyRyoKl+oZWvEpnjZevXQFqEfGzkL7bA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-stack': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-stream': 3.358.0
-      '@smithy/types': 1.1.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/token-providers/3.358.0:
-    resolution: {integrity: sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/client-sso-oidc': 3.358.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/shared-ini-file-loader': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/property-provider': 2.0.12
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
       tslib: 2.6.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
     optional: true
 
-  /@aws-sdk/types/3.357.0:
-    resolution: {integrity: sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==}
+  /@aws-sdk/types/3.425.0:
+    resolution: {integrity: sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/url-parser/3.357.0:
-    resolution: {integrity: sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==}
-    dependencies:
-      '@aws-sdk/querystring-parser': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-base64/3.310.0:
-    resolution: {integrity: sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==}
+  /@aws-sdk/util-endpoints/3.427.0:
+    resolution: {integrity: sha512-rSyiAIFF/EVvity/+LWUqoTMJ0a25RAc9iqx0WZ4tf1UjuEXRRXxZEb+jEZg1bk+pY84gdLdx9z5E+MSJCZxNQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/util-buffer-from': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-body-length-browser/3.310.0:
-    resolution: {integrity: sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==}
-    dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-body-length-node/3.310.0:
-    resolution: {integrity: sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-buffer-from/3.310.0:
-    resolution: {integrity: sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/is-array-buffer': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-config-provider/3.310.0:
-    resolution: {integrity: sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-defaults-mode-browser/3.358.0:
-    resolution: {integrity: sha512-KGfw64wRL/gROLD4Gatda8cUsaNKNhSnx+yDDcG2WkFlFfLr6FHvTijpRxvIM2Jau2ZhcdGzbegLjsFxviTJAA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      bowser: 2.11.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-defaults-mode-node/3.358.0:
-    resolution: {integrity: sha512-2C5on0yppDS0xGpFkHRqfrG9TeTq6ive1hPX1V8UCkiI/TBQYl88XCKCKct8zTcejyK9klZUDGI8QQTan2UWkw==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/config-resolver': 3.357.0
-      '@aws-sdk/credential-provider-imds': 3.357.0
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/property-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-endpoints/3.357.0:
-    resolution: {integrity: sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-hex-encoding/3.310.0:
-    resolution: {integrity: sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
+      '@aws-sdk/types': 3.425.0
+      '@smithy/node-config-provider': 2.1.1
       tslib: 2.6.0
     dev: false
     optional: true
@@ -1046,57 +763,18 @@ packages:
     dev: false
     optional: true
 
-  /@aws-sdk/util-middleware/3.357.0:
-    resolution: {integrity: sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==}
-    engines: {node: '>=14.0.0'}
+  /@aws-sdk/util-user-agent-browser/3.425.0:
+    resolution: {integrity: sha512-22Y9iMtjGcFjGILR6/xdp1qRezlHVLyXtnpEsbuPTiernRCPk6zfAnK/ATH77r02MUjU057tdxVkd5umUBTn9Q==}
     dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-retry/3.357.0:
-    resolution: {integrity: sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==}
-    engines: {node: '>= 14.0.0'}
-    dependencies:
-      '@aws-sdk/service-error-classification': 3.357.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-stream/3.358.0:
-    resolution: {integrity: sha512-zUhpjxAXV2+0eALlTU6uXRYMs10XYpcYzl3NtLRe4wWgnrOOOZnF/t5LQDoKXOfaMdzwZ+i90+PYr+6JQ58+7g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/fetch-http-handler': 3.357.0
-      '@aws-sdk/node-http-handler': 3.357.0
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-buffer-from': 3.310.0
-      '@aws-sdk/util-hex-encoding': 3.310.0
-      '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-uri-escape/3.310.0:
-    resolution: {integrity: sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-user-agent-browser/3.357.0:
-    resolution: {integrity: sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==}
-    dependencies:
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/types': 2.3.5
       bowser: 2.11.0
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@aws-sdk/util-user-agent-node/3.357.0:
-    resolution: {integrity: sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==}
+  /@aws-sdk/util-user-agent-node/3.425.0:
+    resolution: {integrity: sha512-SIR4F5uQeeVAi8lv4OgRirtdtNi5zeyogTuQgGi9su8F/WP1N6JqxofcwpUY5f8/oJ2UlXr/tx1f09UHfJJzvA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -1104,8 +782,9 @@ packages:
       aws-crt:
         optional: true
     dependencies:
-      '@aws-sdk/node-config-provider': 3.357.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
@@ -1113,15 +792,6 @@ packages:
   /@aws-sdk/util-utf8-browser/3.259.0:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     dependencies:
-      tslib: 2.6.0
-    dev: false
-    optional: true
-
-  /@aws-sdk/util-utf8/3.310.0:
-    resolution: {integrity: sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/util-buffer-from': 3.310.0
       tslib: 2.6.0
     dev: false
     optional: true
@@ -1330,8 +1000,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -3782,19 +3452,385 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
-  /@smithy/protocol-http/1.1.0:
-    resolution: {integrity: sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==}
+  /@smithy/abort-controller/2.0.11:
+    resolution: {integrity: sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 1.1.0
+      '@smithy/types': 2.3.5
       tslib: 2.6.0
     dev: false
     optional: true
 
-  /@smithy/types/1.1.0:
-    resolution: {integrity: sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==}
+  /@smithy/config-resolver/2.0.14:
+    resolution: {integrity: sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
+      '@smithy/util-config-provider': 2.0.0
+      '@smithy/util-middleware': 2.0.4
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/credential-provider-imds/2.0.16:
+    resolution: {integrity: sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/eventstream-codec/2.0.11:
+    resolution: {integrity: sha512-BQCTjxhCYRZIfXapa2LmZSaH8QUBGwMZw7XRN83hrdixbLjIcj+o549zjkedFS07Ve2TlvWUI6BTzP+nv7snBA==}
+    dependencies:
+      '@aws-crypto/crc32': 3.0.0
+      '@smithy/types': 2.3.5
+      '@smithy/util-hex-encoding': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/fetch-http-handler/2.2.3:
+    resolution: {integrity: sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==}
+    dependencies:
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/querystring-builder': 2.0.11
+      '@smithy/types': 2.3.5
+      '@smithy/util-base64': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/hash-node/2.0.11:
+    resolution: {integrity: sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      '@smithy/util-buffer-from': 2.0.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/invalid-dependency/2.0.11:
+    resolution: {integrity: sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/is-array-buffer/2.0.0:
+    resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/middleware-content-length/2.0.13:
+    resolution: {integrity: sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/middleware-endpoint/2.1.0:
+    resolution: {integrity: sha512-e6HZbfrp9CNTJqIPSgkydB9mNQXiq5pkHF3ZB6rOzPPR9PkJBoGFo9TcM7FaaKFUaH4Kc20AX6WwwVyIlNhXTA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-middleware': 2.0.4
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/middleware-retry/2.0.16:
+    resolution: {integrity: sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/service-error-classification': 2.0.4
+      '@smithy/types': 2.3.5
+      '@smithy/util-middleware': 2.0.4
+      '@smithy/util-retry': 2.0.4
+      tslib: 2.6.0
+      uuid: 8.3.2
+    dev: false
+    optional: true
+
+  /@smithy/middleware-serde/2.0.11:
+    resolution: {integrity: sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/middleware-stack/2.0.5:
+    resolution: {integrity: sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/node-config-provider/2.1.1:
+    resolution: {integrity: sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/node-http-handler/2.1.7:
+    resolution: {integrity: sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 2.0.11
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/querystring-builder': 2.0.11
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/property-provider/2.0.12:
+    resolution: {integrity: sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/protocol-http/3.0.7:
+    resolution: {integrity: sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/querystring-builder/2.0.11:
+    resolution: {integrity: sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      '@smithy/util-uri-escape': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/querystring-parser/2.0.11:
+    resolution: {integrity: sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/service-error-classification/2.0.4:
+    resolution: {integrity: sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+    dev: false
+    optional: true
+
+  /@smithy/shared-ini-file-loader/2.2.0:
+    resolution: {integrity: sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/signature-v4/2.0.11:
+    resolution: {integrity: sha512-EFVU1dT+2s8xi227l1A9O27edT/GNKvyAK6lZnIZ0zhIHq/jSLznvkk15aonGAM1kmhmZBVGpI7Tt0odueZK9A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/eventstream-codec': 2.0.11
+      '@smithy/is-array-buffer': 2.0.0
+      '@smithy/types': 2.3.5
+      '@smithy/util-hex-encoding': 2.0.0
+      '@smithy/util-middleware': 2.0.4
+      '@smithy/util-uri-escape': 2.0.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/smithy-client/2.1.11:
+    resolution: {integrity: sha512-okjMbuBBCTiieK665OFN/ap6u9+Z9z55PMphS5FYCsS6Zfp137Q3qlnt0OgBAnUVnH/mNGyoJV0LBX9gkTWptg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/types': 2.3.5
+      '@smithy/util-stream': 2.0.16
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/types/2.3.5:
+    resolution: {integrity: sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/url-parser/2.0.11:
+    resolution: {integrity: sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==}
+    dependencies:
+      '@smithy/querystring-parser': 2.0.11
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-base64/2.0.0:
+    resolution: {integrity: sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-body-length-browser/2.0.0:
+    resolution: {integrity: sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-body-length-node/2.1.0:
+    resolution: {integrity: sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-buffer-from/2.0.0:
+    resolution: {integrity: sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-config-provider/2.0.0:
+    resolution: {integrity: sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-defaults-mode-browser/2.0.15:
+    resolution: {integrity: sha512-2raMZOYKSuke7QlDg/HDcxQdrp0zteJ8z+S0B9Rn23J55ZFNK1+IjG4HkN6vo/0u3Xy/JOdJ93ibiBSB8F7kOw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@smithy/property-provider': 2.0.12
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      bowser: 2.11.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-defaults-mode-node/2.0.19:
+    resolution: {integrity: sha512-7pScU4jBFADB2MBYKM3zb5onMh6Nn0X3IfaFVLYPyCarTIZDLUtUl1GtruzEUJPmDzP+uGeqOtU589HDY0Ni6g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/property-provider': 2.0.12
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-hex-encoding/2.0.0:
+    resolution: {integrity: sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-middleware/2.0.4:
+    resolution: {integrity: sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-retry/2.0.4:
+    resolution: {integrity: sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@smithy/service-error-classification': 2.0.4
+      '@smithy/types': 2.3.5
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-stream/2.0.16:
+    resolution: {integrity: sha512-b5ZSRh1KzUzC7LoJcpfk7+iXGoRr3WylEfmPd4FnBLm90OwxSB9VgK1fDZwicfYxSEvWHdYXgvvjPtenEYBBhw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/types': 2.3.5
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-buffer-from': 2.0.0
+      '@smithy/util-hex-encoding': 2.0.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-uri-escape/2.0.0:
+    resolution: {integrity: sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.0
+    dev: false
+    optional: true
+
+  /@smithy/util-utf8/2.0.0:
+    resolution: {integrity: sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.0.0
       tslib: 2.6.0
     dev: false
     optional: true
@@ -5707,7 +5743,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr/1.1.4:
@@ -7648,8 +7684,8 @@ packages:
     resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
     dev: true
 
-  /fast-xml-parser/4.2.4:
-    resolution: {integrity: sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==}
+  /fast-xml-parser/4.2.5:
+    resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -7962,8 +7998,8 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -10420,7 +10456,7 @@ packages:
       mongodb-connection-string-url: 2.6.0
       socks: 2.7.1
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.358.0
+      '@aws-sdk/credential-providers': 3.427.0
       '@mongodb-js/saslprep': 1.1.0
     transitivePeerDependencies:
       - aws-crt

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -81,7 +81,7 @@
 		"@changesets/cli": "^2.26.1",
 		"@fluid-private/changelog-generator-wrapper": "file:../../tools/changelog-generator-wrapper",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -29,7 +29,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@2.0.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -33,7 +33,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@2.0.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@2.0.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@2.0.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@2.0.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -79,7 +79,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@2.0.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@2.0.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -85,7 +85,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-local-server": "workspace:~",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-local-server": "workspace:~",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -74,7 +74,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@2.0.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@2.0.0",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@2.0.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@2.0.0",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -33,7 +33,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@2.0.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@2.0.0",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@2.0.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -72,7 +72,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@2.0.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@2.0.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@2.0.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@changesets/cli': ^2.26.1
       '@fluid-private/changelog-generator-wrapper': file:../../tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@microsoft/api-documenter': ^7.21.6
       '@microsoft/api-extractor': ^7.34.4
@@ -31,7 +31,7 @@ importers:
       '@changesets/cli': 2.26.2
       '@fluid-private/changelog-generator-wrapper': file:../../tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@microsoft/api-documenter': 7.22.21
       '@microsoft/api-extractor': 7.36.0
@@ -49,7 +49,7 @@ importers:
   packages/gitresources:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources-previous': npm:@fluidframework/gitresources@2.0.0
@@ -60,7 +60,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/gitresources-previous': /@fluidframework/gitresources/2.0.0
@@ -73,7 +73,7 @@ importers:
   packages/kafka-orderer:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -90,7 +90,7 @@ importers:
       '@fluidframework/server-services-core': link:../services-core
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-kafka-orderer-previous': /@fluidframework/server-kafka-orderer/2.0.0
@@ -104,7 +104,7 @@ importers:
   packages/lambdas:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions': ^1.0.0
       '@fluidframework/common-utils': ^3.0.0
@@ -175,7 +175,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-lambdas-previous': /@fluidframework/server-lambdas/2.0.0
@@ -203,7 +203,7 @@ importers:
   packages/lambdas-driver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -242,7 +242,7 @@ importers:
       serialize-error: 8.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-lambdas-driver-previous': /@fluidframework/server-lambdas-driver/2.0.0
@@ -262,7 +262,7 @@ importers:
   packages/local-server:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -311,7 +311,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_dsbdoiloonfjopmmsiqdtk2mza
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_qiwzlxsc7nv6vcdymu2njnpbxe
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server-previous': /@fluidframework/server-local-server/2.0.0
@@ -337,7 +337,7 @@ importers:
   packages/memory-orderer:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -394,7 +394,7 @@ importers:
       ws: 7.5.9
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-memory-orderer-previous': /@fluidframework/server-memory-orderer/2.0.0
@@ -412,7 +412,7 @@ importers:
   packages/protocol-base:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -439,7 +439,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/protocol-base-previous': /@fluidframework/protocol-base/2.0.0
@@ -459,7 +459,7 @@ importers:
   packages/routerlicious:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -513,7 +513,7 @@ importers:
       winston: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server': link:../local-server
@@ -530,7 +530,7 @@ importers:
   packages/routerlicious-base:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -630,7 +630,7 @@ importers:
       ws: 7.5.9
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server': link:../local-server
@@ -667,7 +667,7 @@ importers:
   packages/services:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -741,7 +741,7 @@ importers:
       winston: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-previous': /@fluidframework/server-services/2.0.0
@@ -768,7 +768,7 @@ importers:
   packages/services-client:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -816,7 +816,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-client-previous': /@fluidframework/server-services-client/2.0.0
@@ -839,7 +839,7 @@ importers:
   packages/services-core:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -871,7 +871,7 @@ importers:
       nconf: 0.12.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-core-previous': /@fluidframework/server-services-core/2.0.0
@@ -884,7 +884,7 @@ importers:
   packages/services-ordering-kafkanode:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/server-services-client': workspace:~
@@ -918,7 +918,7 @@ importers:
       sillyname: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-kafkanode-previous': /@fluidframework/server-services-ordering-kafkanode/2.0.0
@@ -937,7 +937,7 @@ importers:
   packages/services-ordering-rdkafka:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -972,7 +972,7 @@ importers:
       sillyname: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-rdkafka-previous': /@fluidframework/server-services-ordering-rdkafka/2.0.0
@@ -992,7 +992,7 @@ importers:
   packages/services-ordering-zookeeper:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/server-services-core': workspace:~
@@ -1014,7 +1014,7 @@ importers:
       zookeeper: 5.6.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-zookeeper-previous': /@fluidframework/server-services-ordering-zookeeper/2.0.0
@@ -1033,7 +1033,7 @@ importers:
   packages/services-shared:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -1103,7 +1103,7 @@ importers:
       winston: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-shared-previous': /@fluidframework/server-services-shared/2.0.0
@@ -1128,7 +1128,7 @@ importers:
   packages/services-telemetry:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -1157,7 +1157,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-telemetry-previous': /@fluidframework/server-services-telemetry/2.0.0
@@ -1177,7 +1177,7 @@ importers:
   packages/services-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -1238,7 +1238,7 @@ importers:
       winston-transport: 4.5.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-utils-previous': /@fluidframework/server-services-utils/2.0.0
@@ -1266,7 +1266,7 @@ importers:
   packages/test-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -1312,7 +1312,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-test-utils-previous': /@fluidframework/server-test-utils/2.0.0
@@ -1346,7 +1346,7 @@ packages:
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
       tslib: 1.14.1
     optional: true
 
@@ -1363,7 +1363,7 @@ packages:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
       '@aws-sdk/util-locate-window': 3.310.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
@@ -1373,7 +1373,7 @@ packages:
     resolution: {integrity: sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
       tslib: 1.14.1
     optional: true
 
@@ -1386,659 +1386,409 @@ packages:
   /@aws-crypto/util/3.0.0:
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
     dependencies:
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
     optional: true
 
-  /@aws-sdk/abort-controller/3.347.0:
-    resolution: {integrity: sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/client-cognito-identity/3.354.0:
-    resolution: {integrity: sha512-VYoPiup85Zn1uiqn6X7Kl1/5AsihyW0jOPpO5Xv39shRKFTLYWIgPxjg7k+dNPVAX62XrWoWNkGR6sB/JN9Qdg==}
+  /@aws-sdk/client-cognito-identity/3.427.0:
+    resolution: {integrity: sha512-9brRaNnl6haE7R3R43A5CSNw0k1YtB3xjuArbMg/p6NDUpvRSRgOVNWu2R02Yjh/j2ZuaLOCPLuCipb+PHQPKQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.354.0
-      '@aws-sdk/config-resolver': 3.354.0
-      '@aws-sdk/credential-provider-node': 3.354.0
-      '@aws-sdk/fetch-http-handler': 3.353.0
-      '@aws-sdk/hash-node': 3.347.0
-      '@aws-sdk/invalid-dependency': 3.347.0
-      '@aws-sdk/middleware-content-length': 3.347.0
-      '@aws-sdk/middleware-endpoint': 3.347.0
-      '@aws-sdk/middleware-host-header': 3.347.0
-      '@aws-sdk/middleware-logger': 3.347.0
-      '@aws-sdk/middleware-recursion-detection': 3.347.0
-      '@aws-sdk/middleware-retry': 3.354.0
-      '@aws-sdk/middleware-serde': 3.347.0
-      '@aws-sdk/middleware-signing': 3.354.0
-      '@aws-sdk/middleware-stack': 3.347.0
-      '@aws-sdk/middleware-user-agent': 3.352.0
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/node-http-handler': 3.350.0
-      '@aws-sdk/smithy-client': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/url-parser': 3.347.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.353.0
-      '@aws-sdk/util-defaults-mode-node': 3.354.0
-      '@aws-sdk/util-endpoints': 3.352.0
-      '@aws-sdk/util-retry': 3.347.0
-      '@aws-sdk/util-user-agent-browser': 3.347.0
-      '@aws-sdk/util-user-agent-node': 3.354.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
+      '@aws-sdk/client-sts': 3.427.0
+      '@aws-sdk/credential-provider-node': 3.427.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-signing': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/region-config-resolver': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/client-sso-oidc/3.354.0:
-    resolution: {integrity: sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==}
+  /@aws-sdk/client-sso/3.427.0:
+    resolution: {integrity: sha512-sFVFEmsQ1rmgYO1SgrOTxE/MTKpeE4hpOkm1WqhLQK7Ij136vXpjCxjH1JYZiHiUzO1wr9t4ex4dlB5J3VS/Xg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.354.0
-      '@aws-sdk/fetch-http-handler': 3.353.0
-      '@aws-sdk/hash-node': 3.347.0
-      '@aws-sdk/invalid-dependency': 3.347.0
-      '@aws-sdk/middleware-content-length': 3.347.0
-      '@aws-sdk/middleware-endpoint': 3.347.0
-      '@aws-sdk/middleware-host-header': 3.347.0
-      '@aws-sdk/middleware-logger': 3.347.0
-      '@aws-sdk/middleware-recursion-detection': 3.347.0
-      '@aws-sdk/middleware-retry': 3.354.0
-      '@aws-sdk/middleware-serde': 3.347.0
-      '@aws-sdk/middleware-stack': 3.347.0
-      '@aws-sdk/middleware-user-agent': 3.352.0
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/node-http-handler': 3.350.0
-      '@aws-sdk/smithy-client': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/url-parser': 3.347.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.353.0
-      '@aws-sdk/util-defaults-mode-node': 3.354.0
-      '@aws-sdk/util-endpoints': 3.352.0
-      '@aws-sdk/util-retry': 3.347.0
-      '@aws-sdk/util-user-agent-browser': 3.347.0
-      '@aws-sdk/util-user-agent-node': 3.354.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/region-config-resolver': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/client-sso/3.354.0:
-    resolution: {integrity: sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==}
+  /@aws-sdk/client-sts/3.427.0:
+    resolution: {integrity: sha512-le2wLJKILyWuRfPz2HbyaNtu5kEki+ojUkTqCU6FPDRrqUvEkaaCBH9Awo/2AtrCfRkiobop8RuTTj6cAnpiJg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.354.0
-      '@aws-sdk/fetch-http-handler': 3.353.0
-      '@aws-sdk/hash-node': 3.347.0
-      '@aws-sdk/invalid-dependency': 3.347.0
-      '@aws-sdk/middleware-content-length': 3.347.0
-      '@aws-sdk/middleware-endpoint': 3.347.0
-      '@aws-sdk/middleware-host-header': 3.347.0
-      '@aws-sdk/middleware-logger': 3.347.0
-      '@aws-sdk/middleware-recursion-detection': 3.347.0
-      '@aws-sdk/middleware-retry': 3.354.0
-      '@aws-sdk/middleware-serde': 3.347.0
-      '@aws-sdk/middleware-stack': 3.347.0
-      '@aws-sdk/middleware-user-agent': 3.352.0
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/node-http-handler': 3.350.0
-      '@aws-sdk/smithy-client': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/url-parser': 3.347.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.353.0
-      '@aws-sdk/util-defaults-mode-node': 3.354.0
-      '@aws-sdk/util-endpoints': 3.352.0
-      '@aws-sdk/util-retry': 3.347.0
-      '@aws-sdk/util-user-agent-browser': 3.347.0
-      '@aws-sdk/util-user-agent-node': 3.354.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
+      '@aws-sdk/credential-provider-node': 3.427.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-sdk-sts': 3.425.0
+      '@aws-sdk/middleware-signing': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/region-config-resolver': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
+      fast-xml-parser: 4.2.5
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/client-sts/3.354.0:
-    resolution: {integrity: sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==}
+  /@aws-sdk/credential-provider-cognito-identity/3.427.0:
+    resolution: {integrity: sha512-BQNzNrMJlBAfXhYNdAUqaVASpT9Aho5swj7glZKxx4Uds1w5Pih2e14JWgnl8XgUWAZ36pchTrV1aA4JT7N8vw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.354.0
-      '@aws-sdk/credential-provider-node': 3.354.0
-      '@aws-sdk/fetch-http-handler': 3.353.0
-      '@aws-sdk/hash-node': 3.347.0
-      '@aws-sdk/invalid-dependency': 3.347.0
-      '@aws-sdk/middleware-content-length': 3.347.0
-      '@aws-sdk/middleware-endpoint': 3.347.0
-      '@aws-sdk/middleware-host-header': 3.347.0
-      '@aws-sdk/middleware-logger': 3.347.0
-      '@aws-sdk/middleware-recursion-detection': 3.347.0
-      '@aws-sdk/middleware-retry': 3.354.0
-      '@aws-sdk/middleware-sdk-sts': 3.354.0
-      '@aws-sdk/middleware-serde': 3.347.0
-      '@aws-sdk/middleware-signing': 3.354.0
-      '@aws-sdk/middleware-stack': 3.347.0
-      '@aws-sdk/middleware-user-agent': 3.352.0
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/node-http-handler': 3.350.0
-      '@aws-sdk/smithy-client': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/url-parser': 3.347.0
-      '@aws-sdk/util-base64': 3.310.0
-      '@aws-sdk/util-body-length-browser': 3.310.0
-      '@aws-sdk/util-body-length-node': 3.310.0
-      '@aws-sdk/util-defaults-mode-browser': 3.353.0
-      '@aws-sdk/util-defaults-mode-node': 3.354.0
-      '@aws-sdk/util-endpoints': 3.352.0
-      '@aws-sdk/util-retry': 3.347.0
-      '@aws-sdk/util-user-agent-browser': 3.347.0
-      '@aws-sdk/util-user-agent-node': 3.354.0
-      '@aws-sdk/util-utf8': 3.310.0
-      '@smithy/protocol-http': 1.1.0
-      '@smithy/types': 1.1.0
-      fast-xml-parser: 4.2.4
+      '@aws-sdk/client-cognito-identity': 3.427.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/config-resolver/3.354.0:
-    resolution: {integrity: sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==}
+  /@aws-sdk/credential-provider-env/3.425.0:
+    resolution: {integrity: sha512-J20etnLvMKXRVi5FK4F8yOCNm2RTaQn5psQTGdDEPWJNGxohcSpzzls8U2KcMyUJ+vItlrThr4qwgpHG3i/N0w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-config-provider': 3.310.0
-      '@aws-sdk/util-middleware': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/credential-provider-cognito-identity/3.354.0:
-    resolution: {integrity: sha512-Q5UcqASJWqwD4AXpfv4Zpw5tUV/fzbhnEC9TzyB39zXcu4Qd0cQgVQOOq9FX1GbtLNOzkPnbvHsbv2PdEaNM4A==}
+  /@aws-sdk/credential-provider-http/3.425.0:
+    resolution: {integrity: sha512-aP9nkoVWf+OlNMecrUqe4+RuQrX13nucVbty0HTvuwfwJJj0T6ByWZzle+fo1D+5OxvJmtzTflBWt6jUERdHWA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    transitivePeerDependencies:
-      - aws-crt
-    optional: true
-
-  /@aws-sdk/credential-provider-env/3.353.0:
-    resolution: {integrity: sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/property-provider': 2.0.12
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/credential-provider-imds/3.354.0:
-    resolution: {integrity: sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==}
+  /@aws-sdk/credential-provider-ini/3.427.0:
+    resolution: {integrity: sha512-NmH1cO/w98CKMltYec3IrJIIco19wRjATFNiw83c+FGXZ+InJwReqBnruxIOmKTx2KDzd6fwU1HOewS7UjaaaQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/url-parser': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/credential-provider-ini/3.354.0:
-    resolution: {integrity: sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.353.0
-      '@aws-sdk/credential-provider-imds': 3.354.0
-      '@aws-sdk/credential-provider-process': 3.354.0
-      '@aws-sdk/credential-provider-sso': 3.354.0
-      '@aws-sdk/credential-provider-web-identity': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/shared-ini-file-loader': 3.354.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/credential-provider-env': 3.425.0
+      '@aws-sdk/credential-provider-process': 3.425.0
+      '@aws-sdk/credential-provider-sso': 3.427.0
+      '@aws-sdk/credential-provider-web-identity': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/credential-provider-node/3.354.0:
-    resolution: {integrity: sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==}
+  /@aws-sdk/credential-provider-node/3.427.0:
+    resolution: {integrity: sha512-wYYbQ57nKL8OfgRbl8k6uXcdnYml+p3LSSfDUAuUEp1HKlQ8lOXFJ3BdLr5qrk7LhpyppSRnWBmh2c3kWa7ANQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.353.0
-      '@aws-sdk/credential-provider-imds': 3.354.0
-      '@aws-sdk/credential-provider-ini': 3.354.0
-      '@aws-sdk/credential-provider-process': 3.354.0
-      '@aws-sdk/credential-provider-sso': 3.354.0
-      '@aws-sdk/credential-provider-web-identity': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/shared-ini-file-loader': 3.354.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/credential-provider-env': 3.425.0
+      '@aws-sdk/credential-provider-ini': 3.427.0
+      '@aws-sdk/credential-provider-process': 3.425.0
+      '@aws-sdk/credential-provider-sso': 3.427.0
+      '@aws-sdk/credential-provider-web-identity': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/credential-provider-process/3.354.0:
-    resolution: {integrity: sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==}
+  /@aws-sdk/credential-provider-process/3.425.0:
+    resolution: {integrity: sha512-YY6tkLdvtb1Fgofp3b1UWO+5vwS14LJ/smGmuGpSba0V7gFJRdcrJ9bcb9vVgAGuMdjzRJ+bUKlLLtqXkaykEw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/shared-ini-file-loader': 3.354.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/credential-provider-sso/3.354.0:
-    resolution: {integrity: sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==}
+  /@aws-sdk/credential-provider-sso/3.427.0:
+    resolution: {integrity: sha512-c+tXyS/i49erHs4bAp6vKNYeYlyQ0VNMBgoco0LCn1rL0REtHbfhWMnqDLF6c2n3yIWDOTrQu0D73Idnpy16eA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sso': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/shared-ini-file-loader': 3.354.0
-      '@aws-sdk/token-providers': 3.354.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/client-sso': 3.427.0
+      '@aws-sdk/token-providers': 3.427.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/credential-provider-web-identity/3.354.0:
-    resolution: {integrity: sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==}
+  /@aws-sdk/credential-provider-web-identity/3.425.0:
+    resolution: {integrity: sha512-/0R65TgRzL01JU3SzloivWNwdkbIhr06uY/F5pBHf/DynQqaspKNfdHn6AiozgSVDfwRHFjKBTUy6wvf3QFkuA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/credential-providers/3.354.0:
-    resolution: {integrity: sha512-GjkSKGWL+lbEVAYGRvE2kdKn8lnhLEBB98yKMz6k9VhqVBrMPZVGTFTlNNtPRZ7IfnnmgLnk6IHtue9xgaycfg==}
+  /@aws-sdk/credential-providers/3.427.0:
+    resolution: {integrity: sha512-rKKohSHju462vo+uQnPjcEZPBAfAMgGH6K1XyyCNpuOC0yYLkG87PYpvAQeb8riTrkHPX0dYUHuTHZ6zQgMGjA==}
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.354.0
-      '@aws-sdk/client-sso': 3.354.0
-      '@aws-sdk/client-sts': 3.354.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.354.0
-      '@aws-sdk/credential-provider-env': 3.353.0
-      '@aws-sdk/credential-provider-imds': 3.354.0
-      '@aws-sdk/credential-provider-ini': 3.354.0
-      '@aws-sdk/credential-provider-node': 3.354.0
-      '@aws-sdk/credential-provider-process': 3.354.0
-      '@aws-sdk/credential-provider-sso': 3.354.0
-      '@aws-sdk/credential-provider-web-identity': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/client-cognito-identity': 3.427.0
+      '@aws-sdk/client-sso': 3.427.0
+      '@aws-sdk/client-sts': 3.427.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.427.0
+      '@aws-sdk/credential-provider-env': 3.425.0
+      '@aws-sdk/credential-provider-http': 3.425.0
+      '@aws-sdk/credential-provider-ini': 3.427.0
+      '@aws-sdk/credential-provider-node': 3.427.0
+      '@aws-sdk/credential-provider-process': 3.425.0
+      '@aws-sdk/credential-provider-sso': 3.427.0
+      '@aws-sdk/credential-provider-web-identity': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/eventstream-codec/3.347.0:
-    resolution: {integrity: sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==}
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-hex-encoding': 3.310.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/fetch-http-handler/3.353.0:
-    resolution: {integrity: sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/querystring-builder': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-base64': 3.310.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/hash-node/3.347.0:
-    resolution: {integrity: sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==}
+  /@aws-sdk/middleware-host-header/3.425.0:
+    resolution: {integrity: sha512-E5Gt41LObQ+cr8QnLthwsH3MtVSNXy1AKJMowDr85h0vzqA/FHUkgHyOGntgozzjXT5M0MaSRYxS0xwTR5D4Ew==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-buffer-from': 3.310.0
-      '@aws-sdk/util-utf8': 3.310.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/invalid-dependency/3.347.0:
-    resolution: {integrity: sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==}
+  /@aws-sdk/middleware-logger/3.425.0:
+    resolution: {integrity: sha512-INE9XWRXx2f4a/r2vOU0tAmgctVp7nEaEasemNtVBYhqbKLZvr9ndLBSgKGgJ8LIcXAoISipaMuFiqIGkFsm7A==}
+    engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/is-array-buffer/3.310.0:
-    resolution: {integrity: sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==}
+  /@aws-sdk/middleware-recursion-detection/3.425.0:
+    resolution: {integrity: sha512-77gnzJ5b91bgD75L/ugpOyerx6lR3oyS4080X1YI58EzdyBMkDrHM4FbMcY2RynETi3lwXCFzLRyZjWXY1mRlw==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      '@aws-sdk/types': 3.425.0
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/middleware-content-length/3.347.0:
-    resolution: {integrity: sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==}
+  /@aws-sdk/middleware-sdk-sts/3.425.0:
+    resolution: {integrity: sha512-JFojrg76oKAoBknnr9EL5N2aJ1mRCtBqXoZYST58GSx8uYdFQ89qS65VNQ8JviBXzsrCNAn4vDhZ5Ch5E6TxGQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/middleware-signing': 3.425.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/middleware-endpoint/3.347.0:
-    resolution: {integrity: sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==}
+  /@aws-sdk/middleware-signing/3.425.0:
+    resolution: {integrity: sha512-ZpOfgJHk7ovQ0sSwg3tU4NxFOnz53lJlkJRf7S+wxQALHM0P2MJ6LYBrZaFMVsKiJxNIdZBXD6jclgHg72ZW6Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/middleware-serde': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/url-parser': 3.347.0
-      '@aws-sdk/util-middleware': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/property-provider': 2.0.12
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/signature-v4': 2.0.11
+      '@smithy/types': 2.3.5
+      '@smithy/util-middleware': 2.0.4
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/middleware-host-header/3.347.0:
-    resolution: {integrity: sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==}
+  /@aws-sdk/middleware-user-agent/3.427.0:
+    resolution: {integrity: sha512-y9HxYsNvnA3KqDl8w1jHeCwz4P9CuBEtu/G+KYffLeAMBsMZmh4SIkFFCO9wE/dyYg6+yo07rYcnnIfy7WA0bw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/middleware-logger/3.347.0:
-    resolution: {integrity: sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==}
+  /@aws-sdk/region-config-resolver/3.425.0:
+    resolution: {integrity: sha512-u7uv/iUOapIJdRgRkO3wnpYsUgV6ponsZJQgVg/8L+n+Vo5PQL5gAcIuAOwcYSKQPFaeK+KbmByI4SyOK203Vw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.347.0
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
+      '@smithy/util-config-provider': 2.0.0
+      '@smithy/util-middleware': 2.0.4
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/middleware-recursion-detection/3.347.0:
-    resolution: {integrity: sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==}
+  /@aws-sdk/token-providers/3.427.0:
+    resolution: {integrity: sha512-4E5E+4p8lJ69PBY400dJXF06LUHYx5lkKzBEsYqWWhoZcoftrvi24ltIhUDoGVLkrLcTHZIWSdFAWSos4hXqeg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/middleware-retry/3.354.0:
-    resolution: {integrity: sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/service-error-classification': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-middleware': 3.347.0
-      '@aws-sdk/util-retry': 3.347.0
-      tslib: 2.5.3
-      uuid: 8.3.2
-    optional: true
-
-  /@aws-sdk/middleware-sdk-sts/3.354.0:
-    resolution: {integrity: sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-signing': 3.354.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/middleware-serde/3.347.0:
-    resolution: {integrity: sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/middleware-signing/3.354.0:
-    resolution: {integrity: sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/signature-v4': 3.354.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-middleware': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/middleware-stack/3.347.0:
-    resolution: {integrity: sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/middleware-user-agent/3.352.0:
-    resolution: {integrity: sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-endpoints': 3.352.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/node-config-provider/3.354.0:
-    resolution: {integrity: sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/shared-ini-file-loader': 3.354.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/node-http-handler/3.350.0:
-    resolution: {integrity: sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/abort-controller': 3.347.0
-      '@aws-sdk/protocol-http': 3.347.0
-      '@aws-sdk/querystring-builder': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/property-provider/3.353.0:
-    resolution: {integrity: sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/protocol-http/3.347.0:
-    resolution: {integrity: sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/querystring-builder/3.347.0:
-    resolution: {integrity: sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-uri-escape': 3.310.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/querystring-parser/3.347.0:
-    resolution: {integrity: sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/service-error-classification/3.347.0:
-    resolution: {integrity: sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==}
-    engines: {node: '>=14.0.0'}
-    optional: true
-
-  /@aws-sdk/shared-ini-file-loader/3.354.0:
-    resolution: {integrity: sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/signature-v4/3.354.0:
-    resolution: {integrity: sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/eventstream-codec': 3.347.0
-      '@aws-sdk/is-array-buffer': 3.310.0
-      '@aws-sdk/types': 3.347.0
-      '@aws-sdk/util-hex-encoding': 3.310.0
-      '@aws-sdk/util-middleware': 3.347.0
-      '@aws-sdk/util-uri-escape': 3.310.0
-      '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/smithy-client/3.347.0:
-    resolution: {integrity: sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-stack': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/token-providers/3.354.0:
-    resolution: {integrity: sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/client-sso-oidc': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/shared-ini-file-loader': 3.354.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/middleware-host-header': 3.425.0
+      '@aws-sdk/middleware-logger': 3.425.0
+      '@aws-sdk/middleware-recursion-detection': 3.425.0
+      '@aws-sdk/middleware-user-agent': 3.427.0
+      '@aws-sdk/types': 3.425.0
+      '@aws-sdk/util-endpoints': 3.427.0
+      '@aws-sdk/util-user-agent-browser': 3.425.0
+      '@aws-sdk/util-user-agent-node': 3.425.0
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/hash-node': 2.0.11
+      '@smithy/invalid-dependency': 2.0.11
+      '@smithy/middleware-content-length': 2.0.13
+      '@smithy/middleware-endpoint': 2.1.0
+      '@smithy/middleware-retry': 2.0.16
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/property-provider': 2.0.12
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-body-length-browser': 2.0.0
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.15
+      '@smithy/util-defaults-mode-node': 2.0.19
+      '@smithy/util-retry': 2.0.4
+      '@smithy/util-utf8': 2.0.0
       tslib: 2.5.3
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/types/3.347.0:
-    resolution: {integrity: sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==}
+  /@aws-sdk/types/3.425.0:
+    resolution: {integrity: sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/url-parser/3.347.0:
-    resolution: {integrity: sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==}
-    dependencies:
-      '@aws-sdk/querystring-parser': 3.347.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-base64/3.310.0:
-    resolution: {integrity: sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==}
+  /@aws-sdk/util-endpoints/3.427.0:
+    resolution: {integrity: sha512-rSyiAIFF/EVvity/+LWUqoTMJ0a25RAc9iqx0WZ4tf1UjuEXRRXxZEb+jEZg1bk+pY84gdLdx9z5E+MSJCZxNQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/util-buffer-from': 3.310.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-body-length-browser/3.310.0:
-    resolution: {integrity: sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==}
-    dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-body-length-node/3.310.0:
-    resolution: {integrity: sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-buffer-from/3.310.0:
-    resolution: {integrity: sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/is-array-buffer': 3.310.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-config-provider/3.310.0:
-    resolution: {integrity: sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-defaults-mode-browser/3.353.0:
-    resolution: {integrity: sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
-      bowser: 2.11.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-defaults-mode-node/3.354.0:
-    resolution: {integrity: sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/config-resolver': 3.354.0
-      '@aws-sdk/credential-provider-imds': 3.354.0
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/property-provider': 3.353.0
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-endpoints/3.352.0:
-    resolution: {integrity: sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-hex-encoding/3.310.0:
-    resolution: {integrity: sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
+      '@aws-sdk/types': 3.425.0
+      '@smithy/node-config-provider': 2.1.1
       tslib: 2.5.3
     optional: true
 
@@ -2049,38 +1799,17 @@ packages:
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/util-middleware/3.347.0:
-    resolution: {integrity: sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==}
-    engines: {node: '>=14.0.0'}
+  /@aws-sdk/util-user-agent-browser/3.425.0:
+    resolution: {integrity: sha512-22Y9iMtjGcFjGILR6/xdp1qRezlHVLyXtnpEsbuPTiernRCPk6zfAnK/ATH77r02MUjU057tdxVkd5umUBTn9Q==}
     dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-retry/3.347.0:
-    resolution: {integrity: sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==}
-    engines: {node: '>= 14.0.0'}
-    dependencies:
-      '@aws-sdk/service-error-classification': 3.347.0
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-uri-escape/3.310.0:
-    resolution: {integrity: sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-user-agent-browser/3.347.0:
-    resolution: {integrity: sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==}
-    dependencies:
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/types': 2.3.5
       bowser: 2.11.0
       tslib: 2.5.3
     optional: true
 
-  /@aws-sdk/util-user-agent-node/3.354.0:
-    resolution: {integrity: sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==}
+  /@aws-sdk/util-user-agent-node/3.425.0:
+    resolution: {integrity: sha512-SIR4F5uQeeVAi8lv4OgRirtdtNi5zeyogTuQgGi9su8F/WP1N6JqxofcwpUY5f8/oJ2UlXr/tx1f09UHfJJzvA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -2088,22 +1817,15 @@ packages:
       aws-crt:
         optional: true
     dependencies:
-      '@aws-sdk/node-config-provider': 3.354.0
-      '@aws-sdk/types': 3.347.0
+      '@aws-sdk/types': 3.425.0
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
   /@aws-sdk/util-utf8-browser/3.259.0:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     dependencies:
-      tslib: 2.5.3
-    optional: true
-
-  /@aws-sdk/util-utf8/3.310.0:
-    resolution: {integrity: sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/util-buffer-from': 3.310.0
       tslib: 2.5.3
     optional: true
 
@@ -2646,8 +2368,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -2871,11 +2593,24 @@ packages:
     resolution: {integrity: sha512-A4e5dixApwICz5RcD3f2D0qDWPo7gPhJxKH/lrBrPrWotDfg2eCR+sVIMbG95C/uW4gQQpDIGYw2w5vu2hQjDA==}
     dev: true
 
+  /@fluidframework/gitresources/2.0.1:
+    resolution: {integrity: sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA==}
+    dev: true
+
   /@fluidframework/protocol-base/2.0.0:
     resolution: {integrity: sha512-vbA2tHDkBzu3MoO+TG9sBwwcUT2iVtHJWsJUegm8m72yGicOCZsrIoHdzSQDGTlwySlarxB21Z9Cr3ryg/zS+A==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      events: 3.3.0
+    dev: true
+
+  /@fluidframework/protocol-base/2.0.1:
+    resolution: {integrity: sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
     dev: true
@@ -2889,7 +2624,16 @@ packages:
     resolution: {integrity: sha512-3Wn0XLecbz8kytyfE4mukFUUeoEEnzAFFfEBzjBelpkS6bbAZ/7TdLLJ34q9JS8Cnb5vqreFfJCaHbboIUe6YQ==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-core': 2.0.0
+      '@fluidframework/server-services-core': 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-kafka-orderer/2.0.1:
+    resolution: {integrity: sha512-kZ8aEYoQWStQ8FPPwQwxcZoCFSpUk/3B8IZZCfc3Rn2CGAoG+8rffuRwgRKnyWbJ0DWgcTgPuXO3b/2Vc4gARw==}
+    dependencies:
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-core': 2.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2898,9 +2642,26 @@ packages:
     resolution: {integrity: sha512-DJS/YFS2DqvPq8g9vsXAtZyE32oDvN81wSTNxoI6jhQyJOuMwB6Uii7kPYtkyiRN2N5jdHu3dsfrhtuZL5hZLA==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      assert: 2.0.0
+      async: 3.2.4
+      events: 3.3.0
+      lodash: 4.17.21
+      nconf: 0.12.0
+      serialize-error: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-lambdas-driver/2.0.1:
+    resolution: {integrity: sha512-MkgY/5WzDw8K5g3aK9E65zkvXXt4UTlca0kx89uGuYJZhMuB/D0sgPD9BmuYlLf0fczwaqy1nuegQXJNGMF7jA==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       assert: 2.0.0
       async: 3.2.4
       events: 3.3.0
@@ -2916,15 +2677,45 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 1.0.0
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
-      '@fluidframework/protocol-base': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-lambdas-driver': 2.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-lambdas-driver': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       '@types/semver': 7.5.0
       assert: 2.0.0
+      async: 3.2.4
+      axios: 0.26.1
+      buffer: 6.0.3
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      json-stringify-safe: 5.0.1
+      lodash: 4.17.21
+      nconf: 0.12.0
+      semver: 7.5.3
+      sha.js: 2.4.11
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-lambdas/2.0.1:
+    resolution: {integrity: sha512-vmg7dLYWdJNl2moi4t3W9oessTUte/yE9yDKyAMQ1YbMadfoFtQtaMo3QVWqfh5QhFT+7LiCWBWwwXOtVdVr/Q==}
+    dependencies:
+      '@fluidframework/common-definitions': 1.0.0
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-lambdas-driver': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@types/semver': 7.5.3
+      assert: 2.1.0
       async: 3.2.4
       axios: 0.26.1
       buffer: 6.0.3
@@ -2941,20 +2732,20 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas/2.0.0_debug@4.3.4:
-    resolution: {integrity: sha512-+ORFTBjZmCdk4E6K5+1VKYHSzB4Q4EtI+VopDFm8vysngy00IiXuOFlJ0oiGPNuSzdLxwc2F5Ggn3ol9XzKcGg==}
+  /@fluidframework/server-lambdas/2.0.1_debug@4.3.4:
+    resolution: {integrity: sha512-vmg7dLYWdJNl2moi4t3W9oessTUte/yE9yDKyAMQ1YbMadfoFtQtaMo3QVWqfh5QhFT+7LiCWBWwwXOtVdVr/Q==}
     dependencies:
       '@fluidframework/common-definitions': 1.0.0
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
-      '@fluidframework/protocol-base': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-lambdas-driver': 2.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
-      '@types/semver': 7.5.0
-      assert: 2.0.0
+      '@fluidframework/server-lambdas-driver': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@types/semver': 7.5.3
+      assert: 2.1.0
       async: 3.2.4
       axios: 0.26.1_debug@4.3.4
       buffer: 6.0.3
@@ -2976,12 +2767,12 @@ packages:
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-lambdas': 2.0.0_debug@4.3.4
-      '@fluidframework/server-memory-orderer': 2.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
-      '@fluidframework/server-test-utils': 2.0.0
+      '@fluidframework/server-lambdas': 2.0.1_debug@4.3.4
+      '@fluidframework/server-memory-orderer': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@fluidframework/server-test-utils': 2.0.1
       debug: 4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -2996,12 +2787,12 @@ packages:
     resolution: {integrity: sha512-5LauJcZUQ20LPVveHSBZeI1nbH/mVvCSZcN3EcqRQD+4BxGey2G7keiRvj2acsjMjD+MMNN8QQb/GM4yRT3S3g==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/protocol-base': 2.0.0
+      '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-lambdas': 2.0.0_debug@4.3.4
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-lambdas': 2.0.1_debug@4.3.4
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       '@types/debug': 4.1.8
       '@types/double-ended-queue': 2.1.2
       '@types/lodash': 4.14.195
@@ -3021,24 +2812,53 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@fluidframework/server-memory-orderer/2.0.1:
+    resolution: {integrity: sha512-YblwjozusA54xX0uZMaUpj+RJ8losh0zWEvgcR0Biur1kQYSO6add/o834MrNHAsFRD3MH1YmuRTlGTzIQmDqQ==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/protocol-base': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-lambdas': 2.0.1_debug@4.3.4
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@types/debug': 4.1.9
+      '@types/double-ended-queue': 2.1.4
+      '@types/lodash': 4.14.199
+      '@types/node': 18.17.6
+      '@types/ws': 6.0.4
+      assert: 2.1.0
+      debug: 4.3.4
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lodash: 4.17.21
+      sillyname: 0.1.0
+      uuid: 9.0.0
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@fluidframework/server-routerlicious-base/2.0.0:
     resolution: {integrity: sha512-4vK98dX/Vwj/dq5t0Y8HYrZaVrve1x013Qy/Jf6cXylo/Tf+TA/UNKvnPUAf4E6aARCrQ4jHiUvZbsOisds1Qw==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-kafka-orderer': 2.0.0
-      '@fluidframework/server-lambdas': 2.0.0
-      '@fluidframework/server-lambdas-driver': 2.0.0
-      '@fluidframework/server-memory-orderer': 2.0.0
-      '@fluidframework/server-services': 2.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-ordering-kafkanode': 2.0.0
-      '@fluidframework/server-services-ordering-rdkafka': 2.0.0
-      '@fluidframework/server-services-ordering-zookeeper': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
-      '@fluidframework/server-services-utils': 2.0.0
+      '@fluidframework/server-kafka-orderer': 2.0.1
+      '@fluidframework/server-lambdas': 2.0.1
+      '@fluidframework/server-lambdas-driver': 2.0.1
+      '@fluidframework/server-memory-orderer': 2.0.1
+      '@fluidframework/server-services': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-ordering-kafkanode': 2.0.1
+      '@fluidframework/server-services-ordering-rdkafka': 2.0.1
+      '@fluidframework/server-services-ordering-zookeeper': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@fluidframework/server-services-utils': 2.0.1
       body-parser: 1.20.2
       bytes: 3.1.2
       compression: 1.7.4
@@ -3063,23 +2883,65 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@fluidframework/server-routerlicious-base/2.0.1:
+    resolution: {integrity: sha512-/HPqWNQeYv5ETuNwO2uIGoTkxzOwzen0um3V2cbLzN3ny7FsL+qoPg5GGTF0YoA8XcH3+lyNflXoXB9IHvRvvQ==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-kafka-orderer': 2.0.1
+      '@fluidframework/server-lambdas': 2.0.1
+      '@fluidframework/server-lambdas-driver': 2.0.1
+      '@fluidframework/server-memory-orderer': 2.0.1
+      '@fluidframework/server-services': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-ordering-kafkanode': 2.0.1
+      '@fluidframework/server-services-ordering-rdkafka': 2.0.1
+      '@fluidframework/server-services-ordering-zookeeper': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@fluidframework/server-services-utils': 2.0.1
+      body-parser: 1.20.2
+      bytes: 3.1.2
+      compression: 1.7.4
+      cookie-parser: 1.4.6
+      cors: 2.8.5
+      express: 4.18.2
+      ioredis: 5.3.2
+      json-stringify-safe: 5.0.1
+      jsonwebtoken: 9.0.2
+      lodash: 4.17.21
+      nconf: 0.12.0
+      serialize-error: 8.1.0
+      sillyname: 0.1.0
+      uuid: 9.0.1
+      winston: 3.9.0
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@fluidframework/server-routerlicious/2.0.0:
     resolution: {integrity: sha512-pCYr3FTQQezRflneFF6TAItXz6FhTwe6zx927gAiyj1p49QPytUh9hm0sPd8sPfXf2CpzzGm69koi3uqSpFlGw==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-kafka-orderer': 2.0.0
-      '@fluidframework/server-lambdas': 2.0.0
-      '@fluidframework/server-lambdas-driver': 2.0.0
-      '@fluidframework/server-memory-orderer': 2.0.0
-      '@fluidframework/server-routerlicious-base': 2.0.0
-      '@fluidframework/server-services': 2.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-shared': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
-      '@fluidframework/server-services-utils': 2.0.0
+      '@fluidframework/server-kafka-orderer': 2.0.1
+      '@fluidframework/server-lambdas': 2.0.1
+      '@fluidframework/server-lambdas-driver': 2.0.1
+      '@fluidframework/server-memory-orderer': 2.0.1
+      '@fluidframework/server-routerlicious-base': 2.0.1
+      '@fluidframework/server-services': 2.0.1
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-shared': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@fluidframework/server-services-utils': 2.0.1
       commander: 2.20.3
       express: 4.18.2
       ioredis: 5.3.2
@@ -3097,8 +2959,28 @@ packages:
     resolution: {integrity: sha512-ZWk93IsE65UME7qcQMBEh7IuUwIwcI8tRjlCFvHcdptKJOOUxgAyNwWUGBvG/UL4FPJvAUg5NQdBCOu3uyBTTg==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
-      '@fluidframework/protocol-base': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      axios: 0.26.1_debug@4.3.4
+      crc-32: 1.2.0
+      debug: 4.3.4
+      json-stringify-safe: 5.0.1
+      jsrsasign: 10.8.6
+      jwt-decode: 3.1.2
+      querystring: 0.2.1
+      sillyname: 0.1.0
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-services-client/2.0.1:
+    resolution: {integrity: sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
       axios: 0.26.1_debug@4.3.4
       crc-32: 1.2.0
@@ -3117,11 +2999,28 @@ packages:
     resolution: {integrity: sha512-qyx2Ghu4GDSlY88NbPOAe1qPutcvv4C1QtH4SB1jkNzmqxTWJlXJl8glm+KukbjFNk+ULr7S1GYPQtD3lTafmQ==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       '@types/nconf': 0.10.3
+      '@types/node': 18.17.6
+      debug: 4.3.4
+      events: 3.3.0
+      nconf: 0.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-services-core/2.0.1:
+    resolution: {integrity: sha512-FPK88g0RGn+Peh13Q57A06kETUpvu0cFSDXtePEosNsanx7MTzkMpZug8jMMYVVsWQfFZ41tjJdsOeMj/Ae1kQ==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@types/nconf': 0.10.4
       '@types/node': 18.17.6
       debug: 4.3.4
       events: 3.3.0
@@ -3133,10 +3032,25 @@ packages:
   /@fluidframework/server-services-ordering-kafkanode/2.0.0:
     resolution: {integrity: sha512-Zwu9gHKoCdB25NWqgojGJSMtjR2sM9l0bUOggRMx4E1X+ifI1Ul6l9IOwZ6qUPOBLPHO/0gB1oKJehV80ra3HA==}
     dependencies:
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-ordering-zookeeper': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-ordering-zookeeper': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      events: 3.3.0
+      kafka-node: 5.0.0
+      nconf: 0.12.0
+      sillyname: 0.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-services-ordering-kafkanode/2.0.1:
+    resolution: {integrity: sha512-ADtIvYVI2FGvFehj/R3DiGlxsdlQ25aCNsMCb4JS/gu+QaZkS20fJxWVS3X49VCCU7Y480Q1eif4+8LHvg2fpg==}
+    dependencies:
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-ordering-zookeeper': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       events: 3.3.0
       kafka-node: 5.0.0
       nconf: 0.12.0
@@ -3149,9 +3063,9 @@ packages:
     resolution: {integrity: sha512-sF7Ags7y3JeKhkUje3HSU0x1c2Poeb0Kgt0jELF4Xwl37Y9s/18y3jMu07RZNOn2dTSOULqDiCDMVRU9rgUlaA==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       events: 3.3.0
       nconf: 0.12.0
       node-rdkafka: 2.16.1
@@ -3160,10 +3074,34 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/server-services-ordering-rdkafka/2.0.1:
+    resolution: {integrity: sha512-yIRYs2LiM9ytVsjrjZaCzohSRXo2XgRETRjrIzFJzF4y1noFhqEiqCH8Q4bQt1L95/FeMlo9qJbjc1K39LtR3w==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      events: 3.3.0
+      nconf: 0.12.0
+      node-rdkafka: 2.17.0
+      sillyname: 0.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@fluidframework/server-services-ordering-zookeeper/2.0.0:
     resolution: {integrity: sha512-pl+BUpakXYuEdfXKXgTNCqNd8kAlS9j0oubmBCVs/rhkXpca6yNnA9mPnjxaaDnSIySQeL2tvWbBStdvS1bHEw==}
     dependencies:
-      '@fluidframework/server-services-core': 2.0.0
+      '@fluidframework/server-services-core': 2.0.1
+      zookeeper: 5.6.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-services-ordering-zookeeper/2.0.1:
+    resolution: {integrity: sha512-aSWu4ngQ0T4EagcosgodKT6XBhM0EKVo7kS42aAnD7uJqVc0TsXSj1TpngeETI7Gyy3H+gcrVnUeXK+eBOgdnA==}
+    dependencies:
+      '@fluidframework/server-services-core': 2.0.1
       zookeeper: 5.6.0
     transitivePeerDependencies:
       - supports-color
@@ -3173,12 +3111,12 @@ packages:
     resolution: {integrity: sha512-wqs5ALcPWocNSRmunmGCGtQ684l31cZR+BKvPNBpL5NXuAEbljIzg4FDdsvQiZlzdj1wUe6VzXkR5Nz9RxoSIg==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
-      '@fluidframework/protocol-base': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       '@socket.io/redis-adapter': 7.2.0
       body-parser: 1.20.2
       debug: 4.3.4
@@ -3200,8 +3138,49 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@fluidframework/server-services-shared/2.0.1:
+    resolution: {integrity: sha512-p0mz/9ZEoyVX21hWHwrOSoPN7D7UPyad38lrl2Ts05j5izhxjhokIqdS348vEKIonRtIUv3sj2wuPcbDXQ5WGQ==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@socket.io/redis-adapter': 7.2.0
+      body-parser: 1.20.2
+      debug: 4.3.4
+      events: 3.3.0
+      ioredis: 5.3.2
+      lodash: 4.17.21
+      nconf: 0.12.0
+      notepack.io: 2.3.0
+      querystring: 0.2.1
+      serialize-error: 8.1.0
+      socket.io: 4.7.2
+      socket.io-adapter: 2.5.2
+      socket.io-parser: 4.2.4
+      uuid: 9.0.1
+      winston: 3.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@fluidframework/server-services-telemetry/2.0.0:
     resolution: {integrity: sha512-sKDBO2sYxMn0pEn673HL/aXeWJzxZjXTUGgY5337EzZ7f1U06EA4pKLm1s59QPPaVNQ0lBhqwANwVgvKfQc4cA==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      json-stringify-safe: 5.0.1
+      path-browserify: 1.0.1
+      serialize-error: 8.1.0
+      uuid: 9.0.0
+    dev: true
+
+  /@fluidframework/server-services-telemetry/2.0.1:
+    resolution: {integrity: sha512-XM3QMhJ0IHygvaHahayzJAYcxOO0TvhLIiIM4jGWRsxAbEMQPWGcWfMmK/xnVti+Uq6Lyx5FOT3mEVSeFDW2Dg==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       json-stringify-safe: 5.0.1
@@ -3214,9 +3193,9 @@ packages:
     resolution: {integrity: sha512-EG/t7WtEpOJfROUJzTz34skLDSYlsYbJvW20+4xYPY1olO39YXugHOTf78HRVel7OnMUjPVwgL3Zws3Oj5XojA==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       debug: 4.3.4
       express: 4.18.2
       ioredis: 5.3.2
@@ -3234,18 +3213,42 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/server-services-utils/2.0.1:
+    resolution: {integrity: sha512-DKDeNY4tqKPOC2gBqqZT49ZPGMxg6RV2mN/t5A0mxOkNjzwx0BuCxEEtxQAtavVP9Q/Gu4yMRQgcj/XfnM6Mdw==}
+    dependencies:
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      debug: 4.3.4
+      express: 4.18.2
+      ioredis: 5.3.2
+      json-stringify-safe: 5.0.1
+      jsonwebtoken: 9.0.2
+      morgan: 1.10.0
+      nconf: 0.12.0
+      serialize-error: 8.1.0
+      sillyname: 0.1.0
+      split: 1.0.1
+      uuid: 9.0.1
+      winston: 3.9.0
+      winston-transport: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@fluidframework/server-services/2.0.0:
     resolution: {integrity: sha512-viIDTqmDPl0RnEsEpY7DWTDCzjjbUnfLlsXqWsOg4LRA1h8alf1MhoJtKouKYwX4lEXpGXrqEABl5bKbllg+3Q==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-ordering-kafkanode': 2.0.0
-      '@fluidframework/server-services-ordering-rdkafka': 2.0.0
-      '@fluidframework/server-services-shared': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
-      '@fluidframework/server-services-utils': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-ordering-kafkanode': 2.0.1
+      '@fluidframework/server-services-ordering-rdkafka': 2.0.1
+      '@fluidframework/server-services-shared': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@fluidframework/server-services-utils': 2.0.1
       '@socket.io/redis-emitter': 4.1.1
       amqplib: 0.10.3
       axios: 0.26.1_debug@4.3.4
@@ -3266,17 +3269,69 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@fluidframework/server-services/2.0.1:
+    resolution: {integrity: sha512-e0Ep0H0jE0oYWt3XWIdYJS6mR1aM6nW1NmI+v8FQlHV8R8o5ssYZiHJIGZf9jKslORY53zv4yTn7ndgUOpWDSw==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-ordering-kafkanode': 2.0.1
+      '@fluidframework/server-services-ordering-rdkafka': 2.0.1
+      '@fluidframework/server-services-shared': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      '@fluidframework/server-services-utils': 2.0.1
+      '@socket.io/redis-emitter': 4.1.1
+      amqplib: 0.10.3
+      axios: 0.26.1_debug@4.3.4
+      debug: 4.3.4
+      events: 3.3.0
+      ioredis: 5.3.2
+      lru-cache: 6.0.0
+      mongodb: 4.17.0
+      nconf: 0.12.0
+      socket.io: 4.7.2
+      telegrafjs: 0.1.3
+      uuid: 9.0.1
+      winston: 3.9.0
+    transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@fluidframework/server-test-utils/2.0.0:
     resolution: {integrity: sha512-/u5lH/yxS+aJHZGsLsvb2VSrmNAeBRw4B3gGCvl3cE48YQtuXSj2VKNuE7Xs0GrvQzMaKW9UHDpL1FiYJHKRDg==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/gitresources': 2.0.0
-      '@fluidframework/protocol-base': 2.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-client': 2.0.0
-      '@fluidframework/server-services-core': 2.0.0
-      '@fluidframework/server-services-telemetry': 2.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
       assert: 2.0.0
+      debug: 4.3.4
+      events: 3.3.0
+      lodash: 4.17.21
+      string-hash: 1.1.3
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/server-test-utils/2.0.1:
+    resolution: {integrity: sha512-bfAAqP7szXWtFs6vJaFK7+Naavwd5GjYjYAfeWzJFwbuKjWAl5lhx/RcsryBDlJ0HztGksEsHoMP2GDpnIW1eg==}
+    dependencies:
+      '@fluidframework/common-utils': 3.0.0
+      '@fluidframework/gitresources': 2.0.1
+      '@fluidframework/protocol-base': 2.0.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-client': 2.0.1
+      '@fluidframework/server-services-core': 2.0.1
+      '@fluidframework/server-services-telemetry': 2.0.1
+      assert: 2.1.0
       debug: 4.3.4
       events: 3.3.0
       lodash: 4.17.21
@@ -4127,7 +4182,7 @@ packages:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
       '@babel/runtime': 7.22.5
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       find-up: 4.1.0
       fs-extra: 8.1.0
     dev: true
@@ -4137,7 +4192,7 @@ packages:
     engines: {node: '>=14.18.0'}
     dependencies:
       '@manypkg/tools': 1.1.0
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       find-up: 4.1.0
       fs-extra: 8.1.0
     dev: true
@@ -4624,7 +4679,7 @@ packages:
       nx: 15.9.4
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@nrwl/nx-darwin-arm64/15.9.4:
@@ -4728,7 +4783,7 @@ packages:
       chalk: 4.1.2
       strip-ansi: 6.0.1
       supports-color: 8.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@oclif/core/2.9.3_i66k3arednklksy2ivodm65s6a:
@@ -5556,7 +5611,7 @@ packages:
   /@octokit/types/2.16.2:
     resolution: {integrity: sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@octokit/types/6.41.0:
@@ -5783,18 +5838,348 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
-  /@smithy/protocol-http/1.1.0:
-    resolution: {integrity: sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==}
+  /@smithy/abort-controller/2.0.11:
+    resolution: {integrity: sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 1.1.0
+      '@smithy/types': 2.3.5
       tslib: 2.5.3
     optional: true
 
-  /@smithy/types/1.1.0:
-    resolution: {integrity: sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==}
+  /@smithy/config-resolver/2.0.14:
+    resolution: {integrity: sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
+      '@smithy/util-config-provider': 2.0.0
+      '@smithy/util-middleware': 2.0.4
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/credential-provider-imds/2.0.16:
+    resolution: {integrity: sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/property-provider': 2.0.12
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/eventstream-codec/2.0.11:
+    resolution: {integrity: sha512-BQCTjxhCYRZIfXapa2LmZSaH8QUBGwMZw7XRN83hrdixbLjIcj+o549zjkedFS07Ve2TlvWUI6BTzP+nv7snBA==}
+    dependencies:
+      '@aws-crypto/crc32': 3.0.0
+      '@smithy/types': 2.3.5
+      '@smithy/util-hex-encoding': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/fetch-http-handler/2.2.3:
+    resolution: {integrity: sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==}
+    dependencies:
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/querystring-builder': 2.0.11
+      '@smithy/types': 2.3.5
+      '@smithy/util-base64': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/hash-node/2.0.11:
+    resolution: {integrity: sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      '@smithy/util-buffer-from': 2.0.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/invalid-dependency/2.0.11:
+    resolution: {integrity: sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/is-array-buffer/2.0.0:
+    resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/middleware-content-length/2.0.13:
+    resolution: {integrity: sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/middleware-endpoint/2.1.0:
+    resolution: {integrity: sha512-e6HZbfrp9CNTJqIPSgkydB9mNQXiq5pkHF3ZB6rOzPPR9PkJBoGFo9TcM7FaaKFUaH4Kc20AX6WwwVyIlNhXTA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/middleware-serde': 2.0.11
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/types': 2.3.5
+      '@smithy/url-parser': 2.0.11
+      '@smithy/util-middleware': 2.0.4
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/middleware-retry/2.0.16:
+    resolution: {integrity: sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/service-error-classification': 2.0.4
+      '@smithy/types': 2.3.5
+      '@smithy/util-middleware': 2.0.4
+      '@smithy/util-retry': 2.0.4
+      tslib: 2.5.3
+      uuid: 8.3.2
+    optional: true
+
+  /@smithy/middleware-serde/2.0.11:
+    resolution: {integrity: sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/middleware-stack/2.0.5:
+    resolution: {integrity: sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/node-config-provider/2.1.1:
+    resolution: {integrity: sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/property-provider': 2.0.12
+      '@smithy/shared-ini-file-loader': 2.2.0
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/node-http-handler/2.1.7:
+    resolution: {integrity: sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 2.0.11
+      '@smithy/protocol-http': 3.0.7
+      '@smithy/querystring-builder': 2.0.11
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/property-provider/2.0.12:
+    resolution: {integrity: sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/protocol-http/3.0.7:
+    resolution: {integrity: sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/querystring-builder/2.0.11:
+    resolution: {integrity: sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      '@smithy/util-uri-escape': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/querystring-parser/2.0.11:
+    resolution: {integrity: sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/service-error-classification/2.0.4:
+    resolution: {integrity: sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+    optional: true
+
+  /@smithy/shared-ini-file-loader/2.2.0:
+    resolution: {integrity: sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/signature-v4/2.0.11:
+    resolution: {integrity: sha512-EFVU1dT+2s8xi227l1A9O27edT/GNKvyAK6lZnIZ0zhIHq/jSLznvkk15aonGAM1kmhmZBVGpI7Tt0odueZK9A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/eventstream-codec': 2.0.11
+      '@smithy/is-array-buffer': 2.0.0
+      '@smithy/types': 2.3.5
+      '@smithy/util-hex-encoding': 2.0.0
+      '@smithy/util-middleware': 2.0.4
+      '@smithy/util-uri-escape': 2.0.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/smithy-client/2.1.11:
+    resolution: {integrity: sha512-okjMbuBBCTiieK665OFN/ap6u9+Z9z55PMphS5FYCsS6Zfp137Q3qlnt0OgBAnUVnH/mNGyoJV0LBX9gkTWptg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/middleware-stack': 2.0.5
+      '@smithy/types': 2.3.5
+      '@smithy/util-stream': 2.0.16
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/types/2.3.5:
+    resolution: {integrity: sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/url-parser/2.0.11:
+    resolution: {integrity: sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==}
+    dependencies:
+      '@smithy/querystring-parser': 2.0.11
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-base64/2.0.0:
+    resolution: {integrity: sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-body-length-browser/2.0.0:
+    resolution: {integrity: sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-body-length-node/2.1.0:
+    resolution: {integrity: sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-buffer-from/2.0.0:
+    resolution: {integrity: sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-config-provider/2.0.0:
+    resolution: {integrity: sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-defaults-mode-browser/2.0.15:
+    resolution: {integrity: sha512-2raMZOYKSuke7QlDg/HDcxQdrp0zteJ8z+S0B9Rn23J55ZFNK1+IjG4HkN6vo/0u3Xy/JOdJ93ibiBSB8F7kOw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@smithy/property-provider': 2.0.12
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      bowser: 2.11.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-defaults-mode-node/2.0.19:
+    resolution: {integrity: sha512-7pScU4jBFADB2MBYKM3zb5onMh6Nn0X3IfaFVLYPyCarTIZDLUtUl1GtruzEUJPmDzP+uGeqOtU589HDY0Ni6g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@smithy/config-resolver': 2.0.14
+      '@smithy/credential-provider-imds': 2.0.16
+      '@smithy/node-config-provider': 2.1.1
+      '@smithy/property-provider': 2.0.12
+      '@smithy/smithy-client': 2.1.11
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-hex-encoding/2.0.0:
+    resolution: {integrity: sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-middleware/2.0.4:
+    resolution: {integrity: sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-retry/2.0.4:
+    resolution: {integrity: sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@smithy/service-error-classification': 2.0.4
+      '@smithy/types': 2.3.5
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-stream/2.0.16:
+    resolution: {integrity: sha512-b5ZSRh1KzUzC7LoJcpfk7+iXGoRr3WylEfmPd4FnBLm90OwxSB9VgK1fDZwicfYxSEvWHdYXgvvjPtenEYBBhw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/fetch-http-handler': 2.2.3
+      '@smithy/node-http-handler': 2.1.7
+      '@smithy/types': 2.3.5
+      '@smithy/util-base64': 2.0.0
+      '@smithy/util-buffer-from': 2.0.0
+      '@smithy/util-hex-encoding': 2.0.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-uri-escape/2.0.0:
+    resolution: {integrity: sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.5.3
+    optional: true
+
+  /@smithy/util-utf8/2.0.0:
+    resolution: {integrity: sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.0.0
       tslib: 2.5.3
     optional: true
 
@@ -5935,7 +6320,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       '@types/responselike': 1.0.0
     dev: true
 
@@ -5946,7 +6331,7 @@ packages:
   /@types/cli-progress/3.11.0:
     resolution: {integrity: sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/compression/0.0.33:
@@ -5978,14 +6363,30 @@ packages:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
       '@types/node': 18.17.6
+    dev: true
+
+  /@types/cors/2.8.14:
+    resolution: {integrity: sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==}
+    dependencies:
+      '@types/node': 18.17.6
 
   /@types/debug/4.1.8:
     resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
     dependencies:
       '@types/ms': 0.7.31
 
+  /@types/debug/4.1.9:
+    resolution: {integrity: sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==}
+    dependencies:
+      '@types/ms': 0.7.32
+    dev: true
+
   /@types/double-ended-queue/2.1.2:
     resolution: {integrity: sha512-iAjbBa3X4UQtYxcCsAr0YaZMRwyC79q4KHui0XtEN7GGLJA4fzD116KUYXXZKskaOYSchnaOFT/a8zSlEx3P9Q==}
+
+  /@types/double-ended-queue/2.1.4:
+    resolution: {integrity: sha512-Os5C/SdJzK5PWQvMIqk3yqc11IdTp7rx37hdXgjWLw/ba9G8VkhJUfX6Q3Cnp1yMGRLiv5y/5V2vI740xBFvkw==}
+    dev: true
 
   /@types/eslint-scope/3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
@@ -6034,7 +6435,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/http-cache-semantics/4.0.1:
@@ -6088,11 +6489,15 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/lodash/4.14.195:
     resolution: {integrity: sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==}
+
+  /@types/lodash/4.14.199:
+    resolution: {integrity: sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==}
+    dev: true
 
   /@types/lru-cache/5.1.1:
     resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
@@ -6131,8 +6536,16 @@ packages:
   /@types/ms/0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
 
+  /@types/ms/0.7.32:
+    resolution: {integrity: sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==}
+    dev: true
+
   /@types/nconf/0.10.3:
     resolution: {integrity: sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==}
+
+  /@types/nconf/0.10.4:
+    resolution: {integrity: sha512-6IBSPamvlKHm8tVHdDLzvwaETL1ThpNB/aGWo/vXHFYwQEezHbi4uJHf60OOu2kmJqhmCp4Vq/2JD408ljCdBw==}
+    dev: true
 
   /@types/nock/9.3.1:
     resolution: {integrity: sha512-eOVHXS5RnWOjTVhu3deCM/ruy9E6JCgeix2g7wpFiekQh3AaEAK1cz43tZDukKmtSmQnwvSySq7ubijCA32I7Q==}
@@ -6142,6 +6555,10 @@ packages:
 
   /@types/node/18.17.6:
     resolution: {integrity: sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==}
+
+  /@types/node/18.18.4:
+    resolution: {integrity: sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ==}
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -6162,11 +6579,15 @@ packages:
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/semver/7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+
+  /@types/semver/7.5.3:
+    resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
+    dev: true
 
   /@types/send/0.17.1:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
@@ -6226,17 +6647,17 @@ packages:
     resolution: {integrity: sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==}
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
-  /@types/webidl-conversions/7.0.0:
-    resolution: {integrity: sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==}
+  /@types/webidl-conversions/7.0.1:
+    resolution: {integrity: sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg==}
 
   /@types/whatwg-url/8.2.2:
     resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
     dependencies:
       '@types/node': 18.17.6
-      '@types/webidl-conversions': 7.0.0
+      '@types/webidl-conversions': 7.0.1
 
   /@types/ws/6.0.4:
     resolution: {integrity: sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==}
@@ -6582,7 +7003,7 @@ packages:
     resolution: {integrity: sha512-qEewJouhRvaecGjbkjz9kMKn96UASbDodNrE5MYy2TrXkHcisIkbMxZdGBYfAq+s1dFtCSx/5H4k5bEkfakM+A==}
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@zkochan/js-yaml/0.0.6:
@@ -6895,7 +7316,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
       get-intrinsic: 1.2.1
       is-string: 1.0.7
@@ -6911,7 +7332,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
     dev: true
@@ -6921,7 +7342,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
     dev: true
@@ -6947,6 +7368,16 @@ packages:
       is-nan: 1.3.2
       object-is: 1.1.5
       util: 0.12.5
+
+  /assert/2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+    dependencies:
+      call-bind: 1.0.2
+      is-nan: 1.3.2
+      object-is: 1.1.5
+      object.assign: 4.1.4
+      util: 0.12.5
+    dev: true
 
   /astral-regex/2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -7012,7 +7443,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.3
     transitivePeerDependencies:
       - debug
     dev: true
@@ -7020,7 +7451,7 @@ packages:
   /axios/0.26.1_debug@4.3.4:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.3_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: true
@@ -7033,6 +7464,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: false
 
   /axios/1.5.0_debug@4.3.4:
     resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
@@ -7042,6 +7474,16 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  /axios/1.5.1:
+    resolution: {integrity: sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==}
+    dependencies:
+      follow-redirects: 1.15.3
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /azure-devops-node-api/11.2.0:
     resolution: {integrity: sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==}
@@ -7278,7 +7720,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.2.1
+      ieee754: 1.1.13
       isarray: 1.0.0
     dev: true
 
@@ -7582,7 +8024,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr/1.1.4:
@@ -8068,7 +8510,7 @@ packages:
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       meow: 8.1.2
-      semver: 6.3.0
+      semver: 6.3.1
       split: 1.0.1
       through2: 4.0.2
     dev: true
@@ -8215,7 +8657,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.1
+      semver: 5.7.2
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
@@ -8503,15 +8945,24 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /define-data-property/1.1.0:
+    resolution: {integrity: sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.1
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.0
+
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
     dev: true
 
-  /define-properties/1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
+  /define-properties/1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
+      define-data-property: 1.1.0
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
 
@@ -8661,7 +9112,7 @@ packages:
     dependencies:
       commander: 2.20.3
       lru-cache: 4.1.5
-      semver: 5.7.1
+      semver: 5.7.2
       sigmund: 1.0.1
     dev: true
 
@@ -8716,12 +9167,17 @@ packages:
     resolution: {integrity: sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==}
     engines: {node: '>=10.0.0'}
 
+  /engine.io-parser/5.2.1:
+    resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
+    engines: {node: '>=10.0.0'}
+    dev: true
+
   /engine.io/6.4.2:
     resolution: {integrity: sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==}
     engines: {node: '>=10.0.0'}
     dependencies:
       '@types/cookie': 0.4.1
-      '@types/cors': 2.8.13
+      '@types/cors': 2.8.14
       '@types/node': 18.17.6
       accepts: 1.3.8
       base64id: 2.0.0
@@ -8734,6 +9190,26 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  /engine.io/6.5.3:
+    resolution: {integrity: sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      '@types/cookie': 0.4.1
+      '@types/cors': 2.8.14
+      '@types/node': 18.17.6
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.4.2
+      cors: 2.8.5
+      debug: 4.3.4
+      engine.io-parser: 5.2.1
+      ws: 8.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
 
   /enhanced-resolve/5.15.0:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
@@ -8789,7 +9265,7 @@ packages:
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
-      has: 1.0.3
+      has: 1.0.4
       has-property-descriptors: 1.0.0
       has-proto: 1.0.1
       has-symbols: 1.0.3
@@ -8800,7 +9276,7 @@ packages:
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
       is-weakref: 1.0.2
       object-inspect: 1.12.3
       object-keys: 1.1.1
@@ -8812,7 +9288,7 @@ packages:
       string.prototype.trimstart: 1.0.6
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.9
+      which-typed-array: 1.1.11
     dev: true
 
   /es-module-lexer/1.3.0:
@@ -8824,14 +9300,14 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.1
-      has: 1.0.3
+      has: 1.0.4
       has-tostringtag: 1.0.0
     dev: true
 
   /es-shim-unscopables/1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
     dependencies:
-      has: 1.0.3
+      has: 1.0.4
     dev: true
 
   /es-to-primitive/1.2.1:
@@ -9002,7 +9478,7 @@ packages:
       eslint: 8.27.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0_n3azjztrxivblbr45iafblicwy
-      has: 1.0.3
+      has: 1.0.4
       is-core-module: 2.12.1
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -9061,7 +9537,7 @@ packages:
       object.values: 1.1.6
       prop-types: 15.8.1
       resolve: 2.0.0-next.4
-      semver: 6.3.0
+      semver: 6.3.1
       string.prototype.matchall: 4.0.8
     dev: true
 
@@ -9396,8 +9872,8 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.5
-      '@types/lodash': 4.14.195
-      '@types/node': 18.17.6
+      '@types/lodash': 4.14.199
+      '@types/node': 18.18.4
       '@types/sinon': 9.0.11
       lodash: 4.17.21
       mock-stdin: 1.0.0
@@ -9455,8 +9931,8 @@ packages:
     resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
     dev: true
 
-  /fast-xml-parser/4.2.4:
-    resolution: {integrity: sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==}
+  /fast-xml-parser/4.2.5:
+    resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -9637,6 +10113,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
 
   /follow-redirects/1.15.2_debug@4.3.4:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
@@ -9648,6 +10125,28 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
+
+  /follow-redirects/1.15.3:
+    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
+
+  /follow-redirects/1.15.3_debug@4.3.4:
+    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -9772,8 +10271,8 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -9788,7 +10287,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
       functions-have-names: 1.2.3
     dev: true
@@ -9851,7 +10350,7 @@ packages:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
       function-bind: 1.1.1
-      has: 1.0.3
+      has: 1.0.4
       has-proto: 1.0.1
       has-symbols: 1.0.3
 
@@ -9969,7 +10468,7 @@ packages:
     hasBin: true
     dependencies:
       meow: 8.1.2
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /git-up/7.0.0:
@@ -10134,7 +10633,7 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.2.1
     dev: true
 
   /globby/10.0.0:
@@ -10318,11 +10817,9 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /has/1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+  /has/1.0.4:
+    resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
     engines: {node: '>= 0.4.0'}
-    dependencies:
-      function-bind: 1.1.1
 
   /hasurl/1.0.0:
     resolution: {integrity: sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==}
@@ -10652,7 +11149,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.1
-      has: 1.0.3
+      has: 1.0.4
       side-channel: 1.0.4
     dev: true
 
@@ -10716,7 +11213,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
     dev: true
 
   /is-arrayish/0.2.1:
@@ -10780,7 +11277,7 @@ packages:
   /is-core-module/2.12.1:
     resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
     dependencies:
-      has: 1.0.3
+      has: 1.0.4
 
   /is-date-object/1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -10855,7 +11352,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
 
   /is-natural-number/4.0.1:
     resolution: {integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==}
@@ -10986,15 +11483,11 @@ packages:
       text-extensions: 1.9.0
     dev: true
 
-  /is-typed-array/1.1.10:
-    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+  /is-typed-array/1.1.12:
+    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
+      which-typed-array: 1.1.11
 
   /is-typedarray/1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -11257,7 +11750,7 @@ packages:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 5.7.1
+      semver: 5.7.2
     dev: true
 
   /jsonwebtoken/9.0.0:
@@ -11268,6 +11761,22 @@ packages:
       lodash: 4.17.21
       ms: 2.1.3
       semver: 7.5.4
+
+  /jsonwebtoken/9.0.2:
+    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    dependencies:
+      jws: 3.2.2
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.5.4
+    dev: true
 
   /jsrsasign/10.8.6:
     resolution: {integrity: sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==}
@@ -11791,14 +12300,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 5.7.1
+      semver: 5.7.2
     dev: true
 
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /make-error/1.3.6:
@@ -11939,7 +12448,7 @@ packages:
     resolution: {integrity: sha512-GftCCBs6EN8sz3BoWO1bCj8t7YBtT713d8bUgbhg9Iel5kFSqnSvCK06TYIDJAtJ51cSiWkM/YemlT0dfoFycw==}
     engines: {node: '>=12'}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       '@types/vinyl': 2.0.7
       vinyl: 2.2.1
       vinyl-file: 3.0.0
@@ -12305,7 +12814,7 @@ packages:
       mongodb-connection-string-url: 2.6.0
       socks: 2.7.1
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.354.0
+      '@aws-sdk/credential-providers': 3.427.0
       '@mongodb-js/saslprep': 1.1.0
     transitivePeerDependencies:
       - aws-crt
@@ -12319,7 +12828,7 @@ packages:
       mongodb-connection-string-url: 2.6.0
       socks: 2.7.1
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.354.0
+      '@aws-sdk/credential-providers': 3.427.0
       '@mongodb-js/saslprep': 1.1.0
     transitivePeerDependencies:
       - aws-crt
@@ -12373,6 +12882,9 @@ packages:
 
   /nan/2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+
+  /nan/2.18.0:
+    resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
 
   /nanoid/3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
@@ -12444,7 +12956,7 @@ packages:
   /node-abi/2.30.1:
     resolution: {integrity: sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==}
     dependencies:
-      semver: 5.7.1
+      semver: 5.7.2
     optional: true
 
   /node-abi/3.45.0:
@@ -12530,6 +13042,15 @@ packages:
       bindings: 1.5.0
       nan: 2.17.0
 
+  /node-rdkafka/2.17.0:
+    resolution: {integrity: sha512-vFABzRcE5FaH0WqfqJRxDoqeG6P8UEB3M4qFQ7SkwMgQueMMO78+fm8MYfl5hLW3bBYfBekK2BXIIr0lDQtSEQ==}
+    engines: {node: '>=6.0.0'}
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.18.0
+    dev: true
+
   /node-releases/2.0.12:
     resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
     dev: true
@@ -12566,7 +13087,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.2
-      semver: 5.7.1
+      semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -13004,7 +13525,7 @@ packages:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.48.1
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.5.0
+      axios: 1.5.1
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -13029,7 +13550,7 @@ packages:
       tar-stream: 2.2.0
       tmp: 0.2.1
       tsconfig-paths: 4.2.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       v8-compile-cache: 2.3.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
@@ -13059,7 +13580,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -13075,7 +13596,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: true
@@ -13085,7 +13606,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
@@ -13094,14 +13615,14 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
   /object.hasown/1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
@@ -13110,7 +13631,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
@@ -13431,7 +13952,7 @@ packages:
       got: 9.6.0
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /package-json/8.1.1:
@@ -14305,7 +14826,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       functions-have-names: 1.2.3
     dev: true
 
@@ -14585,12 +15106,12 @@ packages:
     resolution: {integrity: sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==}
     dev: true
 
-  /semver/5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+  /semver/5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
 
-  /semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+  /semver/6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
     dev: true
 
@@ -14869,7 +15390,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.17.0
+      nan: 2.18.0
       prebuild-install: 5.3.0
     optional: true
 
@@ -14904,6 +15425,23 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  /socket.io/4.7.2:
+    resolution: {integrity: sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.4
+      engine.io: 6.5.3
+      socket.io-adapter: 2.5.2
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
 
   /socks-proxy-agent/6.2.1:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
@@ -15164,7 +15702,7 @@ packages:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
       get-intrinsic: 1.2.1
       has-symbols: 1.0.3
@@ -15178,7 +15716,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
@@ -15186,7 +15724,7 @@ packages:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
@@ -15194,7 +15732,7 @@ packages:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       es-abstract: 1.21.2
     dev: true
 
@@ -15865,6 +16403,10 @@ packages:
   /tslib/2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
 
+  /tslib/2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
+
   /tsutils/3.21.0_typescript@4.5.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -15995,7 +16537,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
     dev: true
 
   /typed-rest-client/1.8.9:
@@ -16223,8 +16765,8 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
-      which-typed-array: 1.1.9
+      is-typed-array: 1.1.12
+      which-typed-array: 1.1.11
 
   /utils-merge/1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -16247,6 +16789,11 @@ packages:
   /uuid/9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
+
+  /uuid/9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: true
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -16613,8 +17160,8 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /which-typed-array/1.1.9:
-    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+  /which-typed-array/1.1.11:
+    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
@@ -16622,7 +17169,6 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
-      is-typed-array: 1.1.10
 
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -70,7 +70,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/server/tinylicious/pnpm-lock.yaml
+++ b/server/tinylicious/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^2.0.1
@@ -108,7 +108,7 @@ importers:
       uuid: 9.0.0
       winston: 3.8.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.34.4_@types+node@16.18.21
@@ -223,8 +223,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -1636,7 +1636,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /ci-info/3.7.0:
@@ -2989,12 +2989,12 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.17.0
+      nan: 2.18.0
     dev: true
     optional: true
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -4175,8 +4175,8 @@ packages:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: true
 
-  /nan/2.17.0:
-    resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+  /nan/2.18.0:
+    resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
     requiresBuild: true
     dev: true
     optional: true

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -67,7 +67,7 @@
 		"chalk": "^4.1.2"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
@@ -45,7 +45,7 @@ importers:
       '@rushstack/node-core-library': 3.55.2_@types+node@18.15.11
       chalk: 4.1.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@18.15.11
       '@fluidframework/eslint-config-fluid': 2.0.0_flcvfono3v34oogyclggnmpgme
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
@@ -184,8 +184,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -1800,7 +1800,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chrome-trace-event/1.0.3:
@@ -2935,8 +2935,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -43,7 +43,7 @@
 		"moment": "^2.21.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
       '@microsoft/api-extractor': ^7.22.2
@@ -36,7 +36,7 @@ importers:
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -109,8 +109,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -958,7 +958,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /ci-info/3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
@@ -1743,8 +1743,8 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true

--- a/tools/changelog-generator-wrapper/package.json
+++ b/tools/changelog-generator-wrapper/package.json
@@ -39,7 +39,7 @@
 		"typescript": "~4.5.5"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/tools/changelog-generator-wrapper/pnpm-lock.yaml
+++ b/tools/changelog-generator-wrapper/pnpm-lock.yaml
@@ -6,7 +6,7 @@ importers:
     specifiers:
       '@changesets/cli': ^2.26.1
       '@changesets/types': ^5.2.1
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       changesets-format-with-issue-links: ^0.3.0
       concurrently: ^8.2.1
@@ -21,7 +21,7 @@ importers:
       changesets-format-with-issue-links: 0.3.0_@changesets+cli@2.26.1
       typescript: 4.5.5
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       concurrently: 8.2.1
       copyfiles: 2.4.1
@@ -265,8 +265,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -26,7 +26,7 @@
 		"test": "node src/index.cjs --files test/**/*.md !test/README.md"
 	},
 	"dependencies": {
-		"@fluidframework/build-common": "^1.1.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@tylerbu/markdown-magic": "^2.4.0-tylerbu-1",
 		"chalk": "^2.4.2",

--- a/tools/markdown-magic/pnpm-lock.yaml
+++ b/tools/markdown-magic/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^1.1.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@tylerbu/markdown-magic': ^2.4.0-tylerbu-1
       chalk: ^2.4.2
@@ -13,7 +13,7 @@ importers:
       prettier: ~3.0.3
       yargs: ^17.6.2
     dependencies:
-      '@fluidframework/build-common': 1.2.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/eslint-config-fluid': 2.0.0
       '@tylerbu/markdown-magic': 2.4.0-tylerbu-1
       chalk: 2.4.2
@@ -92,8 +92,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@fluidframework/build-common/1.2.0:
-    resolution: {integrity: sha512-YZFWe0fv2opDR+zSdsZDakj0ExtwCE5ztIB3/EMXOCI8DTN3HYL4Cv4j81zgxcQc+aomR4JzRSpHEIOB0eejNw==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: false
 

--- a/tools/telemetry-generator/package-lock.json
+++ b/tools/telemetry-generator/package-lock.json
@@ -1,45 +1,68 @@
 {
 	"name": "@fluid-tools/telemetry-generator",
 	"version": "1.0.0",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@azure/abort-controller": {
+	"packages": {
+		"": {
+			"name": "@fluid-tools/telemetry-generator",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
+				"@oclif/core": "^1.12.0",
+				"applicationinsights": "^2.4.1"
+			},
+			"devDependencies": {
+				"@fluidframework/build-common": "^2.0.1",
+				"@fluidframework/eslint-config-fluid": "^2.0.0",
+				"@types/node": "^14.18.0",
+				"concurrently": "^8.2.1",
+				"eslint": "~8.6.0",
+				"prettier": "~3.0.3",
+				"rimraf": "^2.6.2",
+				"typescript": "~4.5.5"
+			}
+		},
+		"node_modules/@azure/abort-controller": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
 			"integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-			"requires": {
+			"dependencies": {
 				"tslib": "^2.2.0"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"@azure/core-auth": {
+		"node_modules/@azure/abort-controller/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@azure/core-auth": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
 			"integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
-			"requires": {
+			"dependencies": {
 				"@azure/abort-controller": "^1.0.0",
 				"tslib": "^2.2.0"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"@azure/core-rest-pipeline": {
+		"node_modules/@azure/core-auth/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@azure/core-rest-pipeline": {
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
 			"integrity": "sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==",
-			"requires": {
+			"dependencies": {
 				"@azure/abort-controller": "^1.0.0",
 				"@azure/core-auth": "^1.4.0",
 				"@azure/core-tracing": "^1.0.1",
@@ -51,161 +74,202 @@
 				"tslib": "^2.2.0",
 				"uuid": "^8.3.0"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
-		"@azure/core-tracing": {
+		"node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@azure/core-tracing": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
 			"integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-			"requires": {
+			"dependencies": {
 				"tslib": "^2.2.0"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"@azure/core-util": {
+		"node_modules/@azure/core-tracing/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@azure/core-util": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.1.1.tgz",
 			"integrity": "sha512-A4TBYVQCtHOigFb2ETiiKFDocBoI1Zk2Ui1KpI42aJSIDexF7DHQFpnjonltXAIU/ceH+1fsZAWWgvX6/AKzog==",
-			"requires": {
+			"dependencies": {
 				"@azure/abort-controller": "^1.0.0",
 				"tslib": "^2.2.0"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"@azure/logger": {
+		"node_modules/@azure/core-util/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@azure/logger": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
 			"integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
-			"requires": {
+			"dependencies": {
 				"tslib": "^2.2.0"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"@babel/code-frame": {
+		"node_modules/@azure/logger/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@babel/code-frame": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
 			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/highlight": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"@babel/helper-validator-identifier": {
+		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.19.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
 			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
-		"@babel/highlight": {
+		"node_modules/@babel/highlight": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
 			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"@es-joy/jsdoccomment": {
+		"node_modules/@babel/highlight/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.23.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+			"integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.33.4",
 			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.33.4.tgz",
 			"integrity": "sha512-02XyYuvR/Gn+3BT6idHVNQ4SSQlA1X1FeEfeKm2ypv8ANB6Lt9KRFZ2S7y5xjwR+EPQ/Rzb0XFaD+xKyqe4ALw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
 				"jsdoc-type-pratt-parser": "~3.1.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			}
 		},
-		"@eslint/eslintrc": {
+		"node_modules/@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
 			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^9.3.2",
@@ -215,46 +279,52 @@
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"@fluidframework/build-common": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-1.1.0.tgz",
-			"integrity": "sha512-ueCMYxa8/xgptrQc3JDAUio9HaXbwpiHe1A/CllbRXRlJfKJa31m6wcoBpmqkDzNPbCS+oehNDZOd6ZpnrUwnA==",
-			"dev": true
+		"node_modules/@fluidframework/build-common": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.1.tgz",
+			"integrity": "sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==",
+			"dev": true,
+			"bin": {
+				"gen-version": "bin/gen-version"
+			}
 		},
-		"@fluidframework/common-definitions": {
+		"node_modules/@fluidframework/common-definitions": {
 			"version": "0.20.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
 			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
-		"@fluidframework/core-interfaces": {
+		"node_modules/@fluidframework/core-interfaces": {
 			"version": "2.0.0-internal.1.0.0.84253",
 			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.1.0.0.84253.tgz",
 			"integrity": "sha512-l70zkACBXqmLGArg1QOchvIT3wR1KT4EpAKHhVYxTVOUiVMR6fP1Ui5s6KPCBdX6YeEydZEyLmBsuDPNENQ+9w=="
 		},
-		"@fluidframework/driver-definitions": {
+		"node_modules/@fluidframework/driver-definitions": {
 			"version": "2.0.0-internal.1.0.0.84253",
 			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.1.0.0.84253.tgz",
 			"integrity": "sha512-SKXNJpyPeaLb6DgbQRMXUjZ4XsHdkk7aKN9ztOXixhS3QL3wH4RqVfrX38xv5kMWzQ6EiHPO+KEPtUtliKmv3Q==",
-			"requires": {
+			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "2.0.0-internal.1.0.0.84253",
 				"@fluidframework/protocol-definitions": "^1.0.0"
 			}
 		},
-		"@fluidframework/eslint-config-fluid": {
+		"node_modules/@fluidframework/eslint-config-fluid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
 			"integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",
 				"@rushstack/eslint-plugin-security": "~0.2.5",
 				"@typescript-eslint/eslint-plugin": "~5.9.0",
 				"@typescript-eslint/parser": "~5.9.0",
-				"eslint-config-prettier": "~9.0.0",
+				"eslint-config-prettier": "~8.5.0",
 				"eslint-plugin-editorconfig": "~3.2.0",
 				"eslint-plugin-eslint-comments": "~3.2.0",
 				"eslint-plugin-import": "~2.25.4",
@@ -266,19 +336,19 @@
 				"eslint-plugin-unused-imports": "~2.0.0"
 			}
 		},
-		"@fluidframework/protocol-definitions": {
+		"node_modules/@fluidframework/protocol-definitions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.0.0.tgz",
 			"integrity": "sha512-ulowxU/6yVLQ2A+bJ2BD2yomKjRkGYwj91jdvmEtb7dWICnQpvgwxdcGnbxd2F6g3FnP9BmtZYRB2IQNMovk3A==",
-			"requires": {
+			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
-		"@fluidframework/test-driver-definitions": {
+		"node_modules/@fluidframework/test-driver-definitions": {
 			"version": "2.0.0-internal.1.0.0.84253",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.1.0.0.84253.tgz",
 			"integrity": "sha512-r27bTX2bXAgSJeoIw9p7u7zhNz+eLbKlGRS/gBivFy2DPC9y3YJEY/XbDyn3710dS/2RJT5NEv22fgSw3h107A==",
-			"requires": {
+			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "2.0.0-internal.1.0.0.84253",
 				"@fluidframework/driver-definitions": "2.0.0-internal.1.0.0.84253",
@@ -286,86 +356,99 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"@humanwhocodes/config-array": {
+		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.9.5",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
 			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=10.10.0"
 			}
 		},
-		"@humanwhocodes/object-schema": {
+		"node_modules/@humanwhocodes/object-schema": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@microsoft/applicationinsights-web-snippet": {
+		"node_modules/@microsoft/applicationinsights-web-snippet": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
 			"integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
 		},
-		"@microsoft/tsdoc": {
+		"node_modules/@microsoft/tsdoc": {
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
 			"integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
 			"dev": true
 		},
-		"@microsoft/tsdoc-config": {
+		"node_modules/@microsoft/tsdoc-config": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
 			"integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@microsoft/tsdoc": "0.14.2",
 				"ajv": "~6.12.6",
 				"jju": "~1.4.0",
 				"resolve": "~1.19.0"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.1.0",
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
-		"@nodelib/fs.scandir": {
+		"node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.1.0",
+				"path-parse": "^1.0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@nodelib/fs.stat": {
+		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"@nodelib/fs.walk": {
+		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@oclif/core": {
+		"node_modules/@oclif/core": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.12.0.tgz",
 			"integrity": "sha512-TR7k5EaekRH+TI1KxpxGda6DirGmUjVi+rz/RBtVxXTyGS446ZHRjlmogU7TIfTGLd1fdS0w0Eo8AHPjd3kh1w==",
-			"requires": {
+			"dependencies": {
 				"@oclif/linewrap": "^1.0.0",
 				"@oclif/screen": "^3.0.2",
 				"ansi-escapes": "^4.3.2",
@@ -395,153 +478,200 @@
 				"widest-line": "^3.1.0",
 				"wrap-ansi": "^7.0.0"
 			},
-			"dependencies": {
-				"argparse": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-					"requires": {
-						"sprintf-js": "~1.0.2"
-					}
-				},
-				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-				}
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"@oclif/linewrap": {
+		"node_modules/@oclif/core/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@oclif/core/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@oclif/core/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/@oclif/core/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@oclif/linewrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
 			"integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
 		},
-		"@oclif/screen": {
+		"node_modules/@oclif/screen": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
-			"integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ=="
+			"integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
+			"deprecated": "Deprecated in favor of @oclif/core",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
-		"@opentelemetry/api": {
+		"node_modules/@opentelemetry/api": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.0.tgz",
-			"integrity": "sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g=="
+			"integrity": "sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
 		},
-		"@opentelemetry/core": {
+		"node_modules/@opentelemetry/core": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
 			"integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
-			"requires": {
+			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.9.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.5.0"
 			}
 		},
-		"@opentelemetry/resources": {
+		"node_modules/@opentelemetry/resources": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.1.tgz",
 			"integrity": "sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==",
-			"requires": {
+			"dependencies": {
 				"@opentelemetry/core": "1.9.1",
 				"@opentelemetry/semantic-conventions": "1.9.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.5.0"
 			}
 		},
-		"@opentelemetry/sdk-trace-base": {
+		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.9.1.tgz",
 			"integrity": "sha512-Y9gC5M1efhDLYHeeo2MWcDDMmR40z6QpqcWnPCm4Dmh+RHAMf4dnEBBntIe1dDpor686kyU6JV1D29ih1lZpsQ==",
-			"requires": {
+			"dependencies": {
 				"@opentelemetry/core": "1.9.1",
 				"@opentelemetry/resources": "1.9.1",
 				"@opentelemetry/semantic-conventions": "1.9.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.5.0"
 			}
 		},
-		"@opentelemetry/semantic-conventions": {
+		"node_modules/@opentelemetry/semantic-conventions": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
-			"integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg=="
+			"integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
+			"engines": {
+				"node": ">=14"
+			}
 		},
-		"@rushstack/eslint-patch": {
+		"node_modules/@rushstack/eslint-patch": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
 			"integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
 			"dev": true
 		},
-		"@rushstack/eslint-plugin": {
+		"node_modules/@rushstack/eslint-plugin": {
 			"version": "0.8.6",
 			"resolved": "https://registry.npmjs.org/@rushstack/eslint-plugin/-/eslint-plugin-0.8.6.tgz",
 			"integrity": "sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@rushstack/tree-pattern": "0.2.3",
 				"@typescript-eslint/experimental-utils": "~5.6.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"@rushstack/eslint-plugin-security": {
+		"node_modules/@rushstack/eslint-plugin-security": {
 			"version": "0.2.6",
 			"resolved": "https://registry.npmjs.org/@rushstack/eslint-plugin-security/-/eslint-plugin-security-0.2.6.tgz",
 			"integrity": "sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@rushstack/tree-pattern": "0.2.3",
 				"@typescript-eslint/experimental-utils": "~5.6.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"@rushstack/tree-pattern": {
+		"node_modules/@rushstack/tree-pattern": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@rushstack/tree-pattern/-/tree-pattern-0.2.3.tgz",
 			"integrity": "sha512-8KWZxzn6XKuy3iKRSAd2CHXSXneRlGCmH9h/qM7jYQDekp+U18oUzub5xqOqHS2PLUC+torOMYZxgAIO/fF86A==",
 			"dev": true
 		},
-		"@tootallnate/once": {
+		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"engines": {
+				"node": ">= 10"
+			}
 		},
-		"@types/json-schema": {
+		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
-		"@types/json5": {
+		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"@types/node": {
+		"node_modules/@types/node": {
 			"version": "14.18.23",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
 			"integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
 			"dev": true
 		},
-		"@types/normalize-package-data": {
+		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
-		"@typescript-eslint/eslint-plugin": {
+		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.9.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
 			"integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/experimental-utils": "5.9.1",
 				"@typescript-eslint/scope-manager": "5.9.1",
 				"@typescript-eslint/type-utils": "5.9.1",
@@ -552,223 +682,406 @@
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
 			},
-			"dependencies": {
-				"@typescript-eslint/experimental-utils": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
-					"integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.9",
-						"@typescript-eslint/scope-manager": "5.9.1",
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/typescript-estree": "5.9.1",
-						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0"
-					}
-				},
-				"@typescript-eslint/scope-manager": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-					"integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/visitor-keys": "5.9.1"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-					"integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-					"integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/visitor-keys": "5.9.1",
-						"debug": "^4.3.2",
-						"globby": "^11.0.4",
-						"is-glob": "^4.0.3",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-					"integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"eslint-visitor-keys": "^3.0.0"
-					}
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
 				}
 			}
 		},
-		"@typescript-eslint/experimental-utils": {
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/experimental-utils": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+			"integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"@typescript-eslint/scope-manager": "5.9.1",
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/typescript-estree": "5.9.1",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+			"integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/visitor-keys": "5.9.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+			"integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+			"integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/visitor-keys": "5.9.1",
+				"debug": "^4.3.2",
+				"globby": "^11.0.4",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+			"integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/experimental-utils": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz",
 			"integrity": "sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"@typescript-eslint/scope-manager": "5.6.0",
 				"@typescript-eslint/types": "5.6.0",
 				"@typescript-eslint/typescript-estree": "5.6.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
 			}
 		},
-		"@typescript-eslint/parser": {
+		"node_modules/@typescript-eslint/parser": {
 			"version": "5.9.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
 			"integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.9.1",
 				"@typescript-eslint/types": "5.9.1",
 				"@typescript-eslint/typescript-estree": "5.9.1",
 				"debug": "^4.3.2"
 			},
-			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-					"integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/visitor-keys": "5.9.1"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-					"integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-					"integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/visitor-keys": "5.9.1",
-						"debug": "^4.3.2",
-						"globby": "^11.0.4",
-						"is-glob": "^4.0.3",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-					"integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"eslint-visitor-keys": "^3.0.0"
-					}
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
 				}
 			}
 		},
-		"@typescript-eslint/scope-manager": {
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+			"integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/visitor-keys": "5.9.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+			"integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+			"integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/visitor-keys": "5.9.1",
+				"debug": "^4.3.2",
+				"globby": "^11.0.4",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+			"integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz",
 			"integrity": "sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.6.0",
 				"@typescript-eslint/visitor-keys": "5.6.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"@typescript-eslint/type-utils": {
+		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.9.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
 			"integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/experimental-utils": "5.9.1",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
-			"dependencies": {
-				"@typescript-eslint/experimental-utils": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
-					"integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.9",
-						"@typescript-eslint/scope-manager": "5.9.1",
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/typescript-estree": "5.9.1",
-						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0"
-					}
-				},
-				"@typescript-eslint/scope-manager": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-					"integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/visitor-keys": "5.9.1"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-					"integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-					"integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"@typescript-eslint/visitor-keys": "5.9.1",
-						"debug": "^4.3.2",
-						"globby": "^11.0.4",
-						"is-glob": "^4.0.3",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "5.9.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-					"integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.9.1",
-						"eslint-visitor-keys": "^3.0.0"
-					}
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
 				}
 			}
 		},
-		"@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/experimental-utils": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+			"integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"@typescript-eslint/scope-manager": "5.9.1",
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/typescript-estree": "5.9.1",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+			"integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/visitor-keys": "5.9.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+			"integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+			"integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"@typescript-eslint/visitor-keys": "5.9.1",
+				"debug": "^4.3.2",
+				"globby": "^11.0.4",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+			"integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.9.1",
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.6.0.tgz",
 			"integrity": "sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
 		},
-		"@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
 			"integrity": "sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.6.0",
 				"@typescript-eslint/visitor-keys": "5.6.0",
 				"debug": "^4.3.2",
@@ -776,94 +1089,151 @@
 				"is-glob": "^4.0.3",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz",
 			"integrity": "sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.6.0",
 				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"acorn": {
+		"node_modules/acorn": {
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
 			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"acorn-jsx": {
+		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
 		},
-		"agent-base": {
+		"node_modules/agent-base": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"requires": {
+			"dependencies": {
 				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
-		"ajv": {
+		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"ansi-colors": {
+		"node_modules/ansi-colors": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
 			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"ansi-escapes": {
+		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
 			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"requires": {
+			"dependencies": {
 				"type-fest": "^0.21.3"
 			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.21.3",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
-				}
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"ansi-regex": {
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"ansi-styles": {
+		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"requires": {
+			"dependencies": {
 				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"ansicolors": {
+		"node_modules/ansicolors": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
 			"integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
 		},
-		"applicationinsights": {
+		"node_modules/applicationinsights": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.4.2.tgz",
 			"integrity": "sha512-cFI5r2JA4JhPvxLKwWzHgryrRc/3X2gR36iE7OWvdX4neltFzJyrYWXraWYMHpHqQojhmcX++Q7bT0XR8tzegA==",
-			"requires": {
+			"dependencies": {
 				"@azure/core-auth": "^1.4.0",
 				"@azure/core-rest-pipeline": "^1.10.0",
 				"@microsoft/applicationinsights-web-snippet": "^1.0.1",
@@ -875,462 +1245,628 @@
 				"continuation-local-storage": "^3.2.1",
 				"diagnostic-channel": "1.1.0",
 				"diagnostic-channel-publishers": "1.0.5"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"applicationinsights-native-metrics": "*"
+			},
+			"peerDependenciesMeta": {
+				"applicationinsights-native-metrics": {
+					"optional": true
+				}
 			}
 		},
-		"argparse": {
+		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"array-includes": {
+		"node_modules/array-includes": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
 			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4",
 				"get-intrinsic": "^1.1.3",
 				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"array-union": {
+		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"array.prototype.flat": {
+		"node_modules/array.prototype.flat": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
 			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4",
 				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"array.prototype.flatmap": {
+		"node_modules/array.prototype.flatmap": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
 			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4",
 				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"async": {
+		"node_modules/async": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
 		},
-		"async-hook-jl": {
+		"node_modules/async-hook-jl": {
 			"version": "1.7.6",
 			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
 			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-			"requires": {
+			"dependencies": {
 				"stack-chain": "^1.3.7"
+			},
+			"engines": {
+				"node": "^4.7 || >=6.9 || >=7.3"
 			}
 		},
-		"async-listener": {
+		"node_modules/async-listener": {
 			"version": "0.6.10",
 			"resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
 			"integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-			"requires": {
+			"dependencies": {
 				"semver": "^5.3.0",
 				"shimmer": "^1.1.0"
 			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-				}
+			"engines": {
+				"node": "<=0.11.8 || >0.11.10"
 			}
 		},
-		"asynckit": {
+		"node_modules/async-listener/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
-		"at-least-node": {
+		"node_modules/at-least-node": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
-		"balanced-match": {
+		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
-		"brace-expansion": {
+		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
+			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
-		"braces": {
+		"node_modules/braces": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"requires": {
+			"dependencies": {
 				"fill-range": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"builtin-modules": {
+		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"call-bind": {
+		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"callsites": {
+		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"cardinal": {
+		"node_modules/cardinal": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
 			"integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
-			"requires": {
+			"dependencies": {
 				"ansicolors": "~0.3.2",
 				"redeyed": "~2.1.0"
+			},
+			"bin": {
+				"cdl": "bin/cdl.js"
 			}
 		},
-		"chalk": {
+		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"ci-info": {
+		"node_modules/ci-info": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
 			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"clean-regexp": {
+		"node_modules/clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
 			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"escape-string-regexp": "^1.0.5"
 			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"clean-stack": {
+		"node_modules/clean-regexp/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/clean-stack": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
 			"integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
-			"requires": {
+			"dependencies": {
 				"escape-string-regexp": "4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"cli-progress": {
+		"node_modules/cli-progress": {
 			"version": "3.11.2",
 			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
 			"integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
-			"requires": {
+			"dependencies": {
 				"string-width": "^4.2.3"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
+				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
-		"cls-hooked": {
+		"node_modules/cls-hooked": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
 			"integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-			"requires": {
+			"dependencies": {
 				"async-hook-jl": "^1.7.6",
 				"emitter-listener": "^1.0.1",
 				"semver": "^5.4.1"
 			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-				}
+			"engines": {
+				"node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
 			}
 		},
-		"color-convert": {
+		"node_modules/cls-hooked/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"requires": {
+			"dependencies": {
 				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
 			}
 		},
-		"color-name": {
+		"node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"combined-stream": {
+		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
+			"dependencies": {
 				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
-		"commander": {
+		"node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
-		"comment-parser": {
+		"node_modules/comment-parser": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
 			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			}
 		},
-		"concat-map": {
+		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
-		"concurrently": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.5.1.tgz",
-			"integrity": "sha512-FlSwNpGjWQfRwPLXvJ/OgysbBxPkWpiVjy1042b0U7on7S7qwwMIILRj7WTN1mTgqa582bG6NFuScOoh6Zgdag==",
+		"node_modules/concurrently": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.1.tgz",
+			"integrity": "sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==",
 			"dev": true,
-			"requires": {
-				"chalk": "^4.1.0",
-				"date-fns": "^2.16.1",
-				"lodash": "^4.17.21",
-				"rxjs": "^6.6.3",
-				"spawn-command": "^0.0.2-1",
-				"supports-color": "^8.1.0",
-				"tree-kill": "^1.2.2",
-				"yargs": "^16.2.0"
-			},
 			"dependencies": {
-				"supports-color": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"chalk": "^4.1.2",
+				"date-fns": "^2.30.0",
+				"lodash": "^4.17.21",
+				"rxjs": "^7.8.1",
+				"shell-quote": "^1.8.1",
+				"spawn-command": "0.0.2",
+				"supports-color": "^8.1.1",
+				"tree-kill": "^1.2.2",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"conc": "dist/bin/concurrently.js",
+				"concurrently": "dist/bin/concurrently.js"
+			},
+			"engines": {
+				"node": "^14.13.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
 			}
 		},
-		"continuation-local-storage": {
+		"node_modules/concurrently/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/continuation-local-storage": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
 			"integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-			"requires": {
+			"dependencies": {
 				"async-listener": "^0.6.0",
 				"emitter-listener": "^1.1.1"
 			}
 		},
-		"cross-spawn": {
+		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"date-fns": {
-			"version": "2.29.2",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.2.tgz",
-			"integrity": "sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==",
-			"dev": true
+		"node_modules/date-fns": {
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.21.0"
+			},
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
+			}
 		},
-		"debug": {
+		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"requires": {
+			"dependencies": {
 				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
-		"deep-is": {
+		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
-		"define-properties": {
+		"node_modules/define-properties": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
 			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"delayed-stream": {
+		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"diagnostic-channel": {
+		"node_modules/diagnostic-channel": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
 			"integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
-			"requires": {
-				"semver": "^5.3.0"
-			},
 			"dependencies": {
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-				}
+				"semver": "^5.3.0"
 			}
 		},
-		"diagnostic-channel-publishers": {
+		"node_modules/diagnostic-channel-publishers": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
-			"integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg=="
+			"integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
+			"peerDependencies": {
+				"diagnostic-channel": "*"
+			}
 		},
-		"dir-glob": {
+		"node_modules/diagnostic-channel/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"requires": {
+			"dependencies": {
 				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"doctrine": {
+		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
-		"editorconfig": {
+		"node_modules/editorconfig": {
 			"version": "0.15.3",
 			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
 			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"commander": "^2.19.0",
 				"lru-cache": "^4.1.5",
 				"semver": "^5.6.0",
 				"sigmund": "^1.0.1"
 			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-					"dev": true
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-					"dev": true
-				}
+			"bin": {
+				"editorconfig": "bin/editorconfig"
 			}
 		},
-		"ejs": {
+		"node_modules/editorconfig/node_modules/lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/editorconfig/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/editorconfig/node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+			"dev": true
+		},
+		"node_modules/ejs": {
 			"version": "3.1.8",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
 			"integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
-			"requires": {
+			"dependencies": {
 				"jake": "^10.8.5"
+			},
+			"bin": {
+				"ejs": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"emitter-listener": {
+		"node_modules/emitter-listener": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
 			"integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-			"requires": {
+			"dependencies": {
 				"shimmer": "^1.2.0"
 			}
 		},
-		"emoji-regex": {
+		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
-		"enquirer": {
+		"node_modules/enquirer": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
 			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-colors": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"error-ex": {
+		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-arrayish": "^0.2.1"
 			}
 		},
-		"es-abstract": {
+		"node_modules/es-abstract": {
 			"version": "1.20.5",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
 			"integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
@@ -1356,45 +1892,66 @@
 				"string.prototype.trimend": "^1.0.6",
 				"string.prototype.trimstart": "^1.0.6",
 				"unbox-primitive": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"es-shim-unscopables": {
+		"node_modules/es-shim-unscopables": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
 			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has": "^1.0.3"
 			}
 		},
-		"es-to-primitive": {
+		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"escalade": {
+		"node_modules/escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"escape-string-regexp": {
+		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"eslint": {
+		"node_modules/eslint": {
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
 			"integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@eslint/eslintrc": "^1.0.5",
 				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
@@ -1434,123 +1991,119 @@
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
-			"dependencies": {
-				"eslint-scope": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-					"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^5.2.0"
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				},
-				"glob-parent": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-					"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.3"
-					}
-				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				}
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"eslint-config-prettier": {
+		"node_modules/eslint-config-prettier": {
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
+			}
 		},
-		"eslint-import-resolver-node": {
+		"node_modules/eslint-import-resolver-node": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
 			"integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"debug": "^3.2.7",
 				"resolve": "^1.20.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
 			}
 		},
-		"eslint-module-utils": {
+		"node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-module-utils": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
 			"integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"debug": "^3.2.7"
 			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
 				}
 			}
 		},
-		"eslint-plugin-editorconfig": {
+		"node_modules/eslint-module-utils/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-editorconfig": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-editorconfig/-/eslint-plugin-editorconfig-3.2.0.tgz",
 			"integrity": "sha512-XiUg69+qgv6BekkPCjP8+2DMODzPqtLV5i0Q9FO1v40P62pfodG1vjIihVbw/338hS5W26S+8MTtXaAlrg37QQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.0.0",
 				"editorconfig": "^0.15.0",
 				"eslint": "^8.0.1",
 				"klona": "^2.0.4"
 			}
 		},
-		"eslint-plugin-eslint-comments": {
+		"node_modules/eslint-plugin-eslint-comments": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
 			"integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"escape-string-regexp": "^1.0.5",
 				"ignore": "^5.0.5"
 			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=6.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=4.19.1"
 			}
 		},
-		"eslint-plugin-import": {
+		"node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/eslint-plugin-import": {
 			"version": "2.25.4",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
 			"integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flat": "^1.2.5",
 				"debug": "^2.6.9",
@@ -1565,39 +2118,46 @@
 				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.12.0"
 			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
 			}
 		},
-		"eslint-plugin-jsdoc": {
+		"node_modules/eslint-plugin-import/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/eslint-plugin-jsdoc": {
 			"version": "39.3.25",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.25.tgz",
 			"integrity": "sha512-7JiFOOaipz7Z7lNQ9sMJ6cdvclmVUwNYtFWGS3a0k0uEFcdZPPD64WOfENuyNHpl86C0AKIEPgOpZby5kd+pew==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@es-joy/jsdoccomment": "~0.33.4",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
@@ -1605,20 +2165,32 @@
 				"esquery": "^1.4.0",
 				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
+			},
+			"engines": {
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
-		"eslint-plugin-promise": {
+		"node_modules/eslint-plugin-promise": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.1.tgz",
 			"integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
 		},
-		"eslint-plugin-react": {
+		"node_modules/eslint-plugin-react": {
 			"version": "7.28.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
 			"integrity": "sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flatmap": "^1.2.5",
 				"doctrine": "^2.1.0",
@@ -1634,57 +2206,76 @@
 				"semver": "^6.3.0",
 				"string.prototype.matchall": "^4.0.6"
 			},
-			"dependencies": {
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "2.0.0-next.4",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-					"integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.9.0",
-						"path-parse": "^1.0.7",
-						"supports-preserve-symlinks-flag": "^1.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
 			}
 		},
-		"eslint-plugin-tsdoc": {
+		"node_modules/eslint-plugin-react/node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/resolve": {
+			"version": "2.0.0-next.4",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+			"integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-plugin-tsdoc": {
 			"version": "0.2.17",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz",
 			"integrity": "sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@microsoft/tsdoc": "0.14.2",
 				"@microsoft/tsdoc-config": "0.16.2"
 			}
 		},
-		"eslint-plugin-unicorn": {
+		"node_modules/eslint-plugin-unicorn": {
 			"version": "40.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-40.0.0.tgz",
 			"integrity": "sha512-5GRXISfBk8jMmYk1eeNDw8zSRnWTxBjWkzx2Prre6E2/yLu2twozZ3EomLWCBu9nWms/ZE361BItyMQwfnG1qA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.15.7",
 				"ci-info": "^3.3.0",
 				"clean-regexp": "^1.0.0",
@@ -1699,1457 +2290,2078 @@
 				"safe-regex": "^2.1.1",
 				"semver": "^7.3.5",
 				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.32.0"
 			}
 		},
-		"eslint-plugin-unused-imports": {
+		"node_modules/eslint-plugin-unused-imports": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
 			"integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"eslint-rule-composer": "^0.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": "^5.0.0",
+				"eslint": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/eslint-plugin": {
+					"optional": true
+				}
 			}
 		},
-		"eslint-rule-composer": {
+		"node_modules/eslint-rule-composer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
 			"integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
 		},
-		"eslint-scope": {
+		"node_modules/eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
-		"eslint-utils": {
+		"node_modules/eslint-utils": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"eslint-visitor-keys": "^2.0.0"
 			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				}
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
 			}
 		},
-		"eslint-visitor-keys": {
+		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
 			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
 		},
-		"espree": {
+		"node_modules/eslint/node_modules/eslint-scope": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/espree": {
 			"version": "9.3.3",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
 			"integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"esprima": {
+		"node_modules/esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"esquery": {
+		"node_modules/esquery": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
 			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
-		"esrecurse": {
+		"node_modules/esquery/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
-		"estraverse": {
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
-		"esutils": {
+		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"fast-deep-equal": {
+		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
-		"fast-glob": {
+		"node_modules/fast-glob": {
 			"version": "3.2.11",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
 			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
 				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
 			}
 		},
-		"fast-json-stable-stringify": {
+		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
-		"fast-levenshtein": {
+		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
-		"fastq": {
+		"node_modules/fastq": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
 			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-			"requires": {
+			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
-		"file-entry-cache": {
+		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"filelist": {
+		"node_modules/filelist": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
 			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-			"requires": {
-				"minimatch": "^5.0.1"
-			},
 			"dependencies": {
-				"brace-expansion": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-					"requires": {
-						"balanced-match": "^1.0.0"
-					}
-				},
-				"minimatch": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-					"integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-					"requires": {
-						"brace-expansion": "^2.0.1"
-					}
-				}
+				"minimatch": "^5.0.1"
 			}
 		},
-		"fill-range": {
+		"node_modules/filelist/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/filelist/node_modules/minimatch": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+			"integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"requires": {
+			"dependencies": {
 				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"find-up": {
+		"node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"flat-cache": {
+		"node_modules/flat-cache": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
 			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"flatted": {
+		"node_modules/flat-cache/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/flatted": {
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
 			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
 			"dev": true
 		},
-		"form-data": {
+		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
 			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"requires": {
+			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"fs-extra": {
+		"node_modules/fs-extra": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
 			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"requires": {
+			"dependencies": {
 				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"fs.realpath": {
+		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"function-bind": {
+		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"function.prototype.name": {
+		"node_modules/function.prototype.name": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
 			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.19.0",
 				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"functional-red-black-tree": {
+		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
-		"functions-have-names": {
+		"node_modules/functions-have-names": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"get-caller-file": {
+		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
 		},
-		"get-intrinsic": {
+		"node_modules/get-intrinsic": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
 			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"get-package-type": {
+		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
 		},
-		"get-symbol-description": {
+		"node_modules/get-symbol-description": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
 			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"glob": {
+		"node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
 				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"glob-parent": {
+		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"requires": {
+			"dependencies": {
 				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"globals": {
+		"node_modules/globals": {
 			"version": "13.17.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
 			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"globby": {
+		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"requires": {
+			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
 				"fast-glob": "^3.2.9",
 				"ignore": "^5.2.0",
 				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"gopd": {
+		"node_modules/gopd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"graceful-fs": {
+		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
 		},
-		"has": {
+		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
-		"has-bigints": {
+		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
 			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"has-flag": {
+		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"has-property-descriptors": {
+		"node_modules/has-property-descriptors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
 			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"has-symbols": {
+		"node_modules/has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"has-tostringtag": {
+		"node_modules/has-tostringtag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
 			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"hosted-git-info": {
+		"node_modules/hosted-git-info": {
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
-		"http-proxy-agent": {
+		"node_modules/http-proxy-agent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
 			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-			"requires": {
+			"dependencies": {
 				"@tootallnate/once": "2",
 				"agent-base": "6",
 				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"https-proxy-agent": {
+		"node_modules/https-proxy-agent": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"requires": {
+			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"hyperlinker": {
+		"node_modules/hyperlinker": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
-			"integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ=="
+			"integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"ignore": {
+		"node_modules/ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"engines": {
+				"node": ">= 4"
+			}
 		},
-		"import-fresh": {
+		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"imurmurhash": {
+		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
 		},
-		"indent-string": {
+		"node_modules/indent-string": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"inflight": {
+		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
 			}
 		},
-		"inherits": {
+		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
-		"internal-slot": {
+		"node_modules/internal-slot": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
 			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"get-intrinsic": "^1.1.0",
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"is-arrayish": {
+		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
 		},
-		"is-bigint": {
+		"node_modules/is-bigint": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
 			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-boolean-object": {
+		"node_modules/is-boolean-object": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
 			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-builtin-module": {
+		"node_modules/is-builtin-module": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
 			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"builtin-modules": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"is-callable": {
+		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-core-module": {
+		"node_modules/is-core-module": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
 			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-date-object": {
+		"node_modules/is-date-object": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
 			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-docker": {
+		"node_modules/is-docker": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"is-extglob": {
+		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"is-fullwidth-code-point": {
+		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"is-glob": {
+		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"requires": {
+			"dependencies": {
 				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"is-negative-zero": {
+		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
 			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-number": {
+		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
-		"is-number-object": {
+		"node_modules/is-number-object": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
 			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-regex": {
+		"node_modules/is-regex": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
 			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-shared-array-buffer": {
+		"node_modules/is-shared-array-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
 			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-string": {
+		"node_modules/is-string": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
 			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-symbol": {
+		"node_modules/is-symbol": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
 			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-weakref": {
+		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
 			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-wsl": {
+		"node_modules/is-wsl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-			"requires": {
+			"dependencies": {
 				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"isexe": {
+		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
-		"jake": {
+		"node_modules/jake": {
 			"version": "10.8.5",
 			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
 			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
-			"requires": {
+			"dependencies": {
 				"async": "^3.2.3",
 				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
+			},
+			"bin": {
+				"jake": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"jju": {
+		"node_modules/jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
 			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
-		"js-tokens": {
+		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
-		"js-yaml": {
+		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"jsdoc-type-pratt-parser": {
+		"node_modules/jsdoc-type-pratt-parser": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
 			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
-		"json-parse-even-better-errors": {
+		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
-		"json-schema-traverse": {
+		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify-without-jsonify": {
+		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
-		"json5": {
+		"node_modules/json5": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
 			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
 			}
 		},
-		"jsonfile": {
+		"node_modules/jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"requires": {
-				"graceful-fs": "^4.1.6",
+			"dependencies": {
 				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
-		"jsx-ast-utils": {
+		"node_modules/jsx-ast-utils": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
 			"integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array-includes": "^3.1.5",
 				"object.assign": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
-		"klona": {
+		"node_modules/klona": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
 			"integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"levn": {
+		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"lines-and-columns": {
+		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
-		"locate-path": {
+		"node_modules/locate-path": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"lodash": {
+		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
-		"lodash.merge": {
+		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"loose-envify": {
+		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
 			}
 		},
-		"lru-cache": {
+		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"requires": {
+			"dependencies": {
 				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"merge2": {
+		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"micromatch": {
+		"node_modules/micromatch": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
 			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-			"requires": {
+			"dependencies": {
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"mime-db": {
+		"node_modules/mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
-		"mime-types": {
+		"node_modules/mime-types": {
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"requires": {
+			"dependencies": {
 				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
-		"min-indent": {
+		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"minimatch": {
+		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"requires": {
+			"dependencies": {
 				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
-		"minimist": {
+		"node_modules/minimist": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
 			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"ms": {
+		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"natural-compare": {
+		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"natural-orderby": {
+		"node_modules/natural-orderby": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
-			"integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q=="
+			"integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
+			"engines": {
+				"node": "*"
+			}
 		},
-		"nice-try": {
+		"node_modules/nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
-		"normalize-package-data": {
+		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"hosted-git-info": "^2.1.4",
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-					"dev": true
-				}
 			}
 		},
-		"object-assign": {
+		"node_modules/normalize-package-data/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"object-inspect": {
+		"node_modules/object-inspect": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
 			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"object-keys": {
+		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
-		"object-treeify": {
+		"node_modules/object-treeify": {
 			"version": "1.1.33",
 			"resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-			"integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="
+			"integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
+			"engines": {
+				"node": ">= 10"
+			}
 		},
-		"object.assign": {
+		"node_modules/object.assign": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
 			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"object.entries": {
+		"node_modules/object.entries": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
 			"integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"object.fromentries": {
+		"node_modules/object.fromentries": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
 			"integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"object.hasown": {
+		"node_modules/object.hasown": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
 			"integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"object.values": {
+		"node_modules/object.values": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
 			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"once": {
+		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"wrappy": "1"
 			}
 		},
-		"optionator": {
+		"node_modules/optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
 			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
 				"word-wrap": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"p-limit": {
+		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"p-locate": {
+		"node_modules/p-locate": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"p-try": {
+		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"parent-module": {
+		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"parse-json": {
+		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
 				"json-parse-even-better-errors": "^2.3.0",
 				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"password-prompt": {
+		"node_modules/password-prompt": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
 			"integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
-			"requires": {
+			"dependencies": {
 				"ansi-escapes": "^3.1.0",
 				"cross-spawn": "^6.0.5"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
-				},
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
 			}
 		},
-		"path-exists": {
+		"node_modules/password-prompt/node_modules/ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/password-prompt/node_modules/cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dependencies": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"engines": {
+				"node": ">=4.8"
+			}
+		},
+		"node_modules/password-prompt/node_modules/path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/password-prompt/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/password-prompt/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/password-prompt/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/password-prompt/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"path-is-absolute": {
+		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"path-key": {
+		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"path-parse": {
+		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
-		"path-type": {
+		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"picomatch": {
+		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
-		"pluralize": {
+		"node_modules/pluralize": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
 			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"prelude-ls": {
+		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
 		},
-		"prettier": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-			"integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-			"dev": true
+		"node_modules/prettier": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+			"integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
 		},
-		"progress": {
+		"node_modules/progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"prop-types": {
+		"node_modules/prop-types": {
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
 				"react-is": "^16.13.1"
 			}
 		},
-		"pseudomap": {
+		"node_modules/pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
-		"punycode": {
+		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"queue-microtask": {
+		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"react-is": {
+		"node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
 		},
-		"read-pkg": {
+		"node_modules/read-pkg": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
 			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/normalize-package-data": "^2.4.0",
 				"normalize-package-data": "^2.5.0",
 				"parse-json": "^5.0.0",
 				"type-fest": "^0.6.0"
 			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"read-pkg-up": {
+		"node_modules/read-pkg-up": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
 			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"find-up": "^4.1.0",
 				"read-pkg": "^5.2.0",
 				"type-fest": "^0.8.1"
 			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"redeyed": {
+		"node_modules/read-pkg-up/node_modules/type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/redeyed": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
 			"integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
-			"requires": {
+			"dependencies": {
 				"esprima": "~4.0.0"
 			}
 		},
-		"regexp-tree": {
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+			"dev": true
+		},
+		"node_modules/regexp-tree": {
 			"version": "0.1.24",
 			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
 			"integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"regexp-tree": "bin/regexp-tree"
+			}
 		},
-		"regexp.prototype.flags": {
+		"node_modules/regexp.prototype.flags": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
 			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
 				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"regexpp": {
+		"node_modules/regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
 		},
-		"require-directory": {
+		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"resolve": {
+		"node_modules/resolve": {
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
 			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"resolve-from": {
+		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"reusify": {
+		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
 		},
-		"rimraf": {
+		"node_modules/rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
 			}
 		},
-		"run-parallel": {
+		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"requires": {
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"rxjs": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+		"node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
-		"safe-regex": {
+		"node_modules/rxjs/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"dev": true
+		},
+		"node_modules/safe-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
 			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"regexp-tree": "~0.1.1"
 			}
 		},
-		"safe-regex-test": {
+		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
 			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.3",
 				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"semver": {
+		"node_modules/semver": {
 			"version": "7.5.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
 			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"requires": {
+			"dependencies": {
 				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"shebang-command": {
+		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"shebang-regex": {
+		"node_modules/shebang-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"shimmer": {
+		"node_modules/shell-quote": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/shimmer": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
 		},
-		"side-channel": {
+		"node_modules/side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
 				"object-inspect": "^1.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"sigmund": {
+		"node_modules/sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
-		"slash": {
+		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"spawn-command": {
-			"version": "0.0.2-1",
-			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+		"node_modules/spawn-command": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
 			"dev": true
 		},
-		"spdx-correct": {
+		"node_modules/spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
 			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"spdx-exceptions": {
+		"node_modules/spdx-exceptions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
 			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
 			"dev": true
 		},
-		"spdx-expression-parse": {
+		"node_modules/spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"spdx-license-ids": {
+		"node_modules/spdx-license-ids": {
 			"version": "3.0.12",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
 			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
-		"sprintf-js": {
+		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
-		"stack-chain": {
+		"node_modules/stack-chain": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
 			"integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
 		},
-		"string-width": {
+		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"requires": {
+			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"string.prototype.matchall": {
+		"node_modules/string.prototype.matchall": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
 			"integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4",
@@ -3158,280 +4370,383 @@
 				"internal-slot": "^1.0.3",
 				"regexp.prototype.flags": "^1.4.3",
 				"side-channel": "^1.0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"string.prototype.trimend": {
+		"node_modules/string.prototype.trimend": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
 			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"string.prototype.trimstart": {
+		"node_modules/string.prototype.trimstart": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
 			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
 				"es-abstract": "^1.20.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"strip-ansi": {
+		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"requires": {
+			"dependencies": {
 				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"strip-bom": {
+		"node_modules/strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"strip-indent": {
+		"node_modules/strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
 			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"strip-json-comments": {
+		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"supports-color": {
+		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"requires": {
+			"dependencies": {
 				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"supports-hyperlinks": {
+		"node_modules/supports-hyperlinks": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
 			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
-			"requires": {
+			"dependencies": {
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"supports-preserve-symlinks-flag": {
+		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"text-table": {
+		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
-		"to-regex-range": {
+		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"requires": {
+			"dependencies": {
 				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
-		"tree-kill": {
+		"node_modules/tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
 			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tree-kill": "cli.js"
+			}
 		},
-		"tsconfig-paths": {
+		"node_modules/tsconfig-paths": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
 			"integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/json5": "^0.0.29",
 				"json5": "^1.0.1",
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
 			}
 		},
-		"tslib": {
+		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
-		"tsutils": {
+		"node_modules/tsutils": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
 			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"tslib": "^1.8.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
-		"type-check": {
+		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"type-fest": {
+		"node_modules/type-fest": {
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"typescript": {
+		"node_modules/typescript": {
 			"version": "4.5.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
 			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"unbox-primitive": {
+		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
 			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-bigints": "^1.0.2",
 				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"universalify": {
+		"node_modules/universalify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
-		"uri-js": {
+		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
-		"uuid": {
+		"node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
-		"v8-compile-cache": {
+		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"validate-npm-package-license": {
+		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"which": {
+		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"which-boxed-primitive": {
+		"node_modules/which-boxed-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
 			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"widest-line": {
+		"node_modules/widest-line": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
 			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-			"requires": {
+			"dependencies": {
 				"string-width": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"word-wrap": {
+		"node_modules/word-wrap": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
 			"integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"wrap-ansi": {
+		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"wrappy": {
+		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
 		},
-		"y18n": {
+		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
 		},
-		"yallist": {
+		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
-		"yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dev": true,
-			"requires": {
-				"cliui": "^7.0.2",
+			"dependencies": {
+				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
+				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
-		"yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
 		}
 	}
 }

--- a/tools/telemetry-generator/package.json
+++ b/tools/telemetry-generator/package.json
@@ -34,7 +34,7 @@
 		"applicationinsights": "^2.4.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^1.1.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/node": "^14.18.0",
 		"concurrently": "^8.2.1",

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -11,7 +11,7 @@
  * @param logger - An ITelemetryBufferedLogger. Call its send() method to write the output telemetry events.
  */
 module.exports = function handler(fileData, logger) {
-	if (fileData.resultSummary == null ) {
+	if (fileData.resultSummary == null) {
 		console.log(`Could not locate test result info.`);
 		return;
 	}

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -29,9 +29,8 @@
 		"test": "mocha",
 		"tsc": "tsc"
 	},
-	"dependencies": {},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0",
+		"@fluidframework/build-common": "^2.0.1",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/mocha": "^10.0.0",

--- a/tools/test-tools/pnpm-lock.yaml
+++ b/tools/test-tools/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.0
+      '@fluidframework/build-common': ^2.0.1
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@types/mocha': ^10.0.0
@@ -19,7 +19,7 @@ importers:
       rimraf: ^2.6.2
       typescript: ~4.5.5
     devDependencies:
-      '@fluidframework/build-common': 2.0.0
+      '@fluidframework/build-common': 2.0.1
       '@fluidframework/build-tools': 0.25.0_@types+node@14.18.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 10.0.1
@@ -142,8 +142,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.0:
-    resolution: {integrity: sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==}
+  /@fluidframework/build-common/2.0.1:
+    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
     hasBin: true
     dev: true
 
@@ -1578,7 +1578,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chrome-trace-event/1.0.3:
@@ -2629,8 +2629,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true


### PR DESCRIPTION
Updates all deps across the repo.

Also fixes outdated formatting in a TypeScript module in `telemetry-generator`.