### PR TITLE
Remove Pending State Deprecations

### DIFF
--- a/.changeset/little-mirrors-carry.md
+++ b/.changeset/little-mirrors-carry.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-definitions": major
+"@fluidframework/container-runtime": major
+---
+
+Remove Pending State Related Deprecations
+
+This change removes the deprecated `IPendingLocalState` and `IRuntiume.notifyAttaching`. There is no replacement as they are not longer used.

--- a/.changeset/open-women-yawn.md
+++ b/.changeset/open-women-yawn.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/container-definitions": major
+"@fluidframework/container-loader": major
+"@fluidframework/datastore": major
+"@fluidframework/runtime-utils": major
+---
+
+Fix ISnapshotTreeWithBlobContents and mark internal
+
+ISnapshotTreeWithBlobContents is an internal type that should not be used externally. Additionally, the type didn't match the usage, specifically in runtime-utils where an `any` cast was used to work around undefined blobContents. The type has been updated to reflect that blobContents can be undefined

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -420,14 +420,6 @@ export type ILoaderOptions = {
     maxClientLeaveWaitTime?: number;
 };
 
-// @public @deprecated (undocumented)
-export interface IPendingLocalState {
-    // (undocumented)
-    pendingRuntimeState: unknown;
-    // (undocumented)
-    url: string;
-}
-
 // @public (undocumented)
 export interface IProvideFluidCodeDetailsComparer {
     // (undocumented)
@@ -459,8 +451,6 @@ export interface IRuntime extends IDisposable {
     getPendingLocalState(props?: {
         notifyImminentClosure?: boolean;
     }): unknown;
-    // @deprecated
-    notifyAttaching(snapshot: ISnapshotTreeWithBlobContents): void;
     notifyOpReplay?(message: ISequencedDocumentMessage): Promise<void>;
     process(message: ISequencedDocumentMessage, local: boolean): any;
     processSignal(message: any, local: boolean): any;
@@ -487,10 +477,10 @@ export const isFluidCodeDetails: (details: unknown) => details is Readonly<IFlui
 // @public
 export const isFluidPackage: (pkg: unknown) => pkg is Readonly<IFluidPackage>;
 
-// @public
+// @internal
 export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
     // (undocumented)
-    blobsContents: {
+    blobsContents?: {
         [path: string]: ArrayBufferLike;
     };
     // (undocumented)

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -189,8 +189,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     readonly logger: ITelemetryLoggerExt;
     // (undocumented)
-    notifyAttaching(): void;
-    // (undocumented)
     notifyOpReplay(message: ISequencedDocumentMessage): Promise<void>;
     // (undocumented)
     readonly options: ILoaderOptions;

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -20,6 +20,7 @@ import { IResponse } from '@fluidframework/core-interfaces';
 import { IRuntime } from '@fluidframework/container-definitions';
 import { IRuntimeFactory } from '@fluidframework/container-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
+import { ISnapshotTreeWithBlobContents } from '@fluidframework/container-definitions';
 import { ISummarizeResult } from '@fluidframework/runtime-definitions';
 import { ISummaryBlob } from '@fluidframework/protocol-definitions';
 import { ISummaryStats } from '@fluidframework/runtime-definitions';
@@ -44,7 +45,7 @@ export function addTreeToSummary(summary: ISummaryTreeWithStats, key: string, su
 export function calculateStats(summary: SummaryObject): ISummaryStats;
 
 // @public
-export function convertSnapshotTreeToSummaryTree(snapshot: ISnapshotTree): ISummaryTreeWithStats;
+export function convertSnapshotTreeToSummaryTree(snapshot: ISnapshotTreeWithBlobContents): ISummaryTreeWithStats;
 
 // @public
 export function convertSummaryTreeToITree(summaryTree: ISummaryTree): ITree;

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -60,6 +60,17 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterfaceDeclaration_IPendingLocalState": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IRuntime": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ISnapshotTreeWithBlobContents": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -42,7 +42,6 @@ export {
 	ILoader,
 	ILoaderHeader,
 	ILoaderOptions,
-	IPendingLocalState,
 	IProvideLoader,
 	IResolvedFluidCodeDetails,
 	ISnapshotTreeWithBlobContents,

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -678,22 +678,14 @@ export interface IProvideLoader {
 }
 
 /**
- * @deprecated 0.48, This API will be removed in 0.50
- * No replacement since it is not expected anyone will depend on this outside container-loader
- * See {@link https://github.com/microsoft/FluidFramework/issues/9711} for context.
- */
-export interface IPendingLocalState {
-	url: string;
-	pendingRuntimeState: unknown;
-}
-
-/**
  * This is used when we rehydrate a container from the snapshot. Here we put the blob contents
  * in separate property: {@link ISnapshotTreeWithBlobContents.blobsContents}.
  *
  * @remarks This is used as the `ContainerContext`'s base snapshot when attaching.
+ *
+ * @internal
  */
 export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
-	blobsContents: { [path: string]: ArrayBufferLike };
+	blobsContents?: { [path: string]: ArrayBufferLike };
 	trees: { [path: string]: ISnapshotTreeWithBlobContents };
 }

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -681,7 +681,6 @@ export interface IProvideLoader {
  * This is used when we rehydrate a container from the snapshot. Here we put the blob contents
  * in separate property: {@link ISnapshotTreeWithBlobContents.blobsContents}.
  *
- * @remarks This is used as the `ContainerContext`'s base snapshot when attaching.
  *
  * @internal
  */

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -26,7 +26,7 @@ import {
 import { IAudience } from "./audience";
 import { IDeltaManager } from "./deltas";
 import { ICriticalContainerError } from "./error";
-import { ILoader, ILoaderOptions, ISnapshotTreeWithBlobContents } from "./loader";
+import { ILoader, ILoaderOptions } from "./loader";
 import { IFluidCodeDetails } from "./fluidPackage";
 
 /**
@@ -101,13 +101,6 @@ export interface IRuntime extends IDisposable {
 	 * {@link https://github.com/microsoft/FluidFramework/packages/tree/main/loader/container-loader/closeAndGetPendingLocalState.md}
 	 */
 	getPendingLocalState(props?: { notifyImminentClosure?: boolean }): unknown;
-
-	/**
-	 * Notify runtime that container is moving to "Attaching" state
-	 * @param snapshot - snapshot created at attach time
-	 * @deprecated - not necessary after op replay moved to Container
-	 */
-	notifyAttaching(snapshot: ISnapshotTreeWithBlobContents): void;
 
 	/**
 	 * Notify runtime that we have processed a saved message, so that it can do async work (applying

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -1032,26 +1032,14 @@ use_old_TypeAliasDeclaration_ILoaderOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingLocalState": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingLocalState": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IPendingLocalState():
-    TypeOnly<old.IPendingLocalState>;
-declare function use_current_InterfaceDeclaration_IPendingLocalState(
-    use: TypeOnly<current.IPendingLocalState>);
-use_current_InterfaceDeclaration_IPendingLocalState(
-    get_old_InterfaceDeclaration_IPendingLocalState());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingLocalState": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingLocalState": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingLocalState():
-    TypeOnly<current.IPendingLocalState>;
-declare function use_old_InterfaceDeclaration_IPendingLocalState(
-    use: TypeOnly<old.IPendingLocalState>);
-use_old_InterfaceDeclaration_IPendingLocalState(
-    get_current_InterfaceDeclaration_IPendingLocalState());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1171,6 +1159,7 @@ declare function get_current_InterfaceDeclaration_IRuntime():
 declare function use_old_InterfaceDeclaration_IRuntime(
     use: TypeOnly<old.IRuntime>);
 use_old_InterfaceDeclaration_IRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRuntime());
 
 /*
@@ -1243,6 +1232,7 @@ declare function get_current_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
 declare function use_old_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
     use: TypeOnly<old.ISnapshotTreeWithBlobContents>);
 use_old_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISnapshotTreeWithBlobContents());
 
 /*

--- a/packages/dds/migration-shim/src/packageVersion.ts
+++ b/packages/dds/migration-shim/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/migration-shim";
-export const pkgVersion = "2.0.0-internal.7.1.0";
+export const pkgVersion = "2.0.0-internal.8.0.0";

--- a/packages/dds/migration-shim/src/packageVersion.ts
+++ b/packages/dds/migration-shim/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/migration-shim";
-export const pkgVersion = "2.0.0-internal.8.0.0";
+export const pkgVersion = "2.0.0-internal.7.1.0";

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -106,8 +106,10 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 	}
 
 	private getBlobContents(snapshotTree: ISnapshotTreeWithBlobContents) {
-		for (const [id, value] of Object.entries(snapshotTree.blobsContents)) {
-			this.blobContents[id] = value;
+		if (snapshotTree.blobsContents !== undefined) {
+			for (const [id, value] of Object.entries(snapshotTree.blobsContents)) {
+				this.blobContents[id] = value;
+			}
 		}
 		for (const [_, tree] of Object.entries(snapshotTree.trees)) {
 			this.getBlobContents(tree);
@@ -302,7 +304,7 @@ function getBlobContentsFromTreeWithBlobContentsCore(
 		}
 	}
 	for (const id of Object.values(tree.blobs)) {
-		const blob = tree.blobsContents[id];
+		const blob = tree.blobsContents?.[id];
 		assert(blob !== undefined, 0x2ec /* "Blob must be present in blobsContents" */);
 		// ArrayBufferLike will not survive JSON.stringify()
 		blobs[id] = bufferToString(blob, "utf8");
@@ -315,7 +317,7 @@ function getBlobManagerTreeFromTreeWithBlobContents(
 	blobs: ISerializableBlobContents,
 ) {
 	const id = tree.blobs[redirectTableBlobName];
-	const blob = tree.blobsContents[id];
+	const blob = tree.blobsContents?.[id];
 	assert(blob !== undefined, 0x70f /* Blob must be present in blobsContents */);
 	// ArrayBufferLike will not survive JSON.stringify()
 	blobs[id] = bufferToString(blob, "utf8");

--- a/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
@@ -65,26 +65,22 @@ describe("Dehydrate Container", () => {
 
 		// Validate the ".component" blob.
 		const defaultDataStoreBlobId = snapshotTree.trees.default.blobs[".component"];
+		const defaultDataStoreBlob =
+			snapshotTree.trees.default.blobsContents?.[defaultDataStoreBlobId];
+		assert.strict(defaultDataStoreBlob, "defaultDataStoreBlob undefined");
 		assert.strictEqual(
-			JSON.parse(
-				bufferToString(
-					snapshotTree.trees.default.blobsContents[defaultDataStoreBlobId],
-					"utf8",
-				),
-			),
+			JSON.parse(bufferToString(defaultDataStoreBlob, "utf8")),
 			"defaultDataStore",
 			"The .component blob's content is incorrect",
 		);
 
 		// Validate "root" sub-tree.
 		const rootAttributesBlobId = snapshotTree.trees.default.trees.root.blobs.attributes;
+		const rootAttributesBlob =
+			snapshotTree.trees.default.trees.root.blobsContents?.[rootAttributesBlobId];
+		assert.strict(rootAttributesBlob, "rootAttributesBlob undefined");
 		assert.strictEqual(
-			JSON.parse(
-				bufferToString(
-					snapshotTree.trees.default.trees.root.blobsContents[rootAttributesBlobId],
-					"utf8",
-				),
-			),
+			JSON.parse(bufferToString(rootAttributesBlob, "utf8")),
 			"rootattributes",
 			"The root sub-tree's content is incorrect",
 		);

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -110,6 +110,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_ContainerRuntime": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3886,8 +3886,6 @@ export class ContainerRuntime
 		);
 	}
 
-	public notifyAttaching() {} // do nothing (deprecated method)
-
 	public async getPendingLocalState(props?: {
 		notifyImminentClosure: boolean;
 	}): Promise<unknown> {

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -163,6 +163,7 @@ declare function get_current_ClassDeclaration_ContainerRuntime():
 declare function use_old_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<old.ContainerRuntime>);
 use_old_ClassDeclaration_ContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ContainerRuntime());
 
 /*

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -17,6 +17,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { assert, Lazy, LazyPromise } from "@fluidframework/core-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions";
 import {
 	ChannelServiceEndpoints,
 	createChannelServiceEndpoints,
@@ -245,18 +246,19 @@ export class RehydratedLocalChannelContext extends LocalChannelContextBase {
 	}
 
 	private isSnapshotInOldFormatAndCollectBlobs(
-		snapshotTree: ISnapshotTree,
+		snapshotTree: ISnapshotTreeWithBlobContents,
 		blobMap: Map<string, ArrayBufferLike>,
 	): boolean {
 		let sanitize = false;
-		const blobsContents: { [path: string]: ArrayBufferLike } = (snapshotTree as any)
-			.blobsContents;
-		Object.entries(blobsContents).forEach(([key, value]) => {
-			blobMap.set(key, value);
-			if (snapshotTree.blobs[key] !== undefined) {
-				sanitize = true;
-			}
-		});
+		const blobsContents = snapshotTree.blobsContents;
+		if (blobsContents !== undefined) {
+			Object.entries(blobsContents).forEach(([key, value]) => {
+				blobMap.set(key, value);
+				if (snapshotTree.blobs[key] !== undefined) {
+					sanitize = true;
+				}
+			});
+		}
 		for (const value of Object.values(snapshotTree.trees)) {
 			sanitize = sanitize || this.isSnapshotInOldFormatAndCollectBlobs(value, blobMap);
 		}

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -20,7 +20,6 @@ import {
 	ISummaryBlob,
 	TreeEntry,
 	ITreeEntry,
-	ISnapshotTree,
 } from "@fluidframework/protocol-definitions";
 import {
 	ISummaryStats,
@@ -29,6 +28,7 @@ import {
 	ITelemetryContext,
 	IGarbageCollectionData,
 } from "@fluidframework/runtime-definitions";
+import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions";
 
 /**
  * Combines summary stats by adding their totals together.
@@ -273,12 +273,14 @@ export function convertToSummaryTree(snapshot: ITree, fullTree: boolean = false)
  * was taken by serialize api in detached container.
  * @param snapshot - snapshot in ISnapshotTree format
  */
-export function convertSnapshotTreeToSummaryTree(snapshot: ISnapshotTree): ISummaryTreeWithStats {
+export function convertSnapshotTreeToSummaryTree(
+	snapshot: ISnapshotTreeWithBlobContents,
+): ISummaryTreeWithStats {
 	const builder = new SummaryTreeBuilder();
 	for (const [path, id] of Object.entries(snapshot.blobs)) {
 		let decoded: string | undefined;
-		if ((snapshot as any).blobsContents !== undefined) {
-			const content: ArrayBufferLike = (snapshot as any).blobsContents[id];
+		if (snapshot.blobsContents !== undefined) {
+			const content: ArrayBufferLike = snapshot.blobsContents[id];
 			if (content !== undefined) {
 				decoded = bufferToString(content, "utf-8");
 			}

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -9,7 +9,6 @@ import { MockDocumentDeltaConnection } from "@fluid-internal/test-loader-utils";
 import { IErrorBase, IRequest, IRequestHeader } from "@fluidframework/core-interfaces";
 import {
 	ContainerErrorType,
-	IPendingLocalState,
 	IFluidCodeDetails,
 	IContainer,
 	LoaderHeader,
@@ -26,7 +25,6 @@ import {
 	FiveDaysMs,
 	IAnyDriverError,
 	IDocumentServiceFactory,
-	IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import {
 	LocalCodeLoader,
@@ -348,9 +346,9 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 			await localTestObjectProvider.makeTestContainer(testContainerConfig);
 		const pendingString = await container.closeAndGetPendingLocalState?.();
 		assert.ok(pendingString);
-		const pendingLocalState: IPendingLocalState = JSON.parse(pendingString);
+		const pendingLocalState: { url?: string } = JSON.parse(pendingString);
 		assert.strictEqual(container.closed, true);
-		assert.strictEqual(pendingLocalState.url, (container.resolvedUrl as IResolvedUrl).url);
+		assert.strictEqual(pendingLocalState.url, container.resolvedUrl?.url);
 	});
 
 	it("can call connect() and disconnect() on Container", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -155,7 +155,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 	function assertBlobContents<T>(subtree: ISnapshotTreeWithBlobContents, key: string): T {
 		const id = subtree.blobs[key];
 		assert(id, `blob id for ${key} missing`);
-		const contents = subtree.blobsContents[id];
+		const contents = subtree.blobsContents?.[id];
 		assert(contents, `blob contents for ${key} missing`);
 		return JSON.parse(bufferToString(contents, "utf8")) as T;
 	}
@@ -278,7 +278,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 			// Check blobs contents for protocolAttributes
 			const protocolAttributesBlobId = snapshotTree.trees[".protocol"].blobs.attributes;
 			assert(
-				snapshotTree.trees[".protocol"].blobsContents[protocolAttributesBlobId] !==
+				snapshotTree.trees[".protocol"].blobsContents?.[protocolAttributesBlobId] !==
 					undefined,
 				"Blobs should contain attributes blob",
 			);


### PR DESCRIPTION
## Remove Pending State Related Deprecations

This change removes the deprecated `IPendingLocalState` and `IRuntiume.notifyAttaching`. There is no replacement as they are not longer used.

## Fix ISnapshotTreeWithBlobContents and mark internal

ISnapshotTreeWithBlobContents is an internal type that should not be used externally. Additionally, the type didn't match the usage, specifically in runtime-utils where an `any` cast was used to work around undefined blobContents. The type has been updated to reflect that blobContents can be undefined

fixes [AB#5796](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5796)