### PR TITLE
Fix/improve blob expiration tests

### DIFF
--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -143,4 +143,55 @@ describe("getPendingLocalState", () => {
 		assert.strictEqual(summaryData2.ids.length, 3);
 		assert.strictEqual(summaryData2.redirectTable.size, 3);
 	});
+
+	it("does not restart upload after applying stashed ops if not expired", async () => {
+		await runtime.attach();
+		await runtime.connect();
+		const blob = IsoBuffer.from("blob", "utf8");
+		const handleP = runtime.createBlob(blob);
+		await runtime.processBlobs();
+		const pendingStateP = runtime.getPendingLocalState();
+		await runtime.processHandles();
+		await assert.doesNotReject(handleP);
+		const pendingState = await pendingStateP;
+		const pendingBlobs = pendingState[1] ?? {};
+		assert.ok(pendingBlobs[Object.keys(pendingBlobs)[0]].storageId);
+		const summaryData = validateSummary(runtime);
+
+		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
+		await runtime2.attach();
+		assert.strictEqual(runtime2.unprocessedBlobs.size, 0);
+		await runtime2.connect();
+		await runtime2.processAll();
+
+		const summaryData2 = validateSummary(runtime2);
+		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.redirectTable.size, 1);
+	});
+
+	it("does restart upload after applying stashed ops if expired", async () => {
+		await runtime.attach();
+		await runtime.connect();
+		runtime.attachedStorage.minTTL = 0.1; 
+		const blob = IsoBuffer.from("blob", "utf8");
+		const handleP = runtime.createBlob(blob);
+		await runtime.processBlobs();
+		const pendingStateP = runtime.getPendingLocalState();
+		await runtime.processHandles();
+		await assert.doesNotReject(handleP);
+		const pendingState = await pendingStateP;
+		const pendingBlobs = pendingState[1] ?? {};
+		assert.ok(pendingBlobs[Object.keys(pendingBlobs)[0]].storageId);
+		const summaryData = validateSummary(runtime);
+
+		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
+		await runtime2.attach();
+		await runtime2.connect();
+		await runtime2.processAll();
+
+		const summaryData2 = validateSummary(runtime2);
+		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.redirectTable.size, 1);
+	});
+
 });

--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -172,7 +172,7 @@ describe("getPendingLocalState", () => {
 	it("does restart upload after applying stashed ops if expired", async () => {
 		await runtime.attach();
 		await runtime.connect();
-		runtime.attachedStorage.minTTL = 0.1; 
+		runtime.attachedStorage.minTTL = 0.001;
 		const blob = IsoBuffer.from("blob", "utf8");
 		const handleP = runtime.createBlob(blob);
 		await runtime.processBlobs();
@@ -193,5 +193,4 @@ describe("getPendingLocalState", () => {
 		assert.strictEqual(summaryData2.ids.length, 1);
 		assert.strictEqual(summaryData2.redirectTable.size, 1);
 	});
-
 });


### PR DESCRIPTION
I have validated our current blob expiration tests work as expected after all recent changes in blob manager. I also added a couple of scenarios we didn't have unit tests for which are: when applying stashed blobs, restart an upload or not depending on blob expiration and validate it's included in the new summary for both scenarios.