### PR TITLE
tree2: Remove several usages of custom leaf schema

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -37,6 +37,9 @@ leafValue: ValueSchema.String;
 export type AllowedTypes = readonly [Any] | readonly LazyItem<TreeSchema>[];
 
 // @alpha
+export type AllowedTypeSet = Any | ReadonlySet<TreeSchema>;
+
+// @alpha
 type AllowedTypesToTypedTrees<Mode extends ApiMode, T extends AllowedTypes> = [
 T extends InternalTypedSchemaTypes.FlexList<TreeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray<Mode, Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<T>, readonly TreeSchema[]>>> : UntypedApi<Mode>
 ][_InlineTrick];
@@ -684,6 +687,7 @@ interface Fields {
 export class FieldSchema<out Kind extends FieldKind = FieldKind, const out Types extends Unenforced<AllowedTypes> = AllowedTypes> {
     // (undocumented)
     readonly allowedTypes: Types;
+    get allowedTypeSet(): AllowedTypeSet;
     static create<Kind extends FieldKind, const Types extends AllowedTypes>(kind: Kind, allowedTypes: Types): FieldSchema<Kind, Types>;
     static createUnsafe<Kind extends FieldKind, const Types>(kind: Kind, allowedTypes: Types): FieldSchema<Kind, Types>;
     static readonly empty: FieldSchema<Forbidden, readonly []>;
@@ -692,7 +696,6 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, const out Types
     readonly kind: Kind;
     // (undocumented)
     protected _typeCheck?: MakeNominal;
-    // (undocumented)
     get types(): TreeTypeSet;
 }
 
@@ -1532,6 +1535,9 @@ interface OldContent<TTree = ProtoNode> {
 export const on: unique symbol;
 
 // @alpha
+export function oneFromSet<T>(set: ReadonlySet<T> | undefined): T | undefined;
+
+// @alpha
 export type Opaque<T extends Brand<any, string>> = T extends Brand<infer ValueType, infer Name> ? BrandedType<ValueType, Name> : never;
 
 // @alpha
@@ -1840,6 +1846,9 @@ export interface SchemaEvents {
     afterSchemaChange(newSchema: SchemaData): void;
     beforeSchemaChange(newSchema: SchemaData): void;
 }
+
+// @alpha
+export function schemaIsFieldNode(schema: TreeSchema): schema is FieldNodeSchema;
 
 // @alpha
 export interface SchemaLibrary extends TypedSchemaCollection {

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/schemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/schemaConverter.spec.ts
@@ -8,7 +8,6 @@ import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import {
 	brand,
 	FieldKinds,
-	ValueSchema,
 	fail,
 	Any,
 	TreeSchemaIdentifier,
@@ -16,6 +15,10 @@ import {
 	getPrimaryField,
 	isPrimitive,
 	FieldKey,
+	leaf,
+	EmptyKey,
+	schemaIsFieldNode,
+	oneFromSet,
 } from "@fluid-experimental/tree2";
 import { PropertyFactory } from "@fluid-experimental/property-properties";
 import {
@@ -29,6 +32,12 @@ describe("schema converter", () => {
 	describe("with built-in schemas only", () => {
 		it(`has built-in primitive types and collections`, () => {
 			const fullSchemaData = convertSchema(FieldKinds.optional, Any);
+			// Float64
+			assert(fullSchemaData.treeSchema.get(leaf.number.name) === leaf.number);
+			// String
+			assert(fullSchemaData.treeSchema.get(leaf.string.name) === leaf.string);
+			// Bool
+			assert(fullSchemaData.treeSchema.get(leaf.boolean.name) === leaf.boolean);
 			[
 				"Int8",
 				"Int16",
@@ -45,11 +54,20 @@ describe("schema converter", () => {
 				"String",
 				"Reference",
 			].forEach((typeName) => {
-				const primitiveSchema = fullSchemaData.treeSchema.get(
-					brand(`converted.${typeName}`),
-				);
-				assert(primitiveSchema !== undefined);
-				assert(isPrimitive(primitiveSchema));
+				if (!new Set(["Float64", "Bool", "String"]).has(typeName)) {
+					const primitiveSchema = fullSchemaData.treeSchema.get(
+						brand(`converted.${typeName}`),
+					);
+					assert(primitiveSchema !== undefined);
+					schemaIsFieldNode(primitiveSchema);
+
+					const innerTypes =
+						primitiveSchema.structFields.get(EmptyKey)?.allowedTypeSet ??
+						fail("missing schema");
+					assert(innerTypes !== Any);
+					const innerSchema = oneFromSet(innerTypes) ?? fail("unexpected polymorphism");
+					assert(isPrimitive(innerSchema));
+				}
 				assert(
 					fullSchemaData.treeSchema.get(brand(`converted.map<${typeName}>`)) !==
 						undefined,
@@ -79,7 +97,7 @@ describe("schema converter", () => {
 					assert.deepEqual(idFieldSchema.kind, FieldKinds.required);
 					assert.deepEqual(
 						[...(idFieldSchema.types ?? fail("expected types"))],
-						["converted.String"],
+						[leaf.string.name],
 					);
 				} else {
 					if (typeName === nodePropertySchema.name) {
@@ -99,7 +117,7 @@ describe("schema converter", () => {
 						assert.deepEqual(idFieldSchema.kind, FieldKinds.required);
 						assert.deepEqual(
 							[...(idFieldSchema.types ?? fail("expected types"))],
-							["converted.String"],
+							[leaf.string.name],
 						);
 						if (typeName === "converted.RelationshipProperty") {
 							const toFieldSchema =
@@ -283,8 +301,8 @@ describe("schema converter", () => {
 				],
 			);
 
-			// 60 types (all types, their arrays and maps)
-			assert.equal(fullSchemaData.treeSchema.size, 60);
+			// 61 types (all types (including built in leaf types), their arrays and maps)
+			assert.equal(fullSchemaData.treeSchema.size, 61);
 			const nodePropertySchemaLookedUp = fullSchemaData.treeSchema.get(
 				brand("com.fluidframework.PropertyDDSBuiltIn.NodeProperty"),
 			);
@@ -435,8 +453,12 @@ describe("schema converter", () => {
 			const enumSchema = fullSchemaData.treeSchema.get(
 				brand(`converted.enum<${enumTypeName}>`),
 			);
-			assert(enumSchema && isPrimitive(enumSchema));
-			assert.equal(enumSchema.leafValue, ValueSchema.Number);
+			assert(enumSchema && schemaIsFieldNode(enumSchema));
+			assert(
+				(enumSchema.structFields.get(EmptyKey) ?? fail("missing schema")).equals(
+					FieldSchema.create(FieldKinds.required, [leaf.number]),
+				),
+			);
 
 			const arrayOfEnums = fullSchemaData.treeSchema.get(
 				brand(`converted.array<enum<${enumTypeName}>>`),

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/tableExampleSchemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/tableExampleSchemaConverter.spec.ts
@@ -6,11 +6,13 @@
 import { strict as assert } from "assert";
 import { PropertyFactory } from "@fluid-experimental/property-properties";
 import {
-	ValueSchema,
 	brand,
 	EmptyKey,
 	FieldKinds,
 	TreeSchemaIdentifier,
+	schemaIsFieldNode,
+	FieldSchema,
+	leaf,
 } from "@fluid-experimental/tree2";
 import { convertPropertyToSharedTreeSchema as convertSchema } from "../schemaConverter";
 
@@ -164,8 +166,14 @@ describe("LlsSchemaConverter", () => {
 		assert(uint64.types !== undefined);
 		expect(uint64.types.has(brand("converted.Uint64"))).toBeTruthy();
 		assert(uint64.types.has(brand("converted.Uint64")));
-		const uint64Type = fullSchemaData.treeSchema.get(brand("converted.Uint64"));
-		assert(uint64Type?.leafValue === ValueSchema.Number);
+		const uint64Type =
+			fullSchemaData.treeSchema.get(brand("converted.Uint64")) ?? fail("missing schema");
+		assert(schemaIsFieldNode(uint64Type));
+		assert(
+			uint64Type.structFields
+				.get(EmptyKey)
+				?.equals(FieldSchema.create(FieldKinds.required, [leaf.number])),
+		);
 	});
 
 	it("Inheritance Translation", () => {

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -158,6 +158,7 @@ export {
 	fieldApiPrefixes,
 	validateStructFieldName,
 	Unenforced,
+	AllowedTypeSet,
 } from "./typed-schema";
 
 export { SchemaBuilderBase, SchemaLibrary } from "./schemaBuilderBase";

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -20,6 +20,7 @@ export {
 	schemaIsStruct,
 	TypedSchemaCollection,
 	Unenforced,
+	AllowedTypeSet,
 } from "./typedTreeSchema";
 
 export { ViewSchema } from "./view";

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -102,6 +102,7 @@ export {
 	BrandedMapSubset,
 	RangeEntry,
 	Named,
+	oneFromSet,
 } from "./util";
 
 export {
@@ -274,6 +275,8 @@ export {
 	ImplicitFieldSchema,
 	ImplicitAllowedTypes,
 	Unenforced,
+	schemaIsFieldNode,
+	AllowedTypeSet,
 } from "./feature-libraries";
 
 export {

--- a/experimental/dds/tree2/src/test/cursorTestSuite.ts
+++ b/experimental/dds/tree2/src/test/cursorTestSuite.ts
@@ -24,39 +24,37 @@ import {
 	compareFieldUpPaths,
 	FieldUpPath,
 	PathRootPrefix,
-	ValueSchema,
 } from "../core";
 import { brand } from "../util";
+import { leaf } from "../domains";
 import { expectEqualFieldPaths, expectEqualPaths } from "./utils";
 
-const schemaBuilder = new SchemaBuilder({ scope: "Cursor Test Suite" });
-const leafString = schemaBuilder.leaf("string", ValueSchema.String);
-const leafBoolean = schemaBuilder.leaf("boolean", ValueSchema.Boolean);
-const leafNumber = schemaBuilder.leaf("number", ValueSchema.Number);
+const schemaBuilder = new SchemaBuilder({ scope: "Cursor Test Suite", libraries: [leaf.library] });
+
 export const emptySchema = schemaBuilder.struct("Empty Struct", {});
 const emptySchema2 = schemaBuilder.struct("Empty Struct 2", {});
 const emptySchema3 = schemaBuilder.struct("Empty Struct 3", {});
 export const mapSchema = schemaBuilder.map("Map", SchemaBuilder.sequence(Any));
 // Struct with fixed shape
 export const structSchema = schemaBuilder.struct("struct", {
-	child: leafNumber,
+	child: leaf.number,
 });
 
 export const testTreeSchema = schemaBuilder.toDocumentSchema(SchemaBuilder.sequence(Any));
 
 export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 	["minimal", { type: emptySchema.name }],
-	["true boolean", { type: leafBoolean.name, value: true }],
-	["false boolean", { type: leafBoolean.name, value: false }],
-	["integer", { type: leafNumber.name, value: Number.MIN_SAFE_INTEGER - 1 }],
-	["string", { type: leafString.name, value: "test" }],
-	["string with escaped characters", { type: leafString.name, value: '\\"\b\f\n\r\t' }],
-	["string with emoticon", { type: leafString.name, value: "😀" }],
+	["true boolean", { type: leaf.boolean.name, value: true }],
+	["false boolean", { type: leaf.boolean.name, value: false }],
+	["integer", { type: leaf.number.name, value: Number.MIN_SAFE_INTEGER - 1 }],
+	["string", { type: leaf.string.name, value: "test" }],
+	["string with escaped characters", { type: leaf.string.name, value: '\\"\b\f\n\r\t' }],
+	["string with emoticon", { type: leaf.string.name, value: "😀" }],
 	[
 		"field",
 		{
 			type: mapSchema.name,
-			fields: { x: [{ type: emptySchema.name }, { type: leafNumber.name, value: 6 }] },
+			fields: { x: [{ type: emptySchema.name }, { type: leaf.number.name, value: 6 }] },
 		},
 	],
 	[
@@ -93,7 +91,7 @@ export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 					{
 						type: mapSchema.name,
 						fields: {
-							c: [{ type: leafNumber.name, value: 6 }],
+							c: [{ type: leaf.number.name, value: 6 }],
 						},
 					},
 				],
@@ -124,7 +122,7 @@ export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 			fields: {
 				child: [
 					{
-						type: leafNumber.name,
+						type: leaf.number.name,
 						value: 1,
 					},
 				],
@@ -143,7 +141,7 @@ export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 						fields: {
 							child: [
 								{
-									type: leafNumber.name,
+									type: leaf.number.name,
 									value: 1,
 								},
 							],
@@ -166,7 +164,7 @@ export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 					{ type: emptySchema3.name },
 					{ type: emptySchema3.name },
 					{ type: emptySchema3.name },
-					{ type: leafNumber.name, value: 1 },
+					{ type: leaf.number.name, value: 1 },
 					{ type: emptySchema3.name },
 				],
 			},
@@ -512,7 +510,7 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
 				it("first node in a root field", () => {
 					const cursor = factory({
 						type: mapSchema.name,
-						fields: { key: [{ type: leafNumber.name, value: 0 }] },
+						fields: { key: [{ type: leaf.number.name, value: 0 }] },
 					});
 					cursor.enterField(brand("key"));
 					cursor.firstNode();
@@ -528,8 +526,8 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
 						type: mapSchema.name,
 						fields: {
 							key: [
-								{ type: leafNumber.name, value: 0 },
-								{ type: leafNumber.name, value: 1 },
+								{ type: leaf.number.name, value: 0 },
+								{ type: leaf.number.name, value: 1 },
 							],
 						},
 					});

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -23,6 +23,7 @@ import {
 	SchemaBuilder,
 	jsonableTreeFromCursor,
 } from "../../feature-libraries";
+import { leaf } from "../../domains";
 
 describe("ContextuallyTyped", () => {
 	it("isPrimitiveValue", () => {
@@ -92,9 +93,11 @@ describe("ContextuallyTyped", () => {
 	});
 
 	it("applyTypesFromContext omits empty fields", () => {
-		const builder = new SchemaBuilder({ scope: "applyTypesFromContext" });
-		const numberSchema = builder.leaf("number", ValueSchema.Number);
-		const numberSequence = SchemaBuilder.sequence(numberSchema);
+		const builder = new SchemaBuilder({
+			scope: "applyTypesFromContext",
+			libraries: [leaf.library],
+		});
+		const numberSequence = SchemaBuilder.sequence(leaf.number);
 		const numbersObject = builder.struct("numbers", { numbers: numberSequence });
 		const schema = builder.toDocumentSchema(numberSequence);
 		const mapTree = applyTypesFromContext({ schema }, new Set([numbersObject.name]), {
@@ -105,9 +108,11 @@ describe("ContextuallyTyped", () => {
 	});
 
 	it("applyTypesFromContext omits empty primary fields", () => {
-		const builder = new SchemaBuilder({ scope: "applyTypesFromContext" });
-		const numberSchema = builder.leaf("number", ValueSchema.Number);
-		const numberSequence = SchemaBuilder.sequence(numberSchema);
+		const builder = new SchemaBuilder({
+			scope: "applyTypesFromContext",
+			libraries: [leaf.library],
+		});
+		const numberSequence = SchemaBuilder.sequence(leaf.number);
 		const primaryObject = builder.struct("numbers", { [EmptyKey]: numberSequence });
 		const schema = builder.toDocumentSchema(numberSequence);
 		const mapTree = applyTypesFromContext({ schema }, new Set([primaryObject.name]), []);
@@ -117,10 +122,12 @@ describe("ContextuallyTyped", () => {
 
 	describe("cursorFromContextualData adds field", () => {
 		it("for empty contextual data.", () => {
-			const builder = new SchemaBuilder({ scope: "cursorFromContextualData" });
-			const generatedSchema = builder.leaf("generated", ValueSchema.String);
+			const builder = new SchemaBuilder({
+				scope: "cursorFromContextualData",
+				libraries: [leaf.library],
+			});
 			const nodeSchema = builder.struct("node", {
-				foo: generatedSchema,
+				foo: leaf.string,
 			});
 
 			const nodeSchemaData = builder.toDocumentSchema(builder.optional(nodeSchema));
@@ -129,7 +136,7 @@ describe("ContextuallyTyped", () => {
 			const generatedField = [
 				{
 					value: "x",
-					type: generatedSchema.name,
+					type: leaf.string.name,
 					fields: new Map(),
 				},
 			];
@@ -148,11 +155,13 @@ describe("ContextuallyTyped", () => {
 		});
 
 		it("for nested contextual data.", () => {
-			const builder = new SchemaBuilder({ scope: "Identifier Domain" });
-			const generatedSchema = builder.leaf("generated", ValueSchema.String);
+			const builder = new SchemaBuilder({
+				scope: "Identifier Domain",
+				libraries: [leaf.library],
+			});
 
 			const nodeSchema = builder.structRecursive("node", {
-				foo: builder.required(generatedSchema),
+				foo: builder.required(leaf.string),
 				child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchema]),
 			});
 
@@ -162,7 +171,7 @@ describe("ContextuallyTyped", () => {
 			const generatedField = [
 				{
 					value: "x",
-					type: generatedSchema.name,
+					type: leaf.string.name,
 					fields: new Map(),
 				},
 			];

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/fieldKindTestUtils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/fieldKindTestUtils.ts
@@ -3,17 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import {
-	FieldKinds,
-	NodeChangeset,
-	SchemaBuilder,
-	singleTextCursor,
-} from "../../../feature-libraries";
-import { FieldKey, ValueSchema, JsonableTree, ITreeCursorSynchronous } from "../../../core";
+import { FieldKinds, NodeChangeset, singleTextCursor } from "../../../feature-libraries";
+import { FieldKey, JsonableTree, ITreeCursorSynchronous } from "../../../core";
 import { brand } from "../../../util";
-
-const builder = new SchemaBuilder({ scope: "defaultFieldKinds tests" });
-export const testLeaf = builder.leaf("TestLeaf", ValueSchema.String);
+import { leaf } from "../../../domains";
 
 // TODO: Users of this are mainly working with in memory representations.
 // Therefore it should not be using JsonableTrees.
@@ -23,7 +16,7 @@ export const testLeaf = builder.leaf("TestLeaf", ValueSchema.String);
  * Arbitrary tree with value `s`
  */
 export function testTree(s: string): JsonableTree {
-	return { type: testLeaf.name, value: s };
+	return { type: leaf.string.name, value: s };
 }
 
 /**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.identifier.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.identifier.spec.ts
@@ -12,15 +12,16 @@ import {
 	nodeKeyFieldKey,
 	NodeKeyManager,
 } from "../../../feature-libraries";
-import { nodeKeyField, nodeKeySchema } from "../../../domains";
-import { ValueSchema } from "../../../core";
+import { leaf, nodeKeyField, nodeKeySchema } from "../../../domains";
 import { treeWithContent } from "../../utils";
 
-const builder = new SchemaBuilder({ scope: "EditableTree Node Keys", libraries: [nodeKeySchema] });
-const stringSchema = builder.leaf("string", ValueSchema.String);
+const builder = new SchemaBuilder({
+	scope: "EditableTree Node Keys",
+	libraries: [nodeKeySchema, leaf.library],
+});
 const childNodeSchema = builder.struct("ChildNode", {
 	...nodeKeyField,
-	name: stringSchema,
+	name: leaf.string,
 });
 
 const parentNodeSchema = builder.struct("ParentNode", {

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/typedTreeSchema.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/typedTreeSchema.spec.ts
@@ -80,6 +80,13 @@ describe("typedTreeSchema", () => {
 			assert.deepEqual(schema.allowedTypeSet, new Set([leaf.number]));
 			assert.deepEqual(schema.types, new Set([leaf.number.name]));
 		});
+
+		it("types - lazy", () => {
+			const schema = FieldSchema.create(FieldKinds.optional, [() => leaf.number]);
+			assert(!allowedTypesIsAny(schema.allowedTypes));
+			assert.deepEqual(schema.allowedTypeSet, new Set([leaf.number]));
+			assert.deepEqual(schema.types, new Set([leaf.number.name]));
+		});
 	});
 
 	{

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/typedTreeSchema.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/typedTreeSchema.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { jsonArray, jsonBoolean, jsonObject, jsonSchema } from "../../../domains";
+import { jsonArray, jsonBoolean, jsonObject, jsonSchema, leaf } from "../../../domains";
 import { isAssignableTo, requireAssignableTo, requireFalse, requireTrue } from "../../../util";
 import {
 	Any,
@@ -13,6 +13,7 @@ import {
 	LeafSchema,
 	MapSchema,
 	StructSchema,
+	allowedTypesIsAny,
 	schemaIsFieldNode,
 	schemaIsLeaf,
 	schemaIsMap,
@@ -62,6 +63,23 @@ describe("typedTreeSchema", () => {
 		assert(!schemaIsFieldNode(recursiveStruct));
 		assert(schemaIsStruct(recursiveStruct));
 		assert(!schemaIsMap(recursiveStruct));
+	});
+
+	describe("FieldSchema", () => {
+		it("types - any", () => {
+			const schema = FieldSchema.create(FieldKinds.optional, [Any]);
+			assert(allowedTypesIsAny(schema.allowedTypes));
+			assert.equal(schema.allowedTypeSet, Any);
+			assert.equal(schema.types, undefined);
+		});
+
+		it("types - single", () => {
+			const schema = FieldSchema.create(FieldKinds.optional, [leaf.number]);
+			assert(!allowedTypesIsAny(schema.allowedTypes));
+			assert.deepEqual(schema.allowedTypes, [leaf.number]);
+			assert.deepEqual(schema.allowedTypeSet, new Set([leaf.number]));
+			assert.deepEqual(schema.types, new Set([leaf.number.name]));
+		});
 	});
 
 	{

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTreeView.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTreeView.spec.ts
@@ -5,17 +5,22 @@
 import { strict as assert } from "assert";
 import { SchemaBuilder, Any } from "../../feature-libraries";
 import { createSharedTreeView } from "../../shared-tree";
-import { ValueSchema, AllowedUpdateType, storedEmptyFieldSchema } from "../../core";
+import { AllowedUpdateType, storedEmptyFieldSchema } from "../../core";
+import { leaf } from "../../domains";
 
-const builder = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests" });
-const root = builder.leaf("root", ValueSchema.Number);
-const schema = builder.toDocumentSchema(SchemaBuilder.optional(root));
+const builder = new SchemaBuilder({
+	scope: "test",
+	name: "Schematize Tree Tests",
+	libraries: [leaf.library],
+});
+const schema = builder.toDocumentSchema(SchemaBuilder.optional(leaf.number));
 
 const builderGeneralized = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests Generalized",
+	libraries: [leaf.library],
 });
-const rootGeneralized = builderGeneralized.leaf("root", ValueSchema.Number);
+
 const schemaGeneralized = builderGeneralized.toDocumentSchema(SchemaBuilder.optional(Any));
 
 describe("sharedTreeView", () => {

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -428,6 +428,7 @@ export function transformObjectMap<MapKey extends string | number | symbol, MapV
 
 /**
  * Returns the value from `set` if it contains exactly one item, otherwise `undefined`.
+ * @alpha
  */
 export function oneFromSet<T>(set: ReadonlySet<T> | undefined): T | undefined {
 	if (set === undefined) {


### PR DESCRIPTION
## Description

Creation of custom leaf schema types is being removed.
This migrates several users of this pattern to use the built-in leaf library.
There are still several other usages: this just fixes some of them.

While updating the PropertyDDS schema converter, some API quality issues became apparent which are also fixed in this change.
Mainly there was not a good way to get a hold of a child schema object from a field schema.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
