### PR TITLE
fix (server): Retroactively add changesets for server changes

### DIFF
--- a/server/routerlicious/.changeset/blue-crews-cry.md
+++ b/server/routerlicious/.changeset/blue-crews-cry.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/server-services-client": major
+---
+
+Use RawAxiosRequestHeaders instead of AxiosRequestHeaders
+
+BasicRestWrapper class contrsuctor now takes input of RawAxiosRequestHeaders for the defaultHeaders argument and refreshDefaultHeaders argument.
+
+This changeset was retroactively added for commit d840deda657ff33a7767933bb796a89ffdf44d90

--- a/server/routerlicious/.changeset/blue-crews-cry.md
+++ b/server/routerlicious/.changeset/blue-crews-cry.md
@@ -2,8 +2,8 @@
 "@fluidframework/server-services-client": major
 ---
 
-Use RawAxiosRequestHeaders instead of AxiosRequestHeaders
+Use RawAxiosRequestHeaders instead of AxiosRequestHeaders in BasicRestWrapper constructor.
 
-BasicRestWrapper class contrsuctor now takes input of RawAxiosRequestHeaders for the defaultHeaders argument and refreshDefaultHeaders argument.
+The `BasicRestWrapper` class constructor now uses `RawAxiosRequestHeaders` from the `axios` package instead of `AxiosRequestHeaders`. This applies to both the `defaultHeaders` and `refreshDefaultHeaders` arguments.
 
-This changeset was retroactively added for commit d840deda657ff33a7767933bb796a89ffdf44d90
+This changeset was retroactively added for commit `d840deda657ff33a7767933bb796a89ffdf44d90`.

--- a/server/routerlicious/.changeset/ready-colts-bake.md
+++ b/server/routerlicious/.changeset/ready-colts-bake.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/server-services-client": major
+---
+
+Export ITimeoutContext, getGlobalTimeoutContext, and setGlobalTimeoutContext from @fluidframework/server-services-client
+
+The `@fluidframework/server-services-client` package now exports interface `ITimeoutContext` and functions `getGlobalTimeoutContext` and `setGlobalTimeoutContext`.
+
+This changeset was retroactively added for commit `a8692f9a72eb6613b675f20487a1f1055e059ed7`.


### PR DESCRIPTION
## Description

This PR retroactively adds changesets for commits d840deda657ff33a7767933bb796a89ffdf44d90 and a8692f9a72eb6613b675f20487a1f1055e059ed7.

[AB#5457](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5457)
