### PR TITLE
Add tree-comparison demo

### DIFF
--- a/examples/apps/tree-comparison/.eslintrc.js
+++ b/examples/apps/tree-comparison/.eslintrc.js
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	rules: {},
+};

--- a/examples/apps/tree-comparison/.gitignore
+++ b/examples/apps/tree-comparison/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+lib

--- a/examples/apps/tree-comparison/.npmignore
+++ b/examples/apps/tree-comparison/.npmignore
@@ -1,0 +1,6 @@
+nyc
+*.log
+**/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/apps/tree-comparison/LICENSE
+++ b/examples/apps/tree-comparison/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/apps/tree-comparison/README.md
+++ b/examples/apps/tree-comparison/README.md
@@ -1,0 +1,101 @@
+# @fluid-example/tree-comparison
+
+This example experiments with an approach for migrating data from an existing Fluid container into a new Fluid container which may have a different schema or code running on it.
+
+Please note that the ideas explored here are experimental and under development. They are not yet recommended for broad use in production.
+
+## Scenario
+
+Once a Fluid container has been created, it will contain some set of persisted data in the form of the summary as well as any unsummarized ops. This persisted data can only be correctly interpreted by a compatible container code (typically the same one that created it, or a newer backwards-compatible one). This container code knows the appropriate data stores to load to interpret the summary and process the outstanding ops, as well as provides public access to those data stores for use.
+
+However, suppose you want to change your application's schema in a manner that is not backwards compatible. Examples of this might include:
+
+-   Changing a DDS type used to store some data (e.g. Cell -> Map as this example demonstrates)
+-   Removing a piece of the data that is no longer relevant (e.g. for an app feature that has been removed)
+-   Reorganize data (e.g. split Directory data into subdirectories, or change the key used for a value in a Map)
+
+## Strategy overview
+
+This example explores one technique to permit these types of changes. It employs a multi-stage process to do so:
+
+1. Reach consensus amongst connected clients to perform the migration
+1. Extract the data from the existing container
+1. Transform the data as needed
+1. Create a new container with the new code and import the transformed data
+1. Redirect clients to the new container
+
+### Reach consensus amongst connected clients to perform the migration
+
+At any given moment, connected clients may have data in flight - ops that are unsequenced or that not all other clients are aware of. To avoid losing this data during the migration, we use a Quorum DDS to partition the op stream and establish the version we are migrating to. Ops sent before the Quorum value acceptance will be included, and clients are expected to stop generating ops after observing the proposal. After the Quorum value is accepted, we know there are no more ops in flight that should be included in the migration, and that the version we are migrating to is the one specified in the Quorum.
+
+### Extract the data from the existing container
+
+The container model is expected to provide a mechanism to extract the data from within for migration purposes. The format of the extracted data is up to the model - it could be a string, JSON, some well known file format like .csv, etc. Complex Javascript objects could even be used (since we will be performing the data import locally), but some serializable format is probably the most durable option.
+
+### Transform the data as needed
+
+If the new model is incapable of importing the export format of the old model, the format should be transformed accordingly. This can be skipped if the exported format is directly consumable by the new model.
+
+### Create a new container with the new code and import the transformed data
+
+With the exported and transformed data in hand, we can create a new container using the new container code and import the data. We ideally only upload (attach) a single migrated container, since duplicative containers are wasted storage. We use a TaskManager to select a single volunteer for this purpose. Once the container is attached, we write the new container's id into the old container (using a ConsensusRegisterCollection) to finalize the migration - all clients can now know the migration is complete and the data has been migrated to the specified container.
+
+### Redirect clients to the new container
+
+As clients observe the migration complete, they load the new container and swap it in for the old one. This includes loading in the approporate new container code, model code, and view code if necessary. Once complete, the client can begin collaborating on the new container.
+
+## Other concepts
+
+This example also explores other concepts that are new but not core to the migration process.
+
+### Container model
+
+In many other examples, we use a "root/default data object" concept (Spaces is a good example, pretty much all of the /examples/data-objects examples as well). The root data object exposes the API that the container wants to expose to the app (host). However, accessing this API is indirect, as the app must first retrieve this data object from the IContainer using `container.request()`.
+
+The container model concept introduced in this example serves a similar purpose of exposing an API for the app, but does so by wrapping the IContainer rather than living inside it as a data object. This removes a layer of indirection for the app, who can load this model directly (see next section). The app can then start using the API surface immediately without the extra step of going through the request pattern.
+
+When the container API surface has been externalized from the container, this can also open up new options for how the data might be represented and organized. There's no longer a need to craft a data object that holds references to all the container's contents if it's not required for the scenario. In this example, the model code knows how to access both the inventory list as well as the killbit, but these two objects remain completely separate from each other in the data schema.
+
+### Model loading
+
+As mentioned above, the `ModelLoader` is able to load directly to a container model. To do this, it wraps a `Loader` to load containers, and uses an `IModelCodeLoader` (similar to the `ICodeDetailsLoader` used in the Container) to match the model code against the container code. This extra code loader is required because the model code must be compatible with the container code within. The model code loader is also the opportunity to run any further async initialization steps that are needed to present the correct API surface on the model (e.g. retrieving handles to have important data available synchronously).
+
+### View loading
+
+Similarly, the view used on a model must be compatible with that model. A view loader can inspect the model and load the appropriate view. This portion is still under development, but will likely be similar to the model loading flow.
+
+<!-- AUTO-GENERATED-CONTENT:START (README_EXAMPLE_GETTING_STARTED_SECTION:usesTinylicious=TRUE) -->
+
+<!-- prettier-ignore-start -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
+
+## Getting Started
+
+You can run this example using the following steps:
+
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
+    - For an even faster build, you can add the package name to the build command, like this:
+      `pnpm run build:fast --nolint @fluid-example/app-integration-schema-upgrade`
+1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+
+<!-- prettier-ignore-end -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+## Testing
+
+```bash
+    npm run test:jest
+```
+
+For in browser testing update `./jest-puppeteer.config.js` to:
+
+```javascript
+  launch: {
+    dumpio: true, // output browser console to cmd line
+    slowMo: 500,
+    headless: false,
+  },
+```

--- a/examples/apps/tree-comparison/README.md
+++ b/examples/apps/tree-comparison/README.md
@@ -1,68 +1,6 @@
 # @fluid-example/tree-comparison
 
-This example experiments with an approach for migrating data from an existing Fluid container into a new Fluid container which may have a different schema or code running on it.
-
-Please note that the ideas explored here are experimental and under development. They are not yet recommended for broad use in production.
-
-## Scenario
-
-Once a Fluid container has been created, it will contain some set of persisted data in the form of the summary as well as any unsummarized ops. This persisted data can only be correctly interpreted by a compatible container code (typically the same one that created it, or a newer backwards-compatible one). This container code knows the appropriate data stores to load to interpret the summary and process the outstanding ops, as well as provides public access to those data stores for use.
-
-However, suppose you want to change your application's schema in a manner that is not backwards compatible. Examples of this might include:
-
--   Changing a DDS type used to store some data (e.g. Cell -> Map as this example demonstrates)
--   Removing a piece of the data that is no longer relevant (e.g. for an app feature that has been removed)
--   Reorganize data (e.g. split Directory data into subdirectories, or change the key used for a value in a Map)
-
-## Strategy overview
-
-This example explores one technique to permit these types of changes. It employs a multi-stage process to do so:
-
-1. Reach consensus amongst connected clients to perform the migration
-1. Extract the data from the existing container
-1. Transform the data as needed
-1. Create a new container with the new code and import the transformed data
-1. Redirect clients to the new container
-
-### Reach consensus amongst connected clients to perform the migration
-
-At any given moment, connected clients may have data in flight - ops that are unsequenced or that not all other clients are aware of. To avoid losing this data during the migration, we use a Quorum DDS to partition the op stream and establish the version we are migrating to. Ops sent before the Quorum value acceptance will be included, and clients are expected to stop generating ops after observing the proposal. After the Quorum value is accepted, we know there are no more ops in flight that should be included in the migration, and that the version we are migrating to is the one specified in the Quorum.
-
-### Extract the data from the existing container
-
-The container model is expected to provide a mechanism to extract the data from within for migration purposes. The format of the extracted data is up to the model - it could be a string, JSON, some well known file format like .csv, etc. Complex Javascript objects could even be used (since we will be performing the data import locally), but some serializable format is probably the most durable option.
-
-### Transform the data as needed
-
-If the new model is incapable of importing the export format of the old model, the format should be transformed accordingly. This can be skipped if the exported format is directly consumable by the new model.
-
-### Create a new container with the new code and import the transformed data
-
-With the exported and transformed data in hand, we can create a new container using the new container code and import the data. We ideally only upload (attach) a single migrated container, since duplicative containers are wasted storage. We use a TaskManager to select a single volunteer for this purpose. Once the container is attached, we write the new container's id into the old container (using a ConsensusRegisterCollection) to finalize the migration - all clients can now know the migration is complete and the data has been migrated to the specified container.
-
-### Redirect clients to the new container
-
-As clients observe the migration complete, they load the new container and swap it in for the old one. This includes loading in the approporate new container code, model code, and view code if necessary. Once complete, the client can begin collaborating on the new container.
-
-## Other concepts
-
-This example also explores other concepts that are new but not core to the migration process.
-
-### Container model
-
-In many other examples, we use a "root/default data object" concept (Spaces is a good example, pretty much all of the /examples/data-objects examples as well). The root data object exposes the API that the container wants to expose to the app (host). However, accessing this API is indirect, as the app must first retrieve this data object from the IContainer using `container.request()`.
-
-The container model concept introduced in this example serves a similar purpose of exposing an API for the app, but does so by wrapping the IContainer rather than living inside it as a data object. This removes a layer of indirection for the app, who can load this model directly (see next section). The app can then start using the API surface immediately without the extra step of going through the request pattern.
-
-When the container API surface has been externalized from the container, this can also open up new options for how the data might be represented and organized. There's no longer a need to craft a data object that holds references to all the container's contents if it's not required for the scenario. In this example, the model code knows how to access both the inventory list as well as the killbit, but these two objects remain completely separate from each other in the data schema.
-
-### Model loading
-
-As mentioned above, the `ModelLoader` is able to load directly to a container model. To do this, it wraps a `Loader` to load containers, and uses an `IModelCodeLoader` (similar to the `ICodeDetailsLoader` used in the Container) to match the model code against the container code. This extra code loader is required because the model code must be compatible with the container code within. The model code loader is also the opportunity to run any further async initialization steps that are needed to present the correct API surface on the model (e.g. retrieving handles to have important data available synchronously).
-
-### View loading
-
-Similarly, the view used on a model must be compatible with that model. A view loader can inspect the model and load the appropriate view. This portion is still under development, but will likely be similar to the model loading flow.
+This example compares usage of the legacy SharedTree with the new SharedTree to build the same inventory list application.
 
 <!-- AUTO-GENERATED-CONTENT:START (README_EXAMPLE_GETTING_STARTED_SECTION:usesTinylicious=TRUE) -->
 
@@ -76,7 +14,7 @@ You can run this example using the following steps:
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `pnpm run build:fast --nolint @fluid-example/app-integration-schema-upgrade`
+      `pnpm run build:fast --nolint @fluid-example/tree-comparison`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 

--- a/examples/apps/tree-comparison/jest-puppeteer.config.js
+++ b/examples/apps/tree-comparison/jest-puppeteer.config.js
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	server: {
+		command: `npm run start:test -- --no-live-reload --port ${process.env["PORT"]}`,
+		port: process.env["PORT"],
+		launchTimeout: 10000,
+		usedPortAction: "error",
+	},
+	launch: {
+		args: ["--no-sandbox", "--disable-setuid-sandbox"], // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
+		dumpio: process.env.FLUID_TEST_VERBOSE !== undefined, // output browser console to cmd line
+		// slowMo: 500, // slows down process for easier viewing
+		// headless: false, // run in the browser
+	},
+};

--- a/examples/apps/tree-comparison/jest.config.js
+++ b/examples/apps/tree-comparison/jest.config.js
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Get the test port from the global map and set it in env for this test
+const testTools = require("@fluidframework/test-tools");
+const { name } = require("./package.json");
+
+mappedPort = testTools.getTestPort(name);
+process.env["PORT"] = mappedPort;
+
+module.exports = {
+	preset: "jest-puppeteer",
+	globals: {
+		PATH: `http://localhost:${mappedPort}`,
+	},
+	testMatch: ["**/?(*.)+(spec|test).[t]s"],
+	testPathIgnorePatterns: ["/node_modules/", "dist"],
+	transform: {
+		"^.+\\.ts?$": "ts-jest",
+	},
+	reporters: [
+		"default",
+		[
+			"jest-junit",
+			{
+				outputDirectory: "nyc",
+				outputName: "jest-junit-report.xml",
+			},
+		],
+	],
+};

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -1,0 +1,112 @@
+{
+	"name": "@fluid-example/tree-comparison",
+	"version": "2.0.0-internal.7.1.0",
+	"private": true,
+	"description": "Comparing API usage in legacy SharedTree and new SharedTree.",
+	"homepage": "https://fluidframework.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/FluidFramework.git",
+		"directory": "examples/apps/tree-comparison"
+	},
+	"license": "MIT",
+	"author": "Microsoft and contributors",
+	"main": "lib/index.js",
+	"module": "lib/index.js",
+	"types": "lib/index.d.ts",
+	"scripts": {
+		"build": "fluid-build . --task build",
+		"build:compile": "fluid-build . --task compile",
+		"build:esnext": "tsc",
+		"clean": "rimraf --glob 'dist' 'lib' '*.tsbuildinfo' '*.build.log' 'nyc'",
+		"eslint": "eslint --format stylish src",
+		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
+		"format": "npm run prettier:fix",
+		"lint": "npm run prettier && npm run eslint",
+		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
+		"prepack": "npm run webpack",
+		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
+		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
+		"start": "webpack serve",
+		"start:test": "webpack serve --config webpack.test.js",
+		"test": "npm run test:jest",
+		"test:jest": "jest",
+		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest",
+		"webpack": "webpack --env production",
+		"webpack:dev": "webpack --env development"
+	},
+	"dependencies": {
+		"@fluid-example/example-utils": "workspace:~",
+		"@fluid-experimental/react-inputs": "workspace:~",
+		"@fluid-experimental/tree": "workspace:~",
+		"@fluid-experimental/tree2": "workspace:~",
+		"@fluid-internal/client-utils": "workspace:~",
+		"@fluidframework/aqueduct": "workspace:~",
+		"@fluidframework/container-definitions": "workspace:~",
+		"@fluidframework/container-loader": "workspace:~",
+		"@fluidframework/container-runtime-definitions": "workspace:~",
+		"@fluidframework/core-interfaces": "workspace:~",
+		"@fluidframework/driver-definitions": "workspace:~",
+		"@fluidframework/driver-utils": "workspace:~",
+		"@fluidframework/request-handler": "workspace:~",
+		"@fluidframework/routerlicious-driver": "workspace:~",
+		"@fluidframework/runtime-utils": "workspace:~",
+		"@fluidframework/sequence": "workspace:~",
+		"@fluidframework/task-manager": "workspace:~",
+		"@fluidframework/telemetry-utils": "workspace:~",
+		"@fluidframework/tinylicious-driver": "workspace:~",
+		"events": "^3.1.0",
+		"react": "^17.0.1",
+		"react-dom": "^17.0.1",
+		"tiny-typed-emitter": "^2.1.0",
+		"uuid": "^9.0.0"
+	},
+	"devDependencies": {
+		"@fluid-tools/build-cli": "^0.25.0",
+		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-tools": "^0.25.0",
+		"@fluidframework/eslint-config-fluid": "^3.0.0",
+		"@fluidframework/test-tools": "^1.0.195075",
+		"@types/expect-puppeteer": "2.2.1",
+		"@types/jest": "29.5.3",
+		"@types/jest-environment-puppeteer": "2.2.0",
+		"@types/node": "^16.18.38",
+		"@types/puppeteer": "1.3.0",
+		"@types/react": "^17.0.44",
+		"@types/react-dom": "^17.0.18",
+		"@types/uuid": "^9.0.2",
+		"cross-env": "^7.0.3",
+		"css-loader": "^1.0.0",
+		"eslint": "~8.50.0",
+		"html-webpack-plugin": "^5.5.0",
+		"jest": "^29.6.2",
+		"jest-junit": "^10.0.0",
+		"jest-puppeteer": "^6.2.0",
+		"prettier": "~3.0.3",
+		"process": "^0.11.10",
+		"puppeteer": "^17.1.3",
+		"rimraf": "^4.4.0",
+		"style-loader": "^1.0.0",
+		"ts-jest": "^29.1.1",
+		"ts-loader": "^9.3.0",
+		"typescript": "~5.1.6",
+		"webpack": "^5.82.0",
+		"webpack-cli": "^4.9.2",
+		"webpack-dev-server": "~4.6.0",
+		"webpack-merge": "^5.8.0"
+	},
+	"fluid": {
+		"browser": {
+			"umd": {
+				"files": [
+					"main.bundle.js"
+				],
+				"library": "main"
+			}
+		}
+	},
+	"typeValidation": {
+		"disabled": true,
+		"broken": {}
+	}
+}

--- a/examples/apps/tree-comparison/prettier.config.cjs
+++ b/examples/apps/tree-comparison/prettier.config.cjs
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/examples/apps/tree-comparison/src/index.html
+++ b/examples/apps/tree-comparison/src/index.html
@@ -1,0 +1,15 @@
+<!-- Copyright (c) Microsoft Corporation and contributors. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+<!doctype html>
+<html lang="en" style="height: 100%">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Test application</title>
+	</head>
+	<body style="margin: 0">
+		<div id="app"></div>
+		<div id="debug"></div>
+	</body>
+</html>

--- a/examples/apps/tree-comparison/src/model/appModel.ts
+++ b/examples/apps/tree-comparison/src/model/appModel.ts
@@ -6,10 +6,8 @@
 import type { IInventoryListAppModel, IInventoryList } from "../modelInterfaces";
 
 /**
- * The InventoryListAppModel serves the purpose of wrapping this particular Container in a friendlier interface,
- * with stronger typing and accessory functionality.  It should have the same layering restrictions as we want for
- * the Container (e.g. no direct access to the Loader).  It does not have a goal of being general-purpose like
- * Container does -- instead it is specially designed for the specific container code.
+ * The InventoryListAppModel provides two inventory lists, one using legacy SharedTree
+ * and the other using new SharedTree.  They function the same and share the same interface.
  */
 export class InventoryListAppModel implements IInventoryListAppModel {
 	public constructor(

--- a/examples/apps/tree-comparison/src/model/appModel.ts
+++ b/examples/apps/tree-comparison/src/model/appModel.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IInventoryListAppModel, IInventoryList } from "../modelInterfaces";
+
+/**
+ * The InventoryListAppModel serves the purpose of wrapping this particular Container in a friendlier interface,
+ * with stronger typing and accessory functionality.  It should have the same layering restrictions as we want for
+ * the Container (e.g. no direct access to the Loader).  It does not have a goal of being general-purpose like
+ * Container does -- instead it is specially designed for the specific container code.
+ */
+export class InventoryListAppModel implements IInventoryListAppModel {
+	public constructor(
+		public readonly legacyTreeInventoryList: IInventoryList,
+		public readonly treeInventoryList: IInventoryList,
+	) {}
+}

--- a/examples/apps/tree-comparison/src/model/containerCode.ts
+++ b/examples/apps/tree-comparison/src/model/containerCode.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ModelContainerRuntimeFactory } from "@fluid-example/example-utils";
+import type { IContainer } from "@fluidframework/container-definitions";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+// eslint-disable-next-line import/no-deprecated
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+
+import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces";
+import { InventoryListAppModel } from "./appModel";
+import { LegacyTreeInventoryListFactory } from "./legacyTreeInventoryList";
+import { TreeInventoryListFactory } from "./treeInventoryList";
+
+export const legacyTreeInventoryListId = "legacy-tree-inventory-list";
+export const treeInventoryListId = "tree-inventory-list";
+
+export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeFactory<IInventoryListAppModel> {
+	public constructor() {
+		super(
+			new Map([
+				LegacyTreeInventoryListFactory.registryEntry,
+				TreeInventoryListFactory.registryEntry,
+			]), // registryEntries
+		);
+	}
+
+	/**
+	 * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
+	 */
+	protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
+		const legacyTreeInventoryList = await runtime.createDataStore(
+			LegacyTreeInventoryListFactory.type,
+		);
+		await legacyTreeInventoryList.trySetAlias(legacyTreeInventoryListId);
+		const treeInventoryList = await runtime.createDataStore(TreeInventoryListFactory.type);
+		await treeInventoryList.trySetAlias(treeInventoryListId);
+	}
+
+	/**
+	 * {@inheritDoc ModelContainerRuntimeFactory.createModel}
+	 */
+	protected async createModel(runtime: IContainerRuntime, container: IContainer) {
+		// eslint-disable-next-line import/no-deprecated
+		const legacyTreeInventoryList = await requestFluidObject<IInventoryList>(
+			await runtime.getRootDataStore(legacyTreeInventoryListId),
+			"",
+		);
+		// eslint-disable-next-line import/no-deprecated
+		const treeInventoryList = await requestFluidObject<IInventoryList>(
+			await runtime.getRootDataStore(treeInventoryListId),
+			"",
+		);
+		return new InventoryListAppModel(legacyTreeInventoryList, treeInventoryList);
+	}
+}

--- a/examples/apps/tree-comparison/src/model/index.ts
+++ b/examples/apps/tree-comparison/src/model/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { InventoryListContainerRuntimeFactory } from "./containerCode";

--- a/examples/apps/tree-comparison/src/model/inventoryItem.ts
+++ b/examples/apps/tree-comparison/src/model/inventoryItem.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TypedEmitter } from "tiny-typed-emitter";
+
+import type { IInventoryItem, IInventoryItemEvents } from "../modelInterfaces";
+
+/**
+ * InventoryItem is the local object with the friendly interface for the view to use.
+ * It binds to either legacy or new SharedTree by abstracting out how the values are
+ * changed.
+ */
+export class InventoryItem extends TypedEmitter<IInventoryItemEvents> implements IInventoryItem {
+	public get id() {
+		return this._id;
+	}
+	public get name() {
+		return this._name;
+	}
+	public get quantity() {
+		return this._quantity;
+	}
+	public set quantity(newQuantity: number) {
+		// Setting the quantity does not directly update the value, but rather roundtrips it through
+		// the backing data by using the provided callback.  We trust that later this will result in
+		// handleQuantityUpdate getting called when the true backing data changes.
+		this._setQuantity(newQuantity);
+	}
+	/**
+	 * handleQuantityUpdate is not available on IInventoryItem intentionally, since it should not be
+	 * available to the view.  Instead it is to be called by the backing data when the true value
+	 * of the data changes.
+	 */
+	public handleQuantityUpdate(newQuantity: number) {
+		this._quantity = newQuantity;
+		this.emit("quantityChanged");
+	}
+	public constructor(
+		private readonly _id: string,
+		private readonly _name: string,
+		private _quantity: number,
+		private readonly _setQuantity: (quantity: number) => void,
+		public readonly deleteItem: () => void,
+	) {
+		super();
+	}
+}

--- a/examples/apps/tree-comparison/src/model/legacyTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/legacyTreeInventoryList.ts
@@ -1,0 +1,244 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	BuildNode,
+	Change,
+	EagerCheckout,
+	SharedTree as LegacySharedTree,
+	NodeId,
+	StablePlace,
+	StableRange,
+	TraitLabel,
+	TreeView,
+	TreeViewNode,
+} from "@fluid-experimental/tree";
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+
+import type { IInventoryItem, IInventoryList } from "../modelInterfaces";
+import { InventoryItem } from "./inventoryItem";
+
+const legacySharedTreeKey = "legacySharedTree";
+
+// TODO: Do I want string here or number?  Prob don't want anything tree-specific
+// since this gets exposed to the view.  I've currently removed any reverse lookups so it doesn't
+// matter too much.
+const nodeIdToInventoryItemId = (nodeId: NodeId) => nodeId.toString();
+
+export class LegacyTreeInventoryList extends DataObject implements IInventoryList {
+	private _tree: LegacySharedTree | undefined;
+	private readonly _inventoryItems = new Map<string, InventoryItem>();
+
+	private get tree() {
+		if (this._tree === undefined) {
+			throw new Error("Not initialized properly");
+		}
+		return this._tree;
+	}
+
+	public readonly addItem = (name: string, quantity: number) => {
+		const addedNode: BuildNode = {
+			definition: "inventoryItem",
+			traits: {
+				name: {
+					definition: "name",
+					payload: name,
+				},
+				quantity: {
+					definition: "quantity",
+					payload: quantity,
+				},
+			},
+		};
+		const rootNode = this.tree.currentView.getViewNode(this.tree.currentView.root);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const inventoryNodeId = rootNode.traits.get("inventory" as TraitLabel)![0];
+		this.tree.applyEdit(
+			Change.insertTree(
+				addedNode,
+				StablePlace.atEndOf({
+					parent: inventoryNodeId,
+					label: "inventoryItems" as TraitLabel,
+				}),
+			),
+		);
+	};
+
+	public readonly getItems = (): IInventoryItem[] => {
+		return [...this._inventoryItems.values()];
+	};
+
+	protected async initializingFirstTime(): Promise<void> {
+		const legacySharedTree = this.runtime.createChannel(
+			undefined,
+			LegacySharedTree.getFactory().type,
+		) as LegacySharedTree;
+
+		const inventoryNode: BuildNode = {
+			definition: "inventory",
+			traits: {
+				// REV: If I try to remove these sample items (leaving inventoryItems as an empty array)
+				// the trait is removed entirely (undefined).  It seems that empty traits are discarded?
+				// This is a problem when later I want to iterate over it (in hasInitialized, when
+				// building up my initial set of InventoryItem objects), since I'll get a not-iterable error.
+				inventoryItems: [
+					{
+						definition: "inventoryItem",
+						traits: {
+							// REV: I tried adding an explicit "ID" trait here and using that for tracking,
+							// rather than the NodeId itself.  However, when deleting a node the "removed" member
+							// of the "viewChange" event args only includes the NodeId and the nodes are already
+							// gone (cannot be retrieved).  So the ID is lost at that point.  I could maintain a
+							// separate NodeId -> ID mapping to track, but this feels kind of clunky and defeats
+							// the point of getting away from direct usage of NodeIds.
+							name: {
+								definition: "name",
+								payload: "nut",
+							},
+							quantity: {
+								definition: "quantity",
+								payload: 0,
+							},
+						},
+					},
+					{
+						definition: "inventoryItem",
+						traits: {
+							name: {
+								definition: "name",
+								payload: "bolt",
+							},
+							quantity: {
+								definition: "quantity",
+								payload: 0,
+							},
+						},
+					},
+				],
+			},
+		};
+		legacySharedTree.applyEdit(
+			Change.insertTree(
+				inventoryNode,
+				StablePlace.atStartOf({
+					parent: legacySharedTree.currentView.root,
+					label: "inventory" as TraitLabel,
+				}),
+			),
+		);
+
+		this.root.set(legacySharedTreeKey, legacySharedTree.handle);
+	}
+
+	/**
+	 * hasInitialized is run by each client as they load the DataObject.  Here we use it to set up usage of the
+	 * DataObject, by registering an event listener for changes to the inventory list.
+	 */
+	protected async hasInitialized() {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		this._tree = await this.root
+			.get<IFluidHandle<LegacySharedTree>>(legacySharedTreeKey)!
+			.get();
+
+		// REV: Not exactly sure why a checkout is required to get "viewChange" events, seems like it should be able
+		// to fire off the legacy shared tree itself?
+		const checkout = new EagerCheckout(this._tree);
+		// This event handler fires for any change to the tree, so it needs to handle all possibilities (change, add, remove).
+		checkout.on("viewChange", (before: TreeView, after: TreeView) => {
+			const { changed, added, removed } = before.delta(after);
+			for (const quantityNodeId of changed) {
+				const quantityNode = this.tree.currentView.getViewNode(quantityNodeId);
+				// REV: This is annoying to iterate over since I can't filter until I've retrieved the node object.
+				// When adding a node the "inventory" node changes too, but we don't want to handle that here.
+				if (quantityNode.definition === "quantity") {
+					const newQuantity = quantityNode.payload as number;
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					const inventoryItemNodeId = quantityNode.parentage!.parent;
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					this._inventoryItems
+						.get(nodeIdToInventoryItemId(inventoryItemNodeId))!
+						.handleQuantityUpdate(newQuantity);
+				}
+			}
+
+			for (const inventoryNodeId of added) {
+				const inventoryItemNode = this.tree.currentView.getViewNode(inventoryNodeId);
+				// REV: Similar to above, this can't be filtered without grabbing the actual node objects.
+				// This list will include the "name" and "quantity" nodes too, but we only want to handle the "inventoryItem".
+				if (inventoryItemNode.definition === "inventoryItem") {
+					const addedInventoryItem =
+						this.makeInventoryItemFromInventoryItemNode(inventoryItemNode);
+					this._inventoryItems.set(addedInventoryItem.id, addedInventoryItem);
+					this.emit("itemAdded", addedInventoryItem);
+				}
+			}
+
+			for (const inventoryNodeId of removed) {
+				// REV: A twist on the filtering issue, but would be nice to have a way to filter the nodes prior to iterating.
+				// This list will include the "name" and "quantity" nodes too, but we only want to handle the "inventoryItem".
+				// However, since the nodes were deleted we can't fetch them and filter on definition as for changed/added.
+				// Instead we'll just compare the IDs against the inventory items we're tracking (since the name/quantity won't
+				// be in there).
+				const inventoryItemId = nodeIdToInventoryItemId(inventoryNodeId);
+				const deletedInventoryItem = this._inventoryItems.get(inventoryItemId);
+				if (deletedInventoryItem !== undefined) {
+					this._inventoryItems.delete(inventoryItemId);
+					this.emit("itemDeleted", deletedInventoryItem);
+				}
+			}
+		});
+
+		// Last step of initializing is to populate our map of InventoryItems.
+		// REV: Seems strange that this.tree.currentView.rootNode is private.
+		const rootNode = this.tree.currentView.getViewNode(this.tree.currentView.root);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const inventoryItemsNodeIds = this.tree.currentView
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			.getViewNode(rootNode.traits.get("inventory" as TraitLabel)![0])
+			.traits.get("inventoryItems" as TraitLabel)!;
+		for (const inventoryItemNodeId of inventoryItemsNodeIds) {
+			const inventoryItemNode = this.tree.currentView.getViewNode(inventoryItemNodeId);
+			const newInventoryItem = this.makeInventoryItemFromInventoryItemNode(inventoryItemNode);
+			this._inventoryItems.set(newInventoryItem.id, newInventoryItem);
+		}
+	}
+
+	private makeInventoryItemFromInventoryItemNode(inventoryItemNode: TreeViewNode): InventoryItem {
+		const id = nodeIdToInventoryItemId(inventoryItemNode.identifier);
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const nameNodeId = inventoryItemNode.traits.get("name" as TraitLabel)![0];
+		const nameNode = this.tree.currentView.getViewNode(nameNodeId);
+		const name = nameNode.payload as string;
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const quantityNodeId = inventoryItemNode.traits.get("quantity" as TraitLabel)![0];
+		const quantityNode = this.tree.currentView.getViewNode(quantityNodeId);
+		const quantity = quantityNode.payload as number;
+
+		const setQuantity = (newQuantity: number) => {
+			this.tree.applyEdit(Change.setPayload(quantityNodeId, newQuantity));
+		};
+
+		const deleteItem = () => {
+			this.tree.applyEdit(Change.delete(StableRange.only(inventoryItemNode.identifier)));
+		};
+
+		return new InventoryItem(id, name, quantity, setQuantity, deleteItem);
+	}
+}
+
+/**
+ * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
+ * and the constructor it will call.  The third argument lists the other data structures it will utilize.  In this
+ * scenario, the fourth argument is not used.
+ */
+export const LegacyTreeInventoryListFactory = new DataObjectFactory<LegacyTreeInventoryList>(
+	"legacy-tree-inventory-list",
+	LegacyTreeInventoryList,
+	[LegacySharedTree.getFactory()],
+	{},
+);

--- a/examples/apps/tree-comparison/src/model/schema.ts
+++ b/examples/apps/tree-comparison/src/model/schema.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { leaf, SchemaBuilder, TypedField, TypedNode } from "@fluid-experimental/tree2";
+
+// By importing the leaf library we don't have to define our own string and number types.
+const builder = new SchemaBuilder({ scope: "inventory app", libraries: [leaf.library] });
+
+const inventoryItem = builder.struct("Contoso:InventoryItem-1.0.0", {
+	// REV: I added an ID here because I didn't find a unique identifier on the node.
+	// I'm not necessarily opposed to this, but I wonder if it's needed/duplicative.
+	id: leaf.string,
+	name: leaf.string,
+	quantity: leaf.number,
+});
+export type InventoryItemNode = TypedNode<typeof inventoryItem>;
+
+// REV: Building this up as a series of builder invocations makes it hard to read the schema.
+// Would be nice if instead we could define some single big Serializable or similar that laid the
+// schema out and then pass that in.
+const inventory = builder.struct("Contoso:Inventory-1.0.0", {
+	inventoryItems: builder.sequence(inventoryItem),
+});
+export type InventoryNode = TypedNode<typeof inventory>;
+
+// REV: The rootField feels extra to me.  Is there a way to omit it?  Something like
+// builder.intoDocumentSchema(inventory)
+const inventoryField = SchemaBuilder.required(inventory);
+export type InventoryField = TypedField<typeof inventoryField>;
+
+export const schema = builder.toDocumentSchema(inventoryField);

--- a/examples/apps/tree-comparison/src/model/treeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/treeInventoryList.ts
@@ -1,0 +1,188 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	AllowedUpdateType,
+	ForestType,
+	typeboxValidator,
+	TypedTreeChannel,
+	TypedTreeFactory,
+} from "@fluid-experimental/tree2";
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { v4 as uuid } from "uuid";
+
+import type { IInventoryItem, IInventoryList } from "../modelInterfaces";
+import { InventoryItem } from "./inventoryItem";
+import { InventoryNode, InventoryField, InventoryItemNode, schema } from "./schema";
+
+const factory = new TypedTreeFactory({
+	// REV: I'm not exactly sure why a validator should be passed here?  Like what it's used for,
+	// so it's hard to know what a "correct" choice would be as a result.
+	jsonValidator: typeboxValidator,
+	// REV: I copied this from another example but I have no idea what it means - documentation is
+	// self-referencing.
+	forest: ForestType.Reference,
+	// REV: What's the scenario where I'd want to leverage the subtype?  Documentation makes it sound
+	// like it should be optional at least.
+	subtype: "InventoryList",
+});
+
+const sharedTreeKey = "sharedTree";
+
+export class TreeInventoryList extends DataObject implements IInventoryList {
+	private _sharedTree: TypedTreeChannel | undefined;
+	private get sharedTree(): TypedTreeChannel {
+		if (this._sharedTree === undefined) {
+			throw new Error("Not initialized properly");
+		}
+		return this._sharedTree;
+	}
+	private _inventory: InventoryField | undefined;
+	private get inventory(): InventoryNode {
+		if (this._inventory === undefined) {
+			throw new Error("Not initialized properly");
+		}
+		return this._inventory.content;
+	}
+	private readonly _inventoryItems = new Map<string, InventoryItem>();
+
+	public readonly addItem = (name: string, quantity: number) => {
+		this.inventory.inventoryItems.insertAtEnd([
+			{
+				// REV: I think this might be a good place to use the SharedTree ID generation?
+				// If so, could use a pointer to how to do that?
+				id: uuid(),
+				name,
+				quantity,
+			},
+		]);
+	};
+
+	public readonly getItems = (): IInventoryItem[] => {
+		return [...this._inventoryItems.values()];
+	};
+
+	protected async initializingFirstTime(): Promise<void> {
+		this._sharedTree = this.runtime.createChannel(undefined, factory.type) as TypedTreeChannel;
+		this.root.set(sharedTreeKey, this._sharedTree.handle);
+	}
+
+	// REV: Have to use initializingFromExisting here rather than hasInitialized due to a bug - getting
+	// the handle on the creating client retrieves the wrong object.
+	protected async initializingFromExisting(): Promise<void> {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		this._sharedTree = await this.root
+			.get<IFluidHandle<TypedTreeChannel>>(sharedTreeKey)!
+			.get();
+	}
+
+	protected async hasInitialized(): Promise<void> {
+		// REV: I don't particularly like the combined schematize/initialize.  My preference would be for
+		// separate schematize/initialize calls.
+		this._inventory = this.sharedTree.schematize({
+			initialTree: {
+				inventoryItems: [
+					{
+						id: uuid(),
+						name: "nut",
+						quantity: 0,
+					},
+					{
+						id: uuid(),
+						name: "bolt",
+						quantity: 0,
+					},
+				],
+			},
+			allowedSchemaModifications: AllowedUpdateType.None,
+			schema,
+		});
+		// REV: This event feels overly-broad for what I'm looking for, but I'm having issues with
+		// more node-specific events ("changing", etc.).  I also personally find the deviation from
+		// standard EventEmitter API surprising/unintuitive/inconvenient.
+		this.inventory.context.on("afterChange", () => {
+			// Since "afterChange" doesn't provide event args, we need to scan the tree and compare
+			// it to our InventoryItems to find what changed.  This event handler fires for any
+			// change to the tree, so it needs to handle all possibilities (change, add, remove).
+			for (const inventoryItemNode of this.inventory.inventoryItems) {
+				const upToDateQuantity = inventoryItemNode.quantity;
+				const inventoryItem = this._inventoryItems.get(inventoryItemNode.id);
+				// If we're not currently tracking some item in the tree, then it must have been
+				// added in this change.
+				if (inventoryItem === undefined) {
+					const newInventoryItem =
+						this.makeInventoryItemFromInventoryItemNode(inventoryItemNode);
+					this._inventoryItems.set(inventoryItemNode.id, newInventoryItem);
+					this.emit("itemAdded");
+				}
+				// If the quantity of our tracking item is different from the tree, then the
+				// quantity must have changed in this change.
+				if (inventoryItem !== undefined && inventoryItem.quantity !== upToDateQuantity) {
+					inventoryItem.handleQuantityUpdate(upToDateQuantity);
+				}
+			}
+
+			// Search for deleted inventory items to update our collection
+			const currentInventoryIds = [...this.inventory.inventoryItems].map(
+				(inventoryItemNode) => {
+					return inventoryItemNode.id;
+				},
+			);
+			for (const trackedItemId of this._inventoryItems.keys()) {
+				// If the tree doesn't contain the id of an item we're tracking, then it must have
+				// been deleted in this change.
+				if (!currentInventoryIds.includes(trackedItemId)) {
+					this._inventoryItems.delete(trackedItemId);
+					this.emit("itemDeleted");
+				}
+			}
+		});
+
+		// Last step of initializing is to populate our map of InventoryItems.
+		for (const inventoryItemNode of this.inventory.inventoryItems) {
+			const inventoryItem = this.makeInventoryItemFromInventoryItemNode(inventoryItemNode);
+			this._inventoryItems.set(inventoryItemNode.id, inventoryItem);
+		}
+	}
+
+	private makeInventoryItemFromInventoryItemNode(
+		inventoryItemNode: InventoryItemNode,
+	): InventoryItem {
+		const setQuantity = (newQuantity: number) => {
+			// REV: This still seems surprising to me that it's making the remote change, I think
+			// it would be more apparent as .setContent() rather than using the setter.
+			inventoryItemNode.boxedQuantity.content = newQuantity;
+		};
+		const deleteItem = () => {
+			// REV: Is this the best way to do this?  Was hoping for maybe just an inventoryItemNode.delete().
+			this.inventory.inventoryItems.removeAt(inventoryItemNode.parentField.index);
+		};
+		// REV: Per-node events seem buggy (this fires twice per change, presumably for local change + ack?)
+		// inventoryItemNode.on("changing", () => {
+		// 	console.log(`changing: ${inventoryItemNode.quantity}`);
+		// 	inventoryItem.handleQuantityUpdate(inventoryItemNode.quantity);
+		// });
+		return new InventoryItem(
+			inventoryItemNode.id,
+			inventoryItemNode.name,
+			inventoryItemNode.quantity,
+			setQuantity,
+			deleteItem,
+		);
+	}
+}
+
+/**
+ * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
+ * and the constructor it will call.  The third argument lists the other data structures it will utilize.  In this
+ * scenario, the fourth argument is not used.
+ */
+export const TreeInventoryListFactory = new DataObjectFactory<TreeInventoryList>(
+	"tree-inventory-list",
+	TreeInventoryList,
+	[factory],
+	{},
+);

--- a/examples/apps/tree-comparison/src/modelInterfaces.ts
+++ b/examples/apps/tree-comparison/src/modelInterfaces.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EventEmitter } from "events";
+import { TypedEmitter } from "tiny-typed-emitter";
+
+/**
+ * For demo purposes this is a super-simple interface, but in a real scenario this should have all relevant surface
+ * for the application to run.
+ */
+export interface IInventoryListAppModel {
+	/**
+	 * An inventory tracker list using the legacy shared tree.
+	 */
+	readonly legacyTreeInventoryList: IInventoryList;
+	/**
+	 * An inventory tracker list using the new shared tree.
+	 */
+	readonly treeInventoryList: IInventoryList;
+}
+
+export interface IInventoryItemEvents {
+	quantityChanged: () => void;
+}
+
+export interface IInventoryItem extends TypedEmitter<IInventoryItemEvents> {
+	readonly id: string;
+	readonly name: string;
+	quantity: number;
+	readonly deleteItem: () => void;
+}
+
+/**
+ * IInventoryList describes the public API surface for our inventory list object.
+ */
+export interface IInventoryList extends EventEmitter {
+	readonly addItem: (name: string, quantity: number) => void;
+
+	readonly getItems: () => IInventoryItem[];
+
+	/**
+	 * The listChanged event will fire whenever an item is added/removed, either locally or remotely.
+	 * TODO: Consider using tiny-typed-emitter if not using DataObject
+	 */
+	on(event: "itemAdded" | "itemDeleted", listener: (item: IInventoryItem) => void): this;
+}

--- a/examples/apps/tree-comparison/src/start.ts
+++ b/examples/apps/tree-comparison/src/start.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
+import { InventoryListContainerRuntimeFactory } from "./model";
+import type { IInventoryListAppModel } from "./modelInterfaces";
+import { DebugView, InventoryListAppView } from "./view";
+
+const updateTabForId = (id: string) => {
+	// Update the URL with the actual ID
+	location.hash = id;
+
+	// Put the ID in the tab title
+	document.title = id;
+};
+
+const render = (model: IInventoryListAppModel) => {
+	const appDiv = document.getElementById("app") as HTMLDivElement;
+	ReactDOM.unmountComponentAtNode(appDiv);
+	ReactDOM.render(React.createElement(InventoryListAppView, { model }), appDiv);
+
+	// The DebugView is just for demo purposes, in case we want to access internal state or have debug controls.
+	const debugDiv = document.getElementById("debug") as HTMLDivElement;
+	ReactDOM.unmountComponentAtNode(debugDiv);
+	ReactDOM.render(
+		React.createElement(DebugView, {
+			model,
+		}),
+		debugDiv,
+	);
+};
+
+async function start(): Promise<void> {
+	const modelLoader = new TinyliciousModelLoader<IInventoryListAppModel>(
+		new StaticCodeLoader(new InventoryListContainerRuntimeFactory()),
+	);
+
+	let id: string;
+	let model: IInventoryListAppModel;
+
+	if (location.hash.length === 0) {
+		const createResponse = await modelLoader.createDetached("1.0");
+		model = createResponse.model;
+		id = await createResponse.attach();
+	} else {
+		id = location.hash.substring(1);
+		model = await modelLoader.loadExisting(id);
+	}
+
+	render(model);
+	updateTabForId(id);
+}
+
+start().catch((error) => console.error(error));

--- a/examples/apps/tree-comparison/src/view/appView.tsx
+++ b/examples/apps/tree-comparison/src/view/appView.tsx
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+import type { IInventoryListAppModel } from "../modelInterfaces";
+import { InventoryListView } from "./inventoryView";
+
+export interface IInventoryListAppViewProps {
+	model: IInventoryListAppModel;
+}
+
+/**
+ * The InventoryListAppView is the top-level app view.  It is made to pair with an InventoryListAppModel and
+ * render its contents appropriately.
+ */
+export const InventoryListAppView: React.FC<IInventoryListAppViewProps> = (
+	props: IInventoryListAppViewProps,
+) => {
+	const { model } = props;
+
+	return (
+		<>
+			<h1>Using legacy SharedTree</h1>
+			<InventoryListView inventoryList={model.legacyTreeInventoryList} />
+			<h1>Using new SharedTree</h1>
+			<InventoryListView inventoryList={model.treeInventoryList} />
+		</>
+	);
+};

--- a/examples/apps/tree-comparison/src/view/debugView.tsx
+++ b/examples/apps/tree-comparison/src/view/debugView.tsx
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+import type { IInventoryListAppModel } from "../modelInterfaces";
+
+export interface IDebugViewProps {
+	model: IInventoryListAppModel;
+}
+
+export const DebugView: React.FC<IDebugViewProps> = (props: IDebugViewProps) => {
+	return (
+		<div>
+			<h2 style={{ textDecoration: "underline" }}>Debug info</h2>
+		</div>
+	);
+};

--- a/examples/apps/tree-comparison/src/view/index.ts
+++ b/examples/apps/tree-comparison/src/view/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { IDebugViewProps, DebugView } from "./debugView";
+export { IInventoryListAppViewProps, InventoryListAppView } from "./appView";

--- a/examples/apps/tree-comparison/src/view/inventoryView.tsx
+++ b/examples/apps/tree-comparison/src/view/inventoryView.tsx
@@ -1,0 +1,179 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React, { FC, useEffect, useRef, useState } from "react";
+import { IInventoryList, IInventoryItem } from "../modelInterfaces";
+
+export interface IInventoryItemViewProps {
+	inventoryItem: IInventoryItem;
+	disabled?: boolean;
+}
+
+export const InventoryItemView: FC<IInventoryItemViewProps> = (props: IInventoryItemViewProps) => {
+	const { inventoryItem, disabled } = props;
+	const quantityRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		const updateFromRemoteQuantity = () => {
+			if (quantityRef.current !== null) {
+				quantityRef.current.value = inventoryItem.quantity.toString();
+			}
+		};
+		inventoryItem.on("quantityChanged", updateFromRemoteQuantity);
+		updateFromRemoteQuantity();
+		return () => {
+			inventoryItem.off("quantityChanged", updateFromRemoteQuantity);
+		};
+	}, [inventoryItem]);
+
+	const inputHandler = (e) => {
+		const newValue = parseInt(e.target.value, 10);
+		inventoryItem.quantity = newValue;
+	};
+
+	return (
+		<tr>
+			<td>{inventoryItem.name}</td>
+			<td>
+				<input
+					ref={quantityRef}
+					onInput={inputHandler}
+					type="number"
+					style={{ width: "60px" }}
+					disabled={disabled}
+				></input>
+			</td>
+			<td>
+				<button
+					onClick={inventoryItem.deleteItem}
+					style={{ border: "none", background: "none" }}
+					disabled={disabled}
+				>
+					❌
+				</button>
+			</td>
+		</tr>
+	);
+};
+
+interface IAddItemViewProps {
+	readonly addItem: (name: string, quantity: number) => void;
+	disabled?: boolean;
+}
+
+const AddItemView: FC<IAddItemViewProps> = (props: IAddItemViewProps) => {
+	const { addItem, disabled } = props;
+	const nameRef = useRef<HTMLInputElement>(null);
+	const quantityRef = useRef<HTMLInputElement>(null);
+
+	const onAddItemButtonClick = () => {
+		if (nameRef.current === null || quantityRef.current === null) {
+			throw new Error("Couldn't get the new item info");
+		}
+
+		// Extract the values from the inputs and add the new item
+		const name = nameRef.current.value;
+		const quantityString = quantityRef.current.value;
+		const quantity = quantityString !== "" ? parseInt(quantityString, 10) : 0;
+		addItem(name, quantity);
+
+		// Clear the input form
+		nameRef.current.value = "";
+		quantityRef.current.value = "";
+	};
+
+	return (
+		<>
+			<tr style={{ borderTop: "3px solid black" }}>
+				<td>
+					<input
+						ref={nameRef}
+						type="text"
+						placeholder="New item"
+						style={{ width: "200px" }}
+						disabled={disabled}
+					/>
+				</td>
+				<td>
+					<input
+						ref={quantityRef}
+						type="number"
+						placeholder="0"
+						style={{ width: "60px" }}
+						disabled={disabled}
+					/>
+				</td>
+			</tr>
+			<tr>
+				<td colSpan={2}>
+					<button
+						style={{ width: "100%" }}
+						onClick={onAddItemButtonClick}
+						disabled={disabled}
+					>
+						Add new item
+					</button>
+				</td>
+			</tr>
+		</>
+	);
+};
+
+export interface IInventoryListViewProps {
+	inventoryList: IInventoryList;
+	disabled?: boolean;
+}
+
+export const InventoryListView: FC<IInventoryListViewProps> = (props: IInventoryListViewProps) => {
+	const { inventoryList, disabled } = props;
+
+	const [inventoryItems, setInventoryItems] = useState<IInventoryItem[]>(
+		inventoryList.getItems(),
+	);
+	useEffect(() => {
+		const updateItems = () => {
+			// TODO: This blows away all the inventory items, making the granular add/delete events
+			// not so useful.  Is there a good way to make a more granular change?
+			setInventoryItems(inventoryList.getItems());
+		};
+		inventoryList.on("itemAdded", updateItems);
+		inventoryList.on("itemDeleted", updateItems);
+
+		return () => {
+			inventoryList.off("itemAdded", updateItems);
+			inventoryList.off("itemDeleted", updateItems);
+		};
+	}, [inventoryList]);
+
+	const inventoryItemViews = inventoryItems.map((inventoryItem) => {
+		return (
+			<InventoryItemView
+				key={inventoryItem.id}
+				inventoryItem={inventoryItem}
+				disabled={disabled}
+			/>
+		);
+	});
+
+	return (
+		<table style={{ margin: "0 auto", textAlign: "left", borderCollapse: "collapse" }}>
+			<thead>
+				<tr>
+					<th>Inventory item</th>
+					<th>Quantity</th>
+				</tr>
+			</thead>
+			<tbody>
+				{inventoryItemViews.length > 0 ? (
+					inventoryItemViews
+				) : (
+					<tr>
+						<td colSpan={2}>No items in inventory</td>
+					</tr>
+				)}
+				<AddItemView addItem={inventoryList.addItem} disabled={disabled} />
+			</tbody>
+		</table>
+	);
+};

--- a/examples/apps/tree-comparison/tests/index.html
+++ b/examples/apps/tree-comparison/tests/index.html
@@ -1,0 +1,35 @@
+<!-- Copyright (c) Microsoft Corporation and contributors. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+<!doctype html>
+<html lang="en" style="height: 100%">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Test - InventoryList</title>
+	</head>
+	<body style="margin: 0; height: 100%">
+		<div id="content" style="min-height: 100%; display: flex">
+			<div
+				id="sbs-left"
+				style="
+					flex-grow: 1;
+					width: 50%;
+					border: 1px solid lightgray;
+					box-sizing: border-box;
+					position: relative;
+				"
+			></div>
+			<div
+				id="sbs-right"
+				style="
+					flex-grow: 1;
+					width: 50%;
+					border: 1px solid lightgray;
+					box-sizing: border-box;
+					position: relative;
+				"
+			></div>
+		</div>
+	</body>
+</html>

--- a/examples/apps/tree-comparison/tests/index.tsx
+++ b/examples/apps/tree-comparison/tests/index.tsx
@@ -1,0 +1,99 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { InventoryListContainerRuntimeFactory } from "../src/model";
+import type { IInventoryListAppModel } from "../src/modelInterfaces";
+import { DebugView, InventoryListAppView } from "../src/view";
+
+const updateTabForId = (id: string) => {
+	// Update the URL with the actual ID
+	location.hash = id;
+
+	// Put the ID in the tab title
+	document.title = id;
+};
+
+/**
+ * This is a helper function for loading the page. It's required because getting the Fluid Container
+ * requires making async calls.
+ */
+export async function createContainerAndRenderInElement(element: HTMLDivElement) {
+	const modelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(
+		new StaticCodeLoader(new InventoryListContainerRuntimeFactory()),
+	);
+	let id: string;
+	let model: IInventoryListAppModel;
+
+	if (location.hash.length === 0) {
+		// Normally our code loader is expected to match up with the version passed here.
+		// But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+		// the version doesn't actually matter.
+		const createResponse = await modelLoader.createDetached("one");
+		model = createResponse.model;
+
+		// Should be the same as the uuid we generated above.
+		id = await createResponse.attach();
+	} else {
+		id = location.hash.substring(1);
+		model = await modelLoader.loadExisting(id);
+	}
+
+	const appDiv = document.createElement("div");
+	const debugDiv = document.createElement("div");
+
+	const render = (model: IInventoryListAppModel) => {
+		ReactDOM.unmountComponentAtNode(appDiv);
+		ReactDOM.render(React.createElement(InventoryListAppView, { model }), appDiv);
+
+		// The DebugView is just for demo purposes, to manually control code proposal and inspect the state.
+		ReactDOM.unmountComponentAtNode(debugDiv);
+		ReactDOM.render(
+			React.createElement(DebugView, {
+				model,
+			}),
+			debugDiv,
+		);
+	};
+
+	// update the browser URL and the window title with the actual container ID
+	updateTabForId(id);
+	// Render it
+	render(model);
+
+	element.append(appDiv, debugDiv);
+
+	// Setting "fluidStarted" is just for our test automation
+	// eslint-disable-next-line @typescript-eslint/dot-notation
+	window["fluidStarted"] = true;
+}
+
+/**
+ * For local testing we have two div's that we are rendering into independently.
+ */
+async function setup() {
+	const leftElement = document.getElementById("sbs-left") as HTMLDivElement;
+	if (leftElement === null) {
+		throw new Error("sbs-left does not exist");
+	}
+	await createContainerAndRenderInElement(leftElement);
+	const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
+	if (rightElement === null) {
+		throw new Error("sbs-right does not exist");
+	}
+	await createContainerAndRenderInElement(rightElement);
+}
+
+setup().catch((e) => {
+	console.error(e);
+	console.log(
+		"%cThere were issues setting up and starting the in memory Fluid Server",
+		"font-size:30px",
+	);
+});

--- a/examples/apps/tree-comparison/tests/inventoryList.test.ts
+++ b/examples/apps/tree-comparison/tests/inventoryList.test.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { globals } from "../jest.config";
+
+// Tests disabled -- requires Tinylicious to be running, which our test environment doesn't do.
+describe("inventoryList", () => {
+	beforeAll(async () => {
+		// Wait for the page to load first before running any tests
+		// so this time isn't attributed to the first test
+		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+	}, 45000);
+
+	describe("Smoke test", () => {
+		beforeEach(async () => {
+			await page.goto(globals.PATH, { waitUntil: "load" });
+			await page.waitForFunction(() => window["fluidStarted"]);
+		});
+
+		it("loads and there's an input", async () => {
+			// Validate the input shows up
+			await page.waitForSelector("input");
+		});
+	});
+});

--- a/examples/apps/tree-comparison/tsconfig.json
+++ b/examples/apps/tree-comparison/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"outDir": "lib",
+		"jsx": "react",
+		"types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer", "react"],
+	},
+	"include": ["src/**/*", "tests/**/*"],
+}

--- a/examples/apps/tree-comparison/webpack.config.js
+++ b/examples/apps/tree-comparison/webpack.config.js
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const path = require("path");
+const { merge } = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const webpack = require("webpack");
+// const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+
+module.exports = (env) => {
+	const isProduction = env?.production;
+
+	return merge(
+		{
+			entry: {
+				start: "./src/start.ts",
+			},
+			resolve: {
+				extensions: [".ts", ".tsx", ".js"],
+			},
+			module: {
+				rules: [
+					{
+						test: /\.tsx?$/,
+						loader: "ts-loader",
+					},
+				],
+			},
+			output: {
+				filename: "[name].bundle.js",
+				path: path.resolve(__dirname, "dist"),
+				library: "[name]",
+				// https://github.com/webpack/webpack/issues/5767
+				// https://github.com/webpack/webpack/issues/7939
+				devtoolNamespace: "fluid-example/app-integration-external-data",
+				libraryTarget: "umd",
+			},
+			plugins: [
+				new webpack.ProvidePlugin({
+					process: "process/browser",
+				}),
+				new HtmlWebpackPlugin({
+					template: "./src/index.html",
+				}),
+				// new CleanWebpackPlugin(),
+			],
+		},
+		isProduction ? require("./webpack.prod") : require("./webpack.dev"),
+	);
+};

--- a/examples/apps/tree-comparison/webpack.dev.js
+++ b/examples/apps/tree-comparison/webpack.dev.js
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	mode: "development",
+	devtool: "inline-source-map",
+};

--- a/examples/apps/tree-comparison/webpack.prod.js
+++ b/examples/apps/tree-comparison/webpack.prod.js
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	mode: "production",
+	devtool: "source-map",
+};

--- a/examples/apps/tree-comparison/webpack.test.js
+++ b/examples/apps/tree-comparison/webpack.test.js
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const webpack = require("webpack");
+
+module.exports = (env) => {
+	return {
+		entry: {
+			app: "./tests/index.tsx",
+		},
+		resolve: {
+			extensions: [".ts", ".tsx", ".js"],
+		},
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					loader: "ts-loader",
+				},
+				{
+					test: /\.css$/i,
+					use: ["style-loader", "css-loader"],
+				},
+			],
+		},
+		output: {
+			filename: "[name].bundle.js",
+			path: path.resolve(__dirname, "dist"),
+			library: "[name]",
+			// https://github.com/webpack/webpack/issues/5767
+			// https://github.com/webpack/webpack/issues/7939
+			devtoolNamespace: "fluid-example/draft-js",
+			libraryTarget: "umd",
+		},
+		devServer: {
+			static: {
+				directory: path.join(__dirname, "tests"),
+			},
+		},
+		plugins: [
+			new webpack.ProvidePlugin({
+				process: "process/browser",
+			}),
+			new HtmlWebpackPlugin({
+				template: "./tests/index.html",
+			}),
+		],
+		mode: "development",
+		devtool: "inline-source-map",
+	};
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1015,6 +1015,123 @@ importers:
       webpack-dev-server: 4.6.0_qrfhhavll5uorjbg2snjvnp22u
       webpack-merge: 5.8.0
 
+  examples/apps/tree-comparison:
+    specifiers:
+      '@fluid-example/example-utils': workspace:~
+      '@fluid-experimental/react-inputs': workspace:~
+      '@fluid-experimental/tree': workspace:~
+      '@fluid-experimental/tree2': workspace:~
+      '@fluid-internal/client-utils': workspace:~
+      '@fluid-tools/build-cli': ^0.25.0
+      '@fluidframework/aqueduct': workspace:~
+      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-tools': ^0.25.0
+      '@fluidframework/container-definitions': workspace:~
+      '@fluidframework/container-loader': workspace:~
+      '@fluidframework/container-runtime-definitions': workspace:~
+      '@fluidframework/core-interfaces': workspace:~
+      '@fluidframework/driver-definitions': workspace:~
+      '@fluidframework/driver-utils': workspace:~
+      '@fluidframework/eslint-config-fluid': ^3.0.0
+      '@fluidframework/request-handler': workspace:~
+      '@fluidframework/routerlicious-driver': workspace:~
+      '@fluidframework/runtime-utils': workspace:~
+      '@fluidframework/sequence': workspace:~
+      '@fluidframework/task-manager': workspace:~
+      '@fluidframework/telemetry-utils': workspace:~
+      '@fluidframework/test-tools': ^1.0.195075
+      '@fluidframework/tinylicious-driver': workspace:~
+      '@types/expect-puppeteer': 2.2.1
+      '@types/jest': 29.5.3
+      '@types/jest-environment-puppeteer': 2.2.0
+      '@types/node': ^16.18.38
+      '@types/puppeteer': 1.3.0
+      '@types/react': ^17.0.44
+      '@types/react-dom': ^17.0.18
+      '@types/uuid': ^9.0.2
+      cross-env: ^7.0.3
+      css-loader: ^1.0.0
+      eslint: ~8.50.0
+      events: ^3.1.0
+      html-webpack-plugin: ^5.5.0
+      jest: ^29.6.2
+      jest-junit: ^10.0.0
+      jest-puppeteer: ^6.2.0
+      prettier: ~3.0.3
+      process: ^0.11.10
+      puppeteer: ^17.1.3
+      react: ^17.0.1
+      react-dom: ^17.0.1
+      rimraf: ^4.4.0
+      style-loader: ^1.0.0
+      tiny-typed-emitter: ^2.1.0
+      ts-jest: ^29.1.1
+      ts-loader: ^9.3.0
+      typescript: ~5.1.6
+      uuid: ^9.0.0
+      webpack: ^5.82.0
+      webpack-cli: ^4.9.2
+      webpack-dev-server: ~4.6.0
+      webpack-merge: ^5.8.0
+    dependencies:
+      '@fluid-example/example-utils': link:../../utils/example-utils
+      '@fluid-experimental/react-inputs': link:../../../experimental/framework/react-inputs
+      '@fluid-experimental/tree': link:../../../experimental/dds/tree
+      '@fluid-experimental/tree2': link:../../../experimental/dds/tree2
+      '@fluid-internal/client-utils': link:../../../packages/common/client-utils
+      '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
+      '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
+      '@fluidframework/container-loader': link:../../../packages/loader/container-loader
+      '@fluidframework/container-runtime-definitions': link:../../../packages/runtime/container-runtime-definitions
+      '@fluidframework/core-interfaces': link:../../../packages/common/core-interfaces
+      '@fluidframework/driver-definitions': link:../../../packages/common/driver-definitions
+      '@fluidframework/driver-utils': link:../../../packages/loader/driver-utils
+      '@fluidframework/request-handler': link:../../../packages/framework/request-handler
+      '@fluidframework/routerlicious-driver': link:../../../packages/drivers/routerlicious-driver
+      '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
+      '@fluidframework/sequence': link:../../../packages/dds/sequence
+      '@fluidframework/task-manager': link:../../../packages/dds/task-manager
+      '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
+      '@fluidframework/tinylicious-driver': link:../../../packages/drivers/tinylicious-driver
+      events: 3.3.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tiny-typed-emitter: 2.1.0
+      uuid: 9.0.1
+    devDependencies:
+      '@fluid-tools/build-cli': 0.25.0_ezpnjx26gdvgxsqdwiz4hmz33y
+      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-tools': 0.25.0_ezpnjx26gdvgxsqdwiz4hmz33y
+      '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
+      '@fluidframework/test-tools': 1.0.195075
+      '@types/expect-puppeteer': 2.2.1
+      '@types/jest': 29.5.3
+      '@types/jest-environment-puppeteer': 2.2.0
+      '@types/node': 16.18.53
+      '@types/puppeteer': 1.3.0
+      '@types/react': 17.0.52
+      '@types/react-dom': 17.0.18
+      '@types/uuid': 9.0.2
+      cross-env: 7.0.3
+      css-loader: 1.0.1_webpack@5.88.2
+      eslint: 8.50.0
+      html-webpack-plugin: 5.5.1_webpack@5.88.2
+      jest: 29.6.2_@types+node@16.18.53
+      jest-junit: 10.0.0
+      jest-puppeteer: 6.2.0_puppeteer@17.1.3
+      prettier: 3.0.3
+      process: 0.11.10
+      puppeteer: 17.1.3
+      rimraf: 4.4.1
+      style-loader: 1.3.0_webpack@5.88.2
+      ts-jest: 29.1.1_bd7t4cpe6hueih24owb27fpuam
+      ts-loader: 9.4.2_wlox7xpecxj4rvkt6b6o7frtlu
+      typescript: 5.1.6
+      webpack: 5.88.2_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_ai6cu5vnuisb2akyozxbiaqwvu
+      webpack-dev-server: 4.6.0_w3wu7rcwmvifygnqiqkxwjppse
+      webpack-merge: 5.8.0
+
   examples/benchmarks/bubblebench/baseline:
     specifiers:
       '@fluid-example/bubblebench-common': workspace:~
@@ -16537,6 +16654,63 @@ packages:
       - webpack-cli
     dev: true
 
+  /@fluid-tools/build-cli/0.25.0_ezpnjx26gdvgxsqdwiz4hmz33y:
+    resolution: {integrity: sha512-woQkhL+/4gcuJX69UkdxUWv4pJUM3/wmpxzDG0Lu9vBvEU4fKAdamzB5UsI4DatnaLmaet5ex06TfP8SaxNTtQ==}
+    engines: {node: '>=14.17.0'}
+    hasBin: true
+    dependencies:
+      '@fluid-tools/version-tools': 0.25.0
+      '@fluidframework/build-tools': 0.25.0_ezpnjx26gdvgxsqdwiz4hmz33y
+      '@fluidframework/bundle-size-tools': 0.25.0_webpack-cli@4.10.0
+      '@oclif/core': 2.4.0
+      '@oclif/plugin-autocomplete': 2.3.8
+      '@oclif/plugin-commands': 2.2.25
+      '@oclif/plugin-help': 5.2.19
+      '@oclif/plugin-not-found': 2.4.1
+      '@oclif/plugin-plugins': 3.7.1
+      '@oclif/test': 2.3.28
+      '@octokit/core': 4.2.4
+      '@rushstack/node-core-library': 3.60.0_@types+node@16.18.53
+      async: 3.2.4
+      chalk: 2.4.2
+      danger: 10.9.0_@octokit+core@4.2.4
+      date-fns: 2.30.0
+      execa: 5.1.1
+      fs-extra: 9.1.0
+      globby: 11.1.0
+      gray-matter: 4.0.3
+      human-id: 4.0.0
+      inquirer: 8.2.5
+      jssm: 5.89.2
+      jssm-viz-cli: 5.89.2
+      latest-version: 5.1.0
+      minimatch: 7.4.6
+      node-fetch: 2.7.0
+      npm-check-updates: 16.10.15
+      oclif: 3.9.1
+      prettier: 3.0.3
+      prompts: 2.4.2
+      read-pkg-up: 7.0.1
+      semver: 7.5.4
+      semver-utils: 1.1.4
+      simple-git: 3.19.1
+      sort-json: 2.0.1
+      sort-package-json: 1.57.0
+      strip-ansi: 6.0.1
+      table: 6.8.1
+      type-fest: 2.19.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/node'
+      - bluebird
+      - encoding
+      - esbuild
+      - mem-fs
+      - supports-color
+      - uglify-js
+      - webpack-cli
+    dev: true
+
   /@fluid-tools/fetch-tool/2.0.0-internal.7.0.0:
     resolution: {integrity: sha512-yKVfQbk7ujJAg6+CmMzcg8HW+kctIfrc/4KnXrvmtjGJJNfucEHtkTEQW40DjsF9+tdOAQZZViDyo/zT4yYWXw==}
     hasBin: true
@@ -16989,6 +17163,53 @@ packages:
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.60.0_@types+node@16.18.40
+      async: 3.2.4
+      chalk: 2.4.2
+      commander: 6.2.1
+      cosmiconfig: 8.3.6_typescript@5.1.6
+      danger: 10.9.0_@octokit+core@4.2.4
+      date-fns: 2.30.0
+      debug: 4.3.4
+      detect-indent: 6.1.0
+      execa: 5.1.1
+      find-up: 5.0.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      ignore: 5.2.4
+      json5: 2.2.3
+      lodash: 4.17.21
+      lodash.isequal: 4.5.0
+      lodash.merge: 4.6.2
+      minimatch: 7.4.6
+      replace-in-file: 6.3.5
+      rimraf: 4.4.1
+      semver: 7.5.4
+      shelljs: 0.8.5
+      sort-package-json: 1.57.0
+      ts-morph: 17.0.1
+      type-fest: 2.19.0
+      typescript: 5.1.6
+      yaml: 2.3.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/node'
+      - encoding
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+    dev: true
+
+  /@fluidframework/build-tools/0.25.0_ezpnjx26gdvgxsqdwiz4hmz33y:
+    resolution: {integrity: sha512-+z0JVpteTpDjtQkybVmyvVoxxElt3ueZYiWXhtP6IeWnhIAx+r7E9338dN4xCBsFl+mqUp2KKSX9qhgNteWFLg==}
+    engines: {node: '>=14.17.0'}
+    hasBin: true
+    dependencies:
+      '@fluid-tools/version-tools': 0.25.0
+      '@fluidframework/bundle-size-tools': 0.25.0_webpack-cli@4.10.0
+      '@manypkg/get-packages': 2.2.0
+      '@octokit/core': 4.2.4
+      '@rushstack/node-core-library': 3.60.0_@types+node@16.18.53
       async: 3.2.4
       chalk: 2.4.2
       commander: 6.2.1
@@ -18854,7 +19075,7 @@ packages:
     dependencies:
       '@jest/environment': 29.6.2
       '@jest/expect': 29.6.2
-      '@jest/types': 29.6.1
+      '@jest/types': 29.6.3
       jest-mock: 29.6.2
     transitivePeerDependencies:
       - supports-color
@@ -20569,7 +20790,7 @@ packages:
       - supports-color
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.10_bw64nqwvg33hl7aokjyon4wd5e:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.10_qwmpmonxbjrn34cr3lonpiscue:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -20605,7 +20826,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
       webpack-dev-server: 4.6.0_qrfhhavll5uorjbg2snjvnp22u
     dev: true
 
@@ -21598,29 +21819,29 @@ packages:
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 16.18.38
-      babel-loader: 8.3.0_spm6r2fjendvm5kc54vm4y2hgi
+      '@types/node': 16.18.53
+      babel-loader: 8.3.0_zox4djqyiuykqs7qgskext5kye
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.30.2
-      css-loader: 5.2.7_webpack@5.87.0
-      fork-ts-checker-webpack-plugin: 6.5.3_65527pk6g3aog56bmjhzoekt2i
+      css-loader: 5.2.7_webpack@5.88.2
+      fork-ts-checker-webpack-plugin: 6.5.3_akl3vdtgyyeugw5ehlnrx437rm
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
-      html-webpack-plugin: 5.5.1_webpack@5.87.0
+      html-webpack-plugin: 5.5.1_webpack@5.88.2
       path-browserify: 1.0.1
       process: 0.11.10
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       stable: 0.1.8
-      style-loader: 2.0.0_webpack@5.87.0
-      terser-webpack-plugin: 5.3.8_webpack@5.87.0
+      style-loader: 2.0.0_webpack@5.88.2
+      terser-webpack-plugin: 5.3.8_webpack@5.88.2
       ts-dedent: 2.2.0
       typescript: 5.1.6
       util-deprecate: 1.0.2
-      webpack: 5.87.0_webpack-cli@4.10.0
-      webpack-dev-middleware: 4.3.0_webpack@5.87.0
+      webpack: 5.88.2_webpack-cli@4.10.0
+      webpack-dev-middleware: 4.3.0_webpack@5.88.2
       webpack-hot-middleware: 2.25.3
       webpack-virtual-modules: 0.4.6
     transitivePeerDependencies:
@@ -21719,7 +21940,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.16_bbgzpo3nehcc56hlvwzpj6fvwi:
+  /@storybook/core-client/6.5.16_5npx26362hckf33otlq6krx6mi:
     resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || 17.0.2
@@ -21753,7 +21974,7 @@ packages:
       typescript: 5.1.6
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /@storybook/core-client/6.5.16_ckew2m44drzujokcqnl6nbwrlq:
@@ -21949,7 +22170,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.16_xpnfmd36ybvr6vbku7zs5nndrm:
+  /@storybook/core/6.5.16_7prha2kcb42tpecoyx2ql4icfq:
     resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -21967,13 +22188,13 @@ packages:
         optional: true
     dependencies:
       '@storybook/builder-webpack5': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
-      '@storybook/core-client': 6.5.16_bbgzpo3nehcc56hlvwzpj6fvwi
+      '@storybook/core-client': 6.5.16_5npx26362hckf33otlq6krx6mi
       '@storybook/core-server': 6.5.16_2xw2wsgvvw3gljtfpdguvkoehm
       '@storybook/manager-webpack5': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       typescript: 5.1.6
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - bluebird
@@ -22107,21 +22328,21 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.8
       '@babel/preset-react': 7.18.6_@babel+core@7.21.8
       '@storybook/addons': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-client': 6.5.16_bbgzpo3nehcc56hlvwzpj6fvwi
+      '@storybook/core-client': 6.5.16_5npx26362hckf33otlq6krx6mi
       '@storybook/core-common': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
       '@storybook/node-logger': 6.5.16
       '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/ui': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 16.18.38
-      babel-loader: 8.3.0_spm6r2fjendvm5kc54vm4y2hgi
+      '@types/node': 16.18.53
+      babel-loader: 8.3.0_zox4djqyiuykqs7qgskext5kye
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
       core-js: 3.30.2
-      css-loader: 5.2.7_webpack@5.87.0
+      css-loader: 5.2.7_webpack@5.88.2
       express: 4.18.2
       find-up: 5.0.0
       fs-extra: 9.1.0
-      html-webpack-plugin: 5.5.1_webpack@5.87.0
+      html-webpack-plugin: 5.5.1_webpack@5.88.2
       node-fetch: 2.6.11
       process: 0.11.10
       react: 17.0.2
@@ -22129,14 +22350,14 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
-      style-loader: 2.0.0_webpack@5.87.0
+      style-loader: 2.0.0_webpack@5.88.2
       telejson: 6.0.8
-      terser-webpack-plugin: 5.3.8_webpack@5.87.0
+      terser-webpack-plugin: 5.3.8_webpack@5.88.2
       ts-dedent: 2.2.0
       typescript: 5.1.6
       util-deprecate: 1.0.2
-      webpack: 5.87.0_webpack-cli@4.10.0
-      webpack-dev-middleware: 4.3.0_webpack@5.87.0
+      webpack: 5.88.2_webpack-cli@4.10.0
+      webpack-dev-middleware: 4.3.0_webpack@5.88.2
       webpack-virtual-modules: 0.4.6
     transitivePeerDependencies:
       - '@swc/core'
@@ -22230,7 +22451,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_lzoc5dymzawnmbeuuundb75q2q:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_wlox7xpecxj4rvkt6b6o7frtlu:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -22244,7 +22465,7 @@ packages:
       react-docgen-typescript: 2.2.2_typescript@5.1.6
       tslib: 2.6.2
       typescript: 5.1.6
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22280,21 +22501,21 @@ packages:
       '@babel/core': 7.21.8
       '@babel/preset-flow': 7.21.4_@babel+core@7.21.8
       '@babel/preset-react': 7.18.6_@babel+core@7.21.8
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_bw64nqwvg33hl7aokjyon4wd5e
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_qwmpmonxbjrn34cr3lonpiscue
       '@storybook/addons': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/builder-webpack5': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
       '@storybook/client-logger': 6.5.16
-      '@storybook/core': 6.5.16_xpnfmd36ybvr6vbku7zs5nndrm
+      '@storybook/core': 6.5.16_7prha2kcb42tpecoyx2ql4icfq
       '@storybook/core-common': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/manager-webpack5': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
       '@storybook/node-logger': 6.5.16
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_lzoc5dymzawnmbeuuundb75q2q
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_wlox7xpecxj4rvkt6b6o7frtlu
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@types/estree': 0.0.51
-      '@types/node': 16.18.38
+      '@types/node': 16.18.53
       '@types/webpack-env': 1.18.0
       acorn: 7.4.1
       acorn-jsx: 5.3.2_acorn@7.4.1
@@ -22318,7 +22539,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 5.1.6
       util-deprecate: 1.0.2
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - '@swc/core'
@@ -22680,7 +22901,7 @@ packages:
   /@types/cheerio/0.22.31:
     resolution: {integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==}
     dependencies:
-      '@types/node': 16.18.38
+      '@types/node': 16.18.53
     dev: true
 
   /@types/chrome/0.0.232:
@@ -22712,7 +22933,7 @@ packages:
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 16.18.40
+      '@types/node': 16.18.53
 
   /@types/d3-array/3.0.5:
     resolution: {integrity: sha512-Qk7fpJ6qFp+26VeQ47WY0mkwXaiq8+76RJcncDEfMc2ocRzXLO67bLFRNI4OX1aGBoPzsM5Y2T+/m1pldOgD+A==}
@@ -22860,7 +23081,7 @@ packages:
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 16.18.38
+      '@types/node': 16.18.53
     dev: true
 
   /@types/glob/7.2.0:
@@ -23025,7 +23246,7 @@ packages:
   /@types/loader-utils/1.1.6:
     resolution: {integrity: sha512-0U4S5kLpm3Cu9YkO46JrmujS2abL2tWsxA1SR8km6X0a1E96tfPu34zRdQSZsJ6dfRYwQpmuKmy9Mx2Od7AXag==}
     dependencies:
-      '@types/node': 16.18.38
+      '@types/node': 16.18.53
       '@types/webpack': 4.41.33
     dev: true
 
@@ -23093,7 +23314,7 @@ packages:
   /@types/node-fetch/2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 16.18.38
+      '@types/node': 16.18.53
       form-data: 3.0.1
     dev: true
 
@@ -23103,6 +23324,7 @@ packages:
 
   /@types/node/16.18.40:
     resolution: {integrity: sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA==}
+    dev: true
 
   /@types/node/16.18.53:
     resolution: {integrity: sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==}
@@ -23165,8 +23387,8 @@ packages:
   /@types/puppeteer/1.3.0:
     resolution: {integrity: sha512-kp1R8cTYymvYezTYWSECtSEDbxnCQaNe3i+fdsZh3dVz7umB8q6LATv0VdJp1DT0evS8YqCrFI5+DaDYJYo6Vg==}
     dependencies:
-      '@types/events': 3.0.0
-      '@types/node': 16.18.40
+      '@types/events': 3.0.1
+      '@types/node': 16.18.53
     dev: true
 
   /@types/q/1.5.5:
@@ -23246,7 +23468,7 @@ packages:
   /@types/sha.js/2.4.0:
     resolution: {integrity: sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==}
     dependencies:
-      '@types/node': 16.18.40
+      '@types/node': 16.18.53
     dev: true
 
   /@types/shelljs/0.8.12:
@@ -23983,6 +24205,16 @@ packages:
     dependencies:
       webpack: 5.83.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_dfe3q2c2dnof5cignr4xxddwka
+
+  /@webpack-cli/configtest/1.2.0_w3wu7rcwmvifygnqiqkxwjppse:
+    resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
+    peerDependencies:
+      webpack: 4.x.x || 5.x.x || ^5.82.0
+      webpack-cli: 4.x.x
+    dependencies:
+      webpack: 5.88.2_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_ai6cu5vnuisb2akyozxbiaqwvu
+    dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -25104,7 +25336,7 @@ packages:
       webpack: 5.83.0
     dev: true
 
-  /babel-loader/8.3.0_spm6r2fjendvm5kc54vm4y2hgi:
+  /babel-loader/8.3.0_zox4djqyiuykqs7qgskext5kye:
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -25116,7 +25348,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /babel-messages/6.23.0:
@@ -27502,6 +27734,27 @@ packages:
       source-list-map: 2.0.1
       webpack: 5.83.0_webpack-cli@4.10.0
 
+  /css-loader/1.0.1_webpack@5.88.2:
+    resolution: {integrity: sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==}
+    engines: {node: '>= 6.9.0 <7.0.0 || >= 8.9.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.82.0
+    dependencies:
+      babel-code-frame: 6.26.0
+      css-selector-tokenizer: 0.7.3
+      icss-utils: 2.1.0
+      loader-utils: 1.4.2
+      lodash: 4.17.21
+      postcss: 6.0.23
+      postcss-modules-extract-imports: 1.2.1
+      postcss-modules-local-by-default: 1.2.0
+      postcss-modules-scope: 1.1.0
+      postcss-modules-values: 1.3.0
+      postcss-value-parser: 3.3.1
+      source-list-map: 2.0.1
+      webpack: 5.88.2_webpack-cli@4.10.0
+    dev: true
+
   /css-loader/3.6.0_webpack@4.47.0:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
@@ -27524,23 +27777,23 @@ packages:
       webpack: 4.47.0_webpack-cli@4.10.0
     dev: true
 
-  /css-loader/5.2.7_webpack@5.87.0:
+  /css-loader/5.2.7_webpack@5.88.2:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       webpack: ^4.27.0 || ^5.0.0 || ^5.82.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.23
+      icss-utils: 5.1.0_postcss@8.4.28
       loader-utils: 2.0.4
-      postcss: 8.4.23
-      postcss-modules-extract-imports: 3.0.0_postcss@8.4.23
-      postcss-modules-local-by-default: 4.0.0_postcss@8.4.23
-      postcss-modules-scope: 3.0.0_postcss@8.4.23
-      postcss-modules-values: 4.0.0_postcss@8.4.23
+      postcss: 8.4.28
+      postcss-modules-extract-imports: 3.0.0_postcss@8.4.28
+      postcss-modules-local-by-default: 4.0.0_postcss@8.4.28
+      postcss-modules-scope: 3.0.0_postcss@8.4.28
+      postcss-modules-values: 4.0.0_postcss@8.4.28
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.5.4
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /css-select-base-adapter/0.1.1:
@@ -30229,7 +30482,7 @@ packages:
       jest-get-type: 29.4.3
       jest-matcher-utils: 29.6.2
       jest-message-util: 29.6.2
-      jest-util: 29.6.2
+      jest-util: 29.7.0
     dev: true
 
   /express-http-proxy/1.5.1:
@@ -30995,7 +31248,7 @@ packages:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.3_65527pk6g3aog56bmjhzoekt2i:
+  /fork-ts-checker-webpack-plugin/6.5.3_akl3vdtgyyeugw5ehlnrx437rm:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -31024,7 +31277,7 @@ packages:
       semver: 7.5.4
       tapable: 1.1.3
       typescript: 5.1.6
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /fork-ts-checker-webpack-plugin/6.5.3_b24uacssrbpw3jh3dz5nca7j6a:
@@ -31738,7 +31991,7 @@ packages:
       picomatch: 2.3.1
       strip-json-comments: 3.1.1
       tsconfig-paths: 3.14.2
-      typescript: 4.5.5
+      typescript: 4.9.5
     dev: true
 
   /gopd/1.0.1:
@@ -32287,7 +32540,7 @@ packages:
       webpack: 5.83.0_webpack-cli@4.10.0
     dev: true
 
-  /html-webpack-plugin/5.5.1_webpack@5.87.0:
+  /html-webpack-plugin/5.5.1_webpack@5.88.2:
     resolution: {integrity: sha512-cTUzZ1+NqjGEKjmVgZKLMdiFg3m9MdRXkZW2OEe69WYVi5ONLMmlnSZdXzGGMOq0C8jGDrL6EWyEDDUioHO/pA==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -32298,7 +32551,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /htmlparser2/3.10.1:
@@ -32634,13 +32887,13 @@ packages:
       postcss: 7.0.39
     dev: true
 
-  /icss-utils/5.1.0_postcss@8.4.23:
+  /icss-utils/5.1.0_postcss@8.4.28:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.23
+      postcss: 8.4.28
     dev: true
 
   /idb/6.1.5:
@@ -33755,7 +34008,7 @@ packages:
       '@jest/environment': 29.6.2
       '@jest/expect': 29.6.2
       '@jest/test-result': 29.6.2
-      '@jest/types': 29.6.1
+      '@jest/types': 29.6.3
       '@types/node': 16.18.53
       chalk: 4.1.2
       co: 4.6.0
@@ -33766,7 +34019,7 @@ packages:
       jest-message-util: 29.6.2
       jest-runtime: 29.6.2
       jest-snapshot: 29.6.2
-      jest-util: 29.6.2
+      jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.6.2
       pure-rand: 6.0.2
@@ -33882,6 +34135,35 @@ packages:
       graceful-fs: 4.2.11
       import-local: 3.1.0
       jest-config: 29.6.2_@types+node@16.18.40
+      jest-util: 29.6.2
+      jest-validate: 29.6.2
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest-cli/29.6.2_@types+node@16.18.53:
+    resolution: {integrity: sha512-TT6O247v6dCEX2UGHGyflMpxhnrL0DNqP2fRTKYm3nJJpCTfXX3GCMQPGFjXDoj0i5/Blp3jriKXFgdfmbYB6Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.6.2
+      '@jest/test-result': 29.6.2
+      '@jest/types': 29.6.1
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.6.2_@types+node@16.18.53
       jest-util: 29.6.2
       jest-validate: 29.6.2
       prompts: 2.4.2
@@ -34199,10 +34481,10 @@ packages:
     resolution: {integrity: sha512-MsrsqA0Ia99cIpABBc3izS1ZYoYfhIy0NNWqPSE0YXbQjwchyt6B1HD2khzyPe1WiJA7hbxXy77ZoUQxn8UlSw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.6.1
+      '@jest/types': 29.6.3
       chalk: 4.1.2
       jest-get-type: 29.4.3
-      jest-util: 29.6.2
+      jest-util: 29.7.0
       pretty-format: 29.6.2
     dev: true
 
@@ -34219,7 +34501,7 @@ packages:
       '@jest/fake-timers': 29.6.2
       '@jest/types': 29.6.1
       '@types/jsdom': 20.0.1
-      '@types/node': 16.18.40
+      '@types/node': 16.18.53
       jest-mock: 29.6.2
       jest-util: 29.6.2
       jsdom: 20.0.3
@@ -34247,10 +34529,10 @@ packages:
     dependencies:
       '@jest/environment': 29.6.2
       '@jest/fake-timers': 29.6.2
-      '@jest/types': 29.6.1
+      '@jest/types': 29.6.3
       '@types/node': 16.18.53
       jest-mock: 29.6.2
-      jest-util: 29.6.2
+      jest-util: 29.7.0
     dev: true
 
   /jest-environment-puppeteer/4.4.0:
@@ -34780,6 +35062,27 @@ packages:
       '@jest/types': 29.6.1
       import-local: 3.1.0
       jest-cli: 29.6.2_@types+node@16.18.40
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest/29.6.2_@types+node@16.18.53:
+    resolution: {integrity: sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.6.2
+      '@jest/types': 29.6.1
+      import-local: 3.1.0
+      jest-cli: 29.6.2_@types+node@16.18.53
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39061,13 +39364,13 @@ packages:
       postcss: 7.0.39
     dev: true
 
-  /postcss-modules-extract-imports/3.0.0_postcss@8.4.23:
+  /postcss-modules-extract-imports/3.0.0_postcss@8.4.28:
     resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.23
+      postcss: 8.4.28
     dev: true
 
   /postcss-modules-local-by-default/1.2.0:
@@ -39086,14 +39389,14 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-modules-local-by-default/4.0.0_postcss@8.4.23:
+  /postcss-modules-local-by-default/4.0.0_postcss@8.4.28:
     resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.23
-      postcss: 8.4.23
+      icss-utils: 5.1.0_postcss@8.4.28
+      postcss: 8.4.28
       postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
     dev: true
@@ -39112,13 +39415,13 @@ packages:
       postcss-selector-parser: 6.0.13
     dev: true
 
-  /postcss-modules-scope/3.0.0_postcss@8.4.23:
+  /postcss-modules-scope/3.0.0_postcss@8.4.28:
     resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.23
+      postcss: 8.4.28
       postcss-selector-parser: 6.0.13
     dev: true
 
@@ -39135,14 +39438,14 @@ packages:
       postcss: 7.0.39
     dev: true
 
-  /postcss-modules-values/4.0.0_postcss@8.4.23:
+  /postcss-modules-values/4.0.0_postcss@8.4.28:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.23
-      postcss: 8.4.23
+      icss-utils: 5.1.0_postcss@8.4.28
+      postcss: 8.4.28
     dev: true
 
   /postcss-prefix-selector/1.16.0_postcss@5.2.18:
@@ -39192,15 +39495,6 @@ packages:
     dependencies:
       picocolors: 0.2.1
       source-map: 0.6.1
-    dev: true
-
-  /postcss/8.4.23:
-    resolution: {integrity: sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
     dev: true
 
   /postcss/8.4.28:
@@ -39355,7 +39649,7 @@ packages:
     resolution: {integrity: sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.6.0
+      '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -42824,7 +43118,18 @@ packages:
       schema-utils: 2.7.1
       webpack: 5.83.0_webpack-cli@4.10.0
 
-  /style-loader/2.0.0_webpack@5.87.0:
+  /style-loader/1.3.0_webpack@5.88.2:
+    resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}
+    engines: {node: '>= 8.9.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0 || ^5.82.0
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 2.7.1
+      webpack: 5.88.2_webpack-cli@4.10.0
+    dev: true
+
+  /style-loader/2.0.0_webpack@5.88.2:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -42832,7 +43137,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /style-to-object/0.3.0:
@@ -43223,7 +43528,7 @@ packages:
       terser: 5.20.0
       webpack: 5.83.0_webpack-cli@4.10.0
 
-  /terser-webpack-plugin/5.3.8_webpack@5.87.0:
+  /terser-webpack-plugin/5.3.8_webpack@5.88.2:
     resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -43244,31 +43549,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.20.0
-      webpack: 5.87.0_webpack-cli@4.10.0
-    dev: true
-
-  /terser-webpack-plugin/5.3.9_webpack@5.87.0:
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0 || ^5.82.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.19
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.20.0
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /terser-webpack-plugin/5.3.9_webpack@5.88.2:
@@ -43411,6 +43692,10 @@ packages:
       es5-ext: 0.10.62
       next-tick: 1.1.0
     dev: true
+
+  /tiny-typed-emitter/2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
+    dev: false
 
   /tiny-warning/1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
@@ -43718,6 +44003,21 @@ packages:
       semver: 7.5.1
       typescript: 5.1.6
       webpack: 5.83.0_webpack-cli@4.10.0
+    dev: true
+
+  /ts-loader/9.4.2_wlox7xpecxj4rvkt6b6o7frtlu:
+    resolution: {integrity: sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      typescript: '*'
+      webpack: ^5.0.0 || ^5.82.0
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.14.0
+      micromatch: 4.0.5
+      semver: 7.5.1
+      typescript: 5.1.6
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /ts-morph/17.0.1:
@@ -45185,6 +45485,42 @@ packages:
       - utf-8-validate
     dev: true
 
+  /webpack-cli/4.10.0_ai6cu5vnuisb2akyozxbiaqwvu:
+    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@webpack-cli/generators': '*'
+      '@webpack-cli/migrate': '*'
+      webpack: 4.x.x || 5.x.x || ^5.82.0
+      webpack-bundle-analyzer: '*'
+      webpack-dev-server: '*'
+    peerDependenciesMeta:
+      '@webpack-cli/generators':
+        optional: true
+      '@webpack-cli/migrate':
+        optional: true
+      webpack-bundle-analyzer:
+        optional: true
+      webpack-dev-server:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@webpack-cli/configtest': 1.2.0_w3wu7rcwmvifygnqiqkxwjppse
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_hxwqhfj3xkkgp5omnyg2m7pnsm
+      colorette: 2.0.20
+      commander: 7.2.0
+      cross-spawn: 7.0.3
+      fastest-levenshtein: 1.0.16
+      import-local: 3.1.0
+      interpret: 2.2.0
+      rechoir: 0.7.1
+      webpack: 5.88.2_webpack-cli@4.10.0
+      webpack-dev-server: 4.6.0_w3wu7rcwmvifygnqiqkxwjppse
+      webpack-merge: 5.8.0
+    dev: true
+
   /webpack-cli/4.10.0_dfe3q2c2dnof5cignr4xxddwka:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
     engines: {node: '>=10.13.0'}
@@ -45342,7 +45678,7 @@ packages:
       webpack-log: 2.0.0
     dev: true
 
-  /webpack-dev-middleware/4.3.0_webpack@5.87.0:
+  /webpack-dev-middleware/4.3.0_webpack@5.88.2:
     resolution: {integrity: sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==}
     engines: {node: '>= v10.23.3'}
     peerDependencies:
@@ -45354,7 +45690,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 3.3.0
-      webpack: 5.87.0_webpack-cli@4.10.0
+      webpack: 5.88.2_webpack-cli@4.10.0
     dev: true
 
   /webpack-dev-middleware/5.3.3_webpack@5.83.0:
@@ -45369,6 +45705,20 @@ packages:
       range-parser: 1.2.1
       schema-utils: 4.0.1
       webpack: 5.83.0_webpack-cli@4.10.0
+
+  /webpack-dev-middleware/5.3.3_webpack@5.88.2:
+    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0 || ^5.82.0
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.1
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.0.1
+      webpack: 5.88.2_webpack-cli@4.10.0
+    dev: true
 
   /webpack-dev-server/4.6.0_jwgjd6qujecmgjcspzyejei2g4:
     resolution: {integrity: sha512-oojcBIKvx3Ya7qs1/AVWHDgmP1Xml8rGsEBnSobxU/UJSX1xP1GPM3MwsAnDzvqcVmVki8tV7lbcsjEjk0PtYg==}
@@ -45505,6 +45855,52 @@ packages:
       - debug
       - supports-color
       - utf-8-validate
+
+  /webpack-dev-server/4.6.0_w3wu7rcwmvifygnqiqkxwjppse:
+    resolution: {integrity: sha512-oojcBIKvx3Ya7qs1/AVWHDgmP1Xml8rGsEBnSobxU/UJSX1xP1GPM3MwsAnDzvqcVmVki8tV7lbcsjEjk0PtYg==}
+    engines: {node: '>= 12.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack: ^4.37.0 || ^5.0.0 || ^5.82.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      ansi-html-community: 0.0.8
+      bonjour: 3.5.0
+      chokidar: 3.5.3
+      colorette: 2.0.20
+      compression: 1.7.4
+      connect-history-api-fallback: 1.6.0
+      default-gateway: 6.0.3
+      del: 6.1.1
+      express: 4.18.2
+      graceful-fs: 4.2.11
+      html-entities: 2.3.3
+      http-proxy-middleware: 2.0.6
+      ipaddr.js: 2.0.1
+      open: 8.4.2
+      p-retry: 4.6.2
+      portfinder: 1.0.32
+      schema-utils: 4.0.1
+      selfsigned: 1.10.14
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      strip-ansi: 7.0.1
+      url: 0.11.0
+      webpack: 5.88.2_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_ai6cu5vnuisb2akyozxbiaqwvu
+      webpack-dev-middleware: 5.3.3_webpack@5.88.2
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - '@types/express'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    dev: true
 
   /webpack-filter-warnings-plugin/1.2.1_webpack@4.47.0:
     resolution: {integrity: sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==}
@@ -45681,47 +46077,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-
-  /webpack/5.87.0_webpack-cli@4.10.0:
-    resolution: {integrity: sha512-GOu1tNbQ7p1bDEoFRs2YPcfyGs8xq52yyPBZ3m2VGnXGtV9MxjrkABHm4V9Ia280OefsSLzvbVoXcfLxjKY/Iw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0_acorn@8.10.0
-      browserslist: 4.21.11
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9_webpack@5.87.0
-      watchpack: 2.4.0
-      webpack-cli: 4.10.0_dfe3q2c2dnof5cignr4xxddwka
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: true
 
   /webpack/5.88.2:
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}


### PR DESCRIPTION
In #17568 I modified the inventory-app demo to explore usage of both legacy and new SharedTree API surface directly.  @CraigMacomber suggested doing this separate from the existing demo - this PR is that separate demo.

The content is now closer to the demo that we use in the version-migration set (which will be nice, since ultimately this demo will be the starting point of the migration-shim demo to demo tree migration).  This also lets it explore tree modifications like insert/remove (whereas the inventory-app is only modifying payload), and additional eventing scenarios as a result.

As before, I've marked with `REV:` comments where I'd particularly like feedback or hit interesting issues.

<img width="416" alt="Screenshot 2023-10-11 at 7 02 48 PM" src="https://github.com/microsoft/FluidFramework/assets/4276348/a427fb0e-c52e-4219-948f-093d92f1b6e8">

[AB#5657](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5657)