### PR TITLE
fix (server): Add @internal tag to new APIs

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -94,7 +94,7 @@ export function generateUser(): IUser;
 // @public (undocumented)
 export const getAuthorizationTokenFromCredentials: (credentials: ICredentials) => string;
 
-// @internal (undocumented)
+// @internal
 export const getGlobalTimeoutContext: () => ITimeoutContext;
 
 // @public (undocumented)
@@ -397,7 +397,7 @@ export interface ISummaryUploadManager {
     writeSummaryTree(summaryTree: api.ISummaryTree, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
 }
 
-// @internal (undocumented)
+// @internal
 export interface ITimeoutContext {
     bindTimeout(maxDurationMs: number, callback: () => void): void;
     bindTimeoutAsync<T>(maxDurationMs: number, callback: () => Promise<T>): Promise<T>;
@@ -588,7 +588,7 @@ export abstract class RestWrapper {
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 }
 
-// @internal (undocumented)
+// @internal
 export const setGlobalTimeoutContext: (timeoutContext: ITimeoutContext) => void;
 
 // @public

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -94,7 +94,7 @@ export function generateUser(): IUser;
 // @public (undocumented)
 export const getAuthorizationTokenFromCredentials: (credentials: ICredentials) => string;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const getGlobalTimeoutContext: () => ITimeoutContext;
 
 // @public (undocumented)
@@ -397,7 +397,7 @@ export interface ISummaryUploadManager {
     writeSummaryTree(summaryTree: api.ISummaryTree, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface ITimeoutContext {
     bindTimeout(maxDurationMs: number, callback: () => void): void;
     bindTimeoutAsync<T>(maxDurationMs: number, callback: () => Promise<T>): Promise<T>;
@@ -588,7 +588,7 @@ export abstract class RestWrapper {
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const setGlobalTimeoutContext: (timeoutContext: ITimeoutContext) => void;
 
 // @public

--- a/server/routerlicious/packages/services-client/src/timeoutContext.ts
+++ b/server/routerlicious/packages/services-client/src/timeoutContext.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Binds and tracks timeout info through a given codepath.
+ * The timeout can be checked manually to stop exit out of the codepath if the timeout has been exceeded.
+ *
+ * @internal
+ */
 export interface ITimeoutContext {
 	/**
 	 * Attaches timeout info to the callback context.
@@ -39,9 +45,20 @@ const nullTimeoutContext = new NullTimeoutContext();
 declare var global: typeof globalThis;
 export const getGlobal = (): any => (typeof window !== "undefined" ? window : global);
 
+/**
+ * Retrieves the global ITimeoutContext instance if available.
+ * If not available, returns a NullTimeoutContext instance which behaves as a no-op.
+ *
+ * @internal
+ */
 export const getGlobalTimeoutContext = () =>
 	(getGlobal()?.timeoutContext as ITimeoutContext | undefined) ?? nullTimeoutContext;
 
+/**
+ * Sets the global ITimeoutContext instance.
+ *
+ * @internal
+ */
 export const setGlobalTimeoutContext = (timeoutContext: ITimeoutContext) => {
 	if (!getGlobal()) return;
 	getGlobal().timeoutContext = timeoutContext;


### PR DESCRIPTION
## Description

Tagging newly added internal APIs with the `@internal` decorator.

Follow up from https://github.com/microsoft/FluidFramework/pull/17730
