### PR TITLE
improvement(build-common): Update default untrimmed rollup module name

### DIFF
--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -39,7 +39,7 @@
 		"alphaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-alpha.d.ts",
 		"betaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-beta.d.ts",
 		"publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts",
-		"untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts"
+		"untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-untrimmed.d.ts"
 	},
 
 	/**

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-common",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "Package containing common configs",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Updates the default file naming to include a `-untrimmed` postfix.

The primary motivation here is to avoid potential name collisions with actual modules in a given package. E.g. A package whose unscoped name is `sequence` with a module called `sequence.ts` at its root (see [here](https://github.com/microsoft/FluidFramework/pull/17734/files#diff-301a9986eb983bbf96e1a7015104f6dd096f01582bca59af652241958cfbc07e)). It is not uncommon for packages to include a module with the same name, so this should hopefully prevent conflicts.