### PR TITLE
Remove AbortSignal casts

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -115,17 +115,6 @@ function isClientMessage(message: ISequencedDocumentMessage | IDocumentMessage):
 }
 
 /**
- * Type is used to cast AbortController to represent new version of DOM API and prevent build issues
- * TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
- */
-type AbortControllerReal = AbortController & { abort(reason?: any): void };
-/**
- * Type is used to cast AbortSignal to represent new version of DOM API and prevent build issues
- * TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
- */
-type AbortSignalReal = AbortSignal & { reason: any };
-
-/**
  * Manages the flow of both inbound and outbound messages. This class ensures that shared objects receive delta
  * messages in order regardless of possible network conditions or timings causing out of order delivery.
  */
@@ -667,8 +656,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			// This is useless for known ranges (to is defined) as it means request is over either way.
 			// And it will cancel unbound request too early, not allowing us to learn where the end of the file is.
 			if (!opsFromFetch && cancelFetch(op)) {
-				// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-				(controller as AbortControllerReal).abort("DeltaManager getDeltas fetch cancelled");
+				controller.abort("DeltaManager getDeltas fetch cancelled");
 				this._inbound.off("push", opListener);
 			}
 		};
@@ -677,10 +665,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			this._inbound.on("push", opListener);
 			assert(this.closeAbortController.signal.onabort === null, 0x1e8 /* "reentrancy" */);
 			this.closeAbortController.signal.onabort = () =>
-				// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-				(controller as AbortControllerReal).abort(
-					(this.closeAbortController.signal as AbortSignalReal).reason,
-				);
+				controller.abort(this.closeAbortController.signal.reason);
 
 			const stream = this.deltaStorage.fetchMessages(
 				from, // inclusive
@@ -708,8 +693,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				this.logger.sendTelemetryEvent({
 					eventName: "DeltaManager_GetDeltasAborted",
 					fetchReason,
-					// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-					reason: (controller.signal as AbortSignalReal).reason,
+					reason: controller.signal.reason,
 				});
 			}
 			this.closeAbortController.signal.onabort = null;
@@ -766,8 +750,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	private clearQueues() {
-		// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-		(this.closeAbortController as AbortControllerReal).abort("DeltaManager is closed");
+		this.closeAbortController.abort("DeltaManager is closed");
 
 		this._inbound.clear();
 		this._inboundSignal.clear();

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -518,10 +518,7 @@ describe("Loader", () => {
 									};
 								});
 
-								throw new Error(
-									// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-									(abortSignal as AbortSignal & { reason: any }).reason,
-								);
+								throw new Error(abortSignal?.reason);
 							},
 						};
 					},

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -81,8 +81,7 @@ export async function runWithRetry<T>(
 						retry: numRetries,
 						duration: performance.now() - startTime,
 						fetchCallName,
-						// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-						reason: (progress.cancel as AbortSignal & { reason: any }).reason,
+						reason: progress.cancel.reason,
 					},
 					err,
 				);
@@ -92,8 +91,7 @@ export async function runWithRetry<T>(
 					{
 						driverVersion: pkgVersion,
 						fetchCallName,
-						// TODO: Remove when typescript version of the repo contains the AbortSignal.reason property (AB#5045)
-						reason: (progress.cancel as AbortSignal & { reason: any }).reason,
+						reason: progress.cancel.reason,
 					},
 				);
 			}


### PR DESCRIPTION
Typescript version has been upgraded, so we no longer need to cast the AbortSignal/AbortController types

[AB#5045](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5045)