### PR TITLE
refactor(tree2): Remove redundant assert

### DIFF
--- a/experimental/dds/tree2/src/core/tree/anchorSet.ts
+++ b/experimental/dds/tree2/src/core/tree/anchorSet.ts
@@ -858,7 +858,6 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents>, AnchorLoca
 					this.pathVisitors.delete(p);
 				});
 				const parent = this.parent;
-				assert(parent !== undefined, 0x769 /* Unable to exit root node */);
 				this.parentField = parent.parentField;
 				this.parent = parent.parent;
 			},

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1352,7 +1352,6 @@ export const shortCodeMap = {
 	"0x766": "proposalHandle should be available",
 	"0x767": "Must release existing visitor before acquiring another",
 	"0x768": "Multiple free calls for same visitor",
-	"0x769": "Unable to exit root node",
 	"0x76a": "Must release existing visitor before acquiring another",
 	"0x76b": "Multiple free calls for same visitor",
 	"0x76c": "Must release existing visitor before acquiring another",


### PR DESCRIPTION
## Description

Removes what seems to be a redundant assert (original discussion [here](https://github.com/microsoft/FluidFramework/pull/17724#discussion_r1355835074)) when exiting a node in a delta visitor. The assert on line 855 validates the same object reference against undefined, and the code in between shouldn't change `this.parent`.

@jenn-le double checking that this isn't handling some edge case or something you found in https://github.com/microsoft/FluidFramework/pull/17163?

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

