### PR TITLE
refactor(build-tools): Enable unicorn/prefer-node-protocol lint rule

### DIFF
--- a/build-tools/packages/build-cli/.eslintrc.cjs
+++ b/build-tools/packages/build-cli/.eslintrc.cjs
@@ -44,9 +44,6 @@ module.exports = {
 		// The default for this rule is 4, but 5 is better
 		"max-params": ["warn", 5],
 
-		// Causes issues with some versions of node
-		"unicorn/prefer-node-protocol": "off",
-
 		// Too strict for our needs
 		"unicorn/filename-case": "off",
 

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { Flags } from "@oclif/core";
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import * as semver from "semver";

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 import { Flags } from "@oclif/core";
-import * as childProcess from "child_process";
-import * as fs from "fs";
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs";
 import { readJson } from "fs-extra";
-import { EOL as newline } from "os";
-import path from "path";
+import { EOL as newline } from "node:os";
+import path from "node:path";
 
 import { getFluidBuildConfig, Handler, policyHandlers } from "@fluidframework/build-tools";
 

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 import { Flags } from "@oclif/core";
-import * as childProcess from "child_process";
-import * as fs from "fs";
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs";
 
 import { getIsLatest, getSimpleVersion } from "@fluid-tools/version-tools";
 

--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -4,7 +4,7 @@
  */
 import { Flags } from "@oclif/core";
 import { copySync, existsSync, readJson } from "fs-extra";
-import path from "path";
+import path from "node:path";
 
 import { BaseCommand } from "../../base";
 import { PnpmListEntry, pnpmList } from "../../pnpm";

--- a/build-tools/packages/build-cli/src/commands/generate/changelog.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changelog.ts
@@ -7,7 +7,7 @@ import { Package, FluidRepo } from "@fluidframework/build-tools";
 import { fromInternalScheme, isInternalVersionScheme } from "@fluid-tools/version-tools";
 import { Flags } from "@oclif/core";
 import { command as execCommand } from "execa";
-import { readFile, writeFile } from "fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { inc } from "semver";
 import { CleanOptions } from "simple-git";
 

--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -4,7 +4,7 @@
  */
 
 import fetch from "node-fetch";
-import * as fs from "fs/promises";
+import * as fs from "node:fs/promises";
 import { Flags } from "@oclif/core";
 import { Logger } from "@fluidframework/build-tools";
 import { BaseCommand } from "../../base";

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 import { ux, Flags, Command } from "@oclif/core";
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import chalk from "chalk";
 import { differenceInBusinessDays, formatDistanceToNow } from "date-fns";
 import { writeJson } from "fs-extra";
 import inquirer from "inquirer";
-import path from "path";
+import path from "node:path";
 import sortJson from "sort-json";
 import { table } from "table";
 

--- a/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts
+++ b/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts
@@ -9,7 +9,7 @@ import { ExtractorConfig } from "@microsoft/api-extractor";
 import { CommandLogger } from "../../logging";
 import path from "node:path";
 import { strict as assert } from "node:assert";
-import * as fs from "fs";
+import * as fs from "node:fs";
 
 /**
  * Represents a list of package categorized into two arrays

--- a/build-tools/packages/build-cli/src/commands/run/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/run/bundleStats.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 import { Flags } from "@oclif/core";
-import { execSync } from "child_process";
-import path from "path";
+import { execSync } from "node:child_process";
+import path from "node:path";
 
 import { BaseCommand } from "../../base";
 

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import execa from "execa";
 import inquirer from "inquirer";
 import { Machine } from "jssm";

--- a/build-tools/packages/build-cli/src/handlers/doFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/doFunctions.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import chalk from "chalk";
 import { Machine } from "jssm";
 

--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -22,7 +22,7 @@ import {
 	isWorkspaceRange,
 } from "@fluid-tools/version-tools";
 import { PackageName } from "@rushstack/node-core-library";
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import { compareDesc, differenceInBusinessDays } from "date-fns";
 import execa from "execa";
 import { readJson, readJsonSync, writeFile } from "fs-extra";
@@ -30,7 +30,7 @@ import latestVersion from "latest-version";
 import ncu from "npm-check-updates";
 import type { Index } from "npm-check-updates/build/src/types/IndexType";
 import { VersionSpec } from "npm-check-updates/build/src/types/VersionSpec";
-import path from "path";
+import path from "node:path";
 import { format as prettier, resolveConfig as resolvePrettierConfig } from "prettier";
 import * as semver from "semver";
 

--- a/build-tools/packages/build-cli/src/machines/fluidReleaseMachine.ts
+++ b/build-tools/packages/build-cli/src/machines/fluidReleaseMachine.ts
@@ -4,7 +4,7 @@
  */
 import { FileSystem as fs } from "@rushstack/node-core-library";
 import { from as createStateMachine } from "jssm";
-import path from "path";
+import path from "node:path";
 
 // eslint-disable-next-line unicorn/prefer-module
 const machineDefinitionFile = path.join(__dirname, "FluidRelease.fsl");

--- a/build-tools/packages/readme-command/.eslintrc.cjs
+++ b/build-tools/packages/readme-command/.eslintrc.cjs
@@ -44,9 +44,6 @@ module.exports = {
 		// The default for this rule is 4, but 5 is better
 		"max-params": ["warn", 5],
 
-		// Causes issues with some versions of node
-		"unicorn/prefer-node-protocol": "off",
-
 		// Deprecated in 2018: https://eslint.org/blog/2018/11/jsdoc-end-of-life/
 		"valid-jsdoc": "off",
 	},


### PR DESCRIPTION
Enable the unicorn/prefer-node-protocol rule in build-tools and fix violations.