### PR TITLE
tree2: Expose leaf schema on builder

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -23,17 +23,6 @@ export interface Adapters {
 }
 
 // @alpha
-const all: readonly [TreeSchema<"com.fluidframework.leaf.handle", {
-leafValue: ValueSchema.FluidHandle;
-}>, TreeSchema<"com.fluidframework.leaf.number", {
-leafValue: ValueSchema.Number;
-}>, TreeSchema<"com.fluidframework.leaf.boolean", {
-leafValue: ValueSchema.Boolean;
-}>, TreeSchema<"com.fluidframework.leaf.string", {
-leafValue: ValueSchema.String;
-}>];
-
-// @alpha
 export type AllowedTypes = readonly [Any] | readonly LazyItem<TreeSchema>[];
 
 // @alpha
@@ -231,11 +220,6 @@ export interface BindTree<T = BindTreeDefault> extends PathStep {
 
 // @alpha
 export type BindTreeDefault = BindTree;
-
-// @alpha (undocumented)
-const boolean: TreeSchema<"com.fluidframework.leaf.boolean", {
-leafValue: ValueSchema.Boolean;
-}>;
 
 // @alpha
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
@@ -808,11 +792,6 @@ export function getPrimaryField(schema: TreeStoredSchema): {
 } | undefined;
 
 // @alpha (undocumented)
-const handle: TreeSchema<"com.fluidframework.leaf.handle", {
-leafValue: ValueSchema.FluidHandle;
-}>;
-
-// @alpha (undocumented)
 export interface HasListeners<E extends Events<E>> {
     hasListeners(eventName?: keyof Events<E>): boolean;
 }
@@ -1263,18 +1242,38 @@ export interface Leaf<TSchema extends LeafSchema> extends TreeNode {
     readonly value: SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>;
 }
 
-declare namespace leaf {
-    export {
-        number,
-        boolean,
-        string,
-        handle,
-        primitives,
-        all,
-        library
-    }
-}
-export { leaf }
+// @alpha
+export const leaf: {
+    number: TreeSchema<"com.fluidframework.leaf.number", {
+    leafValue: ValueSchema.Number;
+    }>;
+    boolean: TreeSchema<"com.fluidframework.leaf.boolean", {
+    leafValue: ValueSchema.Boolean;
+    }>;
+    string: TreeSchema<"com.fluidframework.leaf.string", {
+    leafValue: ValueSchema.String;
+    }>;
+    handle: TreeSchema<"com.fluidframework.leaf.handle", {
+    leafValue: ValueSchema.FluidHandle;
+    }>;
+    primitives: readonly [TreeSchema<"com.fluidframework.leaf.number", {
+    leafValue: ValueSchema.Number;
+    }>, TreeSchema<"com.fluidframework.leaf.boolean", {
+    leafValue: ValueSchema.Boolean;
+    }>, TreeSchema<"com.fluidframework.leaf.string", {
+    leafValue: ValueSchema.String;
+    }>];
+    all: readonly [TreeSchema<"com.fluidframework.leaf.handle", {
+    leafValue: ValueSchema.FluidHandle;
+    }>, TreeSchema<"com.fluidframework.leaf.number", {
+    leafValue: ValueSchema.Number;
+    }>, TreeSchema<"com.fluidframework.leaf.boolean", {
+    leafValue: ValueSchema.Boolean;
+    }>, TreeSchema<"com.fluidframework.leaf.string", {
+    leafValue: ValueSchema.String;
+    }>];
+    library: SchemaLibrary;
+};
 
 // @alpha (undocumented)
 export type LeafSchema = TreeSchema & LeafSchemaSpecification;
@@ -1287,9 +1286,6 @@ interface LeafSchemaSpecification {
 
 // @alpha (undocumented)
 const library: SchemaLibrary;
-
-// @alpha (undocumented)
-const library_2: SchemaLibrary;
 
 // @alpha
 export enum LocalCommitSource {
@@ -1509,11 +1505,6 @@ type NormalizeStructFieldsInner<T extends Fields> = {
     [Property in keyof T]: NormalizeField<T[Property]>;
 };
 
-// @alpha (undocumented)
-const number: TreeSchema<"com.fluidframework.leaf.number", {
-leafValue: ValueSchema.Number;
-}>;
-
 // @alpha
 type ObjectToMap<ObjectMap, MapKey extends number | string, MapValue> = ReadonlyMap<MapKey, MapValue> & {
     get<TKey extends keyof ObjectMap>(key: TKey): ObjectMap[TKey];
@@ -1621,15 +1612,6 @@ export function prefixFieldPath(prefix: PathRootPrefix | undefined, path: FieldU
 
 // @alpha
 export function prefixPath(prefix: PathRootPrefix | undefined, path: UpPath | undefined): UpPath | undefined;
-
-// @alpha (undocumented)
-const primitives: readonly [TreeSchema<"com.fluidframework.leaf.number", {
-leafValue: ValueSchema.Number;
-}>, TreeSchema<"com.fluidframework.leaf.boolean", {
-leafValue: ValueSchema.Boolean;
-}>, TreeSchema<"com.fluidframework.leaf.string", {
-leafValue: ValueSchema.String;
-}>];
 
 // @alpha (undocumented)
 export type PrimitiveValue = string | boolean | number;
@@ -1774,12 +1756,28 @@ export { SchemaAware }
 // @alpha @sealed
 export class SchemaBuilder<TScope extends string = string> extends SchemaBuilderBase<TScope, typeof FieldKinds.required> {
     constructor(options: SchemaBuilderOptions<TScope>);
+    // (undocumented)
+    readonly boolean: TreeSchema<"com.fluidframework.leaf.boolean", {
+    leafValue: import("..").ValueSchema.Boolean;
+    }>;
+    // (undocumented)
+    readonly handle: TreeSchema<"com.fluidframework.leaf.handle", {
+    leafValue: import("..").ValueSchema.FluidHandle;
+    }>;
+    // (undocumented)
+    readonly number: TreeSchema<"com.fluidframework.leaf.number", {
+    leafValue: import("..").ValueSchema.Number;
+    }>;
     static optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Optional, NormalizeAllowedTypes<T>>;
     readonly optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Optional, NormalizeAllowedTypes<T>>;
     static required: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Required_2, NormalizeAllowedTypes<T>>;
     readonly required: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Required_2, NormalizeAllowedTypes<T>>;
     static sequence: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Sequence, NormalizeAllowedTypes<T>>;
     readonly sequence: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Sequence, NormalizeAllowedTypes<T>>;
+    // (undocumented)
+    readonly string: TreeSchema<"com.fluidframework.leaf.string", {
+    leafValue: import("..").ValueSchema.String;
+    }>;
 }
 
 // @alpha
@@ -1980,11 +1978,6 @@ export interface StoredSchemaRepository extends Dependee, ISubscribable<SchemaEv
     update(newSchema: SchemaData): void;
 }
 
-// @alpha (undocumented)
-const string: TreeSchema<"com.fluidframework.leaf.string", {
-leafValue: ValueSchema.String;
-}>;
-
 // @alpha
 export interface Struct extends TreeNode {
     readonly localNodeKey?: LocalNodeKey;
@@ -2025,7 +2018,7 @@ declare namespace testRecursiveDomain {
     export {
         recursiveStruct,
         recursiveStruct2,
-        library_2 as library
+        library
     }
 }
 export { testRecursiveDomain }

--- a/experimental/dds/tree2/src/domains/index.ts
+++ b/experimental/dds/tree2/src/domains/index.ts
@@ -20,8 +20,7 @@ export {
 
 export { nodeKeyField, nodeKeySchema, nodeKeyTreeSchema } from "./nodeKey";
 
-import * as leaf from "./leafDomain";
-export { leaf };
+export { leaf } from "./leafDomain";
 
 import * as testRecursiveDomain from "./testRecursiveDomain";
 export { testRecursiveDomain };

--- a/experimental/dds/tree2/src/domains/json/jsonCursor.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonCursor.ts
@@ -14,7 +14,7 @@ import {
 } from "../../core";
 import { JsonCompatible } from "../../util";
 import { CursorAdapter, isPrimitiveValue, singleStackTreeCursor } from "../../feature-libraries";
-import * as leaf from "../leafDomain";
+import { leaf } from "../leafDomain";
 import { jsonArray, jsonNull, jsonObject } from "./jsonDomainSchema";
 
 const adapter: CursorAdapter<JsonCompatible> = {

--- a/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
@@ -10,7 +10,7 @@ import {
 	SchemaBuilderInternal,
 } from "../../feature-libraries";
 import { requireAssignableTo } from "../../util";
-import * as leaf from "../leafDomain";
+import { leaf } from "../leafDomain";
 
 const builder = new SchemaBuilderInternal({
 	scope: "com.fluidframework.json",

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -34,7 +34,7 @@ export const leaf = {
 	 * - `NaN`, and the infinities should not be used.
 	 * - `-0` may be converted to `0` in some cases.
 	 *
-	 * These limitations come from the use of JSON.
+	 * These limitations match the limitations of JSON.
 	 * @privateRemarks
 	 * TODO:
 	 * We should be much more clear about what happens if you use problematic values.

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -11,35 +11,77 @@ import { ValueSchema } from "../core";
  */
 const builder = new SchemaBuilderInternal({ scope: "com.fluidframework.leaf" });
 
-/**
- * @alpha
- */
-export const number = builder.leaf("number", ValueSchema.Number);
-/**
- * @alpha
- */
-export const boolean = builder.leaf("boolean", ValueSchema.Boolean);
-/**
- * @alpha
- */
-export const string = builder.leaf("string", ValueSchema.String);
-/**
- * @alpha
- */
-export const handle = builder.leaf("handle", ValueSchema.FluidHandle);
+const number = builder.leaf("number", ValueSchema.Number);
+const boolean = builder.leaf("boolean", ValueSchema.Boolean);
+const string = builder.leaf("string", ValueSchema.String);
+const handle = builder.leaf("handle", ValueSchema.FluidHandle);
+
+const primitives = [number, boolean, string] as const;
+const all = [handle, ...primitives] as const;
+
+const library = builder.finalize();
 
 /**
+ * Schema for the built-in {@link Leaf} node types.
  * @alpha
  */
-export const primitives = [number, boolean, string] as const;
+export const leaf = {
+	/**
+	 * {@link TreeSchema} for a {@link Leaf} holding a JavaScript `number`.
+	 *
+	 * @remarks
+	 * The number is a [double-precision 64-bit binary format IEEE 754](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) value, however there are some exceptions:
+	 * - `NaN`, and the infinities should not be used.
+	 * - `-0` may be converted to `0` in some cases.
+	 *
+	 * These limitations come from the use of JSON.
+	 * @privateRemarks
+	 * TODO:
+	 * We should be much more clear about what happens if you use problematic values.
+	 * We should validate and/or normalize them when inserting content.
+	 */
+	number,
 
-/**
- * Types allowed as roots of Json content.
- * @alpha
- */
-export const all = [handle, ...primitives] as const;
+	/**
+	 * {@link TreeSchema} for a {@link Leaf} holding a boolean.
+	 */
+	boolean,
 
-/**
- * @alpha
- */
-export const library = builder.finalize();
+	/**
+	 * {@link TreeSchema} for a {@link Leaf} holding a JavaScript `string`.
+	 *
+	 * @remarks
+	 * Strings containing unpaired UTF-16 surrogate pair code units may not be handled correctly.
+	 *
+	 * These limitations come from the use of UTF-8 encoding of the strings, which requires them to be valid unicode.
+	 * JavaScript does not make this requirement for its strings so not all possible JavaScript strings are supported.
+	 * @privateRemarks
+	 * TODO:
+	 * We should be much more clear about what happens if you use problematic values.
+	 * We should validate and/or normalize them when inserting content.
+	 */
+	string,
+
+	/**
+	 * {@link TreeSchema} for a {@link Leaf} holding an {@link @fluidframework/core-interfaces#IFluidHandle}.
+	 */
+	handle,
+
+	/**
+	 * The set of leaf schema which correspond to JavaScript primitive (non-object) types.
+	 */
+	primitives,
+
+	/**
+	 * Types allowed as roots of Json content.
+	 */
+	all,
+
+	/**
+	 * {@link SchemaLibrary} of the Leaf Schema types.
+	 *
+	 * @remarks
+	 * This is included by default in schema produced with {@link SchemaBuilder}.
+	 */
+	library,
+};

--- a/experimental/dds/tree2/src/domains/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/domains/schemaBuilder.ts
@@ -104,6 +104,26 @@ export class SchemaBuilder<TScope extends string = string> extends SchemaBuilder
 	 * therefore this method is the same as the static version.
 	 */
 	public readonly sequence = SchemaBuilder.sequence;
+
+	/**
+	 * {@link leaf.number}
+	 */
+	public readonly number = leaf.number;
+
+	/**
+	 * {@link leaf.boolean}
+	 */
+	public readonly boolean = leaf.boolean;
+
+	/**
+	 * {@link leaf.string}
+	 */
+	public readonly string = leaf.string;
+
+	/**
+	 * {@link leaf.handle}
+	 */
+	public readonly handle = leaf.handle;
 }
 
 /**

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -12,7 +12,7 @@
 
 import { AllowedTypes, FieldKinds, FieldSchema } from "../feature-libraries";
 import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../util";
-import * as leaf from "./leafDomain";
+import { leaf } from "./leafDomain";
 import { SchemaBuilder } from "./schemaBuilder";
 
 const builder = new SchemaBuilder({ scope: "Test Recursive Domain" });


### PR DESCRIPTION
## Description

Expose leaf schema as properties on schema builder to align with spec.

Making documentation on these members was using {inheritdoc} didn't work in VSCode, and using @link broke API extractor. Refactoring the domain export to be an object instead of a module make the links not break api extractor. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

