### PR TITLE
keep isSessionActive as true if global checkpoint fails

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -66,6 +66,8 @@ export class CheckpointContext {
 			databaseCheckpointFailed = true;
 		}
 
+		// We write a kafka checkpoint if either the local or global checkpoint succeeds
+		// databaseCheckpointFailed is true only if both local and global checkpoint fail
 		if (!databaseCheckpointFailed) {
 			// Kafka checkpoint
 			try {
@@ -127,7 +129,7 @@ export class CheckpointContext {
 
 		let updateP: Promise<void>;
 
-		const localCheckpointEnabled = this.checkpointService?.localCheckpointEnabled;
+		const localCheckpointEnabled = this.checkpointService?.getLocalCheckpointEnabled();
 
 		// determine if checkpoint is local
 		const isLocal =

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -715,7 +715,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		if (this.serviceConfiguration.enableLumberjack) {
 			this.logSessionEndMetrics(closeType);
 			if (
-				this.checkpointService?.localCheckpointEnabled &&
+				this.checkpointService?.getLocalCheckpointEnabled() &&
 				!this.globalCheckpointOnly &&
 				closeType === LambdaCloseType.ActivityTimeout
 			) {
@@ -1978,6 +1978,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					kafkaCheckpointOffset: checkpointParams.kafkaCheckpointMessage?.offset,
 					kafkaCheckpointPartition: checkpointParams.kafkaCheckpointMessage?.partition,
 				};
+				const checkpointReason = CheckpointReason[checkpointParams.reason];
+				lumberjackProperties.checkpointReason = checkpointReason;
+				const checkpointMessage = `Writing checkpoint. Reason: ${checkpointReason}`;
+				Lumberjack.info(checkpointMessage, lumberjackProperties);
 				this.checkpointContext
 					.checkpoint(
 						checkpointParams,
@@ -1987,10 +1991,6 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					.catch((error) => {
 						Lumberjack.error("Error writing checkpoint", lumberjackProperties, error);
 					});
-				const checkpointReason = CheckpointReason[checkpointParams.reason];
-				lumberjackProperties.checkpointReason = checkpointReason;
-				const checkpointResult = `Writing checkpoint. Reason: ${checkpointReason}`;
-				Lumberjack.info(checkpointResult, lumberjackProperties);
 			})
 			.catch((error) => {
 				const errorMsg = `Could not send message to scriptorium`;

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -262,13 +262,14 @@ export class DeliLambdaFactory
 						return;
 					}
 					const filter = { documentId, tenantId, session: { $exists: true } };
+					const keepSessionActive = this.checkpointService.getGlobalCheckpointFailed();
 					const data = {
 						"session.isSessionAlive": false,
-						"session.isSessionActive": false,
+						"session.isSessionActive": keepSessionActive,
 						"lastAccessTime": Date.now(),
 					};
 					await this.documentRepository.updateOne(filter, data, undefined);
-					const message = `Marked session alive and active as false for closeType:
+					const message = `Marked session alive as false and active as ${keepSessionActive} for closeType:
                         ${JSON.stringify(closeType)}`;
 
 					context.log?.info(message, { messageMetaData });

--- a/server/routerlicious/packages/lambdas/src/utils/validateDocument.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/validateDocument.ts
@@ -23,11 +23,16 @@ export function isDocumentSessionValid(
 		// No session location to validate.
 		return true;
 	}
+	const isSessionInThisCluster =
+		document.session.ordererUrl === serviceConfiguration.externalOrdererUrl;
+	if (document.session.isSessionActive && isSessionInThisCluster) {
+		return true;
+	}
 	if (!document.session.isSessionAlive) {
 		// Session is not "alive", so client has bypassed discovery flow.
 		// Other clients could be routed to alternate locations, resulting in "split-brain" scenario.
 		// Prevent Deli from processing ops.
 		return false;
 	}
-	return document.session.ordererUrl === serviceConfiguration.externalOrdererUrl;
+	return isSessionInThisCluster;
 }

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -86,6 +86,14 @@
 			"InterfaceDeclaration_IOrdererConnection": {
 				"forwardCompat": false,
 				"backCompat": true
+			},
+			"ClassDeclaration_CheckpointService": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ICheckpointService": {
+				"forwardCompat": false,
+				"backCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -116,9 +116,7 @@ export class CheckpointService implements ICheckpointService {
 
 		try {
 			await this.documentRepository.updateOne(checkpointFilter, checkpointData, null);
-			if (this.globalCheckpointFailed) {
-				this.globalCheckpointFailed = false;
-			}
+			this.globalCheckpointFailed = false;
 		} catch (error) {
 			Lumberjack.error(
 				`Error writing checkpoint to the global database.`,

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -55,6 +55,7 @@ declare function get_old_ClassDeclaration_CheckpointService():
 declare function use_current_ClassDeclaration_CheckpointService(
     use: TypeOnly<current.CheckpointService>);
 use_current_ClassDeclaration_CheckpointService(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_CheckpointService());
 
 /*
@@ -67,6 +68,7 @@ declare function get_current_ClassDeclaration_CheckpointService():
 declare function use_old_ClassDeclaration_CheckpointService(
     use: TypeOnly<old.CheckpointService>);
 use_old_ClassDeclaration_CheckpointService(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_CheckpointService());
 
 /*
@@ -464,6 +466,7 @@ declare function get_old_InterfaceDeclaration_ICheckpointService():
 declare function use_current_InterfaceDeclaration_ICheckpointService(
     use: TypeOnly<current.ICheckpointService>);
 use_current_InterfaceDeclaration_ICheckpointService(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICheckpointService());
 
 /*
@@ -476,6 +479,7 @@ declare function get_current_InterfaceDeclaration_ICheckpointService():
 declare function use_old_InterfaceDeclaration_ICheckpointService(
     use: TypeOnly<old.ICheckpointService>);
 use_old_InterfaceDeclaration_ICheckpointService(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ICheckpointService());
 
 /*

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -86,6 +86,11 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_TestNotImplementedCheckpointService": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -439,6 +439,7 @@ declare function get_old_ClassDeclaration_TestNotImplementedCheckpointService():
 declare function use_current_ClassDeclaration_TestNotImplementedCheckpointService(
     use: TypeOnly<current.TestNotImplementedCheckpointService>);
 use_current_ClassDeclaration_TestNotImplementedCheckpointService(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestNotImplementedCheckpointService());
 
 /*
@@ -451,6 +452,7 @@ declare function get_current_ClassDeclaration_TestNotImplementedCheckpointServic
 declare function use_old_ClassDeclaration_TestNotImplementedCheckpointService(
     use: TypeOnly<old.TestNotImplementedCheckpointService>);
 use_old_ClassDeclaration_TestNotImplementedCheckpointService(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TestNotImplementedCheckpointService());
 
 /*

--- a/server/routerlicious/packages/test-utils/src/testNotImplementedCheckpointService.ts
+++ b/server/routerlicious/packages/test-utils/src/testNotImplementedCheckpointService.ts
@@ -13,8 +13,12 @@ import {
 const defaultErrorMsg = "Method not implemented. Provide your own mock.";
 
 export class TestNotImplementedCheckpointService implements ICheckpointService {
-	localCheckpointEnabled: boolean = false;
-
+	getGlobalCheckpointFailed(): boolean {
+		throw new Error(defaultErrorMsg);
+	}
+	getLocalCheckpointEnabled(): boolean {
+		throw new Error(defaultErrorMsg);
+	}
 	async writeCheckpoint(
 		documentId: string,
 		tenantId: string,


### PR DESCRIPTION
If local checkpointing is enabled, and the global checkpoint fails, a new session that does not have access to the local cosmosDB will not be able to start from the latest checkpoint.

In order to handle this case, we will keep `isSessionActive` as `true` when the final global checkpoint fails. This way, we ensure that the same local cosmos DB instance is used so that the next session may restart using the latest checkpoint.