### PR TITLE
change some ephemeral document logs to verbose to reduce noise

### DIFF
--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -104,7 +104,7 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 					isEphemeral = staticProps?.isEphemeralContainer ?? false;
 					await cache?.set(isEphemeralKey, isEphemeral); // Cache the value from the static data
 				} catch (e) {
-					Lumberjack.error(
+					Lumberjack.verbose(
 						`Failed to retrieve static data from document when checking isEphemeral flag.`,
 						getLumberBaseProperties(documentId, tenantId),
 					);
@@ -113,10 +113,12 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 			}
 		}
 	}
-	Lumberjack.info(
-		`Document is ephemeral? ${isEphemeral}`,
-		getLumberBaseProperties(documentId, tenantId),
-	);
+	if (isEphemeral) {
+		Lumberjack.info(
+			`Document is ephemeral.`,
+			getLumberBaseProperties(documentId, tenantId),
+		);
+	}
 
 	const calculatedStorageName =
 		initialUpload && storageName

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -114,10 +114,7 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 		}
 	}
 	if (isEphemeral) {
-		Lumberjack.info(
-			`Document is ephemeral.`,
-			getLumberBaseProperties(documentId, tenantId),
-		);
+		Lumberjack.info(`Document is ephemeral.`, getLumberBaseProperties(documentId, tenantId));
 	}
 
 	const calculatedStorageName =

--- a/server/routerlicious/packages/services/src/documentManager.ts
+++ b/server/routerlicious/packages/services/src/documentManager.ts
@@ -59,7 +59,7 @@ export class DocumentManager implements IDocumentManager {
 	): Promise<IDocumentStaticProperties | undefined> {
 		// If the cache is undefined, fetch the document from the database
 		if (!this.documentStaticDataCache) {
-			Lumberjack.info(
+			Lumberjack.verbose(
 				"Falling back to database after attempting to read cached static document data, because the DocumentManager cache is undefined.",
 				getLumberBaseProperties(documentId, tenantId),
 			);
@@ -73,7 +73,7 @@ export class DocumentManager implements IDocumentManager {
 
 		// If there are no cached static document props, fetch the document from the database
 		if (!staticPropsStr) {
-			Lumberjack.info(
+			Lumberjack.verbose(
 				"Falling back to database after attempting to read cached static document data.",
 				getLumberBaseProperties(documentId, tenantId),
 			);


### PR DESCRIPTION
## Description
We have 1) `Document is ephemeral? false` logging 10M per hour, 2) `Falling back to database after attempting to read cached static document data.` logging 2.7M per hour, 3) `Failed to retrieve static data from document when checking isEphemeral flag.` 2.7M per hour in FRS. To reduce noise, we only log when 1) is true, we change from `info` level to `verbose` level for 2). And after we look into 3), we find out it's actually caused by documents which were already created before we introduced ephemeral documents, and they don't have ephemeral flag at all, so changing it to `verbose` for now until we have better logic to bypass the empty flag.