### PR TITLE
tree2: Remove SchemaBuilder.leaf

### DIFF
--- a/.changeset/olive-parts-move.md
+++ b/.changeset/olive-parts-move.md
@@ -1,0 +1,7 @@
+---
+"@fluid-experimental/tree2": minor
+---
+
+Remove SchemaBuilder.leaf
+
+Custom schema should use the predefined leaf domain, or wrap its leaf types instead of defining new leaf schema.

--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1798,9 +1798,6 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     }>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<Unenforced<TreeSchema>>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     finalize(): SchemaLibrary;
-    leaf<Name extends TName, const T extends ValueSchema>(name: Name, t: T): TreeSchema<`${TScope}.${Name}`, {
-        leafValue: T;
-    }>;
     map<Name extends TName, const T extends ImplicitFieldSchema>(name: Name, fieldSchema: T): TreeSchema<`${TScope}.${Name}`, {
         mapFields: NormalizeField_2<T, TDefaultKind>;
     }>;

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilder.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { ValueSchema } from "../core";
 import { SchemaBuilderBase, SchemaBuilderOptions } from "./schemaBuilderBase";
 import { FieldKinds } from "./default-field-kinds";
+import { TreeSchema } from "./typed-schema";
 
 /**
  * Extends {@link SchemaBuilderBase} with functionality only used to create built in special libraries.
@@ -16,5 +18,27 @@ export class SchemaBuilderInternal<
 > extends SchemaBuilderBase<TScope, typeof FieldKinds.required> {
 	public constructor(options: SchemaBuilderOptions<TScope>) {
 		super(FieldKinds.required, options);
+	}
+
+	/**
+	 * Define (and add to this library) a {@link TreeSchema} for a node that wraps a value.
+	 * Such nodes will be implicitly unwrapped to the value in some APIs.
+	 *
+	 * The name must be unique among all TreeSchema in the the document schema.
+	 *
+	 * In addition to the normal properties of all nodes (having a schema for example),
+	 * Leaf nodes only contain a value.
+	 * Leaf nodes cannot have fields.
+	 *
+	 * TODO: Maybe ban undefined from allowed values here.
+	 * TODO: Decide and document how unwrapping works for non-primitive terminals.
+	 */
+	public leaf<Name extends string, const T extends ValueSchema>(
+		name: Name,
+		t: T,
+	): TreeSchema<`${TScope}.${Name}`, { leafValue: T }> {
+		const schema = new TreeSchema(this, this.scoped(name), { leafValue: t });
+		this.addNodeSchema(schema);
+		return schema;
 	}
 }

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { Adapters, TreeSchemaIdentifier, ValueSchema } from "../core";
+import { Adapters, TreeSchemaIdentifier } from "../core";
 import { Assume, RestrictiveReadonlyRecord, transformObjectMap } from "../util";
 import {
 	SchemaLibraryData,
@@ -299,29 +299,6 @@ export class SchemaBuilderBase<
 			`${TScope}.${Name}`,
 			{ structFields: { [""]: T } }
 		>;
-	}
-
-	// TODO: move this to SchemaBuilderInternal once usages of it have been replaces with use of the leaf domain.
-	/**
-	 * Define (and add to this library) a {@link TreeSchema} for a node that wraps a value.
-	 * Such nodes will be implicitly unwrapped to the value in some APIs.
-	 *
-	 * The name must be unique among all TreeSchema in the the document schema.
-	 *
-	 * In addition to the normal properties of all nodes (having a schema for example),
-	 * Leaf nodes only contain a value.
-	 * Leaf nodes cannot have fields.
-	 *
-	 * TODO: Maybe ban undefined from allowed values here.
-	 * TODO: Decide and document how unwrapping works for non-primitive terminals.
-	 */
-	public leaf<Name extends TName, const T extends ValueSchema>(
-		name: Name,
-		t: T,
-	): TreeSchema<`${TScope}.${Name}`, { leafValue: T }> {
-		const schema = new TreeSchema(this, this.scoped(name), { leafValue: t });
-		this.addNodeSchema(schema);
-		return schema;
 	}
 
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -274,7 +274,7 @@ export interface MapSchemaSpecification {
 export type MapFieldSchema = FieldSchema<typeof FieldKinds.optional | typeof FieldKinds.sequence>;
 
 /**
- * `TreeSchemaSpecification` for {@link SchemaBuilderBase.leaf}.
+ * `TreeSchemaSpecification` for {@link Leaf}.
  * @alpha
  */
 export interface LeafSchemaSpecification {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.binder.bench.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.binder.bench.ts
@@ -30,14 +30,14 @@ import { fieldPhones, retrieveNodes } from "./editableTree.binder.spec";
 
 describe("Data binder benchmarks", () => {
 	describe("Direct data binder", () => {
-		// TODO: Do not create shared trees during test enumeration.
-		const { tree, root, address } = retrieveNodes();
-		const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
-		const options: BinderOptions = createBinderOptions({});
 		benchmark({
 			type: BenchmarkType.Measurement,
 			title: `Direct data binder: single insert callback`,
 			benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+				const { tree, root, address } = retrieveNodes();
+				const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
+				const options: BinderOptions = createBinderOptions({});
+
 				let time = 0;
 				do {
 					const dataBinder: DataBinder<OperationBinderEvents> = createDataBinderDirect(
@@ -63,15 +63,15 @@ describe("Data binder benchmarks", () => {
 	});
 
 	describe("Invalidation data binder", () => {
-		const { tree, root, address } = retrieveNodes();
-		const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
-		const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
-			autoFlushPolicy: "afterBatch",
-		});
 		benchmark({
 			type: BenchmarkType.Measurement,
 			title: `Invalidation data binder: single insert invalidation callback`,
 			benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+				const { tree, root, address } = retrieveNodes();
+				const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
+				const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
+					autoFlushPolicy: "afterBatch",
+				});
 				let time = 0;
 				do {
 					const dataBinder: FlushableDataBinder<InvalidationBinderEvents> =
@@ -95,15 +95,15 @@ describe("Data binder benchmarks", () => {
 	});
 
 	describe("Buffering data binder", () => {
-		const { tree, root, address } = retrieveNodes();
-		const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
-		const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
-			autoFlushPolicy: "afterBatch",
-		});
 		benchmark({
 			type: BenchmarkType.Measurement,
 			title: `Buffering data binder: single insert callback`,
 			benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+				const { tree, root, address } = retrieveNodes();
+				const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
+				const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
+					autoFlushPolicy: "afterBatch",
+				});
 				let time = 0;
 				do {
 					const dataBinder: FlushableDataBinder<OperationBinderEvents> =
@@ -128,11 +128,6 @@ describe("Data binder benchmarks", () => {
 
 	for (const listeners of [10, 50, 100, 500, 1000]) {
 		describe(`Buffering data binder, invoke ${listeners} listener of ${2 * listeners}`, () => {
-			const { tree, root, address } = retrieveNodes();
-			const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
-			const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
-				autoFlushPolicy: "afterBatch",
-			});
 			benchmark({
 				type: BenchmarkType.Measurement,
 				title: `Buffering data binder: single insert callback, invoke  ${listeners} listener of ${
@@ -140,6 +135,12 @@ describe("Data binder benchmarks", () => {
 				}`,
 				benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
 					let time = 0;
+					const { tree, root, address } = retrieveNodes();
+					const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
+					const options: FlushableBinderOptions<ViewEvents> =
+						createFlushableBinderOptions({
+							autoFlushPolicy: "afterBatch",
+						});
 					do {
 						const dataBinder: FlushableDataBinder<OperationBinderEvents> =
 							createDataBinderBuffering(tree.events, options);
@@ -164,16 +165,15 @@ describe("Data binder benchmarks", () => {
 		});
 	}
 	describe("Buffering data binder, batched notification", () => {
-		// TODO: Do not create shared trees during test enumeration.
-		const { tree, root, address } = retrieveNodes();
-		const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
-		const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
-			autoFlushPolicy: "afterBatch",
-		});
 		benchmark({
 			type: BenchmarkType.Measurement,
 			title: `Buffering data binder: batch callback`,
 			benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+				const { tree, root, address } = retrieveNodes();
+				const bindTree: BindPolicy = compileSyntaxTree({ address: true }, "subtree");
+				const options: FlushableBinderOptions<ViewEvents> = createFlushableBinderOptions({
+					autoFlushPolicy: "afterBatch",
+				});
 				let time = 0;
 				do {
 					const dataBinder: FlushableDataBinder<OperationBinderEvents> =

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -87,15 +87,6 @@ describe("editable-tree: editing", () => {
 		} as any; // TODO: schema aware typing.
 		// unambiguous type
 		maybePerson.salary = "not ok";
-		// ambiguous type since there are multiple options which are numbers:
-		assert.throws(
-			() => (maybePerson.salary = 99.99),
-			(e: Error) =>
-				validateAssertionError(
-					e,
-					"data compatible with more than one type allowed by the schema",
-				),
-		);
 		// explicit typing
 		maybePerson.salary = {
 			[typeNameSymbol]: float64Schema.name,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.events.spec.ts
@@ -21,13 +21,13 @@ import {
 import { brand } from "../../../util";
 import { getField, jsonableTreeFromCursor, on, singleTextCursor } from "../../../feature-libraries";
 import { IEmitter } from "../../../events";
+import { leaf } from "../../../domains";
 import {
 	fullSchemaData,
 	personData,
 	getReadonlyEditableTreeContext,
 	setupForest,
 	addressSchema,
-	int32Schema,
 } from "./mockData";
 
 const fieldAddress: FieldKey = brand("address");
@@ -80,7 +80,7 @@ describe("editable-tree: event subscription", () => {
 							fields: {
 								zip: [
 									{
-										type: int32Schema.name,
+										type: leaf.number.name,
 										value: 33428,
 									},
 								],
@@ -117,7 +117,7 @@ describe("editable-tree: event subscription", () => {
 				fields: {
 					zip: [
 						{
-							type: int32Schema.name,
+							type: leaf.number.name,
 							value: 33428,
 						},
 					],

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -41,7 +41,7 @@ import {
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../../feature-libraries/editable-tree/editableTreeContext";
 
-import { SchemaBuilder } from "../../../domains";
+import { SchemaBuilder, leaf } from "../../../domains";
 import {
 	fullSchemaData,
 	personSchema,
@@ -51,7 +51,6 @@ import {
 	stringSchema,
 	phonesSchema,
 	optionalChildSchema,
-	int32Schema,
 	personData,
 	personJsonableTree,
 	buildTestSchema,
@@ -295,7 +294,7 @@ describe("editable-tree: read-only", () => {
 
 		const fullOptional = buildTestTree(
 			{
-				child: { [typeNameSymbol]: int32Schema.name, [valueSymbol]: 1 },
+				child: { [typeNameSymbol]: leaf.number.name, [valueSymbol]: 1 },
 			},
 			FieldSchema.create(FieldKinds.required, [optionalChildSchema]),
 		).unwrappedRoot;
@@ -376,12 +375,12 @@ describe("editable-tree: read-only", () => {
 	});
 
 	it("primitives are unwrapped at root", () => {
-		const rootSchema = FieldSchema.create(FieldKinds.required, [int32Schema]);
+		const rootSchema = FieldSchema.create(FieldKinds.required, [leaf.number]);
 		const schemaData = buildTestSchema(rootSchema);
 		const forest = setupForest(schemaData, 1);
 		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert.equal(context.unwrappedRoot, 1);
-		expectFieldEquals(schemaData, context.root, [{ type: int32Schema.name, value: 1 }]);
+		expectFieldEquals(schemaData, context.root, [{ type: leaf.number.name, value: 1 }]);
 		context.free();
 	});
 
@@ -434,7 +433,7 @@ describe("editable-tree: read-only", () => {
 			const data = [
 				{
 					type: phonesSchema.name,
-					fields: { [EmptyKey]: [{ type: int32Schema.name, value: 1 }] },
+					fields: { [EmptyKey]: [{ type: leaf.number.name, value: 1 }] },
 				},
 			];
 			const forest = setupForest(schemaData, [1]);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -26,7 +26,6 @@ import {
 	SchemaAware,
 } from "../../../feature-libraries";
 import {
-	ValueSchema,
 	FieldKey,
 	EmptyKey,
 	JsonableTree,
@@ -36,17 +35,15 @@ import {
 	SchemaData,
 } from "../../../core";
 import { brand, Brand } from "../../../util";
-import { SchemaBuilder } from "../../../domains";
+import { SchemaBuilder, leaf } from "../../../domains";
 
 const builder = new SchemaBuilder({ scope: "mock data" });
 
-export const stringSchema = builder.leaf("String", ValueSchema.String);
+export const stringSchema = leaf.string;
 
-export const int32Schema = builder.leaf("Int32", ValueSchema.Number);
+export const float64Schema = leaf.number;
 
-export const float64Schema = builder.leaf("Float64", ValueSchema.Number);
-
-export const boolSchema = builder.leaf("Bool", ValueSchema.Boolean);
+export const boolSchema = leaf.boolean;
 
 export const simplePhonesSchema = builder.struct("Test:SimplePhones-1.0.0", {
 	[EmptyKey]: FieldSchema.create(FieldKinds.sequence, [stringSchema]),
@@ -62,7 +59,7 @@ export const phonesSchema = builder.fieldNode(
 	"Test:Phones-1.0.0",
 	builder.sequence([
 		stringSchema,
-		int32Schema,
+		leaf.number,
 		complexPhoneSchema,
 		// array of arrays
 		simplePhonesSchema,
@@ -70,7 +67,7 @@ export const phonesSchema = builder.fieldNode(
 );
 
 export const addressSchema = builder.struct("Test:Address-1.0.0", {
-	zip: [stringSchema, int32Schema],
+	zip: [stringSchema, leaf.number],
 	street: FieldSchema.create(FieldKinds.optional, [stringSchema]),
 	city: FieldSchema.create(FieldKinds.optional, [stringSchema]),
 	country: FieldSchema.create(FieldKinds.optional, [stringSchema]),
@@ -85,9 +82,9 @@ export const mapStringSchema = builder.map(
 
 export const personSchema = builder.struct("Test:Person-1.0.0", {
 	name: stringSchema,
-	age: FieldSchema.create(FieldKinds.optional, [int32Schema]),
+	age: FieldSchema.create(FieldKinds.optional, [leaf.number]),
 	adult: FieldSchema.create(FieldKinds.optional, [boolSchema]),
-	salary: FieldSchema.create(FieldKinds.optional, [float64Schema, int32Schema, stringSchema]),
+	salary: FieldSchema.create(FieldKinds.optional, [float64Schema, leaf.number, stringSchema]),
 	friends: FieldSchema.create(FieldKinds.optional, [mapStringSchema]),
 	address: FieldSchema.create(FieldKinds.optional, [addressSchema]),
 });
@@ -98,7 +95,7 @@ export const optionalChildSchema = builder.struct("Test:OptionalChild-1.0.0", {
 
 export const arraySchema = builder.fieldNode(
 	"Test:Array-1.0.0",
-	FieldSchema.create(FieldKinds.sequence, [stringSchema, int32Schema]),
+	FieldSchema.create(FieldKinds.sequence, [stringSchema, leaf.number]),
 );
 
 export const rootPersonSchema = FieldSchema.create(FieldKinds.optional, [personSchema]);
@@ -111,6 +108,7 @@ export const fullSchemaData = buildTestSchema(rootPersonSchema);
 
 // TODO: provide relaxed types like these based on ContextuallyTyped setters
 
+// TODO: these types don't make sense. Values can't be both primitives and EditableTree, and this isn't how Brand or TreeSchemaIdentifiers are used.
 export type Float64 = Brand<number, "editable-tree.Float64"> & EditableTree;
 export type Int32 = Brand<number, "editable-tree.Int32"> & EditableTree;
 export type Bool = Brand<boolean, "editable-tree.Bool"> & EditableTree;

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/utilities.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/utilities.spec.ts
@@ -19,19 +19,13 @@ import {
 	keyIsValidIndex,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/editable-tree/utilities";
-import {
-	arraySchema,
-	buildTestSchema,
-	int32Schema,
-	mapStringSchema,
-	optionalChildSchema,
-	stringSchema,
-} from "./mockData";
+import { leaf } from "../../../domains";
+import { arraySchema, buildTestSchema, mapStringSchema, optionalChildSchema } from "./mockData";
 
 describe("editable-tree utilities", () => {
 	it("isPrimitive", () => {
-		assert(isPrimitive(int32Schema));
-		assert(isPrimitive(stringSchema));
+		assert(isPrimitive(leaf.number));
+		assert(isPrimitive(leaf.string));
 		assert(!isPrimitive(mapStringSchema));
 		assert(!isPrimitive(optionalChildSchema));
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -17,7 +17,6 @@ import {
 	FieldStoredSchema,
 	TreeStoredSchema,
 	TreeSchemaIdentifier,
-	ValueSchema,
 	InMemoryStoredSchemaRepository,
 	Adapters,
 	Compatibility,
@@ -82,8 +81,7 @@ describe("Schema Evolution Examples", () => {
 		name: "Schema Evolution Examples: default content types",
 	});
 
-	const number = contentTypesBuilder.leaf("Number", ValueSchema.Number);
-	const codePoint = contentTypesBuilder.leaf("Primitive.CodePoint", ValueSchema.Number);
+	const codePoint = contentTypesBuilder.fieldNode("Primitive.CodePoint", leaf.number);
 
 	// String made of unicode code points, allowing for sequence editing of a string.
 	const text = contentTypesBuilder.struct("Text", {
@@ -91,8 +89,8 @@ describe("Schema Evolution Examples", () => {
 	});
 
 	const point = contentTypesBuilder.struct("Point", {
-		x: number,
-		y: number,
+		x: leaf.number,
+		y: leaf.number,
 	});
 
 	const defaultContentLibrary = contentTypesBuilder.finalize();
@@ -221,7 +219,7 @@ describe("Schema Evolution Examples", () => {
 			// (either eagerly or lazily when first needing to do so when writing into the document).
 			// Once again the order does not matter:
 			assert(stored.tryUpdateTreeSchema(canvas.name, canvas));
-			assert(stored.tryUpdateTreeSchema(number.name, number));
+			assert(stored.tryUpdateTreeSchema(leaf.number.name, leaf.number));
 			assert(stored.tryUpdateTreeSchema(point.name, point));
 			assert(stored.tryUpdateTreeSchema(positionedCanvasItem.name, positionedCanvasItem));
 			assert(stored.tryUpdateTreeSchema(text.name, text));
@@ -248,7 +246,7 @@ describe("Schema Evolution Examples", () => {
 			});
 
 			const counter = builderWithCounter.struct("Counter", {
-				count: number,
+				count: leaf.number,
 			});
 			// Lets allow counters inside positionedCanvasItem, instead of just text:
 			const positionedCanvasItem2 = builderWithCounter.struct("PositionedCanvasItem", {

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -21,7 +21,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/schema-aware/schemaAware";
 
-import { AllowedUpdateType, TreeSchemaIdentifier, ValueSchema } from "../../../core";
+import { AllowedUpdateType, TreeSchemaIdentifier } from "../../../core";
 import { areSafelyAssignable, requireAssignableTo, requireTrue } from "../../../util";
 import {
 	valueSymbol,
@@ -216,22 +216,22 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 	// Test polymorphic cases:
 	{
 		const builder2 = new SchemaBuilder({ scope: "SchemaAwarePolymorphicTest" });
-		const bool = builder2.leaf("bool", ValueSchema.Boolean);
-		const str = builder2.leaf("str", ValueSchema.String);
+		const bool = leaf.boolean;
+		const str = leaf.string;
 		const parentField = SchemaBuilder.required([str, bool]);
 		const parent = builder2.struct("parent", { child: parentField });
 
 		type FlexBool =
 			| boolean
 			| {
-					[typeNameSymbol]?: "SchemaAwarePolymorphicTest.bool";
+					[typeNameSymbol]?: UnbrandedName<typeof leaf.boolean.name>;
 					[valueSymbol]: boolean;
 			  };
 
 		type FlexStr =
 			| string
 			| {
-					[typeNameSymbol]?: "SchemaAwarePolymorphicTest.str";
+					[typeNameSymbol]?: UnbrandedName<typeof leaf.string.name>;
 					[valueSymbol]: string;
 			  };
 		interface FlexParent {

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-inner-declarations */
 
-import { ValueSchema } from "../../../core";
 import { SchemaBuilder } from "../../../domains";
 import { FieldKinds, FieldSchema, SchemaAware, TreeSchema } from "../../../feature-libraries";
 import { requireAssignableTo } from "../../../util";
@@ -13,7 +12,7 @@ import { requireAssignableTo } from "../../../util";
 const builder = new SchemaBuilder({ scope: "Complex Schema Example" });
 
 // Schema
-export const stringTaskSchema = builder.leaf("StringTask", ValueSchema.String);
+export const stringTaskSchema = builder.fieldNode("StringTask", builder.string);
 // Polymorphic recursive schema:
 export const listTaskSchema = builder.structRecursive("ListTask", {
 	items: FieldSchema.createUnsafe(FieldKinds.sequence, [stringTaskSchema, () => listTaskSchema]),
@@ -40,11 +39,17 @@ type FlexibleTask = SchemaAware.AllowedTypesToTypedTrees<
 	typeof rootFieldSchema.allowedTypes
 >;
 
+type FlexibleStringTask = SchemaAware.TypedNode<
+	typeof stringTaskSchema,
+	SchemaAware.ApiMode.Flexible
+>;
+
 // Example Use
 {
-	const task1: FlexibleTask = "do it";
+	const stringTask: FlexibleStringTask = { [""]: "do it" };
+	const task1: FlexibleTask = { [""]: "do it" };
 	const task2: FlexibleTask = {
-		items: ["FHL", "record video"],
+		items: [{ [""]: "FHL" }, { [""]: "record video" }],
 	};
 	// const task3: FlexibleTask = {
 	// 	[typeNameSymbol]: stringTaskSchema.name,
@@ -53,8 +58,8 @@ type FlexibleTask = SchemaAware.AllowedTypesToTypedTrees<
 
 	function makeTask(tasks: string[]): FlexibleTask {
 		if (tasks.length === 1) {
-			return tasks[0];
+			return { [""]: tasks[0] };
 		}
-		return { items: tasks };
+		return { items: tasks.map((s) => ({ [""]: s })) };
 	}
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -3,22 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { ValueSchema, SchemaAware, typeNameSymbol, valueSymbol, SchemaBuilder } from "../../../";
+import { SchemaAware, typeNameSymbol, valueSymbol, SchemaBuilder, leaf } from "../../../";
 
 const builder = new SchemaBuilder({ scope: "Simple Schema" });
 
 // Schema
-export const numberSchema = builder.leaf("number", ValueSchema.Number);
-
 export const pointSchema = builder.struct("point", {
-	x: numberSchema,
-	y: numberSchema,
+	x: builder.number,
+	y: builder.number,
 });
 
 export const appSchemaData = builder.toDocumentSchema(builder.sequence(pointSchema));
 
 // Schema aware types
-export type Number = SchemaAware.TypedNode<typeof numberSchema>;
+export type Number = SchemaAware.TypedNode<typeof leaf.number>;
 
 export type Point = SchemaAware.TypedNode<typeof pointSchema>;
 
@@ -29,7 +27,7 @@ function dotProduct(a: Point, b: Point): number {
 
 // More Schema aware APIs
 {
-	type FlexibleNumber = SchemaAware.TypedNode<typeof numberSchema, SchemaAware.ApiMode.Flexible>;
+	type FlexibleNumber = SchemaAware.TypedNode<typeof leaf.number, SchemaAware.ApiMode.Flexible>;
 
 	type FlexiblePoint = SchemaAware.TypedNode<typeof pointSchema, SchemaAware.ApiMode.Flexible>;
 

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
@@ -91,22 +91,22 @@ describe("SchemaBuilderBase", () => {
 	describe("toDocumentSchema", () => {
 		it("Simple", () => {
 			const schemaBuilder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
-			const leafSchema = schemaBuilder.leaf("leaf", ValueSchema.Boolean);
-			const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(leafSchema));
+			const empty = schemaBuilder.struct("empty", {});
+			const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(empty));
 
-			assert.equal(schema.treeSchema.size, 1); // "leaf"
-			assert.equal(schema.treeSchema.get(brand("test.leaf")), leafSchema);
+			assert.equal(schema.treeSchema.size, 1); // "empty"
+			assert.equal(schema.treeSchema.get(brand("test.empty")), empty);
 		});
 	});
 
 	describe("intoLibrary", () => {
 		it("Simple", () => {
 			const schemaBuilder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
-			const leafSchema = schemaBuilder.leaf("leaf", ValueSchema.Boolean);
+			const empty = schemaBuilder.struct("empty", {});
 			const schema = schemaBuilder.finalize();
 
-			assert.equal(schema.treeSchema.size, 1); // "leaf"
-			assert.equal(schema.treeSchema.get(brand("test.leaf")), leafSchema);
+			assert.equal(schema.treeSchema.size, 1); // "empty"
+			assert.equal(schema.treeSchema.get(brand("test.empty")), empty);
 		});
 	});
 

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -22,7 +22,6 @@ import {
 	clonePath,
 	ITreeCursor,
 	EmptyKey,
-	ValueSchema,
 	FieldUpPath,
 } from "../core";
 import {
@@ -34,6 +33,7 @@ import {
 	jsonBoolean,
 	jsonString,
 	SchemaBuilder,
+	leaf,
 } from "../domains";
 import { JsonCompatible, brand, brandOpaque } from "../util";
 import {
@@ -852,10 +852,9 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 			it("when moving the last node in the field", () => {
 				const builder = new SchemaBuilder({ scope: "moving" });
-				const leaf = builder.leaf("leaf", ValueSchema.Number);
 				const root = builder.struct("root", {
-					x: SchemaBuilder.sequence(leaf),
-					y: SchemaBuilder.sequence(leaf),
+					x: SchemaBuilder.sequence(leaf.number),
+					y: SchemaBuilder.sequence(leaf.number),
 				});
 				const schema = builder.toDocumentSchema(builder.optional(root));
 

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -18,10 +18,9 @@ import {
 	moveToDetachedField,
 	rootFieldKey,
 	Value,
-	ValueSchema,
 } from "../../core";
 import { typeboxValidator } from "../../external-utilities";
-import { SchemaBuilder } from "../../domains";
+import { SchemaBuilder, leaf } from "../../domains";
 
 // Notes:
 // 1. Within this file "percentile" is commonly used, and seems to refer to a portion (0 to 1) or some maximum size.
@@ -35,9 +34,8 @@ import { SchemaBuilder } from "../../domains";
 
 const builder = new SchemaBuilder({ scope: "opSize" });
 
-const stringSchema = builder.leaf("String", ValueSchema.String);
 const childSchema = builder.struct("Test:Opsize-Bench-Child", {
-	data: stringSchema,
+	data: leaf.string,
 });
 const parentSchema = builder.struct("Test:Opsize-Bench-Root", {
 	children: builder.sequence(childSchema),
@@ -74,7 +72,7 @@ function createTreeWithSize(desiredByteSize: number): JsonableTree {
 	const node = {
 		type: childSchema.name,
 		fields: {
-			data: [{ value: "", type: stringSchema.name }],
+			data: [{ value: "", type: leaf.string.name }],
 		},
 	};
 
@@ -225,7 +223,7 @@ function editNodesWithIndividualTransactions(
 				type: childSchema.name,
 				value: editPayload,
 				fields: {
-					data: [{ value: "", type: stringSchema.name }],
+					data: [{ value: "", type: leaf.string.name }],
 				},
 			}),
 		);
@@ -253,7 +251,7 @@ function editNodesWithSingleTransaction(
 				type: childSchema.name,
 				value: editPayload,
 				fields: {
-					data: [{ value: "", type: stringSchema.name }],
+					data: [{ value: "", type: leaf.string.name }],
 				},
 			}),
 		);

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -14,7 +14,6 @@ import {
 } from "../../feature-libraries";
 import { ViewEvents } from "../../shared-tree";
 import {
-	ValueSchema,
 	AllowedUpdateType,
 	SimpleObservingDependent,
 	InMemoryStoredSchemaRepository,
@@ -25,21 +24,21 @@ import { jsonSequenceRootSchema } from "../utils";
 // eslint-disable-next-line import/no-internal-modules
 import { TreeContent, initializeContent, schematize } from "../../shared-tree/schematizedTree";
 import { createEmitter } from "../../events";
-import { SchemaBuilder } from "../../domains";
+import { SchemaBuilder, leaf } from "../../domains";
 
 const builder = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests" });
-const root = builder.leaf("root", ValueSchema.Number);
+const root = leaf.number;
 const schema = builder.toDocumentSchema(SchemaBuilder.optional(root));
 
 const builderGeneralized = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests Generalized",
 });
-const rootGeneralized = builderGeneralized.leaf("root", ValueSchema.Number);
+
 const schemaGeneralized = builderGeneralized.toDocumentSchema(SchemaBuilder.optional(Any));
 
 const builderValue = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests2" });
-const root2 = builderValue.leaf("root", ValueSchema.Number);
+
 const schemaValueRoot = builderValue.toDocumentSchema(SchemaBuilder.required(Any));
 
 const emptySchema = new SchemaBuilder({

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -55,7 +55,6 @@ import {
 	Value,
 	moveToDetachedField,
 	SchemaData,
-	ValueSchema,
 	AllowedUpdateType,
 	LocalCommitSource,
 	storedEmptyFieldSchema,
@@ -1064,9 +1063,8 @@ describe("SharedTree", () => {
 	// TODO: many of these events tests should be tests of SharedTreeView instead.
 	describe("Events", () => {
 		const builder = new SchemaBuilder({ scope: "Events test schema" });
-		const numberSchema = builder.leaf("number", ValueSchema.Number);
 		const treeSchema = builder.struct("root", {
-			x: numberSchema,
+			x: builder.number,
 		});
 		const schema = builder.toDocumentSchema(builder.optional(Any));
 
@@ -1886,10 +1884,9 @@ describe("SharedTree", () => {
 
 			const rootFieldSchema = SchemaBuilder.required(Any);
 			const testSchemaBuilder = new SchemaBuilder({ scope: "testSchema" });
-			const numberSchema = testSchemaBuilder.leaf("Number", ValueSchema.Number);
 			const rootNodeSchema = testSchemaBuilder.structRecursive("Node", {
-				foo: SchemaBuilder.sequence(numberSchema),
-				foo2: SchemaBuilder.sequence(numberSchema),
+				foo: SchemaBuilder.sequence(leaf.number),
+				foo2: SchemaBuilder.sequence(leaf.number),
 			});
 			const testSchema = testSchemaBuilder.toDocumentSchema(rootFieldSchema);
 
@@ -1898,14 +1895,14 @@ describe("SharedTree", () => {
 				type: rootNodeSchema.name,
 				fields: {
 					foo: [
-						{ type: numberSchema.name, value: 0 },
-						{ type: numberSchema.name, value: 1 },
-						{ type: numberSchema.name, value: 2 },
+						{ type: leaf.number.name, value: 0 },
+						{ type: leaf.number.name, value: 1 },
+						{ type: leaf.number.name, value: 2 },
 					],
 					foo2: [
-						{ type: numberSchema.name, value: 0 },
-						{ type: numberSchema.name, value: 1 },
-						{ type: numberSchema.name, value: 2 },
+						{ type: leaf.number.name, value: 0 },
+						{ type: leaf.number.name, value: 1 },
+						{ type: leaf.number.name, value: 2 },
 					],
 				},
 			};


### PR DESCRIPTION
## Description

Remove SchemaBuilder.leaf, and update tests accordingly.

## Breaking Changes

Custom schema should use the predefined leaf domain, or wrap its leaf types instead of defining new leaf schema.

A way forward that that preserves support for old documents across these schema changes is not currently available as the document format is not yet stable, and schema evolution features are not yet implemented.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

