### PR TITLE
refactor(tree): unify attaches and reattaches representation

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/helperTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/helperTypes.ts
@@ -3,31 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import {
-	CellId,
-	HasMarkFields,
-	Detach,
-	Insert,
-	Mark,
-	NewAttach,
-	Revive,
-	Transient,
-} from "./format";
+import { CellId, HasMarkFields, Detach, Insert, Mark, Transient } from "./format";
 
 export type EmptyInputCellMark<TNodeChange> = Mark<TNodeChange> & DetachedCellMark;
-
-/**
- * A mark that spans one or more cells.
- * The spanned cells may be populated (e.g., "Delete") or not (e.g., "Revive").
- */
-export type CellSpanningMark<TNodeChange> = Exclude<Mark<TNodeChange>, NewAttach<TNodeChange>>;
 
 export interface DetachedCellMark extends HasMarkFields {
 	cellId: CellId;
 }
 
-export type GenerativeMark<TNodeChange> = Insert<TNodeChange> | Revive<TNodeChange>;
-
-export type TransientMark<TNodeChange> = GenerativeMark<TNodeChange> & Transient;
+export type TransientMark<TNodeChange> = Insert<TNodeChange> & Transient;
 
 export type EmptyOutputCellMark<TNodeChange> = TransientMark<TNodeChange> | Detach<TNodeChange>;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
@@ -4,8 +4,6 @@
  */
 
 export {
-	Attach,
-	NewAttach,
 	Changeset,
 	Delete,
 	Detach,
@@ -20,10 +18,8 @@ export {
 	CellCount as NodeCount,
 	MoveId,
 	ProtoNode,
-	Reattach,
+	Attach,
 	ReturnFrom,
-	ReturnTo,
-	Revive,
 	NoopMark,
 	LineageEvent,
 	HasReattachFields,
@@ -49,7 +45,6 @@ export {
 	areRebasable,
 	getInputLength,
 	isDetachMark,
-	isReattach,
 	DetachedNodeTracker,
 	newCrossFieldTable,
 	newMoveEffectTable,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -7,7 +7,7 @@ import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { RevisionTag } from "../../core";
 import { CrossFieldManager, CrossFieldTarget } from "../modular-schema";
 import { RangeEntry } from "../../util";
-import { Mark, MoveId, MoveIn, MoveOut, ReturnFrom, ReturnTo } from "./format";
+import { Mark, MoveId, MoveIn, MoveOut, ReturnFrom } from "./format";
 import { cloneMark, splitMark } from "./utils";
 
 export type MoveEffectTable<T> = CrossFieldManager<MoveEffect<T>>;
@@ -95,14 +95,13 @@ export function getMoveEffect<T>(
 	return moveEffects.get(target, revision, id, count, addDependency);
 }
 
-export type MoveMark<T> = MoveOut<T> | MoveIn | ReturnFrom<T> | ReturnTo;
+export type MoveMark<T> = MoveOut<T> | MoveIn | ReturnFrom<T>;
 
 export function isMoveMark<T>(mark: Mark<T>): mark is MoveMark<T> {
 	switch (mark.type) {
 		case "MoveIn":
 		case "MoveOut":
 		case "ReturnFrom":
-		case "ReturnTo":
 			return true;
 		default:
 			return false;
@@ -110,12 +109,12 @@ export function isMoveMark<T>(mark: Mark<T>): mark is MoveMark<T> {
 }
 
 function applyMoveEffectsToDest<T>(
-	mark: MoveIn | ReturnTo,
+	mark: MoveIn,
 	revision: RevisionTag | undefined,
 	effects: MoveEffectTable<T>,
 	consumeEffect: boolean,
 ): Mark<T> {
-	const newMark: MoveIn | ReturnTo = {
+	const newMark: MoveIn = {
 		...mark,
 	};
 
@@ -257,8 +256,7 @@ export function applyMoveEffectsToMark<T>(
 					),
 				];
 			}
-			case "MoveIn":
-			case "ReturnTo": {
+			case "MoveIn": {
 				const effect = getMoveEffect(
 					effects,
 					CrossFieldTarget.Destination,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -16,7 +16,6 @@ import {
 import {
 	getInputLength,
 	isDetachMark,
-	isNewAttach,
 	cloneMark,
 	areInputCellsEmpty,
 	markEmptiesCells,
@@ -28,8 +27,10 @@ import {
 	areOverlappingIdRanges,
 	cloneCellId,
 	areOutputCellsEmpty,
+	isNewAttach,
 	getDetachCellId,
 	getInputCellId,
+	isReattach,
 } from "./utils";
 import {
 	Changeset,
@@ -362,7 +363,7 @@ function rebaseMark<TNodeChange>(
 					rebasedMark.count,
 					PairedMarkUpdate.Deactivated,
 				);
-			} else if (rebasedMark.type === "ReturnTo") {
+			} else if (isReattach(rebasedMark)) {
 				setPairedMarkStatus(
 					moveEffects,
 					CrossFieldTarget.Source,
@@ -405,7 +406,7 @@ function rebaseMark<TNodeChange>(
 					rebasedMark.count,
 					PairedMarkUpdate.Reactivated,
 				);
-			} else if (rebasedMark.type === "ReturnTo") {
+			} else if (isReattach(rebasedMark)) {
 				setPairedMarkStatus(
 					moveEffects,
 					CrossFieldTarget.Source,
@@ -451,13 +452,12 @@ function markFollowsMoves(mark: Mark<unknown>): boolean {
 	switch (type) {
 		case "Delete":
 		case "MoveOut":
-		case "Revive":
 			return true;
+		case "Insert":
+			return isReattach(mark);
 		case NoopMarkType:
 		case "ReturnFrom":
-		case "Insert":
 		case "MoveIn":
-		case "ReturnTo":
 		case "Placeholder":
 			return false;
 		default:
@@ -614,10 +614,7 @@ function amendRebaseI<TNodeChange>(
 			factory.push(withNodeChange(newMark, rebaseChild(newMark.changes, undefined)));
 		}
 
-		if (
-			baseMark !== undefined &&
-			(baseMark.type === "MoveIn" || baseMark.type === "ReturnTo")
-		) {
+		if (baseMark !== undefined && baseMark.type === "MoveIn") {
 			const movedMark = getMovedMark(
 				moveEffects,
 				baseMark.revision ?? baseRevision,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
@@ -28,12 +28,10 @@ function makeV0Codec<TNodeChange>(
 				switch (type) {
 					case NoopMarkType:
 					case "MoveIn":
-					case "ReturnTo":
 					case "Insert":
 					case "Delete":
 					case "MoveOut":
 					case "ReturnFrom":
-					case "Revive":
 						break;
 					case "Placeholder":
 						fail("Should not have placeholders in serialized changeset");
@@ -57,12 +55,10 @@ function makeV0Codec<TNodeChange>(
 				switch (type) {
 					case NoopMarkType:
 					case "MoveIn":
-					case "ReturnTo":
 					case "Insert":
 					case "Delete":
 					case "MoveOut":
 					case "ReturnFrom":
-					case "Revive":
 						break;
 					case "Placeholder":
 						fail("Should not have placeholders in serialized changeset");

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -15,9 +15,8 @@ import {
 	Mark,
 	MoveId,
 	NodeChangeType,
-	Reattach,
 	ReturnFrom,
-	ReturnTo,
+	MoveIn,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 
@@ -75,8 +74,8 @@ export const sequenceFieldEditor = {
 		isIntention: boolean = false,
 	): Changeset<never> => {
 		assert(detachEvent.revision !== undefined, 0x724 /* Detach event must have a revision */);
-		const mark: Reattach<never> = {
-			type: "Revive",
+		const mark: Insert<never> = {
+			type: "Insert",
 			count,
 			cellId: detachEvent,
 		};
@@ -125,8 +124,8 @@ export const sequenceFieldEditor = {
 			count,
 		};
 
-		const returnTo: ReturnTo = {
-			type: "ReturnTo",
+		const returnTo: MoveIn = {
+			type: "MoveIn",
 			id,
 			count,
 			cellId: detachEvent,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -13,6 +13,7 @@ import {
 	areInputCellsEmpty,
 	areOutputCellsEmpty,
 	getEffectiveNodeChanges,
+	isNewAttach,
 	markIsTransient,
 } from "./utils";
 
@@ -63,24 +64,7 @@ function cellDeltaFromMark<TNodeChange>(
 		const type = mark.type;
 		// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 		switch (type) {
-			case "Insert": {
-				const cursors = mark.content.map(singleTextCursor);
-				const insertMark: Mutable<Delta.Insert> = {
-					type: Delta.MarkType.Insert,
-					content: cursors,
-				};
-				if (mark.transientDetach !== undefined) {
-					const majorForTransient = mark.transientDetach.revision ?? revision;
-					const detachId: Delta.DetachedNodeId = { minor: mark.transientDetach.localId };
-					if (majorForTransient !== undefined) {
-						detachId.major = majorForTransient;
-					}
-					insertMark.detachId = detachId;
-				}
-				return [insertMark];
-			}
-			case "MoveIn":
-			case "ReturnTo": {
+			case "MoveIn": {
 				const ranges = idAllocator.allocate(mark.revision ?? revision, mark.id, mark.count);
 				return ranges.map(({ first, count }) => ({
 					type: Delta.MarkType.MoveIn,
@@ -114,38 +98,58 @@ function cellDeltaFromMark<TNodeChange>(
 					count,
 				}));
 			}
-			case "Revive": {
-				const cellId = mark.cellId;
-				assert(
-					cellId !== undefined,
-					0x7bb /* Effective revive must target an empty cell */,
-				);
-				const hasTransience: { detachId?: Delta.DetachedNodeId } = {};
-				if (mark.transientDetach !== undefined) {
-					const majorForTransient = mark.transientDetach.revision ?? revision;
-					const hasMajorForTransient: { major?: RevisionTag } = {};
-					if (majorForTransient !== undefined) {
-						hasMajorForTransient.major = majorForTransient;
-					}
-					hasTransience.detachId = {
-						...hasMajorForTransient,
-						minor: mark.transientDetach.localId,
+			case "Insert": {
+				if (isNewAttach(mark)) {
+					assert(mark.content !== undefined, "New insert must have content");
+					const cursors = mark.content.map(singleTextCursor);
+					const insertMark: Mutable<Delta.Insert> = {
+						type: Delta.MarkType.Insert,
+						content: cursors,
 					};
+					if (mark.transientDetach !== undefined) {
+						const majorForTransient = mark.transientDetach.revision ?? revision;
+						const detachId: Delta.DetachedNodeId = {
+							minor: mark.transientDetach.localId,
+						};
+						if (majorForTransient !== undefined) {
+							detachId.major = majorForTransient;
+						}
+						insertMark.detachId = detachId;
+					}
+					return [insertMark];
+				} else {
+					const cellId = mark.cellId;
+					assert(
+						cellId !== undefined,
+						0x7bb /* Effective revive must target an empty cell */,
+					);
+					const hasTransience: { detachId?: Delta.DetachedNodeId } = {};
+					if (mark.transientDetach !== undefined) {
+						const majorForTransient = mark.transientDetach.revision ?? revision;
+						const hasMajorForTransient: { major?: RevisionTag } = {};
+						if (majorForTransient !== undefined) {
+							hasMajorForTransient.major = majorForTransient;
+						}
+						hasTransience.detachId = {
+							...hasMajorForTransient,
+							minor: mark.transientDetach.localId,
+						};
+					}
+					const major = cellId.revision ?? revision;
+					const restoreId: Delta.DetachedNodeId = { minor: cellId.localId };
+					if (major !== undefined) {
+						restoreId.major = major;
+					}
+					const restoreMark: Mutable<Delta.Restore> = {
+						type: Delta.MarkType.Restore,
+						count: mark.count,
+						newContent: {
+							restoreId,
+							...hasTransience,
+						},
+					};
+					return [restoreMark];
 				}
-				const major = cellId.revision ?? revision;
-				const restoreId: Delta.DetachedNodeId = { minor: cellId.localId };
-				if (major !== undefined) {
-					restoreId.major = major;
-				}
-				const restoreMark: Mutable<Delta.Restore> = {
-					type: Delta.MarkType.Restore,
-					count: mark.count,
-					newContent: {
-						restoreId,
-						...hasTransience,
-					},
-				};
-				return [restoreMark];
 			}
 			case "Placeholder":
 				fail("Should not have placeholders in a changeset being converted to delta");

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -21,15 +21,11 @@ import {
 	LineageEvent,
 	Mark,
 	MoveIn,
-	NewAttach,
 	MoveOut,
-	Reattach,
 	ReturnFrom,
-	ReturnTo,
 	NoopMark,
 	Changeset,
 	MoveId,
-	Revive,
 	Delete,
 	NoopMarkType,
 	Transient,
@@ -38,44 +34,41 @@ import {
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import { isMoveMark, MoveEffectTable } from "./moveEffectTable";
-import { GenerativeMark, TransientMark, EmptyInputCellMark, DetachedCellMark } from "./helperTypes";
+import { TransientMark, EmptyInputCellMark, DetachedCellMark } from "./helperTypes";
 
 export function isEmpty<T>(change: Changeset<T>): boolean {
 	return change.length === 0;
 }
 
-export function isNewAttach<TNodeChange>(mark: Mark<TNodeChange>): mark is NewAttach<TNodeChange> {
-	return mark.type === "Insert" || mark.type === "MoveIn";
+export function isNewAttach<TNodeChange>(mark: Mark<TNodeChange>, revision?: RevisionTag): boolean {
+	return (
+		isAttach(mark) &&
+		mark.cellId !== undefined &&
+		(mark.revision ?? revision) === (mark.cellId.revision ?? revision)
+	);
 }
 
-export function isGenerativeMark<TNodeChange>(
-	mark: Mark<TNodeChange>,
-): mark is GenerativeMark<TNodeChange> {
-	return mark.type === "Insert" || mark.type === "Revive";
+export function isInsert<TNodeChange>(mark: Mark<TNodeChange>): mark is Insert<TNodeChange> {
+	return mark.type === "Insert";
 }
 
 export function isAttach<TNodeChange>(mark: Mark<TNodeChange>): mark is Attach<TNodeChange> {
-	return isNewAttach(mark) || isReattach(mark);
+	return mark.type === "Insert" || mark.type === "MoveIn";
 }
 
-export function isReattach<TNodeChange>(mark: Mark<TNodeChange>): mark is Reattach<TNodeChange> {
-	return mark.type === "Revive" || mark.type === "ReturnTo";
+export function isReattach<TNodeChange>(mark: Mark<TNodeChange>): boolean {
+	return isAttach(mark) && !isNewAttach(mark);
 }
 
 export function isActiveReattach<TNodeChange>(
 	mark: Mark<TNodeChange>,
-): mark is Reattach<TNodeChange> & { conflictsWith?: undefined } {
-	// No need to check Reattach.lastDeletedBy because it can only be set if the mark is conflicted
-	return isReattach(mark) && !isConflictedReattach(mark);
+): mark is Attach<TNodeChange> {
+	// No need to check Attach.lastDeletedBy because it can only be set if the mark is conflicted
+	return isAttach(mark) && isReattach(mark) && !isReattachConflicted(mark);
 }
 
 // TODO: Name is misleading
-export function isConflictedReattach<TNodeChange>(mark: Mark<TNodeChange>): boolean {
-	return isReattach(mark) && isReattachConflicted(mark);
-}
-
-// TODO: Name is misleading
-export function isReattachConflicted(mark: Reattach<unknown>): boolean {
+export function isReattachConflicted(mark: Attach<unknown>): boolean {
 	return mark.cellId === undefined || isRevertOnlyReattachPreempted(mark);
 }
 
@@ -84,11 +77,11 @@ export function isReattachConflicted(mark: Reattach<unknown>): boolean {
  * populated (and possibly emptied) by unrelated changes. Here, "unrelated" specifically means they are not an
  * undo/redo pair of the change this this mark is the inverse of.
  */
-function isRevertOnlyReattachPreempted(mark: Reattach<unknown>): boolean {
+function isRevertOnlyReattachPreempted(mark: Attach<unknown>): boolean {
 	return mark.inverseOf !== undefined && mark.inverseOf !== mark.cellId?.revision;
 }
 
-export function isReturnMuted(mark: ReturnTo): boolean {
+export function isReturnMuted(mark: MoveIn): boolean {
 	return mark.isSrcConflicted ?? isReattachConflicted(mark);
 }
 
@@ -144,7 +137,7 @@ function inlineCellIdRevision(cellId: CellId, revision: RevisionTag | undefined)
 
 export function cloneMark<TMark extends Mark<TNodeChange>, TNodeChange>(mark: TMark): TMark {
 	const clone = { ...mark };
-	if (clone.type === "Insert") {
+	if (clone.type === "Insert" && clone.content !== undefined) {
 		clone.content = [...clone.content];
 	}
 	if (clone.cellId !== undefined) {
@@ -219,7 +212,7 @@ export function markHasCellEffect(mark: Mark<unknown>): boolean {
 }
 
 export function markIsTransient<T>(mark: Mark<T>): mark is TransientMark<T> {
-	return isGenerativeMark(mark) && mark.transientDetach !== undefined;
+	return isInsert(mark) && mark.transientDetach !== undefined;
 }
 
 /**
@@ -233,20 +226,19 @@ export function getEffectiveNodeChanges<TNodeChange>(
 		return undefined;
 	}
 	const type = mark.type;
-	assert(
-		type !== "MoveIn" && type !== "ReturnTo",
-		0x72f /* MoveIn/ReturnTo marks should not have changes */,
-	);
+	assert(type !== "MoveIn", "MoveIn marks should not have changes");
 	switch (type) {
 		case "Insert":
-			return changes;
-		case "Revive":
-			// So long as the input cell is populated, the nested changes are still effective
-			// (even if the revive is preempted) because the nested changes can only target the node in the populated
-			// cell.
-			return areInputCellsEmpty(mark) && isRevertOnlyReattachPreempted(mark)
-				? undefined
-				: changes;
+			if (isNewAttach(mark)) {
+				return changes;
+			} else {
+				// So long as the input cell is populated, the nested changes are still effective
+				// (even if the revive is preempted) because the nested changes can only target the node in the populated
+				// cell.
+				return areInputCellsEmpty(mark) && isRevertOnlyReattachPreempted(mark)
+					? undefined
+					: changes;
+			}
 		case NoopMarkType:
 		case "Placeholder":
 		case "Delete":
@@ -268,25 +260,36 @@ export function areOutputCellsEmpty(mark: Mark<unknown>): boolean {
 		case NoopMarkType:
 		case "Placeholder":
 			return mark.cellId !== undefined;
-		case "Insert":
-			return mark.transientDetach !== undefined;
-		case "MoveIn":
-			return mark.isSrcConflicted ?? false;
 		case "Delete":
 		case "MoveOut":
 			return true;
 		case "ReturnFrom":
 			return mark.cellId !== undefined || !mark.isDstConflicted;
-		case "ReturnTo":
+		case "MoveIn":
+		case "Insert":
+			return mark.cellId !== undefined && (isMuted(mark) || markIsTransient(mark));
+		default:
+			unreachableCase(type);
+	}
+}
+
+export function isMuted(mark: Mark<unknown>): boolean {
+	const type = mark.type;
+	switch (type) {
+		case NoopMarkType:
+		case "Placeholder":
+			return false;
+		case "Delete":
+		case "MoveOut":
+			return mark.cellId !== undefined;
+		case "ReturnFrom":
+			return mark.cellId !== undefined || (mark.isDstConflicted ?? false);
+		case "MoveIn":
 			return (
-				mark.cellId !== undefined &&
-				((mark.isSrcConflicted ?? false) || isReattachConflicted(mark))
+				(mark.isSrcConflicted ?? false) || (isReattach(mark) && isReattachConflicted(mark))
 			);
-		case "Revive":
-			return (
-				(mark.cellId !== undefined && isReattachConflicted(mark)) ||
-				mark.transientDetach !== undefined
-			);
+		case "Insert":
+			return mark.cellId === undefined || (isReattach(mark) && isReattachConflicted(mark));
 		default:
 			unreachableCase(type);
 	}
@@ -406,36 +409,14 @@ export function tryExtendMark<T>(lhs: Mark<T>, rhs: Readonly<Mark<T>>): boolean 
 	}
 
 	switch (type) {
-		case "Insert": {
-			const lhsInsert = lhs as Insert;
-			if (
-				areMergeableChangeAtoms(lhsInsert.transientDetach, lhs.count, rhs.transientDetach)
-			) {
-				lhsInsert.content.push(...rhs.content);
-				lhsInsert.count += rhs.count;
-				return true;
-			}
-			break;
-		}
 		case "MoveIn": {
 			const lhsMoveIn = lhs as MoveIn;
 			if (
+				lhsMoveIn.inverseOf === rhs.inverseOf &&
 				lhsMoveIn.isSrcConflicted === rhs.isSrcConflicted &&
 				(lhsMoveIn.id as number) + lhsMoveIn.count === rhs.id
 			) {
 				lhsMoveIn.count += rhs.count;
-				return true;
-			}
-			break;
-		}
-		case "ReturnTo": {
-			const lhsReturnTo = lhs as ReturnTo;
-			if (
-				lhsReturnTo.inverseOf === rhs.inverseOf &&
-				lhsReturnTo.isSrcConflicted === rhs.isSrcConflicted &&
-				(lhsReturnTo.id as number) + lhsReturnTo.count === rhs.id
-			) {
-				lhsReturnTo.count += rhs.count;
 				return true;
 			}
 			break;
@@ -457,13 +438,19 @@ export function tryExtendMark<T>(lhs: Mark<T>, rhs: Readonly<Mark<T>>): boolean 
 			}
 			break;
 		}
-		case "Revive": {
-			const lhsRevive = lhs as Revive;
+		case "Insert": {
+			const lhsInsert = lhs as Insert;
 			if (
-				lhsRevive.inverseOf === rhs.inverseOf &&
-				areMergeableChangeAtoms(lhsRevive.transientDetach, lhs.count, rhs.transientDetach)
+				lhsInsert.inverseOf === rhs.inverseOf &&
+				areMergeableChangeAtoms(lhsInsert.transientDetach, lhs.count, rhs.transientDetach)
 			) {
-				lhsRevive.count += rhs.count;
+				if (rhs.content === undefined) {
+					assert(lhsInsert.content === undefined, "Insert content type mismatch");
+				} else {
+					assert(lhsInsert.content !== undefined, "Insert content type mismatch");
+					lhsInsert.content.push(...rhs.content);
+				}
+				lhsInsert.count += rhs.count;
 				return true;
 			}
 			break;
@@ -846,12 +833,18 @@ export function splitMark<T, TMark extends Mark<T>>(mark: TMark, length: number)
 			return [mark1, mark2];
 		}
 		case "Insert": {
-			const mark1: TMark = { ...mark, content: mark.content.slice(0, length), count: length };
-			const mark2: TMark = {
+			const mark1: Insert<T> = {
 				...mark,
-				content: mark.content.slice(length),
+				count: length,
+			};
+			const mark2: Insert<T> = {
+				...mark,
 				count: remainder,
 			};
+			if (mark.content !== undefined) {
+				mark1.content = mark.content.slice(0, length);
+				mark2.content = mark.content.slice(length);
+			}
 			if (mark2.cellId !== undefined) {
 				mark2.cellId = splitDetachEvent(mark2.cellId, length);
 			}
@@ -861,32 +854,13 @@ export function splitMark<T, TMark extends Mark<T>>(mark: TMark, length: number)
 					localId: brand((mark.transientDetach.localId as number) + length),
 				};
 			}
-			return [mark1, mark2];
+			return [mark1, mark2] as [TMark, TMark];
 		}
-		case "MoveIn":
-		case "ReturnTo": {
+		case "MoveIn": {
 			const mark1: TMark = { ...mark, count: length };
 			const mark2: TMark = { ...mark, id: (mark.id as number) + length, count: remainder };
 			if (mark.cellId !== undefined) {
-				(mark2 as ReturnTo).cellId = splitDetachEvent(mark.cellId, length);
-			}
-			return [mark1, mark2];
-		}
-		case "Revive": {
-			const mark1: TMark = { ...mark, count: length };
-			const mark2: TMark = {
-				...mark,
-				count: remainder,
-			};
-
-			if (mark.cellId !== undefined) {
-				(mark2 as Revive).cellId = splitDetachEvent(mark.cellId, length);
-			}
-			if (mark.transientDetach !== undefined) {
-				(mark2 as Transient).transientDetach = {
-					revision: mark.transientDetach.revision,
-					localId: brand((mark.transientDetach.localId as number) + length),
-				};
+				(mark2 as MoveIn).cellId = splitDetachEvent(mark.cellId, length);
 			}
 			return [mark1, mark2];
 		}
@@ -976,7 +950,7 @@ export function withNodeChange<TNodeChange>(
 	const newMark = { ...mark };
 	if (changes !== undefined) {
 		assert(
-			mark.type !== "MoveIn" && mark.type !== "ReturnTo",
+			mark.type !== "MoveIn",
 			0x6a7 /* Cannot have a node change on a MoveIn or ReturnTo mark */,
 		);
 		newMark.changes = changes;

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -91,7 +91,7 @@ function createReviveChangeset(
 	lastDetach?: SF.CellId,
 ): SF.Changeset<never> {
 	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent);
-	const mark = markList[markList.length - 1] as SF.Reattach;
+	const mark = markList[markList.length - 1] as SF.Attach;
 	if (lastDetach !== undefined) {
 		mark.cellId = lastDetach;
 	}
@@ -105,7 +105,7 @@ function createRedundantReviveChangeset(
 	isIntention?: boolean,
 ): SF.Changeset<never> {
 	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, isIntention);
-	const mark = markList[markList.length - 1] as SF.Reattach;
+	const mark = markList[markList.length - 1] as SF.Attach;
 	delete mark.cellId;
 	return markList;
 }
@@ -117,7 +117,7 @@ function createBlockedReviveChangeset(
 	lastDetach: SF.CellId,
 ): SF.Changeset<never> {
 	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent);
-	const mark = markList[markList.length - 1] as SF.Reattach;
+	const mark = markList[markList.length - 1] as SF.Attach;
 	mark.cellId = lastDetach;
 	return markList;
 }
@@ -129,7 +129,7 @@ function createIntentionalReviveChangeset(
 	lastDetach?: SF.CellId,
 ): SF.Changeset<never> {
 	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, true);
-	const mark = markList[markList.length - 1] as SF.Reattach;
+	const mark = markList[markList.length - 1] as SF.Attach;
 
 	if (lastDetach !== undefined) {
 		mark.cellId = lastDetach;
@@ -215,10 +215,10 @@ function createInsertMark<TChange = never>(
 function createReviveMark<TChange = never>(
 	count: number,
 	cellId?: SF.CellId,
-	overrides?: Partial<SF.Revive<TChange>>,
-): SF.Revive<TChange> {
-	const mark: SF.Revive<TChange> = {
-		type: "Revive",
+	overrides?: Partial<SF.Insert<TChange>>,
+): SF.Insert<TChange> {
+	const mark: SF.Insert<TChange> = {
+		type: "Insert",
 		count,
 	};
 	if (cellId !== undefined) {
@@ -331,11 +331,11 @@ function createReturnToMark(
 	count: number,
 	markId: ChangesetLocalId | ChangeAtomId,
 	cellId?: SF.CellId,
-	overrides?: Partial<SF.ReturnTo>,
-): SF.ReturnTo {
+	overrides?: Partial<SF.MoveIn>,
+): SF.MoveIn {
 	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
-	const mark: SF.ReturnTo = {
-		type: "ReturnTo",
+	const mark: SF.MoveIn = {
+		type: "MoveIn",
 		id: atomId.localId,
 		count,
 	};


### PR DESCRIPTION
Unifies the representation of sequence marks that represent attaches and reattaches, effectively merging the representations for inserts and revives, and, separately, move-ins and return-tos.

Note that this refactor does not mean those are now indistinguishable.
 
This allows some logic to be deduplicated. The PR is not meant to meant to change merge semantics in any way.
