### PR TITLE
fluid-build: Remove unused nohoist option

### DIFF
--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -251,7 +251,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 		);
 
 		if (shouldInstall) {
-			if (!(await FluidRepo.ensureInstalled(updatedPackages, false))) {
+			if (!(await FluidRepo.ensureInstalled(updatedPackages))) {
 				this.error("Install failed.");
 			}
 		} else {

--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -234,7 +234,7 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand> {
 
 		if (updatedPackages.length > 0) {
 			if (shouldInstall) {
-				if (!(await FluidRepo.ensureInstalled(updatedPackages, false))) {
+				if (!(await FluidRepo.ensureInstalled(updatedPackages))) {
 					this.error("Install failed.");
 				}
 			} else {

--- a/build-tools/packages/build-cli/src/commands/generate/changelog.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changelog.ts
@@ -97,7 +97,7 @@ export default class GenerateChangeLogCommand extends BaseCommand<typeof Generat
 			: // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			  [context.fullPackageMap.get(releaseGroup)!];
 
-		const installed = await FluidRepo.ensureInstalled(packagesToCheck, true);
+		const installed = await FluidRepo.ensureInstalled(packagesToCheck);
 
 		if (!installed) {
 			this.error(`Error installing dependencies for: ${releaseGroup}`);

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -241,7 +241,7 @@ export const checkDependenciesInstalled: StateHandlerFunction = async (
 		: // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		  [context.fullPackageMap.get(releaseGroup)!];
 
-	const installed = await FluidRepo.ensureInstalled(packagesToCheck, true);
+	const installed = await FluidRepo.ensureInstalled(packagesToCheck);
 
 	if (installed) {
 		BaseStateHandler.signalSuccess(machine, state);

--- a/build-tools/packages/build-cli/src/handlers/doFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/doFunctions.ts
@@ -119,7 +119,6 @@ export const doBumpReleasedDependencies: StateHandlerFunction = async (
 				? context.packagesInReleaseGroup(releaseGroup)
 				: // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				  [context.fullPackageMap.get(releaseGroup)!],
-			false,
 		);
 		// There were updates, which is considered a failure.
 		BaseStateHandler.signalFailure(machine, state);
@@ -176,7 +175,7 @@ export const doReleaseGroupBump: StateHandlerFunction = async (
 		log,
 	);
 
-	if (shouldInstall === true && !(await FluidRepo.ensureInstalled(packages, false))) {
+	if (shouldInstall === true && !(await FluidRepo.ensureInstalled(packages))) {
 		log.errorLog("Install failed.");
 		BaseStateHandler.signalFailure(machine, state);
 		return true;

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -320,29 +320,24 @@ export class FluidRepo {
 		this.packages.packages.forEach((pkg) => pkg.reload());
 	}
 
-	public static async ensureInstalled(packages: Package[], check: boolean = true) {
+	public static async ensureInstalled(packages: Package[]) {
 		const installedMonoRepo = new Set<MonoRepo>();
 		const installPromises: Promise<ExecAsyncResult>[] = [];
 		for (const pkg of packages) {
-			if (!check || !(await pkg.checkInstall(false))) {
-				if (pkg.monoRepo) {
-					if (!installedMonoRepo.has(pkg.monoRepo)) {
-						installedMonoRepo.add(pkg.monoRepo);
-						installPromises.push(pkg.monoRepo.install());
-					}
-				} else {
-					installPromises.push(pkg.install());
+			if (pkg.monoRepo) {
+				if (!installedMonoRepo.has(pkg.monoRepo)) {
+					installedMonoRepo.add(pkg.monoRepo);
+					installPromises.push(pkg.monoRepo.install());
 				}
+			} else {
+				installPromises.push(pkg.install());
 			}
 		}
 		const rets = await Promise.all(installPromises);
 		return !rets.some((ret) => ret.error);
 	}
 
-	public async install(nohoist: boolean = false) {
-		if (nohoist) {
-			return this.packages.noHoistInstall(this.resolvedRoot);
-		}
+	public async install() {
 		return FluidRepo.ensureInstalled(this.packages.packages);
 	}
 

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -247,7 +247,7 @@ export class MonoRepo {
 	}
 
 	public async install() {
-		this.logger.info(`${this.kind}: Installing - ${this.installCommand}`);
+		this.logger.log(`Release group ${this.kind}: Installing - ${this.installCommand}`);
 		return execWithErrorAsync(this.installCommand, { cwd: this.repoPath }, this.repoPath);
 	}
 	public async uninstall() {

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -3,13 +3,11 @@
  * Licensed under the MIT License.
  */
 import chalk from "chalk";
-import * as path from "path";
 
 import { commonOptions } from "../common/commonOptions";
 import { getResolvedFluidRoot } from "../common/fluidUtils";
 import { defaultLogger } from "../common/logging";
 import { Timer } from "../common/timer";
-import { existsSync } from "../common/utils";
 import { BuildGraph, BuildResult } from "./buildGraph";
 import { FluidRepoBuild } from "./fluidRepoBuild";
 import { options, parseOptions } from "./options";
@@ -23,15 +21,6 @@ async function main() {
 	const resolvedRoot = await getResolvedFluidRoot();
 
 	log(`Fluid Repo Root: ${resolvedRoot}`);
-
-	// Detect nohoist state mismatch and infer uninstall switch
-	if (options.install) {
-		const hasRootNodeModules = existsSync(path.join(resolvedRoot, "node_modules"));
-		if (hasRootNodeModules === options.nohoist) {
-			// We need to uninstall if nohoist doesn't match the current state of installation
-			options.uninstall = true;
-		}
-	}
 
 	// Load the package
 	const repo = new FluidRepoBuild(resolvedRoot);
@@ -77,7 +66,7 @@ async function main() {
 	// Install or check install
 	if (options.install) {
 		log("Installing packages");
-		if (!(await repo.install(options.nohoist))) {
+		if (!(await repo.install())) {
 			error(`Install failed`);
 			process.exit(-5);
 		}

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -29,7 +29,6 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 	install: boolean;
 	uninstall: boolean;
 	concurrency: number;
-	fix: boolean;
 	worker: boolean;
 	workerThreads: boolean;
 	workerMemoryLimit: number;
@@ -54,7 +53,6 @@ export const options: FastBuildOptions = {
 	install: false,
 	uninstall: false,
 	concurrency: os.cpus().length,
-	fix: false,
 	all: false,
 	worker: false,
 	workerThreads: false,
@@ -160,12 +158,6 @@ export function parseOptions(argv: string[]) {
 
 		if (arg === "-f" || arg === "--force") {
 			options.force = true;
-			continue;
-		}
-
-		if (arg === "--fix") {
-			options.fix = true;
-			setBuild(false);
 			continue;
 		}
 

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -27,7 +27,6 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 	depcheck: boolean;
 	force: boolean;
 	install: boolean;
-	nohoist: boolean;
 	uninstall: boolean;
 	concurrency: number;
 	fix: boolean;
@@ -53,7 +52,6 @@ export const options: FastBuildOptions = {
 	depcheck: false,
 	force: false,
 	install: false,
-	nohoist: false,
 	uninstall: false,
 	concurrency: os.cpus().length,
 	fix: false,
@@ -104,14 +102,13 @@ function setBuild(build: boolean) {
 	}
 }
 
-function setReinstall(nohoist: boolean) {
+function setReinstall() {
 	options.uninstall = true;
-	setInstall(nohoist);
+	setInstall();
 }
 
-function setInstall(nohoist: boolean) {
+function setInstall() {
 	options.install = true;
-	options.nohoist = nohoist;
 	setBuild(false);
 }
 
@@ -173,22 +170,12 @@ export function parseOptions(argv: string[]) {
 		}
 
 		if (arg === "--install") {
-			setInstall(false);
-			continue;
-		}
-
-		if (arg === "--install:nohoist") {
-			setInstall(true);
+			setInstall();
 			continue;
 		}
 
 		if (arg === "--reinstall") {
-			setReinstall(false);
-			continue;
-		}
-
-		if (arg === "--reinstall:nohoist") {
-			setReinstall(true);
+			setReinstall();
 			continue;
 		}
 


### PR DESCRIPTION
- nohoist was useful when we use `lerna`, to check if the dependency per package was complete.  Now that we switch to `pnpm`, it is not useful anymore.
- remove imperfect check to see if we have installed packages before invoking `pnpm`. `pnpm` does it pretty quick now, and the benefit of avoid calling `pnpm` isn't that great anymore.
- Remove unused command line options `--fix`