### PR TITLE
[tree2] Add skipped regression test demonstrating issues with successive optional field rebases

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -667,8 +667,10 @@ describe("SharedTree", () => {
 			};
 
 			const provider = new TestTreeProviderLite(3);
-			const [tree1, tree2, tree3] = provider.trees.map((t) => t.schematize(config).editableTree2(schema));
-			
+			const [tree1, tree2, tree3] = provider.trees.map((t) =>
+				t.schematize(config).editableTree2(schema),
+			);
+
 			tree1.content = 1;
 			tree2.content = 2;
 			tree3.content = 3;

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -657,6 +657,29 @@ describe("SharedTree", () => {
 			}
 		});
 
+		it.skip("Regression test for 0x370", async () => {
+			const b = new SchemaBuilder({ scope: "0x370 repro" });
+			const schema = b.toDocumentSchema(b.optional(leaf.number));
+			const config: InitializeAndSchematizeConfiguration<typeof schema.rootFieldSchema> = {
+				schema,
+				initialTree: undefined,
+				allowedSchemaModifications: AllowedUpdateType.None,
+			};
+
+			const provider = new TestTreeProviderLite(3);
+			const [tree1, tree2, tree3] = provider.trees.map((t) => t.schematize(config).editableTree2(schema));
+			
+			tree1.content = 1;
+			tree2.content = 2;
+			tree3.content = 3;
+
+			provider.processMessages();
+
+			assert.equal(tree1.content, 3);
+			assert.equal(tree2.content, 3);
+			assert.equal(tree3.content, 3);
+		});
+
 		it("can move nodes across fields", () => {
 			const provider = new TestTreeProviderLite(2);
 			const tree1 = provider.trees[0].view;
@@ -711,6 +734,10 @@ describe("SharedTree", () => {
 			};
 			validateTree(tree1, [expectedState]);
 			validateTree(tree2, [expectedState]);
+		});
+
+		it("can process multiple optional sets", () => {
+
 		});
 
 		// TODO: unskip once the bug which compose is fixed

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -657,31 +657,6 @@ describe("SharedTree", () => {
 			}
 		});
 
-		it.skip("Regression test for 0x370", async () => {
-			const b = new SchemaBuilder({ scope: "0x370 repro" });
-			const schema = b.toDocumentSchema(b.optional(leaf.number));
-			const config: InitializeAndSchematizeConfiguration<typeof schema.rootFieldSchema> = {
-				schema,
-				initialTree: undefined,
-				allowedSchemaModifications: AllowedUpdateType.None,
-			};
-
-			const provider = new TestTreeProviderLite(3);
-			const [tree1, tree2, tree3] = provider.trees.map((t) =>
-				t.schematize(config).editableTree2(schema),
-			);
-
-			tree1.content = 1;
-			tree2.content = 2;
-			tree3.content = 3;
-
-			provider.processMessages();
-
-			assert.equal(tree1.content, 3);
-			assert.equal(tree2.content, 3);
-			assert.equal(tree3.content, 3);
-		});
-
 		it("can move nodes across fields", () => {
 			const provider = new TestTreeProviderLite(2);
 			const tree1 = provider.trees[0].view;

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -736,10 +736,6 @@ describe("SharedTree", () => {
 			validateTree(tree2, [expectedState]);
 		});
 
-		it("can process multiple optional sets", () => {
-
-		});
-
 		// TODO: unskip once the bug which compose is fixed
 		it.skip("can make multiple moves in a transaction", () => {
 			const provider = new TestTreeProviderLite();


### PR DESCRIPTION
## Description

Adds a regression test for a merge scenario which causes 0x370. Fuzz test changes in #17560 discovered this.
