### PR TITLE
tree2: Add "list" schema building

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1763,23 +1763,33 @@ declare namespace SchemaAware {
 export { SchemaAware }
 
 // @alpha @sealed
-export class SchemaBuilder<TScope extends string = string> extends SchemaBuilderBase<TScope, typeof FieldKinds.required> {
+export class SchemaBuilder<TScope extends string = string, TName extends string | number = string> extends SchemaBuilderBase<TScope, typeof FieldKinds.required, TName> {
     constructor(options: SchemaBuilderOptions<TScope>);
     // (undocumented)
     readonly boolean: TreeSchema<"com.fluidframework.leaf.boolean", {
-    leafValue: import("..").ValueSchema.Boolean;
+        leafValue: import("..").ValueSchema.Boolean;
     }>;
     // (undocumented)
     readonly handle: TreeSchema<"com.fluidframework.leaf.handle", {
-    leafValue: import("..").ValueSchema.FluidHandle;
+        leafValue: import("..").ValueSchema.FluidHandle;
+    }>;
+    list<const T extends TreeSchema | Any | readonly TreeSchema[]>(allowedTypes: T): TreeSchema<`${TScope}.List<${string}>`, {
+        structFields: {
+            [""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+        };
+    }>;
+    list<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeSchema<`${TScope}.${Name}`, {
+        structFields: {
+            [""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+        };
     }>;
     // (undocumented)
     readonly null: TreeSchema<"com.fluidframework.leaf.null", {
-    leafValue: import("..").ValueSchema.Null;
+        leafValue: import("..").ValueSchema.Null;
     }>;
     // (undocumented)
     readonly number: TreeSchema<"com.fluidframework.leaf.number", {
-    leafValue: import("..").ValueSchema.Number;
+        leafValue: import("..").ValueSchema.Number;
     }>;
     static optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Optional, NormalizeAllowedTypes<T>>;
     readonly optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Optional, NormalizeAllowedTypes<T>>;
@@ -1789,7 +1799,7 @@ export class SchemaBuilder<TScope extends string = string> extends SchemaBuilder
     readonly sequence: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => FieldSchema<Sequence, NormalizeAllowedTypes<T>>;
     // (undocumented)
     readonly string: TreeSchema<"com.fluidframework.leaf.string", {
-    leafValue: import("..").ValueSchema.String;
+        leafValue: import("..").ValueSchema.String;
     }>;
 }
 

--- a/experimental/dds/tree2/src/domains/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/domains/schemaBuilder.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils";
 import { leaf } from "../domains";
 import {
+	Any,
 	FieldKind,
 	FieldKinds,
 	FieldSchema,
@@ -12,7 +14,9 @@ import {
 	NormalizeAllowedTypes,
 	SchemaBuilderBase,
 	SchemaBuilderOptions,
+	TreeSchema,
 } from "../feature-libraries";
+import { getOrCreate, isAny, requireFalse } from "../util";
 
 /**
  * Builds schema libraries, and the schema within them.
@@ -35,15 +39,153 @@ import {
  * TODO: figure out a way to link `leaf` above without breaking API Extractor.
  * @sealed @alpha
  */
-export class SchemaBuilder<TScope extends string = string> extends SchemaBuilderBase<
-	TScope,
-	typeof FieldKinds.required
-> {
+export class SchemaBuilder<
+	TScope extends string = string,
+	TName extends string | number = string,
+> extends SchemaBuilderBase<TScope, typeof FieldKinds.required, TName> {
+	private readonly structuralTypes: Map<string, TreeSchema> = new Map();
+
 	public constructor(options: SchemaBuilderOptions<TScope>) {
 		super(FieldKinds.required, {
 			...options,
 			libraries: [...(options.libraries ?? []), leaf.library],
 		});
+	}
+
+	/**
+	 * Define (and add to this library if not already present) a structurally typed {@link TreeSchema} for a {@link FieldNode} of a {@link Sequence}.
+	 *
+	 * @remarks
+	 * The {@link TreeSchemaIdentifier} for this List is defined as a function of the provided types.
+	 * It is still scoped to this SchemaBuilder, but multiple calls with the same arguments will return the same schema object, providing somewhat structural typing.
+	 * This does not support recursive types.
+	 *
+	 * If using these structurally named lists, other types in this schema builder should avoid names of the form `List<${string}>`.
+	 *
+	 * @privateRemarks
+	 * The name produced at the type level here is not as specific as it could be, however doing type level sorting and escaping is a real mess.
+	 * There are cases where not having this full type provided will be less than ideal since TypeScript's structural types.
+	 * For example attempts to narrow unions of structural lists by name won't work.
+	 * Planned future changes to move to a class based schema system as well as factor function based node construction should mostly avoid these issues,
+	 * though there may still be some problematic cases even after that work is done.
+	 */
+	public list<const T extends TreeSchema | Any | readonly TreeSchema[]>(
+		allowedTypes: T,
+	): TreeSchema<
+		`${TScope}.List<${string}>`,
+		{
+			structFields: {
+				[""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+			};
+		}
+	>;
+
+	/**
+	 * Define (and add to this library) a {@link TreeSchema} for a {@link FieldNode} of a {@link Sequence}.
+	 *
+	 * The name must be unique among all TreeSchema in the the document schema.
+	 */
+	public list<Name extends TName, const T extends ImplicitAllowedTypes>(
+		name: Name,
+		allowedTypes: T,
+	): TreeSchema<
+		`${TScope}.${Name}`,
+		{
+			structFields: {
+				[""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+			};
+		}
+	>;
+
+	public list<const T extends ImplicitAllowedTypes>(
+		nameOrAllowedTypes: TName | ((T & TreeSchema) | Any | readonly TreeSchema[]),
+		allowedTypes?: T,
+	): TreeSchema<
+		`${TScope}.${string}`,
+		{
+			structFields: {
+				[""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+			};
+		}
+	> {
+		if (allowedTypes === undefined) {
+			let inner: string;
+			const types = nameOrAllowedTypes as (T & TreeSchema) | Any | readonly TreeSchema[];
+			if (types === Any) {
+				inner = "Any";
+			} else if (types instanceof TreeSchema) {
+				// Call back into this with a array to ensure version with array gets named identical to version with single item.
+				return this.list([types]) as TreeSchema<
+					`${TScope}.${string}`,
+					{
+						structFields: {
+							[""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+						};
+					}
+				>;
+			} else {
+				assert(Array.isArray(types), "Types should be an array");
+				const names = types.map((t): string => {
+					// Ensure that lazy types (functions) don't slip through here.
+					assert(t instanceof TreeSchema, "invalid type provided");
+					// TypeScript should know `t.name` is a string (from the extends constraint on TreeSchema's name), but the linter objects.
+					// @ts-expect-error: Apparently TypeScript also fails to apply this constraint for some reason and is giving any:
+					type _check = requireFalse<isAny<typeof t.name>>;
+					// Adding `as string` here would silence the linter, but make this code less type safe (since if this became not a string, it would still build).
+					// Thus we explicitly check that this satisfies string.
+					// This would best be done by appending `satisfies string`, but the linter also rejects this.
+					// Therefor introducing a variable to do the same thing as `satisfies string` but such that the linter can understand:
+					const name: string = t.name;
+					// Just incase the compiler and linter really are onto something and this might sometimes not be a string, validate it:
+					assert(typeof name === "string", "Name should be a string");
+					return name;
+				});
+				// Ensure name is order independent
+				names.sort();
+				// Ensure name can't have collisions by quoting and escaping any quotes in the names of types.
+				// Using JSON is a simple way to accomplish this.
+				// The outer `[]` around the result are also needed so that a single type name "Any" would not collide with the "any" case above.
+				inner = JSON.stringify(names);
+			}
+			const fullName = `List<${inner}>`;
+			return getOrCreate(this.structuralTypes, fullName, () =>
+				this.namedList(fullName, nameOrAllowedTypes as T),
+			) as TreeSchema<
+				`${TScope}.${string}`,
+				{
+					structFields: {
+						[""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+					};
+				}
+			>;
+		}
+		return this.namedList(nameOrAllowedTypes as TName, allowedTypes);
+	}
+
+	/**
+	 * Define (and add to this library) a {@link TreeSchema} for a {@link FieldNode} of a {@link Sequence}.
+	 *
+	 * The name must be unique among all TreeSchema in the the document schema.
+	 *
+	 * @privateRemarks
+	 * TODO: If A custom "List" API is added as a subtype of {@link FieldNode}, this would opt into that.
+	 */
+	private namedList<Name extends TName | string, const T extends ImplicitAllowedTypes>(
+		name: Name,
+		allowedTypes: T,
+	): TreeSchema<
+		`${TScope}.${Name}`,
+		{
+			structFields: {
+				[""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
+			};
+		}
+	> {
+		const schema = new TreeSchema(this, this.scoped(name as TName & Name), {
+			structFields: { [""]: this.sequence(allowedTypes) },
+		});
+		this.addNodeSchema(schema);
+		return schema;
 	}
 
 	/**

--- a/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
@@ -1,0 +1,166 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { SchemaBuilder } from "../../domains";
+import {
+	Any,
+	FieldKinds,
+	FieldSchema,
+	Sequence2,
+	TreeSchema,
+	schemaIsFieldNode,
+} from "../../feature-libraries";
+// eslint-disable-next-line import/no-internal-modules
+import { UnboxNode } from "../../feature-libraries/editable-tree-2/editableTreeTypes";
+import { areSafelyAssignable, requireTrue } from "../../util";
+
+describe("domains - SchemaBuilder", () => {
+	describe("list", () => {
+		describe("structural", () => {
+			it("Any", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+
+				const listAny = builder.list(Any);
+				assert(schemaIsFieldNode(listAny));
+				assert.equal(listAny.name, "scope.List<Any>");
+				assert(
+					listAny.structFields
+						.get("")
+						.equals(FieldSchema.create(FieldKinds.sequence, [Any])),
+				);
+				type ListAny = UnboxNode<typeof listAny>;
+				type _check = requireTrue<areSafelyAssignable<ListAny, Sequence2<readonly [Any]>>>;
+
+				assert.equal(builder.list(Any), listAny);
+			});
+
+			it("never", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+
+				const listNever = builder.list([]);
+				assert(schemaIsFieldNode(listNever));
+				assert.equal(listNever.name, "scope.List<[]>");
+				assert(
+					listNever.structFields
+						.get("")
+						.equals(FieldSchema.create(FieldKinds.sequence, [])),
+				);
+				type ListAny = UnboxNode<typeof listNever>;
+				type _check = requireTrue<areSafelyAssignable<ListAny, Sequence2<readonly []>>>;
+
+				assert.equal(builder.list([]), listNever);
+			});
+
+			it("implicit", () => {
+				const builder = new SchemaBuilder({ scope: "scope2" });
+
+				const listImplicit = builder.list(builder.number);
+				assert(schemaIsFieldNode(listImplicit));
+				assert.equal(listImplicit.name, `scope2.List<["${builder.number.name}"]>`);
+				assert(
+					listImplicit.structFields
+						.get("")
+						.equals(FieldSchema.create(FieldKinds.sequence, [builder.number])),
+				);
+				type ListAny = UnboxNode<typeof listImplicit>;
+				type _check = requireTrue<
+					areSafelyAssignable<ListAny, Sequence2<readonly [typeof builder.number]>>
+				>;
+
+				assert.equal(builder.list(builder.number), listImplicit);
+			});
+
+			it("implicit normalizes", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+
+				const listImplicit = builder.list(builder.number);
+				const listExplicit = builder.list([builder.number]);
+
+				assert.equal(listImplicit, listExplicit);
+			});
+
+			it("union", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+
+				const listUnion = builder.list([builder.number, builder.boolean]);
+				assert(schemaIsFieldNode(listUnion));
+
+				assert.equal(
+					listUnion.name,
+					// Sorted alphabetically
+					`scope.List<["${builder.boolean.name}","${builder.number.name}"]>`,
+				);
+				assert(
+					listUnion.structFields
+						.get("")
+						.equals(
+							FieldSchema.create(FieldKinds.sequence, [
+								builder.number,
+								builder.boolean,
+							]),
+						),
+				);
+				type ListAny = UnboxNode<typeof listUnion>;
+				type _check = requireTrue<
+					areSafelyAssignable<
+						ListAny,
+						Sequence2<readonly [typeof builder.number, typeof builder.boolean]>
+					>
+				>;
+				// TODO: this should compile: ideally EditableTree's use of AllowedTypes would be compile time order independent like it is runtime order independent, but its currently not.
+				type _check2 = requireTrue<
+					// @ts-expect-error Currently not order independent: ideally this would compile
+					areSafelyAssignable<
+						ListAny,
+						Sequence2<readonly [typeof builder.boolean, typeof builder.number]>
+					>
+				>;
+
+				assert.equal(builder.list([builder.number, builder.boolean]), listUnion);
+				assert.equal(builder.list([builder.boolean, builder.number]), listUnion);
+			});
+
+			it("escaped names", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+				const doubleName = builder.struct(`bar","scope.foo`, {});
+
+				const listDoubleName = builder.list(doubleName);
+				assert(schemaIsFieldNode(listDoubleName));
+				assert.equal(listDoubleName.name, `scope.List<["scope.bar\\",\\"scope.foo"]>`);
+
+				// This escaping ensures named don't collide:
+				const foo = builder.struct("foo", {});
+				const bar = builder.struct("bar", {});
+				const listUnion = builder.list([bar, foo]);
+				assert(listUnion.name !== listDoubleName.name);
+			});
+		});
+
+		it("named list", () => {
+			it("implicit normalizes", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+
+				const list = builder.list("Foo", builder.number);
+				assert(schemaIsFieldNode(list));
+				assert.equal(list.name, `scope2.Foo`);
+				assert(
+					list.structFields
+						.get("")
+						.equals(FieldSchema.create(FieldKinds.sequence, [builder.number])),
+				);
+				type ListAny = UnboxNode<typeof list>;
+				type _check = requireTrue<
+					areSafelyAssignable<ListAny, Sequence2<readonly [typeof builder.number]>>
+				>;
+
+				// Not cached for structural use
+				assert((builder.list(builder.number) as TreeSchema) !== list);
+				// Creating again errors instead or reuses
+				assert.throws(() => builder.list("Foo", builder.number));
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Description

Add shorthand for field schema for sequences called "list", with option to infer name from content structually.

Fix that domain SchemaBuilder didn't allow non-string namining.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

