### PR TITLE
docs(protocol-definitions): Add explicit release tags to API members

### DIFF
--- a/common/lib/protocol-definitions/api-extractor.json
+++ b/common/lib/protocol-definitions/api-extractor.json
@@ -1,12 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-	"messages": {
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				// TODO: Fix violations and remove this rule override
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -70,9 +70,7 @@ export interface IClient {
 
 // @public
 export interface IClientConfiguration {
-    // (undocumented)
     blockSize: number;
-    // (undocumented)
     maxMessageSize: number;
     noopCountFrequency?: number;
     noopTimeFrequency?: number;
@@ -270,9 +268,7 @@ export interface ISequencedDocumentMessage {
     clientSequenceNumber: number;
     compression?: string;
     contents: unknown;
-    // (undocumented)
     data?: string;
-    // @alpha
     expHash1?: string;
     metadata?: unknown;
     minimumSequenceNumber: number;
@@ -374,15 +370,10 @@ export interface ISummaryBlob {
 
 // @public (undocumented)
 export interface ISummaryContent {
-    // (undocumented)
     details?: IUploadedSummaryDetails;
-    // (undocumented)
     handle: string;
-    // (undocumented)
     head: string;
-    // (undocumented)
     message: string;
-    // (undocumented)
     parents: string[];
 }
 
@@ -483,7 +474,6 @@ export type ITreeEntry = {
 
 // @public (undocumented)
 export interface IUploadedSummaryDetails {
-    // (undocumented)
     includesProtocolTree?: boolean;
 }
 
@@ -518,13 +508,9 @@ export enum MessageType {
 
 // @public
 export enum NackErrorType {
-    // (undocumented)
     BadRequestError = "BadRequestError",
-    // (undocumented)
     InvalidScopeError = "InvalidScopeError",
-    // (undocumented)
     LimitExceededError = "LimitExceededError",
-    // (undocumented)
     ThrottlingError = "ThrottlingError"
 }
 

--- a/common/lib/protocol-definitions/src/clients.ts
+++ b/common/lib/protocol-definitions/src/clients.ts
@@ -12,12 +12,16 @@ import { IUser } from "./users";
  *
  * Note: a user's connection mode is dependent on their permissions.
  * E.g. a user with read-only permissions will not be allowed a "write" connection mode.
+ *
+ * @public
  */
 export type ConnectionMode = "write" | "read";
 
 /**
  * Capabilities of a Client.
  * In particular, whether or not the client is {@link ICapabilities.interactive}.
+ *
+ * @public
  */
 export interface ICapabilities {
 	/**
@@ -34,6 +38,8 @@ export interface ICapabilities {
 
 /**
  * {@link IClient} connection / environment metadata.
+ *
+ * @public
  */
 export interface IClientDetails {
 	/**
@@ -60,6 +66,8 @@ export interface IClientDetails {
 
 /**
  * Represents a client connected to a Fluid service, including associated user details, permissions, and connection mode.
+ *
+ * @public
  */
 export interface IClient {
 	/**
@@ -92,6 +100,8 @@ export interface IClient {
 
 /**
  * A {@link IClient} that has been acknowledged by the sequencer.
+ *
+ * @public
  */
 export interface ISequencedClient {
 	/**
@@ -105,6 +115,9 @@ export interface ISequencedClient {
 	sequenceNumber: number;
 }
 
+/**
+ * @public
+ */
 export interface ISignalClient {
 	/**
 	 * The {@link ISignalClient.client}'s unique ID.
@@ -129,6 +142,8 @@ export interface ISignalClient {
 
 /**
  * Contents sent with a `ClientJoin` message.
+ *
+ * @public
  */
 export interface IClientJoin {
 	/**

--- a/common/lib/protocol-definitions/src/config.ts
+++ b/common/lib/protocol-definitions/src/config.ts
@@ -4,13 +4,19 @@
  */
 
 /**
- * Key value store of service configuration properties provided to the client as part of connection
+ * Key value store of service configuration properties provided to the client as part of connection.
+ *
+ * @public
  */
 export interface IClientConfiguration {
-	// Max message size the server will accept before requiring chunking
+	/**
+	 * Max message size the server will accept before requiring chunking.
+	 */
 	maxMessageSize: number;
 
-	// Server defined ideal block size for storing snapshots
+	/**
+	 * Server-defined ideal block size for storing snapshots.
+	 */
 	blockSize: number;
 
 	/**

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -9,9 +9,12 @@ import { ISequencedClient } from "./clients";
 /**
  * Proposal to set the given key/value pair.
  *
+ * @remarks
  * Consensus on the proposal is achieved if the MSN is \>= the sequence number
  * at which the proposal is made and no client within the collaboration window rejects
  * the proposal.
+ *
+ * @public
  */
 export interface IProposal {
 	/**
@@ -26,22 +29,30 @@ export interface IProposal {
 }
 
 /**
- * Similar to IProposal except includes the sequence number when it was made in addition to the fields on IProposal
+ * Similar to {@link IProposal} except it also includes the sequence number when it was made.
+ *
+ * @public
  */
 export type ISequencedProposal = { sequenceNumber: number } & IProposal;
 
 /**
- * Adds the sequence number at which the message was approved to an ISequencedProposal
+ * Adds the sequence number at which the message was approved to an {@link ISequencedProposal}.
+ *
+ * @public
  */
 export type IApprovedProposal = { approvalSequenceNumber: number } & ISequencedProposal;
 
 /**
- * Adds the sequence number at which the message was committed to an IApprovedProposal
+ * Adds the sequence number at which the message was committed to an {@link IApprovedProposal}.
+ *
+ * @public
  */
 export type ICommittedProposal = { commitSequenceNumber: number } & IApprovedProposal;
 
 /**
  * Events fired by a Quorum in response to client tracking.
+ *
+ * @public
  */
 export interface IQuorumClientsEvents extends IErrorEvent {
 	(event: "addMember", listener: (clientId: string, details: ISequencedClient) => void);
@@ -50,6 +61,8 @@ export interface IQuorumClientsEvents extends IErrorEvent {
 
 /**
  * Events fired by a Quorum in response to proposal tracking.
+ *
+ * @public
  */
 export interface IQuorumProposalsEvents extends IErrorEvent {
 	(event: "addProposal", listener: (proposal: ISequencedProposal) => void);
@@ -65,12 +78,16 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
 }
 
 /**
- * All events fired by an IQuorum, both client tracking and proposal tracking.
+ * All events fired by {@link IQuorum}, both client tracking and proposal tracking.
+ *
+ * @public
  */
 export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
 
 /**
  * Interface for tracking clients in the Quorum.
+ *
+ * @public
  */
 export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents> {
 	getMembers(): Map<string, ISequencedClient>;
@@ -80,6 +97,8 @@ export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents> {
 
 /**
  * Interface for tracking proposals in the Quorum.
+ *
+ * @public
  */
 export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents> {
 	propose(key: string, value: unknown): Promise<void>;
@@ -91,12 +110,17 @@ export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>
 
 /**
  * Interface combining tracking of clients as well as proposals in the Quorum.
+ *
+ * @public
  */
 export interface IQuorum
 	extends Omit<IQuorumClients, "on" | "once" | "off">,
 		Omit<IQuorumProposals, "on" | "once" | "off">,
 		IEventProvider<IQuorumEvents> {}
 
+/**
+ * @public
+ */
 export interface IProtocolState {
 	sequenceNumber: number;
 	minimumSequenceNumber: number;
@@ -105,6 +129,9 @@ export interface IProtocolState {
 	values: [string, ICommittedProposal][];
 }
 
+/**
+ * @public
+ */
 export interface IProcessMessageResult {
 	immediateNoOp?: boolean;
 }

--- a/common/lib/protocol-definitions/src/date.ts
+++ b/common/lib/protocol-definitions/src/date.ts
@@ -4,6 +4,8 @@
  */
 
 /**
- * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 format} date: `YYYY-MM-DDTHH:MM:SSZ`
+ * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 format} date: `YYYY-MM-DDTHH:MM:SSZ`.
+ *
+ * @public
  */
 export type IsoDate = string;

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @public
+ */
 export enum MessageType {
 	/**
 	 * Empty operation message. Used to send an updated reference sequence number.
@@ -73,6 +76,9 @@ export enum MessageType {
 	Control = "control",
 }
 
+/**
+ * @public
+ */
 export enum SignalType {
 	/**
 	 * System signal sent to indicate a new client has joined the collaboration.
@@ -86,7 +92,9 @@ export enum SignalType {
 }
 
 /**
- * Messages to track latency trace
+ * Messages to track latency trace.
+ *
+ * @public
  */
 export interface ITrace {
 	/**
@@ -105,6 +113,9 @@ export interface ITrace {
 	timestamp: number;
 }
 
+/**
+ * @public
+ */
 export interface INack {
 	/**
 	 * The operation that was just nacked.
@@ -123,7 +134,9 @@ export interface INack {
 }
 
 /**
- * Document specific message
+ * Document-specific message.
+ *
+ * @public
  */
 export interface IDocumentMessage {
 	/**
@@ -170,13 +183,17 @@ export interface IDocumentMessage {
 
 /**
  * Document Message with optional system level data field.
+ *
+ * @public
  */
 export interface IDocumentSystemMessage extends IDocumentMessage {
 	data: string;
 }
 
 /**
- * Branch origin information
+ * Branch origin information.
+ *
+ * @public
  */
 export interface IBranchOrigin {
 	/**
@@ -196,7 +213,9 @@ export interface IBranchOrigin {
 }
 
 /**
- * Sequenced message for a distributed document
+ * Sequenced message for a distributed document.
+ *
+ * @public
  */
 export interface ISequencedDocumentMessage {
 	/**
@@ -263,12 +282,13 @@ export interface ISequencedDocumentMessage {
 	 */
 	timestamp: number;
 
-	// Data provided by service. Only present in service generated messages.
+	/**
+	 * Data provided by service. Only present in service generated messages.
+	 */
 	data?: string;
 
 	/**
 	 * Experimental field for storing the rolling hash at sequence number.
-	 * @alpha
 	 */
 	expHash1?: string;
 
@@ -279,16 +299,24 @@ export interface ISequencedDocumentMessage {
 	compression?: string;
 }
 
+/**
+ * @public
+ */
 export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessage {
 	data: string;
 }
 
+/**
+ * @public
+ */
 export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMessage {
 	additionalContent: string;
 }
 
 /**
- * Common interface between incoming and outgoing signals
+ * Common interface between incoming and outgoing signals.
+ *
+ * @public
  */
 export interface ISignalMessageBase {
 	/**
@@ -313,7 +341,9 @@ export interface ISignalMessageBase {
 }
 
 /**
- * Interface for signals sent by the server to clients
+ * Interface for signals sent by the server to clients.
+ *
+ * @public
  */
 export interface ISignalMessage extends ISignalMessageBase {
 	/**
@@ -325,7 +355,9 @@ export interface ISignalMessage extends ISignalMessageBase {
 }
 
 /**
- * Interface for signals sent by clients to the server when submit_signals_v2 is enabled
+ * Interface for signals sent by clients to the server when submit_signals_v2 is enabled.
+ *
+ * @public
  */
 export interface ISentSignalMessage extends ISignalMessageBase {
 	/**
@@ -334,25 +366,43 @@ export interface ISentSignalMessage extends ISignalMessageBase {
 	targetClientId?: string;
 }
 
+/**
+ * @public
+ */
 export interface IUploadedSummaryDetails {
-	// Indicates whether the uploaded summary contains ".protocol" tree
+	/**
+	 * Indicates whether the uploaded summary contains ".protocol" tree.
+	 */
 	includesProtocolTree?: boolean;
 }
 
+/**
+ * @public
+ */
 export interface ISummaryContent {
-	// Handle reference to the summary data
+	/**
+	 * Handle reference to the summary data.
+	 */
 	handle: string;
 
-	// Message included as part of the summary
+	/**
+	 * Message included as part of the summary.
+	 */
 	message: string;
 
-	// Handles to parent summaries of the proposed new summary
+	/**
+	 * Handles to parent summaries of the proposed new summary.
+	 */
 	parents: string[];
 
-	// Handle to the current latest summary stored by the service
+	/**
+	 * Handle to the current latest summary stored by the service
+	 */
 	head: string;
 
-	// Details of the uploaded summary
+	/**
+	 * Details of the uploaded summary.
+	 */
 	details?: IUploadedSummaryDetails;
 
 	// TODO - need an epoch/reload bit to indicate to clients that the summary has changed and requires a reload
@@ -362,6 +412,8 @@ export interface ISummaryContent {
 /**
  * General errors returned from the server.
  * May want to add error code or something similar in the future.
+ *
+ * @public
  */
 export interface IServerError {
 	/**
@@ -372,6 +424,8 @@ export interface IServerError {
 
 /**
  * Data about the original proposed summary message.
+ *
+ * @public
  */
 export interface ISummaryProposal {
 	/**
@@ -382,6 +436,8 @@ export interface ISummaryProposal {
 
 /**
  * Contents of summary ack expected from the server.
+ *
+ * @public
  */
 export interface ISummaryAck {
 	/**
@@ -397,6 +453,8 @@ export interface ISummaryAck {
 
 /**
  * Contents of summary nack expected from the server.
+ *
+ * @public
  */
 export interface ISummaryNack {
 	/**
@@ -426,6 +484,8 @@ export interface ISummaryNack {
 
 /**
  * Interface for nack content.
+ *
+ * @public
  */
 export interface INackContent {
 	/**
@@ -454,15 +514,28 @@ export interface INackContent {
 }
 
 /**
- * Type of the Nack.
- * InvalidScopeError: Client's token is not valid for the intended message.
- * ThrottlingError: Retriable after retryAfter number.
- * BadRequestError: Clients message is invalid and should retry immediately with a valid message.
- * LimitExceededError: Service is having issues. Client should not retry.
+ * Type of the nack.
+ *
+ * @public
  */
 export enum NackErrorType {
+	/**
+	 * Retriable after {@link ISummaryNack.retryAfter} seconds.
+	 */
 	ThrottlingError = "ThrottlingError",
+
+	/**
+	 * Client's token is not valid for the intended message.
+	 */
 	InvalidScopeError = "InvalidScopeError",
+
+	/**
+	 * Clients message is invalid and should retry immediately with a valid message.
+	 */
 	BadRequestError = "BadRequestError",
+
+	/**
+	 * Service is having issues. Client should not retry.
+	 */
 	LimitExceededError = "LimitExceededError",
 }

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -289,12 +289,22 @@ export interface ISequencedDocumentMessage {
 
 	/**
 	 * Experimental field for storing the rolling hash at sequence number.
+	 *
+	 * @privateRemarks
+	 * TODO: this property was previously marked as `@alpha`, without an explanation for why it was added.
+	 * We should investigate whether or not this is actually in use, and determine a plan to either make it not
+	 * "experimental", or deprecate it for future removal.
+	 *
 	 */
 	expHash1?: string;
 
 	/**
 	 * The compression algorithm that was used to compress contents of this message.
-	 * @experimental Not ready for use.
+	 *
+	 * @privateRemarks
+	 * TODO: this property was previously marked as `@experimental`, without an explanation for why it was added.
+	 * We should investigate whether or not this is actually in use, and determine a plan to either make it not
+	 * "experimental", or deprecate it for future removal.
 	 */
 	compression?: string;
 }

--- a/common/lib/protocol-definitions/src/scopes.ts
+++ b/common/lib/protocol-definitions/src/scopes.ts
@@ -4,7 +4,9 @@
  */
 
 /**
- * Defines scope access for a Container/Document
+ * Defines scope access for a Container/Document.
+ *
+ * @public
  */
 export enum ScopeType {
 	/**

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -9,7 +9,9 @@ import { ISequencedDocumentMessage, ISignalMessage } from "./protocol";
 import { ITokenClaims } from "./tokens";
 
 /**
- * Message sent to connect to the given document
+ * Message sent to connect to the given document.
+ *
+ * @public
  */
 export interface IConnect {
 	/**
@@ -77,7 +79,9 @@ export interface IConnect {
 }
 
 /**
- * Message sent to indicate a client has connected to the server
+ * Message sent to indicate a client has connected to the server.
+ *
+ * @public
  */
 export interface IConnected {
 	/**

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -5,6 +5,9 @@
 
 import { IsoDate } from "./date";
 
+/**
+ * @public
+ */
 export interface IDocumentAttributes {
 	/**
 	 * Sequence number at which the snapshot was taken
@@ -17,6 +20,9 @@ export interface IDocumentAttributes {
 	minimumSequenceNumber: number;
 }
 
+/**
+ * @public
+ */
 export enum FileMode {
 	File = "100644",
 	Executable = "100755",
@@ -25,7 +31,9 @@ export enum FileMode {
 }
 
 /**
- * Raw blob stored within the tree
+ * Raw blob stored within the tree.
+ *
+ * @public
  */
 export interface IBlob {
 	/**
@@ -39,16 +47,24 @@ export interface IBlob {
 	encoding: "utf-8" | "base64";
 }
 
+/**
+ * @public
+ */
 export interface IAttachment {
 	id: string;
 }
 
+/**
+ * @public
+ */
 export interface ICreateBlobResponse {
 	id: string;
 }
 
 /**
- * A tree entry wraps a path with a type of node
+ * A tree entry wraps a path with a type of node.
+ *
+ * @public
  */
 export type ITreeEntry = {
 	/**
@@ -77,7 +93,9 @@ export type ITreeEntry = {
 );
 
 /**
- * Type of entries that can be stored in a tree
+ * Type of entries that can be stored in a tree.
+ *
+ * @public
  */
 export enum TreeEntry {
 	Blob = "Blob",
@@ -85,6 +103,9 @@ export enum TreeEntry {
 	Attachment = "Attachment",
 }
 
+/**
+ * @public
+ */
 export interface ITree {
 	entries: ITreeEntry[];
 
@@ -100,6 +121,9 @@ export interface ITree {
 	unreferenced?: true;
 }
 
+/**
+ * @public
+ */
 export interface ISnapshotTree {
 	id?: string;
 	blobs: { [path: string]: string };
@@ -111,13 +135,18 @@ export interface ISnapshotTree {
 	unreferenced?: true;
 }
 
+/**
+ * @public
+ */
 export interface ISnapshotTreeEx extends ISnapshotTree {
 	id: string;
 	trees: { [path: string]: ISnapshotTreeEx };
 }
 
 /**
- * Represents a version of the snapshot of a data store
+ * Represents a version of the snapshot of a data store.
+ *
+ * @public
  */
 export interface IVersion {
 	/**

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -5,17 +5,25 @@
 
 /**
  * Object representing a node within a summary tree.
+ *
+ * @remarks
  * If any particular node is an {@link ISummaryTree}, it can contain additional `SummaryObject`s as its children.
+ *
+ * @public
  */
 export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 
 /**
  * The root of the summary tree.
+ *
+ * @public
  */
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 /**
  * Type tag used to distinguish different types of nodes in a {@link ISummaryTree}.
+ *
+ * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace SummaryType {
@@ -51,6 +59,8 @@ export namespace SummaryType {
 
 /**
  * {@inheritDoc (SummaryType:namespace)}
+ *
+ * @public
  */
 export type SummaryType =
 	| SummaryType.Attachment
@@ -64,6 +74,8 @@ export type SummaryType =
  * @remarks
  * Summary handles are often used to point to summary tree objects contained within older summaries, thus avoiding
  * the need to re-send the entire subtree if summary object has not changed.
+ *
+ * @public
  */
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
 
@@ -75,6 +87,8 @@ export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryT
  * To illustrate, if a DataStore did not change since last summary, the framework runtime will use a handle for the
  * entire DataStore instead of re-sending the entire subtree. The same concept applies for a DDS.
  * An example of handle would be: '/<DataStoreId>/<DDSId>'.
+ *
+ * @public
  */
 export interface ISummaryHandle {
 	type: SummaryType.Handle;
@@ -92,10 +106,16 @@ export interface ISummaryHandle {
 
 /**
  * String or Binary data to be uploaded to the server as part of the container's Summary.
- * Note: Already uploaded blobs would be referenced by a ISummaryAttachment.
+ *
+ * @remarks
+ * Note: Already uploaded blobs would be referenced by an {@link ISummaryAttachment}.
  * Additional information can be found here: {@link https://github.com/microsoft/FluidFramework/issues/6568}
- * @example "content": "\{ \"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",
+ *
+ * @example
+ * "content": "\{ \"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",
  *                    \"summaryFormatVersion\":2,\"isRootDataStore\":false \}"
+ *
+ * @public
  */
 export interface ISummaryBlob {
 	type: SummaryType.Blob;
@@ -103,12 +123,18 @@ export interface ISummaryBlob {
 }
 
 /**
- * Unique identifier for blobs uploaded outside of the summary. Attachment Blobs are uploaded and
- * downloaded separately and do not take part of the snapshot payload.
- * The id gets returned from the backend after the attachment has been uploaded.
+ * Unique identifier for blobs uploaded outside of the summary.
+ *
+ * @remarks
+ *
+ * Attachment Blobs are uploaded and downloaded separately and do not take part of the snapshot payload.
+ * The ID gets returned from the backend after the attachment has been uploaded.
  * Additional information can be found here: {@link https://github.com/microsoft/FluidFramework/issues/6374}
  *
- * @example "id": "bQAQKARDdMdTgqICmBa_ZB86YXwGP"
+ * @example
+ * "id": "bQAQKARDdMdTgqICmBa_ZB86YXwGP"
+ *
+ * @public
  */
 export interface ISummaryAttachment {
 	type: SummaryType.Attachment;
@@ -118,6 +144,8 @@ export interface ISummaryAttachment {
 /**
  * Tree Node data structure with children that are nodes of SummaryObject type:
  * Blob, Handle, Attachment or another Tree.
+ *
+ * @public
  */
 export interface ISummaryTree {
 	type: SummaryType.Tree;

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -9,6 +9,8 @@ import { IUser } from "./users";
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
  * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
+ *
+ * @public
  */
 export interface ITokenClaims {
 	/**
@@ -68,6 +70,8 @@ export interface ITokenClaims {
 
 /**
  * @deprecated Please use client-specific types instead. E.g. from `@fluidframework/routerlicious-driver`.
+ *
+ * @public
  */
 export interface ISummaryTokenClaims {
 	sub: string;
@@ -77,6 +81,8 @@ export interface ISummaryTokenClaims {
 
 /**
  * @deprecated Please use client-specific types instead. E.g. from `@fluidframework/routerlicious-driver`.
+ *
+ * @public
  */
 export interface IActorClient {
 	sub: string;
@@ -84,6 +90,8 @@ export interface IActorClient {
 
 /**
  * @deprecated Please use client-specific types instead. E.g. from `@fluidframework/routerlicious-driver`.
+ *
+ * @public
  */
 export interface ITokenService {
 	extractClaims(token: string): ITokenClaims;
@@ -91,6 +99,8 @@ export interface ITokenService {
 
 /**
  * @deprecated Please use client-specific types instead. E.g. from `@fluidframework/routerlicious-driver`.
+ *
+ * @public
  */
 export interface ITokenProvider {
 	/**

--- a/common/lib/protocol-definitions/src/users.ts
+++ b/common/lib/protocol-definitions/src/users.ts
@@ -5,6 +5,8 @@
 
 /**
  * Base user definition. It is valid to extend this interface when adding new details to the user object.
+ *
+ * @public
  */
 export interface IUser {
 	/**


### PR DESCRIPTION
Removes rule overrides in the package's api-extractor.json and fixes violations by adding explicit release tags.

Also updates existing documentation to better utilize TSDoc syntax.

[AB#5813](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5813)