### PR TITLE
refactor(protocol-definitions): Move experimental properties to separate type

### DIFF
--- a/.changeset/brave-frogs-deny.md
+++ b/.changeset/brave-frogs-deny.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/protocol-definitions": minor
+---
+
+Deprecate ISequencedDocumentMessage properties "compression" and "expHash1"
+
+The properties have been extracted into a separate interface, "ISequencedDocumentMessageExperimental" and should be used from there instead.

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -268,11 +268,12 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 export interface ISequencedDocumentMessage {
     clientId: string | null;
     clientSequenceNumber: number;
+    // @deprecated
     compression?: string;
     contents: unknown;
     // (undocumented)
     data?: string;
-    // @alpha
+    // @deprecated
     expHash1?: string;
     metadata?: unknown;
     minimumSequenceNumber: number;
@@ -284,6 +285,12 @@ export interface ISequencedDocumentMessage {
     traces?: ITrace[];
     type: string;
 }
+
+// @alpha
+export type ISequencedDocumentMessageExperimental = Omit<ISequencedDocumentMessage, "expHash1" | "compression"> & {
+    expHash1?: string;
+    compression?: string;
+};
 
 // @public (undocumented)
 export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessage {

--- a/common/lib/protocol-definitions/src/index.ts
+++ b/common/lib/protocol-definitions/src/index.ts
@@ -44,6 +44,7 @@ export {
 	ISentSignalMessage,
 	ISequencedDocumentAugmentedMessage,
 	ISequencedDocumentMessage,
+	ISequencedDocumentMessageExperimental,
 	ISequencedDocumentSystemMessage,
 	IServerError,
 	ISignalMessage,

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -268,16 +268,38 @@ export interface ISequencedDocumentMessage {
 
 	/**
 	 * Experimental field for storing the rolling hash at sequence number.
-	 * @alpha
+	 *
+	 * @deprecated Use {@link ISequencedDocumentMessageExperimental} instead.
 	 */
 	expHash1?: string;
 
 	/**
 	 * The compression algorithm that was used to compress contents of this message.
-	 * @experimental Not ready for use.
+	 *
+	 * @deprecated Use {@link ISequencedDocumentMessageExperimental} instead.
 	 */
 	compression?: string;
 }
+
+/**
+ * {@link ISequencedDocumentAugmentedMessage} with experimental properties.
+ *
+ * @alpha
+ */
+export type ISequencedDocumentMessageExperimental = Omit<
+	ISequencedDocumentMessage,
+	"expHash1" | "compression"
+> & {
+	/**
+	 * Stores the rolling hash at sequence number.
+	 */
+	expHash1?: string;
+
+	/**
+	 * The compression algorithm that was used to compress contents of this message.
+	 */
+	compression?: string;
+};
 
 export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessage {
 	data: string;


### PR DESCRIPTION
Marks existing "experimental" properties `compression` and `expHash1` of `ISequencedDocumentMessage` as deprecated, and introduces a new "Experimental" type with those properties.