### PR TITLE
Revert "refactor(shared-tree): Rename SchemaBuilder's `toDocumentSchema` method to be an overload of `finalize`"

### DIFF
--- a/examples/apps/tree-comparison/src/model/schema.ts
+++ b/examples/apps/tree-comparison/src/model/schema.ts
@@ -30,4 +30,4 @@ export type InventoryNode = TypedNode<typeof inventory>;
 const inventoryField = SchemaBuilder.required(inventory);
 export type InventoryField = TypedField<typeof inventoryField>;
 
-export const schema = builder.finalize(inventoryField);
+export const schema = builder.toDocumentSchema(inventoryField);

--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
@@ -24,7 +24,7 @@ export const clientSchema = builder.struct("BubbleBenchAppStateClient-1.0.0", {
 
 export const rootAppStateSchema = SchemaBuilder.sequence(clientSchema);
 
-export const appSchemaData = builder.finalize(rootAppStateSchema);
+export const appSchemaData = builder.toDocumentSchema(rootAppStateSchema);
 
 export type Bubble = SchemaAware.TypedNode<typeof bubbleSchema>;
 export type Client = SchemaAware.TypedNode<typeof clientSchema>;

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -16,7 +16,7 @@ export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	parts: builder.sequence(part),
 });
 
-export const schema = builder.finalize(inventory);
+export const schema = builder.toDocumentSchema(inventory);
 
 export type InventoryField = TypedField<typeof schema.rootFieldSchema>;
 export type Inventory = TypedNode<typeof inventory>;

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -359,5 +359,5 @@ export function convertPropertyToSharedTreeSchema<Kind extends FieldKind = Field
 		rootFieldKind,
 		...allowedTypes,
 	);
-	return builder.finalize(rootSchema);
+	return builder.toDocumentSchema(rootSchema);
 }

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1811,7 +1811,6 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     }>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<Unenforced<TreeSchema>>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     finalize(): SchemaLibrary;
-    finalize<const TSchema extends ImplicitFieldSchema>(root: TSchema): TypedSchemaCollection<NormalizeField_2<TSchema, TDefaultKind>>;
     map<Name extends TName, const T extends ImplicitFieldSchema>(name: Name, fieldSchema: T): TreeSchema<`${TScope}.${Name}`, {
         mapFields: NormalizeField_2<T, TDefaultKind>;
     }>;
@@ -1831,6 +1830,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     structRecursive<Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeSchema<`${TScope}.${Name}`, {
         structFields: T;
     }>;
+    toDocumentSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TypedSchemaCollection<NormalizeField_2<TSchema, TDefaultKind>>;
 }
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -141,46 +141,10 @@ export class SchemaBuilderBase<
 	}
 
 	/**
-	 * Finalizes the schema builder, producing {@link SchemaLibrary}s that capture the content added to this builder
-	 * and any additional `SchemaLibrary`s that were added to it.
-	 *
-	 * @remarks
-	 * May only be called once after adding content to builder is complete.
-	 *
-	 * @returns A {@link SchemaLibrary} usable with future `SchemaBuilder`s
-	 */
-	public finalize(): SchemaLibrary;
-
-	/**
-	 * Finalizes the schema builder, producing SchemaLibraries that capture the content added to this builder,
-	 * any additional SchemaLibraries that were added to it, and the schema of a root field.
-	 *
-	 * @remarks
-	 * May only be called once after adding content to builder is complete.
-	 *
-	 * @param root - The root field schema.
-	 * @typeParam TSchema - The kind of field schema of `root`.
-	 *
-	 * @returns A {@link TypedSchemaCollection} that may be used in the construction of trees.
-	 */
-	public finalize<const TSchema extends ImplicitFieldSchema>(
-		root: TSchema,
-	): TypedSchemaCollection<NormalizeField<TSchema, TDefaultKind>>;
-
-	// Implementation of `finalize` signatures above.
-	public finalize<const TSchema extends ImplicitFieldSchema>(
-		root?: TSchema,
-	): SchemaLibrary | TypedSchemaCollection<NormalizeField<TSchema, TDefaultKind>> {
-		return root === undefined ? this.toLibrarySchema() : this.toDocumentSchema(root);
-	}
-
-	/**
 	 * Produce SchemaLibraries which capture the content added to this builder, as well as any additional SchemaLibraries that were added to it.
-	 *
-	 * @remarks
 	 * May only be called once after adding content to builder is complete.
 	 */
-	private toLibrarySchema(): SchemaLibrary {
+	public finalize(): SchemaLibrary {
 		this.finalizeCommon();
 
 		// Check for errors:
@@ -196,7 +160,7 @@ export class SchemaBuilderBase<
 	 * @remarks
 	 * May only be called once after adding content to builder is complete.
 	 */
-	private toDocumentSchema<const TSchema extends ImplicitFieldSchema>(
+	public toDocumentSchema<const TSchema extends ImplicitFieldSchema>(
 		root: TSchema,
 	): TypedSchemaCollection<NormalizeField<TSchema, TDefaultKind>> {
 		// return this.toDocumentSchemaInternal(normalizeField(root, DefaultFieldKind));

--- a/experimental/dds/tree2/src/test/cursorTestSuite.ts
+++ b/experimental/dds/tree2/src/test/cursorTestSuite.ts
@@ -39,7 +39,7 @@ export const structSchema = schemaBuilder.struct("struct", {
 	child: leaf.number,
 });
 
-export const testTreeSchema = schemaBuilder.finalize(SchemaBuilder.sequence(Any));
+export const testTreeSchema = schemaBuilder.toDocumentSchema(SchemaBuilder.sequence(Any));
 
 export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 	["minimal", { type: emptySchema.name }],

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -54,7 +54,7 @@ function bench(
 	const schemaCollection = new SchemaBuilder({
 		scope: "JsonCursor benchmark",
 		libraries: [jsonSchema],
-	}).finalize(SchemaBuilder.optional(jsonRoot));
+	}).toDocumentSchema(SchemaBuilder.optional(jsonRoot));
 	const schema = new InMemoryStoredSchemaRepository(schemaCollection);
 	for (const { name, getJson, dataConsumer } of data) {
 		describe(name, () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -106,7 +106,7 @@ describe("ContextuallyTyped", () => {
 		});
 		const numberSequence = SchemaBuilder.sequence(leaf.number);
 		const numbersObject = builder.struct("numbers", { numbers: numberSequence });
-		const schema = builder.finalize(numberSequence);
+		const schema = builder.toDocumentSchema(numberSequence);
 		const mapTree = applyTypesFromContext({ schema }, new Set([numbersObject.name]), {
 			numbers: [],
 		});
@@ -121,7 +121,7 @@ describe("ContextuallyTyped", () => {
 		});
 		const numberSequence = SchemaBuilder.sequence(leaf.number);
 		const primaryObject = builder.struct("numbers", { [EmptyKey]: numberSequence });
-		const schema = builder.finalize(numberSequence);
+		const schema = builder.toDocumentSchema(numberSequence);
 		const mapTree = applyTypesFromContext({ schema }, new Set([primaryObject.name]), []);
 		const expected: MapTree = { fields: new Map(), type: primaryObject.name, value: undefined };
 		assert.deepEqual(mapTree, expected);
@@ -137,7 +137,7 @@ describe("ContextuallyTyped", () => {
 				foo: leaf.string,
 			});
 
-			const nodeSchemaData = builder.finalize(builder.optional(nodeSchema));
+			const nodeSchemaData = builder.toDocumentSchema(builder.optional(nodeSchema));
 			const contextualData: ContextuallyTypedNodeDataObject = {};
 
 			const generatedField = [
@@ -172,7 +172,7 @@ describe("ContextuallyTyped", () => {
 				child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchema]),
 			});
 
-			const nodeSchemaData = builder.finalize(builder.optional(nodeSchema));
+			const nodeSchemaData = builder.toDocumentSchema(builder.optional(nodeSchema));
 			const contextualData: ContextuallyTypedNodeDataObject = { child: {} };
 
 			const generatedField = [

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.identifier.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.identifier.spec.ts
@@ -27,7 +27,7 @@ const parentNodeSchema = builder.struct("ParentNode", {
 	...nodeKeyField,
 	children: builder.sequence(childNodeSchema),
 });
-const schema = builder.finalize(parentNodeSchema);
+const schema = builder.toDocumentSchema(parentNodeSchema);
 
 // TODO: this can probably be removed once daesun's stuff goes in
 function addKey(view: NodeKeyManager, key: LocalNodeKey): { [nodeKeyFieldKey]: StableNodeKey } {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
@@ -77,7 +77,7 @@ describe("LazyField", () => {
 	it("LazyField implementations do not allow edits to detached trees", () => {
 		const builder = new SchemaBuilder({ scope: "lazyTree" });
 		builder.struct("empty", {});
-		const schema = builder.finalize(SchemaBuilder.optional(Any));
+		const schema = builder.toDocumentSchema(SchemaBuilder.optional(Any));
 		const forest = forestWithContent({ schema, initialTree: {} });
 		const context = getReadonlyContext(forest, schema);
 		const cursor = initializeCursor(context, detachedFieldAnchor);
@@ -132,7 +132,7 @@ describe("LazyField", () => {
 
 		const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 		const rootSchema = SchemaBuilder.optional(builder.struct("struct", {}));
-		const schema = builder.finalize(rootSchema);
+		const schema = builder.toDocumentSchema(rootSchema);
 
 		// Note: this tree initialization is strictly to enable construction of the lazy field.
 		// The test cases below are strictly in terms of the schema of the created fields.
@@ -194,7 +194,7 @@ describe("LazyField", () => {
 			foo: SchemaBuilder.optional(leafDomain.primitives),
 		});
 		const rootSchema = SchemaBuilder.optional(struct);
-		const schema = builder.finalize(rootSchema);
+		const schema = builder.toDocumentSchema(rootSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -233,7 +233,7 @@ describe("LazyField", () => {
 describe("LazyOptionalField", () => {
 	const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 	const rootSchema = SchemaBuilder.optional(leafDomain.number);
-	const schema = builder.finalize(rootSchema);
+	const schema = builder.toDocumentSchema(rootSchema);
 
 	describe("Field with value", () => {
 		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
@@ -307,7 +307,7 @@ describe("LazyOptionalField", () => {
 describe("LazyValueField", () => {
 	const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 	const rootSchema = SchemaBuilder.required(leafDomain.string);
-	const schema = builder.finalize(rootSchema);
+	const schema = builder.toDocumentSchema(rootSchema);
 
 	const initialTree = "Hello world";
 
@@ -346,7 +346,7 @@ describe("LazyValueField", () => {
 describe("LazySequence", () => {
 	const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 	const rootSchema = SchemaBuilder.sequence(leafDomain.number);
-	const schema = builder.finalize(rootSchema);
+	const schema = builder.toDocumentSchema(rootSchema);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
@@ -131,7 +131,7 @@ describe("LazyTree", () => {
 	it("property names", () => {
 		const builder = new SchemaBuilder({ scope: "lazyTree" });
 		const emptyStruct = builder.struct("empty", {});
-		const testSchema = builder.finalize(SchemaBuilder.optional(emptyStruct));
+		const testSchema = builder.toDocumentSchema(SchemaBuilder.optional(emptyStruct));
 
 		const { cursor, context } = initializeTreeWithContent({
 			schema: testSchema,
@@ -199,7 +199,7 @@ describe("LazyTree", () => {
 			SchemaBuilder.optional(leafDomain.string),
 		);
 
-		const schema = schemaBuilder.finalize(fieldNodeOptionalAnySchema);
+		const schema = schemaBuilder.toDocumentSchema(fieldNodeOptionalAnySchema);
 
 		// #endregion
 
@@ -236,7 +236,7 @@ describe("LazyTree", () => {
 			"field",
 			SchemaBuilder.optional(leafDomain.string),
 		);
-		const schema = schemaBuilder.finalize(fieldNodeSchema);
+		const schema = schemaBuilder.toDocumentSchema(fieldNodeSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -302,7 +302,7 @@ describe("LazyFieldNode", () => {
 		"field",
 		SchemaBuilder.optional(leafDomain.string),
 	);
-	const schema = schemaBuilder.finalize(fieldNodeSchema);
+	const schema = schemaBuilder.toDocumentSchema(fieldNodeSchema);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,
@@ -331,7 +331,7 @@ describe("LazyLeaf", () => {
 		scope: "test",
 		libraries: [leafDomain.library],
 	});
-	const schema = schemaBuilder.finalize(leafDomain.string);
+	const schema = schemaBuilder.toDocumentSchema(leafDomain.string);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,
@@ -354,7 +354,7 @@ describe("LazyMap", () => {
 		libraries: [leafDomain.library],
 	});
 	const mapNodeSchema = schemaBuilder.map("mapString", SchemaBuilder.optional(leafDomain.string));
-	const schema = schemaBuilder.finalize(mapNodeSchema);
+	const schema = schemaBuilder.toDocumentSchema(mapNodeSchema);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,
@@ -389,7 +389,7 @@ describe("LazyStruct", () => {
 		foo: SchemaBuilder.optional(leafDomain.string),
 		bar: SchemaBuilder.sequence(leafDomain.number),
 	});
-	const schema = schemaBuilder.finalize(SchemaBuilder.optional(Any));
+	const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(Any));
 
 	// Count the number of times edits have been generated.
 	let editCallCount = 0;
@@ -458,7 +458,7 @@ describe("buildLazyStruct", () => {
 		required: SchemaBuilder.required(leafDomain.boolean),
 		sequence: SchemaBuilder.sequence(leafDomain.number),
 	});
-	const schema = schemaBuilder.finalize(SchemaBuilder.optional(Any));
+	const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(Any));
 
 	const context = contextWithContentReadonly({
 		schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
@@ -20,7 +20,7 @@ const root = builder.struct("root", {
 	numbers: numberList,
 });
 
-const schema = builder.finalize(root);
+const schema = builder.toDocumentSchema(root);
 
 describe("List", () => {
 	/** Formats 'args' array, inserting commas and eliding trailing undefines.  */

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -103,7 +103,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.struct("empty", {});
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: {},
 	},
@@ -115,7 +115,7 @@ const tcs: TestCase[] = [
 				number: leaf.number,
 				string: leaf.string,
 			});
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: {
 			boolean: false,
@@ -131,7 +131,7 @@ const tcs: TestCase[] = [
 				number: _.optional(leaf.number),
 				string: _.optional(leaf.string),
 			});
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: {},
 	},
@@ -143,7 +143,7 @@ const tcs: TestCase[] = [
 				number: _.optional(leaf.number),
 				string: _.optional(leaf.string),
 			});
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: {
 			boolean: true,
@@ -161,7 +161,7 @@ const tcs: TestCase[] = [
 				nested: inner,
 			});
 
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: { nested: {} },
 	},
@@ -169,7 +169,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.fieldNode("List<string> len(0)", _.sequence(leaf.string));
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: [],
 	},
@@ -177,7 +177,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.fieldNode("List<string> len(1)", _.sequence(leaf.string));
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: ["A"],
 	},
@@ -185,7 +185,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.fieldNode("List<string> len(2)", _.sequence(leaf.string));
-			return _.finalize($);
+			return _.toDocumentSchema($);
 		})(),
 		initialTree: ["A", "B"],
 	},

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
@@ -8,7 +8,7 @@ import { leaf, SchemaBuilder } from "../../../domains";
 import { createTreeView, pretty } from "./utils";
 
 const _ = new SchemaBuilder({ scope: "test", libraries: [leaf.library] });
-const schema = _.finalize(_.optional(leaf.all));
+const schema = _.toDocumentSchema(_.optional(leaf.all));
 
 const testCases = [
 	undefined, // via optional root

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -23,7 +23,7 @@ describe("SharedTree proxies", () => {
 		list: sb.fieldNode("list", sb.sequence(leaf.number)),
 	});
 
-	const schema = sb.finalize(parentSchema);
+	const schema = sb.toDocumentSchema(parentSchema);
 
 	const initialTree = {
 		struct: { content: 42 },
@@ -69,7 +69,7 @@ describe("SharedTreeObject", () => {
 		list: sb.fieldNode("list", sb.sequence(numberChild)),
 	});
 
-	const schema = sb.finalize(parentSchema);
+	const schema = sb.toDocumentSchema(parentSchema);
 
 	const initialTree = {
 		content: 42,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/structFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/structFactory.spec.ts
@@ -28,7 +28,7 @@ describe("raw structs", () => {
 			baz: builder.sequence(leaf.boolean),
 		});
 		const rootFieldSchema = SchemaBuilder.required(structSchema);
-		const schema = builder.finalize(rootFieldSchema);
+		const schema = builder.toDocumentSchema(rootFieldSchema);
 		const context = contextWithContentReadonly({
 			schema,
 			initialTree: { foo: 42, baz: [] },

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
@@ -61,7 +61,7 @@ describe("unboxedField", () => {
 		it("No value", () => {
 			const builder = new SchemaBuilder({ scope: "test" });
 			const fieldSchema = SchemaBuilder.optional(leafDomain.number);
-			const schema = builder.finalize(fieldSchema);
+			const schema = builder.toDocumentSchema(fieldSchema);
 
 			const { context, cursor } = initializeTreeWithContent({
 				schema,
@@ -74,7 +74,7 @@ describe("unboxedField", () => {
 		it("With value (leaf)", () => {
 			const builder = new SchemaBuilder({ scope: "test" });
 			const fieldSchema = SchemaBuilder.optional(leafDomain.number);
-			const schema = builder.finalize(fieldSchema);
+			const schema = builder.toDocumentSchema(fieldSchema);
 
 			const { context, cursor } = initializeTreeWithContent({
 				schema,
@@ -92,7 +92,7 @@ describe("unboxedField", () => {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => structSchema]),
 		});
 		const fieldSchema = SchemaBuilder.optional(structSchema);
-		const schema = builder.finalize(fieldSchema);
+		const schema = builder.toDocumentSchema(fieldSchema);
 
 		const initialTree = {
 			name: "Foo",
@@ -119,7 +119,7 @@ describe("unboxedField", () => {
 	it("Sequence field", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.sequence(leafDomain.string);
-		const schema = builder.finalize(fieldSchema);
+		const schema = builder.toDocumentSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -134,7 +134,7 @@ describe("unboxedField", () => {
 	it("Schema: Any", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.optional(Any);
-		const schema = builder.finalize(fieldSchema);
+		const schema = builder.toDocumentSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
 
@@ -149,7 +149,7 @@ describe("unboxedField", () => {
 describe("unboxedTree", () => {
 	it("Leaf", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
-		const schema = builder.finalize(leafDomain.string);
+		const schema = builder.toDocumentSchema(leafDomain.string);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -164,7 +164,7 @@ describe("unboxedTree", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const mapSchema = builder.map("map", builder.optional(leafDomain.string));
 		const rootSchema = SchemaBuilder.optional(mapSchema);
-		const schema = builder.finalize(rootSchema);
+		const schema = builder.toDocumentSchema(rootSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -188,7 +188,7 @@ describe("unboxedTree", () => {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => structSchema]),
 		});
 		const rootSchema = builder.optional(structSchema);
-		const schema = builder.finalize(rootSchema);
+		const schema = builder.toDocumentSchema(rootSchema);
 
 		const initialTree = {
 			name: "Foo",
@@ -214,7 +214,7 @@ describe("unboxedUnion", () => {
 	it("Any", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.optional(Any);
-		const schema = builder.finalize(fieldSchema);
+		const schema = builder.toDocumentSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
 		cursor.enterNode(0); // Root node field has 1 node; move into it
@@ -228,7 +228,7 @@ describe("unboxedUnion", () => {
 	it("Single type", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.required(leafDomain.boolean);
-		const schema = builder.finalize(fieldSchema);
+		const schema = builder.toDocumentSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -242,7 +242,7 @@ describe("unboxedUnion", () => {
 	it("Multi-type", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.optional([leafDomain.string, leafDomain.handle]);
-		const schema = builder.finalize(fieldSchema);
+		const schema = builder.toDocumentSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -53,7 +53,7 @@ function getTestSchema<Kind extends FieldKind>(fieldKind: Kind) {
 		foo: FieldSchema.create(fieldKind, [stringSchema]),
 		foo2: FieldSchema.create(fieldKind, [stringSchema]),
 	});
-	return builder.finalize(FieldSchema.create(FieldKinds.optional, [rootNodeSchema]));
+	return builder.toDocumentSchema(FieldSchema.create(FieldKinds.optional, [rootNodeSchema]));
 }
 
 describe("editable-tree: editing", () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -390,7 +390,7 @@ describe("editable-tree: read-only", () => {
 			child: stringSchema,
 		});
 		const rootSchema = FieldSchema.create(FieldKinds.required, [parentSchema]);
-		const schemaData = builder.finalize(rootSchema);
+		const schemaData = builder.toDocumentSchema(rootSchema);
 		const forest = setupForest(schemaData, { child: "x" });
 		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert(isEditableTree(context.unwrappedRoot));

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -249,7 +249,7 @@ export function buildTestSchema<TSchema extends ImplicitFieldSchema>(
 	return new SchemaBuilder({
 		scope: "buildTestSchema",
 		libraries: [personSchemaLibrary],
-	}).finalize(rootField);
+	}).toDocumentSchema(rootField);
 }
 
 export function getReadonlyEditableTreeContext(

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -131,7 +131,7 @@ describe("Schema Evolution Examples", () => {
 			scope: "test",
 			name: "basic usage",
 			libraries: [treeViewSchema],
-		}).finalize(root);
+		}).toDocumentSchema(root);
 
 		// This is where legacy schema handling logic for schematize.
 		const adapters: Adapters = {};
@@ -182,7 +182,7 @@ describe("Schema Evolution Examples", () => {
 				scope: "test",
 				name: "basic usage2",
 				libraries: [treeViewSchema],
-			}).finalize(tolerantRoot);
+			}).toDocumentSchema(tolerantRoot);
 			const view2 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection2);
 			// When we open this document, we should check it's compatibility with our application:
 			const compat = view2.checkCompatibility(stored);
@@ -259,7 +259,7 @@ describe("Schema Evolution Examples", () => {
 				items: FieldSchema.create(FieldKinds.sequence, [positionedCanvasItem2]),
 			});
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const viewCollection3: TypedSchemaCollection = builderWithCounter.finalize(
+			const viewCollection3: TypedSchemaCollection = builderWithCounter.toDocumentSchema(
 				FieldSchema.create(FieldKinds.optional, [canvas2]),
 			);
 			const view3 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection3);
@@ -407,7 +407,7 @@ describe("Schema Evolution Examples", () => {
 	// 		items: FieldSchema.create(FieldKinds.sequence, positionedCanvasItemNew),
 	// 	});
 
-	// 	const viewCollection: SchemaCollection = builder.finalize(
+	// 	const viewCollection: SchemaCollection = builder.toDocumentSchema(
 	// 		SchemaBuilder.required(canvas2),
 	// 	);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -34,7 +34,7 @@ const nodeSchema = builder.structRecursive("node", {
 	...nodeKeyField,
 	child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchema]),
 });
-const nodeSchemaData = builder.finalize(SchemaBuilder.optional(nodeSchema));
+const nodeSchemaData = builder.toDocumentSchema(SchemaBuilder.optional(nodeSchema));
 
 // TODO: this can probably be removed once daesun's stuff goes in
 function contextualizeKey(view: NodeKeys, key: LocalNodeKey): { [nodeKeyFieldKey]: StableNodeKey } {
@@ -214,7 +214,9 @@ describe("Node Key Index", () => {
 		});
 		const nodeSchemaNoKey = builder2.map("node", SchemaBuilder.optional(Any));
 
-		const nodeSchemaDataNoKey = builder2.finalize(SchemaBuilder.optional(nodeSchemaNoKey));
+		const nodeSchemaDataNoKey = builder2.toDocumentSchema(
+			SchemaBuilder.optional(nodeSchemaNoKey),
+		);
 		assert(!nodeSchemaDataNoKey.treeSchema.has(nodeKeyTreeSchema.name));
 
 		const nodeKeyManager = createMockNodeKeyManager();
@@ -267,7 +269,7 @@ describe("Node Key Index", () => {
 		const nodeSchemaNoKey = builder2.structRecursive("node", {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchemaNoKey]),
 		});
-		const nodeSchemaDataNoKey = builder2.finalize(
+		const nodeSchemaDataNoKey = builder2.toDocumentSchema(
 			SchemaBuilder.optional(nodeSchemaNoKey),
 		);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -462,7 +462,9 @@ describe("SchemaAware Editing", () => {
 		const rootNodeSchema = builder.struct("Test", {
 			children: SchemaBuilder.sequence(leaf.string),
 		});
-		const schema = builder.finalize(FieldSchema.create(FieldKinds.required, [rootNodeSchema]));
+		const schema = builder.toDocumentSchema(
+			FieldSchema.create(FieldKinds.required, [rootNodeSchema]),
+		);
 		const view = createSharedTreeView().schematize({
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -25,7 +25,7 @@ export const listTaskSchema = builder.structRecursive("ListTask", {
 
 export const rootFieldSchema = SchemaBuilder.required([stringTaskSchema, listTaskSchema]);
 
-export const appSchemaData = builder.finalize(rootFieldSchema);
+export const appSchemaData = builder.toDocumentSchema(rootFieldSchema);
 
 // Schema aware types
 export type StringTask = SchemaAware.TypedNode<typeof stringTaskSchema>;

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -13,7 +13,7 @@ export const pointSchema = builder.struct("point", {
 	y: builder.number,
 });
 
-export const appSchemaData = builder.finalize(builder.sequence(pointSchema));
+export const appSchemaData = builder.toDocumentSchema(builder.sequence(pointSchema));
 
 // Schema aware types
 export type Number = SchemaAware.TypedNode<typeof leaf.number>;

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
@@ -92,7 +92,7 @@ describe("SchemaBuilderBase", () => {
 		it("Simple", () => {
 			const schemaBuilder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
 			const empty = schemaBuilder.struct("empty", {});
-			const schema = schemaBuilder.finalize(SchemaBuilder.optional(empty));
+			const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(empty));
 
 			assert.equal(schema.treeSchema.size, 1); // "empty"
 			assert.equal(schema.treeSchema.get(brand("test.empty")), empty);

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaIndex.spec.ts
@@ -23,7 +23,7 @@ describe("SchemaIndex", () => {
 		const data: SchemaData = new SchemaBuilder({
 			scope: "roundtrip",
 			libraries: [jsonSchema],
-		}).finalize(SchemaBuilder.optional(jsonRoot));
+		}).toDocumentSchema(SchemaBuilder.optional(jsonRoot));
 		const s = codec.encode(data);
 		const parsed = codec.decode(s);
 		const s2 = codec.encode(parsed);

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
@@ -31,4 +31,4 @@ const diagramSchema = builder.structRecursive("Diagram", {
 const rootField = builder.optional(diagramSchema);
 
 // Collect the schema together.
-const schemaData = builder.finalize(rootField);
+const schemaData = builder.toDocumentSchema(rootField);

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -66,7 +66,7 @@ export interface ForestTestConfiguration {
 const jsonDocumentSchema = new SchemaBuilder({
 	scope: "jsonDocumentSchema",
 	libraries: [jsonSchema],
-}).finalize(SchemaBuilder.sequence(jsonRoot));
+}).toDocumentSchema(SchemaBuilder.sequence(jsonRoot));
 
 const detachId = { minor: 42 };
 
@@ -853,7 +853,7 @@ export function testForest(config: ForestTestConfiguration): void {
 					x: SchemaBuilder.sequence(leaf.number),
 					y: SchemaBuilder.sequence(leaf.number),
 				});
-				const schema = builder.finalize(builder.optional(root));
+				const schema = builder.toDocumentSchema(builder.optional(root));
 
 				const forest = factory(new InMemoryStoredSchemaRepository(schema));
 				initializeForest(forest, [

--- a/experimental/dds/tree2/src/test/scalableTestTrees.ts
+++ b/experimental/dds/tree2/src/test/scalableTestTrees.ts
@@ -47,9 +47,9 @@ export const wideRootSchema = wideBuilder.struct("WideRoot", {
 	foo: FieldSchema.create(FieldKinds.sequence, [leaf.number]),
 });
 
-export const wideSchema = wideBuilder.finalize(wideRootSchema);
+export const wideSchema = wideBuilder.toDocumentSchema(wideRootSchema);
 
-export const deepSchema = deepBuilder.finalize([linkedListSchema, leaf.number]);
+export const deepSchema = deepBuilder.toDocumentSchema([linkedListSchema, leaf.number]);
 
 /**
  * JS object like a deep tree.

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -333,7 +333,7 @@ describe("SharedTreeCore", () => {
 		const node = b.structRecursive("test node", {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => node, leaf.number]),
 		});
-		const schema = b.finalize(b.optional(node));
+		const schema = b.toDocumentSchema(b.optional(node));
 
 		const tree2 = await factory.load(
 			dataStoreRuntime2,

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -41,7 +41,7 @@ const parentSchema = builder.struct("Test:Opsize-Bench-Root", {
 	children: builder.sequence(childSchema),
 });
 
-const fullSchemaData = builder.finalize(parentSchema);
+const fullSchemaData = builder.toDocumentSchema(parentSchema);
 
 const initialTestJsonTree = {
 	type: parentSchema.name,

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -28,18 +28,18 @@ import { SchemaBuilder, leaf } from "../../domains";
 
 const builder = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests" });
 const root = leaf.number;
-const schema = builder.finalize(SchemaBuilder.optional(root));
+const schema = builder.toDocumentSchema(SchemaBuilder.optional(root));
 
 const builderGeneralized = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests Generalized",
 });
 
-const schemaGeneralized = builderGeneralized.finalize(SchemaBuilder.optional(Any));
+const schemaGeneralized = builderGeneralized.toDocumentSchema(SchemaBuilder.optional(Any));
 
 const builderValue = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests2" });
 
-const schemaValueRoot = builderValue.finalize(SchemaBuilder.required(Any));
+const schemaValueRoot = builderValue.toDocumentSchema(SchemaBuilder.required(Any));
 
 const emptySchema = new SchemaBuilder({
 	scope: "Empty",
@@ -47,7 +47,7 @@ const emptySchema = new SchemaBuilder({
 		rejectEmpty: false,
 		rejectForbidden: false,
 	},
-}).finalize(FieldSchema.empty);
+}).toDocumentSchema(FieldSchema.empty);
 
 function expectSchema(actual: SchemaData, expected: SchemaData): void {
 	// Check schema match

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -97,7 +97,7 @@ describe("SharedTree", () => {
 
 	it("editable-tree-2-end-to-end", () => {
 		const builder = new SchemaBuilder({ scope: "e2e" });
-		const schema = builder.finalize(leaf.number);
+		const schema = builder.toDocumentSchema(leaf.number);
 		const factory = new SharedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,
@@ -538,7 +538,7 @@ describe("SharedTree", () => {
 			const schema = new SchemaBuilder({
 				scope: "optional",
 				libraries: [jsonSchema],
-			}).finalize(SchemaBuilder.optional(leaf.number));
+			}).toDocumentSchema(SchemaBuilder.optional(leaf.number));
 			const config: InitializeAndSchematizeConfiguration = {
 				schema,
 				initialTree: value,
@@ -1066,7 +1066,7 @@ describe("SharedTree", () => {
 		const treeSchema = builder.struct("root", {
 			x: builder.number,
 		});
-		const schema = builder.finalize(builder.optional(Any));
+		const schema = builder.toDocumentSchema(builder.optional(Any));
 
 		it("triggers events for local and subtree changes", () => {
 			const view = viewWithContent({
@@ -1888,7 +1888,7 @@ describe("SharedTree", () => {
 				foo: SchemaBuilder.sequence(leaf.number),
 				foo2: SchemaBuilder.sequence(leaf.number),
 			});
-			const testSchema = testSchemaBuilder.finalize(rootFieldSchema);
+			const testSchema = testSchemaBuilder.toDocumentSchema(rootFieldSchema);
 
 			// TODO: if this tests is just about deleting the root, it should use a simpler tree.
 			const initialTreeState: JsonableTree = {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTreeView.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTreeView.spec.ts
@@ -12,14 +12,14 @@ const builder = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests",
 });
-const schema = builder.finalize(SchemaBuilder.optional(leaf.number));
+const schema = builder.toDocumentSchema(SchemaBuilder.optional(leaf.number));
 
 const builderGeneralized = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests Generalized",
 });
 
-const schemaGeneralized = builderGeneralized.finalize(SchemaBuilder.optional(Any));
+const schemaGeneralized = builderGeneralized.toDocumentSchema(SchemaBuilder.optional(Any));
 
 describe("sharedTreeView", () => {
 	describe("schematize", () => {

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -30,7 +30,7 @@ const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
 
 const builder = new SchemaBuilder({ scope: "test trees" });
 const rootNodeSchema = builder.map("TestInner", SchemaBuilder.sequence(Any));
-const testSchema = builder.finalize(SchemaBuilder.sequence(Any));
+const testSchema = builder.toDocumentSchema(SchemaBuilder.sequence(Any));
 
 function generateCompleteTree(
 	fields: FieldKey[],
@@ -268,7 +268,9 @@ export function generateTestTrees() {
 					scope: "has-handle",
 					libraries: [leaf.library],
 				});
-				const docSchema = innerBuilder.finalize(SchemaBuilder.optional(leaf.handle));
+				const docSchema = innerBuilder.toDocumentSchema(
+					SchemaBuilder.optional(leaf.handle),
+				);
 
 				const config = {
 					allowedSchemaModifications: AllowedUpdateType.None,
@@ -299,7 +301,9 @@ export function generateTestTrees() {
 					"SeqMap",
 					FieldSchema.createUnsafe(FieldKinds.sequence, [() => seqMapSchema]),
 				);
-				const docSchema = innerBuilder.finalize(SchemaBuilder.sequence(seqMapSchema));
+				const docSchema = innerBuilder.toDocumentSchema(
+					SchemaBuilder.sequence(seqMapSchema),
+				);
 
 				const config = {
 					allowedSchemaModifications: AllowedUpdateType.None,

--- a/experimental/dds/tree2/src/test/testTrees.ts
+++ b/experimental/dds/tree2/src/test/testTrees.ts
@@ -53,7 +53,7 @@ function testField<T extends FieldSchema>(
 		scope: name,
 		lint: { rejectForbidden: false, rejectEmpty: false },
 		libraries: [schemaLibrary],
-	}).finalize(rootField);
+	}).toDocumentSchema(rootField);
 	return {
 		name,
 		schemaData: schema,

--- a/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
@@ -13,7 +13,7 @@ import { leaf, SchemaBuilder } from "../../domains";
 describe("TypedTree", () => {
 	it("editable-tree-2-end-to-end", () => {
 		const builder = new SchemaBuilder({ scope: "e2e" });
-		const schema = builder.finalize(leaf.number);
+		const schema = builder.toDocumentSchema(leaf.number);
 		const factory = new TypedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -624,7 +624,7 @@ const jsonSequenceRootField = SchemaBuilder.sequence(jsonRoot);
 export const jsonSequenceRootSchema = new SchemaBuilder({
 	scope: "JsonSequenceRoot",
 	libraries: [jsonSchema],
-}).finalize(jsonSequenceRootField);
+}).toDocumentSchema(jsonSequenceRootField);
 
 export const emptyJsonSequenceConfig: InitializeAndSchematizeConfiguration = {
 	schema: jsonSequenceRootSchema,
@@ -900,7 +900,7 @@ export const wrongSchema = new SchemaBuilder({
 	lint: {
 		rejectEmpty: false,
 	},
-}).finalize(SchemaBuilder.sequence(Any));
+}).toDocumentSchema(SchemaBuilder.sequence(Any));
 
 /**
  * Schematize config Schema which is not correct.

--- a/experimental/framework/tree-react-api/src/test/schema.ts
+++ b/experimental/framework/tree-react-api/src/test/schema.ts
@@ -12,6 +12,6 @@ export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	bolts: leaf.number,
 });
 
-export const schema = builder.finalize(inventory);
+export const schema = builder.toDocumentSchema(inventory);
 
 export type Inventory = TypedField<typeof schema.rootFieldSchema>;

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -423,7 +423,7 @@ describe("DefaultVisualizers unit tests", () => {
 			childrenTwo: leaf.number,
 		});
 
-		const schema = builder.finalize(rootNodeSchema);
+		const schema = builder.toDocumentSchema(rootNodeSchema);
 
 		sharedTree.schematize({
 			schema,

--- a/packages/tools/devtools/devtools-example/src/FluidObject.ts
+++ b/packages/tools/devtools/devtools-example/src/FluidObject.ts
@@ -236,7 +236,7 @@ export class AppData extends DataObject {
 			childrenTwo: leaf.number,
 		});
 
-		const schema = builder.finalize(rootNodeSchema);
+		const schema = builder.toDocumentSchema(rootNodeSchema);
 
 		sharedTree.schematize({
 			schema,


### PR DESCRIPTION
Reverts microsoft/FluidFramework#17792 which broke the build with:
@***-experimental/tree2: src/test/feature-libraries/editable-tree-2/utils.ts:75:17 - error TS2341: Property 'toDocumentSchema' is private and only accessible within class 'SchemaBuilderBase<TScope, TDefaultKind, TName>'.
