### PR TITLE
fix: Fix lingering usages of `toDocumentSchema`

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -257,7 +257,7 @@ describe("Object-like", () => {
 			const parent = _.struct("parent", {
 				child,
 			});
-			const schema = _.toDocumentSchema(parent);
+			const schema = _.finalize(parent);
 
 			const before = { objId: 0 };
 			const after = { objId: 1 };
@@ -282,7 +282,7 @@ describe("Object-like", () => {
 			const parent = _.struct("parent", {
 				child: _.optional(child),
 			});
-			const schema = _.toDocumentSchema(parent);
+			const schema = _.finalize(parent);
 
 			const before = { objId: 0 };
 			const after = { objId: 1 };

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -72,7 +72,7 @@ export function makeSchema<const TSchema extends ImplicitFieldSchema>(
 		scope: `test.schema.${Math.random().toString(36).slice(2)}`,
 	});
 	const root = fn(builder);
-	return builder.toDocumentSchema(root);
+	return builder.finalize(root);
 }
 
 export function itWithRoot<TSchema extends TypedSchemaCollection<any>>(


### PR DESCRIPTION
New usages of `SchemaBuilderBase.toDocumentSchema` were introduced while #17792 was an open PR. This resulted in build failures. This PR fixes those new usages of `toDocumentSchema` to instead call `finalize`.