### PR TITLE
docs(container-definitions): Add explicit release tags to exported API members

### DIFF
--- a/packages/common/container-definitions/api-extractor.json
+++ b/packages/common/container-definitions/api-extractor.json
@@ -1,12 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-	"messages": {
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				// TODO: Fix violations and remove this rule override
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -481,7 +481,7 @@ export interface IRuntimeFactory extends IProvideRuntimeFactory {
 // @public
 export const isFluidBrowserPackage: (maybePkg: unknown) => maybePkg is Readonly<IFluidBrowserPackage>;
 
-// @public (undocumented)
+// @public
 export const isFluidCodeDetails: (details: unknown) => details is Readonly<IFluidCodeDetails>;
 
 // @public

--- a/packages/common/container-definitions/src/audience.ts
+++ b/packages/common/container-definitions/src/audience.ts
@@ -10,6 +10,7 @@ import { IClient } from "@fluidframework/protocol-definitions";
 
 /**
  * Manages the state and the members for {@link IAudience}
+ * @public
  */
 export interface IAudienceOwner extends IAudience {
 	/**
@@ -29,6 +30,7 @@ export interface IAudienceOwner extends IAudience {
  *
  * See {@link https://nodejs.org/api/events.html#class-eventemitter | here} for an overview of the `EventEmitter`
  * class.
+ * @public
  */
 export interface IAudience extends EventEmitter {
 	/**

--- a/packages/common/container-definitions/src/browserPackage.ts
+++ b/packages/common/container-definitions/src/browserPackage.ts
@@ -7,6 +7,7 @@ import { IFluidPackage, isFluidPackage, IFluidPackageEnvironment } from "./fluid
 
 /**
  * A specific Fluid package environment for browsers
+ * @public
  */
 export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironment {
 	/**
@@ -30,6 +31,7 @@ export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironmen
 
 /**
  * A Fluid package for specification for browser environments
+ * @public
  */
 export interface IFluidBrowserPackage extends IFluidPackage {
 	/**
@@ -50,6 +52,7 @@ export interface IFluidBrowserPackage extends IFluidPackage {
 /**
  * Determines if any object is an IFluidBrowserPackage
  * @param maybePkg - The object to check for compatibility with IFluidBrowserPackage
+ * @public
  */
 export const isFluidBrowserPackage = (
 	maybePkg: unknown,

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -22,6 +22,7 @@ import {
 
 /**
  * Contract representing the result of a newly established connection to the server for syncing deltas.
+ * @public
  */
 export interface IConnectionDetails {
 	clientId: string;
@@ -43,6 +44,7 @@ export interface IConnectionDetails {
 
 /**
  * Contract supporting delivery of outbound messages to the server
+ * @public
  */
 export interface IDeltaSender {
 	/**
@@ -53,6 +55,7 @@ export interface IDeltaSender {
 
 /**
  * Events emitted by {@link IDeltaManager}.
+ * @public
  */
 export interface IDeltaManagerEvents extends IEvent {
 	/**
@@ -132,6 +135,7 @@ export interface IDeltaManagerEvents extends IEvent {
 
 /**
  * Manages the transmission of ops between the runtime and storage.
+ * @public
  */
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender {
 	/**
@@ -217,6 +221,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 
 /**
  * Events emitted by {@link IDeltaQueue}.
+ * @public
  */
 export interface IDeltaQueueEvents<T> extends IErrorEvent {
 	/**
@@ -259,6 +264,7 @@ export interface IDeltaQueueEvents<T> extends IErrorEvent {
 
 /**
  * Queue of ops to be sent to or processed from storage
+ * @public
  */
 export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, IDisposable {
 	/**
@@ -306,6 +312,9 @@ export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, ID
 	waitTillProcessingDone(): Promise<{ count: number; duration: number }>;
 }
 
+/**
+ * @public
+ */
 export type ReadOnlyInfo =
 	| {
 			readonly readonly: false | undefined;

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -7,6 +7,7 @@ import { FluidErrorTypes, IErrorBase } from "@fluidframework/core-interfaces";
 
 /**
  * Different error types the ClientSession may report out to the Host.
+ * @public
  */
 export const ContainerErrorTypes = {
 	...FluidErrorTypes,
@@ -16,12 +17,17 @@ export const ContainerErrorTypes = {
 	 */
 	clientSessionExpiredError: "clientSessionExpiredError",
 } as const;
+
+/**
+ * @public
+ */
 export type ContainerErrorTypes = (typeof ContainerErrorTypes)[keyof typeof ContainerErrorTypes];
 
 /**
  * Different error types the Container may report out to the Host.
  *
  * @deprecated ContainerErrorType is being deprecated as a public export. Please use {@link ContainerErrorTypes#clientSessionExpiredError} instead.
+ * @public
  */
 export enum ContainerErrorType {
 	/**
@@ -58,6 +64,7 @@ export enum ContainerErrorType {
 
 /**
  * Represents warnings raised on container.
+ * @public
  */
 export interface ContainerWarning extends IErrorBase {
 	/**
@@ -83,5 +90,6 @@ export interface ContainerWarning extends IErrorBase {
  *
  * - {@link @fluidframework/routerlicious-driver#RouterliciousErrorType}
  *
+ * @public
  */
 export type ICriticalContainerError = IErrorBase;

--- a/packages/common/container-definitions/src/fluidModule.ts
+++ b/packages/common/container-definitions/src/fluidModule.ts
@@ -7,6 +7,9 @@ import { FluidObject } from "@fluidframework/core-interfaces";
 import { IProvideFluidCodeDetailsComparer } from "./fluidPackage";
 import { IRuntimeFactory } from "./runtime";
 
+/**
+ * @public
+ */
 export interface IFluidModule {
 	fluidExport: FluidObject<IRuntimeFactory & IProvideFluidCodeDetailsComparer>;
 }

--- a/packages/common/container-definitions/src/fluidPackage.ts
+++ b/packages/common/container-definitions/src/fluidPackage.ts
@@ -5,6 +5,7 @@
 
 /**
  * Specifies an environment on Fluid property of a IFluidPackage.
+ * @public
  */
 export interface IFluidPackageEnvironment {
 	/**
@@ -35,6 +36,7 @@ export interface IFluidPackageEnvironment {
  * While compatible with the npm package format it is not necessary that that package is an
  * npm package:
  * {@link https://stackoverflow.com/questions/10065564/add-custom-metadata-or-config-to-package-json-is-it-valid}
+ * @public
  */
 export interface IFluidPackage {
 	/**
@@ -62,6 +64,7 @@ export interface IFluidPackage {
 /**
  * Check if the package.json defines a Fluid package
  * @param pkg - the package json data to check if it is a Fluid package.
+ * @public
  */
 export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
 	typeof pkg === "object" &&
@@ -70,6 +73,7 @@ export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
 
 /**
  * Package manager configuration. Provides a key value mapping of config values
+ * @public
  */
 export interface IFluidCodeDetailsConfig {
 	readonly [key: string]: string;
@@ -77,6 +81,7 @@ export interface IFluidCodeDetailsConfig {
 
 /**
  * Data structure used to describe the code to load on the Fluid document
+ * @public
  */
 export interface IFluidCodeDetails {
 	/**
@@ -94,6 +99,10 @@ export interface IFluidCodeDetails {
 	readonly config?: IFluidCodeDetailsConfig;
 }
 
+/**
+ * Determines if any object is an IFluidCodeDetails
+ * @public
+ */
 export const isFluidCodeDetails = (details: unknown): details is Readonly<IFluidCodeDetails> => {
 	const maybeCodeDetails = details as Partial<IFluidCodeDetails> | undefined;
 	return (
@@ -104,15 +113,22 @@ export const isFluidCodeDetails = (details: unknown): details is Readonly<IFluid
 	);
 };
 
+/**
+ * @public
+ */
 export const IFluidCodeDetailsComparer: keyof IProvideFluidCodeDetailsComparer =
 	"IFluidCodeDetailsComparer";
 
+/**
+ * @public
+ */
 export interface IProvideFluidCodeDetailsComparer {
 	readonly IFluidCodeDetailsComparer: IFluidCodeDetailsComparer;
 }
 
 /**
  * Provides capability to compare Fluid code details.
+ * @public
  */
 export interface IFluidCodeDetailsComparer extends IProvideFluidCodeDetailsComparer {
 	/**

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -30,6 +30,7 @@ import { IFluidCodeDetails, IFluidPackage, IProvideFluidCodeDetailsComparer } fr
 
 /**
  * Encapsulates a module entry point with corresponding code details.
+ * @public
  */
 export interface IFluidModuleWithDetails {
 	/**
@@ -49,6 +50,7 @@ export interface IFluidModuleWithDetails {
 /**
  * Fluid code loader resolves a code module matching the document schema, i.e. code details, such as
  * a package name and package version range.
+ * @public
  */
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
 	/**
@@ -63,6 +65,7 @@ export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComp
 /**
  * The interface returned from a IFluidCodeResolver which represents IFluidCodeDetails
  * that have been resolved and are ready to load
+ * @public
  */
 export interface IResolvedFluidCodeDetails extends IFluidCodeDetails {
 	/**
@@ -81,6 +84,7 @@ export interface IResolvedFluidCodeDetails extends IFluidCodeDetails {
  * The Fluid code resolver is coupled to a specific cdn and knows how to resolve
  * the code detail for loading from that cdn. This include resolving to the most recent
  * version of package that supports the provided code details.
+ * @public
  */
 export interface IFluidCodeResolver {
 	/**
@@ -94,6 +98,7 @@ export interface IFluidCodeResolver {
 
 /**
  * Events emitted by the {@link IContainer} "upwards" to the Loader and Host.
+ * @public
  */
 export interface IContainerEvents extends IEvent {
 	/**
@@ -253,6 +258,7 @@ export interface IContainerEvents extends IEvent {
 /**
  * Namespace for the different connection states a container can be in.
  * PLEASE NOTE: The sequence of the numerical values does no correspond to the typical connection state progression.
+ * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ConnectionState {
@@ -282,6 +288,7 @@ export namespace ConnectionState {
 
 /**
  * Type defining the different states of connectivity a Container can be in.
+ * @public
  */
 export type ConnectionState =
 	| ConnectionState.Disconnected
@@ -291,6 +298,7 @@ export type ConnectionState =
 
 /**
  * The Host's view of a Container and its connection to storage
+ * @public
  */
 // eslint-disable-next-line import/no-deprecated
 export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRouter {
@@ -499,6 +507,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 
 /**
  * The Runtime's view of the Loader, used for loading Containers
+ * @public
  */
 export interface ILoader extends Partial<IProvideLoader> {
 	/**
@@ -526,6 +535,7 @@ export interface ILoader extends Partial<IProvideLoader> {
 
 /**
  * The Host's view of the Loader, used for loading Containers
+ * @public
  */
 export interface IHostLoader extends ILoader {
 	/**
@@ -541,6 +551,9 @@ export interface IHostLoader extends ILoader {
 	rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
 }
 
+/**
+ * @public
+ */
 export type ILoaderOptions = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[key in string | number]: any;
@@ -573,6 +586,7 @@ export type ILoaderOptions = {
 
 /**
  * Accepted header keys for requests coming to the Loader
+ * @public
  */
 export enum LoaderHeader {
 	/**
@@ -603,6 +617,9 @@ export enum LoaderHeader {
 	version = "version",
 }
 
+/**
+ * @public
+ */
 export interface IContainerLoadMode {
 	opsBeforeReturn?: /*
 	 * No trailing ops are applied before container is returned.
@@ -656,6 +673,7 @@ export interface IContainerLoadMode {
 
 /**
  * Set of Request Headers that the Loader understands and may inspect or modify
+ * @public
  */
 export interface ILoaderHeader {
 	/**
@@ -673,6 +691,9 @@ export interface ILoaderHeader {
 	[LoaderHeader.version]: string | undefined;
 }
 
+/**
+ * @public
+ */
 export interface IProvideLoader {
 	readonly ILoader: ILoader;
 }
@@ -681,6 +702,7 @@ export interface IProvideLoader {
  * @deprecated 0.48, This API will be removed in 0.50
  * No replacement since it is not expected anyone will depend on this outside container-loader
  * See {@link https://github.com/microsoft/FluidFramework/issues/9711} for context.
+ * @public
  */
 export interface IPendingLocalState {
 	url: string;
@@ -692,6 +714,7 @@ export interface IPendingLocalState {
  * in separate property: {@link ISnapshotTreeWithBlobContents.blobsContents}.
  *
  * @remarks This is used as the `ContainerContext`'s base snapshot when attaching.
+ * @public
  */
 export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
 	blobsContents: { [path: string]: ArrayBufferLike };

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -32,6 +32,7 @@ import { IFluidCodeDetails } from "./fluidPackage";
 /**
  * The attachment state of some Fluid data (e.g. a container or data store), denoting whether it is uploaded to the
  * service.  The transition from detached to attached state is a one-way transition.
+ * @public
  */
 export enum AttachState {
 	/**
@@ -55,6 +56,7 @@ export enum AttachState {
 /**
  * The IRuntime represents an instantiation of a code package within a Container.
  * Primarily held by the ContainerContext to be able to interact with the running instance of the Container.
+ * @public
  */
 export interface IRuntime extends IDisposable {
 	/**
@@ -126,6 +128,7 @@ export interface IRuntime extends IDisposable {
 
 /**
  * Payload type for IContainerContext.submitBatchFn()
+ * @public
  */
 export interface IBatchMessage {
 	contents?: string;
@@ -138,6 +141,7 @@ export interface IBatchMessage {
  * IContainerContext is fundamentally just the set of things that an IRuntimeFactory (and IRuntime) will consume from the
  * loader layer.  It gets passed into the IRuntimeFactory.instantiateRuntime call.  Only include members on this interface
  * if you intend them to be consumed/called from the runtime layer.
+ * @public
  */
 export interface IContainerContext {
 	readonly options: ILoaderOptions;
@@ -217,8 +221,14 @@ export interface IContainerContext {
 	readonly id: string;
 }
 
+/**
+ * @public
+ */
 export const IRuntimeFactory: keyof IProvideRuntimeFactory = "IRuntimeFactory";
 
+/**
+ * @public
+ */
 export interface IProvideRuntimeFactory {
 	readonly IRuntimeFactory: IRuntimeFactory;
 }
@@ -228,6 +238,7 @@ export interface IProvideRuntimeFactory {
  *
  * Provides the entry point for the ContainerContext to load the proper IRuntime
  * to start up the running instance of the Container.
+ * @public
  */
 export interface IRuntimeFactory extends IProvideRuntimeFactory {
 	/**

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="mocha" />
+
 // @public (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @public (undocumented)
 export const mochaHooks: {
     beforeAll(): void;


### PR DESCRIPTION
[AB#5878](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5878)

## Description

This PR adds the @public explicit release tag for all exported interfaces in the container-definitions package.

### Reviewer Guidance 
Any interfaces/functions that should be tagged with something else?