### PR TITLE
Remove closing summarizer on stale events

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3814,16 +3814,6 @@ export class ContainerRuntime
 	}
 
 	private async closeStaleSummarizer(codePath: string): Promise<void> {
-		this.mc.logger.sendTelemetryEvent(
-			{
-				eventName: "ClosingSummarizerOnSummaryStale",
-				codePath,
-				message: "Stopping fetch from storage",
-				closeSummarizerDelayMs: this.closeSummarizerDelayMs,
-			},
-			new GenericError("Restarting summarizer instead of refreshing"),
-		);
-
 		// Delay before restarting summarizer to prevent the summarizer from restarting too frequently.
 		await delay(this.closeSummarizerDelayMs);
 		this._summarizer?.stop("latestSummaryStateStale");

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -48,9 +48,6 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 					"fluid:telemetry:Summarizer:Running:RefreshLatestSummaryFromServerFetch_end",
 			},
 			{
-				eventName: "fluid:telemetry:ContainerRuntime:ClosingSummarizerOnSummaryStale",
-			},
-			{
 				eventName: "fluid:telemetry:Container:ContainerDispose",
 				category: "generic",
 			},
@@ -84,9 +81,6 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 		[
 			{
 				eventName: "fluid:telemetry:SummarizerNode:refreshLatestSummary_end",
-			},
-			{
-				eventName: "fluid:telemetry:ContainerRuntime:ClosingSummarizerOnSummaryStale",
 			},
 			{
 				eventName: "fluid:telemetry:Container:ContainerDispose",
@@ -123,9 +117,6 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 	itExpects(
 		"Closes the summarizing client instead of refreshing when loading from an older summary",
 		[
-			{
-				eventName: "fluid:telemetry:ContainerRuntime:ClosingSummarizerOnSummaryStale",
-			},
 			{
 				eventName: "fluid:telemetry:Container:ContainerDispose",
 				category: "generic",
@@ -177,9 +168,6 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 			{
 				eventName:
 					"fluid:telemetry:Summarizer:Running:RefreshLatestSummaryFromServerFetch_end",
-			},
-			{
-				eventName: "fluid:telemetry:ContainerRuntime:ClosingSummarizerOnSummaryStale",
 			},
 			{
 				eventName: "fluid:telemetry:Container:ContainerDispose",


### PR DESCRIPTION
[AB#5146](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5146)

Originally this was added to differentiate between the Refresh from Server code and the Close Code which has already been removed: https://github.com/microsoft/FluidFramework/pull/16657, as we always close.

The information this event is already contained in both `RefreshLatestSummaryFromServerFetch_end` and during `Summarize_cancel`.

Remove ClosingSummarizerOnSummaryStale telemetry as it is duplicate to both `RefreshLatestSummaryFromServerFetch_end` and `RefreshLatestSummaryAckFetch_end` telemetry