### PR TITLE
refactor(odsp-driver): Add explicit release tags to exported API members and add missing package exports

### DIFF
--- a/packages/drivers/odsp-driver/api-extractor.json
+++ b/packages/drivers/odsp-driver/api-extractor.json
@@ -1,15 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-	"messages": {
-		// TODO: Fix violations and remove this rule override
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				"logLevel": "none"
-			},
-			"ae-forgotten-export": {
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -57,6 +57,46 @@ export function createOdspUrl(l: OdspFluidDataStoreLocator): string;
 export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocator): string;
 
 // @public
+export class EpochTracker implements IPersistedFileCache {
+    constructor(cache: IPersistedCache, fileEntry: IFileEntry, logger: ITelemetryLoggerExt, clientIsSummarizer?: boolean | undefined);
+    // (undocumented)
+    protected readonly cache: IPersistedCache;
+    // (undocumented)
+    protected readonly clientIsSummarizer?: boolean | undefined;
+    fetch(url: string, fetchOptions: RequestInit, fetchType: FetchType, addInBody?: boolean, fetchReason?: string): Promise<IOdspResponse<Response>>;
+    fetchAndParseAsJSON<T>(url: string, fetchOptions: RequestInit, fetchType: FetchType, addInBody?: boolean, fetchReason?: string): Promise<IOdspResponse<T>>;
+    fetchArray(url: string, fetchOptions: {
+        [index: string]: any;
+    }, fetchType: FetchType, addInBody?: boolean, fetchReason?: string): Promise<IOdspResponse<ArrayBuffer>>;
+    // (undocumented)
+    protected readonly fileEntry: IFileEntry;
+    // (undocumented)
+    get fluidEpoch(): string | undefined;
+    // (undocumented)
+    get(entry: IEntry): Promise<any>;
+    // (undocumented)
+    protected readonly logger: ITelemetryLoggerExt;
+    // (undocumented)
+    put(entry: IEntry, value: any): Promise<void>;
+    // (undocumented)
+    readonly rateLimiter: RateLimiter;
+    // (undocumented)
+    removeEntries(): Promise<void>;
+    // (undocumented)
+    setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void;
+    // (undocumented)
+    validateEpoch(epoch: string | undefined, fetchType: FetchType): Promise<void>;
+    // (undocumented)
+    protected validateEpochFromResponse(epochFromResponse: string | undefined, fetchType: FetchTypeInternal, fromCache?: boolean): void;
+}
+
+// @public (undocumented)
+export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "ops" | "test" | "snapshotTree" | "treesLatest" | "uploadSummary" | "push" | "versions";
+
+// @public (undocumented)
+export type FetchTypeInternal = FetchType | "cache";
+
+// @public
 export function getApiRoot(origin: string): string;
 
 // @public (undocumented)
@@ -69,9 +109,62 @@ export function getLocatorFromOdspUrl(url: URL, requireFluidSignature?: boolean)
 export function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefined>;
 
 // @public (undocumented)
+export interface ICacheAndTracker {
+    // (undocumented)
+    cache: IOdspCache;
+    // (undocumented)
+    epochTracker: EpochTracker;
+}
+
+// @public (undocumented)
 export interface IClpCompliantAppHeader {
     // (undocumented)
     [ClpCompliantAppHeader.isClpCompliantApp]: boolean;
+}
+
+// @public
+export interface INonPersistentCache {
+    readonly fileUrlCache: PromiseCache<string, IOdspResolvedUrl>;
+    readonly sessionJoinCache: PromiseCache<string, {
+        entryTime: number;
+        joinSessionResponse: ISocketStorageDiscovery;
+    }>;
+    readonly snapshotPrefetchResultCache: PromiseCache<string, IPrefetchSnapshotContents>;
+}
+
+// @public
+export interface IOdspCache extends INonPersistentCache {
+    readonly persistedCache: IPersistedFileCache;
+}
+
+// @public (undocumented)
+export interface IOdspResponse<T> {
+    // (undocumented)
+    content: T;
+    // (undocumented)
+    duration: number;
+    // (undocumented)
+    headers: Map<string, string>;
+    // (undocumented)
+    propsToLog: ITelemetryProperties;
+}
+
+// @public
+export interface IPersistedFileCache {
+    // (undocumented)
+    get(entry: IEntry): Promise<any>;
+    // (undocumented)
+    put(entry: IEntry, value: any): Promise<void>;
+    // (undocumented)
+    removeEntries(): Promise<void>;
+}
+
+// @public (undocumented)
+export interface IPrefetchSnapshotContents extends ISnapshotContents {
+    // (undocumented)
+    fluidEpoch: string;
+    // (undocumented)
+    prefetchStartTime: number;
 }
 
 // @public (undocumented)
@@ -93,6 +186,12 @@ export interface ISnapshotContents {
 }
 
 // @public
+export interface ISnapshotContentsWithProps extends ISnapshotContents {
+    // (undocumented)
+    telemetryProps: Record<string, number>;
+}
+
+// @public
 export function isOdcOrigin(origin: string): boolean;
 
 // @public
@@ -101,7 +200,7 @@ export function isOdcUrl(url: string | URL): boolean;
 // @public
 export function isSpoUrl(url: string): boolean;
 
-// @public (undocumented)
+// @public
 export const locatorQueryParamName = "nav";
 
 // @public (undocumented)
@@ -187,6 +286,16 @@ export interface ShareLinkFetcherProps {
 export enum SharingLinkHeader {
     // (undocumented)
     isSharingLinkToRedeem = "isSharingLinkToRedeem"
+}
+
+// @public
+export enum SnapshotFormatSupportType {
+    // (undocumented)
+    Binary = 1,
+    // (undocumented)
+    Json = 0,
+    // (undocumented)
+    JsonAndBinary = 2
 }
 
 // @public

--- a/packages/drivers/odsp-driver/src/checkUrl.ts
+++ b/packages/drivers/odsp-driver/src/checkUrl.ts
@@ -11,6 +11,7 @@ import { getLocatorFromOdspUrl } from "./odspFluidFileLink";
  * Note that returning information here is NOT a full guarantee that resolve will ultimately be successful.
  * Instead, this should be used as a lightweight check that can filter out easily detectable unsupported URLs
  * before the entire Fluid loading process needs to be kicked off.
+ * @public
  */
 export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined {
 	const locator = getLocatorFromOdspUrl(documentUrl);

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -27,6 +27,7 @@ export const currentReadVersion = "1.0";
 /**
  * The parsing is significantly faster if the position of props is well known instead of dynamic. So these variables
  * represents how many times slower parsing path is executed. This will be then logged into telemetry.
+ * @public
  */
 export interface ISnapshotContentsWithProps extends ISnapshotContents {
 	telemetryProps: Record<string, number>;
@@ -216,6 +217,7 @@ function readSnapshotSection(node: NodeTypes) {
  * Converts snapshot from binary compact representation to tree/blobs/ops.
  * @param buffer - Compact snapshot to be parsed into tree/blobs/ops.
  * @returns Tree, blobs and ops from the snapshot.
+ * @public
  */
 export function parseCompactSnapshotResponse(
 	buffer: Uint8Array,

--- a/packages/drivers/odsp-driver/src/constants.ts
+++ b/packages/drivers/odsp-driver/src/constants.ts
@@ -3,5 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @public
+ */
 export const OdcApiSiteOrigin = "https://my.microsoftpersonalcontent.com";
+
+/**
+ * @public
+ */
 export const OdcFileSiteOrigin = "https://1drv.ms";

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -5,6 +5,9 @@
 
 import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions";
 
+/**
+ * @public
+ */
 export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 	dataStorePath: string;
 	appName?: string;
@@ -13,22 +16,33 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 	context?: string;
 }
 
+/**
+ * @public
+ */
 export enum SharingLinkHeader {
 	// Can be used in request made to resolver, to tell the resolver that the passed in URL is a sharing link
 	// which can be redeemed at server to get permissions.
 	isSharingLinkToRedeem = "isSharingLinkToRedeem",
 }
 
+/**
+ * @public
+ */
 export interface ISharingLinkHeader {
 	[SharingLinkHeader.isSharingLinkToRedeem]: boolean;
 }
-
+/**
+ * @public
+ */
 export enum ClpCompliantAppHeader {
 	// Can be used in request made to resolver, to tell the resolver that the host app is CLP compliant.
 	// Odsp will not return Classified, labeled, or protected documents if the host app cannot support them.
 	isClpCompliantApp = "X-CLP-Compliant-App",
 }
 
+/**
+ * @public
+ */
 export interface IClpCompliantAppHeader {
 	[ClpCompliantAppHeader.isClpCompliantApp]: boolean;
 }

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -15,6 +15,7 @@ import { buildOdspShareLinkReqParams } from "./odspUtils";
  * @param fileName - name of the new file to be created
  * @param createShareLinkType - type of sharing link you would like to create for this file. ShareLinkTypes
  * will be deprecated soon, so for any new implementation please provide createShareLinkType of type ShareLink
+ * @public
  */
 export function createOdspCreateContainerRequest(
 	siteUrl: string,

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -12,6 +12,7 @@ import { OdspFluidDataStoreLocator } from "./contractsPublic";
 /**
  * Encodes ODC/SPO information into a URL format that can be handled by the Loader
  * @param l -The property bag of necessary properties to locate a Fluid data store and craft a url for it
+ * @public
  */
 export function createOdspUrl(l: OdspFluidDataStoreLocator): string {
 	let odspUrl = `${l.siteUrl}?driveId=${encodeURIComponent(

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -43,6 +43,9 @@ import { ClpCompliantAppHeader } from "./contractsPublic";
 import { pkgVersion as driverVersion } from "./packageVersion";
 import { patchOdspResolvedUrl } from "./odspLocationRedirection";
 
+/**
+ * @public
+ */
 export type FetchType =
 	| "blob"
 	| "createBlob"
@@ -56,6 +59,9 @@ export type FetchType =
 	| "push"
 	| "versions";
 
+/**
+ * @public
+ */
 export type FetchTypeInternal = FetchType | "cache";
 
 export const Odsp409Error = "Odsp409Error";
@@ -77,6 +83,7 @@ export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000; // 2
  * server can match it with its epoch value in order to match the version.
  * It also validates the epoch value received in response of fetch calls. If the epoch does not match,
  * then it also clears all the cached entries for the given container.
+ * @public
  */
 export class EpochTracker implements IPersistedFileCache {
 	private _fluidEpoch: string | undefined;
@@ -595,6 +602,9 @@ export class EpochTrackerWithRedemption extends EpochTracker {
 	}
 }
 
+/**
+ * @public
+ */
 export interface ICacheAndTracker {
 	cache: IOdspCache;
 	epochTracker: EpochTracker;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -56,6 +56,7 @@ import { pkgVersion } from "./packageVersion";
 
 /**
  * Enum to support different types of snapshot formats.
+ * @public
  */
 export enum SnapshotFormatSupportType {
 	Json = 0,

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -49,4 +49,13 @@ export {
 	storeLocatorInOdspUrl,
 } from "./odspFluidFileLink";
 
-export { parseCompactSnapshotResponse } from "./compactSnapshotParser";
+export {
+	IOdspCache,
+	IPersistedFileCache,
+	INonPersistentCache,
+	IPrefetchSnapshotContents,
+} from "./odspCache";
+export { ICacheAndTracker, EpochTracker, FetchType, FetchTypeInternal } from "./epochTracker";
+export { IOdspResponse } from "./odspUtils";
+export { SnapshotFormatSupportType } from "./fetchSnapshot";
+export { ISnapshotContentsWithProps, parseCompactSnapshotResponse } from "./compactSnapshotParser";

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -55,7 +55,7 @@ export {
 	INonPersistentCache,
 	IPrefetchSnapshotContents,
 } from "./odspCache";
-export { ICacheAndTracker, EpochTracker, FetchType, FetchTypeInternal } from "./epochTracker";
+export { ICacheAndTracker, type EpochTracker, FetchType, FetchTypeInternal } from "./epochTracker";
 export { IOdspResponse } from "./odspUtils";
 export { SnapshotFormatSupportType } from "./fetchSnapshot";
 export { ISnapshotContentsWithProps, parseCompactSnapshotResponse } from "./compactSnapshotParser";

--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -16,6 +16,7 @@ import { ISnapshotContents } from "./odspPublicUtils";
 
 /**
  * Similar to IPersistedCache, but exposes cache interface for single file
+ * @public
  */
 export interface IPersistedFileCache {
 	get(entry: IEntry): Promise<any>;
@@ -90,6 +91,7 @@ export class PromiseCacheWithOneHourSlidingExpiry<T> extends PromiseCache<string
 
 /**
  * Internal cache interface used within driver only
+ * @public
  */
 export interface INonPersistentCache {
 	/**
@@ -114,6 +116,7 @@ export interface INonPersistentCache {
 
 /**
  * Internal cache interface used within driver only
+ * @public
  */
 export interface IOdspCache extends INonPersistentCache {
 	/**
@@ -136,6 +139,9 @@ export class NonPersistentCache implements INonPersistentCache {
 	>();
 }
 
+/**
+ * @public
+ */
 export interface IPrefetchSnapshotContents extends ISnapshotContents {
 	fluidEpoch: string;
 	prefetchStartTime: number;

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -17,6 +17,7 @@ import { LocalOdspDocumentServiceFactory } from "./localOdspDriver/localOdspDocu
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
  * use the sharepoint implementation.
+ * @public
  */
 export class OdspDocumentServiceFactory extends OdspDocumentServiceFactoryCore {
 	constructor(
@@ -29,6 +30,9 @@ export class OdspDocumentServiceFactory extends OdspDocumentServiceFactoryCore {
 	}
 }
 
+/**
+ * @public
+ */
 export function createLocalOdspDocumentServiceFactory(
 	localSnapshot: Uint8Array | string,
 ): IDocumentServiceFactory {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -50,6 +50,7 @@ import {
  *
  * This constructor should be used by environments that support dynamic imports and that wish
  * to leverage code splitting as a means to keep bundles as small as possible.
+ * @public
  */
 export class OdspDocumentServiceFactoryCore
 	implements IDocumentServiceFactory, IRelaySessionAwareDriverFactory

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -15,6 +15,7 @@ import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore
 /**
  * @deprecated - This is deprecated in favour of OdspDocumentServiceFactory as the socket io is now loaded inside the
  * other dynamically imported module.
+ * @public
  */
 export class OdspDocumentServiceFactoryWithCodeSplit
 	extends OdspDocumentServiceFactoryCore

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -80,6 +80,7 @@ function removeBeginningSlash(str: string): string {
 /**
  * Resolver to resolve urls like the ones created by createOdspUrl which is driver inner
  * url format. Ex: `${siteUrl}?driveId=${driveId}&itemId=${itemId}&path=${path}`
+ * @public
  */
 export class OdspDriverUrlResolver implements IUrlResolver {
 	constructor() {}

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -30,6 +30,7 @@ import { getFileLink } from "./getFileLink";
 
 /**
  * Properties passed to the code responsible for fetching share link for a file.
+ * @public
  */
 export interface ShareLinkFetcherProps {
 	/**
@@ -46,6 +47,7 @@ export interface ShareLinkFetcherProps {
  * Resolver to resolve urls like the ones created by createOdspUrl which is driver inner
  * url format and the ones which have things like driveId, siteId, itemId etc encoded in nav param.
  * This resolver also handles share links and try to generate one for the use by the app.
+ * @public
  */
 export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 	private readonly logger: ITelemetryLoggerExt;

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -22,6 +22,7 @@ const additionalContextParamName = "x";
  * Transforms given Fluid data store locator into string that can be embedded into url
  * @param locator - describes Fluid data store locator info to be encoded
  * @returns string representing encoded Fluid data store locator info
+ * @public
  */
 export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocator): string {
 	const siteUrl = new URL(locator.siteUrl);
@@ -108,14 +109,18 @@ function decodeOdspFluidDataStoreLocator(
 	};
 }
 
-// This parameter is provided by host in the resolve request and it contains information about the file
-// like driveId, itemId, siteUrl, datastorePath, packageName etc.
+/**
+ * This parameter is provided by host in the resolve request and it contains information about the file
+ * like driveId, itemId, siteUrl, datastorePath, packageName etc.
+ * @public
+ */
 export const locatorQueryParamName = "nav";
 
 /**
  * Embeds Fluid data store locator data into given ODSP url
  * @param url - file url in ODSP format (can be either canonical or share link)
  * @param locator - object representing Fluid data store location in ODSP terms
+ * @public
  */
 export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocator) {
 	const encodedLocatorValue = encodeOdspFluidDataStoreLocator(locator);
@@ -130,6 +135,7 @@ export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocat
  * @param url - ODSP url representing Fluid file link
  * @param requireFluidSignature - flag representing if the Fluid signature is expected in the url, default true
  * @returns object representing Fluid data store location in ODSP terms
+ * @public
  */
 export function getLocatorFromOdspUrl(
 	url: URL,

--- a/packages/drivers/odsp-driver/src/odspPublicUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspPublicUtils.ts
@@ -6,11 +6,17 @@
 import { hashFile, IsoBuffer } from "@fluid-internal/client-utils";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 
+/**
+ * @public
+ */
 export async function getHashedDocumentId(driveId: string, itemId: string): Promise<string> {
 	const buffer = IsoBuffer.from(`${driveId}_${itemId}`);
 	return encodeURIComponent(await hashFile(buffer, "SHA-256", "base64"));
 }
 
+/**
+ * @public
+ */
 export interface ISnapshotContents {
 	snapshotTree: ISnapshotTree;
 	blobs: Map<string, ArrayBuffer>;

--- a/packages/drivers/odsp-driver/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-driver/src/odspUrlHelper.ts
@@ -10,6 +10,7 @@ import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions";
 /**
  * Checks whether or not the given URL origin is an ODC origin
  * @param origin - The URL origin to check
+ * @public
  */
 export function isOdcOrigin(origin: string): boolean {
 	return (
@@ -27,6 +28,7 @@ export function isOdcOrigin(origin: string): boolean {
 /**
  * Gets the correct API root for the given ODSP url, e.g. 'https://foo-my.sharepoint.com/_api/v2.1'
  * @param origin - The URL origin
+ * @public
  */
 export function getApiRoot(origin: string): string {
 	let prefix = "_api/";
@@ -40,6 +42,7 @@ export function getApiRoot(origin: string): string {
 /**
  * Whether or not the given URL is a valid SPO/ODB URL
  * @param url - The URL to check
+ * @public
  */
 export function isSpoUrl(url: string): boolean {
 	const urlLower = url.toLowerCase();
@@ -52,6 +55,7 @@ export function isSpoUrl(url: string): boolean {
 /**
  * Whether or not the given URL is a valid ODC URL
  * @param url - The URL to check
+ * @public
  */
 export function isOdcUrl(url: string | URL): boolean {
 	const urlObj = typeof url === "string" ? new URL(url) : url;
@@ -76,6 +80,7 @@ export function isOdcUrl(url: string | URL): boolean {
  * Breaks an ODSP URL into its parts, extracting the site, drive ID, and item ID.
  * Returns undefined for invalid/malformed URLs.
  * @param url - The (raw) URL to parse
+ * @public
  */
 export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefined> {
 	const pathname = url.pathname;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -50,6 +50,9 @@ export const getWithRetryForTokenRefreshRepeat = "getWithRetryForTokenRefreshRep
 /** Parse the given url and return the origin (host name) */
 export const getOrigin = (url: string) => new URL(url).origin;
 
+/**
+ * @public
+ */
 export interface IOdspResponse<T> {
 	content: T;
 	headers: Map<string, string>;


### PR DESCRIPTION
[AB#5892](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5892)

## Description

This PR adds the @public explicit release tag for all exported interfaces in the odsp-driver package and adds missing package exports. New exports represent types that were transitively referenced by existing exports, and therefore must be exported for API completeness.

### Reviewer Guidance
 
Are there any interfaces/functions that should be tagged with something else?