### PR TITLE
tree2: Rename TypedSchemaCollection to DocumentSchema

### DIFF
--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/README.md
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/README.md
@@ -6,7 +6,7 @@ from `PropertyDDS` to the new `SharedTree` DDS (see the
 
 ## Schema converter (runtime)
 
-A [`schema-converter`](./src/schemaConverter.ts) converts a `PropertyDDS` schema template into a [`TypedSchemaCollection`](https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/schemaBuilder.ts) at runtime, so that the resulting schema can be used by the `SharedTree`, for example:
+A [`schema-converter`](./src/schemaConverter.ts) converts a `PropertyDDS` schema template into a [`DocumentSchema`](https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/schemaBuilder.ts) at runtime, so that the resulting schema can be used by the `SharedTree`, for example:
 
 ```ts
 PropertyFactory.register(propertyDDSSchemas);

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -320,7 +320,7 @@ export const nodePropertySchema = builtinBuilder.map(
 const builtinLibrary = builtinBuilder.finalize();
 
 /**
- * Creates a TypedSchemaCollection out of PropertyDDS schema templates.
+ * Creates a DocumentSchema out of PropertyDDS schema templates.
  * The templates must be registered beforehand using {@link PropertyFactory.register}.
  * @param rootFieldKind - The kind of the root field.
  * @param allowedRootTypes - The types of children nodes allowed for the root field.

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -495,6 +495,18 @@ export type DetachedPlaceUpPath = Brand<Omit<PlaceUpPath, "parent">, "DetachedRa
 export type DetachedRangeUpPath = Brand<Omit<RangeUpPath, "parent">, "DetachedRangeUpPath">;
 
 // @alpha
+export interface DocumentSchema<out T extends FieldSchema = FieldSchema> {
+    // (undocumented)
+    readonly adapters: Adapters;
+    // (undocumented)
+    readonly policy: FullSchemaPolicy;
+    // (undocumented)
+    readonly rootFieldSchema: T;
+    // (undocumented)
+    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
+}
+
+// @alpha
 function downCast<TSchema extends TreeSchema>(schema: TSchema, tree: UntypedTreeCore<any, any>): tree is TypedNode_2<TSchema>;
 
 // @alpha
@@ -1044,7 +1056,7 @@ export interface ISharedTreeBranchView extends ISharedTreeView {
 // @alpha
 export interface ISharedTreeView extends AnchorLocator {
     readonly context: EditableTreeContext;
-    editableTree2<TRoot extends FieldSchema>(viewSchema: TypedSchemaCollection<TRoot>): TypedField<TRoot>;
+    editableTree2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): TypedField<TRoot>;
     readonly editor: IDefaultEditBuilder;
     readonly events: ISubscribable<ViewEvents>;
     readonly forest: IForestSubscription;
@@ -1055,7 +1067,7 @@ export interface ISharedTreeView extends AnchorLocator {
     redo(): void;
     get root(): UnwrappedEditableField;
     // (undocumented)
-    root2<TRoot extends FieldSchema>(viewSchema: TypedSchemaCollection<TRoot>): ProxyField<TRoot>;
+    root2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): ProxyField<TRoot>;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
     // @deprecated (undocumented)
     schematize<TRoot extends FieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
@@ -1830,7 +1842,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     structRecursive<Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeSchema<`${TScope}.${Name}`, {
         structFields: T;
     }>;
-    toDocumentSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TypedSchemaCollection<NormalizeField_2<TSchema, TDefaultKind>>;
+    toDocumentSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): DocumentSchema<NormalizeField_2<TSchema, TDefaultKind>>;
 }
 
 // @alpha
@@ -1843,7 +1855,7 @@ export interface SchemaBuilderOptions<TScope extends string = string> {
 
 // @alpha
 export interface SchemaConfiguration<TRoot extends FieldSchema = FieldSchema> {
-    readonly schema: TypedSchemaCollection<TRoot>;
+    readonly schema: DocumentSchema<TRoot>;
 }
 
 // @alpha
@@ -1864,7 +1876,7 @@ export interface SchemaEvents {
 export function schemaIsFieldNode(schema: TreeSchema): schema is FieldNodeSchema;
 
 // @alpha
-export interface SchemaLibrary extends TypedSchemaCollection {
+export interface SchemaLibrary extends DocumentSchema {
     readonly libraries: ReadonlySet<SchemaLibraryData>;
 }
 
@@ -2088,7 +2100,7 @@ export interface TreeContext extends ISubscribable<ForestEvents> {
     // (undocumented)
     readonly nodeKeys: NodeKeys;
     get root(): TreeField;
-    readonly schema: TypedSchemaCollection;
+    readonly schema: DocumentSchema;
 }
 
 // @alpha
@@ -2248,18 +2260,6 @@ type TypedNode_2<TSchema extends TreeSchema, Mode extends ApiMode = ApiMode.Edit
 
 // @alpha
 export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>, readonly TreeSchema[]>>> : TreeNode;
-
-// @alpha
-export interface TypedSchemaCollection<T extends FieldSchema = FieldSchema> {
-    // (undocumented)
-    readonly adapters: Adapters;
-    // (undocumented)
-    readonly policy: FullSchemaPolicy;
-    // (undocumented)
-    readonly rootFieldSchema: T;
-    // (undocumented)
-    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
-}
 
 // @alpha
 export interface TypedTreeChannel extends IChannel {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/context.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/context.ts
@@ -15,7 +15,7 @@ import { ISubscribable } from "../../events";
 import { DefaultEditBuilder } from "../default-field-kinds";
 import { NodeKeyIndex, NodeKeyManager } from "../node-key";
 import { FieldGenerator } from "../contextuallyTyped";
-import { TypedSchemaCollection } from "../typed-schema";
+import { DocumentSchema } from "../typed-schema";
 import { disposeSymbol, IDisposable } from "../../util";
 import { TreeField } from "./editableTreeTypes";
 import { makeField } from "./lazyField";
@@ -37,7 +37,7 @@ export interface TreeContext extends ISubscribable<ForestEvents> {
 	 * Schema used within this context.
 	 * All data must conform to these schema.
 	 */
-	readonly schema: TypedSchemaCollection;
+	readonly schema: DocumentSchema;
 
 	// TODO: Add more members:
 	// - transaction APIs
@@ -65,7 +65,7 @@ export class Context implements TreeContext, IDisposable {
 	 * If present, clients may query the {@link LocalNodeKey} of a node directly via the {@link localNodeKeySymbol}.
 	 */
 	public constructor(
-		public readonly schema: TypedSchemaCollection,
+		public readonly schema: DocumentSchema,
 		public readonly forest: IEditableForest,
 		public readonly editor: DefaultEditBuilder,
 		public readonly nodeKeys: NodeKeys,
@@ -141,7 +141,7 @@ export class Context implements TreeContext, IDisposable {
  * This is necessary for supporting using this tree across edits to the forest, and not leaking memory.
  */
 export function getTreeContext(
-	schema: TypedSchemaCollection,
+	schema: DocumentSchema,
 	forest: IEditableForest,
 	editor: DefaultEditBuilder,
 	nodeKeyManager: NodeKeyManager,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -17,7 +17,7 @@ import {
 	MapSchema,
 	StructSchema,
 	TreeSchema,
-	TypedSchemaCollection,
+	DocumentSchema,
 } from "../../typed-schema";
 import {
 	CheckTypesOverlap,
@@ -264,8 +264,8 @@ export type ProxyNode<
 
 /** The root type (the type of the entire tree) for a given schema collection */
 export type ProxyRoot<
-	TSchema extends TypedSchemaCollection<any>,
+	TSchema extends DocumentSchema,
 	API extends "javaScript" | "sharedTree" = "sharedTree",
-> = TSchema extends TypedSchemaCollection<infer TRootFieldSchema>
+> = TSchema extends DocumentSchema<infer TRootFieldSchema>
 	? ProxyField<TRootFieldSchema, API>
 	: never;

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -139,7 +139,7 @@ export {
 	TreeSchema,
 	AllowedTypes,
 	FieldSchema,
-	TypedSchemaCollection,
+	DocumentSchema,
 	Any,
 	SchemaLibraryData,
 	LazyTreeSchema,

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -14,7 +14,7 @@ import {
 	AllowedTypes,
 	TreeSchema,
 	FieldSchema,
-	TypedSchemaCollection,
+	DocumentSchema,
 	FlexList,
 	Unenforced,
 	Any,
@@ -154,7 +154,7 @@ export class SchemaBuilderBase<
 	}
 
 	/**
-	 * Produce a TypedSchemaCollection which captures the content added to this builder, any additional SchemaLibraries that were added to it and a root field.
+	 * Produce a DocumentSchema which captures the content added to this builder, any additional SchemaLibraries that were added to it and a root field.
 	 * Can be used with schematize to provide schema aware access to document content.
 	 *
 	 * @remarks
@@ -162,7 +162,7 @@ export class SchemaBuilderBase<
 	 */
 	public toDocumentSchema<const TSchema extends ImplicitFieldSchema>(
 		root: TSchema,
-	): TypedSchemaCollection<NormalizeField<TSchema, TDefaultKind>> {
+	): DocumentSchema<NormalizeField<TSchema, TDefaultKind>> {
 		// return this.toDocumentSchemaInternal(normalizeField(root, DefaultFieldKind));
 		const field = this.normalizeField(root);
 		this.finalizeCommon();
@@ -176,7 +176,7 @@ export class SchemaBuilderBase<
 			rootLibrary,
 			...this.libraries,
 		]);
-		const typed: TypedSchemaCollection<NormalizeField<TSchema, TDefaultKind>> = {
+		const typed: DocumentSchema<NormalizeField<TSchema, TDefaultKind>> = {
 			...collection,
 			rootFieldSchema: field,
 		};
@@ -355,7 +355,7 @@ export class SchemaBuilderBase<
  * Can be aggregated into other libraries by adding to their builders.
  * @alpha
  */
-export interface SchemaLibrary extends TypedSchemaCollection {
+export interface SchemaLibrary extends DocumentSchema {
 	/**
 	 * Schema data aggregated from a collection of libraries by a SchemaBuilder.
 	 */

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -18,7 +18,7 @@ export {
 	schemaIsLeaf,
 	schemaIsMap,
 	schemaIsStruct,
-	TypedSchemaCollection,
+	DocumentSchema,
 	Unenforced,
 	AllowedTypeSet,
 } from "./typedTreeSchema";

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
@@ -8,12 +8,7 @@ import { Adapters, TreeAdapter, TreeSchemaIdentifier } from "../../core";
 import { FieldKind, FullSchemaPolicy } from "../modular-schema";
 import { capitalize, fail, requireAssignableTo } from "../../util";
 import { defaultSchemaPolicy, FieldKinds } from "../default-field-kinds";
-import {
-	FieldSchema,
-	TreeSchema,
-	allowedTypesIsAny,
-	TypedSchemaCollection,
-} from "./typedTreeSchema";
+import { FieldSchema, TreeSchema, allowedTypesIsAny, DocumentSchema } from "./typedTreeSchema";
 import { normalizeFlexListEager } from "./flexList";
 import { Sourced } from "./view";
 
@@ -66,7 +61,7 @@ export const schemaLintDefault: SchemaLintConfiguration = {
 export function buildViewSchemaCollection(
 	lintConfiguration: SchemaLintConfiguration,
 	libraries: Iterable<SchemaLibraryData>,
-): TypedSchemaCollection {
+): DocumentSchema {
 	let rootFieldSchema: FieldSchema | undefined;
 	const treeSchema: Map<TreeSchemaIdentifier, TreeSchema> = new Map();
 	const adapters: SourcedAdapters = { tree: [] };

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -469,14 +469,13 @@ export function allowedTypesToTypeSet(t: AllowedTypes): TreeTypeSet {
  * Strongly typed over its rootFieldSchema.
  *
  * @remarks
- * This type is mainly used as a type constraint to mean that the code working with it requires strongly typed schema.
- * The actual type used will include detailed schema information for all the types in the collection.
- * This pattern is used to implement SchemaAware APIs.
+ * The type of the rootFieldSchema is used to implement SchemaAware APIs.
+ * Cases that do not require being compile time schema aware can omit the explicit type for it.
  *
  * @alpha
  */
 
-export interface TypedSchemaCollection<T extends FieldSchema = FieldSchema> {
+export interface DocumentSchema<out T extends FieldSchema = FieldSchema> {
 	readonly rootFieldSchema: T;
 	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 	readonly policy: FullSchemaPolicy;

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/view.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/view.ts
@@ -15,7 +15,7 @@ import {
 	Compatibility,
 } from "../../core";
 import { FullSchemaPolicy, allowsRepoSuperset, isNeverTree } from "../modular-schema";
-import { TypedSchemaCollection } from "./typedTreeSchema";
+import { DocumentSchema } from "./typedTreeSchema";
 
 /**
  * A collection of View information for schema, including policy.
@@ -24,7 +24,7 @@ export class ViewSchema {
 	public constructor(
 		public readonly policy: FullSchemaPolicy,
 		public readonly adapters: Adapters,
-		public readonly schema: TypedSchemaCollection,
+		public readonly schema: DocumentSchema,
 	) {}
 
 	/**

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -193,7 +193,7 @@ export {
 	Sequence,
 	NodeKeyFieldKind,
 	Forbidden,
-	TypedSchemaCollection,
+	DocumentSchema,
 	SchemaLibrary,
 	SchemaLibraryData,
 	FieldSchema,

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -17,7 +17,7 @@ import {
 	defaultSchemaPolicy,
 	FieldKinds,
 	allowsRepoSuperset,
-	TypedSchemaCollection,
+	DocumentSchema,
 	SchemaAware,
 	FieldSchema,
 	ViewSchema,
@@ -40,7 +40,7 @@ import { ViewEvents } from "./sharedTreeView";
  */
 export function initializeContent(
 	storedSchema: StoredSchemaRepository,
-	schema: TypedSchemaCollection,
+	schema: DocumentSchema,
 	setInitialTree: () => void,
 ): void {
 	assert(schemaDataIsEmpty(storedSchema), 0x743 /* cannot initialize after a schema is set */);
@@ -191,7 +191,7 @@ export interface SchemaConfiguration<TRoot extends FieldSchema = FieldSchema> {
 	/**
 	 * The schema which the application wants to view the tree with.
 	 */
-	readonly schema: TypedSchemaCollection<TRoot>;
+	readonly schema: DocumentSchema<TRoot>;
 }
 
 /**

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -36,7 +36,7 @@ import {
 	NewFieldContent,
 	NodeKeyManager,
 	FieldSchema,
-	TypedSchemaCollection,
+	DocumentSchema,
 	getTreeContext,
 	TypedField,
 	createNodeKeyManager,
@@ -238,11 +238,9 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * If the stored schema is edited and becomes incompatible (or was not originally compatible),
 	 * using the returned tree is invalid and is likely to error or corrupt the document.
 	 */
-	editableTree2<TRoot extends FieldSchema>(
-		viewSchema: TypedSchemaCollection<TRoot>,
-	): TypedField<TRoot>;
+	editableTree2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): TypedField<TRoot>;
 
-	root2<TRoot extends FieldSchema>(viewSchema: TypedSchemaCollection<TRoot>): ProxyField<TRoot>;
+	root2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): ProxyField<TRoot>;
 }
 
 /**
@@ -427,7 +425,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 	}
 
 	public editableTree2<TRoot extends FieldSchema>(
-		viewSchema: TypedSchemaCollection<TRoot>,
+		viewSchema: DocumentSchema<TRoot>,
 		nodeKeyManager?: NodeKeyManager,
 		nodeKeyFieldKey?: FieldKey,
 	): TypedField<TRoot> {
@@ -441,7 +439,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 		return context.root as TypedField<TRoot>;
 	}
 
-	public root2<TRoot extends FieldSchema>(viewSchema: TypedSchemaCollection<TRoot>) {
+	public root2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>) {
 		const rootField = this.editableTree2(viewSchema);
 		return getProxyForField(rootField);
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { LeafSchema, TypedSchemaCollection } from "../../../feature-libraries";
+import { LeafSchema, DocumentSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
 
 // eslint-disable-next-line import/no-internal-modules
@@ -13,7 +13,7 @@ import { createTreeView, itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
 	initialTree: object;
-	schema: TypedSchemaCollection;
+	schema: DocumentSchema;
 }
 
 function testObjectLike(testCases: TestCase[]) {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -10,7 +10,7 @@ import {
 	ImplicitFieldSchema,
 	ProxyField,
 	ProxyRoot,
-	TypedSchemaCollection,
+	DocumentSchema,
 	createMockNodeKeyManager,
 	nodeKeyFieldKey,
 } from "../../../feature-libraries";
@@ -22,10 +22,7 @@ import { TestTreeProviderLite, forestWithContent } from "../../utils";
 import { brand } from "../../../util";
 import { SchemaBuilder } from "../../../domains";
 
-export function getReadonlyContext(
-	forest: IEditableForest,
-	schema: TypedSchemaCollection,
-): Context {
+export function getReadonlyContext(forest: IEditableForest, schema: DocumentSchema): Context {
 	// This will error if someone tries to call mutation methods on it
 	const dummyEditor = {} as unknown as DefaultEditBuilder;
 	return getTreeContext(
@@ -54,7 +51,7 @@ export function createTree(): ISharedTree {
 }
 
 export function createTreeView<TRoot extends FieldSchema>(
-	schema: TypedSchemaCollection<TRoot>,
+	schema: DocumentSchema<TRoot>,
 	initialTree: any,
 ): ISharedTreeView {
 	return createTree().schematize({
@@ -75,10 +72,10 @@ export function makeSchema<const TSchema extends ImplicitFieldSchema>(
 	return builder.toDocumentSchema(root);
 }
 
-export function itWithRoot<TSchema extends TypedSchemaCollection<any>>(
+export function itWithRoot<TRoot extends FieldSchema>(
 	title: string,
-	schema: TSchema,
-	initialTree: ProxyRoot<TSchema, "javaScript">,
+	schema: DocumentSchema<TRoot>,
+	initialTree: ProxyRoot<DocumentSchema<TRoot>, "javaScript">,
 	fn: (root: ProxyField<(typeof schema)["rootFieldSchema"]>) => void,
 ): void {
 	it(title, () => {
@@ -88,7 +85,9 @@ export function itWithRoot<TSchema extends TypedSchemaCollection<any>>(
 	});
 }
 
-/** Similar to JSON stringify, but preserves 'undefined' and leaves numbers as-is. */
-export function pretty(arg: any) {
+/**
+ * Similar to JSON stringify, but preserves `undefined` and numbers numbers as-is at the root.
+ */
+export function pretty(arg: unknown): number | undefined | string {
 	return arg === undefined ? "undefined" : typeof arg === "number" ? arg : JSON.stringify(arg);
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -20,7 +20,7 @@ import {
 	getEditableTreeContext,
 	FieldSchema,
 	Any,
-	TypedSchemaCollection,
+	DocumentSchema,
 	NormalizeField,
 	ImplicitFieldSchema,
 	SchemaAware,
@@ -245,7 +245,7 @@ export function getPerson(): Person {
  */
 export function buildTestSchema<TSchema extends ImplicitFieldSchema>(
 	rootField: TSchema,
-): TypedSchemaCollection<NormalizeField<TSchema, typeof FieldKinds.required>> {
+): DocumentSchema<NormalizeField<TSchema, typeof FieldKinds.required>> {
 	return new SchemaBuilder({
 		scope: "buildTestSchema",
 		libraries: [personSchemaLibrary],
@@ -262,7 +262,7 @@ export function getReadonlyEditableTreeContext(
 }
 
 export function setupForest<T extends FieldSchema>(
-	schema: TypedSchemaCollection<T>,
+	schema: DocumentSchema<T>,
 	data: ContextuallyTypedNodeData | undefined,
 ): IEditableForest {
 	const schemaRepo = new InMemoryStoredSchemaRepository(schema);

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -11,7 +11,7 @@ import {
 	ViewSchema,
 	FieldKinds,
 	defaultSchemaPolicy,
-	TypedSchemaCollection,
+	DocumentSchema,
 } from "../../../feature-libraries";
 import {
 	FieldStoredSchema,
@@ -127,7 +127,7 @@ describe("Schema Evolution Examples", () => {
 	it("basic usage", () => {
 		// Collect our view schema.
 		// This will represent our view schema for a simple canvas application.
-		const viewCollection: TypedSchemaCollection = new SchemaBuilder({
+		const viewCollection: DocumentSchema = new SchemaBuilder({
 			scope: "test",
 			name: "basic usage",
 			libraries: [treeViewSchema],
@@ -259,7 +259,7 @@ describe("Schema Evolution Examples", () => {
 				items: FieldSchema.create(FieldKinds.sequence, [positionedCanvasItem2]),
 			});
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const viewCollection3: TypedSchemaCollection = builderWithCounter.toDocumentSchema(
+			const viewCollection3: DocumentSchema = builderWithCounter.toDocumentSchema(
 				FieldSchema.create(FieldKinds.optional, [canvas2]),
 			);
 			const view3 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection3);

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -5,7 +5,7 @@
 import { strict as assert, fail } from "assert";
 import {
 	Any,
-	TypedSchemaCollection,
+	DocumentSchema,
 	FieldSchema,
 	FieldKinds,
 	allowsRepoSuperset,
@@ -133,7 +133,7 @@ describe("schematizeTree", () => {
 
 	describe("schematize", () => {
 		describe("noop upgrade", () => {
-			const testCases: [string, TypedSchemaCollection][] = [
+			const testCases: [string, DocumentSchema][] = [
 				["empty", emptySchema],
 				["basic-optional", schema],
 				["basic-value", schemaValueRoot],

--- a/experimental/dds/tree2/src/test/testTrees.ts
+++ b/experimental/dds/tree2/src/test/testTrees.ts
@@ -15,7 +15,7 @@ import {
 	SchemaAware,
 	SchemaLibrary,
 	TreeSchema,
-	TypedSchemaCollection,
+	DocumentSchema,
 	cursorsForTypedFieldData,
 	defaultSchemaPolicy,
 	jsonableTreeFromCursor,
@@ -28,7 +28,7 @@ import { leaf, SchemaBuilder } from "../domains";
 
 interface TestTree {
 	readonly name: string;
-	readonly schemaData: TypedSchemaCollection;
+	readonly schemaData: DocumentSchema;
 	readonly policy: FullSchemaPolicy;
 	readonly treeFactory: () => JsonableTree[];
 }


### PR DESCRIPTION
## Breaking Changes

Rename TypedSchemaCollection to DocumentSchema

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

