### PR TITLE
refactor(tree): no dubious type guards

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -60,9 +60,7 @@ export function isReattach<TNodeChange>(mark: Mark<TNodeChange>): boolean {
 	return isAttach(mark) && !isNewAttach(mark);
 }
 
-export function isActiveReattach<TNodeChange>(
-	mark: Mark<TNodeChange>,
-): mark is Attach<TNodeChange> {
+export function isActiveReattach<TNodeChange>(mark: Mark<TNodeChange>): boolean {
 	// No need to check Attach.lastDeletedBy because it can only be set if the mark is conflicted
 	return isAttach(mark) && isReattach(mark) && !isReattachConflicted(mark);
 }


### PR DESCRIPTION
Converts type guards to simple predicates when the false case would otherwise make invalid type inferences.