### PR TITLE
feat(check:policy): Verify all packages have a types field in package.json

### DIFF
--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-	"typings": "dist/index.d.ts",
+	"types": "dist/index.d.ts",
 	"bin": "dist/index.js",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -1127,7 +1127,7 @@ export const handlers: Handler[] = [
 			return result;
 		},
 	},
-  {
+	{
 		name: "npm-package-types-field",
 		match,
 		handler: (file) => {

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -10,7 +10,7 @@ import * as readline from "readline";
 import replace from "replace-in-file";
 import sortPackageJson from "sort-package-json";
 
-import { updatePackageJsonFile } from "../../common/npmPackage";
+import { PackageJson, updatePackageJsonFile } from "../../common/npmPackage";
 import { getFluidBuildConfig } from "../../common/fluidUtils";
 import { Handler, readFile, writeFile } from "../common";
 import { PackageNamePolicyConfig } from "../../common/fluidRepo";
@@ -1125,6 +1125,35 @@ export const handlers: Handler[] = [
 			});
 
 			return result;
+		},
+	},
+  {
+		name: "npm-package-types-field",
+		match,
+		handler: (file) => {
+			// This rule enforces each package has a types field in its package.json
+			let json: PackageJson;
+
+			try {
+				json = JSON.parse(readFile(file));
+			} catch (err) {
+				return "Error parsing JSON file: " + file;
+			}
+
+			if (
+				// Ignore private packages...
+				json.private === true ||
+				// and those without main/module defined
+				(json.main === undefined && json.module === undefined) ||
+				// and packages without a tsconfig
+				!fs.existsSync(path.join(path.dirname(file), "tsconfig.json"))
+			) {
+				return;
+			}
+
+			if (json.types === undefined) {
+				return "Missing 'types' field in package.json.";
+			}
 		},
 	},
 ];

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/fluidFetch.js",
-  "types": "dist/fluidFetch.d.ts",
+	"types": "dist/fluidFetch.d.ts",
 	"bin": {
 		"fluid-fetch": "bin/fluid-fetch"
 	},

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/fluidFetch.js",
+  "types": "dist/fluidFetch.d.ts",
 	"bin": {
 		"fluid-fetch": "bin/fluid-fetch"
 	},

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-  "types": "dist/index.d.ts",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run build:test",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
+  "types": "dist/index.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run build:test",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/www.js",
+  "types": "dist/www.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/www.js",
-  "types": "dist/www.d.ts",
+	"types": "dist/www.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -11,8 +11,8 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
+	"types": "dist/index.d.ts",
+	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run build:test",
 		"build:compile": "npm run build:commonjs",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -11,7 +11,8 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-	"scripts": {
+  "types": "dist/index.d.ts",
+  "scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run build:test",
 		"build:compile": "npm run build:commonjs",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/www.js",
+  "types": "dist/www.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/www.js",
-  "types": "dist/www.d.ts",
+	"types": "dist/www.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/index.js",
-	"typings": "dist/index.d.ts",
+	"types": "dist/index.d.ts",
 	"bin": "dist/index.js",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",

--- a/tools/telemetry-generator/package.json
+++ b/tools/telemetry-generator/package.json
@@ -12,6 +12,7 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/getTestPort.js",
+  "types": "dist/getTestPort.d.ts",
 	"bin": {
 		"assign-test-ports": "bin/assign-test-ports"
 	},

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"main": "dist/getTestPort.js",
-  "types": "dist/getTestPort.d.ts",
+	"types": "dist/getTestPort.d.ts",
 	"bin": {
 		"assign-test-ports": "bin/assign-test-ports"
 	},


### PR DESCRIPTION
Some of our packages don't have a types field defined. This PR adds a new policy handler that will error out if packages are missing types. Packages without a tsconfig.json are excluded.