### PR TITLE
tree2: Add structurally typed maps

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1783,6 +1783,12 @@ export class SchemaBuilder<TScope extends string = string, TName extends string 
             [""]: FieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>;
         };
     }>;
+    map<const T extends TreeSchema | Any | readonly TreeSchema[]>(allowedTypes: T): TreeSchema<`${TScope}.Map<${string}>`, {
+        mapFields: NormalizeField_2<T, typeof FieldKinds.optional>;
+    }>;
+    map<Name extends TName, const T extends MapFieldSchema | ImplicitAllowedTypes>(name: Name, fieldSchema: T): TreeSchema<`${TScope}.${Name}`, {
+        mapFields: NormalizeField_2<T, typeof FieldKinds.optional>;
+    }>;
     // (undocumented)
     readonly null: TreeSchema<"com.fluidframework.leaf.null", {
         leafValue: import("..").ValueSchema.Null;
@@ -1821,10 +1827,10 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     }>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<Unenforced<TreeSchema>>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     finalize(): SchemaLibrary;
-    map<Name extends TName, const T extends ImplicitFieldSchema>(name: Name, fieldSchema: T): TreeSchema<`${TScope}.${Name}`, {
-        mapFields: NormalizeField_2<T, TDefaultKind>;
+    map<Name extends TName, const T extends MapFieldSchema>(name: Name, fieldSchema: T): TreeSchema<`${TScope}.${Name}`, {
+        mapFields: T;
     }>;
-    mapRecursive<Name extends TName, const T extends Unenforced<ImplicitFieldSchema>>(name: Name, t: T): TreeSchema<`${TScope}.${Name}`, {
+    mapRecursive<Name extends TName, const T extends Unenforced<MapFieldSchema>>(name: Name, t: T): TreeSchema<`${TScope}.${Name}`, {
         mapFields: T;
     }>;
     readonly name: string;

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -159,6 +159,7 @@ export {
 	validateStructFieldName,
 	Unenforced,
 	AllowedTypeSet,
+	MapFieldSchema,
 } from "./typed-schema";
 
 export {
@@ -170,6 +171,7 @@ export {
 	NormalizeAllowedTypes,
 	SchemaBuilderOptions,
 	normalizeAllowedTypes,
+	normalizeField,
 } from "./schemaBuilderBase";
 export { SchemaBuilderInternal } from "./schemaBuilder";
 

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -18,6 +18,7 @@ import {
 	FlexList,
 	Unenforced,
 	Any,
+	MapFieldSchema,
 } from "./typed-schema";
 import { FieldKind } from "./modular-schema";
 
@@ -231,12 +232,12 @@ export class SchemaBuilderBase<
 	/**
 	 * Define (and add to this library) a {@link TreeSchema} for a {@link MapNode}.
 	 */
-	public map<Name extends TName, const T extends ImplicitFieldSchema>(
+	public map<Name extends TName, const T extends MapFieldSchema>(
 		name: Name,
 		fieldSchema: T,
-	): TreeSchema<`${TScope}.${Name}`, { mapFields: NormalizeField<T, TDefaultKind> }> {
+	): TreeSchema<`${TScope}.${Name}`, { mapFields: T }> {
 		const schema = new TreeSchema(this, this.scoped(name), {
-			mapFields: this.normalizeField(fieldSchema),
+			mapFields: fieldSchema,
 		});
 		this.addNodeSchema(schema);
 		return schema;
@@ -250,11 +251,11 @@ export class SchemaBuilderBase<
 	 *
 	 * TODO: Make this work with ImplicitFieldSchema.
 	 */
-	public mapRecursive<Name extends TName, const T extends Unenforced<ImplicitFieldSchema>>(
+	public mapRecursive<Name extends TName, const T extends Unenforced<MapFieldSchema>>(
 		name: Name,
 		t: T,
 	): TreeSchema<`${TScope}.${Name}`, { mapFields: T }> {
-		return this.map(name, t as unknown as ImplicitFieldSchema) as unknown as TreeSchema<
+		return this.map(name, t as unknown as MapFieldSchema) as unknown as TreeSchema<
 			`${TScope}.${Name}`,
 			{ mapFields: T }
 		>;

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -21,6 +21,7 @@ export {
 	TypedSchemaCollection,
 	Unenforced,
 	AllowedTypeSet,
+	MapFieldSchema,
 } from "./typedTreeSchema";
 
 export { ViewSchema } from "./view";

--- a/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { SchemaBuilder } from "../../domains";
+import { SchemaBuilder, leaf } from "../../domains";
 import {
 	Any,
 	FieldKinds,
@@ -12,10 +12,13 @@ import {
 	Sequence2,
 	TreeSchema,
 	schemaIsFieldNode,
+	schemaIsMap,
 } from "../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { UnboxNode } from "../../feature-libraries/editable-tree-2/editableTreeTypes";
 import { areSafelyAssignable, requireTrue } from "../../util";
+// eslint-disable-next-line import/no-internal-modules
+import { structuralName } from "../../domains/schemaBuilder";
 
 describe("domains - SchemaBuilder", () => {
 	describe("list", () => {
@@ -35,23 +38,6 @@ describe("domains - SchemaBuilder", () => {
 				type _check = requireTrue<areSafelyAssignable<ListAny, Sequence2<readonly [Any]>>>;
 
 				assert.equal(builder.list(Any), listAny);
-			});
-
-			it("never", () => {
-				const builder = new SchemaBuilder({ scope: "scope" });
-
-				const listNever = builder.list([]);
-				assert(schemaIsFieldNode(listNever));
-				assert.equal(listNever.name, "scope.List<[]>");
-				assert(
-					listNever.structFields
-						.get("")
-						.equals(FieldSchema.create(FieldKinds.sequence, [])),
-				);
-				type ListAny = UnboxNode<typeof listNever>;
-				type _check = requireTrue<areSafelyAssignable<ListAny, Sequence2<readonly []>>>;
-
-				assert.equal(builder.list([]), listNever);
 			});
 
 			it("implicit", () => {
@@ -122,30 +108,15 @@ describe("domains - SchemaBuilder", () => {
 				assert.equal(builder.list([builder.number, builder.boolean]), listUnion);
 				assert.equal(builder.list([builder.boolean, builder.number]), listUnion);
 			});
-
-			it("escaped names", () => {
-				const builder = new SchemaBuilder({ scope: "scope" });
-				const doubleName = builder.struct(`bar","scope.foo`, {});
-
-				const listDoubleName = builder.list(doubleName);
-				assert(schemaIsFieldNode(listDoubleName));
-				assert.equal(listDoubleName.name, `scope.List<["scope.bar\\",\\"scope.foo"]>`);
-
-				// This escaping ensures named don't collide:
-				const foo = builder.struct("foo", {});
-				const bar = builder.struct("bar", {});
-				const listUnion = builder.list([bar, foo]);
-				assert(listUnion.name !== listDoubleName.name);
-			});
 		});
 
-		it("named list", () => {
+		describe("named list", () => {
 			it("implicit normalizes", () => {
 				const builder = new SchemaBuilder({ scope: "scope" });
 
 				const list = builder.list("Foo", builder.number);
 				assert(schemaIsFieldNode(list));
-				assert.equal(list.name, `scope2.Foo`);
+				assert.equal(list.name, `scope.Foo`);
 				assert(
 					list.structFields
 						.get("")
@@ -162,5 +133,74 @@ describe("domains - SchemaBuilder", () => {
 				assert.throws(() => builder.list("Foo", builder.number));
 			});
 		});
+	});
+
+	describe("map", () => {
+		describe("structural", () => {
+			it("implicit", () => {
+				const builder = new SchemaBuilder({ scope: "scope" });
+				const mapAny = builder.map(Any);
+				assert(schemaIsMap(mapAny));
+				// Correct name
+				assert.equal(mapAny.name, "scope.Map<Any>");
+				// Infers optional kind
+				assert(mapAny.mapFields.equals(FieldSchema.create(FieldKinds.optional, [Any])));
+				// Cached and reused
+				assert.equal(builder.map(Any), mapAny);
+			});
+
+			describe("named map", () => {
+				it("implicit normalizes", () => {
+					const builder = new SchemaBuilder({ scope: "scope" });
+
+					const map = builder.map("Foo", builder.number);
+					assert(schemaIsMap(map));
+					assert.equal(map.name, `scope.Foo`);
+					assert(
+						map.mapFields.equals(
+							FieldSchema.create(FieldKinds.optional, [builder.number]),
+						),
+					);
+				});
+
+				it("explicit", () => {
+					const builder = new SchemaBuilder({ scope: "scope" });
+
+					const map = builder.map(
+						"Foo",
+						FieldSchema.create(FieldKinds.sequence, [leaf.string]),
+					);
+					assert(schemaIsMap(map));
+					assert.equal(map.name, `scope.Foo`);
+					assert(
+						map.mapFields.equals(
+							FieldSchema.create(FieldKinds.sequence, [leaf.string]),
+						),
+					);
+				});
+			});
+		});
+	});
+
+	it("structuralName", () => {
+		assert.equal(structuralName("X", Any), "X<Any>");
+		assert.equal(structuralName("Y", []), "Y<[]>");
+		// implicitly normalizes
+		assert.equal(structuralName("List", leaf.number), structuralName("List", [leaf.number]));
+		// Single item
+		assert.equal(structuralName("List", leaf.number), `List<["${leaf.number.name}"]>`);
+		// Sorted alphabetically
+		assert.equal(
+			structuralName("X", [leaf.number, leaf.boolean]),
+			`X<["${leaf.boolean.name}","${leaf.number.name}"]>`,
+		);
+		// escaped names
+		const builder = new SchemaBuilder({ scope: "scope" });
+		const doubleName = builder.struct(`bar","scope.foo`, {});
+		assert.equal(structuralName("X", doubleName), `X<["scope.bar\\",\\"scope.foo"]>`);
+		// This escaping ensures named don't collide:
+		const foo = builder.struct("foo", {});
+		const bar = builder.struct("bar", {});
+		assert(structuralName("X", [bar, foo]) !== structuralName("X", doubleName));
 	});
 });


### PR DESCRIPTION
## Description

Fix schema builder base to not infer field kinds for maps (since this is invalid if the default kind is required, which is what we use).

In domains SchemaBuilder:
- Add support for structurally typed maps.
- Infer optional as default field kind for maps.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

