### PR TITLE
tree2: Add Typed

### DIFF
--- a/examples/apps/tree-comparison/src/model/schema.ts
+++ b/examples/apps/tree-comparison/src/model/schema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { leaf, SchemaBuilder, TypedField, TypedNode } from "@fluid-experimental/tree2";
+import { leaf, SchemaBuilder, Typed } from "@fluid-experimental/tree2";
 
 // By importing the leaf library we don't have to define our own string and number types.
 const builder = new SchemaBuilder({ scope: "inventory app", libraries: [leaf.library] });
@@ -15,7 +15,7 @@ const inventoryItem = builder.struct("Contoso:InventoryItem-1.0.0", {
 	name: leaf.string,
 	quantity: leaf.number,
 });
-export type InventoryItemNode = TypedNode<typeof inventoryItem>;
+export type InventoryItemNode = Typed<typeof inventoryItem>;
 
 // REV: Building this up as a series of builder invocations makes it hard to read the schema.
 // Would be nice if instead we could define some single big Serializable or similar that laid the
@@ -23,11 +23,11 @@ export type InventoryItemNode = TypedNode<typeof inventoryItem>;
 const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	inventoryItems: builder.sequence(inventoryItem),
 });
-export type InventoryNode = TypedNode<typeof inventory>;
+export type InventoryNode = Typed<typeof inventory>;
 
 // REV: The rootField feels extra to me.  Is there a way to omit it?  Something like
 // builder.intoDocumentSchema(inventory)
 const inventoryField = SchemaBuilder.required(inventory);
-export type InventoryField = TypedField<typeof inventoryField>;
+export type InventoryField = Typed<typeof inventoryField>;
 
 export const schema = builder.toDocumentSchema(inventoryField);

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SchemaBuilder, TypedField, TypedNode, leaf } from "@fluid-experimental/tree2";
+import { SchemaBuilder, Typed, leaf } from "@fluid-experimental/tree2";
 
 const builder = new SchemaBuilder({ scope: "inventory app" });
 
@@ -18,5 +18,5 @@ export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 
 export const schema = builder.toDocumentSchema(inventory);
 
-export type InventoryField = TypedField<typeof schema.rootFieldSchema>;
-export type Inventory = TypedNode<typeof inventory>;
+export type InventoryField = Typed<typeof schema.rootFieldSchema>;
+export type Inventory = Typed<typeof inventory>;

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2229,6 +2229,9 @@ TypedNode<Assume<Head, TreeSchema>>,
 export const typeboxValidator: JsonValidator;
 
 // @alpha
+export type Typed<TSchema extends FieldSchema | TreeSchema> = TSchema extends TreeSchema ? TypedNode<TSchema> : TypedField<Assume<TSchema, FieldSchema>>;
+
+// @alpha
 export type TypedField<TSchema extends FieldSchema> = TypedFieldInner<TSchema["kind"], TSchema["allowedTypes"]>;
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -790,6 +790,14 @@ export type TypeArrayToTypedTreeArray<T extends readonly TreeSchema[]> = [
 ][_InlineTrick];
 
 /**
+ * Schema aware specialization of {@link Tree}.
+ * @alpha
+ */
+export type Typed<TSchema extends FieldSchema | TreeSchema> = TSchema extends TreeSchema
+	? TypedNode<TSchema>
+	: TypedField<Assume<TSchema, FieldSchema>>;
+
+/**
  * Schema aware specialization of {@link TreeNode} for a given {@link TreeSchema}.
  * @alpha
  */

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
@@ -24,6 +24,7 @@ export {
 	boxedIterator,
 	CheckTypesOverlap,
 	TreeStatus,
+	Typed,
 } from "./editableTreeTypes";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -265,6 +265,7 @@ export {
 	SharedTreeObject,
 	is,
 	ProxyRoot,
+	Typed,
 } from "./editable-tree-2";
 
 // Split into separate import and export for compatibility with API-Extractor.

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -284,6 +284,7 @@ export {
 	SharedTreeMap,
 	SharedTreeObject,
 	is,
+	Typed,
 } from "./feature-libraries";
 
 export {


### PR DESCRIPTION
## Description

Provide a single shorter import which and can be used for both TypedField and TypedNode.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

