### PR TITLE
docs(protocol-definitions): Update CHANGELOG and remove unneeded changeset doc

### DIFF
--- a/.changeset/brave-frogs-deny.md
+++ b/.changeset/brave-frogs-deny.md
@@ -1,7 +1,0 @@
----
-"@fluidframework/protocol-definitions": minor
----
-
-Deprecate ISequencedDocumentMessage properties "compression" and "expHash1"
-
-The properties have been extracted into a separate interface, "ISequencedDocumentMessageExperimental" and should be used from there instead.

--- a/common/lib/protocol-definitions/CHANGELOG.md
+++ b/common/lib/protocol-definitions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @fluidframework/protocol-definitions Changelog
 
+## [3.1.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v3.1.0)
+
+`ISequencedDocumentMessage` properties `compression` and `expHash1` are deprecated. They have been extracted into a separate interface `ISequencedDocumentMessageExperimental` and should be used from there instead.
+
 ## [3.0.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v3.0.0)
 
 ### Updated @fluidframework/common-definitions


### PR DESCRIPTION
#17795 incorrectly added a changeset entry, rather than updating the package CHANGELOG. This PR removes the changeset entry and adds an entry to the package CHANGELOG.