### PR TITLE
Add one unusual map test case

### DIFF
--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -745,7 +745,8 @@ describe("Map", () => {
 				 * It is an unusual scenario, the client of map1 executes an invalid delete (since "foo" does not exist in its keys),
 				 * but it can remotely delete the "foo" which is locally inserted in map2 but not ack'd yet.
 				 *
-				 * Please communicate any concerns about this design to the DDS team.
+				 * This merge outcome might be undesirable: this test case is mostly here to document Map's behavior.
+				 * Please communicate any concerns about the merge outcome to the DDS team.
 				 */
 				it("Can remotely delete a key which should be unknown to the local client", () => {
 					map1.set("foo", 1);

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -740,6 +740,24 @@ describe("Map", () => {
 						"could not retrieve set key 2 after delete",
 					);
 				});
+
+				/**
+				 * It is an unusual scenario, the client of map1 executes an invalid delete (since "foo" does not exist in its keys),
+				 * but it can remotely delete the "foo" which is locally inserted in map2 but not ack'd yet.
+				 *
+				 * Please communicate any concerns about this design to the DDS team.
+				 */
+				it("Can remotely delete a key which should be unknown to the local client", () => {
+					map1.set("foo", 1);
+					containerRuntimeFactory.processAllMessages();
+					map1.delete("foo");
+					map2.set("foo", 2);
+					map1.delete("foo");
+					containerRuntimeFactory.processAllMessages();
+
+					assert.equal(map1.get("foo"), undefined);
+					assert.equal(map2.get("foo"), undefined);
+				});
 			});
 
 			describe(".forEach()", () => {


### PR DESCRIPTION
Adds a test case for an edge case of `SharedMap.delete`.