### PR TITLE
docs(sequence): Add explicit release tags to exported API members

### DIFF
--- a/packages/dds/sequence/api-extractor.json
+++ b/packages/dds/sequence/api-extractor.json
@@ -7,13 +7,5 @@
 		// This package has a root module named "sequence" which conflicts with the default naming here.
 		// TODO: remove this override once the base config has been updated to append `-untrimmed` globally.
 		"untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-untrimmed.d.ts"
-	},
-	"messages": {
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				// TODO: Fix violations and remove this rule override
-				"logLevel": "none"
-			}
-		}
 	}
 }

--- a/packages/dds/sequence/src/defaultMapInterfaces.ts
+++ b/packages/dds/sequence/src/defaultMapInterfaces.ts
@@ -52,6 +52,7 @@ export interface IMapMessageLocalMetadata {
 
 /**
  * Optional flags that configure options for sequence DDSs
+ * @public
  */
 export interface SequenceOptions {
 	/**

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -88,6 +88,7 @@ import {
  * If a SequencePlace is the endpoint of a range (e.g. start/end of an interval or search range),
  * the Side value means it is exclusive if it is nearer to the other position and inclusive if it is farther.
  * E.g. the start of a range with Side.After is exclusive of the character at the position.
+ * @public
  */
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
@@ -95,6 +96,7 @@ export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
  * A sequence place that does not refer to the special endpoint segments.
  *
  * See {@link SequencePlace} for additional context.
+ * @public
  */
 export interface InteriorSequencePlace {
 	pos: number;
@@ -105,6 +107,7 @@ export interface InteriorSequencePlace {
  * Defines a side relative to a character in a sequence.
  *
  * @remarks See {@link SequencePlace} for additional context on usage.
+ * @public
  */
 export enum Side {
 	Before = 0,
@@ -620,6 +623,9 @@ export function makeOpsMap<T extends ISerializableInterval>(): Map<
 	]);
 }
 
+/**
+ * @public
+ */
 export type DeserializeCallback = (properties: PropertySet) => void;
 
 class IntervalCollectionIterator<TInterval extends ISerializableInterval>
@@ -657,6 +663,7 @@ class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 
 /**
  * Change events emitted by `IntervalCollection`s
+ * @public
  */
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
 	/**
@@ -724,6 +731,7 @@ const isSequencePlace = (place: any): place is SequencePlace => {
 /**
  * Collection of intervals that supports addition, modification, removal, and efficient spatial querying.
  * Changes to this collection will be incur updates on collaborating clients (i.e. they are not local-only).
+ * @public
  */
 export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
@@ -2024,6 +2032,7 @@ function setSlideOnRemove(lref: LocalReferencePosition) {
 
 /**
  * Information that identifies an interval within a `Sequence`.
+ * @public
  */
 export interface IntervalLocator {
 	/**
@@ -2041,6 +2050,7 @@ export interface IntervalLocator {
  * @returns undefined if the reference position is not the endpoint of any interval (e.g. it was created
  * on the merge tree directly by app code), otherwise an {@link IntervalLocator} for the interval this
  * endpoint is a part of.
+ * @public
  */
 export function intervalLocatorFromEndpoint(
 	potentialEndpoint: LocalReferencePosition,

--- a/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
@@ -20,6 +20,7 @@ import { HasComparisonOverride, compareOverrideables, forceCompare } from "./int
  * Collection of intervals.
  *
  * Provide additional APIs to support efficiently querying a collection of intervals whose endpoints fall within a specified range.
+ * @public
  */
 export interface IEndpointInRangeIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {
@@ -104,6 +105,9 @@ export class EndpointInRangeIndex<TInterval extends ISerializableInterval>
 	}
 }
 
+/**
+ * @public
+ */
 export function createEndpointInRangeIndex(
 	sharedString: SharedString,
 ): IEndpointInRangeIndex<SequenceInterval> {

--- a/packages/dds/sequence/src/intervalIndex/endpointIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointIndex.ts
@@ -15,6 +15,9 @@ import {
 import { SharedString } from "../sharedString";
 import { IntervalIndex } from "./intervalIndex";
 
+/**
+ * @public
+ */
 export interface IEndpointIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {
 	/**
@@ -79,6 +82,9 @@ export class EndpointIndex<TInterval extends ISerializableInterval>
 	}
 }
 
+/**
+ * @public
+ */
 export function createEndpointIndex(sharedString: SharedString): IEndpointIndex<SequenceInterval> {
 	const client = (sharedString as unknown as { client: Client }).client;
 	return new EndpointIndex<SequenceInterval>(client, sequenceIntervalHelpers);

--- a/packages/dds/sequence/src/intervalIndex/idIntervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/idIntervalIndex.ts
@@ -9,6 +9,9 @@ import { IntervalIndex } from "./intervalIndex";
 
 const reservedIntervalIdKey = "intervalId";
 
+/**
+ * @public
+ */
 export interface IIdIntervalIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval>,
 		Iterable<TInterval> {
@@ -51,6 +54,9 @@ class IdIntervalIndex<TInterval extends ISerializableInterval>
 	}
 }
 
+/**
+ * @public
+ */
 export function createIdIntervalIndex<
 	TInterval extends ISerializableInterval,
 >(): IIdIntervalIndex<TInterval> {

--- a/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
@@ -13,6 +13,7 @@ import { ISerializableInterval } from "../intervals";
  * - "find all intervals with start endpoint between these two points"
  * - "find all intervals which overlap this range"
  * etc.
+ * @public
  */
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
 	/**

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -17,6 +17,9 @@ import { SharedString } from "../sharedString";
 import { SequencePlace, endpointPosAndSide } from "../intervalCollection";
 import { IntervalIndex } from "./intervalIndex";
 
+/**
+ * @public
+ */
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {
 	/**
@@ -36,6 +39,9 @@ export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInter
 	): void;
 }
 
+/**
+ * @public
+ */
 export class OverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	implements IOverlappingIntervalsIndex<TInterval>
 {
@@ -170,6 +176,9 @@ export class OverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	}
 }
 
+/**
+ * @public
+ */
 export function createOverlappingIntervalsIndex(
 	sharedString: SharedString,
 ): IOverlappingIntervalsIndex<SequenceInterval> {

--- a/packages/dds/sequence/src/intervalIndex/overlappingSequenceIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingSequenceIntervalsIndex.ts
@@ -21,6 +21,9 @@ import { SharedString } from "../sharedString";
 import { SequenceIntervalIndexes } from "./sequenceIntervalIndexes";
 import { OverlappingIntervalsIndex } from "./overlappingIntervalsIndex";
 
+/**
+ * @public
+ */
 class OverlappingSequenceIntervalsIndex
 	extends OverlappingIntervalsIndex<SequenceInterval>
 	implements SequenceIntervalIndexes.Overlapping
@@ -66,6 +69,9 @@ class OverlappingSequenceIntervalsIndex
 	}
 }
 
+/**
+ * @public
+ */
 export function createOverlappingSequenceIntervalsIndex(
 	sharedString: SharedString,
 ): SequenceIntervalIndexes.Overlapping {

--- a/packages/dds/sequence/src/intervalIndex/sequenceIntervalIndexes.ts
+++ b/packages/dds/sequence/src/intervalIndex/sequenceIntervalIndexes.ts
@@ -10,6 +10,7 @@ import { IOverlappingIntervalsIndex } from "./overlappingIntervalsIndex";
 /**
  * This namespace contains specialiazations of indexes which support spatial queries
  * specifically for `SequenceInterval`s.
+ * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace SequenceIntervalIndexes {

--- a/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
@@ -20,6 +20,7 @@ import { HasComparisonOverride, compareOverrideables, forceCompare } from "./int
  * Collection of intervals.
  *
  * Provide additional APIs to support efficiently querying a collection of intervals whose startpoints fall within a specified range.
+ * @public
  */
 export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {
@@ -102,7 +103,9 @@ export class StartpointInRangeIndex<TInterval extends ISerializableInterval>
 		return results;
 	}
 }
-
+/**
+ * @public
+ */
 export function createStartpointInRangeIndex(
 	sharedString: SharedString,
 ): IStartpointInRangeIndex<SequenceInterval> {

--- a/packages/dds/sequence/src/intervals/interval.ts
+++ b/packages/dds/sequence/src/intervals/interval.ts
@@ -21,6 +21,7 @@ const reservedIntervalIdKey = "intervalId";
 
 /**
  * Serializable interval whose endpoints are plain-old numbers.
+ * @public
  */
 export class Interval implements ISerializableInterval {
 	/**

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -16,6 +16,7 @@ import { SequencePlace, Side } from "../intervalCollection";
 
 /**
  * Basic interval abstraction
+ * @public
  */
 export interface IInterval {
 	/**
@@ -80,6 +81,9 @@ export const IntervalOpType = {
 	POSITION_REMOVE: "positionRemove",
 } as const;
 
+/**
+ * @public
+ */
 export enum IntervalType {
 	Simple = 0x0,
 	/**
@@ -132,6 +136,9 @@ export interface ISerializedInterval {
 	properties?: PropertySet;
 }
 
+/**
+ * @public
+ */
 export interface ISerializableInterval extends IInterval {
 	/** Serializable bag of properties associated with the interval. */
 	properties: PropertySet;
@@ -194,6 +201,7 @@ export type CompressedSerializedInterval =
 /**
  * @sealed
  * @deprecated The methods within have substitutions
+ * @public
  */
 export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
 	/**

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -100,6 +100,7 @@ function maxSide(sideA: Side, sideB: Side): Side {
  * `mergeTreeReferencesCanSlideToEndpoint` feature flag set to true, the endpoints
  * of the interval that are exclusive will have the ability to slide to these
  * special endpoint segments.
+ * @public
  */
 export class SequenceInterval implements ISerializableInterval {
 	/**
@@ -636,6 +637,7 @@ export function createSequenceInterval(
 
 /**
  * @deprecated The methods within have substitutions
+ * @public
  */
 export const sequenceIntervalHelpers: IIntervalHelpers<SequenceInterval> = {
 	create: createSequenceInterval,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -68,7 +68,7 @@ const contentPath = "content";
 /**
  * Events emitted in response to changes to the sequence data.
  *
- * @remarks
+ * @remarks @public
  *
  * The following is the list of events emitted.
  *
@@ -113,6 +113,9 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 	);
 }
 
+/**
+ * @public
+ */
 export abstract class SharedSegmentSequence<T extends ISegment>
 	extends SharedObject<ISharedSegmentSequenceEvents>
 	implements ISharedIntervalCollection<SequenceInterval>, MergeTreeRevertibleDriver

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -68,7 +68,7 @@ const contentPath = "content";
 /**
  * Events emitted in response to changes to the sequence data.
  *
- * @remarks @public
+ * @remarks
  *
  * The following is the list of events emitted.
  *
@@ -97,6 +97,7 @@ const contentPath = "content";
  * - `event` - Various information on the segments that were modified.
  *
  * - `target` - The sequence itself.
+ * @public
  */
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 	(

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -23,6 +23,7 @@ import {
  * The properties of this object and its sub-objects represent the state of the sequence at the
  * point in time at which the operation was applied.
  * They will not take into any future modifications performed to the underlying sequence and merge tree.
+ * @public
  */
 export abstract class SequenceEvent<
 	TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes,
@@ -105,6 +106,7 @@ export abstract class SequenceEvent<
  * For group ops, each op will get its own event, and the group op property will be set on the op args.
  *
  * Ops may get multiple events. For instance, an insert-replace will get a remove then an insert event.
+ * @public
  */
 export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
 	/**
@@ -128,6 +130,7 @@ export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationTyp
  * The properties of this object and its sub-objects represent the state of the sequence at the
  * point in time at which the operation was applied.
  * They will not take into consideration any future modifications performed to the underlying sequence and merge tree.
+ * @public
  */
 export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
 	constructor(
@@ -141,6 +144,7 @@ export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenance
 
 /**
  * A range that has changed corresponding to a segment modification.
+ * @public
  */
 export interface ISequenceDeltaRange<
 	TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes,

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -13,6 +13,9 @@ import { Marker, TextSegment } from "@fluidframework/merge-tree";
 import { pkgVersion } from "./packageVersion";
 import { SharedString, SharedStringSegment } from "./sharedString";
 
+/**
+ * @public
+ */
 export class SharedStringFactory implements IChannelFactory {
 	// TODO rename back to https://graph.microsoft.com/types/mergeTree/string once paparazzi is able to dynamically
 	// load code (UPDATE: paparazzi is gone... anything to do here?)

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -33,6 +33,7 @@ const snapshotFileName = "header";
 /**
  * The factory that defines the SharedIntervalCollection.
  * @deprecated `SharedIntervalCollection` is not maintained and is planned to be removed.
+ * @public
  */
 export class SharedIntervalCollectionFactory implements IChannelFactory {
 	public static readonly Type = "https://graph.microsoft.com/types/sharedIntervalCollection";
@@ -74,12 +75,16 @@ export class SharedIntervalCollectionFactory implements IChannelFactory {
 	}
 }
 
+/**
+ * @public
+ */
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
 	getIntervalCollection(label: string): IIntervalCollection<TInterval>;
 }
 
 /**
  * @deprecated `SharedIntervalCollection` is not maintained and is planned to be removed.
+ * @public
  */
 export class SharedIntervalCollection
 	extends SharedObject

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -16,6 +16,7 @@ const MaxRun = 128;
 
 /**
  * @deprecated - IJSONRunSegment will be removed in a upcoming release. It has been moved to the fluid-experimental/sequence-deprecated package
+ * @public
  */
 export interface IJSONRunSegment<T> extends IJSONSegment {
 	items: Serializable<T>[];
@@ -23,6 +24,7 @@ export interface IJSONRunSegment<T> extends IJSONSegment {
 
 /**
  * @deprecated - SubSequence will be removed in a upcoming release. It has been moved to the fluid-experimental/sequence-deprecated package
+ * @public
  */
 export class SubSequence<T> extends BaseSegment {
 	public static readonly typeString: string = "SubSequence";
@@ -106,6 +108,7 @@ export class SubSequence<T> extends BaseSegment {
 
 /**
  * @deprecated - SharedSequence will be removed in a upcoming release. It has been moved to the fluid-experimental/sequence-deprecated package
+ * @public
  */
 export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
 	constructor(

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -24,6 +24,7 @@ import { SharedStringFactory } from "./sequenceFactory";
 
 /**
  * Fluid object interface describing access methods on a SharedString
+ * @public
  */
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
 	/**
@@ -52,6 +53,9 @@ export interface ISharedString extends SharedSegmentSequence<SharedStringSegment
 	posFromRelativePos(relativePos: IRelativePosition): number;
 }
 
+/**
+ * @public
+ */
 export type SharedStringSegment = TextSegment | Marker;
 
 /**
@@ -63,6 +67,7 @@ export type SharedStringSegment = TextSegment | Marker;
  * used to store metadata at positions within the text, like the details of an
  * image or Fluid object that should be rendered with the text.
  *
+ * @public
  */
 export class SharedString
 	extends SharedSegmentSequence<SharedStringSegment>
@@ -309,7 +314,6 @@ interface ITextAndMarkerAccumulator {
  * @param sharedString - String to retrieve text and markers from
  * @param label - label to split on
  * @returns Two parallel lists of text and markers, split by markers with the provided `label`.
- *
  * For example:
  * ```typescript
  * // Say sharedstring has contents "hello<paragraph marker 1>world<paragraph marker 2>missing".
@@ -318,6 +322,7 @@ interface ITextAndMarkerAccumulator {
  * // parallelMarkers === [<paragraph marker 1 object>, <paragraph marker 2 object>]
  * // Note parallelText does not include "missing".
  * ```
+ * @public
  */
 export function getTextAndMarkers(
 	sharedString: SharedString,


### PR DESCRIPTION
[AB#5886](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5886)

## Description
This PR adds the @public explicit release tag for all exported interfaces in the `sequence` package.

### Reviewer Guidance
Any interfaces/functions that should be tagged with something else?