### PR TITLE
build: Update dependencies on `@fluidframework/build-common` from `2.0.1` to `2.0.2`

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.1.0",
 		"@fluidframework/azure-local-service": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/counter": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -36,7 +36,7 @@
 		"tinylicious": "^2.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -43,7 +43,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@fluid-experimental/devtools": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -80,7 +80,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/mocha": "^9.1.1",

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -88,7 +88,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/js-yaml": "^4.0.5",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -71,7 +71,7 @@
 		"@commitlint/config-conventional": "^17.6.6",
 		"@commitlint/cz-commitlint": "^17.5.0",
 		"@fluid-tools/build-cli": "~0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "~0.25.0",
 		"@microsoft/api-documenter": "^7.22.24",
 		"@microsoft/api-extractor": "^7.36.1",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -112,7 +112,7 @@
 	},
 	"devDependencies": {
 		"@fluid-private/readme-command": "workspace:*",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@types/async": "^3.2.20",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -65,7 +65,7 @@
 		"yaml": "^2.3.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/async": "^3.2.20",
 		"@types/fs-extra": "^8.1.2",

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -38,7 +38,7 @@
 		"webpack": "^5.88.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@types/msgpack-lite": "^0.1.8",

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -48,7 +48,7 @@
 		"semver": "^7.5.4"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@oclif/test": "~2.3.27",
 		"@types/chai": "^4.3.5",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@fluid-private/readme-command": "workspace:*",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.36.1",
 		"@oclif/test": "~2.3.27",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@commitlint/config-conventional': ^17.6.6
       '@commitlint/cz-commitlint': ^17.5.0
       '@fluid-tools/build-cli': ~0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ~0.25.0
       '@microsoft/api-documenter': ^7.22.24
       '@microsoft/api-extractor': ^7.36.1
@@ -36,7 +36,7 @@ importers:
       '@commitlint/config-conventional': 17.6.6
       '@commitlint/cz-commitlint': 17.5.0_i4x6owxztfhigiiqlxwntt4k24
       '@fluid-tools/build-cli': 0.25.0_typescript@5.1.6
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@microsoft/api-documenter': 7.22.24
       '@microsoft/api-extractor': 7.36.1
@@ -59,7 +59,7 @@ importers:
     specifiers:
       '@fluid-private/readme-command': workspace:*
       '@fluid-tools/version-tools': workspace:*
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': workspace:*
       '@fluidframework/bundle-size-tools': workspace:*
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -175,7 +175,7 @@ importers:
       type-fest: 2.19.0
     devDependencies:
       '@fluid-private/readme-command': link:../readme-command
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 3.0.0_zo5p53osjv3ha4sgr6kpvl7c7y
       '@types/async': 3.2.20
       '@types/chai': 4.3.5
@@ -211,7 +211,7 @@ importers:
   packages/build-tools:
     specifiers:
       '@fluid-tools/version-tools': workspace:*
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/bundle-size-tools': workspace:*
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@manypkg/get-packages': ^2.2.0
@@ -283,7 +283,7 @@ importers:
       typescript: 5.1.6
       yaml: 2.3.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 3.0.0_zo5p53osjv3ha4sgr6kpvl7c7y
       '@types/async': 3.2.20
       '@types/fs-extra': 8.1.2
@@ -303,7 +303,7 @@ importers:
 
   packages/bundle-size-tools:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@microsoft/api-extractor': ^7.36.1
       '@types/msgpack-lite': ^0.1.8
@@ -328,7 +328,7 @@ importers:
       typescript: 5.1.6
       webpack: 5.88.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 3.0.0_zo5p53osjv3ha4sgr6kpvl7c7y
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
       '@types/msgpack-lite': 0.1.8
@@ -342,7 +342,7 @@ importers:
 
   packages/readme-command:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@oclif/core': ^3.2.1
       '@oclif/plugin-help': ^6.0.2
@@ -374,7 +374,7 @@ importers:
       oclif: 4.0.2_y4ot6xwlhwyri4jfvaeuz6jyfe
       semver: 7.5.4
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 3.0.0_zo5p53osjv3ha4sgr6kpvl7c7y
       '@oclif/test': 2.3.27_vliugzio5c6rxk3co27b7rq74a
       '@types/chai': 4.3.5
@@ -398,7 +398,7 @@ importers:
   packages/version-tools:
     specifiers:
       '@fluid-private/readme-command': workspace:*
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@microsoft/api-extractor': ^7.36.1
       '@oclif/core': ^3.2.1
@@ -445,7 +445,7 @@ importers:
       table: 6.8.1
     devDependencies:
       '@fluid-private/readme-command': link:../readme-command
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 3.0.0_zo5p53osjv3ha4sgr6kpvl7c7y
       '@microsoft/api-extractor': 7.36.1_@types+node@14.18.53
       '@oclif/test': 2.3.27_vliugzio5c6rxk3co27b7rq74a
@@ -883,8 +883,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -43,7 +43,7 @@
 		"eslint-plugin-unused-imports": "~3.0.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.49.0",
 		"prettier": "~3.0.3",

--- a/common/build/eslint-config-fluid/pnpm-lock.yaml
+++ b/common/build/eslint-config-fluid/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@rushstack/eslint-patch': ~1.4.0
       '@rushstack/eslint-plugin': ~0.13.0
       '@rushstack/eslint-plugin-security': ~0.7.0
@@ -42,7 +42,7 @@ importers:
       eslint-plugin-unicorn: 48.0.1_eslint@8.49.0
       eslint-plugin-unused-imports: 3.0.0_xmpxy5vxwoyu2njpjt6m3zinx4
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       concurrently: 8.2.1
       eslint: 8.49.0
       prettier: 3.0.3
@@ -126,8 +126,8 @@ packages:
     resolution: {integrity: sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@0.20.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/common/lib/common-definitions/pnpm-lock.yaml
+++ b/common/lib/common-definitions/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions-previous': npm:@fluidframework/common-definitions@0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -20,7 +20,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_vy4ah4eawmaxtqslmps6irc47e
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/common-definitions-previous': /@fluidframework/common-definitions/0.20.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -262,8 +262,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -85,7 +85,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.1.0",

--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions': ^1.0.0
       '@fluidframework/common-utils-previous': npm:@fluidframework/common-utils@1.0.0
@@ -57,7 +57,7 @@ importers:
       sha.js: 2.4.11
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_vy4ah4eawmaxtqslmps6irc47e
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.38
       '@fluidframework/common-utils-previous': /@fluidframework/common-utils/1.0.0
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -630,8 +630,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@2.0.0",

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -23,7 +23,7 @@ importers:
       '@fluidframework/common-definitions': 1.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/2.0.0
@@ -265,8 +265,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -66,7 +66,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -51,7 +51,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/express": "^4.11.0",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -53,7 +53,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/codemirror": "5.60.7",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/react": "^17.0.44",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -66,7 +66,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -59,7 +59,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/events": "^3.0.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-version-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -92,7 +92,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-version-utils": "workspace:~",
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -82,7 +82,7 @@
 		"valid-url": "^1.0.9"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@cerner/duplicate-package-checker-webpack-plugin": "~2.3.0",
 		"@fluid-tools/version-tools": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/bundle-size-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -76,7 +76,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -78,7 +78,7 @@
 		"react-virtualized-auto-sizer": "^1.0.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -29,7 +29,7 @@
 		"tsc": "tsc"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -78,7 +78,7 @@
 		"@babel/plugin-proposal-decorators": "^7.20.4",
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.2.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -70,7 +70,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/lodash": "^4.14.118",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -65,7 +65,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@fluid-experimental/property-common": "workspace:~",
 		"@fluid-internal/test-drivers": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -65,7 +65,7 @@
 		"@fluid-experimental/property-properties": "workspace:~",
 		"@fluid-experimental/property-proxy": "workspace:~",
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@storybook/addon-actions": "^6.4.22",
 		"@storybook/addon-essentials": "^6.4.22",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -71,7 +71,7 @@
 		"underscore": "^1.13.6"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -44,7 +44,7 @@
 		"@babel/core": "^7.13.0",
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.2.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/jest": "29.5.3",

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
@@ -38,7 +38,7 @@
 		"@fluidframework/core-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@types/jest": "29.5.3",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -78,7 +78,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -70,7 +70,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -59,7 +59,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-drivers": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -87,7 +87,7 @@
 		"@fluid-internal/test-drivers": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -62,7 +62,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -67,7 +67,7 @@
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 		"@changesets/cli": "^2.26.1",
 		"@fluid-private/changelog-generator-wrapper": "file:tools/changelog-generator-wrapper",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-tools": "^1.0.195075",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -64,7 +64,7 @@
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.47.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -71,7 +71,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.1.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -80,7 +80,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.1.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -80,7 +80,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.1.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -81,7 +81,7 @@
 		"@fluid-internal/test-pairwise-generator": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.1.0",

--- a/packages/dds/migration-shim/package.json
+++ b/packages/dds/migration-shim/package.json
@@ -73,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -73,7 +73,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -69,7 +69,7 @@
 	},
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -72,7 +72,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/sequence/api-extractor.json
+++ b/packages/dds/sequence/api-extractor.json
@@ -1,13 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "@fluidframework/build-common/api-extractor-base.json",
-
-	// Configures how the .d.ts rollup file will be generated.
-	"dtsRollup": {
-		// This package has a root module named "sequence" which conflicts with the default naming here.
-		// TODO: remove this override once the base config has been updated to append `-untrimmed` globally.
-		"untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-untrimmed.d.ts"
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			"ae-missing-release-tag": {

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -86,7 +86,7 @@
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -75,7 +75,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.1.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.1.0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.1.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.1.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -79,7 +79,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -83,7 +83,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -75,7 +75,7 @@
 	"devDependencies": {
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -42,7 +42,7 @@
 		"@microsoft/applicationinsights-web": "^2.8.11"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -73,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.1.0",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -63,7 +63,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/datastore": "workspace:~",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.1.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.1.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -75,7 +75,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.1.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"eslint": "~8.50.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -84,7 +84,7 @@
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.1.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.1.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -72,7 +72,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -56,7 +56,7 @@
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-internal/test-pairwise-generator": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/cell": "workspace:~",
 		"@fluidframework/container-definitions": "workspace:~",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.1.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.48.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -37,7 +37,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.1.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -75,7 +75,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -125,7 +125,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -105,7 +105,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -84,7 +84,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -86,7 +86,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -83,7 +83,7 @@
 		"@fluid-example/example-utils": "workspace:~",
 		"@fluid-experimental/react-inputs": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.1.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -70,7 +70,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -64,7 +64,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.1.0",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -48,7 +48,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@types/node": "^16.18.38",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.1.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -64,7 +64,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
 		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -74,7 +74,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       '@changesets/cli': ^2.26.1
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -43,7 +43,7 @@ importers:
       '@changesets/cli': 2.26.2
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -72,7 +72,7 @@ importers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.1.0
       '@fluidframework/azure-local-service': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -126,7 +126,7 @@ importers:
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.1.0
       '@fluidframework/azure-local-service': link:../azure-local-service
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/counter': link:../../../packages/dds/counter
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -149,7 +149,7 @@ importers:
 
   azure/packages/azure-local-service:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@microsoft/api-extractor': ^7.37.0
@@ -165,7 +165,7 @@ importers:
     dependencies:
       tinylicious: 2.0.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
@@ -182,7 +182,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.1.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -203,7 +203,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
       '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.1.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
@@ -219,7 +219,7 @@ importers:
     specifiers:
       '@fluid-experimental/devtools': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -274,7 +274,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-experimental/devtools': link:../../../packages/tools/devtools/devtools
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
@@ -316,7 +316,7 @@ importers:
     specifiers:
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -376,7 +376,7 @@ importers:
       tinylicious: 2.0.1
       uuid: 9.0.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/mocha': 9.1.1
@@ -395,7 +395,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -457,7 +457,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/js-yaml': 4.0.7
@@ -479,7 +479,7 @@ importers:
       '@fluid-experimental/attributor': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -524,7 +524,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -557,7 +557,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -612,7 +612,7 @@ importers:
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -647,7 +647,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -697,7 +697,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -738,7 +738,7 @@ importers:
       '@fluid-example/prosemirror': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -815,7 +815,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -858,7 +858,7 @@ importers:
       '@fluid-experimental/data-objects': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -905,7 +905,7 @@ importers:
       process: 0.11.10
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -937,7 +937,7 @@ importers:
       '@fluid-experimental/oldest-client-observer': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -988,7 +988,7 @@ importers:
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1025,7 +1025,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -1101,7 +1101,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1139,7 +1139,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1181,7 +1181,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1213,7 +1213,7 @@ importers:
       '@fluid-experimental/tree': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1255,7 +1255,7 @@ importers:
       use-resize-observer: 7.1.0_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
@@ -1283,7 +1283,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1328,7 +1328,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1363,7 +1363,7 @@ importers:
       '@fluid-experimental/sharejs-json1': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1408,7 +1408,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1442,7 +1442,7 @@ importers:
       '@fluid-experimental/tree': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1485,7 +1485,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1516,7 +1516,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1560,7 +1560,7 @@ importers:
       webpack-dev-server: 4.6.0_zgvvfjf2tx73ossdpc3n4rrlyy
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/express': 4.17.19
@@ -1587,7 +1587,7 @@ importers:
     specifiers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/app-insights-logger': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -1646,7 +1646,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
@@ -1687,7 +1687,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -1728,7 +1728,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1764,7 +1764,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/counter': workspace:~
@@ -1806,7 +1806,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1838,7 +1838,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -1894,7 +1894,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/codemirror': 5.60.7
@@ -1918,7 +1918,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -1955,7 +1955,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -1989,7 +1989,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -2026,7 +2026,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2058,7 +2058,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -2099,7 +2099,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/react': 17.0.68
@@ -2128,7 +2128,7 @@ importers:
       '@fluid-example/multiview-coordinate-model': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -2162,7 +2162,7 @@ importers:
       '@fluidframework/map': link:../../../../packages/dds/map
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2192,7 +2192,7 @@ importers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-example/multiview-slider-coordinate-view': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2228,7 +2228,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2269,7 +2269,7 @@ importers:
       '@fluid-example/multiview-triangle-view': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -2321,7 +2321,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2356,7 +2356,7 @@ importers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -2387,7 +2387,7 @@ importers:
       '@fluidframework/map': link:../../../../packages/dds/map
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2415,7 +2415,7 @@ importers:
   examples/data-objects/multiview/interface:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@types/expect-puppeteer': 2.2.1
@@ -2435,7 +2435,7 @@ importers:
       webpack-merge: ^5.8.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/expect-puppeteer': 2.2.1
@@ -2458,7 +2458,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2493,7 +2493,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2527,7 +2527,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2562,7 +2562,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2596,7 +2596,7 @@ importers:
     specifiers:
       '@fluid-example/multiview-coordinate-interface': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/test-tools': ^1.0.195075
@@ -2631,7 +2631,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -2665,7 +2665,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2744,7 +2744,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
@@ -2772,7 +2772,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2850,7 +2850,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2887,7 +2887,7 @@ importers:
     specifiers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -2942,7 +2942,7 @@ importers:
       simplemde: 1.11.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/events': 3.0.1
@@ -2966,7 +2966,7 @@ importers:
       '@fluid-internal/test-version-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -3012,7 +3012,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-version-utils': link:../../../packages/test/test-version-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -3041,7 +3041,7 @@ importers:
       '@fluid-example/table-document': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -3082,7 +3082,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
@@ -3107,7 +3107,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -3159,7 +3159,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3195,7 +3195,7 @@ importers:
       '@fluid-internal/test-version-utils': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -3267,7 +3267,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-version-utils': link:../../../packages/test/test-version-utils
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -3314,7 +3314,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3415,7 +3415,7 @@ importers:
       uuid: 9.0.1
       valid-url: 1.0.9
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3463,7 +3463,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/version-tools': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/bundle-size-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
@@ -3502,7 +3502,7 @@ importers:
     devDependencies:
       '@cerner/duplicate-package-checker-webpack-plugin': 2.3.0_webpack@5.88.2
       '@fluid-tools/version-tools': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/bundle-size-tools': 0.25.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -3526,7 +3526,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3583,7 +3583,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -3600,7 +3600,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3654,7 +3654,7 @@ importers:
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3689,7 +3689,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3769,7 +3769,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3810,7 +3810,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -3890,7 +3890,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -3929,7 +3929,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -3982,7 +3982,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -4016,7 +4016,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -4058,7 +4058,7 @@ importers:
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -4091,7 +4091,7 @@ importers:
       '@fluid-example/example-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -4141,7 +4141,7 @@ importers:
       vue: 2.6.14
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
@@ -4183,7 +4183,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4276,7 +4276,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -4316,7 +4316,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4414,7 +4414,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       react-virtualized-auto-sizer: 1.0.7_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_webpack-cli@4.10.0
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -4445,14 +4445,14 @@ importers:
 
   experimental/PropertyDDS/examples/schemas:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       eslint: ~8.50.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
       typescript: ~5.1.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       eslint: 8.50.0
       prettier: 3.0.3
@@ -4470,7 +4470,7 @@ importers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-dds': workspace:~
       '@fluid-experimental/property-properties': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
@@ -4516,7 +4516,7 @@ importers:
       '@babel/plugin-proposal-decorators': 7.23.2_@babel+core@7.23.2
       '@babel/plugin-transform-runtime': 7.23.2_@babel+core@7.23.2
       '@babel/preset-env': 7.23.2_@babel+core@7.23.2
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../../packages/test/test-utils
@@ -4551,7 +4551,7 @@ importers:
   experimental/PropertyDDS/packages/property-changeset:
     specifiers:
       '@fluid-experimental/property-common': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/lodash': ^4.14.118
@@ -4588,7 +4588,7 @@ importers:
       semver: 7.5.4
       traverse: 0.6.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/lodash': 4.14.199
@@ -4611,7 +4611,7 @@ importers:
 
   experimental/PropertyDDS/packages/property-common:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -4656,7 +4656,7 @@ importers:
       semver: 7.5.4
       traverse: 0.6.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
@@ -4692,7 +4692,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-drivers': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -4757,7 +4757,7 @@ importers:
     devDependencies:
       '@fluid-experimental/property-common': link:../property-common
       '@fluid-internal/test-drivers': link:../../../../packages/test/test-drivers
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/container-loader': link:../../../../packages/loader/container-loader
       '@fluidframework/driver-definitions': link:../../../../packages/common/driver-definitions
@@ -4795,7 +4795,7 @@ importers:
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
       '@fluid-tools/webpack-fluid-loader': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@hig/fonts': ^1.0.2
       '@material-ui/core': 4.12.4
@@ -4880,7 +4880,7 @@ importers:
       '@fluid-experimental/property-properties': link:../property-properties
       '@fluid-experimental/property-proxy': link:../property-proxy
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@storybook/addon-actions': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-essentials': 6.5.16_iihciws2wayuowiypdwx4ihdlm
@@ -4931,7 +4931,7 @@ importers:
     specifiers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-common': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/mocha': ^9.1.1
@@ -4967,7 +4967,7 @@ importers:
       traverse: 0.6.6
       underscore: 1.13.6
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/mocha': 9.1.1
@@ -4993,7 +4993,7 @@ importers:
       '@babel/preset-env': ^7.2.0
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-properties': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@types/jest': 29.5.3
@@ -5016,7 +5016,7 @@ importers:
       '@babel/core': 7.23.2
       '@babel/plugin-transform-runtime': 7.23.2_@babel+core@7.23.2
       '@babel/preset-env': 7.23.2_@babel+core@7.23.2
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/jest': 29.5.3
@@ -5091,7 +5091,7 @@ importers:
       '@fluid-experimental/property-changeset': workspace:~
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/tree2': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -5111,7 +5111,7 @@ importers:
       '@fluid-experimental/tree2': link:../../../dds/tree2
       '@fluidframework/core-utils': link:../../../../packages/common/core-utils
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@types/jest': 29.5.3
@@ -5264,7 +5264,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5310,7 +5310,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5335,7 +5335,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5372,7 +5372,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../../packages/dds/shared-object-base
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../../packages/dds/test-dds-utils
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
@@ -5398,7 +5398,7 @@ importers:
     specifiers:
       '@fluid-experimental/ot': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -5433,7 +5433,7 @@ importers:
       ot-json1: 1.0.2
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../../../packages/dds/test-dds-utils
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../../packages/test/mocha-test-setup
@@ -5459,7 +5459,7 @@ importers:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5496,7 +5496,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5524,7 +5524,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-drivers': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -5587,7 +5587,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-internal/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/container-runtime': link:../../../packages/runtime/container-runtime
@@ -5627,7 +5627,7 @@ importers:
       '@fluid-internal/test-drivers': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -5690,7 +5690,7 @@ importers:
       '@fluid-internal/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
@@ -5727,7 +5727,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5755,7 +5755,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -5771,7 +5771,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -5798,7 +5798,7 @@ importers:
       '@fluidframework/shared-summary-block': link:../../../packages/dds/shared-summary-block
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5814,7 +5814,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -5839,7 +5839,7 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -5856,7 +5856,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -5885,7 +5885,7 @@ importers:
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
@@ -5909,7 +5909,7 @@ importers:
   packages/common/client-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -5963,7 +5963,7 @@ importers:
       sha.js: 2.4.11
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6002,7 +6002,7 @@ importers:
   packages/common/container-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.1.0
       '@fluidframework/core-interfaces': workspace:~
@@ -6025,7 +6025,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6041,7 +6041,7 @@ importers:
   packages/common/core-interfaces:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -6054,7 +6054,7 @@ importers:
       typescript: ~5.1.6
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6070,7 +6070,7 @@ importers:
     specifiers:
       '@fluid-tools/benchmark': ^0.47.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -6094,7 +6094,7 @@ importers:
     devDependencies:
       '@fluid-tools/benchmark': 0.47.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6119,7 +6119,7 @@ importers:
   packages/common/driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.1.0
@@ -6136,7 +6136,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6151,7 +6151,7 @@ importers:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.1.0
       '@fluidframework/core-interfaces': workspace:~
@@ -6189,7 +6189,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6213,7 +6213,7 @@ importers:
   packages/dds/counter:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6250,7 +6250,7 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -6274,7 +6274,7 @@ importers:
   packages/dds/ink:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6310,7 +6310,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.1.0
@@ -6337,7 +6337,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6385,7 +6385,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.1.0
@@ -6413,7 +6413,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6470,7 +6470,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.1.0
@@ -6503,7 +6503,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -6550,7 +6550,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.1.0
@@ -6579,7 +6579,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6616,7 +6616,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6641,7 +6641,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6682,7 +6682,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6706,7 +6706,7 @@ importers:
   packages/dds/pact-map:
     specifiers:
       '@fluid-internal/test-dds-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6746,7 +6746,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6773,7 +6773,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6812,7 +6812,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6840,7 +6840,7 @@ importers:
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -6891,7 +6891,7 @@ importers:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6920,7 +6920,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -6969,7 +6969,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6996,7 +6996,7 @@ importers:
   packages/dds/shared-summary-block:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -7033,7 +7033,7 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7061,7 +7061,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -7107,7 +7107,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7134,7 +7134,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -7166,7 +7166,7 @@ importers:
       mocha: 10.2.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7187,7 +7187,7 @@ importers:
   packages/drivers/debugger:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.1.0
@@ -7213,7 +7213,7 @@ importers:
       jsonschema: 1.4.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7229,7 +7229,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7265,7 +7265,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7289,7 +7289,7 @@ importers:
   packages/drivers/driver-web-cache:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7316,7 +7316,7 @@ importers:
       idb: 6.1.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7335,7 +7335,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7362,7 +7362,7 @@ importers:
       '@fluidframework/replay-driver': link:../replay-driver
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.1.0
@@ -7379,7 +7379,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.1.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7409,7 +7409,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.1.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7429,7 +7429,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7489,7 +7489,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.1.0
@@ -7516,7 +7516,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7569,7 +7569,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7596,7 +7596,7 @@ importers:
   packages/drivers/odsp-driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -7613,7 +7613,7 @@ importers:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.1.0
@@ -7629,7 +7629,7 @@ importers:
   packages/drivers/odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -7656,7 +7656,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7677,7 +7677,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7706,7 +7706,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.1.0
@@ -7724,7 +7724,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7784,7 +7784,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7814,7 +7814,7 @@ importers:
   packages/drivers/routerlicious-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -7847,7 +7847,7 @@ importers:
       url: 0.11.3
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7869,7 +7869,7 @@ importers:
   packages/drivers/tinylicious-driver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -7904,7 +7904,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7928,7 +7928,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.1.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -7965,7 +7965,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
       '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.1.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -7981,7 +7981,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.1.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8033,7 +8033,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
       '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.1.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8058,7 +8058,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8107,7 +8107,7 @@ importers:
     devDependencies:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8132,7 +8132,7 @@ importers:
 
   packages/framework/client-logger/app-insights-logger:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8157,7 +8157,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0
@@ -8181,7 +8181,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -8218,7 +8218,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../dds/shared-object-base
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8233,7 +8233,7 @@ importers:
   packages/framework/dds-interceptions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.1.0
@@ -8268,7 +8268,7 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8294,7 +8294,7 @@ importers:
   packages/framework/fluid-framework:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8319,7 +8319,7 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -8335,7 +8335,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8379,7 +8379,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.1.0
@@ -8406,7 +8406,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8431,7 +8431,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../dds/test-dds-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8447,7 +8447,7 @@ importers:
   packages/framework/request-handler:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8482,7 +8482,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8508,7 +8508,7 @@ importers:
   packages/framework/synthesize:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -8534,7 +8534,7 @@ importers:
       '@fluidframework/core-utils': link:../../common/core-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/datastore': link:../../runtime/datastore
@@ -8560,7 +8560,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -8608,7 +8608,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
       '@fluidframework/aqueduct': link:../aqueduct
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
@@ -8630,7 +8630,7 @@ importers:
   packages/framework/undo-redo:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
@@ -8666,7 +8666,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8693,7 +8693,7 @@ importers:
   packages/framework/view-adapters:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8716,7 +8716,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.1.0
@@ -8732,7 +8732,7 @@ importers:
   packages/framework/view-interfaces:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8749,7 +8749,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.1.0
@@ -8767,7 +8767,7 @@ importers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.1.0
@@ -8824,7 +8824,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-loader-utils': link:../test-loader-utils
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8853,7 +8853,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -8900,7 +8900,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8925,7 +8925,7 @@ importers:
   packages/loader/location-redirection-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -8956,7 +8956,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.1.0
@@ -8981,7 +8981,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -9000,7 +9000,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
@@ -9014,7 +9014,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -9076,7 +9076,7 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9104,7 +9104,7 @@ importers:
   packages/runtime/container-runtime-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.1.0
@@ -9127,7 +9127,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9142,7 +9142,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9191,7 +9191,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9216,7 +9216,7 @@ importers:
   packages/runtime/datastore-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9237,7 +9237,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -9251,7 +9251,7 @@ importers:
   packages/runtime/runtime-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9273,7 +9273,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.1.0
@@ -9289,7 +9289,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
@@ -9332,7 +9332,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -9358,7 +9358,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -9413,7 +9413,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -9439,7 +9439,7 @@ importers:
     specifiers:
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-loader': workspace:~
       '@fluidframework/container-runtime': workspace:~
@@ -9471,7 +9471,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-loader-utils': link:../../loader/test-loader-utils
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/container-loader': link:../../loader/container-loader
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
@@ -9504,7 +9504,7 @@ importers:
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9564,7 +9564,7 @@ importers:
       '@fluid-internal/test-loader-utils': link:../../loader/test-loader-utils
       '@fluid-internal/test-pairwise-generator': link:../test-pairwise-generator
       '@fluidframework/aqueduct': link:../../framework/aqueduct
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/cell': link:../../dds/cell
       '@fluidframework/container-definitions': link:../../common/container-definitions
@@ -9623,7 +9623,7 @@ importers:
   packages/test/mocha-test-setup:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9646,7 +9646,7 @@ importers:
       source-map-support: 0.5.21
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.1.0
@@ -9664,7 +9664,7 @@ importers:
       '@fluid-experimental/sequence-deprecated': workspace:~
       '@fluid-internal/replay-tool': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -9726,7 +9726,7 @@ importers:
       mocha: 10.2.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -9745,7 +9745,7 @@ importers:
   packages/test/stochastic-test-utils:
     specifiers:
       '@fluid-tools/benchmark': ^0.48.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9771,7 +9771,7 @@ importers:
       best-random: 1.0.3
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -9794,7 +9794,7 @@ importers:
   packages/test/test-app-insights-logger:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9811,7 +9811,7 @@ importers:
       applicationinsights: 2.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
@@ -9823,7 +9823,7 @@ importers:
   packages/test/test-driver-definitions:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -9844,7 +9844,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.1.0
@@ -9859,7 +9859,7 @@ importers:
     specifiers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -9914,7 +9914,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -9938,7 +9938,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/agent-scheduler': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10048,7 +10048,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@types/mocha': 9.1.1
@@ -10070,7 +10070,7 @@ importers:
   packages/test/test-pairwise-generator:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
@@ -10089,7 +10089,7 @@ importers:
       random-js: 1.0.8
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10112,7 +10112,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10177,7 +10177,7 @@ importers:
       tinylicious: 2.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10195,7 +10195,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10268,7 +10268,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10300,7 +10300,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/version-tools': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10382,7 +10382,7 @@ importers:
       semver: 7.5.4
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
@@ -10414,7 +10414,7 @@ importers:
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.1.0
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -10445,7 +10445,7 @@ importers:
     devDependencies:
       '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.1.0
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
@@ -10477,7 +10477,7 @@ importers:
       '@fluid-experimental/react-inputs': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10558,7 +10558,7 @@ importers:
       '@fluid-example/example-utils': link:../../../../examples/utils/example-utils
       '@fluid-experimental/react-inputs': link:../../../../experimental/framework/react-inputs
       '@fluidframework/aqueduct': link:../../../framework/aqueduct
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/container-definitions': link:../../../common/container-definitions
       '@fluidframework/container-loader': link:../../../loader/container-loader
@@ -10623,7 +10623,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10678,7 +10678,7 @@ importers:
     devDependencies:
       '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.1.0
       '@fluid-tools/build-cli': 0.25.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/driver-definitions': link:../../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -10716,7 +10716,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -10804,7 +10804,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       scheduler: 0.20.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../../test/test-utils
@@ -10849,7 +10849,7 @@ importers:
       '@fluentui/react-icons': ^2.0.201
       '@fluid-experimental/devtools-core': workspace:~
       '@fluid-internal/client-utils': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -10929,7 +10929,7 @@ importers:
       recharts: 2.8.0_oxfzelaz5ynxsop2v2nu2h2m64
       scheduler: 0.20.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
@@ -10984,7 +10984,7 @@ importers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.1.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-runtime': workspace:~
       '@fluidframework/core-interfaces': workspace:~
@@ -11026,7 +11026,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
       '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.1.0
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
@@ -11039,7 +11039,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -11079,7 +11079,7 @@ importers:
       yargs: 13.2.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.1.0
@@ -11102,7 +11102,7 @@ importers:
     specifiers:
       '@fluid-experimental/sequence-deprecated': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/cell': workspace:~
       '@fluidframework/container-definitions': workspace:~
@@ -11171,7 +11171,7 @@ importers:
       json-stable-stringify: 1.0.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -11187,7 +11187,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
       '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.1.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-loader': workspace:~
@@ -11267,7 +11267,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.1.0_zgvvfjf2tx73ossdpc3n4rrlyy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11296,7 +11296,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -11334,7 +11334,7 @@ importers:
       node-fetch: 2.7.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11359,7 +11359,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
@@ -11398,7 +11398,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11425,7 +11425,7 @@ importers:
   packages/utils/tool-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-utils': workspace:~
@@ -11465,7 +11465,7 @@ importers:
       proper-lockfile: 4.1.2
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_@types+node@16.18.58
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -15573,8 +15573,8 @@ packages:
       uuid: 9.0.1
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/async": "^3.2.9",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -78,7 +78,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -41,7 +41,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@types/async': ^3.2.9
@@ -38,7 +38,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_ymnhzceeoeqwo36456pbfebzye
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.7
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/async': 3.2.16
@@ -67,7 +67,7 @@ importers:
 
   packages/gitrest:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitrest-base': workspace:~
       '@fluidframework/server-services-shared': ^3.0.0-192517
@@ -114,7 +114,7 @@ importers:
       uuid: 3.4.0
       winston: 3.8.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/async': 3.2.16
       '@types/cors': 2.8.13
@@ -136,7 +136,7 @@ importers:
 
   packages/gitrest-base:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^3.0.0-192517
@@ -215,7 +215,7 @@ importers:
       uuid: 3.4.0
       winston: 3.8.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/async': 3.2.16
       '@types/cors': 2.8.13
@@ -445,8 +445,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/compression": "0.0.36",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -75,7 +75,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-test-utils": "^3.0.0-192517",
 		"@types/compression": "0.0.36",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
   .:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@types/compression': 0.0.36
@@ -34,7 +34,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/compression': 0.0.36
@@ -125,7 +125,7 @@ importers:
 
   packages/historian-base:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^3.0.0-192517
@@ -196,7 +196,7 @@ importers:
       uuid: 3.4.0
       winston: 3.8.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-test-utils': 3.0.0-192517
       '@types/compression': 0.0.36
@@ -958,8 +958,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -81,7 +81,7 @@
 		"@changesets/cli": "^2.26.1",
 		"@fluid-private/changelog-generator-wrapper": "file:../../tools/changelog-generator-wrapper",
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -30,7 +30,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@2.0.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -33,7 +33,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@2.0.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@2.0.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -77,7 +77,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@2.0.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -71,7 +71,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@2.0.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -79,7 +79,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@2.0.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@2.0.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -85,7 +85,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-local-server": "workspace:~",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-local-server": "workspace:~",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -74,7 +74,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@2.0.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@2.0.0",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@2.0.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@2.0.0",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -33,7 +33,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@2.0.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@2.0.0",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -60,7 +60,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@2.0.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -72,7 +72,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@2.0.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@2.0.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.25.0",
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@2.0.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@changesets/cli': ^2.26.1
       '@fluid-private/changelog-generator-wrapper': file:../../tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@microsoft/api-documenter': ^7.21.6
       '@microsoft/api-extractor': ^7.34.4
@@ -31,7 +31,7 @@ importers:
       '@changesets/cli': 2.26.2
       '@fluid-private/changelog-generator-wrapper': file:../../tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@microsoft/api-documenter': 7.22.21
       '@microsoft/api-extractor': 7.36.0
@@ -49,7 +49,7 @@ importers:
   packages/gitresources:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources-previous': npm:@fluidframework/gitresources@2.0.0
@@ -62,7 +62,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_typescript@4.5.5
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/gitresources-previous': /@fluidframework/gitresources/2.0.0
@@ -77,7 +77,7 @@ importers:
   packages/kafka-orderer:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -94,7 +94,7 @@ importers:
       '@fluidframework/server-services-core': link:../services-core
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-kafka-orderer-previous': /@fluidframework/server-kafka-orderer/2.0.0
@@ -108,7 +108,7 @@ importers:
   packages/lambdas:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-definitions': ^1.0.0
       '@fluidframework/common-utils': ^3.0.0
@@ -179,7 +179,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-lambdas-previous': /@fluidframework/server-lambdas/2.0.0
@@ -207,7 +207,7 @@ importers:
   packages/lambdas-driver:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -246,7 +246,7 @@ importers:
       serialize-error: 8.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-lambdas-driver-previous': /@fluidframework/server-lambdas-driver/2.0.0
@@ -266,7 +266,7 @@ importers:
   packages/local-server:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -316,7 +316,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_dsbdoiloonfjopmmsiqdtk2mza
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_qiwzlxsc7nv6vcdymu2njnpbxe
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server-previous': /@fluidframework/server-local-server/2.0.0
@@ -343,7 +343,7 @@ importers:
   packages/memory-orderer:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -400,7 +400,7 @@ importers:
       ws: 7.5.9
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-memory-orderer-previous': /@fluidframework/server-memory-orderer/2.0.0
@@ -418,7 +418,7 @@ importers:
   packages/protocol-base:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -445,7 +445,7 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/protocol-base-previous': /@fluidframework/protocol-base/2.0.0
@@ -465,7 +465,7 @@ importers:
   packages/routerlicious:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -519,7 +519,7 @@ importers:
       winston: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server': link:../local-server
@@ -536,7 +536,7 @@ importers:
   packages/routerlicious-base:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -636,7 +636,7 @@ importers:
       ws: 7.5.9
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server': link:../local-server
@@ -673,7 +673,7 @@ importers:
   packages/services:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -747,7 +747,7 @@ importers:
       winston: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-previous': /@fluidframework/server-services/2.0.0
@@ -774,7 +774,7 @@ importers:
   packages/services-client:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -822,7 +822,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-client-previous': /@fluidframework/server-services-client/2.0.0
@@ -845,7 +845,7 @@ importers:
   packages/services-core:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -877,7 +877,7 @@ importers:
       nconf: 0.12.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-core-previous': /@fluidframework/server-services-core/2.0.0
@@ -890,7 +890,7 @@ importers:
   packages/services-ordering-kafkanode:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/server-services-client': workspace:~
@@ -924,7 +924,7 @@ importers:
       sillyname: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-kafkanode-previous': /@fluidframework/server-services-ordering-kafkanode/2.0.0
@@ -943,7 +943,7 @@ importers:
   packages/services-ordering-rdkafka:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -978,7 +978,7 @@ importers:
       sillyname: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-rdkafka-previous': /@fluidframework/server-services-ordering-rdkafka/2.0.0
@@ -998,7 +998,7 @@ importers:
   packages/services-ordering-zookeeper:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/server-services-core': workspace:~
@@ -1020,7 +1020,7 @@ importers:
       zookeeper: 5.6.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-zookeeper-previous': /@fluidframework/server-services-ordering-zookeeper/2.0.0
@@ -1039,7 +1039,7 @@ importers:
   packages/services-shared:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -1109,7 +1109,7 @@ importers:
       winston: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-shared-previous': /@fluidframework/server-services-shared/2.0.0
@@ -1134,7 +1134,7 @@ importers:
   packages/services-telemetry:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -1163,7 +1163,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-telemetry-previous': /@fluidframework/server-services-telemetry/2.0.0
@@ -1183,7 +1183,7 @@ importers:
   packages/services-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -1244,7 +1244,7 @@ importers:
       winston-transport: 4.5.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-utils-previous': /@fluidframework/server-services-utils/2.0.0
@@ -1272,7 +1272,7 @@ importers:
   packages/test-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.25.0
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -1318,7 +1318,7 @@ importers:
       uuid: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli': 0.25.0_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-test-utils-previous': /@fluidframework/server-test-utils/2.0.0
@@ -2374,8 +2374,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 
@@ -2651,7 +2651,7 @@ packages:
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-core': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
-      assert: 2.0.0
+      assert: 2.1.0
       async: 3.2.4
       events: 3.3.0
       lodash: 4.17.21
@@ -2668,7 +2668,7 @@ packages:
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-core': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
-      assert: 2.0.0
+      assert: 2.1.0
       async: 3.2.4
       events: 3.3.0
       lodash: 4.17.21
@@ -2690,8 +2690,8 @@ packages:
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-core': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
-      '@types/semver': 7.5.0
-      assert: 2.0.0
+      '@types/semver': 7.5.3
+      assert: 2.1.0
       async: 3.2.4
       axios: 0.26.1
       buffer: 6.0.3
@@ -2700,9 +2700,9 @@ packages:
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       nconf: 0.12.0
-      semver: 7.5.3
+      semver: 7.5.4
       sha.js: 2.4.11
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -2732,7 +2732,7 @@ packages:
       nconf: 0.12.0
       semver: 7.5.4
       sha.js: 2.4.11
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -2762,7 +2762,7 @@ packages:
       nconf: 0.12.0
       semver: 7.5.4
       sha.js: 2.4.11
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -2782,7 +2782,7 @@ packages:
       debug: 4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2799,18 +2799,18 @@ packages:
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-core': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
-      '@types/debug': 4.1.8
-      '@types/double-ended-queue': 2.1.2
-      '@types/lodash': 4.14.195
-      '@types/node': 18.17.6
+      '@types/debug': 4.1.9
+      '@types/double-ended-queue': 2.1.4
+      '@types/lodash': 4.14.199
+      '@types/node': 18.18.4
       '@types/ws': 6.0.4
-      assert: 2.0.0
+      assert: 2.1.0
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lodash: 4.17.21
       sillyname: 0.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -2831,7 +2831,7 @@ packages:
       '@types/debug': 4.1.9
       '@types/double-ended-queue': 2.1.4
       '@types/lodash': 4.14.199
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       '@types/ws': 6.0.4
       assert: 2.1.0
       debug: 4.3.4
@@ -2839,7 +2839,7 @@ packages:
       events: 3.3.0
       lodash: 4.17.21
       sillyname: 0.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -2873,12 +2873,12 @@ packages:
       express: 4.18.2
       ioredis: 5.3.2
       json-stringify-safe: 5.0.1
-      jsonwebtoken: 9.0.0
+      jsonwebtoken: 9.0.2
       lodash: 4.17.21
       nconf: 0.12.0
       serialize-error: 8.1.0
       sillyname: 0.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
       winston: 3.9.0
       ws: 7.5.9
     transitivePeerDependencies:
@@ -2976,7 +2976,7 @@ packages:
       jwt-decode: 3.1.2
       querystring: 0.2.1
       sillyname: 0.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2996,7 +2996,7 @@ packages:
       jwt-decode: 3.1.2
       querystring: 0.2.1
       sillyname: 0.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3009,8 +3009,8 @@ packages:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
-      '@types/nconf': 0.10.3
-      '@types/node': 18.17.6
+      '@types/nconf': 0.10.4
+      '@types/node': 18.18.4
       debug: 4.3.4
       events: 3.3.0
       nconf: 0.12.0
@@ -3027,7 +3027,7 @@ packages:
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
       '@types/nconf': 0.10.4
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       debug: 4.3.4
       events: 3.3.0
       nconf: 0.12.0
@@ -3074,7 +3074,7 @@ packages:
       '@fluidframework/server-services-telemetry': 2.0.1
       events: 3.3.0
       nconf: 0.12.0
-      node-rdkafka: 2.16.1
+      node-rdkafka: 2.17.0
       sillyname: 0.1.0
     transitivePeerDependencies:
       - supports-color
@@ -3133,10 +3133,10 @@ packages:
       notepack.io: 2.3.0
       querystring: 0.2.1
       serialize-error: 8.1.0
-      socket.io: 4.6.2
+      socket.io: 4.7.2
       socket.io-adapter: 2.5.2
       socket.io-parser: 4.2.4
-      uuid: 9.0.0
+      uuid: 9.0.1
       winston: 3.9.0
     transitivePeerDependencies:
       - bufferutil
@@ -3182,7 +3182,7 @@ packages:
       json-stringify-safe: 5.0.1
       path-browserify: 1.0.1
       serialize-error: 8.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     dev: true
 
   /@fluidframework/server-services-telemetry/2.0.1:
@@ -3192,7 +3192,7 @@ packages:
       json-stringify-safe: 5.0.1
       path-browserify: 1.0.1
       serialize-error: 8.1.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     dev: true
 
   /@fluidframework/server-services-utils/2.0.0:
@@ -3206,13 +3206,13 @@ packages:
       express: 4.18.2
       ioredis: 5.3.2
       json-stringify-safe: 5.0.1
-      jsonwebtoken: 9.0.0
+      jsonwebtoken: 9.0.2
       morgan: 1.10.0
       nconf: 0.12.0
       serialize-error: 8.1.0
       sillyname: 0.1.0
       split: 1.0.1
-      uuid: 9.0.0
+      uuid: 9.0.1
       winston: 3.9.0
       winston-transport: 4.5.0
     transitivePeerDependencies:
@@ -3264,9 +3264,9 @@ packages:
       lru-cache: 6.0.0
       mongodb: 4.17.0
       nconf: 0.12.0
-      socket.io: 4.6.2
+      socket.io: 4.7.2
       telegrafjs: 0.1.3
-      uuid: 9.0.0
+      uuid: 9.0.1
       winston: 3.9.0
     transitivePeerDependencies:
       - aws-crt
@@ -3317,12 +3317,12 @@ packages:
       '@fluidframework/server-services-client': 2.0.1
       '@fluidframework/server-services-core': 2.0.1
       '@fluidframework/server-services-telemetry': 2.0.1
-      assert: 2.0.0
+      assert: 2.1.0
       debug: 4.3.4
       events: 3.3.0
       lodash: 4.17.21
       string-hash: 1.1.3
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3342,7 +3342,7 @@ packages:
       events: 3.3.0
       lodash: 4.17.21
       string-hash: 1.1.3
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6349,7 +6349,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/cookie-parser/1.4.3:
@@ -6374,7 +6374,7 @@ packages:
   /@types/cors/2.8.14:
     resolution: {integrity: sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
 
   /@types/debug/4.1.8:
     resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
@@ -6389,6 +6389,7 @@ packages:
 
   /@types/double-ended-queue/2.1.2:
     resolution: {integrity: sha512-iAjbBa3X4UQtYxcCsAr0YaZMRwyC79q4KHui0XtEN7GGLJA4fzD116KUYXXZKskaOYSchnaOFT/a8zSlEx3P9Q==}
+    dev: false
 
   /@types/double-ended-queue/2.1.4:
     resolution: {integrity: sha512-Os5C/SdJzK5PWQvMIqk3yqc11IdTp7rx37hdXgjWLw/ba9G8VkhJUfX6Q3Cnp1yMGRLiv5y/5V2vI740xBFvkw==}
@@ -6564,7 +6565,6 @@ packages:
 
   /@types/node/18.18.4:
     resolution: {integrity: sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ==}
-    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -6599,14 +6599,14 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/serve-static/1.15.1:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/sinon/9.0.11:
@@ -6633,7 +6633,7 @@ packages:
     resolution: {integrity: sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==}
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
     dev: true
 
   /@types/supertest/2.0.12:
@@ -6662,7 +6662,7 @@ packages:
   /@types/whatwg-url/8.2.2:
     resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       '@types/webidl-conversions': 7.0.1
 
   /@types/ws/6.0.4:
@@ -7374,6 +7374,7 @@ packages:
       is-nan: 1.3.2
       object-is: 1.1.5
       util: 0.12.5
+    dev: false
 
   /assert/2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
@@ -7726,7 +7727,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
     dev: true
 
@@ -9172,6 +9173,7 @@ packages:
   /engine.io-parser/5.0.7:
     resolution: {integrity: sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==}
     engines: {node: '>=10.0.0'}
+    dev: false
 
   /engine.io-parser/5.2.1:
     resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
@@ -9184,7 +9186,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.14
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -9196,6 +9198,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /engine.io/6.5.3:
     resolution: {integrity: sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==}
@@ -9203,7 +9206,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.14
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -9345,6 +9348,7 @@ packages:
 
   /es6-object-assign/1.1.0:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
+    dev: false
 
   /es6-promise/4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
@@ -11602,7 +11606,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.17.6
+      '@types/node': 18.18.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -11767,6 +11771,7 @@ packages:
       lodash: 4.17.21
       ms: 2.1.3
       semver: 7.5.4
+    dev: false
 
   /jsonwebtoken/9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
@@ -13047,6 +13052,7 @@ packages:
     dependencies:
       bindings: 1.5.0
       nan: 2.17.0
+    dev: false
 
   /node-rdkafka/2.17.0:
     resolution: {integrity: sha512-vFABzRcE5FaH0WqfqJRxDoqeG6P8UEB3M4qFQ7SkwMgQueMMO78+fm8MYfl5hLW3bBYfBekK2BXIIr0lDQtSEQ==}
@@ -15431,6 +15437,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /socket.io/4.7.2:
     resolution: {integrity: sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==}
@@ -16795,6 +16802,7 @@ packages:
   /uuid/9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
+    dev: false
 
   /uuid/9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -70,7 +70,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/server/tinylicious/pnpm-lock.yaml
+++ b/server/tinylicious/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/common-utils': ^3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^2.0.2
@@ -108,7 +108,7 @@ importers:
       uuid: 9.0.0
       winston: 3.8.1
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.34.4_@types+node@16.18.21
@@ -223,8 +223,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -67,7 +67,7 @@
 		"chalk": "^4.1.2"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
@@ -45,7 +45,7 @@ importers:
       '@rushstack/node-core-library': 3.55.2_@types+node@18.15.11
       chalk: 4.1.2
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@18.15.11
       '@fluidframework/eslint-config-fluid': 2.0.0_flcvfono3v34oogyclggnmpgme
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
@@ -184,8 +184,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -43,7 +43,7 @@
 		"moment": "^2.21.0"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
       '@microsoft/api-extractor': ^7.22.2
@@ -35,7 +35,7 @@ importers:
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -107,8 +107,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/tools/changelog-generator-wrapper/package.json
+++ b/tools/changelog-generator-wrapper/package.json
@@ -39,7 +39,7 @@
 		"typescript": "~4.5.5"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/tools/changelog-generator-wrapper/pnpm-lock.yaml
+++ b/tools/changelog-generator-wrapper/pnpm-lock.yaml
@@ -6,7 +6,7 @@ importers:
     specifiers:
       '@changesets/cli': ^2.26.1
       '@changesets/types': ^5.2.1
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/eslint-config-fluid': ^2.0.0
       changesets-format-with-issue-links: ^0.3.0
       concurrently: ^8.2.1
@@ -21,7 +21,7 @@ importers:
       changesets-format-with-issue-links: 0.3.0_@changesets+cli@2.26.1
       typescript: 4.5.5
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       concurrently: 8.2.1
       copyfiles: 2.4.1
@@ -265,8 +265,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -30,7 +30,7 @@
 		"tsc": "tsc"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.1",
+		"@fluidframework/build-common": "^2.0.2",
 		"@fluidframework/build-tools": "^0.25.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/mocha": "^10.0.0",

--- a/tools/test-tools/pnpm-lock.yaml
+++ b/tools/test-tools/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@fluidframework/build-common': ^2.0.1
+      '@fluidframework/build-common': ^2.0.2
       '@fluidframework/build-tools': ^0.25.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@types/mocha': ^10.0.0
@@ -19,7 +19,7 @@ importers:
       rimraf: ^2.6.2
       typescript: ~4.5.5
     devDependencies:
-      '@fluidframework/build-common': 2.0.1
+      '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.25.0_@types+node@14.18.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 10.0.1
@@ -142,8 +142,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/build-common/2.0.1:
-    resolution: {integrity: sha512-0oow40mp6jrePJtarVScGPbMkogmRNNvc/aIRoxYQO2iTNquQZ/WE6CpJqtabZurpJdd5zISDhie1ShFxOtXfw==}
+  /@fluidframework/build-common/2.0.2:
+    resolution: {integrity: sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
Picks up a needed fix in our new API-Extractor config. Also removes a now-unneeded config workaround in the `sequence` package.