### PR TITLE
tree2: Cleanup relation between DocumentSchema and SchemaLibrary

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -495,15 +495,13 @@ export type DetachedPlaceUpPath = Brand<Omit<PlaceUpPath, "parent">, "DetachedRa
 export type DetachedRangeUpPath = Brand<Omit<RangeUpPath, "parent">, "DetachedRangeUpPath">;
 
 // @alpha
-export interface DocumentSchema<out T extends FieldSchema = FieldSchema> {
+export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
     // (undocumented)
     readonly adapters: Adapters;
     // (undocumented)
     readonly policy: FullSchemaPolicy;
     // (undocumented)
     readonly rootFieldSchema: T;
-    // (undocumented)
-    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 }
 
 // @alpha
@@ -1875,16 +1873,20 @@ export interface SchemaBuilderOptions<TScope extends string = string> {
 }
 
 // @alpha
+export interface SchemaCollection {
+    // (undocumented)
+    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
+}
+
+// @alpha
 export interface SchemaConfiguration<TRoot extends FieldSchema = FieldSchema> {
     readonly schema: DocumentSchema<TRoot>;
 }
 
 // @alpha
-export interface SchemaData {
+export interface SchemaData extends StoredSchemaCollection {
     // (undocumented)
     readonly rootFieldSchema: FieldStoredSchema;
-    // (undocumented)
-    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeStoredSchema>;
 }
 
 // @alpha
@@ -1897,20 +1899,16 @@ export interface SchemaEvents {
 export function schemaIsFieldNode(schema: TreeSchema): schema is FieldNodeSchema;
 
 // @alpha
-export interface SchemaLibrary extends DocumentSchema {
+export interface SchemaLibrary extends SchemaCollection {
     readonly libraries: ReadonlySet<SchemaLibraryData>;
 }
 
 // @alpha
-export interface SchemaLibraryData {
+export interface SchemaLibraryData extends SchemaCollection {
     // (undocumented)
     readonly adapters: Adapters;
     // (undocumented)
     readonly name: string;
-    // (undocumented)
-    readonly rootFieldSchema?: FieldSchema;
-    // (undocumented)
-    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 }
 
 // @alpha
@@ -2035,6 +2033,12 @@ type Skip = number;
 
 // @alpha
 export type StableNodeKey = Brand<StableId, "Stable Node Key">;
+
+// @alpha
+export interface StoredSchemaCollection {
+    // (undocumented)
+    readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeStoredSchema>;
+}
 
 // @alpha
 export interface StoredSchemaRepository extends Dependee, ISubscribable<SchemaEvents>, SchemaData {

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -496,11 +496,8 @@ export type DetachedRangeUpPath = Brand<Omit<RangeUpPath, "parent">, "DetachedRa
 
 // @alpha
 export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
-    // (undocumented)
     readonly adapters: Adapters;
-    // (undocumented)
     readonly policy: FullSchemaPolicy;
-    // (undocumented)
     readonly rootFieldSchema: T;
 }
 
@@ -1873,8 +1870,7 @@ export interface SchemaBuilderOptions<TScope extends string = string> {
 }
 
 // @alpha
-export interface SchemaCollection {
-    // (undocumented)
+export interface SchemaCollection extends StoredSchemaCollection {
     readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 }
 
@@ -1885,7 +1881,6 @@ export interface SchemaConfiguration<TRoot extends FieldSchema = FieldSchema> {
 
 // @alpha
 export interface SchemaData extends StoredSchemaCollection {
-    // (undocumented)
     readonly rootFieldSchema: FieldStoredSchema;
 }
 
@@ -2036,7 +2031,6 @@ export type StableNodeKey = Brand<StableId, "Stable Node Key">;
 
 // @alpha
 export interface StoredSchemaCollection {
-    // (undocumented)
     readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeStoredSchema>;
 }
 

--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -140,6 +140,7 @@ export {
 	forbiddenFieldKindIdentifier,
 	storedEmptyFieldSchema,
 	cloneSchemaData,
+	StoredSchemaCollection,
 } from "./schema-stored";
 
 export { ChangeFamily, ChangeFamilyEditor, EditBuilder } from "./change-family";

--- a/experimental/dds/tree2/src/core/schema-stored/index.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/index.ts
@@ -19,6 +19,7 @@ export {
 	PrimitiveValueSchema,
 	forbiddenFieldKindIdentifier,
 	storedEmptyFieldSchema,
+	StoredSchemaCollection,
 } from "./schema";
 export {
 	StoredSchemaRepository,

--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -191,13 +191,23 @@ export interface TreeStoredSchema {
 }
 
 /**
- * View of schema data that can be stored in a document.
+ * Document schema data that can be stored in a document.
  *
  * Note: the owner of this may modify it over time:
  * thus if needing to hand onto a specific version, make a copy.
  * @alpha
  */
-export interface SchemaData {
+export interface SchemaData extends StoredSchemaCollection {
 	readonly rootFieldSchema: FieldStoredSchema;
+}
+
+/**
+ * Collection of TreeSchema data that can be stored in a document.
+ *
+ * Note: the owner of this may modify it over time:
+ * thus if needing to hand onto a specific version, make a copy.
+ * @alpha
+ */
+export interface StoredSchemaCollection {
 	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeStoredSchema>;
 }

--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -193,21 +193,29 @@ export interface TreeStoredSchema {
 /**
  * Document schema data that can be stored in a document.
  *
+ * @remarks
  * Note: the owner of this may modify it over time:
  * thus if needing to hand onto a specific version, make a copy.
  * @alpha
  */
 export interface SchemaData extends StoredSchemaCollection {
+	/**
+	 * Schema for the root field which contains the whole tree.
+	 */
 	readonly rootFieldSchema: FieldStoredSchema;
 }
 
 /**
  * Collection of TreeSchema data that can be stored in a document.
  *
+ * @remarks
  * Note: the owner of this may modify it over time:
  * thus if needing to hand onto a specific version, make a copy.
  * @alpha
  */
 export interface StoredSchemaCollection {
+	/**
+	 * {@inheritdoc StoredSchemaCollection}
+	 */
 	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeStoredSchema>;
 }

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -17,6 +17,7 @@ import {
 	StoredSchemaRepository,
 	CursorLocationType,
 	SchemaData,
+	StoredSchemaCollection,
 } from "../../core";
 import { FullSchemaPolicy, Multiplicity } from "../modular-schema";
 import { fail } from "../../util";
@@ -194,7 +195,7 @@ export function makePolicy(policy?: Partial<ChunkPolicy>): ChunkPolicy {
 }
 
 export function shapesFromSchema(
-	schema: SchemaData,
+	schema: StoredSchemaCollection,
 	policy: FullSchemaPolicy,
 ): Map<TreeSchemaIdentifier, ShapeInfo> {
 	const shapes: Map<TreeSchemaIdentifier, ShapeInfo> = new Map();
@@ -210,7 +211,7 @@ export function shapesFromSchema(
  * Note that this does not tolerate optional or sequence fields, nor does it optimize for patterns of specific values.
  */
 export function tryShapeFromSchema(
-	schema: SchemaData,
+	schema: StoredSchemaCollection,
 	policy: FullSchemaPolicy,
 	type: TreeSchemaIdentifier,
 	shapes: Map<TreeSchemaIdentifier, ShapeInfo>,
@@ -243,7 +244,7 @@ export function tryShapeFromSchema(
  * Note that this does not tolerate optional or sequence fields, nor does it optimize for patterns of specific values.
  */
 export function tryShapeFromFieldSchema(
-	schema: SchemaData,
+	schema: StoredSchemaCollection,
 	policy: FullSchemaPolicy,
 	type: FieldStoredSchema,
 	key: FieldKey,

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
@@ -7,7 +7,7 @@ import { unreachableCase } from "@fluidframework/core-utils";
 import {
 	FieldStoredSchema,
 	ITreeCursorSynchronous,
-	SchemaData,
+	StoredSchemaCollection,
 	TreeSchemaIdentifier,
 	ValueSchema,
 } from "../../../core";
@@ -33,14 +33,14 @@ import { NodeShape } from "./nodeShape";
  * Optimized for encoded size and encoding performance.
  */
 export function schemaCompressedEncode(
-	schema: SchemaData,
+	schema: StoredSchemaCollection,
 	policy: FullSchemaPolicy,
 	cursor: ITreeCursorSynchronous,
 ): EncodedChunk {
 	return compressedEncode(cursor, buildCache(schema, policy));
 }
 
-export function buildCache(schema: SchemaData, policy: FullSchemaPolicy): EncoderCache {
+export function buildCache(schema: StoredSchemaCollection, policy: FullSchemaPolicy): EncoderCache {
 	const cache: EncoderCache = new EncoderCache(
 		(fieldHandler: FieldShaper, schemaName: TreeSchemaIdentifier) =>
 			treeShaper(schema, policy, fieldHandler, schemaName),
@@ -80,7 +80,7 @@ export function fieldShaper(
  * Selects shapes to use to encode trees.
  */
 export function treeShaper(
-	fullSchema: SchemaData,
+	fullSchema: StoredSchemaCollection,
 	policy: FullSchemaPolicy,
 	fieldHandler: FieldShaper,
 	schemaName: TreeSchemaIdentifier,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -160,6 +160,7 @@ export {
 	Unenforced,
 	AllowedTypeSet,
 	MapFieldSchema,
+	SchemaCollection,
 } from "./typed-schema";
 
 export {

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -9,7 +9,7 @@ import { Assume, RestrictiveReadonlyRecord, transformObjectMap } from "../util";
 import {
 	SchemaLibraryData,
 	SchemaLintConfiguration,
-	buildViewSchemaCollection,
+	aggregateSchemaLibraries,
 	schemaLintDefault,
 	AllowedTypes,
 	TreeSchema,
@@ -142,7 +142,7 @@ export class SchemaBuilderBase<
 		});
 
 		// Check for errors and aggregate data
-		return buildViewSchemaCollection(this.name, this.lintConfiguration, this.libraries, field);
+		return aggregateSchemaLibraries(this.name, this.lintConfiguration, this.libraries, field);
 	}
 
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -33,7 +33,7 @@ export {
 	validateStructFieldName,
 	SchemaLibraryData,
 	SchemaLintConfiguration,
-	aggregateSchemaLibraries as buildViewSchemaCollection,
+	aggregateSchemaLibraries,
 	schemaLintDefault,
 } from "./schemaCollection";
 

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -22,6 +22,7 @@ export {
 	Unenforced,
 	AllowedTypeSet,
 	MapFieldSchema,
+	SchemaCollection,
 } from "./typedTreeSchema";
 
 export { ViewSchema } from "./view";
@@ -32,7 +33,7 @@ export {
 	validateStructFieldName,
 	SchemaLibraryData,
 	SchemaLintConfiguration,
-	buildViewSchemaCollection,
+	aggregateSchemaLibraries as buildViewSchemaCollection,
 	schemaLintDefault,
 } from "./schemaCollection";
 

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -475,9 +475,17 @@ export function allowedTypesToTypeSet(t: AllowedTypes): TreeTypeSet {
  * @alpha
  */
 
-export interface DocumentSchema<out T extends FieldSchema = FieldSchema> {
+export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
 	readonly rootFieldSchema: T;
-	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 	readonly policy: FullSchemaPolicy;
 	readonly adapters: Adapters;
+}
+
+/**
+ * Schema data that can be be used to view a document.
+ * @alpha
+ */
+
+export interface SchemaCollection {
+	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 }

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -8,6 +8,8 @@ import {
 	Adapters,
 	EmptyKey,
 	FieldKey,
+	SchemaData,
+	StoredSchemaCollection,
 	TreeSchemaIdentifier,
 	TreeTypeSet,
 	ValueSchema,
@@ -476,16 +478,40 @@ export function allowedTypesToTypeSet(t: AllowedTypes): TreeTypeSet {
  */
 
 export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
+	/**
+	 * Schema for the root field which contains the whole tree.
+	 */
 	readonly rootFieldSchema: T;
+	/**
+	 * Extra configuration for how this schema is handled at runtime.
+	 */
 	readonly policy: FullSchemaPolicy;
+	/**
+	 * Compatibility information how how to interact with content who's stored schema is not directly compatible with this schema.
+	 */
 	readonly adapters: Adapters;
+}
+
+{
+	// It is convenient that DocumentSchema can be used as a SchemaData with no conversion.
+	// This type check ensures this ability is not broken on accident (if it needs to be broken on purpose for some reason thats fine: just delete this check).
+	// Since TypeScript does not allow extending two types with the same field (even if they are compatible),
+	// this check cannot be done by adding an extends clause to DocumentSchema.
+	type _check = requireAssignableTo<DocumentSchema, SchemaData>;
 }
 
 /**
  * Schema data that can be be used to view a document.
  * @alpha
+ *
+ * @privateRemarks
+ * It is convenient that this can be used as a StoredSchemaCollection with no conversion.
+ * There there isn't a design requirement for this however, so this extends clause can be removed later if needed.
  */
 
-export interface SchemaCollection {
+export interface SchemaCollection extends StoredSchemaCollection {
+	/**
+	 * {@inheritdoc SchemaCollection}
+	 */
 	readonly treeSchema: ReadonlyMap<TreeSchemaIdentifier, TreeSchema>;
 }

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -81,6 +81,7 @@ export {
 	MapTree,
 	LocalCommitSource,
 	forbiddenFieldKindIdentifier,
+	StoredSchemaCollection,
 } from "./core";
 
 export {
@@ -280,6 +281,7 @@ export {
 	SharedTreeObject,
 	is,
 	Typed,
+	SchemaCollection,
 } from "./feature-libraries";
 
 export {

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -42,7 +42,12 @@ import {
 	cursorForTypedTreeData,
 	FieldSchema,
 } from "../feature-libraries";
-import { MockDependent, applyTestDelta, expectEqualFieldPaths } from "./utils";
+import {
+	MockDependent,
+	applyTestDelta,
+	expectEqualFieldPaths,
+	jsonSequenceRootSchema,
+} from "./utils";
 import { testGeneralPurposeTreeCursor, testTreeSchema } from "./cursorTestSuite";
 
 /**
@@ -121,7 +126,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("cursor use", () => {
-			const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
 
 			const reader = forest.allocateCursor();
@@ -400,7 +405,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 
 		it("editing a cloned forest does not modify the original", () => {
-			const schema = new InMemoryStoredSchemaRepository(jsonSchema);
+			const schema = new InMemoryStoredSchemaRepository(jsonSequenceRootSchema);
 			const forest = factory(schema);
 			const content: JsonableTree[] = [
 				{ type: leaf.number.name, value: 1 },
@@ -430,7 +435,9 @@ export function testForest(config: ForestTestConfiguration): void {
 		describe("can apply deltas with", () => {
 			if (!config.skipCursorErrorCheck) {
 				it("ensures cursors are cleared before applying deltas", () => {
-					const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+					const forest = factory(
+						new InMemoryStoredSchemaRepository(jsonSequenceRootSchema),
+					);
 					initializeForest(forest, [singleJsonCursor(1)]);
 					const cursor = forest.allocateCursor();
 					moveToDetachedField(forest, cursor);
@@ -446,7 +453,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			}
 
 			it("set fields as remove and insert", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const setField: Delta.Modify = {
@@ -481,7 +488,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("set fields as replace", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const setField: Delta.Modify = {
@@ -619,7 +626,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("move out and move in", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
@@ -653,7 +660,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("insert and modify", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				const content: JsonCompatible[] = [1, 2];
 				initializeForest(forest, content.map(singleJsonCursor));
 
@@ -694,7 +701,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("modify and remove", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
@@ -720,7 +727,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("modify and move out", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				initializeForest(forest, [singleJsonCursor(nestedContent)]);
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
@@ -778,7 +785,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		describe("top level invalidation", () => {
 			it("data editing", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				const dependent = new MockDependent("dependent");
 				recordDependency(dependent, forest);
 
@@ -802,11 +809,11 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			it("schema editing", () => {
-				const schema = new InMemoryStoredSchemaRepository(jsonSchema);
+				const schema = new InMemoryStoredSchemaRepository(jsonSequenceRootSchema);
 				const forest = factory(schema);
 				const dependent = new MockDependent("dependent");
 				recordDependency(dependent, forest);
-				schema.update(jsonSchema);
+				schema.update(jsonSequenceRootSchema);
 
 				// Forest no longer observes schema and should not be invalidated by it changing.
 				assert.deepEqual(dependent.tokens, []);
@@ -815,7 +822,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		describe("Does not leave an empty field", () => {
 			it("when removing the last node in the field", () => {
-				const forest = factory(new InMemoryStoredSchemaRepository(jsonSchema));
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonSequenceRootSchema));
 				const delta: Delta.Root = new Map([
 					[
 						rootFieldKey,


### PR DESCRIPTION
## Description

SchemaLibrary used to extend DocumentSchema. This was odd since schema libraries don't have a root field, and thus had to make one up.

This change makes both types extends SchemaCollection, which avoids either having things that it logically shouldn't.

## Breaking Changes

Code using a SchemaLibrary as a DocumentSchema will need to do one of:
- Update to use SchemaCollection instead 
- Use SchemaBuilder to generate a DocumentSchema from the library

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

