### PR TITLE
docs(core-utils): Add explicit release tags to exported API members

### DIFF
--- a/packages/common/core-utils/api-extractor.json
+++ b/packages/common/core-utils/api-extractor.json
@@ -1,13 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-
-	// TODO: Fix violations and remove these rule overrides
-	"messages": {
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/packages/common/core-utils/src/assert.ts
+++ b/packages/common/core-utils/src/assert.ts
@@ -12,6 +12,7 @@
  * A number should not be specified manually: use a string.
  * Before a release, policy-check should be run, which will convert any asserts still using strings to
  * use numbered error codes instead.
+ * @public
  */
 export function assert(condition: boolean, message: string | number): asserts condition {
 	if (!condition) {

--- a/packages/common/core-utils/src/delay.ts
+++ b/packages/common/core-utils/src/delay.ts
@@ -6,6 +6,7 @@
 /**
  * Returns a promise that resolves after `timeMs`.
  * @param timeMs - Time in milliseconds to wait.
+ * @public
  */
 export const delay = async (timeMs: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(() => resolve(), timeMs));

--- a/packages/common/core-utils/src/heap.ts
+++ b/packages/common/core-utils/src/heap.ts
@@ -5,6 +5,7 @@
 
 /**
  * Interface for a comparer.
+ * @public
  */
 export interface IComparer<T> {
 	/**
@@ -22,6 +23,7 @@ export interface IComparer<T> {
 
 /**
  * A comparer for numbers.
+ * @public
  */
 export const NumberComparer: IComparer<number> = {
 	/**
@@ -38,6 +40,7 @@ export const NumberComparer: IComparer<number> = {
 
 /**
  * Interface to a node in {@link Heap}.
+ * @public
  */
 export interface IHeapNode<T> {
 	value: T;
@@ -46,6 +49,7 @@ export interface IHeapNode<T> {
 
 /**
  * Ordered {@link https://en.wikipedia.org/wiki/Heap_(data_structure) | Heap} data structure implementation.
+ * @public
  */
 export class Heap<T> {
 	private L: IHeapNode<T>[];

--- a/packages/common/core-utils/src/lazy.ts
+++ b/packages/common/core-utils/src/lazy.ts
@@ -5,6 +5,7 @@
 
 /**
  * Helper class for lazy initialized values. Ensures the value is only generated once, and remain immutable.
+ * @public
  */
 export class Lazy<T> {
 	private _value: T | undefined;
@@ -40,6 +41,7 @@ export class Lazy<T> {
  * the promise is used, e.g. await, then, catch ...
  * The execute function is only called once.
  * All calls are then proxied to the promise returned by the execute method.
+ * @public
  */
 export class LazyPromise<T> implements Promise<T> {
 	public get [Symbol.toStringTag](): string {

--- a/packages/common/core-utils/src/promiseCache.ts
+++ b/packages/common/core-utils/src/promiseCache.ts
@@ -8,6 +8,7 @@
  * - indefinite: entries don't expire and must be explicitly removed
  * - absolute: entries expire after the given duration in MS, even if accessed multiple times in the mean time
  * - sliding: entries expire after the given duration in MS of inactivity (i.e. get resets the clock)
+ * @public
  */
 export type PromiseCacheExpiry =
 	| {
@@ -20,6 +21,7 @@ export type PromiseCacheExpiry =
 
 /**
  * Options for configuring the {@link PromiseCache}
+ * @public
  */
 export interface PromiseCacheOptions {
 	/**
@@ -87,6 +89,7 @@ class GarbageCollector<TKey> {
 /**
  * A specialized cache for async work, allowing you to safely cache the promised result of some async work
  * without fear of running it multiple times or losing track of errors.
+ * @public
  */
 export class PromiseCache<TKey, TResult> {
 	private readonly cache = new Map<TKey, Promise<TResult>>();

--- a/packages/common/core-utils/src/promises.ts
+++ b/packages/common/core-utils/src/promises.ts
@@ -5,6 +5,7 @@
 
 /**
  * A deferred creates a promise and the ability to resolve or reject it
+ * @public
  */
 export class Deferred<T> {
 	private readonly p: Promise<T>;

--- a/packages/common/core-utils/src/timer.ts
+++ b/packages/common/core-utils/src/timer.ts
@@ -6,6 +6,9 @@
 import { assert } from "./assert";
 import { Deferred } from "./promises";
 
+/**
+ * @public
+ */
 export interface ITimer {
 	/**
 	 * True if timer is currently running
@@ -68,6 +71,7 @@ const maxSetTimeoutMs = 0x7fffffff; // setTimeout limit is MAX_INT32=(2^31-1).
  * @param setTimeoutIdFn - Executed to update the timeout if multiple timeouts are required when
  * timeoutMs greater than maxTimeout
  * @returns The initial timeout
+ * @public
  */
 export function setLongTimeout(
 	timeoutFn: () => void,
@@ -95,6 +99,7 @@ export function setLongTimeout(
  * makes it simpler to keep track of recurring timeouts with the same
  * or similar handlers and timeouts. This class supports long timeouts
  * or timeouts exceeding (2^31)-1 ms or approximately 24.8 days.
+ * @public
  */
 export class Timer implements ITimer {
 	/**
@@ -215,6 +220,9 @@ export class Timer implements ITimer {
 	}
 }
 
+/**
+ * @public
+ */
 export interface IPromiseTimerResult {
 	timerResult: "timeout" | "cancel";
 }
@@ -222,6 +230,7 @@ export interface IPromiseTimerResult {
 /**
  * Timer which offers a promise that fulfills when the timer
  * completes.
+ * @public
  */
 export interface IPromiseTimer extends ITimer {
 	/**
@@ -236,6 +245,7 @@ export interface IPromiseTimer extends ITimer {
  * makes it simpler to keep track of recurring timeouts with the
  * same handlers and timeouts, while also providing a promise that
  * resolves when it times out.
+ * @public
  */
 export class PromiseTimer implements IPromiseTimer {
 	private deferred?: Deferred<IPromiseTimerResult>;

--- a/packages/common/core-utils/src/unreachable.ts
+++ b/packages/common/core-utils/src/unreachable.ts
@@ -17,6 +17,7 @@
  *   default: unreachableCase(bool);
  * }
  * ```
+ * @public
  */
 export function unreachableCase(_: never, message = "Unreachable Case"): never {
 	throw new Error(message);


### PR DESCRIPTION
[AB#5880](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5880)

## Description

This PR adds the @public explicit release tag for all exported interfaces in the core-utils package. These interfaces are transitively referenced by existing exports, and therefore must be exported for API completeness.

Reviewer Guidance
Are there any interfaces/functions that should be tagged with something else?