### PR TITLE
tree: fix Object.prototype inheritance

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -331,7 +331,7 @@ staticDispatchMap[Symbol.iterator] = {
 /* eslint-enable @typescript-eslint/unbound-method */
 /* eslint-enable @typescript-eslint/ban-types */
 
-const prototype = Object.create(Object.getPrototypeOf({}), staticDispatchMap);
+const prototype = Object.create(Object.prototype, staticDispatchMap);
 
 /**
  * Helper to coerce property keys to integer indexes (or undefined if not an in-range integer).

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -331,7 +331,7 @@ staticDispatchMap[Symbol.iterator] = {
 /* eslint-enable @typescript-eslint/unbound-method */
 /* eslint-enable @typescript-eslint/ban-types */
 
-const prototype = Object.create(null, staticDispatchMap);
+const prototype = Object.create(Object.getPrototypeOf({}), staticDispatchMap);
 
 /**
  * Helper to coerce property keys to integer indexes (or undefined if not an in-range integer).

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -168,7 +168,7 @@ export function createObjectProxy<TSchema extends StructSchema, TTypes extends A
 				if (key === treeNodeSym) {
 					return { schema };
 				}
-				return undefined;
+				return Reflect.get(target, key);
 			},
 			set(target, key, value) {
 				const fieldSchema = content.schema.structFields.get(key as FieldKey);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -16,6 +16,26 @@ interface TestCase {
 	schema: DocumentSchema;
 }
 
+export function testObjectPrototype(proxy: object, prototype: object) {
+	describe("inherits from Object.prototype", () => {
+		it(`${pretty(proxy)} instanceof Object`, () => {
+			assert(prototype instanceof Object, "object must be instanceof Object");
+		});
+
+		for (const [key, descriptor] of Object.entries(
+			Object.getOwnPropertyDescriptors(Object.prototype),
+		)) {
+			it(`${key} -> ${pretty(descriptor)}}`, () => {
+				assert.deepEqual(
+					Object.getOwnPropertyDescriptor(prototype, key),
+					descriptor,
+					`Proxy must expose Object.prototype.${key}`,
+				);
+			});
+		}
+	});
+}
+
 function testObjectLike(testCases: TestCase[]) {
 	describe("Object-like", () => {
 		describe("satisfies 'deepEquals'", () => {
@@ -24,9 +44,43 @@ function testObjectLike(testCases: TestCase[]) {
 				const real = initialTree;
 				const proxy = view.root2(schema);
 
+				// We do not use 'itWithRoot()' so we can pretty-print the 'proxy' in the test title.
 				it(`deepEquals(${pretty(proxy)}, ${pretty(real)})`, () => {
 					assert.deepEqual(proxy, real, "Proxy must satisfy 'deepEquals'.");
 				});
+			}
+		});
+
+		describe("inherits from Object.prototype", () => {
+			function findObjectPrototype(o: unknown) {
+				return Object.getPrototypeOf(
+					// If 'root' is an array, the immediate prototype is Array.prototype.  We need to go
+					// one additional level to get Object.prototype.
+					Array.isArray(o) ? Object.getPrototypeOf(o) : o,
+				) as object;
+			}
+
+			for (const { schema, initialTree } of testCases) {
+				itWithRoot(
+					`${pretty(initialTree)} instanceof Object`,
+					schema,
+					initialTree,
+					(root) => {
+						assert(root instanceof Object, "object must be instanceof Object");
+					},
+				);
+
+				for (const [key, descriptor] of Object.entries(
+					Object.getOwnPropertyDescriptors(Object.prototype),
+				)) {
+					itWithRoot(`${key} -> ${pretty(descriptor)}}`, schema, initialTree, (root) => {
+						assert.deepEqual(
+							Object.getOwnPropertyDescriptor(findObjectPrototype(root), key),
+							descriptor,
+							`Proxy must expose Object.prototype.${key}`,
+						);
+					});
+				}
 			}
 		});
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -61,26 +61,73 @@ function testObjectLike(testCases: TestCase[]) {
 			}
 
 			for (const { schema, initialTree } of testCases) {
-				itWithRoot(
-					`${pretty(initialTree)} instanceof Object`,
-					schema,
-					initialTree,
-					(root) => {
+				describe("instanceof Object", () => {
+					itWithRoot(`${pretty(initialTree)} -> true`, schema, initialTree, (root) => {
 						assert(root instanceof Object, "object must be instanceof Object");
-					},
-				);
-
-				for (const [key, descriptor] of Object.entries(
-					Object.getOwnPropertyDescriptors(Object.prototype),
-				)) {
-					itWithRoot(`${key} -> ${pretty(descriptor)}}`, schema, initialTree, (root) => {
-						assert.deepEqual(
-							Object.getOwnPropertyDescriptor(findObjectPrototype(root), key),
-							descriptor,
-							`Proxy must expose Object.prototype.${key}`,
-						);
 					});
-				}
+				});
+
+				describe("properties inherited from Object.prototype", () => {
+					for (const [key, descriptor] of Object.entries(
+						Object.getOwnPropertyDescriptors(Object.prototype),
+					)) {
+						itWithRoot(
+							`Object.getOwnPropertyDescriptor(${pretty(
+								initialTree,
+							)}, ${key}) -> ${pretty(descriptor)}}`,
+							schema,
+							initialTree,
+							(root) => {
+								assert.deepEqual(
+									Object.getOwnPropertyDescriptor(findObjectPrototype(root), key),
+									descriptor,
+									`Proxy must expose Object.prototype.${key}`,
+								);
+							},
+						);
+					}
+				});
+
+				describe("methods inherited from Object.prototype", () => {
+					itWithRoot(
+						`${pretty(initialTree)}.isPrototypeOf(Object.create(root)) -> true`,
+						schema,
+						initialTree,
+
+						(root) => {
+							const asObject = root as object;
+							// eslint-disable-next-line no-prototype-builtins -- compatibility test
+							assert.equal(asObject.isPrototypeOf(Object.create(asObject)), true);
+						},
+					);
+
+					itWithRoot(
+						`${pretty(initialTree)}.isPrototypeOf(root) -> false`,
+						schema,
+						initialTree,
+
+						(root) => {
+							const asObject = root as object;
+							// eslint-disable-next-line no-prototype-builtins -- compatibility test
+							assert.equal(asObject.isPrototypeOf(asObject), false);
+						},
+					);
+				});
+
+				describe(`${pretty(initialTree)}.propertyIsEnumerable`, () => {
+					for (const key of Object.getOwnPropertyNames(initialTree)) {
+						const expected = Object.prototype.propertyIsEnumerable.call(
+							initialTree,
+							key,
+						);
+
+						itWithRoot(`${key} -> ${expected}`, schema, initialTree, (root) => {
+							const asObject = root as object;
+							// eslint-disable-next-line no-prototype-builtins -- compatibility test
+							assert.equal(asObject.propertyIsEnumerable(key), expected);
+						});
+					}
+				});
 			}
 		});
 
@@ -120,6 +167,10 @@ function testObjectLike(testCases: TestCase[]) {
 			test1((subject) => Object.prototype.toString.call(subject));
 		});
 
+		describe("Object.prototype.toLocaleString", () => {
+			test1((subject) => Object.prototype.toLocaleString.call(subject));
+		});
+
 		// 'deepEquals' requires that objects have the same prototype to be considered equal.
 		describe("Object.getPrototypeOf", () => {
 			test1((subject) => Object.getPrototypeOf(subject) as unknown);
@@ -145,7 +196,18 @@ function testObjectLike(testCases: TestCase[]) {
 			});
 		});
 
-		// Enumerates keys configured as 'enumerable: true' (both own and inherited.)
+		// Validate that root.toString() === initialTree.toString()
+		describe(".toString()", () => {
+			// eslint-disable-next-line @typescript-eslint/no-base-to-string
+			test1((subject) => subject.toString());
+		});
+
+		// Validate that root.toLocaleString() === initialTree.toLocaleString()
+		describe(".toLocaleString()", () => {
+			test1((subject) => subject.toLocaleString());
+		});
+
+		// Validate that JSON.stringify(root) === JSON.stringify(initialTree)
 		describe("JSON.stringify()", () => {
 			test1((subject) => JSON.stringify(subject));
 		});


### PR DESCRIPTION
Object and list proxies did not correctly include Object.prototype in their inheritance chain.

Consequently, 3rd party code attempting to invoke '.hasOwnProperty' on an Array failed with an undefined reference.