### PR TITLE
Deprecate findTile on sharedString

### DIFF
--- a/.changeset/rare-clouds-see.md
+++ b/.changeset/rare-clouds-see.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/sequence": minor
+---
+
+Deprecation of SharedString.findTile
+
+findTile was previously deprecated on client and mergeTree, but was not on sharedString.

--- a/.changeset/rare-clouds-see.md
+++ b/.changeset/rare-clouds-see.md
@@ -4,4 +4,4 @@
 
 Deprecation of SharedString.findTile
 
-findTile was previously deprecated on client and mergeTree, but was not on sharedString.
+findTile was previously deprecated on client and mergeTree, but was not on sharedString. Usage is mostly the same, with the exception that the parameter 'startPos' must be a number and cannot be undefined. 

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -628,6 +628,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     annotateMarker(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): void;
     annotateMarkerNotifyConsensus(marker: Marker, props: PropertySet, callback: (m: Marker) => void): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): SharedString;
+    // @deprecated
     findTile(startPos: number | undefined, tileLabel: string, preceding?: boolean): {
         tile: ReferencePosition;
         pos: number;
@@ -649,6 +650,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     removeText(start: number, end: number): IMergeTreeRemoveMsg;
     replaceText(start: number, end: number, text: string, props?: PropertySet): void;
     protected rollback(content: any, localOpMetadata: unknown): void;
+    searchForMarker(startPos: number | undefined, markerLabel: string, forwards?: boolean): Marker | undefined;
 }
 
 // @public (undocumented)

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -650,7 +650,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     removeText(start: number, end: number): IMergeTreeRemoveMsg;
     replaceText(start: number, end: number, text: string, props?: PropertySet): void;
     protected rollback(content: any, localOpMetadata: unknown): void;
-    searchForMarker(startPos: number | undefined, markerLabel: string, forwards?: boolean): Marker | undefined;
+    searchForMarker(startPos: number, markerLabel: string, forwards?: boolean): Marker | undefined;
 }
 
 // @public (undocumented)

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -120,6 +120,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_SharedString": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -220,6 +220,7 @@ export class SharedString
 	/**
 	 * Finds the nearest reference with ReferenceType.Tile to `startPos` in the direction dictated by `tilePrecedesPos`.
 	 * Note that Markers receive `ReferenceType.Tile` by default.
+	 * @deprecated - Use `searchForMarker` instead.
 	 * @param startPos - Position at which to start the search
 	 * @param clientId - clientId dictating the perspective to search from
 	 * @param tileLabel - Label of the tile to search for
@@ -236,6 +237,22 @@ export class SharedString
 		  }
 		| undefined {
 		return this.client.findTile(startPos ?? 0, tileLabel, preceding);
+	}
+
+	/**
+	 * Searches a string for the nearest marker in either direction to a given start position.
+	 * The search will include the start position, so markers at the start position are valid
+	 * results of the search.
+	 * @param startPos - Position at which to start the search
+	 * @param markerLabel - Label of the marker to search for
+	 * @param forwards - Whether the desired marker comes before (false) or after (true) `startPos`
+	 */
+	public searchForMarker(
+		startPos: number | undefined,
+		markerLabel: string,
+		forwards = true,
+	): Marker | undefined {
+		return this.client.searchForMarker(startPos ?? 0, markerLabel, forwards);
 	}
 
 	/**

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -252,7 +252,7 @@ export class SharedString
 		markerLabel: string,
 		forwards = true,
 	): Marker | undefined {
-		return this.client.searchForMarker(startPos ?? 0, markerLabel, forwards);
+		return this.client.searchForMarker(startPos, markerLabel, forwards);
 	}
 
 	/**

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -248,7 +248,7 @@ export class SharedString
 	 * @param forwards - Whether the desired marker comes before (false) or after (true) `startPos`
 	 */
 	public searchForMarker(
-		startPos: number | undefined,
+		startPos: number,
 		markerLabel: string,
 		forwards = true,
 	): Marker | undefined {

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -991,6 +991,7 @@ declare function get_old_ClassDeclaration_SharedString():
 declare function use_current_ClassDeclaration_SharedString(
     use: TypeOnly<current.SharedString>);
 use_current_ClassDeclaration_SharedString(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SharedString());
 
 /*


### PR DESCRIPTION
findTile was previously deprecated on client and mergeTree in #16517, but was not deprecated on sharedString. This PR fixes the oversight. 