### PR TITLE
Add containerid to environment details so that it can be added to relayUserAgent in IConnect message

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -586,6 +586,7 @@ export class Container
 	private readonly savedOps: ISequencedDocumentMessage[] = [];
 	private baseSnapshot?: ISnapshotTree;
 	private baseSnapshotBlobs?: ISerializableBlobContents;
+	private readonly _containerId: string;
 
 	private lastVisible: number | undefined;
 	private readonly visibilityEventHandler: (() => void) | undefined;
@@ -821,6 +822,8 @@ export class Container
 		const clientType = `${interactive ? "interactive" : "noninteractive"}${
 			type !== undefined && type !== "" ? `/${type}` : ""
 		}`;
+
+		this._containerId = uuid();
 		// Need to use the property getter for docId because for detached flow we don't have the docId initially.
 		// We assign the id later so property getter is used.
 		this.subLogger = createChildLogger({
@@ -828,7 +831,7 @@ export class Container
 			properties: {
 				all: {
 					clientType, // Differentiating summarizer container from main container
-					containerId: uuid(),
+					containerId: this._containerId,
 					docId: () => this.resolvedUrl?.id,
 					containerAttachState: () => this._attachState,
 					containerLifecycleState: () => this._lifecycleState,
@@ -2014,6 +2017,7 @@ export class Container
 		client.details.environment = [
 			client.details.environment,
 			` loaderVersion:${pkgVersion}`,
+			` containerId:${this._containerId}`,
 		].join(";");
 		return client;
 	}


### PR DESCRIPTION
## Description

Ado item link: https://dev.azure.com/fluidframework/internal/_workitems/edit/5918
Add containerid to environment details so that it can be added to relayUserAgent in IConnect message. This will help to relate the container instance for debugging purposes. 