### PR TITLE
feat(fluid-build): Release group root script support

### DIFF
--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -122,8 +122,8 @@ Note that --symlink\* changes any symlink, the tool will run the clean script fo
 ### Task and dependency definition
 
 `fluid-build` uses task and dependency definitions to construct a build graph. It is used to determine which task and
-the order to run in. The default definitions are located in at the root `fluidBuild.config.cjs` file under the `tasks` property.
-This definitions applies to all packages in the repo. Script tasks and dependencies specified in this default definitions
+the order to run in. The default definitions for packages are located in at the root `fluidBuild.config.cjs` file under the `tasks` property.
+This definitions applies to all packages in the repo (but not release group root). Script tasks and dependencies specified in this default definitions
 doesn't have to appear on every package and will be ignored if it is not found.
 
 The task definitions is an object with task names as keys, the task dependencies and config to define the action of the task.
@@ -169,6 +169,14 @@ For example:
 	}
 }
 ```
+
+When building release group, by default, it will trigger the task on all the packages within the release group.  That also mean
+that scripts at the release group root is not considered. 
+
+Release group root scripts support can be enabled by adding `fluidBuild.tasks` to the release group's `package.json`.  `fluid-build`
+ will follow the definition if specified for the task, or it will trigger the root script if the script isn't invoke `fluid-build`.
+Otherwise, (if the script doesn't exist or if it starts with `fluid-build`) it is go back to the original default of trigger the task 
+on all the packages within the release group. Global definitions in `fluidBuild.config.cjs` doesn't apply to the release group root.
 
 ### Concurrency
 

--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -175,9 +175,8 @@ that scripts at the release group root is not considered.
 
 Release group root scripts support can be enabled by adding `fluidBuild.tasks` to the release group's `package.json`. `fluid-build`
 will follow the definition if specified for the task, or it will trigger the root script if the script doesn't invoke `fluid-build`.
-Otherwise, (if the script doesn't exist or if it starts with `fluid-build`), it is go back to the original default to trigger the task
-on all the packages within the release group. There is no global definitions support and definitions in `fluidBuild.config.cjs` only
-applies to packages, and not release group root.
+If the script doesn't exist or if it starts with `fluid-build`, then fluid-build will fall back to the default behavior of triggering the task
+on all the packages within the release group. There is no support for "global definitions." Task definitions in `fluidBuild.config.cjs` only apply to packages, not release group roots. Release group root scripts must be defined in the `fluidBuild.tasks` section of the root's `package.json`.
 
 ### Concurrency
 

--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -170,13 +170,14 @@ For example:
 }
 ```
 
-When building release group, by default, it will trigger the task on all the packages within the release group.  That also mean
-that scripts at the release group root is not considered. 
+When building release group, by default, it will trigger the task on all the packages within the release group. That also mean
+that scripts at the release group root is not considered.
 
-Release group root scripts support can be enabled by adding `fluidBuild.tasks` to the release group's `package.json`.  `fluid-build`
- will follow the definition if specified for the task, or it will trigger the root script if the script isn't invoke `fluid-build`.
-Otherwise, (if the script doesn't exist or if it starts with `fluid-build`) it is go back to the original default of trigger the task 
-on all the packages within the release group. Global definitions in `fluidBuild.config.cjs` doesn't apply to the release group root.
+Release group root scripts support can be enabled by adding `fluidBuild.tasks` to the release group's `package.json`. `fluid-build`
+will follow the definition if specified for the task, or it will trigger the root script if the script doesn't invoke `fluid-build`.
+Otherwise, (if the script doesn't exist or if it starts with `fluid-build`), it is go back to the original default to trigger the task
+on all the packages within the release group. There is no global definitions support and definitions in `fluidBuild.config.cjs` only
+applies to packages, and not release group root.
 
 ### Concurrency
 

--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -171,7 +171,7 @@ For example:
 ```
 
 When building release group, by default, it will trigger the task on all the packages within the release group. That also mean
-that scripts at the release group root is not considered.
+that scripts at the release group root are not considered.
 
 Release group root scripts support can be enabled by adding `fluidBuild.tasks` to the release group's `package.json`. `fluid-build`
 will follow the definition if specified for the task, or it will trigger the root script if the script doesn't invoke `fluid-build`.

--- a/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
@@ -137,19 +137,25 @@ export function getTaskDefinitions(
 		for (const name in packageTaskDefinitions) {
 			const config = packageTaskDefinitions[name];
 			const full = getFullTaskConfig(config);
-			if (full.script && json.scripts?.[name] === undefined) {
-				throw new Error(`Script not found for task definition '${name}'`);
+			if (full.script) {
+				const script = json.scripts?.[name];
+				if (script === undefined) {
+					throw new Error(`Script not found for task definition '${name}'`);
+				} else if (script.startsWith("fluid-build ")) {
+					throw new Error(`Script task should not invoke 'fluid-build' in '${name}'`);
+				}
 			}
 
+			const currentTaskConfig = taskConfig[name];
 			const dependsOn = full.dependsOn.filter((value) => value !== "...");
-			if (taskConfig[name] !== undefined && dependsOn.length !== full.dependsOn.length) {
-				full.dependsOn = dependsOn.concat(taskConfig[name].dependsOn);
+			if (currentTaskConfig !== undefined && dependsOn.length !== full.dependsOn.length) {
+				full.dependsOn = dependsOn.concat(currentTaskConfig.dependsOn);
 			} else {
 				full.dependsOn = dependsOn;
 			}
 			const before = full.before.filter((value) => value !== "...");
-			if (taskConfig[name] !== undefined && before.length !== full.before.length) {
-				full.before = before.concat(taskConfig[name].before);
+			if (currentTaskConfig !== undefined && before.length !== full.before.length) {
+				full.before = before.concat(currentTaskConfig.before);
 			} else {
 				full.before = before;
 			}

--- a/build-tools/packages/build-tools/src/common/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/common/gitRepo.ts
@@ -208,7 +208,10 @@ export class GitRepo {
 	 * Returns an array containing all the modified files in the repo.
 	 */
 	public async getModifiedFiles(): Promise<string[]> {
-		const results = await this.exec(`ls-files -m --deduplicate`, `get modified files`);
+		const results = await this.exec(
+			`ls-files -mo --exclude-standard --deduplicate`,
+			`get modified files`,
+		);
 		return results.split("\n").filter((t) => t !== undefined && t !== "" && t !== null);
 	}
 

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -123,7 +123,7 @@ export class Package {
 	 * The name of the package including the scope.
 	 */
 	public get name(): string {
-		return this.packageJson.name;
+		return this.isReleaseGroupRoot ? `[group]${this.monoRepo!.kind}` : this.packageJson.name;
 	}
 
 	/**

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -123,8 +123,7 @@ export class Package {
 	 * The name of the package including the scope.
 	 */
 	public get name(): string {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this.isReleaseGroupRoot ? `[group]${this.monoRepo!.kind}` : this.packageJson.name;
+		return this.packageJson.name;
 	}
 
 	/**

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -123,6 +123,7 @@ export class Package {
 	 * The name of the package including the scope.
 	 */
 	public get name(): string {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		return this.isReleaseGroupRoot ? `[group]${this.monoRepo!.kind}` : this.packageJson.name;
 	}
 

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -111,7 +111,7 @@ export class BuildPackage {
 	private getTaskDefinition(taskName: string) {
 		let taskDefinition = this._taskDefinitions[taskName];
 		if (taskDefinition === undefined && this.pkg.isReleaseGroupRoot) {
-			// Only enable release group root script if it is explicitly defined, for places that hasn't migrated to to use it yet
+			// Only enable release group root script if it is explicitly defined, for places that don't use it yet
 			const script = this.pkg.getScript(taskName);
 			if (
 				this.pkg.packageJson.fluidBuild?.tasks === undefined ||

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -240,6 +240,7 @@ export class BuildPackage {
 			}
 			if (taskConfig.before.includes("*")) {
 				this.tasks.forEach((depTask) => {
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					if (depTask !== task && !task.dependentTasks!.includes(depTask)) {
 						traceTaskDepTask(`${depTask.nameColored} -> ${task.nameColored}`);
 						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -71,6 +71,8 @@ export class BuildPackage {
 	public readonly dependentPackages = new Array<BuildPackage>();
 	public level: number = -1;
 	private buildP?: Promise<BuildResult>;
+
+	// This field shouldn't be used directly, use getTaskDefinition instead
 	private readonly _taskDefinitions: TaskDefinitions;
 
 	constructor(

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -242,9 +242,11 @@ export class BuildPackage {
 			}
 			if (taskConfig.before.includes("*")) {
 				this.tasks.forEach((depTask) => {
+					// initializeDependentTask should have been called on all the task already
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					if (depTask !== task && !task.dependentTasks!.includes(depTask)) {
 						traceTaskDepTask(`${depTask.nameColored} -> ${task.nameColored}`);
+						// initializeDependentTask should have been called on all the task already
 						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 						depTask.dependentTasks!.push(task);
 					}
@@ -256,6 +258,7 @@ export class BuildPackage {
 						continue;
 					}
 					traceTaskDepTask(`${depTask.nameColored} -> ${task.nameColored}`);
+					// initializeDependentTask should have been called on all the task already
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					depTask.dependentTasks!.push(task);
 				}

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -69,12 +69,14 @@ export class FluidRepoBuild extends FluidRepo {
 				matched = true;
 			});
 
-			options.releaseGroups.forEach((releaseGroup) => {
-				if (!this.matchWithFilter((pkg) => pkg.monoRepo?.kind === releaseGroup)) {
+			options.releaseGroups.forEach((releaseGroupName) => {
+				const releaseGroup = this.releaseGroups.get(releaseGroupName);
+				if (!releaseGroup) {
 					throw new Error(
-						`Release group '${releaseGroup}' specified is not defined in the repo.`,
+						`Release group '${releaseGroupName}' specified is not defined in the repo.`,
 					);
 				}
+				this.setMatchedReleaseGroup(releaseGroup);
 				matched = true;
 			});
 			return matched;
@@ -127,6 +129,7 @@ export class FluidRepoBuild extends FluidRepo {
 	public createBuildGraph(options: ISymlinkOptions, buildTargetNames: string[]) {
 		return new BuildGraph(
 			this.createPackageMap(),
+			this.getReleaseGroupPackages(),
 			buildTargetNames,
 			getFluidBuildConfig(this.resolvedRoot)?.tasks,
 			(pkg: Package) => {
@@ -135,6 +138,14 @@ export class FluidRepoBuild extends FluidRepo {
 				};
 			},
 		);
+	}
+
+	private getReleaseGroupPackages() {
+		const releaseGroupPackages: Package[] = [];
+		for (const releaseGroup of this.releaseGroups.values()) {
+			releaseGroupPackages.push(releaseGroup.pkg);
+		}
+		return releaseGroupPackages;
 	}
 
 	private matchWithFilter(callback: (pkg: Package) => boolean) {
@@ -148,7 +159,7 @@ export class FluidRepoBuild extends FluidRepo {
 		return matched;
 	}
 
-	private setMatchedDir(dir: string, matchMonoRepo: boolean) {
+	private setMatchedDir(dir: string, matchReleaseGroup: boolean) {
 		const pkgDir = lookUpDirSync(dir, (currentDir) => {
 			return existsSync(path.join(currentDir, "package.json"));
 		});
@@ -156,10 +167,14 @@ export class FluidRepoBuild extends FluidRepo {
 			throw new Error(`Unable to look up package in directory '${dir}'.`);
 		}
 
-		for (const monoRepo of this.releaseGroups.values()) {
-			if (isSameFileOrDir(monoRepo.repoPath, pkgDir)) {
-				log(`Release group ${chalk.cyanBright(monoRepo.kind)} matched (directory: ${dir})`);
-				this.setMatchedMonoRepo(monoRepo);
+		for (const releaseGroup of this.releaseGroups.values()) {
+			if (isSameFileOrDir(releaseGroup.repoPath, pkgDir)) {
+				log(
+					`Release group ${chalk.cyanBright(
+						releaseGroup.kind,
+					)} matched (directory: ${dir})`,
+				);
+				this.setMatchedReleaseGroup(releaseGroup);
 				return;
 			}
 		}
@@ -173,23 +188,21 @@ export class FluidRepoBuild extends FluidRepo {
 			);
 		}
 
-		if (matchMonoRepo && foundPackage.monoRepo !== undefined) {
+		if (matchReleaseGroup && foundPackage.monoRepo !== undefined) {
 			log(
 				`\tRelease group ${chalk.cyanBright(
 					foundPackage.monoRepo.kind,
 				)} matched (directory: ${dir})`,
 			);
-			this.setMatchedMonoRepo(foundPackage.monoRepo);
+			this.setMatchedReleaseGroup(foundPackage.monoRepo);
 		} else {
 			log(`\t${foundPackage.nameColored} matched (${dir})`);
 			this.setMatchedPackage(foundPackage);
 		}
 	}
 
-	private setMatchedMonoRepo(monoRepo: MonoRepo) {
-		if (!this.matchWithFilter((pkg) => MonoRepo.isSame(pkg.monoRepo, monoRepo))) {
-			throw new Error(`Release group '${monoRepo.kind}' does not have any packages`);
-		}
+	private setMatchedReleaseGroup(monoRepo: MonoRepo) {
+		this.setMatchedPackage(monoRepo.pkg);
 	}
 
 	private setMatchedPackage(pkg: Package) {

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -71,7 +71,7 @@ export class FluidRepoBuild extends FluidRepo {
 
 			options.releaseGroups.forEach((releaseGroupName) => {
 				const releaseGroup = this.releaseGroups.get(releaseGroupName);
-				if (!releaseGroup) {
+				if (releaseGroup === undefined) {
 					throw new Error(
 						`Release group '${releaseGroupName}' specified is not defined in the repo.`,
 					);

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -70,7 +70,7 @@ export class FlubCheckPolicyTask extends LeafWithDoneFileTask {
 		);
 		// We are using the "commit" as a summary of the state of unchanged files to speed this up
 		// However, that would mean that the task will activated when the commit is made or file
-		// is stage, even when the file content didn't change.
+		// is staged, even when the file content didn't change.
 		// We probably can do some more complicated but more precise if there are significant benefits.
 		return JSON.stringify({
 			commit: await gitRepo.getCurrentSha(),

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -63,7 +63,9 @@ export class FlubCheckPolicyTask extends LeafWithDoneFileTask {
 		const fileHashP = Promise.all(
 			modifiedFiles.map(async (file) => [
 				file,
-				await this.node.buildContext.fileHashCache.getFileHash(file),
+				await this.node.buildContext.fileHashCache.getFileHash(
+					this.getPackageFileFullPath(file),
+				),
 			]),
 		);
 		// We are using the "commit" as a summary of the state of unchanged files to speed this up

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -43,6 +43,7 @@ export class FlubCheckLayerTask extends LeafWithDoneFileTask {
 		const infoFilePath = path.join(this.node.pkg.directory, infoFile);
 		return existsSync(infoFilePath) ? readFileAsync(infoFilePath) : undefined;
 	}
+
 	public async getDoneFileContent(): Promise<string | undefined> {
 		const layerInfoFile = await this.getLayerInfoFile();
 		return layerInfoFile

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -67,7 +67,9 @@ export class FlubCheckPolicyTask extends LeafWithDoneFileTask {
 			]),
 		);
 		// We are using the "commit" as a summary of the state of unchanged files to speed this up
-		// However, that would mean that it will break incremental for this task when committed.
+		// However, that would mean that the task will activated when the commit is made or file
+		// is stage, even when the file content didn't change.
+		// We probably can do some more complicated but more precise if there are significant benefits.
 		return JSON.stringify({
 			commit: await gitRepo.getCurrentSha(),
 			modifiedFiles: await fileHashP,

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -1,0 +1,76 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { existsSync } from "fs";
+import { LeafWithDoneFileTask } from "./leafTask";
+import path from "path";
+import { readFileAsync } from "../../../common/utils";
+import { GitRepo } from "../../../common/gitRepo";
+
+export class FlubListTask extends LeafWithDoneFileTask {
+	private getResourceGroup() {
+		const split = this.command.split(" ");
+		const index = split.indexOf("-g");
+		return index >= 0 ? split[index + 1] : undefined;
+	}
+	public async getDoneFileContent(): Promise<string | undefined> {
+		const resourceGroup = this.getResourceGroup();
+		if (resourceGroup === undefined) {
+			return undefined;
+		}
+		const packages = Array.from(this.node.buildContext.repoPackageMap.values()).filter(
+			(pkg) => pkg.monoRepo?.kind === resourceGroup,
+		);
+		if (packages.length === 0) {
+			return undefined;
+		}
+		return JSON.stringify(packages.map((pkg) => [pkg.name, pkg.packageJson]));
+	}
+}
+
+export class FlubCheckLayerTask extends LeafWithDoneFileTask {
+	private async getLayerInfoFile() {
+		const split = this.command.split(" ");
+		const index = split.indexOf("--info");
+		if (index < 0) {
+			return undefined;
+		}
+		const infoFile = split[index + 1];
+		if (infoFile === undefined) {
+			return undefined;
+		}
+		const infoFilePath = path.join(this.node.pkg.directory, infoFile);
+		return existsSync(infoFilePath) ? readFileAsync(infoFilePath) : undefined;
+	}
+	public async getDoneFileContent(): Promise<string | undefined> {
+		const layerInfoFile = await this.getLayerInfoFile();
+		return layerInfoFile
+			? JSON.stringify({
+					layerInfo: layerInfoFile,
+					packageJson: Array.from(this.node.buildContext.repoPackageMap.values()).map(
+						(pkg) => pkg.packageJson,
+					),
+			  })
+			: undefined;
+	}
+}
+
+export class FlubCheckPolicyTask extends LeafWithDoneFileTask {
+	public async getDoneFileContent(): Promise<string | undefined> {
+		const gitRepo = new GitRepo(this.node.pkg.directory);
+		const modifiedFiles = await gitRepo.getModifiedFiles();
+		const fileHashP = Promise.all(
+			modifiedFiles.map(async (file) => [
+				file,
+				await this.node.buildContext.fileHashCache.getFileHash(file),
+			]),
+		);
+		// We are using the "commit" as a summary of the state of unchanged files to speed this up
+		// However, that would mean that it will break incremental for this task when committed.
+		return JSON.stringify({
+			commit: await gitRepo.getCurrentSha(),
+			modifiedFiles: await fileHashP,
+		});
+	}
+}

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -11,8 +11,13 @@ import { GitRepo } from "../../../common/gitRepo";
 export class FlubListTask extends LeafWithDoneFileTask {
 	private getResourceGroup() {
 		const split = this.command.split(" ");
-		const index = split.indexOf("-g");
-		return index >= 0 ? split[index + 1] : undefined;
+		for (let i = 0; i < split.length; i++) {
+			const arg = split[i];
+			if (arg === "-g" || arg === "--releaseGroup") {
+				return split[i + 1];
+			}
+		}
+		return undefined;
 	}
 	public async getDoneFileContent(): Promise<string | undefined> {
 		const resourceGroup = this.getResourceGroup();

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -455,7 +455,7 @@ export abstract class LeafWithDoneFileTask extends LeafTask {
 		const doneFileFullPath = this.doneFileFullPath;
 		try {
 			const doneFileExpectedContent = await this.getDoneFileContent();
-			if (doneFileExpectedContent) {
+			if (doneFileExpectedContent !== undefined) {
 				const doneFileContent = await readFileAsync(doneFileFullPath, "utf8");
 				if (doneFileContent === doneFileExpectedContent) {
 					return true;
@@ -476,7 +476,7 @@ export abstract class LeafWithDoneFileTask extends LeafTask {
 	 * Subclass could override this to provide an alternative done file name
 	 */
 	protected get doneFile(): string {
-		const name = path.parse(this.executable).name;
+		const name = path.parse(this.executable).name.replace(/\s/g, "_");
 		// use 8 char of the sha256 hash of the command to distinguish different tasks
 		const hash = crypto.createHash("sha256").update(this.command).digest("hex").substring(0, 8);
 		return `${name}-${hash}.done.build.log`;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -20,6 +20,7 @@ import { TscTask } from "./leaf/tscTask";
 import { WebpackTask } from "./leaf/webpackTask";
 import { GroupTask } from "./groupTask";
 import { Task } from "./task";
+import { FlubListTask, FlubCheckLayerTask, FlubCheckPolicyTask } from "./leaf/flubTasks";
 
 // Map of executable name to LeafTasks
 const executableToLeafTask: {
@@ -37,6 +38,9 @@ const executableToLeafTask: {
 	"gen-version": GenVerTask,
 	"gf": GoodFence,
 	"api-extractor": ApiExtractorTask,
+	"flub list": FlubListTask,
+	"flub check layers": FlubCheckLayerTask,
+	"flub check policy": FlubCheckPolicyTask,
 	"flub generate typetests": TypeValidationTask,
 	"fluid-type-test-generator": TypeValidationTask,
 };

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -1079,7 +1079,7 @@ export const handlers: Handler[] = [
 			const cleanScript = scripts.clean;
 			if (cleanScript) {
 				// Ignore clean scripts that are root of the release group
-				if (cleanScript.startsWith("pnpm")) {
+				if (cleanScript.startsWith("pnpm") || cleanScript.startsWith("fluid-build")) {
 					return undefined;
 				}
 


### PR DESCRIPTION
Allow specifying task in the release group root and allow root script to be invoked.

- Change the mono repo to load the `package.json` file as if it is a package.
- Depends on all the package in the release group for the root package in the build graph.
- Add default task definitions to for release group root if the name doesn't exist as a script, or the script starts with "fluid-build" to just trigger the task of the same name within the release group.
- Add incremental support for `flub list`, `flub check layer` and `flub check policy`
- More argument support for `copyfile` task.
- See #17837 on enable root script for the client release group (can't do it in one go because we need to merge and release a new version first)