### PR TITLE
GC: Do not throw when loading a DDS that is Inactive or Tombstoned.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1778,7 +1778,10 @@ export class ContainerRuntime
 					  }
 					: create404Response(request);
 			} else if (requestParser.pathParts.length > 0) {
-				const dataStore = await this.getDataStoreFromRequest(id, request);
+				// Differentiate between requesting the dataStore directly, or one of its children
+				const requestForChild = !requestParser.isLeaf(1);
+				const dataStore = await this.getDataStoreFromRequest(id, request, requestForChild);
+
 				const subRequest = requestParser.createSubRequest(1);
 				// We always expect createSubRequest to include a leading slash, but asserting here to protect against
 				// unintentionally modifying the url if that changes.
@@ -1811,6 +1814,7 @@ export class ContainerRuntime
 	private async getDataStoreFromRequest(
 		id: string,
 		request: IRequest,
+		requestForChild: boolean,
 	): Promise<IFluidDataStoreChannel> {
 		const headerData: RuntimeHeaderData = {};
 		if (typeof request.headers?.[RuntimeHeaders.wait] === "boolean") {
@@ -1821,6 +1825,11 @@ export class ContainerRuntime
 		}
 		if (typeof request.headers?.[AllowTombstoneRequestHeaderKey] === "boolean") {
 			headerData.allowTombstone = request.headers[AllowTombstoneRequestHeaderKey];
+		}
+
+		// We allow Tombstone requests for sub-DataStore objects
+		if (requestForChild) {
+			headerData.allowTombstone = true;
 		}
 
 		await this.dataStores.waitIfPendingAlias(id);

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -881,8 +881,11 @@ export class GarbageCollector implements IGarbageCollector {
 			viaHandle: requestHeaders?.[RuntimeHeaders.viaHandle],
 		});
 
-		// Unless this is a Loaded event, we're done after telemetry tracking
-		if (reason !== "Loaded") {
+		// Unless this is a Loaded event for a Blob or DataStore, we're done after telemetry tracking
+		if (
+			reason !== "Loaded" ||
+			![GCNodeType.Blob, GCNodeType.DataStore].includes(this.runtime.getNodeType(nodePath))
+		) {
 			return;
 		}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -442,7 +442,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 			);
 
 			itExpects(
-				"throwOnInactiveLoad: true; DDS handle.get -- throws but DOESN'T log",
+				"throwOnInactiveLoad: true; DDS handle.get -- Doesn't throw, and DOESN'T log",
 				[
 					// Bug: It SHOULD actually log
 					// {
@@ -502,20 +502,13 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 						defaultDataStoreContainer2._context.IFluidHandleContext, // yields the ContaineRuntime's handleContext
 						ddsUrl,
 					);
-					try {
-						// This throws because the DataStore is inactive and throwOnInactiveLoad is set
-						await handle.get();
-						assert.fail("Expected handle.get to throw");
-					} catch (error: any) {
-						const inactiveError: InactiveLoadError | undefined = error;
-						assert.equal(inactiveError?.code, 404, "Incorrect error status code");
-						assert.equal(inactiveError?.message, `Object is inactive: ${ddsUrl}`);
-						assert.equal(
-							inactiveError?.underlyingResponseHeaders?.[InactiveResponseHeaderKey],
-							true,
-							"Inactive error from handle.get should include the tombstone flag",
-						);
-					}
+
+					// Even though the DataStore is inactive and throwOnInactiveLoad is set, we don't throw for DDSes for ease of use
+					await assert.doesNotReject(
+						async () => handle.get(),
+						"handle.get() for the DDS should not throw",
+					);
+
 					// Bug: It SHOULD actually log
 					// mockLogger.assertMatch(
 					// 	[

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -435,7 +435,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				const { unreferencedId, summarizingContainer, summarizer } =
 					await summarizationWithUnreferencedDataStoreAfterTime(
 						sweepTimeoutMs,
-						/*includeDds*/ true,
+						/* includeDds */ true,
 					);
 				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 


### PR DESCRIPTION
## Description

Fixes [AB#5953](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5953)

Some early adopters of GC are utilizing the `allowTombstone` header (and something similar for InactiveObject) to take control of how they interact with Tombstoned objects.

They found that while this technique allows them to get at a DataStore-level object, there are some flows where that triggers the load of a DDS via handle.get, which fails.

And since GC Mark happens at DataStore granularity, we are no longer going to enforce Tombstone (or Inactive) state when directly loading a DDS.  (Implication is that an app trying to leverage Tombstone state will miss out on this detection if ever a DDS is loaded directly before its DataStore was loaded).
