### PR TITLE
Event Hubs message broker migration support

### DIFF
--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="mocha" />
+
 // @public (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @public (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -378,6 +378,7 @@ export interface ISession {
     historianUrl: string;
     isSessionActive: boolean;
     isSessionAlive: boolean;
+    messageBrokerId?: string;
     ordererUrl: string;
 }
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -63,6 +63,13 @@ export function create(
 	const externalHistorianUrl: string = config.get("worker:blobStorageUrl");
 	const externalDeltaStreamUrl: string =
 		config.get("worker:deltaStreamUrl") || externalOrdererUrl;
+	const messageBrokerId: string | undefined =
+		config.get("kafka:lib:eventHubConnString") !== undefined
+			? crypto
+					.createHash("sha1")
+					.update(config.get("kafka:lib:endpoint") ?? "")
+					.digest("hex")
+			: undefined;
 	const sessionStickinessDurationMs: number | undefined = config.get(
 		"alfred:sessionStickinessDurationMs",
 	);
@@ -201,6 +208,7 @@ export function create(
 				values,
 				enableDiscovery,
 				isEphemeral,
+				messageBrokerId,
 			);
 
 			// Handle backwards compatibility for older driver versions.
@@ -227,6 +235,8 @@ export function create(
 						isSessionAlive: false,
 						isSessionActive: false,
 					};
+					// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
+					if (messageBrokerId) session.messageBrokerId = messageBrokerId;
 					responseBody.session = session;
 				}
 				handleResponse(
@@ -275,6 +285,7 @@ export function create(
 				documentId,
 				documentRepository,
 				sessionStickinessDurationMs,
+				messageBrokerId,
 			);
 			handleResponse(session, response, false);
 		},

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -236,7 +236,9 @@ export function create(
 						isSessionActive: false,
 					};
 					// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
-					if (messageBrokerId) session.messageBrokerId = messageBrokerId;
+					if (messageBrokerId) {
+						session.messageBrokerId = messageBrokerId;
+					}
 					responseBody.session = session;
 				}
 				handleResponse(

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -161,7 +161,9 @@ async function updateExistingSession(
 		isSessionActive: false,
 	};
 	// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
-	if (updatedMessageBrokerId) updatedSession.messageBrokerId = updatedMessageBrokerId;
+	if (updatedMessageBrokerId) {
+		updatedSession.messageBrokerId = updatedMessageBrokerId;
+	}
 	try {
 		const result = await documentRepository.findOneAndUpdate(
 			{

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -21,6 +21,7 @@ async function createNewSession(
 	documentId,
 	documentRepository: IDocumentRepository,
 	lumberjackProperties: Record<string, any>,
+	messageBrokerId?: string,
 ): Promise<ISession> {
 	const newSession: ISession = {
 		ordererUrl,
@@ -29,6 +30,8 @@ async function createNewSession(
 		isSessionAlive: true,
 		isSessionActive: false,
 	};
+	// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
+	if (messageBrokerId) newSession.messageBrokerId = messageBrokerId;
 	try {
 		await documentRepository.updateOne(
 			{
@@ -73,12 +76,14 @@ async function updateExistingSession(
 	documentRepository: IDocumentRepository,
 	sessionStickinessDurationMs: number,
 	lumberjackProperties: Record<string, any>,
+	messageBrokerId?: string,
 ): Promise<ISession> {
 	let updatedDeli: string | undefined;
 	let updatedScribe: string | undefined;
 	let updatedOrdererUrl: string | undefined;
 	let updatedHistorianUrl: string | undefined;
 	let updatedDeltaStreamUrl: string | undefined;
+	let updatedMessageBrokerId: string | undefined = existingSession.messageBrokerId;
 	// Session stickiness keeps the a given document in 1 location for the configured
 	// stickiness duration after the session ends. In the case of periodic op backup, this can ensure
 	// that ops are backed up to a global location before a session is allowed to move.
@@ -108,7 +113,8 @@ async function updateExistingSession(
 		if (
 			existingSession.ordererUrl !== ordererUrl ||
 			existingSession.historianUrl !== historianUrl ||
-			existingSession.deltaStreamUrl !== deltaStreamUrl
+			existingSession.deltaStreamUrl !== deltaStreamUrl ||
+			existingSession.messageBrokerId !== messageBrokerId
 		) {
 			// Previous session was in a different location. Move to current location.
 			// Reset logOffset, ordererUrl, and historianUrl when moving session location.
@@ -120,12 +126,14 @@ async function updateExistingSession(
 					ordererUrl: existingSession.ordererUrl,
 					historianUrl: existingSession.historianUrl,
 					deltaStreamUrl: existingSession.deltaStreamUrl,
+					messageBrokerId: existingSession.messageBrokerId,
 				},
-				newSessionLocation: { ordererUrl, historianUrl, deltaStreamUrl },
+				newSessionLocation: { ordererUrl, historianUrl, deltaStreamUrl, messageBrokerId },
 			});
 			updatedOrdererUrl = ordererUrl;
 			updatedHistorianUrl = historianUrl;
 			updatedDeltaStreamUrl = deltaStreamUrl;
+			updatedMessageBrokerId = messageBrokerId;
 			if (document.deli !== "") {
 				const deli = JSON.parse(document.deli);
 				deli.logOffset = -1;
@@ -150,6 +158,8 @@ async function updateExistingSession(
 		// If session was not alive, it cannot be "active"
 		isSessionActive: false,
 	};
+	// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
+	if (updatedMessageBrokerId) updatedSession.messageBrokerId = updatedMessageBrokerId;
 	try {
 		const result = await documentRepository.findOneAndUpdate(
 			{
@@ -251,6 +261,7 @@ export async function getSession(
 	documentId: string,
 	documentRepository: IDocumentRepository,
 	sessionStickinessDurationMs: number = defaultSessionStickinessDurationMs,
+	messageBrokerId?: string,
 ): Promise<ISession> {
 	const lumberjackProperties = getLumberBaseProperties(documentId, tenantId);
 
@@ -275,6 +286,7 @@ export async function getSession(
 			documentId,
 			documentRepository,
 			lumberjackProperties,
+			messageBrokerId,
 		);
 		return convertSessionToFreshSession(newSession, lumberjackProperties);
 	}
@@ -296,6 +308,7 @@ export async function getSession(
 		documentRepository,
 		sessionStickinessDurationMs,
 		lumberjackProperties,
+		messageBrokerId,
 	);
 	return convertSessionToFreshSession(updatedSession, lumberjackProperties);
 }

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -31,7 +31,9 @@ async function createNewSession(
 		isSessionActive: false,
 	};
 	// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
-	if (messageBrokerId) newSession.messageBrokerId = messageBrokerId;
+	if (messageBrokerId) {
+		newSession.messageBrokerId = messageBrokerId;
+	}
 	try {
 		await documentRepository.updateOne(
 			{

--- a/server/routerlicious/packages/services-client/src/interfaces.ts
+++ b/server/routerlicious/packages/services-client/src/interfaces.ts
@@ -25,6 +25,10 @@ export interface ISession {
 	 */
 	historianUrl: string;
 	/**
+	 * Message broker ID of the session
+	 */
+	messageBrokerId?: string;
+	/**
 	 * Whether session is "alive".
 	 * Session is considered alive if it has been "discovered" via the HTTP endpoint
 	 * for session discovery, or via document creation. A session being "alive"

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -53,6 +53,7 @@ export interface IDocumentStorage {
 		values: [string, ICommittedProposal][],
 		enableDiscovery: boolean,
 		isEphemeralContainer: boolean,
+		messageBrokerId?: string,
 	): Promise<IDocumentDetails>;
 }
 

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -257,7 +257,9 @@ export class DocumentStorage implements IDocumentStorage {
 		};
 
 		// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
-		if (messageBrokerId) session.messageBrokerId = messageBrokerId;
+		if (messageBrokerId) {
+			session.messageBrokerId = messageBrokerId;
+		}
 
 		Lumberjack.info(
 			`Create session with enableDiscovery as ${enableDiscovery}: ${JSON.stringify(session)}`,

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -129,6 +129,7 @@ export class DocumentStorage implements IDocumentStorage {
 		values: [string, ICommittedProposal][],
 		enableDiscovery: boolean = false,
 		isEphemeralContainer: boolean = false,
+		messageBrokerId?: string,
 	): Promise<IDocumentDetails> {
 		const storageName = await this.storageNameAssigner?.assign(tenantId, documentId);
 		const gitManager = await this.tenantManager.getTenantGitManager(
@@ -254,6 +255,9 @@ export class DocumentStorage implements IDocumentStorage {
 			isSessionAlive: true,
 			isSessionActive: false,
 		};
+
+		// if undefined and added directly to the session object - will be serialized as null in mongo which is undesirable
+		if (messageBrokerId) session.messageBrokerId = messageBrokerId;
 
 		Lumberjack.info(
 			`Create session with enableDiscovery as ${enableDiscovery}: ${JSON.stringify(session)}`,


### PR DESCRIPTION
## Description

Support for Kafka to Event Hubs migration and future EH to EH migrations in FRS.
The change itself is transparent for Kafka and will be changing behavior only in case of Event Hubs activation

## Reviewer Guidance

I had to move messageBrokerId assignment out of ISession object initialization to avoid explicitly assigning "undefined" value right within an object. If you do it, then mongoDB will serialize "undefined" as "null" - which would break the logic for EH migration. It's also possible to provide 'ignoreUndefined: true' option for the mongodb client that fixes the problem, but it could break existing code that might rely on "undefined" being serialized as "null"

Verified session transition scenarios:

- Same FRS cluster: Kafka to Event Hubs, Event Hubs to Kafka, Event Hubs to Event Hubs (different instance)
- Between FRS clusters of the same group: Kafka to Kafka, Kafka to Event Hubs, Event Hubs to Kafka
