### PR TITLE
Mds and other options should be present in querystring

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -508,7 +508,6 @@ export interface ISnapshotRequestAndResponseOptions {
 function getFormBodyAndHeaders(
 	odspResolvedUrl: IOdspResolvedUrl,
 	storageToken: string,
-	snapshotOptions: ISnapshotOptions | undefined,
 	headers?: { [index: string]: string },
 ) {
 	const formBoundary = uuid();
@@ -516,13 +515,7 @@ function getFormBodyAndHeaders(
 	formParams.push(`--${formBoundary}`);
 	formParams.push(`Authorization: Bearer ${storageToken}`);
 	formParams.push(`X-HTTP-Method-Override: GET`);
-	if (snapshotOptions !== undefined) {
-		Object.entries(snapshotOptions).forEach(([key, value]) => {
-			if (value !== undefined) {
-				formParams.push(`${key}: ${value}`);
-			}
-		});
-	}
+
 	if (headers !== undefined) {
 		Object.entries(headers).forEach(([key, value]) => {
 			if (value !== undefined) {
@@ -600,18 +593,25 @@ export async function downloadSnapshot(
 	}
 
 	const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-	const url = `${snapshotUrl}/trees/latest?ump=1`;
+
+	const queryParams = { ump: 1 };
+	if (snapshotOptions !== undefined) {
+		Object.entries(snapshotOptions).forEach(([key, value]) => {
+			// Exclude "timeout" from query string
+			if (value !== undefined && key !== "timeout") {
+				queryParams[key] = value;
+			}
+		});
+	}
+
+	const queryString = getQueryString(queryParams);
+	const url = `${snapshotUrl}/trees/latest${queryString}`;
 	// The location of file can move on Spo in which case server returns 308(Permanent Redirect) error.
 	// Adding below header will make VROOM API return 404 instead of 308 and browser can intercept it.
 	// This error thrown by server will contain the new redirect location. Look at the 404 error parsing
 	// for futher reference here: \packages\utils\odsp-doclib-utils\src\odspErrorUtils.ts
 	const header = { prefer: "manualredirect" };
-	const { body, headers } = getFormBodyAndHeaders(
-		odspResolvedUrl,
-		storageToken,
-		snapshotOptions,
-		header,
-	);
+	const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, storageToken, header);
 	const fetchOptions = {
 		body,
 		headers,


### PR DESCRIPTION
## Description

ADO item: https://dev.azure.com/fluidframework/internal/_workitems/edit/5548
ISnapshotOptions should be present in querystring rather than as form parameters. I ran the stress tests after this change. Seems fine.