### PR TITLE
Expose the parseUrl utility api for loop

### DIFF
--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -92,6 +92,17 @@ export interface ILoaderServices {
 }
 
 // @public (undocumented)
+export interface IParsedUrl {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    path: string;
+    // (undocumented)
+    query: string;
+    version: string | null | undefined;
+}
+
+// @public (undocumented)
 export interface IProtocolHandler extends IProtocolHandler_2 {
     // (undocumented)
     readonly audience: IAudienceOwner;
@@ -124,6 +135,9 @@ export class Loader implements IHostLoader {
     // (undocumented)
     readonly services: ILoaderServices;
 }
+
+// @public
+export function parseIResolvedUrlUrlIntoParts(url: string): IParsedUrl | undefined;
 
 // @public
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -91,13 +91,10 @@ export interface ILoaderServices {
     readonly urlResolver: IUrlResolver;
 }
 
-// @public (undocumented)
+// @public
 export interface IParsedUrl {
-    // (undocumented)
     id: string;
-    // (undocumented)
     path: string;
-    // (undocumented)
     query: string;
     version: string | null | undefined;
 }
@@ -137,9 +134,6 @@ export class Loader implements IHostLoader {
 }
 
 // @public
-export function parseIResolvedUrlUrlIntoParts(url: string): IParsedUrl | undefined;
-
-// @public
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
 
 // @public @deprecated
@@ -147,6 +141,9 @@ export function requestResolvedObjectFromContainer(container: IContainer, header
 
 // @public
 export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger): Promise<T>;
+
+// @public
+export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined;
 
 // @public
 export function waitContainerToCatchUp(container: IContainer): Promise<boolean>;

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -20,4 +20,4 @@ export {
 	resolveWithLocationRedirectionHandling,
 } from "./location-redirection-utilities";
 export { IProtocolHandler, ProtocolHandlerBuilder } from "./protocol";
-export { parseIResolvedUrlUrlIntoParts, IParsedUrl } from "./utils";
+export { tryParseCompatibleResolvedUrl, IParsedUrl } from "./utils";

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -20,3 +20,4 @@ export {
 	resolveWithLocationRedirectionHandling,
 } from "./location-redirection-utilities";
 export { IProtocolHandler, ProtocolHandlerBuilder } from "./protocol";
+export { parseIResolvedUrlUrlIntoParts, IParsedUrl } from "./utils";

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -41,7 +41,7 @@ import {
 } from "@fluidframework/driver-definitions";
 import { IClientDetails } from "@fluidframework/protocol-definitions";
 import { Container, IPendingContainerState } from "./container";
-import { IParsedUrl, parseIResolvedUrlUrlIntoParts } from "./utils";
+import { IParsedUrl, tryParseCompatibleResolvedUrl } from "./utils";
 import { pkgVersion } from "./packageVersion";
 import { ProtocolHandlerBuilder } from "./protocol";
 import { DebugLogger } from "./debugLogger";
@@ -280,7 +280,7 @@ export async function requestResolvedObjectFromContainer(
 	headers?: IRequestHeader,
 ): Promise<IResponse> {
 	ensureResolvedUrlDefined(container.resolvedUrl);
-	const parsedUrl = parseIResolvedUrlUrlIntoParts(container.resolvedUrl.url);
+	const parsedUrl = tryParseCompatibleResolvedUrl(container.resolvedUrl.url);
 
 	if (parsedUrl === undefined) {
 		throw new Error(`Invalid URL ${container.resolvedUrl.url}`);
@@ -422,13 +422,13 @@ export class Loader implements IHostLoader {
 		ensureResolvedUrlDefined(resolvedAsFluid);
 
 		// Parse URL into data stores
-		const parsed = parseIResolvedUrlUrlIntoParts(resolvedAsFluid.url);
+		const parsed = tryParseCompatibleResolvedUrl(resolvedAsFluid.url);
 		if (parsed === undefined) {
 			throw new Error(`Invalid URL ${resolvedAsFluid.url}`);
 		}
 
 		if (pendingLocalState !== undefined) {
-			const parsedPendingUrl = parseIResolvedUrlUrlIntoParts(pendingLocalState.url);
+			const parsedPendingUrl = tryParseCompatibleResolvedUrl(pendingLocalState.url);
 			if (
 				parsedPendingUrl?.id !== parsed.id ||
 				parsedPendingUrl?.path.replace(/\/$/, "") !== parsed.path.replace(/\/$/, "")

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -41,7 +41,7 @@ import {
 } from "@fluidframework/driver-definitions";
 import { IClientDetails } from "@fluidframework/protocol-definitions";
 import { Container, IPendingContainerState } from "./container";
-import { IParsedUrl, parseUrl } from "./utils";
+import { IParsedUrl, parseIResolvedUrlUrlIntoParts } from "./utils";
 import { pkgVersion } from "./packageVersion";
 import { ProtocolHandlerBuilder } from "./protocol";
 import { DebugLogger } from "./debugLogger";
@@ -280,7 +280,7 @@ export async function requestResolvedObjectFromContainer(
 	headers?: IRequestHeader,
 ): Promise<IResponse> {
 	ensureResolvedUrlDefined(container.resolvedUrl);
-	const parsedUrl = parseUrl(container.resolvedUrl.url);
+	const parsedUrl = parseIResolvedUrlUrlIntoParts(container.resolvedUrl.url);
 
 	if (parsedUrl === undefined) {
 		throw new Error(`Invalid URL ${container.resolvedUrl.url}`);
@@ -422,13 +422,13 @@ export class Loader implements IHostLoader {
 		ensureResolvedUrlDefined(resolvedAsFluid);
 
 		// Parse URL into data stores
-		const parsed = parseUrl(resolvedAsFluid.url);
+		const parsed = parseIResolvedUrlUrlIntoParts(resolvedAsFluid.url);
 		if (parsed === undefined) {
 			throw new Error(`Invalid URL ${resolvedAsFluid.url}`);
 		}
 
 		if (pendingLocalState !== undefined) {
-			const parsedPendingUrl = parseUrl(pendingLocalState.url);
+			const parsedPendingUrl = parseIResolvedUrlUrlIntoParts(pendingLocalState.url);
 			if (
 				parsedPendingUrl?.id !== parsed.id ||
 				parsedPendingUrl?.path.replace(/\/$/, "") !== parsed.path.replace(/\/$/, "")

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -55,7 +55,7 @@ export interface IParsedUrl {
  * with urls of type: protocol://<string>/.../..?<querystring>
  * @param url - This is the IResolvedUrl.url part of the resolved url.
  */
-export function parseIResolvedUrlUrlIntoParts(url: string): IParsedUrl | undefined {
+export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined {
 	const parsed = parse(url, true);
 	if (typeof parsed.pathname !== "string") {
 		throw new LoggingError("Failed to parse pathname");

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -23,9 +23,22 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
 	trees: { [path: string]: ISnapshotTreeWithBlobContents };
 }
 
+/**
+ * Interface to represent the parsed parts of IResolvedUrl.url to help
+ * in getting info about different parts of the url.
+ */
 export interface IParsedUrl {
+	/**
+	 * It is combination of tenantid/docId part of the url.
+	 */
 	id: string;
+	/**
+	 * It is the deep link path in the url.
+	 */
 	path: string;
+	/**
+	 * Query string part of the url.
+	 */
 	query: string;
 	/**
 	 * Null means do not use snapshots, undefined means load latest snapshot
@@ -38,6 +51,8 @@ export interface IParsedUrl {
 /**
  * Utility api to parse the IResolvedUrl.url into specific parts like querystring, path to get
  * deep link info etc.
+ * Warning - This function may not be compatible with any Url Resolver's resolved url. It works
+ * with urls of type: protocol://<string>/.../..?<querystring>
  * @param url - This is the IResolvedUrl.url part of the resolved url.
  */
 export function parseIResolvedUrlUrlIntoParts(url: string): IParsedUrl | undefined {

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -35,7 +35,12 @@ export interface IParsedUrl {
 	version: string | null | undefined;
 }
 
-export function parseUrl(url: string): IParsedUrl | undefined {
+/**
+ * Utility api to parse the IResolvedUrl.url into specific parts like querystring, path to get
+ * deep link info etc.
+ * @param url - This is the IResolvedUrl.url part of the resolved url.
+ */
+export function parseIResolvedUrlUrlIntoParts(url: string): IParsedUrl | undefined {
 	const parsed = parse(url, true);
 	if (typeof parsed.pathname !== "string") {
 		throw new LoggingError("Failed to parse pathname");

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -26,6 +26,7 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
 /**
  * Interface to represent the parsed parts of IResolvedUrl.url to help
  * in getting info about different parts of the url.
+ * May not be compatible or relevant for any Url Resolver
  */
 export interface IParsedUrl {
 	/**

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -54,6 +54,7 @@ export interface IParsedUrl {
  * Warning - This function may not be compatible with any Url Resolver's resolved url. It works
  * with urls of type: protocol://<string>/.../..?<querystring>
  * @param url - This is the IResolvedUrl.url part of the resolved url.
+ * @returns The IParsedUrl representing the input URL, or undefined if the format was not supported
  */
 export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined {
 	const parsed = parse(url, true);


### PR DESCRIPTION
## Description

ADO item link: https://dev.azure.com/fluidframework/internal/_workitems/edit/5811/
Expose the parseUrl utility api for loop so that they can use it. Since requestResolvedObjectFromContainer() in loader.ts is deprecated and loop also implement their own routing logic instead of IFluidRouter on container, they can not use this api. In order to request a particular datastore, they need to get the deep link info from the url. That funtionality to get the deep link info from the URL is done in parseURl api present in container loader package. 