### PR TITLE
tree2: DocumentSchema rename

### DIFF
--- a/.changeset/curvy-news-fall.md
+++ b/.changeset/curvy-news-fall.md
@@ -4,3 +4,6 @@
 ---
 
 Rename DocumentSchema to TreeSchema
+
+Rename DocumentSchema to TreeSchema.
+Rename toDocumentSchema to intoSchema.

--- a/.changeset/curvy-news-fall.md
+++ b/.changeset/curvy-news-fall.md
@@ -1,0 +1,6 @@
+---
+"@fluid-experimental/property-shared-tree-interop": minor
+"@fluid-experimental/tree2": minor
+---
+
+Rename DocumentSchema to TreeSchema

--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -38,11 +38,11 @@ const inventorySchema = builder.struct("Contoso:Inventory-1.0.0", {
 type InventoryNode = Typed<typeof inventorySchema>;
 
 // REV: The root inventoryFieldSchema feels extra to me.  Is there a way to omit it?  Something like
-// builder.toDocumentSchema(inventorySchema)
+// builder.intoSchema(inventorySchema)
 const inventoryFieldSchema = SchemaBuilder.required(inventorySchema);
 type InventoryField = Typed<typeof inventoryFieldSchema>;
 
-const schema = builder.toDocumentSchema(inventoryFieldSchema);
+const schema = builder.intoSchema(inventoryFieldSchema);
 
 const newTreeFactory = new TypedTreeFactory({
 	jsonValidator: typeboxValidator,

--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
@@ -24,7 +24,7 @@ export const clientSchema = builder.struct("BubbleBenchAppStateClient-1.0.0", {
 
 export const rootAppStateSchema = SchemaBuilder.sequence(clientSchema);
 
-export const appSchemaData = builder.toDocumentSchema(rootAppStateSchema);
+export const appSchemaData = builder.intoSchema(rootAppStateSchema);
 
 export type Bubble = SchemaAware.TypedNode<typeof bubbleSchema>;
 export type Client = SchemaAware.TypedNode<typeof clientSchema>;

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -16,7 +16,7 @@ export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	parts: builder.sequence(part),
 });
 
-export const schema = builder.toDocumentSchema(inventory);
+export const schema = builder.intoSchema(inventory);
 
 export type InventoryField = Typed<typeof schema.rootFieldSchema>;
 export type Inventory = Typed<typeof inventory>;

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/README.md
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/README.md
@@ -6,7 +6,7 @@ from `PropertyDDS` to the new `SharedTree` DDS (see the
 
 ## Schema converter (runtime)
 
-A [`schema-converter`](./src/schemaConverter.ts) converts a `PropertyDDS` schema template into a [`DocumentSchema`](https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/schemaBuilder.ts) at runtime, so that the resulting schema can be used by the `SharedTree`, for example:
+A [`schema-converter`](./src/schemaConverter.ts) converts a `PropertyDDS` schema template into a [`TreeSchema`](https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/schemaBuilder.ts) at runtime, so that the resulting schema can be used by the `SharedTree`, for example:
 
 ```ts
 PropertyFactory.register(propertyDDSSchemas);

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -359,5 +359,5 @@ export function convertPropertyToSharedTreeSchema<Kind extends FieldKind = Field
 		rootFieldKind,
 		...allowedTypes,
 	);
-	return builder.toDocumentSchema(rootSchema);
+	return builder.intoSchema(rootSchema);
 }

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -320,7 +320,7 @@ export const nodePropertySchema = builtinBuilder.map(
 const builtinLibrary = builtinBuilder.finalize();
 
 /**
- * Creates a DocumentSchema out of PropertyDDS schema templates.
+ * Creates a TreeSchema out of PropertyDDS schema templates.
  * The templates must be registered beforehand using {@link PropertyFactory.register}.
  * @param rootFieldKind - The kind of the root field.
  * @param allowedRootTypes - The types of children nodes allowed for the root field.

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -495,13 +495,6 @@ export type DetachedPlaceUpPath = Brand<Omit<PlaceUpPath, "parent">, "DetachedRa
 export type DetachedRangeUpPath = Brand<Omit<RangeUpPath, "parent">, "DetachedRangeUpPath">;
 
 // @alpha
-export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
-    readonly adapters: Adapters;
-    readonly policy: FullSchemaPolicy;
-    readonly rootFieldSchema: T;
-}
-
-// @alpha
 function downCast<TSchema extends TreeNodeSchema>(schema: TSchema, tree: UntypedTreeCore<any, any>): tree is TypedNode_2<TSchema>;
 
 // @alpha
@@ -1057,7 +1050,7 @@ export interface ISharedTreeBranchView extends ISharedTreeView {
 // @alpha
 export interface ISharedTreeView extends AnchorLocator {
     readonly context: EditableTreeContext;
-    editableTree2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): TypedField<TRoot>;
+    editableTree2<TRoot extends FieldSchema>(viewSchema: TreeSchema<TRoot>): TypedField<TRoot>;
     readonly editor: IDefaultEditBuilder;
     readonly events: ISubscribable<ViewEvents>;
     readonly forest: IForestSubscription;
@@ -1068,7 +1061,7 @@ export interface ISharedTreeView extends AnchorLocator {
     redo(): void;
     get root(): UnwrappedEditableField;
     // (undocumented)
-    root2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): ProxyField<TRoot>;
+    root2<TRoot extends FieldSchema>(viewSchema: TreeSchema<TRoot>): ProxyField<TRoot>;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
     // @deprecated (undocumented)
     schematize<TRoot extends FieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
@@ -1861,7 +1854,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     structRecursive<Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeNodeSchema<`${TScope}.${Name}`, {
         structFields: T;
     }>;
-    toDocumentSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): DocumentSchema<NormalizeField_2<TSchema, TDefaultKind>>;
+    toDocumentSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
 }
 
 // @alpha
@@ -1879,7 +1872,7 @@ export interface SchemaCollection extends StoredSchemaCollection {
 
 // @alpha
 export interface SchemaConfiguration<TRoot extends FieldSchema = FieldSchema> {
-    readonly schema: DocumentSchema<TRoot>;
+    readonly schema: TreeSchema<TRoot>;
 }
 
 // @alpha
@@ -2130,7 +2123,7 @@ export interface TreeContext extends ISubscribable<ForestEvents> {
     // (undocumented)
     readonly nodeKeys: NodeKeys;
     get root(): TreeField;
-    readonly schema: DocumentSchema;
+    readonly schema: TreeSchema;
 }
 
 // @alpha
@@ -2207,6 +2200,13 @@ export interface TreeNodeStoredSchema {
     readonly leafValue?: ValueSchema;
     readonly mapFields?: FieldStoredSchema;
     readonly structFields: ReadonlyMap<FieldKey, FieldStoredSchema>;
+}
+
+// @alpha
+export interface TreeSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
+    readonly adapters: Adapters;
+    readonly policy: FullSchemaPolicy;
+    readonly rootFieldSchema: T;
 }
 
 // @alpha

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1854,7 +1854,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     structRecursive<Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeNodeSchema<`${TScope}.${Name}`, {
         structFields: T;
     }>;
-    toDocumentSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
+    intoSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
 }
 
 // @alpha

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1835,6 +1835,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     }>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<Unenforced<TreeNodeSchema>>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
     finalize(): SchemaLibrary;
+    intoSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
     map<Name extends TName, const T extends MapFieldSchema>(name: Name, fieldSchema: T): TreeNodeSchema<`${TScope}.${Name}`, {
         mapFields: T;
     }>;
@@ -1854,7 +1855,6 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
     structRecursive<Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeNodeSchema<`${TScope}.${Name}`, {
         structFields: T;
     }>;
-    intoSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
 }
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/context.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/context.ts
@@ -15,7 +15,7 @@ import { ISubscribable } from "../../events";
 import { DefaultEditBuilder } from "../default-field-kinds";
 import { NodeKeyIndex, NodeKeyManager } from "../node-key";
 import { FieldGenerator } from "../contextuallyTyped";
-import { DocumentSchema } from "../typed-schema";
+import { TreeSchema } from "../typed-schema";
 import { disposeSymbol, IDisposable } from "../../util";
 import { TreeField } from "./editableTreeTypes";
 import { makeField } from "./lazyField";
@@ -37,7 +37,7 @@ export interface TreeContext extends ISubscribable<ForestEvents> {
 	 * Schema used within this context.
 	 * All data must conform to these schema.
 	 */
-	readonly schema: DocumentSchema;
+	readonly schema: TreeSchema;
 
 	// TODO: Add more members:
 	// - transaction APIs
@@ -65,7 +65,7 @@ export class Context implements TreeContext, IDisposable {
 	 * If present, clients may query the {@link LocalNodeKey} of a node directly via the {@link localNodeKeySymbol}.
 	 */
 	public constructor(
-		public readonly schema: DocumentSchema,
+		public readonly schema: TreeSchema,
 		public readonly forest: IEditableForest,
 		public readonly editor: DefaultEditBuilder,
 		public readonly nodeKeys: NodeKeys,
@@ -141,7 +141,7 @@ export class Context implements TreeContext, IDisposable {
  * This is necessary for supporting using this tree across edits to the forest, and not leaking memory.
  */
 export function getTreeContext(
-	schema: DocumentSchema,
+	schema: TreeSchema,
 	forest: IEditableForest,
 	editor: DefaultEditBuilder,
 	nodeKeyManager: NodeKeyManager,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -17,7 +17,7 @@ import {
 	MapSchema,
 	StructSchema,
 	TreeNodeSchema,
-	DocumentSchema,
+	TreeSchema,
 } from "../../typed-schema";
 import {
 	CheckTypesOverlap,
@@ -281,8 +281,6 @@ export type ProxyNode<
 
 /** The root type (the type of the entire tree) for a given schema collection */
 export type ProxyRoot<
-	TSchema extends DocumentSchema,
+	TSchema extends TreeSchema,
 	API extends "javaScript" | "sharedTree" = "sharedTree",
-> = TSchema extends DocumentSchema<infer TRootFieldSchema>
-	? ProxyField<TRootFieldSchema, API>
-	: never;
+> = TSchema extends TreeSchema<infer TRootFieldSchema> ? ProxyField<TRootFieldSchema, API> : never;

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -139,7 +139,7 @@ export {
 	TreeNodeSchema,
 	AllowedTypes,
 	FieldSchema,
-	DocumentSchema,
+	TreeSchema,
 	Any,
 	SchemaLibraryData,
 	LazyTreeNodeSchema,

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -14,7 +14,7 @@ import {
 	AllowedTypes,
 	TreeNodeSchema,
 	FieldSchema,
-	DocumentSchema,
+	TreeSchema,
 	FlexList,
 	Unenforced,
 	Any,
@@ -159,7 +159,7 @@ export class SchemaBuilderBase<
 	}
 
 	/**
-	 * Produce a DocumentSchema which captures the content added to this builder, any additional SchemaLibraries that were added to it and a root field.
+	 * Produce a TreeSchema which captures the content added to this builder, any additional SchemaLibraries that were added to it and a root field.
 	 * Can be used with schematize to provide schema aware access to document content.
 	 *
 	 * @remarks
@@ -167,12 +167,12 @@ export class SchemaBuilderBase<
 	 */
 	public toDocumentSchema<const TSchema extends ImplicitFieldSchema>(
 		root: TSchema,
-	): DocumentSchema<NormalizeField<TSchema, TDefaultKind>> {
+	): TreeSchema<NormalizeField<TSchema, TDefaultKind>> {
 		// return this.toDocumentSchemaInternal(normalizeField(root, DefaultFieldKind));
 		const field: NormalizeField<TSchema, TDefaultKind> = this.normalizeField(root);
 		const library = this.finalizeCommon(field);
 
-		const typed: DocumentSchema<NormalizeField<TSchema, TDefaultKind>> = {
+		const typed: TreeSchema<NormalizeField<TSchema, TDefaultKind>> = {
 			treeSchema: library.treeSchema,
 			adapters: library.adapters,
 			rootFieldSchema: field,

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -165,7 +165,7 @@ export class SchemaBuilderBase<
 	 * @remarks
 	 * May only be called once after adding content to builder is complete.
 	 */
-	public toDocumentSchema<const TSchema extends ImplicitFieldSchema>(
+	public intoSchema<const TSchema extends ImplicitFieldSchema>(
 		root: TSchema,
 	): TreeSchema<NormalizeField<TSchema, TDefaultKind>> {
 		// return this.toDocumentSchemaInternal(normalizeField(root, DefaultFieldKind));
@@ -306,7 +306,7 @@ export class SchemaBuilderBase<
 	 * Determine the multiplicity, viewing and editing APIs as well as the merge resolution policy.
 	 * @param allowedTypes - What types of children are allowed in this field.
 	 * @returns a {@link FieldSchema} which can be used as a struct field (see {@link SchemaBuilderBase.struct}),
-	 * a map field (see {@link SchemaBuilderBase.map}), a field node(see {@link SchemaBuilderBase.fieldNode}) or the root field (see {@link SchemaBuilderBase.toDocumentSchema}).
+	 * a map field (see {@link SchemaBuilderBase.map}), a field node(see {@link SchemaBuilderBase.fieldNode}) or the root field (see {@link SchemaBuilderBase.intoSchema}).
 	 *
 	 * @privateRemarks
 	 * TODO:

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -18,7 +18,7 @@ export {
 	schemaIsLeaf,
 	schemaIsMap,
 	schemaIsStruct,
-	DocumentSchema,
+	TreeSchema,
 	Unenforced,
 	AllowedTypeSet,
 	MapFieldSchema,

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -477,7 +477,7 @@ export function allowedTypesToTypeSet(t: AllowedTypes): TreeTypeSet {
  * @alpha
  */
 
-export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
+export interface TreeSchema<out T extends FieldSchema = FieldSchema> extends SchemaCollection {
 	/**
 	 * Schema for the root field which contains the whole tree.
 	 */
@@ -493,11 +493,11 @@ export interface DocumentSchema<out T extends FieldSchema = FieldSchema> extends
 }
 
 {
-	// It is convenient that DocumentSchema can be used as a SchemaData with no conversion.
+	// It is convenient that TreeSchema can be used as a SchemaData with no conversion.
 	// This type check ensures this ability is not broken on accident (if it needs to be broken on purpose for some reason thats fine: just delete this check).
 	// Since TypeScript does not allow extending two types with the same field (even if they are compatible),
-	// this check cannot be done by adding an extends clause to DocumentSchema.
-	type _check = requireAssignableTo<DocumentSchema, SchemaData>;
+	// this check cannot be done by adding an extends clause to TreeSchema.
+	type _check = requireAssignableTo<TreeSchema, SchemaData>;
 }
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/view.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/view.ts
@@ -15,7 +15,7 @@ import {
 	Compatibility,
 } from "../../core";
 import { FullSchemaPolicy, allowsRepoSuperset, isNeverTree } from "../modular-schema";
-import { DocumentSchema } from "./typedTreeSchema";
+import { TreeSchema } from "./typedTreeSchema";
 
 /**
  * A collection of View information for schema, including policy.
@@ -24,7 +24,7 @@ export class ViewSchema {
 	public constructor(
 		public readonly policy: FullSchemaPolicy,
 		public readonly adapters: Adapters,
-		public readonly schema: DocumentSchema,
+		public readonly schema: TreeSchema,
 	) {}
 
 	/**

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -189,7 +189,7 @@ export {
 	UntypedTreeOrPrimitive,
 	AllowedTypes,
 	TreeNodeSchema,
-	DocumentSchema,
+	TreeSchema,
 	SchemaLibrary,
 	SchemaLibraryData,
 	FieldSchema,

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -17,7 +17,7 @@ import {
 	defaultSchemaPolicy,
 	FieldKinds,
 	allowsRepoSuperset,
-	DocumentSchema,
+	TreeSchema,
 	SchemaAware,
 	FieldSchema,
 	ViewSchema,
@@ -40,7 +40,7 @@ import { ViewEvents } from "./sharedTreeView";
  */
 export function initializeContent(
 	storedSchema: StoredSchemaRepository,
-	schema: DocumentSchema,
+	schema: TreeSchema,
 	setInitialTree: () => void,
 ): void {
 	assert(schemaDataIsEmpty(storedSchema), 0x743 /* cannot initialize after a schema is set */);
@@ -191,7 +191,7 @@ export interface SchemaConfiguration<TRoot extends FieldSchema = FieldSchema> {
 	/**
 	 * The schema which the application wants to view the tree with.
 	 */
-	readonly schema: DocumentSchema<TRoot>;
+	readonly schema: TreeSchema<TRoot>;
 }
 
 /**

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -36,7 +36,7 @@ import {
 	NewFieldContent,
 	NodeKeyManager,
 	FieldSchema,
-	DocumentSchema,
+	TreeSchema,
 	getTreeContext,
 	TypedField,
 	createNodeKeyManager,
@@ -238,9 +238,9 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * If the stored schema is edited and becomes incompatible (or was not originally compatible),
 	 * using the returned tree is invalid and is likely to error or corrupt the document.
 	 */
-	editableTree2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): TypedField<TRoot>;
+	editableTree2<TRoot extends FieldSchema>(viewSchema: TreeSchema<TRoot>): TypedField<TRoot>;
 
-	root2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>): ProxyField<TRoot>;
+	root2<TRoot extends FieldSchema>(viewSchema: TreeSchema<TRoot>): ProxyField<TRoot>;
 }
 
 /**
@@ -425,7 +425,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 	}
 
 	public editableTree2<TRoot extends FieldSchema>(
-		viewSchema: DocumentSchema<TRoot>,
+		viewSchema: TreeSchema<TRoot>,
 		nodeKeyManager?: NodeKeyManager,
 		nodeKeyFieldKey?: FieldKey,
 	): TypedField<TRoot> {
@@ -439,7 +439,7 @@ export class SharedTreeView implements ISharedTreeBranchView {
 		return context.root as TypedField<TRoot>;
 	}
 
-	public root2<TRoot extends FieldSchema>(viewSchema: DocumentSchema<TRoot>) {
+	public root2<TRoot extends FieldSchema>(viewSchema: TreeSchema<TRoot>) {
 		const rootField = this.editableTree2(viewSchema);
 		return getProxyForField(rootField);
 	}

--- a/experimental/dds/tree2/src/test/cursorTestSuite.ts
+++ b/experimental/dds/tree2/src/test/cursorTestSuite.ts
@@ -39,7 +39,7 @@ export const structSchema = schemaBuilder.struct("struct", {
 	child: leaf.number,
 });
 
-export const testTreeSchema = schemaBuilder.toDocumentSchema(SchemaBuilder.sequence(Any));
+export const testTreeSchema = schemaBuilder.intoSchema(SchemaBuilder.sequence(Any));
 
 export const testTrees: readonly (readonly [string, JsonableTree])[] = [
 	["minimal", { type: emptySchema.name }],

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -54,7 +54,7 @@ function bench(
 	const schemaCollection = new SchemaBuilder({
 		scope: "JsonCursor benchmark",
 		libraries: [jsonSchema],
-	}).toDocumentSchema(SchemaBuilder.optional(jsonRoot));
+	}).intoSchema(SchemaBuilder.optional(jsonRoot));
 	const schema = new InMemoryStoredSchemaRepository(schemaCollection);
 	for (const { name, getJson, dataConsumer } of data) {
 		describe(name, () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -106,7 +106,7 @@ describe("ContextuallyTyped", () => {
 		});
 		const numberSequence = SchemaBuilder.sequence(leaf.number);
 		const numbersObject = builder.struct("numbers", { numbers: numberSequence });
-		const schema = builder.toDocumentSchema(numberSequence);
+		const schema = builder.intoSchema(numberSequence);
 		const mapTree = applyTypesFromContext({ schema }, new Set([numbersObject.name]), {
 			numbers: [],
 		});
@@ -121,7 +121,7 @@ describe("ContextuallyTyped", () => {
 		});
 		const numberSequence = SchemaBuilder.sequence(leaf.number);
 		const primaryObject = builder.struct("numbers", { [EmptyKey]: numberSequence });
-		const schema = builder.toDocumentSchema(numberSequence);
+		const schema = builder.intoSchema(numberSequence);
 		const mapTree = applyTypesFromContext({ schema }, new Set([primaryObject.name]), []);
 		const expected: MapTree = { fields: new Map(), type: primaryObject.name, value: undefined };
 		assert.deepEqual(mapTree, expected);
@@ -137,7 +137,7 @@ describe("ContextuallyTyped", () => {
 				foo: leaf.string,
 			});
 
-			const nodeSchemaData = builder.toDocumentSchema(builder.optional(nodeSchema));
+			const nodeSchemaData = builder.intoSchema(builder.optional(nodeSchema));
 			const contextualData: ContextuallyTypedNodeDataObject = {};
 
 			const generatedField = [
@@ -172,7 +172,7 @@ describe("ContextuallyTyped", () => {
 				child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchema]),
 			});
 
-			const nodeSchemaData = builder.toDocumentSchema(builder.optional(nodeSchema));
+			const nodeSchemaData = builder.intoSchema(builder.optional(nodeSchema));
 			const contextualData: ContextuallyTypedNodeDataObject = { child: {} };
 
 			const generatedField = [

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.identifier.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.identifier.spec.ts
@@ -27,7 +27,7 @@ const parentNodeSchema = builder.struct("ParentNode", {
 	...nodeKeyField,
 	children: builder.sequence(childNodeSchema),
 });
-const schema = builder.toDocumentSchema(parentNodeSchema);
+const schema = builder.intoSchema(parentNodeSchema);
 
 // TODO: this can probably be removed once daesun's stuff goes in
 function addKey(view: NodeKeyManager, key: LocalNodeKey): { [nodeKeyFieldKey]: StableNodeKey } {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
@@ -77,7 +77,7 @@ describe("LazyField", () => {
 	it("LazyField implementations do not allow edits to detached trees", () => {
 		const builder = new SchemaBuilder({ scope: "lazyTree" });
 		builder.struct("empty", {});
-		const schema = builder.toDocumentSchema(SchemaBuilder.optional(Any));
+		const schema = builder.intoSchema(SchemaBuilder.optional(Any));
 		const forest = forestWithContent({ schema, initialTree: {} });
 		const context = getReadonlyContext(forest, schema);
 		const cursor = initializeCursor(context, detachedFieldAnchor);
@@ -132,7 +132,7 @@ describe("LazyField", () => {
 
 		const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 		const rootSchema = SchemaBuilder.optional(builder.struct("struct", {}));
-		const schema = builder.toDocumentSchema(rootSchema);
+		const schema = builder.intoSchema(rootSchema);
 
 		// Note: this tree initialization is strictly to enable construction of the lazy field.
 		// The test cases below are strictly in terms of the schema of the created fields.
@@ -194,7 +194,7 @@ describe("LazyField", () => {
 			foo: SchemaBuilder.optional(leafDomain.primitives),
 		});
 		const rootSchema = SchemaBuilder.optional(struct);
-		const schema = builder.toDocumentSchema(rootSchema);
+		const schema = builder.intoSchema(rootSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -233,7 +233,7 @@ describe("LazyField", () => {
 describe("LazyOptionalField", () => {
 	const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 	const rootSchema = SchemaBuilder.optional(leafDomain.number);
-	const schema = builder.toDocumentSchema(rootSchema);
+	const schema = builder.intoSchema(rootSchema);
 
 	describe("Field with value", () => {
 		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
@@ -307,7 +307,7 @@ describe("LazyOptionalField", () => {
 describe("LazyValueField", () => {
 	const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 	const rootSchema = SchemaBuilder.required(leafDomain.string);
-	const schema = builder.toDocumentSchema(rootSchema);
+	const schema = builder.intoSchema(rootSchema);
 
 	const initialTree = "Hello world";
 
@@ -346,7 +346,7 @@ describe("LazyValueField", () => {
 describe("LazySequence", () => {
 	const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
 	const rootSchema = SchemaBuilder.sequence(leafDomain.number);
-	const schema = builder.toDocumentSchema(rootSchema);
+	const schema = builder.intoSchema(rootSchema);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
@@ -131,7 +131,7 @@ describe("LazyTree", () => {
 	it("property names", () => {
 		const builder = new SchemaBuilder({ scope: "lazyTree" });
 		const emptyStruct = builder.struct("empty", {});
-		const testSchema = builder.toDocumentSchema(SchemaBuilder.optional(emptyStruct));
+		const testSchema = builder.intoSchema(SchemaBuilder.optional(emptyStruct));
 
 		const { cursor, context } = initializeTreeWithContent({
 			schema: testSchema,
@@ -199,7 +199,7 @@ describe("LazyTree", () => {
 			SchemaBuilder.optional(leafDomain.string),
 		);
 
-		const schema = schemaBuilder.toDocumentSchema(fieldNodeOptionalAnySchema);
+		const schema = schemaBuilder.intoSchema(fieldNodeOptionalAnySchema);
 
 		// #endregion
 
@@ -236,7 +236,7 @@ describe("LazyTree", () => {
 			"field",
 			SchemaBuilder.optional(leafDomain.string),
 		);
-		const schema = schemaBuilder.toDocumentSchema(fieldNodeSchema);
+		const schema = schemaBuilder.intoSchema(fieldNodeSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -302,7 +302,7 @@ describe("LazyFieldNode", () => {
 		"field",
 		SchemaBuilder.optional(leafDomain.string),
 	);
-	const schema = schemaBuilder.toDocumentSchema(fieldNodeSchema);
+	const schema = schemaBuilder.intoSchema(fieldNodeSchema);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,
@@ -331,7 +331,7 @@ describe("LazyLeaf", () => {
 		scope: "test",
 		libraries: [leafDomain.library],
 	});
-	const schema = schemaBuilder.toDocumentSchema(leafDomain.string);
+	const schema = schemaBuilder.intoSchema(leafDomain.string);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,
@@ -354,7 +354,7 @@ describe("LazyMap", () => {
 		libraries: [leafDomain.library],
 	});
 	const mapNodeSchema = schemaBuilder.map("mapString", SchemaBuilder.optional(leafDomain.string));
-	const schema = schemaBuilder.toDocumentSchema(mapNodeSchema);
+	const schema = schemaBuilder.intoSchema(mapNodeSchema);
 
 	const { context, cursor } = initializeTreeWithContent({
 		schema,
@@ -389,7 +389,7 @@ describe("LazyStruct", () => {
 		foo: SchemaBuilder.optional(leafDomain.string),
 		bar: SchemaBuilder.sequence(leafDomain.number),
 	});
-	const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(Any));
+	const schema = schemaBuilder.intoSchema(SchemaBuilder.optional(Any));
 
 	// Count the number of times edits have been generated.
 	let editCallCount = 0;
@@ -458,7 +458,7 @@ describe("buildLazyStruct", () => {
 		required: SchemaBuilder.required(leafDomain.boolean),
 		sequence: SchemaBuilder.sequence(leafDomain.number),
 	});
-	const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(Any));
+	const schema = schemaBuilder.intoSchema(SchemaBuilder.optional(Any));
 
 	const context = contextWithContentReadonly({
 		schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
@@ -20,7 +20,7 @@ const root = builder.struct("root", {
 	numbers: numberList,
 });
 
-const schema = builder.toDocumentSchema(root);
+const schema = builder.intoSchema(root);
 
 describe("List", () => {
 	/** Formats 'args' array, inserting commas and eliding trailing undefines.  */

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/node.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/node.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import {
-	DocumentSchema,
+	TreeSchema,
 	ProxyField,
 	ProxyRoot,
 	SharedTreeNode,
@@ -16,7 +16,7 @@ import { itWithRoot, makeSchema } from "./utils";
 
 describe("node() API", () => {
 	describe("events", () => {
-		function check<TSchema extends DocumentSchema<any>>(
+		function check<TSchema extends TreeSchema<any>>(
 			schema: TSchema,
 			initialTree: ProxyRoot<TSchema, "javaScript">,
 			mutate: (root: ProxyField<(typeof schema)["rootFieldSchema"]>) => void,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { LeafSchema, DocumentSchema } from "../../../feature-libraries";
+import { LeafSchema, TreeSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
 
 // eslint-disable-next-line import/no-internal-modules
@@ -13,7 +13,7 @@ import { createTreeView, itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
 	initialTree: object;
-	schema: DocumentSchema;
+	schema: TreeSchema;
 }
 
 export function testObjectPrototype(proxy: object, prototype: object) {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -219,7 +219,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.struct("empty", {});
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: {},
 	},
@@ -231,7 +231,7 @@ const tcs: TestCase[] = [
 				number: leaf.number,
 				string: leaf.string,
 			});
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: {
 			boolean: false,
@@ -247,7 +247,7 @@ const tcs: TestCase[] = [
 				number: _.optional(leaf.number),
 				string: _.optional(leaf.string),
 			});
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: {},
 	},
@@ -259,7 +259,7 @@ const tcs: TestCase[] = [
 				number: _.optional(leaf.number),
 				string: _.optional(leaf.string),
 			});
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: {
 			boolean: true,
@@ -277,7 +277,7 @@ const tcs: TestCase[] = [
 				nested: inner,
 			});
 
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: { nested: {} },
 	},
@@ -285,7 +285,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.fieldNode("List<string> len(0)", _.sequence(leaf.string));
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: [],
 	},
@@ -293,7 +293,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.fieldNode("List<string> len(1)", _.sequence(leaf.string));
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: ["A"],
 	},
@@ -301,7 +301,7 @@ const tcs: TestCase[] = [
 		schema: (() => {
 			const _ = new SchemaBuilder({ scope: "test" });
 			const $ = _.fieldNode("List<string> len(2)", _.sequence(leaf.string));
-			return _.toDocumentSchema($);
+			return _.intoSchema($);
 		})(),
 		initialTree: ["A", "B"],
 	},
@@ -373,7 +373,7 @@ describe("Object-like", () => {
 			const parent = _.struct("parent", {
 				child,
 			});
-			const schema = _.toDocumentSchema(parent);
+			const schema = _.intoSchema(parent);
 
 			const before = { objId: 0 };
 			const after = { objId: 1 };
@@ -398,7 +398,7 @@ describe("Object-like", () => {
 			const parent = _.struct("parent", {
 				child: _.optional(child),
 			});
-			const schema = _.toDocumentSchema(parent);
+			const schema = _.intoSchema(parent);
 
 			const before = { objId: 0 };
 			const after = { objId: 1 };
@@ -424,7 +424,7 @@ describe("Object-like", () => {
 			// const parent = _.struct("parent", {
 			// 	list,
 			// });
-			// const schema = _.toDocumentSchema(parent);
+			// const schema = _.intoSchema(parent);
 			// const before: string[] = [];
 			// const after = ["A"];
 			// itWithRoot(
@@ -445,7 +445,7 @@ describe("Object-like", () => {
 			// const parent = _.struct("parent", {
 			// 	list: _.optional(list),
 			// });
-			// const schema = _.toDocumentSchema(parent);
+			// const schema = _.intoSchema(parent);
 			// const before: string[] = [];
 			// const after = ["A"];
 			// itWithRoot(

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
@@ -8,7 +8,7 @@ import { leaf, SchemaBuilder } from "../../../domains";
 import { createTreeView, pretty } from "./utils";
 
 const _ = new SchemaBuilder({ scope: "test", libraries: [leaf.library] });
-const schema = _.toDocumentSchema(_.optional(leaf.all));
+const schema = _.intoSchema(_.optional(leaf.all));
 
 const testCases = [
 	undefined, // via optional root

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -23,7 +23,7 @@ describe("SharedTree proxies", () => {
 		list: sb.fieldNode("list", sb.sequence(leaf.number)),
 	});
 
-	const schema = sb.toDocumentSchema(parentSchema);
+	const schema = sb.intoSchema(parentSchema);
 
 	const initialTree = {
 		struct: { content: 42 },
@@ -69,7 +69,7 @@ describe("SharedTreeObject", () => {
 		list: sb.fieldNode("list", sb.sequence(numberChild)),
 	});
 
-	const schema = sb.toDocumentSchema(parentSchema);
+	const schema = sb.intoSchema(parentSchema);
 
 	const initialTree = {
 		content: 42,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/structFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/structFactory.spec.ts
@@ -28,7 +28,7 @@ describe("raw structs", () => {
 			baz: builder.sequence(leaf.boolean),
 		});
 		const rootFieldSchema = SchemaBuilder.required(structSchema);
-		const schema = builder.toDocumentSchema(rootFieldSchema);
+		const schema = builder.intoSchema(rootFieldSchema);
 		const context = contextWithContentReadonly({
 			schema,
 			initialTree: { foo: 42, baz: [] },

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/unboxed.spec.ts
@@ -61,7 +61,7 @@ describe("unboxedField", () => {
 		it("No value", () => {
 			const builder = new SchemaBuilder({ scope: "test" });
 			const fieldSchema = SchemaBuilder.optional(leafDomain.number);
-			const schema = builder.toDocumentSchema(fieldSchema);
+			const schema = builder.intoSchema(fieldSchema);
 
 			const { context, cursor } = initializeTreeWithContent({
 				schema,
@@ -74,7 +74,7 @@ describe("unboxedField", () => {
 		it("With value (leaf)", () => {
 			const builder = new SchemaBuilder({ scope: "test" });
 			const fieldSchema = SchemaBuilder.optional(leafDomain.number);
-			const schema = builder.toDocumentSchema(fieldSchema);
+			const schema = builder.intoSchema(fieldSchema);
 
 			const { context, cursor } = initializeTreeWithContent({
 				schema,
@@ -92,7 +92,7 @@ describe("unboxedField", () => {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => structSchema]),
 		});
 		const fieldSchema = SchemaBuilder.optional(structSchema);
-		const schema = builder.toDocumentSchema(fieldSchema);
+		const schema = builder.intoSchema(fieldSchema);
 
 		const initialTree = {
 			name: "Foo",
@@ -119,7 +119,7 @@ describe("unboxedField", () => {
 	it("Sequence field", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.sequence(leafDomain.string);
-		const schema = builder.toDocumentSchema(fieldSchema);
+		const schema = builder.intoSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -134,7 +134,7 @@ describe("unboxedField", () => {
 	it("Schema: Any", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.optional(Any);
-		const schema = builder.toDocumentSchema(fieldSchema);
+		const schema = builder.intoSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
 
@@ -149,7 +149,7 @@ describe("unboxedField", () => {
 describe("unboxedTree", () => {
 	it("Leaf", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
-		const schema = builder.toDocumentSchema(leafDomain.string);
+		const schema = builder.intoSchema(leafDomain.string);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -164,7 +164,7 @@ describe("unboxedTree", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const mapSchema = builder.map("map", builder.optional(leafDomain.string));
 		const rootSchema = SchemaBuilder.optional(mapSchema);
-		const schema = builder.toDocumentSchema(rootSchema);
+		const schema = builder.intoSchema(rootSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -188,7 +188,7 @@ describe("unboxedTree", () => {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => structSchema]),
 		});
 		const rootSchema = builder.optional(structSchema);
-		const schema = builder.toDocumentSchema(rootSchema);
+		const schema = builder.intoSchema(rootSchema);
 
 		const initialTree = {
 			name: "Foo",
@@ -214,7 +214,7 @@ describe("unboxedUnion", () => {
 	it("Any", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.optional(Any);
-		const schema = builder.toDocumentSchema(fieldSchema);
+		const schema = builder.intoSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
 		cursor.enterNode(0); // Root node field has 1 node; move into it
@@ -228,7 +228,7 @@ describe("unboxedUnion", () => {
 	it("Single type", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.required(leafDomain.boolean);
-		const schema = builder.toDocumentSchema(fieldSchema);
+		const schema = builder.intoSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,
@@ -242,7 +242,7 @@ describe("unboxedUnion", () => {
 	it("Multi-type", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const fieldSchema = SchemaBuilder.optional([leafDomain.string, leafDomain.handle]);
-		const schema = builder.toDocumentSchema(fieldSchema);
+		const schema = builder.intoSchema(fieldSchema);
 
 		const { context, cursor } = initializeTreeWithContent({
 			schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -69,7 +69,7 @@ export function makeSchema<const TSchema extends ImplicitFieldSchema>(
 		scope: `test.schema.${Math.random().toString(36).slice(2)}`,
 	});
 	const root = fn(builder);
-	return builder.toDocumentSchema(root);
+	return builder.intoSchema(root);
 }
 
 export function itWithRoot<TRoot extends FieldSchema>(

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -10,7 +10,7 @@ import {
 	ImplicitFieldSchema,
 	ProxyField,
 	ProxyRoot,
-	DocumentSchema,
+	TreeSchema,
 	createMockNodeKeyManager,
 	nodeKeyFieldKey,
 } from "../../../feature-libraries";
@@ -22,7 +22,7 @@ import { TestTreeProviderLite, forestWithContent } from "../../utils";
 import { brand } from "../../../util";
 import { SchemaBuilder } from "../../../domains";
 
-export function getReadonlyContext(forest: IEditableForest, schema: DocumentSchema): Context {
+export function getReadonlyContext(forest: IEditableForest, schema: TreeSchema): Context {
 	// This will error if someone tries to call mutation methods on it
 	const dummyEditor = {} as unknown as DefaultEditBuilder;
 	return getTreeContext(
@@ -51,7 +51,7 @@ export function createTree(): ISharedTree {
 }
 
 export function createTreeView<TRoot extends FieldSchema>(
-	schema: DocumentSchema<TRoot>,
+	schema: TreeSchema<TRoot>,
 	initialTree: any,
 ): ISharedTreeView {
 	return createTree().schematize({
@@ -74,8 +74,8 @@ export function makeSchema<const TSchema extends ImplicitFieldSchema>(
 
 export function itWithRoot<TRoot extends FieldSchema>(
 	title: string,
-	schema: DocumentSchema<TRoot>,
-	initialTree: ProxyRoot<DocumentSchema<TRoot>, "javaScript">,
+	schema: TreeSchema<TRoot>,
+	initialTree: ProxyRoot<TreeSchema<TRoot>, "javaScript">,
 	fn: (root: ProxyField<(typeof schema)["rootFieldSchema"]>) => void,
 ): void {
 	it(title, () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -53,7 +53,7 @@ function getTestSchema<Kind extends FieldKind>(fieldKind: Kind) {
 		foo: FieldSchema.create(fieldKind, [stringSchema]),
 		foo2: FieldSchema.create(fieldKind, [stringSchema]),
 	});
-	return builder.toDocumentSchema(FieldSchema.create(FieldKinds.optional, [rootNodeSchema]));
+	return builder.intoSchema(FieldSchema.create(FieldKinds.optional, [rootNodeSchema]));
 }
 
 describe("editable-tree: editing", () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -390,7 +390,7 @@ describe("editable-tree: read-only", () => {
 			child: stringSchema,
 		});
 		const rootSchema = FieldSchema.create(FieldKinds.required, [parentSchema]);
-		const schemaData = builder.toDocumentSchema(rootSchema);
+		const schemaData = builder.intoSchema(rootSchema);
 		const forest = setupForest(schemaData, { child: "x" });
 		const context = getReadonlyEditableTreeContext(forest, schemaData);
 		assert(isEditableTree(context.unwrappedRoot));

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -20,7 +20,7 @@ import {
 	getEditableTreeContext,
 	FieldSchema,
 	Any,
-	DocumentSchema,
+	TreeSchema,
 	NormalizeField,
 	ImplicitFieldSchema,
 	SchemaAware,
@@ -245,7 +245,7 @@ export function getPerson(): Person {
  */
 export function buildTestSchema<TSchema extends ImplicitFieldSchema>(
 	rootField: TSchema,
-): DocumentSchema<NormalizeField<TSchema, typeof FieldKinds.required>> {
+): TreeSchema<NormalizeField<TSchema, typeof FieldKinds.required>> {
 	return new SchemaBuilder({
 		scope: "buildTestSchema",
 		libraries: [personSchemaLibrary],
@@ -262,7 +262,7 @@ export function getReadonlyEditableTreeContext(
 }
 
 export function setupForest<T extends FieldSchema>(
-	schema: DocumentSchema<T>,
+	schema: TreeSchema<T>,
 	data: ContextuallyTypedNodeData | undefined,
 ): IEditableForest {
 	const schemaRepo = new InMemoryStoredSchemaRepository(schema);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -249,7 +249,7 @@ export function buildTestSchema<TSchema extends ImplicitFieldSchema>(
 	return new SchemaBuilder({
 		scope: "buildTestSchema",
 		libraries: [personSchemaLibrary],
-	}).toDocumentSchema(rootField);
+	}).intoSchema(rootField);
 }
 
 export function getReadonlyEditableTreeContext(

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -11,7 +11,7 @@ import {
 	ViewSchema,
 	FieldKinds,
 	defaultSchemaPolicy,
-	DocumentSchema,
+	TreeSchema,
 } from "../../../feature-libraries";
 import {
 	FieldStoredSchema,
@@ -127,7 +127,7 @@ describe("Schema Evolution Examples", () => {
 	it("basic usage", () => {
 		// Collect our view schema.
 		// This will represent our view schema for a simple canvas application.
-		const viewCollection: DocumentSchema = new SchemaBuilder({
+		const viewCollection: TreeSchema = new SchemaBuilder({
 			scope: "test",
 			name: "basic usage",
 			libraries: [treeViewSchema],
@@ -259,7 +259,7 @@ describe("Schema Evolution Examples", () => {
 				items: FieldSchema.create(FieldKinds.sequence, [positionedCanvasItem2]),
 			});
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const viewCollection3: DocumentSchema = builderWithCounter.toDocumentSchema(
+			const viewCollection3: TreeSchema = builderWithCounter.toDocumentSchema(
 				FieldSchema.create(FieldKinds.optional, [canvas2]),
 			);
 			const view3 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection3);

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -131,7 +131,7 @@ describe("Schema Evolution Examples", () => {
 			scope: "test",
 			name: "basic usage",
 			libraries: [treeViewSchema],
-		}).toDocumentSchema(root);
+		}).intoSchema(root);
 
 		// This is where legacy schema handling logic for schematize.
 		const adapters: Adapters = {};
@@ -182,7 +182,7 @@ describe("Schema Evolution Examples", () => {
 				scope: "test",
 				name: "basic usage2",
 				libraries: [treeViewSchema],
-			}).toDocumentSchema(tolerantRoot);
+			}).intoSchema(tolerantRoot);
 			const view2 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection2);
 			// When we open this document, we should check it's compatibility with our application:
 			const compat = view2.checkCompatibility(stored);
@@ -259,7 +259,7 @@ describe("Schema Evolution Examples", () => {
 				items: FieldSchema.create(FieldKinds.sequence, [positionedCanvasItem2]),
 			});
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const viewCollection3: TreeSchema = builderWithCounter.toDocumentSchema(
+			const viewCollection3: TreeSchema = builderWithCounter.intoSchema(
 				FieldSchema.create(FieldKinds.optional, [canvas2]),
 			);
 			const view3 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection3);
@@ -407,7 +407,7 @@ describe("Schema Evolution Examples", () => {
 	// 		items: FieldSchema.create(FieldKinds.sequence, positionedCanvasItemNew),
 	// 	});
 
-	// 	const viewCollection: SchemaCollection = builder.toDocumentSchema(
+	// 	const viewCollection: SchemaCollection = builder.intoSchema(
 	// 		SchemaBuilder.required(canvas2),
 	// 	);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -34,7 +34,7 @@ const nodeSchema = builder.structRecursive("node", {
 	...nodeKeyField,
 	child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchema]),
 });
-const nodeSchemaData = builder.toDocumentSchema(SchemaBuilder.optional(nodeSchema));
+const nodeSchemaData = builder.intoSchema(SchemaBuilder.optional(nodeSchema));
 
 // TODO: this can probably be removed once daesun's stuff goes in
 function contextualizeKey(view: NodeKeys, key: LocalNodeKey): { [nodeKeyFieldKey]: StableNodeKey } {
@@ -214,9 +214,7 @@ describe("Node Key Index", () => {
 		});
 		const nodeSchemaNoKey = builder2.map("node", SchemaBuilder.optional(Any));
 
-		const nodeSchemaDataNoKey = builder2.toDocumentSchema(
-			SchemaBuilder.optional(nodeSchemaNoKey),
-		);
+		const nodeSchemaDataNoKey = builder2.intoSchema(SchemaBuilder.optional(nodeSchemaNoKey));
 		assert(!nodeSchemaDataNoKey.treeSchema.has(nodeKeyTreeSchema.name));
 
 		const nodeKeyManager = createMockNodeKeyManager();
@@ -269,7 +267,7 @@ describe("Node Key Index", () => {
 		const nodeSchemaNoKey = builder2.structRecursive("node", {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchemaNoKey]),
 		});
-		const nodeSchemaDataNoKey = builder2.toDocumentSchema(
+		const nodeSchemaDataNoKey = builder2.intoSchema(
 			SchemaBuilder.optional(nodeSchemaNoKey),
 		);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -462,7 +462,7 @@ describe("SchemaAware Editing", () => {
 		const rootNodeSchema = builder.struct("Test", {
 			children: SchemaBuilder.sequence(leaf.string),
 		});
-		const schema = builder.toDocumentSchema(
+		const schema = builder.intoSchema(
 			FieldSchema.create(FieldKinds.required, [rootNodeSchema]),
 		);
 		const view = createSharedTreeView().schematize({

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -25,7 +25,7 @@ export const listTaskSchema = builder.structRecursive("ListTask", {
 
 export const rootFieldSchema = SchemaBuilder.required([stringTaskSchema, listTaskSchema]);
 
-export const appSchemaData = builder.toDocumentSchema(rootFieldSchema);
+export const appSchemaData = builder.intoSchema(rootFieldSchema);
 
 // Schema aware types
 export type StringTask = SchemaAware.TypedNode<typeof stringTaskSchema>;

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -13,7 +13,7 @@ export const pointSchema = builder.struct("point", {
 	y: builder.number,
 });
 
-export const appSchemaData = builder.toDocumentSchema(builder.sequence(pointSchema));
+export const appSchemaData = builder.intoSchema(builder.sequence(pointSchema));
 
 // Schema aware types
 export type Number = SchemaAware.TypedNode<typeof leaf.number>;

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
@@ -94,11 +94,11 @@ describe("SchemaBuilderBase", () => {
 		});
 	});
 
-	describe("toDocumentSchema", () => {
+	describe("intoSchema", () => {
 		it("Simple", () => {
 			const schemaBuilder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
 			const empty = schemaBuilder.struct("empty", {});
-			const schema = schemaBuilder.toDocumentSchema(SchemaBuilder.optional(empty));
+			const schema = schemaBuilder.intoSchema(SchemaBuilder.optional(empty));
 
 			assert.equal(schema.treeSchema.size, 1); // "empty"
 			assert.equal(schema.treeSchema.get(brand("test.empty")), empty);

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaIndex.spec.ts
@@ -23,7 +23,7 @@ describe("SchemaIndex", () => {
 		const data: SchemaData = new SchemaBuilder({
 			scope: "roundtrip",
 			libraries: [jsonSchema],
-		}).toDocumentSchema(SchemaBuilder.optional(jsonRoot));
+		}).intoSchema(SchemaBuilder.optional(jsonRoot));
 		const s = codec.encode(data);
 		const parsed = codec.decode(s);
 		const s2 = codec.encode(parsed);

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/example.spec.ts
@@ -31,4 +31,4 @@ const diagramSchema = builder.structRecursive("Diagram", {
 const rootField = builder.optional(diagramSchema);
 
 // Collect the schema together.
-const schemaData = builder.toDocumentSchema(rootField);
+const schemaData = builder.intoSchema(rootField);

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -71,7 +71,7 @@ export interface ForestTestConfiguration {
 const jsonDocumentSchema = new SchemaBuilder({
 	scope: "jsonDocumentSchema",
 	libraries: [jsonSchema],
-}).toDocumentSchema(SchemaBuilder.sequence(jsonRoot));
+}).intoSchema(SchemaBuilder.sequence(jsonRoot));
 
 const detachId = { minor: 42 };
 
@@ -860,7 +860,7 @@ export function testForest(config: ForestTestConfiguration): void {
 					x: SchemaBuilder.sequence(leaf.number),
 					y: SchemaBuilder.sequence(leaf.number),
 				});
-				const schema = builder.toDocumentSchema(builder.optional(root));
+				const schema = builder.intoSchema(builder.optional(root));
 
 				const forest = factory(new InMemoryStoredSchemaRepository(schema));
 				initializeForest(forest, [

--- a/experimental/dds/tree2/src/test/scalableTestTrees.ts
+++ b/experimental/dds/tree2/src/test/scalableTestTrees.ts
@@ -47,9 +47,9 @@ export const wideRootSchema = wideBuilder.struct("WideRoot", {
 	foo: FieldSchema.create(FieldKinds.sequence, [leaf.number]),
 });
 
-export const wideSchema = wideBuilder.toDocumentSchema(wideRootSchema);
+export const wideSchema = wideBuilder.intoSchema(wideRootSchema);
 
-export const deepSchema = deepBuilder.toDocumentSchema([linkedListSchema, leaf.number]);
+export const deepSchema = deepBuilder.intoSchema([linkedListSchema, leaf.number]);
 
 /**
  * JS object like a deep tree.

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -333,7 +333,7 @@ describe("SharedTreeCore", () => {
 		const node = b.structRecursive("test node", {
 			child: FieldSchema.createUnsafe(FieldKinds.optional, [() => node, leaf.number]),
 		});
-		const schema = b.toDocumentSchema(b.optional(node));
+		const schema = b.intoSchema(b.optional(node));
 
 		const tree2 = await factory.load(
 			dataStoreRuntime2,

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -41,7 +41,7 @@ const parentSchema = builder.struct("Test:Opsize-Bench-Root", {
 	children: builder.sequence(childSchema),
 });
 
-const fullSchemaData = builder.toDocumentSchema(parentSchema);
+const fullSchemaData = builder.intoSchema(parentSchema);
 
 const initialTestJsonTree = {
 	type: parentSchema.name,

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -28,18 +28,18 @@ import { SchemaBuilder, leaf } from "../../domains";
 
 const builder = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests" });
 const root = leaf.number;
-const schema = builder.toDocumentSchema(SchemaBuilder.optional(root));
+const schema = builder.intoSchema(SchemaBuilder.optional(root));
 
 const builderGeneralized = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests Generalized",
 });
 
-const schemaGeneralized = builderGeneralized.toDocumentSchema(SchemaBuilder.optional(Any));
+const schemaGeneralized = builderGeneralized.intoSchema(SchemaBuilder.optional(Any));
 
 const builderValue = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests2" });
 
-const schemaValueRoot = builderValue.toDocumentSchema(SchemaBuilder.required(Any));
+const schemaValueRoot = builderValue.intoSchema(SchemaBuilder.required(Any));
 
 const emptySchema = new SchemaBuilder({
 	scope: "Empty",
@@ -47,7 +47,7 @@ const emptySchema = new SchemaBuilder({
 		rejectEmpty: false,
 		rejectForbidden: false,
 	},
-}).toDocumentSchema(FieldSchema.empty);
+}).intoSchema(FieldSchema.empty);
 
 function expectSchema(actual: SchemaData, expected: SchemaData): void {
 	// Check schema match

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -5,7 +5,7 @@
 import { strict as assert, fail } from "assert";
 import {
 	Any,
-	DocumentSchema,
+	TreeSchema,
 	FieldSchema,
 	FieldKinds,
 	allowsRepoSuperset,
@@ -133,7 +133,7 @@ describe("schematizeTree", () => {
 
 	describe("schematize", () => {
 		describe("noop upgrade", () => {
-			const testCases: [string, DocumentSchema][] = [
+			const testCases: [string, TreeSchema][] = [
 				["empty", emptySchema],
 				["basic-optional", schema],
 				["basic-value", schemaValueRoot],

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -97,7 +97,7 @@ describe("SharedTree", () => {
 
 	it("editable-tree-2-end-to-end", () => {
 		const builder = new SchemaBuilder({ scope: "e2e" });
-		const schema = builder.toDocumentSchema(leaf.number);
+		const schema = builder.intoSchema(leaf.number);
 		const factory = new SharedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,
@@ -538,7 +538,7 @@ describe("SharedTree", () => {
 			const schema = new SchemaBuilder({
 				scope: "optional",
 				libraries: [jsonSchema],
-			}).toDocumentSchema(SchemaBuilder.optional(leaf.number));
+			}).intoSchema(SchemaBuilder.optional(leaf.number));
 			const config: InitializeAndSchematizeConfiguration = {
 				schema,
 				initialTree: value,
@@ -1066,7 +1066,7 @@ describe("SharedTree", () => {
 		const treeSchema = builder.struct("root", {
 			x: builder.number,
 		});
-		const schema = builder.toDocumentSchema(builder.optional(Any));
+		const schema = builder.intoSchema(builder.optional(Any));
 
 		it("triggers events for local and subtree changes", () => {
 			const view = viewWithContent({
@@ -1888,7 +1888,7 @@ describe("SharedTree", () => {
 				foo: SchemaBuilder.sequence(leaf.number),
 				foo2: SchemaBuilder.sequence(leaf.number),
 			});
-			const testSchema = testSchemaBuilder.toDocumentSchema(rootFieldSchema);
+			const testSchema = testSchemaBuilder.intoSchema(rootFieldSchema);
 
 			// TODO: if this tests is just about deleting the root, it should use a simpler tree.
 			const initialTreeState: JsonableTree = {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTreeView.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTreeView.spec.ts
@@ -12,14 +12,14 @@ const builder = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests",
 });
-const schema = builder.toDocumentSchema(SchemaBuilder.optional(leaf.number));
+const schema = builder.intoSchema(SchemaBuilder.optional(leaf.number));
 
 const builderGeneralized = new SchemaBuilder({
 	scope: "test",
 	name: "Schematize Tree Tests Generalized",
 });
 
-const schemaGeneralized = builderGeneralized.toDocumentSchema(SchemaBuilder.optional(Any));
+const schemaGeneralized = builderGeneralized.intoSchema(SchemaBuilder.optional(Any));
 
 describe("sharedTreeView", () => {
 	describe("schematize", () => {

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -30,7 +30,7 @@ const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
 
 const builder = new SchemaBuilder({ scope: "test trees" });
 const rootNodeSchema = builder.map("TestInner", SchemaBuilder.sequence(Any));
-const testSchema = builder.toDocumentSchema(SchemaBuilder.sequence(Any));
+const testSchema = builder.intoSchema(SchemaBuilder.sequence(Any));
 
 function generateCompleteTree(
 	fields: FieldKey[],
@@ -268,9 +268,7 @@ export function generateTestTrees() {
 					scope: "has-handle",
 					libraries: [leaf.library],
 				});
-				const docSchema = innerBuilder.toDocumentSchema(
-					SchemaBuilder.optional(leaf.handle),
-				);
+				const docSchema = innerBuilder.intoSchema(SchemaBuilder.optional(leaf.handle));
 
 				const config = {
 					allowedSchemaModifications: AllowedUpdateType.None,
@@ -301,9 +299,7 @@ export function generateTestTrees() {
 					"SeqMap",
 					FieldSchema.createUnsafe(FieldKinds.sequence, [() => seqMapSchema]),
 				);
-				const docSchema = innerBuilder.toDocumentSchema(
-					SchemaBuilder.sequence(seqMapSchema),
-				);
+				const docSchema = innerBuilder.intoSchema(SchemaBuilder.sequence(seqMapSchema));
 
 				const config = {
 					allowedSchemaModifications: AllowedUpdateType.None,

--- a/experimental/dds/tree2/src/test/testTrees.ts
+++ b/experimental/dds/tree2/src/test/testTrees.ts
@@ -15,7 +15,7 @@ import {
 	SchemaAware,
 	SchemaLibrary,
 	TreeNodeSchema,
-	DocumentSchema,
+	TreeSchema,
 	cursorsForTypedFieldData,
 	defaultSchemaPolicy,
 	jsonableTreeFromCursor,
@@ -28,7 +28,7 @@ import { leaf, SchemaBuilder } from "../domains";
 
 interface TestTree {
 	readonly name: string;
-	readonly schemaData: DocumentSchema;
+	readonly schemaData: TreeSchema;
 	readonly policy: FullSchemaPolicy;
 	readonly treeFactory: () => JsonableTree[];
 }

--- a/experimental/dds/tree2/src/test/testTrees.ts
+++ b/experimental/dds/tree2/src/test/testTrees.ts
@@ -53,7 +53,7 @@ function testField<T extends FieldSchema>(
 		scope: name,
 		lint: { rejectForbidden: false, rejectEmpty: false },
 		libraries: [schemaLibrary],
-	}).toDocumentSchema(rootField);
+	}).intoSchema(rootField);
 	return {
 		name,
 		schemaData: schema,

--- a/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
@@ -13,7 +13,7 @@ import { leaf, SchemaBuilder } from "../../domains";
 describe("TypedTree", () => {
 	it("editable-tree-2-end-to-end", () => {
 		const builder = new SchemaBuilder({ scope: "e2e" });
-		const schema = builder.toDocumentSchema(leaf.number);
+		const schema = builder.intoSchema(leaf.number);
 		const factory = new TypedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -624,7 +624,7 @@ const jsonSequenceRootField = SchemaBuilder.sequence(jsonRoot);
 export const jsonSequenceRootSchema = new SchemaBuilder({
 	scope: "JsonSequenceRoot",
 	libraries: [jsonSchema],
-}).toDocumentSchema(jsonSequenceRootField);
+}).intoSchema(jsonSequenceRootField);
 
 export const emptyJsonSequenceConfig: InitializeAndSchematizeConfiguration = {
 	schema: jsonSequenceRootSchema,
@@ -900,7 +900,7 @@ export const wrongSchema = new SchemaBuilder({
 	lint: {
 		rejectEmpty: false,
 	},
-}).toDocumentSchema(SchemaBuilder.sequence(Any));
+}).intoSchema(SchemaBuilder.sequence(Any));
 
 /**
  * Schematize config Schema which is not correct.

--- a/experimental/framework/tree-react-api/src/test/schema.ts
+++ b/experimental/framework/tree-react-api/src/test/schema.ts
@@ -12,6 +12,6 @@ export const inventory = builder.struct("Contoso:Inventory-1.0.0", {
 	bolts: leaf.number,
 });
 
-export const schema = builder.toDocumentSchema(inventory);
+export const schema = builder.intoSchema(inventory);
 
 export type Inventory = TypedField<typeof schema.rootFieldSchema>;

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -423,7 +423,7 @@ describe("DefaultVisualizers unit tests", () => {
 			childrenTwo: leaf.number,
 		});
 
-		const schema = builder.toDocumentSchema(rootNodeSchema);
+		const schema = builder.intoSchema(rootNodeSchema);
 
 		sharedTree.schematize({
 			schema,

--- a/packages/tools/devtools/devtools-example/src/FluidObject.ts
+++ b/packages/tools/devtools/devtools-example/src/FluidObject.ts
@@ -236,7 +236,7 @@ export class AppData extends DataObject {
 			childrenTwo: leaf.number,
 		});
 
-		const schema = builder.toDocumentSchema(rootNodeSchema);
+		const schema = builder.intoSchema(rootNodeSchema);
 
 		sharedTree.schematize({
 			schema,


### PR DESCRIPTION
## Description

Rename DocumentSchema to TreeSchema.

## Breaking Changes

Rename DocumentSchema to TreeSchema.
Rename toDocumentSchema to intoSchema.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

