### PR TITLE
fluid-build: show a clear message when a task is not incremental

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -9,6 +9,9 @@ import { BuildPackage } from "../../buildGraph";
 import { LeafTask, LeafWithDoneFileTask, LeafWithFileStatDoneFileTask } from "./leafTask";
 
 export class EchoTask extends LeafTask {
+	protected get isIncremental() {
+		return true;
+	}
 	protected get taskWeight() {
 		return 0; // generally cheap relative to other tasks
 	}
@@ -18,6 +21,9 @@ export class EchoTask extends LeafTask {
 }
 
 export class LesscTask extends LeafTask {
+	protected get isIncremental() {
+		return true;
+	}
 	protected get taskWeight() {
 		return 0; // generally cheap relative to other tasks
 	}
@@ -151,6 +157,9 @@ export class CopyfilesTask extends LeafWithFileStatDoneFileTask {
 }
 
 export class GenVerTask extends LeafTask {
+	protected get isIncremental() {
+		return true;
+	}
 	protected get taskWeight() {
 		return 0; // generally cheap relative to other tasks
 	}

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -40,6 +40,10 @@ export class TscTask extends LeafTask {
 		return this._tscUtils;
 	}
 
+	protected get isIncremental() {
+		const config = this.readTsConfig();
+		return config?.options.incremental;
+	}
 	protected async checkLeafIsUpToDate() {
 		const tsBuildInfoFileFullPath = this.tsBuildInfoFileFullPath;
 		if (tsBuildInfoFileFullPath === undefined) {
@@ -232,10 +236,6 @@ export class TscTask extends LeafTask {
 				return undefined;
 			}
 			this._tsConfig = options;
-
-			if (!options.options.incremental) {
-				console.warn(`${this.node.pkg.nameColored}: warning: incremental not enabled`);
-			}
 		}
 
 		return this._tsConfig;


### PR DESCRIPTION
When a task doesn't support incremental, be clear on console output to set user expectations.

Make it easier to triage when we receive complain to know whether incremental is not supported versus there is some bugs.