### PR TITLE
Create bare bones migration

### DIFF
--- a/packages/dds/migration-shim/api-report/migration-shim.api.md
+++ b/packages/dds/migration-shim/api-report/migration-shim.api.md
@@ -31,7 +31,7 @@ export interface IMigrationEvent extends IEvent {
 export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements IChannel {
     constructor(id: string, runtime: IFluidDataStoreRuntime, legacyTreeFactory: SharedTreeFactory, newTreeFactory: SharedTreeFactory_2, populateNewSharedObjectFn: (legacyTree: SharedTree, newTree: ISharedTree) => void);
     // (undocumented)
-    attributes: IChannelAttributes;
+    get attributes(): IChannelAttributes;
     // (undocumented)
     connect(services: IChannelServices): void;
     // (undocumented)

--- a/packages/dds/migration-shim/src/migrationShim.ts
+++ b/packages/dds/migration-shim/src/migrationShim.ts
@@ -126,7 +126,7 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 
 	private newTree: ISharedTree | undefined;
 
-	// This is the magic button that tells this Spanner and all other Spanners to swap to the new Shared Object.
+	// Migration occurs once this op is read.
 	public submitMigrateOp(): void {
 		const migrateOp: IMigrationOp = {
 			type: "barrier",
@@ -189,11 +189,14 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 	public isAttached(): boolean {
 		return this.currentTree.isAttached();
 	}
+
+	// Only connect to the legacy shared tree
 	public connect(services: IChannelServices): void {
 		const shimServices = this.generateShimServicesOnce(services);
 		this.legacyTree.connect(shimServices);
 	}
 
+	// Only reconnect to the new shared tree this limits us to only migrating
 	private reconnect(): void {
 		assert(this.services !== undefined, "Not connected");
 		assert(this.newTree !== undefined, "New tree not initialized");

--- a/packages/dds/migration-shim/src/migrationShim.ts
+++ b/packages/dds/migration-shim/src/migrationShim.ts
@@ -27,7 +27,7 @@ import {
 } from "@fluid-experimental/tree";
 import { type SharedTreeFactory, type ISharedTree } from "@fluid-experimental/tree2";
 import { assert } from "@fluidframework/core-utils";
-import { type ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { MessageType, type ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { NoDeltasChannelServices, ShimChannelServices } from "./shimChannelServices";
 import { MigrationShimDeltaHandler } from "./migrationDeltaHandler";
 
@@ -50,7 +50,7 @@ export interface IMigrationOp {
 	/**
 	 * Type of the migration operation.
 	 */
-	type: "hotSwap";
+	type: "barrier";
 	/**
 	 * Old channel attributes so we can do verification and understand what changed. This will allow future clients to
 	 * accurately reason about what state of the document was before the migration op initiated at.
@@ -99,9 +99,15 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 	// Or we pass in this and have some "process and submit logic here"
 	// The cost is that this class gets big.
 	private readonly processMigrateOp = (message: ISequencedDocumentMessage): boolean => {
-		if (message.type !== "migrate") {
+		if (
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+			message.type !== MessageType.Operation ||
+			(message.contents as Partial<IMigrationOp>).type !== "barrier"
+		) {
 			return false;
 		}
+
+		// TODO: some attribute checking here
 		this.newTree = this.newTreeFactory.create(this.runtime, this.id);
 		this.populateNewSharedObjectFn(this.legacyTree, this.newTree);
 		this.reconnect();
@@ -122,10 +128,17 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 
 	// This is the magic button that tells this Spanner and all other Spanners to swap to the new Shared Object.
 	public submitMigrateOp(): void {
-		// These console logs are for compilation purposes
-		console.log(this.newTreeFactory);
-		console.log(this.populateNewSharedObjectFn);
-		throw new Error("Method not implemented.");
+		const migrateOp: IMigrationOp = {
+			type: "barrier",
+			oldAttributes: this.legacyTreeFactory.attributes,
+			newAttributes: this.newTreeFactory.attributes,
+		};
+
+		// This is a copy of submit local message from SharedObject
+		if (this.isAttached()) {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			this.services!.deltaConnection.submit(migrateOp, undefined);
+		}
 	}
 
 	public get currentTree(): LegacySharedTree | ISharedTree {
@@ -150,13 +163,15 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 		this._legacyTree = this.legacyTreeFactory.create(this.runtime, this.id);
 	}
 
-	public attributes!: IChannelAttributes;
+	public get attributes(): IChannelAttributes {
+		return this.currentTree.attributes;
+	}
 	public getAttachSummary(
 		fullTree?: boolean | undefined,
 		trackState?: boolean | undefined,
 		telemetryContext?: ITelemetryContext | undefined,
 	): ISummaryTreeWithStats {
-		throw new Error("Method not implemented.");
+		return this.currentTree.getAttachSummary(fullTree, trackState, telemetryContext);
 	}
 	public async summarize(
 		fullTree?: boolean | undefined,
@@ -164,10 +179,15 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 		telemetryContext?: ITelemetryContext | undefined,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
 	): Promise<ISummaryTreeWithStats> {
-		throw new Error("Method not implemented.");
+		return this.currentTree.summarize(
+			fullTree,
+			trackState,
+			telemetryContext,
+			incrementalSummaryContext,
+		);
 	}
 	public isAttached(): boolean {
-		throw new Error("Method not implemented.");
+		return this.currentTree.isAttached();
 	}
 	public connect(services: IChannelServices): void {
 		const shimServices = this.generateShimServicesOnce(services);
@@ -188,7 +208,7 @@ export class MigrationShim extends TypedEventEmitter<IMigrationEvent> implements
 	}
 
 	public getGCData(fullGC?: boolean | undefined): IGarbageCollectionData {
-		throw new Error("Method not implemented.");
+		return this.currentTree.getGCData(fullGC);
 	}
 	public handle!: IFluidHandle;
 	public IFluidLoadable!: IFluidLoadable;

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -75,9 +75,9 @@
 	"dependencies": {
 		"@fluid-experimental/attributor": "workspace:~",
 		"@fluid-experimental/migration-shim": "workspace:~",
+		"@fluid-experimental/sequence-deprecated": "workspace:~",
 		"@fluid-experimental/tree": "workspace:~",
 		"@fluid-experimental/tree2": "workspace:~",
-		"@fluid-experimental/sequence-deprecated": "workspace:~",
 		"@fluid-internal/client-utils": "workspace:~",
 		"@fluid-internal/test-loader-utils": "workspace:~",
 		"@fluid-internal/test-pairwise-generator": "workspace:~",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -74,6 +74,9 @@
 	},
 	"dependencies": {
 		"@fluid-experimental/attributor": "workspace:~",
+		"@fluid-experimental/migration-shim": "workspace:~",
+		"@fluid-experimental/tree": "workspace:~",
+		"@fluid-experimental/tree2": "workspace:~",
 		"@fluid-experimental/sequence-deprecated": "workspace:~",
 		"@fluid-internal/client-utils": "workspace:~",
 		"@fluid-internal/test-loader-utils": "workspace:~",

--- a/packages/test/test-end-to-end-tests/src/test/dataMigration.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataMigration.spec.ts
@@ -1,0 +1,243 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import {
+	MigrationShim,
+	MigrationShimFactory,
+	SharedTreeShimFactory,
+} from "@fluid-experimental/migration-shim";
+import {
+	BuildNode,
+	Change,
+	SharedTree as LegacySharedTree,
+	StablePlace,
+	TraitLabel,
+} from "@fluid-experimental/tree";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	DataObject,
+	DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IChannel } from "@fluidframework/datastore-definitions";
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import {
+	AllowedUpdateType,
+	ISharedTree,
+	SchemaBuilder,
+	SharedTreeFactory,
+	Typed,
+} from "@fluid-experimental/tree2";
+
+const legacyNodeId: TraitLabel = "inventory" as TraitLabel;
+
+// A Test Data Object that exposes some basic functionality.
+class TestDataObject extends DataObject {
+	private channel?: IChannel;
+
+	// The object starts with a LegacySharedTree
+	public async initializingFirstTime(props?: any): Promise<void> {
+		const legacyTree = this.runtime.createChannel(
+			"tree",
+			LegacySharedTree.getFactory().type,
+		) as LegacySharedTree;
+
+		const inventoryNode: BuildNode = {
+			definition: legacyNodeId,
+			traits: {
+				quantity: {
+					definition: "quantity",
+					payload: 0,
+				},
+			},
+		};
+		legacyTree.applyEdit(
+			Change.insertTree(
+				inventoryNode,
+				StablePlace.atStartOf({
+					parent: legacyTree.currentView.root,
+					label: "inventory" as TraitLabel,
+				}),
+			),
+		);
+
+		this.root.set("tree", legacyTree.handle);
+		this.channel = legacyTree;
+	}
+
+	// Makes it so we can get the tree stored as "tree"
+	public async hasInitialized(): Promise<void> {
+		const tree = await this.runtime.getChannel("tree");
+		this.channel = tree;
+	}
+
+	// Allows us to get the SharedObject with whatever type we want
+	public getTree<T>() {
+		assert(this.channel !== undefined, "Channel should be defined");
+		return this.channel as T;
+	}
+}
+
+const builder = new SchemaBuilder({ scope: "test" });
+// For now this is the schema of the view.root
+const inventorySchema = builder.struct("abcInventory", {
+	quantity: builder.number,
+});
+
+// This is some schema to be updated later
+const inventoryFieldSchema = SchemaBuilder.required(inventorySchema);
+const schema = builder.toDocumentSchema(inventoryFieldSchema);
+
+function getNewTreeView(tree: ISharedTree) {
+	return tree.schematize({
+		initialTree: {
+			quantity: 0,
+		},
+		allowedSchemaModifications: AllowedUpdateType.None,
+		schema,
+	});
+}
+
+describeNoCompat("HotSwap", (getTestObjectProvider) => {
+	// Allow us to control summaries
+	const runtimeOptions: IContainerRuntimeOptions = {
+		summaryOptions: {
+			summaryConfigOverrides: {
+				state: "disabled",
+			},
+		},
+	};
+
+	// V1 of the registry -----------------------------------------
+	// V1 of the code: Registry setup to create the old document
+	const oldChannelFactory = LegacySharedTree.getFactory();
+	const dataObjectFactory1 = new DataObjectFactory(
+		"TestDataObject",
+		TestDataObject,
+		[oldChannelFactory],
+		{},
+	);
+
+	// The 1st runtime factory, V1 of the code
+	const runtimeFactory1 = new ContainerRuntimeFactoryWithDefaultDataStore({
+		defaultFactory: dataObjectFactory1,
+		registryEntries: [dataObjectFactory1.registryEntry],
+	});
+
+	// V2 of the registry (the migration registry) -----------------------------------------
+	// V2 of the code: Registry setup to migrate the document
+	const legacySharedTreeFactory = LegacySharedTree.getFactory();
+	const newSharedTreeFactory = new SharedTreeFactory();
+
+	const migrationShimFactory = new MigrationShimFactory(
+		legacySharedTreeFactory,
+		newSharedTreeFactory,
+		(legacyTree, newTree) => {
+			const rootNode = legacyTree.currentView.getViewNode(legacyTree.currentView.root);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const nodeId = rootNode.traits.get(legacyNodeId)![0];
+			const legacyNode = legacyTree.currentView.getViewNode(nodeId);
+			const quantity = legacyNode.payload.quantity as number;
+			newTree.schematize({
+				initialTree: {
+					quantity,
+				},
+				allowedSchemaModifications: AllowedUpdateType.None,
+				schema,
+			});
+		},
+	);
+
+	const sharedTreeShimFactory = new SharedTreeShimFactory(newSharedTreeFactory);
+
+	const dataObjectFactory2 = new DataObjectFactory(
+		"TestDataObject",
+		TestDataObject,
+		[migrationShimFactory, sharedTreeShimFactory],
+		{},
+	);
+
+	// The 2nd runtime factory, V2 of the code
+	const runtimeFactory2 = new ContainerRuntimeFactoryWithDefaultDataStore({
+		defaultFactory: dataObjectFactory2,
+		registryEntries: [dataObjectFactory2.registryEntry],
+		runtimeOptions,
+	});
+
+	let provider: ITestObjectProvider;
+
+	const originalValue = 3;
+
+	beforeEach(async () => {
+		provider = getTestObjectProvider();
+		// Creates the document as v1 of the code with a SharedCell
+		const container = await provider.createContainer(runtimeFactory1);
+		const testObj = await requestFluidObject<TestDataObject>(container, "/");
+		const legacyTree = testObj.getTree<LegacySharedTree>();
+		const rootNode = legacyTree.currentView.getViewNode(legacyTree.currentView.root);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const nodeId = rootNode.traits.get(legacyNodeId)![0];
+		const change: Change = Change.setPayload(nodeId, { quantity: originalValue });
+		legacyTree.applyEdit(change);
+		// make sure changes are saved.
+		await provider.ensureSynchronized();
+		container.close();
+	});
+
+	it("Can Hot Swap", async () => {
+		// Setup containers and get Spanners instead of SharedCells
+		const container1 = await provider.loadContainer(runtimeFactory2);
+		const testObj1 = await requestFluidObject<TestDataObject>(container1, "/");
+		const shim1 = testObj1.getTree<MigrationShim>();
+
+		const container2 = await provider.loadContainer(runtimeFactory2);
+		const testObj2 = await requestFluidObject<TestDataObject>(container2, "/");
+		const shim2 = testObj2.getTree<MigrationShim>();
+		assert(
+			shim1.currentTree.attributes.type === legacySharedTreeFactory.type,
+			"shim1 is not legacy tree",
+		);
+		assert(
+			shim2.currentTree.attributes.type === legacySharedTreeFactory.type,
+			"shim2 is not legacy tree",
+		);
+
+		await provider.ensureSynchronized();
+
+		// Hot swap
+		shim1.submitMigrateOp();
+
+		// TODO: shim1.on("migrated", () => { ... });
+		// TODO: shim2.on("migrated", () => { ... });
+		await provider.ensureSynchronized();
+		assert(
+			shim1.currentTree.attributes.type === newSharedTreeFactory.type,
+			"should have migrated",
+		);
+		assert(
+			shim2.currentTree.attributes.type === newSharedTreeFactory.type,
+			"should have migrated",
+		);
+		const tree1 = shim1.currentTree as ISharedTree;
+		const tree2 = shim2.currentTree as ISharedTree;
+
+		const view1 = getNewTreeView(tree1);
+		const view2 = getNewTreeView(tree2);
+		const treeNode1 = view1.root as unknown as Typed<typeof inventorySchema>;
+		const treeNode2 = view2.root as unknown as Typed<typeof inventorySchema>;
+
+		// Validate migration succeeded
+		const migratedValue1 = treeNode1.quantity;
+		const migratedValue2 = treeNode2.quantity;
+		assert(
+			migratedValue2 === originalValue && migratedValue2 === migratedValue1,
+			`Failed to migrate values original ${originalValue} migrated 1: ${migratedValue1}, 2: ${migratedValue2}`,
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9937,7 +9937,10 @@ importers:
   packages/test/test-end-to-end-tests:
     specifiers:
       '@fluid-experimental/attributor': workspace:~
+      '@fluid-experimental/migration-shim': workspace:~
       '@fluid-experimental/sequence-deprecated': workspace:~
+      '@fluid-experimental/tree': workspace:~
+      '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/test-loader-utils': workspace:~
       '@fluid-internal/test-pairwise-generator': workspace:~
@@ -10006,7 +10009,10 @@ importers:
       uuid: ^9.0.0
     dependencies:
       '@fluid-experimental/attributor': link:../../framework/attributor
+      '@fluid-experimental/migration-shim': link:../../dds/migration-shim
       '@fluid-experimental/sequence-deprecated': link:../../../experimental/dds/sequence-deprecated
+      '@fluid-experimental/tree': link:../../../experimental/dds/tree
+      '@fluid-experimental/tree2': link:../../../experimental/dds/tree2
       '@fluid-internal/client-utils': link:../../common/client-utils
       '@fluid-internal/test-loader-utils': link:../../loader/test-loader-utils
       '@fluid-internal/test-pairwise-generator': link:../test-pairwise-generator


### PR DESCRIPTION
[AB#5782](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5782)

This enables the `MigrationShim` to do a basic `SharedTree` migration from `LegacySharedTree` to the new `SharedTree` by submitting a migration op. 

The only scenario being tested
1. Document starts in v1 legacy tree code only
2. Document in v1 is closed
3. Document is opened by two clients (A & B) with v2 migration code
4. Client A submits the migration op
5. Client A & B both process the migration op
6. Verifies that Client A and B are using the new `SharedTree`, and the data has been migrated.

Future work:
- Adding summarization tests
- Adding loading tests
- Adding handle tests
- Adding connection state tests (create, binding via handles, rehydration)
- Local state, where v1 ops are resubmitted somehow (maybe this isn't a concern)
- Dropping v1 ops, and stamping v2 ops
- Summarizing in between state where v1 and v2 ops can be mixed