### PR TITLE
tree2: Rename SchemaBuilder.finalize to intoLibrary

### DIFF
--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -317,7 +317,7 @@ export const nodePropertySchema = builtinBuilder.map(
 	nodePropertyType,
 	builtinBuilder.optional(Any),
 );
-const builtinLibrary = builtinBuilder.finalize();
+const builtinLibrary = builtinBuilder.intoLibrary();
 
 /**
  * Creates a TreeSchema out of PropertyDDS schema templates.

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1834,7 +1834,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
         };
     }>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<Unenforced<TreeNodeSchema>>>(kind: Kind, ...allowedTypes: T): FieldSchema<Kind, T>;
-    finalize(): SchemaLibrary;
+    intoLibrary(): SchemaLibrary;
     intoSchema<const TSchema extends ImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
     map<Name extends TName, const T extends MapFieldSchema>(name: Name, fieldSchema: T): TreeNodeSchema<`${TScope}.${Name}`, {
         mapFields: T;

--- a/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
@@ -56,4 +56,4 @@ export const jsonArray = builder.fieldNodeRecursive(
 /**
  * @alpha
  */
-export const jsonSchema = builder.finalize();
+export const jsonSchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -20,7 +20,7 @@ const nullSchema = builder.leaf("null", ValueSchema.Null);
 const primitives = [number, boolean, string] as const;
 const all = [handle, nullSchema, ...primitives] as const;
 
-const library = builder.finalize();
+const library = builder.intoLibrary();
 
 /**
  * Schema for the built-in {@link Leaf} node types.

--- a/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
+++ b/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
@@ -43,4 +43,4 @@ export const nodeKeyField = {
  * Required to use {@link nodeKeyField}.
  * @alpha
  */
-export const nodeKeySchema = builder.finalize();
+export const nodeKeySchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -49,4 +49,4 @@ type _1 = requireTrue<
 /**
  * @alpha
  */
-export const library = builder.finalize();
+export const library = builder.intoLibrary();

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -151,7 +151,7 @@ export class SchemaBuilderBase<
 	 * Produce SchemaLibraries which capture the content added to this builder, as well as any additional SchemaLibraries that were added to it.
 	 * May only be called once after adding content to builder is complete.
 	 */
-	public finalize(): SchemaLibrary {
+	public intoLibrary(): SchemaLibrary {
 		const aggregated = this.finalizeCommon();
 
 		// Full library set (instead of just aggregated) is kept since it is required to handle deduplication of libraries included through different paths.

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -48,7 +48,7 @@ const valueField = SchemaBuilder.required(leaf.number);
 const structValue = builder.struct("structValue", { x: valueField });
 const optionalField = builder.optional(leaf.number);
 const structOptional = builder.struct("structOptional", { x: optionalField });
-const schema = builder.finalize();
+const schema = builder.intoLibrary();
 
 function expectEqual(a: ShapeInfo, b: ShapeInfo): void {
 	assert.deepEqual(a, b);

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/mockData.ts
@@ -100,7 +100,7 @@ export const arraySchema = builder.fieldNode(
 
 export const rootPersonSchema = FieldSchema.create(FieldKinds.optional, [personSchema]);
 
-export const personSchemaLibrary = builder.finalize();
+export const personSchemaLibrary = builder.intoLibrary();
 
 export const fullSchemaData = buildTestSchema(rootPersonSchema);
 

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -93,7 +93,7 @@ describe("Schema Evolution Examples", () => {
 		y: leaf.number,
 	});
 
-	const defaultContentLibrary = contentTypesBuilder.finalize();
+	const defaultContentLibrary = contentTypesBuilder.intoLibrary();
 
 	const containersBuilder = new SchemaBuilder({
 		scope: "test",
@@ -114,7 +114,7 @@ describe("Schema Evolution Examples", () => {
 
 	const tolerantRoot = FieldSchema.create(FieldKinds.optional, [canvas]);
 
-	const treeViewSchema = containersBuilder.finalize();
+	const treeViewSchema = containersBuilder.intoLibrary();
 
 	/**
 	 * This shows basic usage of stored and view schema, including a schema change handled using the

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -97,7 +97,7 @@ import { SimpleNodeDataFor } from "./schemaAwareSimple";
 	}
 
 	type x = typeof numberSchema.name;
-	const schemaData = builder.finalize();
+	const schemaData = builder.intoLibrary();
 
 	// Example Use:
 	type BallTree = TypedNode<typeof ballSchema, ApiMode.Flexible>;

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaBuilder.spec.ts
@@ -109,7 +109,7 @@ describe("SchemaBuilderBase", () => {
 		it("Simple", () => {
 			const schemaBuilder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
 			const empty = schemaBuilder.struct("empty", {});
-			const schema = schemaBuilder.finalize();
+			const schema = schemaBuilder.intoLibrary();
 
 			assert.equal(schema.treeSchema.size, 1); // "empty"
 			assert.equal(schema.treeSchema.get(brand("test.empty")), empty);

--- a/experimental/dds/tree2/src/test/testTrees.ts
+++ b/experimental/dds/tree2/src/test/testTrees.ts
@@ -130,7 +130,7 @@ export const recursiveType = builder.structRecursive("recursiveType", {
 	field: FieldSchema.createUnsafe(FieldKinds.optional, [() => recursiveType]),
 });
 
-export const library = builder.finalize();
+export const library = builder.intoLibrary();
 
 export const testTrees: readonly TestTree[] = [
 	testField("empty", library, SchemaBuilder.optional([]), undefined),


### PR DESCRIPTION
## Description

Rename SchemaBuilder.finalize to intoLibrary.

This helps align the name with intoSchema, and is more clear about what it returns.

## Breaking Changes

Rename SchemaBuilder.finalize to intoLibrary

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

