### PR TITLE
Add interface related to message infraturcture

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,4 +93,5 @@
 		"**/*.log": true,
 		"**/DS_Store": true,
 	},
+	"search.followSymlinks": false
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
@@ -9,6 +9,7 @@ import {
 	ITokenRevocationManager,
 	IRevokedTokenChecker,
 	IWebSocketTracker,
+	IServiceMessageResourceManager,
 } from "@fluidframework/server-services-core";
 import { IDocumentDeleteService } from "./services";
 
@@ -19,4 +20,5 @@ export interface IAlfredResourcesCustomizations {
 	tokenRevocationManager?: ITokenRevocationManager;
 	revokedTokenChecker?: IRevokedTokenChecker;
 	webSocketTracker?: IWebSocketTracker;
+	serviceMessageResourceManager?: IServiceMessageResourceManager;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -117,6 +117,7 @@ export class AlfredResources implements core.IResources {
 		public tokenRevocationManager?: core.ITokenRevocationManager,
 		public revokedTokenChecker?: core.IRevokedTokenChecker,
 		public collaborationSessionEvents?: TypedEventEmitter<ICollaborationSessionEvents>,
+		public serviceMessageResourceManager?: core.IServiceMessageResourceManager,
 	) {
 		const socketIoAdapterConfig = config.get("alfred:socketIoAdapter");
 		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
@@ -147,7 +148,15 @@ export class AlfredResources implements core.IResources {
 		const tokenRevocationManagerP = this.tokenRevocationManager
 			? this.tokenRevocationManager.close()
 			: Promise.resolve();
-		await Promise.all([producerClosedP, mongoClosedP, tokenRevocationManagerP]);
+		const serviceMessageManagerP = this.serviceMessageResourceManager
+			? this.serviceMessageResourceManager.close()
+			: Promise.resolve();
+		await Promise.all([
+			producerClosedP,
+			mongoClosedP,
+			tokenRevocationManagerP,
+			serviceMessageManagerP,
+		]);
 	}
 }
 
@@ -553,6 +562,9 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		const documentDeleteService =
 			customizations?.documentDeleteService ?? new DocumentDeleteService();
 
+		// Service Message setup
+		const serviceMessageResourceManager = customizations?.serviceMessageResourceManager;
+
 		// Set up token revocation if enabled
 		/**
 		 * Always have a revoked token checker,
@@ -607,6 +619,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			tokenRevocationManager,
 			revokedTokenChecker,
 			collaborationSessionEvents,
+			serviceMessageResourceManager,
 		);
 	}
 }

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -163,3 +163,4 @@ export {
 	TokenRevokedError,
 	createCompositeTokenId,
 } from "./tokenRevocationManager";
+export { IServiceMessageResourceManager } from "./serviceMessage";

--- a/server/routerlicious/packages/services-core/src/serviceMessage.ts
+++ b/server/routerlicious/packages/services-core/src/serviceMessage.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Interface of managing resources for messages that are broadcasted among services.
+ * IServiceMessage is not the message that flows through Kafka and not used explicitly in FluidFramework yet.
+ * Its definition is hidden in FluidFramework.
+ * This interface is created to properly clean up resources in IResource.dispose function
+ */
+export interface IServiceMessageResourceManager {
+	/**
+	 * Close and clean up resources
+	 */
+	close(): Promise<void>;
+}

--- a/server/routerlicious/packages/services-core/src/serviceMessage.ts
+++ b/server/routerlicious/packages/services-core/src/serviceMessage.ts
@@ -4,10 +4,10 @@
  */
 
 /**
- * Interface of managing resources for messages that are broadcasted among services.
- * IServiceMessage is not the message that flows through Kafka and not used explicitly in FluidFramework yet.
- * Its definition is hidden in FluidFramework.
- * This interface is created to properly clean up resources in IResource.dispose function
+ * Interface of managing resources (publisher and consumers) for sending and receiving IServiceMessage.
+ * IServiceMessage is the message broadcasted among services, not the one that flows through Ordering service(Kafka).
+ * It is not used explicitly in FluidFramework yet, so its definition is hidden in FluidFramework.
+ * This interface is created to properly clean up resources in current runner framework.
  */
 export interface IServiceMessageResourceManager {
 	/**


### PR DESCRIPTION
This PR include adding a new interface related to IServiceMessage. This message is used in FRS for token revocation purpose and was hidden in the past. Now it needs to be shared and used by other classes. It is used for resource clean up purpose.