### PR TITLE
tree2: Mark TreeNodeSchemaIdentifier beta

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -222,7 +222,7 @@ export interface BindTree<T = BindTreeDefault> extends PathStep {
 export type BindTreeDefault = BindTree;
 
 // @beta
-export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
+type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
 
 // @alpha
 export function brand<T extends Brand<any, string>>(value: T extends BrandedType<infer ValueType, string> ? ValueType : never): T;
@@ -948,6 +948,7 @@ declare namespace InternalTypes {
         isAny,
         RestrictiveReadonlyRecord,
         BrandedKeyContent,
+        Brand,
         NormalizeField_2 as NormalizeField,
         NormalizeAllowedTypes,
         Required_2 as Required,

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -221,7 +221,7 @@ export interface BindTree<T = BindTreeDefault> extends PathStep {
 // @alpha
 export type BindTreeDefault = BindTree;
 
-// @alpha
+// @beta
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
 
 // @alpha
@@ -245,7 +245,7 @@ export interface BrandedMapSubset<K extends BrandedKey<unknown, any>> {
     set<K2 extends K>(key: K2, value: BrandedKeyContent<K2>): this;
 }
 
-// @alpha @sealed
+// @beta @sealed
 abstract class BrandedType<ValueType, Name extends string> {
     protected readonly _type_brand: Name;
     // (undocumented)
@@ -330,13 +330,13 @@ export interface ContextuallyTypedNodeDataObject {
     [key: string]: ContextuallyTypedFieldData;
 }
 
-// @alpha
+// @beta
 interface Contravariant<in T> {
     // (undocumented)
     _removeCovariance?: (_: T) => void;
 }
 
-// @alpha
+// @beta
 interface Covariant<out T> {
     // (undocumented)
     _removeContravariance?: T;
@@ -1008,7 +1008,7 @@ export class InvalidationToken {
     protected readonly _typeCheck: MakeNominal;
 }
 
-// @alpha
+// @beta
 interface Invariant<in out T> extends Contravariant<T>, Covariant<T> {
 }
 
@@ -2192,7 +2192,7 @@ export class TreeNodeSchema<Name extends string = string, T extends Unenforced<T
     readonly structFieldsObject: NormalizeStructFields<Assume<T, TreeSchemaSpecification>["structFields"]>;
 }
 
-// @alpha
+// @beta
 export type TreeNodeSchemaIdentifier = Brand<string, "tree.TreeNodeSchemaIdentifier">;
 
 // @alpha (undocumented)

--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -6,11 +6,11 @@
 import { Brand, brand, brandedStringType } from "../../util";
 
 /**
- * SchemaIdentifier for a TreeNode.
+ * Identifier for a TreeNode schema.
  * Also known as "Definition"
  *
  * Stable identifier, used when persisting data.
- * @alpha
+ * @beta
  */
 export type TreeNodeSchemaIdentifier = Brand<string, "tree.TreeNodeSchemaIdentifier">;
 

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -85,7 +85,6 @@ export {
 } from "./core";
 
 export {
-	Brand,
 	Opaque,
 	extractFromOpaque,
 	brand,

--- a/experimental/dds/tree2/src/internal.ts
+++ b/experimental/dds/tree2/src/internal.ts
@@ -22,6 +22,7 @@ export {
 	isAny,
 	RestrictiveReadonlyRecord,
 	BrandedKeyContent,
+	Brand,
 } from "./util";
 
 export {

--- a/experimental/dds/tree2/src/util/brand.ts
+++ b/experimental/dds/tree2/src/util/brand.ts
@@ -17,7 +17,7 @@ import { Invariant, isAny } from "./typeCheck";
  * `Type 'Name1' is not assignable to type 'Name2'.`
  *
  * These branded types are not opaque: A `Brand<A, B>` can still be used as a `B`.
- * @alpha
+ * @beta
  */
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
 
@@ -35,7 +35,7 @@ export type Brand<ValueType, Name extends string> = ValueType & BrandedType<Valu
  * but the compiler may think it's true in some cases.
  *
  * @sealed
- * @alpha
+ * @beta
  */
 export abstract class BrandedType<ValueType, Name extends string> {
 	protected _typeCheck?: Invariant<ValueType>;

--- a/experimental/dds/tree2/src/util/brand.ts
+++ b/experimental/dds/tree2/src/util/brand.ts
@@ -22,7 +22,7 @@ import { Invariant, isAny } from "./typeCheck";
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
 
 /**
- * Helper for {@link Brand}.
+ * Helper for `Brand`.
  * This is split out into its own as that's the only way to:
  * - have doc comments for the field.
  * - make the field protected (so you don't accidentally try and read it).
@@ -42,7 +42,7 @@ export abstract class BrandedType<ValueType, Name extends string> {
 	/**
 	 * Compile time only marker to make type checking more strict.
 	 * This field will not exist at runtime and accessing it is invalid.
-	 * See {@link Brand} for details.
+	 * See `Brand` for details.
 	 */
 	protected readonly _type_brand!: Name;
 
@@ -120,7 +120,7 @@ export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(
 }
 
 /**
- * Adds a type {@link Brand} to a value.
+ * Adds a type `Brand` to a value.
  *
  * Only do this when specifically allowed by the requirements of the type being converted to.
  * @alpha
@@ -132,7 +132,7 @@ export function brand<T extends Brand<any, string>>(
 }
 
 /**
- * Adds a type {@link Brand} to a value, returning it as a {@link Opaque} handle.
+ * Adds a type `Brand` to a value, returning it as a {@link Opaque} handle.
  *
  * Only do this when specifically allowed by the requirements of the type being converted to.
  * @alpha

--- a/experimental/dds/tree2/src/util/typeCheck.ts
+++ b/experimental/dds/tree2/src/util/typeCheck.ts
@@ -93,7 +93,7 @@ export interface MakeNominal {}
  * protected _typeCheck?: Contravariant<T>;
  * ```
  *
- * @alpha
+ * @beta
  */
 export interface Contravariant<in T> {
 	_removeCovariance?: (_: T) => void;
@@ -108,7 +108,7 @@ export interface Contravariant<in T> {
  * protected _typeCheck?: Covariant<T>;
  * ```
  *
- * @alpha
+ * @beta
  */
 export interface Covariant<out T> {
 	_removeContravariance?: T;
@@ -123,7 +123,7 @@ export interface Covariant<out T> {
  * protected _typeCheck?: Invariant<T>;
  * ```
  *
- * @alpha
+ * @beta
  */
 export interface Invariant<in out T> extends Contravariant<T>, Covariant<T> {}
 


### PR DESCRIPTION
## Description

Mark TreeNodeSchemaIdentifier and its dependencies as `@beta` instead of alpha as a start toward selecting a subset of the current `@alpha` package API to stabilize.

TreeNodeSchemaIdentifier was selected since its part of the schema APIs, so it will be part of the eventual stable package API, and is a simple type.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
