### PR TITLE
adding missing changeset file for ISession.messageBrokerId

### DIFF
--- a/server/routerlicious/.changeset/pretty-birds-pay.md
+++ b/server/routerlicious/.changeset/pretty-birds-pay.md
@@ -5,4 +5,6 @@
 "@fluidframework/server-services-shared": major
 ---
 
-ISession interface was updated with new field 'messageBrokerId' that would be assigned when message broker is set to Event Hubs
+server-services-client: `messageBrokerId` added to `ISession`
+
+The `ISession` interface was updated with new field `messageBrokerId` that would be assigned when message broker is set to Event Hubs.

--- a/server/routerlicious/.changeset/pretty-birds-pay.md
+++ b/server/routerlicious/.changeset/pretty-birds-pay.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/server-routerlicious-base": major
+"@fluidframework/server-services-client": major
+"@fluidframework/server-services-core": major
+"@fluidframework/server-services-shared": major
+---
+
+ISession interface was updated with new field 'messageBrokerId' that would be assigned when message broker is set to Event Hubs


### PR DESCRIPTION
## Description

Adding missing changeset file for ISession.messageBrokerId field that was added as part of [this PR](https://github.com/microsoft/FluidFramework/pull/17844).

