### PR TITLE
refactor(tree2): simplify DetachedFieldIndex data and summary

### DIFF
--- a/experimental/dds/tree2/src/core/tree/detachedFieldIndex.ts
+++ b/experimental/dds/tree2/src/core/tree/detachedFieldIndex.ts
@@ -9,9 +9,8 @@ import {
 	IdAllocator,
 	NestedMap,
 	brand,
-	decodeNestedMap,
 	deleteFromNestedMap,
-	encodeNestedMap,
+	forEachInNestedMap,
 	idAllocatorFromMaxId,
 	populateNestedMap,
 	setInNestedMap,
@@ -28,11 +27,6 @@ import * as Delta from "./delta";
  */
 export type ForestRootId = Brand<number, "tree.ForestRootId">;
 
-export interface Entry {
-	field: FieldKey;
-	root: ForestRootId;
-}
-
 type Major = string | number | undefined;
 type Minor = number;
 
@@ -41,7 +35,7 @@ type Minor = number;
  */
 export class DetachedFieldIndex {
 	// TODO: don't store the field key in the index, it can be derived from the root ID
-	private detachedNodeToField: NestedMap<Major, Minor, Entry> = new Map();
+	private detachedNodeToField: NestedMap<Major, Minor, ForestRootId> = new Map();
 
 	/**
 	 * @param name - A name for the index, used as a prefix for the generated field keys.
@@ -58,15 +52,15 @@ export class DetachedFieldIndex {
 		return clone;
 	}
 
-	public *entries(): Generator<Entry & { id: Delta.DetachedNodeId }> {
+	public *entries(): Generator<{ root: ForestRootId } & { id: Delta.DetachedNodeId }> {
 		for (const [major, innerMap] of this.detachedNodeToField) {
 			if (major !== undefined) {
 				for (const [minor, entry] of innerMap) {
-					yield { id: { major, minor }, ...entry };
+					yield { id: { major, minor }, root: entry };
 				}
 			} else {
 				for (const [minor, entry] of innerMap) {
-					yield { id: { minor }, ...entry };
+					yield { id: { minor }, root: entry };
 				}
 			}
 		}
@@ -103,7 +97,7 @@ export class DetachedFieldIndex {
 	 * Returns the FieldKey associated with the given id.
 	 * Returns undefined if no such id is known to the index.
 	 */
-	public tryGetEntry(id: Delta.DetachedNodeId): Entry | undefined {
+	public tryGetEntry(id: Delta.DetachedNodeId): ForestRootId | undefined {
 		return tryGetFromNestedMap(this.detachedNodeToField, id.major, id.minor);
 	}
 
@@ -111,7 +105,7 @@ export class DetachedFieldIndex {
 	 * Returns the FieldKey associated with the given id.
 	 * Fails if no such id is known to the index.
 	 */
-	public getEntry(id: Delta.DetachedNodeId): Entry {
+	public getEntry(id: Delta.DetachedNodeId): ForestRootId {
 		const key = this.tryGetEntry(id);
 		assert(key !== undefined, 0x7aa /* Unknown removed node ID */);
 		return key;
@@ -121,7 +115,7 @@ export class DetachedFieldIndex {
 	 * Retrieves the associated ForestRootId if any.
 	 * Otherwise, allocates a new one and associates it with the given DetachedNodeId.
 	 */
-	public getOrCreateEntry(nodeId: Delta.DetachedNodeId, count: number = 1): Entry {
+	public getOrCreateEntry(nodeId: Delta.DetachedNodeId, count: number = 1): ForestRootId {
 		return this.tryGetEntry(nodeId) ?? this.createEntry(nodeId);
 	}
 
@@ -133,22 +127,23 @@ export class DetachedFieldIndex {
 	/**
 	 * Associates the DetachedNodeId with a field key and creates an entry for it in the index.
 	 */
-	public createEntry(nodeId?: Delta.DetachedNodeId, count: number = 1): Entry {
+	public createEntry(nodeId?: Delta.DetachedNodeId, count: number = 1): ForestRootId {
 		const root = this.rootIdAllocator.allocate(count);
-		const field = this.toFieldKey(root);
-		const entry = { field, root };
-
 		if (nodeId !== undefined) {
 			for (let i = 0; i < count; i++) {
-				setInNestedMap(this.detachedNodeToField, nodeId.major, nodeId.minor + i, entry);
+				setInNestedMap(this.detachedNodeToField, nodeId.major, nodeId.minor + i, root);
 			}
 		}
-		return entry;
+		return root;
 	}
 
 	public encode(): string {
+		const data: [Major, Minor, ForestRootId][] = [];
+		forEachInNestedMap(this.detachedNodeToField, (root, key1, key2) => {
+			data.push([key1, key2, root]);
+		});
 		return JSON.stringify({
-			data: encodeNestedMap(this.detachedNodeToField),
+			data,
 			id: this.rootIdAllocator.getNextId(),
 		});
 	}
@@ -157,8 +152,13 @@ export class DetachedFieldIndex {
 	 * Loads the tree index from the given string, this overrides any existing data.
 	 */
 	public loadData(data: string): void {
-		const detachedFieldIndex: { data: string; id: number } = JSON.parse(data);
-		this.detachedNodeToField = decodeNestedMap(detachedFieldIndex.data);
+		const detachedFieldIndex: { data: readonly [Major, Minor, ForestRootId][]; id: number } =
+			JSON.parse(data);
+		const map = new Map();
+		for (const [major, minor, root] of detachedFieldIndex.data) {
+			setInNestedMap(map, major, minor, root);
+		}
+		this.detachedNodeToField = map;
 		this.rootIdAllocator = idAllocatorFromMaxId(
 			detachedFieldIndex.id,
 		) as IdAllocator<ForestRootId>;

--- a/experimental/dds/tree2/src/core/tree/detachedFieldIndex.ts
+++ b/experimental/dds/tree2/src/core/tree/detachedFieldIndex.ts
@@ -47,7 +47,10 @@ export class DetachedFieldIndex {
 	) {}
 
 	public clone(): DetachedFieldIndex {
-		const clone = new DetachedFieldIndex(this.name, this.rootIdAllocator);
+		const clone = new DetachedFieldIndex(
+			this.name,
+			idAllocatorFromMaxId(this.rootIdAllocator.getNextId()) as IdAllocator<ForestRootId>,
+		);
 		populateNestedMap(this.detachedNodeToField, clone.detachedNodeToField);
 		return clone;
 	}

--- a/experimental/dds/tree2/src/core/tree/visitDelta.ts
+++ b/experimental/dds/tree2/src/core/tree/visitDelta.ts
@@ -235,7 +235,7 @@ function ensureCreation(mark: Delta.Insert, config: PassConfig): ForestRootId {
 	if (existing !== undefined) {
 		return existing;
 	}
-	const { root } = config.detachedFieldIndex.createEntry(mark.buildId, mark.content.length);
+	const root = config.detachedFieldIndex.createEntry(mark.buildId, mark.content.length);
 	config.insertToRootId.set(mark, root);
 	config.creations.add(mark);
 	return root;
@@ -342,7 +342,7 @@ function asReplaces(
 		case Delta.MarkType.Remove: {
 			if (config.name === "detach") {
 				return makeArray(mark.count, (i) => {
-					const { root } = config.detachedFieldIndex.getOrCreateEntry(
+					const root = config.detachedFieldIndex.getOrCreateEntry(
 						offsetDetachId(mark.detachId, i),
 					);
 					return {
@@ -360,7 +360,7 @@ function asReplaces(
 						major: "move",
 						minor: minor + i,
 					};
-					const { root } = config.detachedFieldIndex.getOrCreateEntry(detachId);
+					const root = config.detachedFieldIndex.getOrCreateEntry(detachId);
 					return {
 						oldContent: { fields: mark.fields, destination: root },
 					};
@@ -377,7 +377,7 @@ function asReplaces(
 						major: "move",
 						minor: minor + i,
 					};
-					const { root } = config.detachedFieldIndex.getOrCreateEntry(nodeId);
+					const root = config.detachedFieldIndex.getOrCreateEntry(nodeId);
 					return { newContent: { source: root, nodeId, fields } };
 				});
 			}
@@ -404,10 +404,9 @@ function asReplaces(
 					}
 					if (mark.oldContent !== undefined) {
 						// Content is being replaced
-						const { root: oldContentDestination } =
-							config.detachedFieldIndex.getOrCreateEntry(
-								offsetDetachId(mark.oldContent.detachId, i),
-							);
+						const oldContentDestination = config.detachedFieldIndex.getOrCreateEntry(
+							offsetDetachId(mark.oldContent.detachId, i),
+						);
 						replace.oldContent = {
 							fields: mark.oldContent.fields,
 							destination: oldContentDestination,
@@ -428,12 +427,12 @@ function asReplaces(
 					const replace: Mutable<Replace> = {};
 					if (mark.newContent.detachId === undefined) {
 						const nodeId = offsetDetachId(mark.newContent.restoreId, i);
-						const { root: restoredRoot } = config.detachedFieldIndex.getEntry(nodeId);
+						const restoredRoot = config.detachedFieldIndex.getEntry(nodeId);
 						const newContent = { source: restoredRoot, nodeId, fields: mark.fields };
 						replace.newContent = newContent;
 					}
 					if (mark.oldContent !== undefined) {
-						const { root } = config.detachedFieldIndex.getOrCreateEntry(
+						const root = config.detachedFieldIndex.getOrCreateEntry(
 							offsetDetachId(mark.oldContent.detachId, i),
 						);
 						replace.oldContent = { destination: root, fields: mark.oldContent.fields };
@@ -475,8 +474,8 @@ function catalogDetachPassRootChanges(mark: Exclude<Delta.Mark, number>, config:
 			if (nodeId !== undefined) {
 				const minor = extractFromOpaque(mark.moveId);
 				const destinationNodeId = { major: "move", minor };
-				const { root: rootSource } = config.detachedFieldIndex.getEntry(nodeId);
-				const { root: rootDestination } =
+				const rootSource = config.detachedFieldIndex.getEntry(nodeId);
+				const rootDestination =
 					config.detachedFieldIndex.getOrCreateEntry(destinationNodeId);
 				addRootReplaces(mark.count, config, rootDestination, rootSource, nodeId);
 			}
@@ -490,7 +489,7 @@ function catalogDetachPassRootChanges(mark: Exclude<Delta.Mark, number>, config:
 			break;
 	}
 	if (nodeId !== undefined && fields !== undefined) {
-		const { root } = config.detachedFieldIndex.getOrCreateEntry(nodeId);
+		const root = config.detachedFieldIndex.getOrCreateEntry(nodeId);
 		config.rootChanges.set(root, fields);
 	}
 }
@@ -513,7 +512,7 @@ function catalogAttachPassRootChanges(mark: Exclude<Delta.Mark, number>, config:
 				fields = mark.fields;
 				if (mark.detachId !== undefined) {
 					const count = mark.content.length;
-					const { root: rootDestination } = config.detachedFieldIndex.getOrCreateEntry(
+					const rootDestination = config.detachedFieldIndex.getOrCreateEntry(
 						mark.detachId,
 						count,
 					);
@@ -533,11 +532,8 @@ function catalogAttachPassRootChanges(mark: Exclude<Delta.Mark, number>, config:
 			if (mark.detachId !== undefined) {
 				const minor = extractFromOpaque(mark.moveId);
 				const sourceNodeId = { major: "move", minor };
-				const { root: rootSource } =
-					config.detachedFieldIndex.getOrCreateEntry(sourceNodeId);
-				const { root: rootDestination } = config.detachedFieldIndex.getOrCreateEntry(
-					mark.detachId,
-				);
+				const rootSource = config.detachedFieldIndex.getOrCreateEntry(sourceNodeId);
+				const rootDestination = config.detachedFieldIndex.getOrCreateEntry(mark.detachId);
 				addRootReplaces(mark.count, config, rootDestination, rootSource, sourceNodeId);
 			}
 			break;
@@ -546,10 +542,10 @@ function catalogAttachPassRootChanges(mark: Exclude<Delta.Mark, number>, config:
 			if (mark.newContent.detachId !== undefined) {
 				nodeId = mark.newContent.detachId;
 				fields = mark.fields;
-				const { root: rootSource } = config.detachedFieldIndex.getOrCreateEntry(
+				const rootSource = config.detachedFieldIndex.getOrCreateEntry(
 					mark.newContent.restoreId,
 				);
-				const { root: rootDestination } = config.detachedFieldIndex.getOrCreateEntry(
+				const rootDestination = config.detachedFieldIndex.getOrCreateEntry(
 					mark.newContent.detachId,
 				);
 				addRootReplaces(
@@ -571,7 +567,7 @@ function catalogAttachPassRootChanges(mark: Exclude<Delta.Mark, number>, config:
 			break;
 	}
 	if (nodeId !== undefined && fields !== undefined) {
-		const { root } = config.detachedFieldIndex.getOrCreateEntry(nodeId);
+		const root = config.detachedFieldIndex.getOrCreateEntry(nodeId);
 		config.rootChanges.set(root, fields);
 	}
 }

--- a/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-0.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-0.json
@@ -294,7 +294,13 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[[\"beefbeef-beef-4000-8000-000000000007\",0,{\"field\":\"repair-4\",\"root\":4}]]",
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-000000000007",
+                      0,
+                      4
+                    ]
+                  ],
                   "id": 4
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-1.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-1.json
@@ -309,7 +309,13 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[[\"beefbeef-beef-4000-8000-000000000013\",0,{\"field\":\"repair-4\",\"root\":4}]]",
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-000000000013",
+                      0,
+                      4
+                    ]
+                  ],
                   "id": 4
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-2.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-2.json
@@ -309,7 +309,13 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[[\"beefbeef-beef-4000-8000-00000000001f\",0,{\"field\":\"repair-4\",\"root\":4}]]",
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-00000000001f",
+                      0,
+                      4
+                    ]
+                  ],
                   "id": 4
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-3.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/competing-deletes-index-3.json
@@ -309,7 +309,13 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[[\"beefbeef-beef-4000-8000-00000000002b\",0,{\"field\":\"repair-4\",\"root\":4}]]",
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-00000000002b",
+                      0,
+                      4
+                    ]
+                  ],
                   "id": 4
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/complete-3x3-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/complete-3x3-final.json
@@ -4372,7 +4372,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 89
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree2.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree2.json
@@ -284,7 +284,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 9
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree2.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree2.json
@@ -285,7 +285,7 @@
                 "type": "blob",
                 "content": {
                   "data": [],
-                  "id": 9
+                  "id": 4
                 },
                 "encoding": "utf-8"
               }

--- a/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree3.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree3.json
@@ -397,7 +397,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 17
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree3.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/concurrent-inserts-tree3.json
@@ -398,7 +398,7 @@
                 "type": "blob",
                 "content": {
                   "data": [],
-                  "id": 17
+                  "id": 8
                 },
                 "encoding": "utf-8"
               }

--- a/experimental/dds/tree2/src/test/snapshots/files/empty-root-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/empty-root-final.json
@@ -98,7 +98,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": -1
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/has-handle-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/has-handle-final.json
@@ -158,7 +158,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 0
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/insert-and-delete-tree-0-after-insert.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/insert-and-delete-tree-0-after-insert.json
@@ -171,7 +171,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 0
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/insert-and-delete-tree-0-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/insert-and-delete-tree-0-final.json
@@ -162,7 +162,13 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[[\"beefbeef-beef-4000-8000-000000000004\",1,{\"field\":\"repair-1\",\"root\":1}]]",
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-000000000004",
+                      1,
+                      1
+                    ]
+                  ],
                   "id": 1
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/insert-and-delete-tree-1-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/insert-and-delete-tree-1-final.json
@@ -170,7 +170,13 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[[\"beefbeef-beef-4000-8000-000000000004\",1,{\"field\":\"repair-1\",\"root\":1}]]",
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-000000000004",
+                      1,
+                      1
+                    ]
+                  ],
                   "id": 1
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/move-across-fields-tree-0-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/move-across-fields-tree-0-final.json
@@ -243,7 +243,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 2
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/nested-sequence-change-final.json
@@ -171,7 +171,7 @@
               "DetachedFieldIndexBlob": {
                 "type": "blob",
                 "content": {
-                  "data": "[]",
+                  "data": [],
                   "id": 1
                 },
                 "encoding": "utf-8"

--- a/experimental/dds/tree2/src/test/tree/visit.spec.ts
+++ b/experimental/dds/tree2/src/test/tree/visit.spec.ts
@@ -168,8 +168,8 @@ describe("visit", () => {
 			index,
 		);
 		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field0, id: { minor: 42 }, root: 0 },
-			{ field: field1, id: { minor: 43 }, root: 1 },
+			{ id: { minor: 42 }, root: 0 },
+			{ id: { minor: 43 }, root: 1 },
 		]);
 	});
 	it("remove child", () => {
@@ -201,9 +201,7 @@ describe("visit", () => {
 			["exitField", rootKey],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field0, id: { minor: 42 }, root: 0 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 0 }]);
 	});
 	it("remove under insert", () => {
 		const index = makeDetachedFieldIndex("");
@@ -239,9 +237,7 @@ describe("visit", () => {
 			["exitField", rootKey],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field1, id: { minor: 42 }, root: 1 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 1 }]);
 	});
 	it("move node to the right", () => {
 		const index = makeDetachedFieldIndex("");
@@ -396,9 +392,7 @@ describe("visit", () => {
 			["exitField", field0],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field0, id: { minor: 42 }, root: 0 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 0 }]);
 	});
 	it("move-out under remove", () => {
 		const index = makeDetachedFieldIndex("");
@@ -442,9 +436,7 @@ describe("visit", () => {
 			["exitField", field0],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field0, id: { minor: 42 }, root: 0 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 0 }]);
 	});
 	it("move-in under move-out", () => {
 		const index = makeDetachedFieldIndex("");
@@ -536,9 +528,7 @@ describe("visit", () => {
 			["exitField", rootKey],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field1, id: { minor: 42 }, root: 1 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 1 }]);
 	});
 	it("transient insert", () => {
 		const index = makeDetachedFieldIndex("");
@@ -559,9 +549,7 @@ describe("visit", () => {
 			["exitField", field0],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field1, id: { minor: 42 }, root: 1 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 1 }]);
 	});
 	it("move-out under transient", () => {
 		const index = makeDetachedFieldIndex("");
@@ -628,9 +616,7 @@ describe("visit", () => {
 			["exitField", field2],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field2, id: { minor: 42 }, root: 2 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 2 }]);
 	});
 	it("restore", () => {
 		const index = makeDetachedFieldIndex("");
@@ -723,9 +709,7 @@ describe("visit", () => {
 			["exitField", field0],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field0, id: { minor: 1 }, root: 0 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 1 }, root: 0 }]);
 	});
 	it("transient move-in and modify", () => {
 		const index = makeDetachedFieldIndex("");
@@ -781,9 +765,7 @@ describe("visit", () => {
 			["exitField", field2],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field2, id: { minor: 42 }, root: 2 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 2 }]);
 	});
 	it("transient restore", () => {
 		const index = makeDetachedFieldIndex("");
@@ -805,8 +787,6 @@ describe("visit", () => {
 			["exitField", field0],
 		];
 		testTreeVisit(delta, expected, index);
-		assert.deepEqual(Array.from(index.entries()), [
-			{ field: field1, id: { minor: 42 }, root: 1 },
-		]);
+		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 1 }]);
 	});
 });

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -21,6 +21,7 @@ export {
 	getOrAddInMap,
 	getOrAddInNestedMap,
 	getOrDefaultInNestedMap,
+	forEachInNestedMap,
 	NestedMap,
 	SizedNestedMap,
 	populateNestedMap,

--- a/experimental/dds/tree2/src/util/nestedMap.ts
+++ b/experimental/dds/tree2/src/util/nestedMap.ts
@@ -186,6 +186,17 @@ export function decodeNestedMap<Key1, Key2, Value>(encoded: string): NestedMap<K
 	return map;
 }
 
+export function forEachInNestedMap<Key1, Key2, Value>(
+	map: NestedMap<Key1, Key2, Value>,
+	delegate: (value: Value, key1: Key1, key2: Key2) => void,
+): void {
+	map.forEach((innerMap, keyFirst) => {
+		innerMap.forEach((val, keySecond) => {
+			delegate(val, keyFirst, keySecond);
+		});
+	});
+}
+
 /**
  * Map with two keys; same semantics as NestedMap, but maintains a size count for the entire collection.
  * Note: undefined is not supported as a value, and will cause incorrect behavior.
@@ -258,11 +269,7 @@ export class SizedNestedMap<Key1, Key2, Value> {
 	 * Runs the supplied delegate for every (value, key1, key2).
 	 */
 	public forEach(delegate: (value: Value, key1: Key1, key2: Key2) => void): void {
-		this.nestedMap.forEach((innerMap, keyFirst) => {
-			innerMap.forEach((val, keySecond) => {
-				delegate(val, keyFirst, keySecond);
-			});
-		});
+		forEachInNestedMap(this.nestedMap, delegate);
 	}
 
 	/**


### PR DESCRIPTION
Simplify `DetachedFieldIndex` internal data and summary (uses a more minimal representation).
Also decouples ID allocators between forks (all forks were using the same allocator which was unnecessary and led to the ID space being consumed faster).