### PR TITLE
tree2: Merge TypedTreeChanel and SharedTree

### DIFF
--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -73,7 +73,7 @@ export class Bubblebench extends DataObject {
 	 * @param tree - ISharedTree
 	 */
 	initializeTree(tree: ISharedTree) {
-		this.view = tree.schematize({
+		this.view = tree.schematizeView({
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [],
 			schema: appSchemaData,

--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -43,22 +43,25 @@ export class InventoryList extends DataObject {
 
 	protected async hasInitialized() {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- field initialized by initializing* methods.
-		this._view = this._tree!.schematize({
+		this._view = this._tree!.schematizeView({
 			initialTree: {
-				parts: [
-					{
-						name: "nut",
-						quantity: 0,
-					},
-					{
-						name: "bolt",
-						quantity: 0,
-					},
-				],
+				// TODO: FieldNodes should not require wrapper object
+				parts: {
+					"": [
+						{
+							name: "nut",
+							quantity: 0,
+						},
+						{
+							name: "bolt",
+							quantity: 0,
+						},
+					],
+				},
 			},
 			allowedSchemaModifications: AllowedUpdateType.None,
 			schema,
-		} as any); // TODO: 'list' should not require cast to any.
+		});
 	}
 }
 

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1036,8 +1036,8 @@ export function isEditableTree(field: UnwrappedEditableField): field is Editable
 export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : false;
 
 // @alpha
-export interface ISharedTree extends ISharedObject {
-    schematize<TRoot extends FieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
+export interface ISharedTree extends ISharedObject, TypedTreeChannel {
+    schematizeView<TRoot extends FieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
     // @deprecated
     readonly view: ISharedTreeView;
 }

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -300,13 +300,14 @@ export {
 	InitializeAndSchematizeConfiguration,
 	SchemaConfiguration,
 	ForestType,
+	TypedTreeFactory,
+	TypedTreeOptions,
+	TypedTreeChannel,
 } from "./shared-tree";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec";
 export { noopValidator } from "./codec";
 export { typeboxValidator } from "./external-utilities";
-
-export { TypedTreeFactory, TypedTreeOptions, TypedTreeChannel } from "./typed-tree";
 
 // Below here are things that are used by the above, but not part of the desired API surface.
 import * as InternalTypes from "./internal";

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -26,3 +26,5 @@ export {
 	InitializeAndSchematizeConfiguration,
 	SchemaConfiguration,
 } from "./schematizedTree";
+
+export { TypedTreeFactory, TypedTreeOptions, TypedTreeChannel } from "./typedTree";

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -34,7 +34,7 @@ import {
 } from "../feature-libraries";
 import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
 import { JsonCompatibleReadOnly, brand } from "../util";
-import { type TypedTreeChannel } from "../typed-tree";
+import { type TypedTreeChannel } from "./typedTree";
 import { InitializeAndSchematizeConfiguration } from "./schematizedTree";
 import {
 	ISharedTreeView,

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -219,7 +219,7 @@ export interface ISharedTreeView extends AnchorLocator {
 	readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
 
 	/**
-	 * @deprecated {@link ISharedTree.schematize} which will replace this. View schema should be applied before creating an ISharedTreeView.
+	 * @deprecated {@link ISharedTree.schematizeView} which will replace this. View schema should be applied before creating an ISharedTreeView.
 	 */
 	schematize<TRoot extends FieldSchema>(
 		config: InitializeAndSchematizeConfiguration<TRoot>,

--- a/experimental/dds/tree2/src/shared-tree/typedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/typedTree.ts
@@ -11,11 +11,8 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import { FieldSchema, TypedField } from "../feature-libraries";
-import {
-	SharedTree,
-	SharedTreeOptions,
-	InitializeAndSchematizeConfiguration,
-} from "../shared-tree";
+import { SharedTree, SharedTreeOptions } from "./sharedTree";
+import { InitializeAndSchematizeConfiguration } from "./schematizedTree";
 
 /**
  * Configuration to specialize a Tree DDS for a particular use.

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -54,7 +54,7 @@ export function createTreeView<TRoot extends FieldSchema>(
 	schema: TreeSchema<TRoot>,
 	initialTree: any,
 ): ISharedTreeView {
-	return createTree().schematize({
+	return createTree().schematizeView({
 		allowedSchemaModifications: AllowedUpdateType.None,
 		initialTree,
 		schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -145,7 +145,7 @@ describe("Node Key Index", () => {
 
 		const manager1 = createMockNodeKeyManager();
 		const key = manager1.generateLocalNodeKey();
-		const view = tree.schematize({
+		tree.schematize({
 			initialTree: {
 				[nodeKeyFieldKey]: manager1.stabilizeNodeKey(key),
 				child: undefined,
@@ -161,7 +161,7 @@ describe("Node Key Index", () => {
 		await provider.ensureSynchronized();
 		const manager2 = createMockNodeKeyManager();
 		const view2 = tree2
-			.schematize({
+			.schematizeView({
 				initialTree: {
 					[nodeKeyFieldKey]: "not used",
 					child: undefined,

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -145,7 +145,7 @@ describe("Node Key Index", () => {
 
 		const manager1 = createMockNodeKeyManager();
 		const key = manager1.generateLocalNodeKey();
-		tree.schematize({
+		tree.schematizeView({
 			initialTree: {
 				[nodeKeyFieldKey]: manager1.stabilizeNodeKey(key),
 				child: undefined,
@@ -159,7 +159,6 @@ describe("Node Key Index", () => {
 		await provider.summarize();
 		const tree2 = await provider.createTree();
 		await provider.ensureSynchronized();
-		const manager2 = createMockNodeKeyManager();
 		const view2 = tree2
 			.schematizeView({
 				initialTree: {
@@ -169,9 +168,10 @@ describe("Node Key Index", () => {
 				schema: nodeSchemaData,
 				allowedSchemaModifications: AllowedUpdateType.None,
 			})
-			.editableTree2(nodeSchemaData, manager2);
+			// Since the key was produced with a MockNodeKeyManager, we must use one to process it.
+			.editableTree2(nodeSchemaData, createMockNodeKeyManager());
 		assertIds(view2.context.nodeKeys, [
-			manager2.localizeNodeKey(manager1.stabilizeNodeKey(key)),
+			view2.context.nodeKeys.localize(manager1.stabilizeNodeKey(key)),
 		]);
 	});
 

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -351,8 +351,8 @@ describe("SharedTreeCore", () => {
 			allowedSchemaModifications: AllowedUpdateType.None,
 		};
 
-		const view1 = tree1.schematize(config);
-		const view2 = tree2.schematize(config);
+		const view1 = tree1.schematizeView(config);
+		const view2 = tree2.schematizeView(config);
 		const editable1 = view1.editableTree2(schema);
 		const editable2 = view2.editableTree2(schema);
 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -77,8 +77,8 @@ describe("SharedTree", () => {
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [1],
 		};
-		const tree1 = provider.trees[0].schematize(content);
-		provider.trees[1].schematize(content);
+		const tree1 = provider.trees[0].schematizeView(content);
+		provider.trees[1].schematizeView(content);
 		provider.processMessages();
 
 		validateRootField(tree1, [1]);
@@ -103,7 +103,7 @@ describe("SharedTree", () => {
 			forest: ForestType.Reference,
 		});
 		const sharedTree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const view = sharedTree.schematize({
+		const view = sharedTree.schematizeView({
 			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 			initialTree: 1,
 			schema,
@@ -125,7 +125,7 @@ describe("SharedTree", () => {
 		const expectedSchema = schemaCodec.encode(jsonSequenceRootSchema);
 
 		// Apply an edit to the first tree which inserts a node with a value
-		const view1 = provider.trees[0].schematize({
+		const view1 = provider.trees[0].schematizeView({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [value],
@@ -145,7 +145,7 @@ describe("SharedTree", () => {
 	it("can summarize and load", async () => {
 		const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
 		const value = 42;
-		const summarizingTree = provider.trees[0].schematize({
+		const summarizingTree = provider.trees[0].schematizeView({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [value],
@@ -165,7 +165,7 @@ describe("SharedTree", () => {
 		const tree3 = (await provider.createTree()).view;
 		const [container1, container2, container3] = provider.containers;
 
-		const tree1 = provider.trees[0].schematize({
+		const tree1 = provider.trees[0].schematizeView({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: ["Z", "A", "C"],
@@ -425,7 +425,7 @@ describe("SharedTree", () => {
 
 	it("has bounded memory growth in EditManager", () => {
 		const provider = new TestTreeProviderLite(2);
-		provider.trees[0].schematize(emptyJsonSequenceConfig);
+		provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 
 		const [tree1, tree2] = provider.trees.map((t) => t.view);
 
@@ -458,7 +458,7 @@ describe("SharedTree", () => {
 
 	it("can process changes while detached", async () => {
 		const onCreate = (t: ISharedTree) => {
-			const view = t.schematize(emptyJsonSequenceConfig);
+			const view = t.schematizeView(emptyJsonSequenceConfig);
 			insertFirstNode(view, "B");
 			insertFirstNode(view, "A");
 			validateRootField(view, ["A", "B"]);
@@ -481,9 +481,9 @@ describe("SharedTree", () => {
 		it("can insert and delete a node in a sequence field", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 
 			// Insert node
@@ -510,11 +510,11 @@ describe("SharedTree", () => {
 					initialTree: [0, 1, 2, 3],
 					allowedSchemaModifications: AllowedUpdateType.None,
 				};
-				const tree1 = provider.trees[0].schematize(config);
+				const tree1 = provider.trees[0].schematizeView(config);
 				provider.processMessages();
-				const tree2 = provider.trees[1].schematize(config);
-				const tree3 = provider.trees[2].schematize(config);
-				const tree4 = provider.trees[3].schematize(config);
+				const tree2 = provider.trees[1].schematizeView(config);
+				const tree3 = provider.trees[2].schematizeView(config);
+				const tree4 = provider.trees[3].schematizeView(config);
 				provider.processMessages();
 
 				remove(tree1, index, 1);
@@ -544,9 +544,9 @@ describe("SharedTree", () => {
 				initialTree: value,
 				allowedSchemaModifications: AllowedUpdateType.None,
 			};
-			const tree1 = provider.trees[0].schematize(config);
+			const tree1 = provider.trees[0].schematizeView(config);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(config);
+			const tree2 = provider.trees[1].schematizeView(config);
 
 			// Delete node
 			tree1.setContent(undefined);
@@ -773,9 +773,9 @@ describe("SharedTree", () => {
 		it("does nothing if there are no commits in the undo stack", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 
 			// Insert node
@@ -819,9 +819,9 @@ describe("SharedTree", () => {
 				initialTree: ["tree2"],
 			};
 			// Do initialization on tree2
-			const tree2 = provider.trees[1].schematize(content);
+			const tree2 = provider.trees[1].schematizeView(content);
 			provider.processMessages();
-			const tree1 = provider.trees[0].schematize(content);
+			const tree1 = provider.trees[0].schematizeView(content);
 			provider.processMessages();
 
 			validateRootField(tree1, ["tree2"]);
@@ -860,9 +860,9 @@ describe("SharedTree", () => {
 		it("the insert of a node in a sequence field", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 
 			// Insert node
@@ -894,7 +894,7 @@ describe("SharedTree", () => {
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: ["A", "B", "C", "D"],
 			};
-			const tree1 = provider.trees[0].schematize(content);
+			const tree1 = provider.trees[0].schematizeView(content);
 			const tree2 = provider.trees[1].view;
 			provider.processMessages();
 
@@ -948,7 +948,7 @@ describe("SharedTree", () => {
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
 			};
-			const tree1 = provider.trees[0].schematize(content);
+			const tree1 = provider.trees[0].schematizeView(content);
 			const tree2 = provider.trees[1].view;
 			provider.processMessages();
 
@@ -1010,7 +1010,7 @@ describe("SharedTree", () => {
 			const value2 = "43";
 			const value3 = "44";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize({
+			const tree1 = provider.trees[0].schematizeView({
 				initialTree: ["A", "B", "C", "D"],
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
@@ -1157,7 +1157,7 @@ describe("SharedTree", () => {
 		it("triggers revertible events for local changes", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			const tree2 = provider.trees[1].view;
 			provider.processMessages();
 
@@ -1232,7 +1232,7 @@ describe("SharedTree", () => {
 		it("doesn't trigger a revertible event for rebases", () => {
 			const provider = new TestTreeProviderLite(2);
 			// Initialize the tree
-			const tree1 = provider.trees[0].schematize({
+			const tree1 = provider.trees[0].schematizeView({
 				initialTree: ["A", "B", "C", "D"],
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
@@ -1280,7 +1280,7 @@ describe("SharedTree", () => {
 	describe("Rebasing", () => {
 		it("rebases stashed ops with prior state present", async () => {
 			const provider = await TestTreeProvider.create(2);
-			const view1 = provider.trees[0].schematize({
+			const view1 = provider.trees[0].schematizeView({
 				initialTree: ["a"],
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
@@ -1581,9 +1581,9 @@ describe("SharedTree", () => {
 
 		it("submit edits to Fluid when merging into the root view", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 			const baseView = tree1.fork();
 			const view = baseView.fork();
@@ -1601,7 +1601,7 @@ describe("SharedTree", () => {
 
 		it("do not squash commits", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1769,7 +1769,7 @@ describe("SharedTree", () => {
 
 		it("don't send ops before committing", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1786,7 +1786,7 @@ describe("SharedTree", () => {
 
 		it("send only one op after committing", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1802,7 +1802,7 @@ describe("SharedTree", () => {
 
 		it("do not send an op after committing if nested", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1823,7 +1823,7 @@ describe("SharedTree", () => {
 
 		it("process changes while detached", async () => {
 			const onCreate = (parentTree: SharedTree) => {
-				const parent = parentTree.schematize({
+				const parent = parentTree.schematizeView({
 					initialTree: ["A"],
 					schema: jsonSequenceRootSchema,
 					allowedSchemaModifications: AllowedUpdateType.None,
@@ -2128,7 +2128,7 @@ function itView(title: string, fn: (view: ISharedTreeView) => void): void {
 	it(`${title} (root view)`, () => {
 		const provider = new TestTreeProviderLite();
 		// Test an actual SharedTree.
-		fn(provider.trees[0].schematize(config));
+		fn(provider.trees[0].schematizeView(config));
 	});
 
 	it(`${title} (reference view)`, () => {
@@ -2137,7 +2137,7 @@ function itView(title: string, fn: (view: ISharedTreeView) => void): void {
 
 	it(`${title} (forked view)`, () => {
 		const provider = new TestTreeProviderLite();
-		fn(provider.trees[0].schematize(config).fork());
+		fn(provider.trees[0].schematizeView(config).fork());
 	});
 
 	it(`${title} (reference forked view)`, () => {

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -41,7 +41,7 @@ function generateCompleteTree(
 		new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 		"test",
 	);
-	const view = tree.schematize({
+	const view = tree.schematizeView({
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema: testSchema,
 		initialTree: [],
@@ -169,9 +169,9 @@ export function generateTestTrees() {
 			runScenario: async (takeSnapshot) => {
 				const value = "42";
 				const provider = new TestTreeProviderLite(2);
-				const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+				const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
 				provider.processMessages();
-				const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig);
+				const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
 				provider.processMessages();
 
 				// Insert node
@@ -199,11 +199,11 @@ export function generateTestTrees() {
 						initialTree: [0, 1, 2, 3],
 						allowedSchemaModifications: AllowedUpdateType.None,
 					};
-					const tree1 = provider.trees[0].schematize(config);
+					const tree1 = provider.trees[0].schematizeView(config);
 					provider.processMessages();
-					const tree2 = provider.trees[1].schematize(config);
-					const tree3 = provider.trees[2].schematize(config);
-					const tree4 = provider.trees[3].schematize(config);
+					const tree2 = provider.trees[1].schematizeView(config);
+					const tree3 = provider.trees[2].schematizeView(config);
+					const tree4 = provider.trees[3].schematizeView(config);
 					provider.processMessages();
 					remove(tree1, index, 1);
 					remove(tree2, index, 1);
@@ -279,7 +279,7 @@ export function generateTestTrees() {
 					new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 					"test",
 				);
-				const view = tree.schematize(config);
+				const view = tree.schematizeView(config);
 
 				const field = view.editor.optionalField({
 					parent: undefined,
@@ -311,7 +311,7 @@ export function generateTestTrees() {
 					new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 					"test",
 				);
-				const view = tree.schematize(config);
+				const view = tree.schematizeView(config);
 				view.transaction.start();
 				// We must make this shallow change to the sequence field as part of the same transaction as the
 				// nested change. Otherwise, the nested change will be represented using the generic field kind.

--- a/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
@@ -4,10 +4,9 @@
  */
 import { strict as assert } from "assert";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
-import { ForestType } from "../../shared-tree";
+import { ForestType, TypedTreeFactory } from "../../shared-tree";
 import { AllowedUpdateType } from "../../core";
 import { typeboxValidator } from "../../external-utilities";
-import { TypedTreeFactory } from "../../typed-tree";
 import { leaf, SchemaBuilder } from "../../domains";
 
 describe("TypedTree", () => {

--- a/experimental/dds/tree2/src/typed-tree/README.md
+++ b/experimental/dds/tree2/src/typed-tree/README.md
@@ -1,3 +1,0 @@
-# typed-tree
-
-Public package API entry point wrapper around shared tree hiding everything except the editable-tree-2 API.

--- a/experimental/dds/tree2/src/typed-tree/fence.json
+++ b/experimental/dds/tree2/src/typed-tree/fence.json
@@ -1,5 +1,0 @@
-{
-	"tags": ["typed-tree"],
-	"exports": ["index"],
-	"imports": ["feature-libraries", "shared-tree", "util"]
-}

--- a/experimental/dds/tree2/src/typed-tree/index.ts
+++ b/experimental/dds/tree2/src/typed-tree/index.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export { TypedTreeFactory, TypedTreeOptions, TypedTreeChannel } from "./typedTree";

--- a/experimental/dds/tree2/src/typed-tree/typedTree.ts
+++ b/experimental/dds/tree2/src/typed-tree/typedTree.ts
@@ -10,25 +10,12 @@ import {
 	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
-import {
-	ITelemetryContext,
-	ISummaryTreeWithStats,
-	IExperimentalIncrementalSummaryContext,
-	IGarbageCollectionData,
-} from "@fluidframework/runtime-definitions";
-import {
-	FieldSchema,
-	TypedField,
-	createNodeKeyManager,
-	nodeKeyFieldKey,
-} from "../feature-libraries";
+import { FieldSchema, TypedField } from "../feature-libraries";
 import {
 	SharedTree,
 	SharedTreeOptions,
 	InitializeAndSchematizeConfiguration,
 } from "../shared-tree";
-import { brand } from "../util";
 
 /**
  * Configuration to specialize a Tree DDS for a particular use.
@@ -113,92 +100,12 @@ export class TypedTreeFactory implements IChannelFactory {
 	): Promise<TypedTreeChannel> {
 		const tree = new SharedTree(id, runtime, channelAttributes, this.options, "SharedTree");
 		await tree.load(services);
-		return new ChannelWrapperWithSchematize(runtime, tree);
+		return tree;
 	}
 
 	public create(runtime: IFluidDataStoreRuntime, id: string): TypedTreeChannel {
 		const tree = new SharedTree(id, runtime, this.attributes, this.options, "SharedTree");
 		tree.initializeLocal();
-		return new ChannelWrapperWithSchematize(runtime, tree);
-	}
-}
-
-/**
- * IChannel wrapper.
- * Subclass to add specific functionality.
- *
- * @remarks
- * This is handy when an implementing IChannelFactory and it's desirable to return a type that's derived from another IChannel implementation.
- */
-class ChannelWrapper implements IChannel {
-	public constructor(private readonly inner: IChannel) {}
-
-	public get id(): string {
-		return this.inner.id;
-	}
-
-	public get attributes(): IChannelAttributes {
-		return this.inner.attributes;
-	}
-
-	public getAttachSummary(
-		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
-		telemetryContext?: ITelemetryContext | undefined,
-	): ISummaryTreeWithStats {
-		return this.inner.getAttachSummary(fullTree, trackState, telemetryContext);
-	}
-
-	public async summarize(
-		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
-		telemetryContext?: ITelemetryContext | undefined,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
-	): Promise<ISummaryTreeWithStats> {
-		return this.inner.summarize(
-			fullTree,
-			trackState,
-			telemetryContext,
-			incrementalSummaryContext,
-		);
-	}
-
-	public isAttached(): boolean {
-		return this.inner.isAttached();
-	}
-
-	public connect(services: IChannelServices): void {
-		return this.inner.connect(services);
-	}
-	public getGCData(fullGC?: boolean | undefined): IGarbageCollectionData {
-		return this.inner.getGCData(fullGC);
-	}
-
-	public get handle(): IFluidHandle {
-		return this.inner.handle;
-	}
-
-	public get IFluidLoadable(): IFluidLoadable {
-		return this.inner.IFluidLoadable;
-	}
-}
-
-/**
- * IChannel wrapper that exposes "schematize".
- */
-class ChannelWrapperWithSchematize extends ChannelWrapper implements TypedTreeChannel {
-	public constructor(
-		private readonly runtime: IFluidDataStoreRuntime,
-		private readonly tree: SharedTree,
-	) {
-		super(tree);
-	}
-
-	public schematize<TRoot extends FieldSchema>(
-		config: InitializeAndSchematizeConfiguration<TRoot>,
-	): TypedField<TRoot> {
-		const nodeKeyManager = createNodeKeyManager(this.runtime.idCompressor);
-		const view = this.tree.schematize(config);
-		return view.editableTree2(config.schema, nodeKeyManager, brand(nodeKeyFieldKey));
+		return tree;
 	}
 }

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -425,7 +425,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 		const schema = builder.intoSchema(rootNodeSchema);
 
-		sharedTree.schematize({
+		sharedTree.schematizeView({
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: {


### PR DESCRIPTION
## Description

Better aligns the desired minimal package API via TypeTree with the actual implementation, removing the wrapper.

## Breaking Changes

ISharedTree.schematize was renamed to schematizeView.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

