### PR TITLE
fix(build-tools): Windows compatible clean policy

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -1154,7 +1154,7 @@ export const handlers: Handler[] = [
 
 			if (cleanScript) {
 				if (cleanScript !== getPreferredCommandLine(cleanScript)) {
-					return "'clean' script double quote the globs and only the globs";
+					return "'clean' script should double quote the globs and only the globs";
 				}
 			}
 		},

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -1169,7 +1169,7 @@ export const handlers: Handler[] = [
 						"Unable to fix 'clean' script that doesn't start with 'rimraf --glob'";
 					return;
 				}
-				if (missing.length !== 0) {
+				if (missing.length > 0) {
 					clean += ` ${missing.join(" ")}`;
 				}
 				// clean up for grouping


### PR DESCRIPTION
single quotes `'` become part of argument on Windows
- policy: require double quotes `"` for globs
- fix resolver logic and new quote policy

add generalized argument validation helpers