### PR TITLE
Couple the client build and test stability pipeline

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -254,18 +254,11 @@ stages:
 
         - template: include-use-node-version.yml
 
-        - ${{ if eq(parameters.packageManager, 'pnpm') }}:
-          - template: include-install-pnpm.yml
-            parameters:
-              buildDirectory: ${{ parameters.buildDirectory }}
-
-        - task: Bash@3
-          displayName: Install dependencies
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ parameters.buildDirectory }}
-            script: |
-              ${{ parameters.packageManagerInstallCommand }}
+        - template: include-install.yml 
+          parameters:
+            packageManager: ${{ parameters.packageManager }}
+            buildDirectory: ${{ parameters.buildDirectory }}
+            packageManagerInstallCommand: ${{ parameters.packageManagerInstallCommand }}
 
         # This check is a workaround. We don't want to set versions for the build-bundle-size-artifacts pipeline because
         # the pipeline is special - it runs a client build but doesn't publish anything. Working around this properly is
@@ -280,23 +273,13 @@ stages:
               tagName: ${{ parameters.tagName }}
               interdependencyRange: ${{ parameters.interdependencyRange }}
 
-        # Build
-        - ${{ if ne(parameters.taskBuild, 'false') }}:
-          - task: Npm@1
-            displayName: npm run ${{ parameters.taskBuild }}
-            inputs:
-              command: 'custom'
-              workingDir: ${{ parameters.buildDirectory }}
-              customCommand: 'run ${{ parameters.taskBuild }}'
-
-        # Lint
-        - ${{ if ne(parameters.taskLint, false) }}:
-          - task: Npm@1
-            displayName: npm run ${{ parameters.taskLintName }}
-            inputs:
-              command: 'custom'
-              workingDir: ${{ parameters.buildDirectory }}
-              customCommand: 'run ${{ parameters.taskLintName }}'
+        # Build and Lint
+        - template: include-build-lint.yml 
+          parameters:
+            taskBuild: ${{ parameters.taskBuild }}
+            taskLint: ${{ parameters.taskLint }}
+            taskLintName: ${{ parameters.taskLintName }}
+            buildDirectory: ${{ parameters.buildDirectory }}
 
         # Test
         - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
@@ -306,35 +289,10 @@ stages:
             displayName: Start Test
 
           - ${{ each taskTestStep in parameters.taskTest }}:
-            # Test - With coverage
-            - ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
-              - task: Npm@1
-                displayName: npm run ${{ taskTestStep }}:coverage
-                inputs:
-                  command: 'custom'
-                  workingDir: ${{ parameters.buildDirectory }}
-                  customCommand: 'run ${{ taskTestStep }}:coverage'
-                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-                env:
-                  ${{ if contains(taskTestStep, 'tinylicious') }}:
-                    # Disable colorization for tinylicious logs (not useful when printing to a file)
-                    logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
-                    logger__morganFormat: tiny
-
-              # Test - No coverage
-            - ${{ else }}:
-              - task: Npm@1
-                displayName: npm run ${{ taskTestStep }}
-                inputs:
-                  command: 'custom'
-                  workingDir: ${{ parameters.buildDirectory }}
-                  customCommand: 'run ${{ taskTestStep }}'
-                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-                env:
-                  ${{ if contains(taskTestStep, 'tinylicious') }}:
-                    # Disable colorization for tinylicious logs (not useful when printing to a file)
-                    logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
-                    logger__morganFormat: tiny
+            - template: include-test-task.yml
+              parameters:
+                taskTestStep: ${{ taskTestStep }}
+                buildDirectory: ${{ parameters.buildDirectory }}
 
           # Test - Upload coverage results
           # Some webpacked file using externals introduce file name with quotes in them

--- a/tools/pipelines/templates/include-build-lint.yml
+++ b/tools/pipelines/templates/include-build-lint.yml
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-build-lint template for the Build and Lint step in client build and test stability pipeline
+
+parameters:
+- name: taskBuild 
+  type: string 
+  default: ci:build
+
+- name: taskLint 
+  type: boolean 
+  default: true
+
+- name: taskLintName
+  type: string
+  default: lint 
+
+- name: buildDirectory
+  type: string 
+
+steps:
+- ${{ if ne(parameters.taskBuild, 'false') }}:
+  - task: Npm@1
+    displayName: npm run ${{ parameters.taskBuild }}
+    inputs:
+      command: 'custom'
+      workingDir: ${{ parameters.buildDirectory }}
+      customCommand: 'run ${{ parameters.taskBuild }}'
+
+- ${{ if ne(parameters.taskLint, false) }}:
+  - task: Npm@1
+    displayName: npm run ${{ parameters.taskLintName }}
+    inputs:
+      command: 'custom'
+      workingDir: ${{ parameters.buildDirectory }}
+      customCommand: 'run ${{ parameters.taskLintName }}'

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-install template for the install step in client build and test stability pipeline
+
+parameters:
+- name: packageManager
+  type: string
+
+- name: buildDirectory
+  type: string 
+
+- name: packageManagerInstallCommand
+  type: string
+
+steps: 
+  - ${{ if eq(parameters.packageManager, 'pnpm') }}:
+    - template: include-install-pnpm.yml
+      parameters:
+        buildDirectory: ${{ parameters.buildDirectory }}
+
+  - task: Bash@3
+    displayName: Install dependencies
+    inputs:
+      targetType: 'inline'
+      workingDirectory: ${{ parameters.buildDirectory }}
+      script: |
+        ${{ parameters.packageManagerInstallCommand }}

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -90,36 +90,18 @@ jobs:
 
     - template: include-use-node-version.yml
 
-    - ${{ if eq(parameters.packageManager, 'pnpm') }}:
-          - template: include-install-pnpm.yml
-            parameters:
-              buildDirectory: ${{ parameters.buildDirectory }}
+    - template: include-install.yml 
+      parameters:
+        packageManager: ${{ parameters.packageManager }}
+        buildDirectory: ${{ parameters.buildDirectory }}
+        packageManagerInstallCommand: ${{ parameters.packageManagerInstallCommand }}
 
-    - task: Bash@3
-      displayName: Install dependencies
-      inputs:
-        targetType: 'inline'
-        workingDirectory: ${{ parameters.buildDirectory }}
-        script: |
-          ${{ parameters.packageManagerInstallCommand }}
-
-    # Build
-    - ${{ if ne(parameters.taskBuild, 'false') }}:
-      - task: Npm@1
-        displayName: npm run ${{ parameters.taskBuild }}
-        inputs:
-          command: 'custom'
-          workingDir: ${{ parameters.buildDirectory }}
-          customCommand: 'run ${{ parameters.taskBuild }}'
-
-    # Lint
-    - ${{ if ne(parameters.taskLint, false) }}:
-      - task: Npm@1
-        displayName: npm run ${{ parameters.taskLintName }}
-        inputs:
-          command: 'custom'
-          workingDir: ${{ parameters.buildDirectory }}
-          customCommand: 'run ${{ parameters.taskLintName }}'
+    - template: include-build-lint.yml 
+      parameters:
+        taskBuild: ${{ parameters.taskBuild }}
+        taskLint: ${{ parameters.taskLint }}
+        taskLintName: ${{ parameters.taskLintName }}
+        buildDirectory: ${{ parameters.buildDirectory }}
 
     # Test
     - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
@@ -129,24 +111,11 @@ jobs:
         displayName: Start Test
 
       - ${{ each taskTestStep in parameters.taskTest }}:
-        # Test - With coverage
-        - ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
-          - task: Npm@1
-            displayName: npm run ${{ taskTestStep }}:coverage
-            inputs:
-              command: 'custom'
-              workingDir: ${{ parameters.buildDirectory }}
-              customCommand: 'run ${{ taskTestStep }}:coverage'
-            condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-        # Test - No coverage
-        - ${{ if or(eq(variables['testCoverage'], false), eq(startsWith(taskTestStep, 'ci:test'), false)) }}:
-            - task: Npm@1
-              displayName: npm run ${{ taskTestStep }}
-              inputs:
-                command: 'custom'
-                workingDir: ${{ parameters.buildDirectory }}
-                customCommand: 'run ${{ taskTestStep }}'
-              condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+        - template: include-task-test.yml
+          parameters:
+            taskTestStep: ${{ taskTestStep }}
+            buildDirectory: ${{ parameters.buildDirectory }}
+            
         # Verify if the tinylicious log exists
         - task: Bash@3
           displayName: Validate Tinylicious Log

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -111,7 +111,7 @@ jobs:
         displayName: Start Test
 
       - ${{ each taskTestStep in parameters.taskTest }}:
-        - template: include-task-test.yml
+        - template: include-test-task.yml
           parameters:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-task-test template to run a single task test with/without coverage
+
+parameters:
+- name: taskTestStep
+  type: string 
+
+- name: buildDirectory
+  type: string 
+
+steps: 
+# Test - With coverage
+- ${{ if and(eq(variables['testCoverage'], true), startsWith(parameters.taskTestStep, 'ci:test')) }}:
+  - task: Npm@1
+    displayName: npm run ${{ parameters.taskTestStep }}:coverage
+    inputs:
+      command: 'custom'
+      workingDir: ${{ parameters.buildDirectory }}
+      customCommand: 'run ${{ taskTestStep }}:coverage'
+    condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+    env:
+      # Tests can use this environment variable to behave differently when running from a test branch
+      ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
+        # Disable colorization for tinylicious logs (not useful when printing to a file)
+        logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+        logger__morganFormat: tiny
+
+# Test - No coverage
+- ${{ else }}:
+  - task: Npm@1
+    displayName: npm run ${{ parameters.taskTestStep }}
+    inputs:
+      command: 'custom'
+      workingDir: ${{ parameters.buildDirectory }}
+      customCommand: 'run ${{ parameters.taskTestStep }}'
+      condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+    env:
+      # Tests can use this environment variable to behave differently when running from a test branch
+      ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
+        # Disable colorization for tinylicious logs (not useful when printing to a file)
+        logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
+        logger__morganFormat: tiny


### PR DESCRIPTION
[AB#4808](https://dev.azure.com/fluidframework/internal/_workitems/edit/4808)

Since the client build pipeline yaml file is updated frequently, there is a risk of breaking the test stability pipeline due to the async changes in Install/Build/Test steps. Moving the overlapped/shared parts to separate template files will help to forcibly keep them in sync and reduce future overhead.

Note: this update was merged but reverted in: https://github.com/microsoft/FluidFramework/pull/16852, now open this PR to restore the change


The affected pipelines with this update were run successfully on the personal test branch:

- Build client package: https://dev.azure.com/fluidframework/internal/_build/results?buildId=202461&view=results
- Test Stability: https://dev.azure.com/fluidframework/internal/_build/results?buildId=202462&view=results



