### PR TITLE
Relax the rule for the repo root package to not require a specific name

### DIFF
--- a/build-tools/packages/build-tools/src/common/fluidUtils.ts
+++ b/build-tools/packages/build-tools/src/common/fluidUtils.ts
@@ -24,7 +24,7 @@ async function isFluidRootPackage(dir: string) {
 	}
 
 	const parsed = await readJson(filename);
-	if (parsed.name === "root" && parsed.private === true) {
+	if (parsed.private === true) {
 		return true;
 	}
 	traceInit(`InferRoot: package.json not matched`);


### PR DESCRIPTION
To allow us to rename our root package.