### PR TITLE
Fix non-incremental message for done file task

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -420,7 +420,7 @@ export abstract class LeafTask extends Task {
 }
 
 export abstract class LeafWithDoneFileTask extends LeafTask {
-	private _isIncremental: boolean = false;
+	private _isIncremental: boolean = true;
 
 	protected get isIncremental() {
 		return this._isIncremental;
@@ -455,13 +455,14 @@ export abstract class LeafWithDoneFileTask extends LeafTask {
 			const content = await this.getDoneFileContent();
 			if (content !== undefined) {
 				await writeFileAsync(doneFileFullPath, content);
-				this._isIncremental = true;
 			} else {
+				this._isIncremental = false;
 				console.warn(
 					`${this.node.pkg.nameColored}: warning: unable to generate content for ${doneFileFullPath}`,
 				);
 			}
 		} catch (error) {
+			this._isIncremental = false;
 			console.warn(
 				`${this.node.pkg.nameColored}: warning: unable to write ${doneFileFullPath}\n error: ${error}`,
 			);


### PR DESCRIPTION
With PR #17857, forthe done file task.  If it is up to date, we would say it is non-incremental, which is incorrect.
Flip the condition so that we would only say it is non-incremental if we failed to generate the done file.