### PR TITLE
Add --outFile options to flub list

### DIFF
--- a/build-tools/packages/build-cli/docs/list.md
+++ b/build-tools/packages/build-cli/docs/list.md
@@ -13,11 +13,13 @@ List packages in a release group in topological order.
 USAGE
   $ flub list -g client|server|azure|build-tools|gitrest|historian [--json] [-v | --quiet] [--feed
     public|internal-build|internal-test|internal-dev|official|internal] [--private] [--scope <value> | --skipScope
-    <value>] [--tarball]
+    <value>] [--tarball] [--outFile <value>]
 
 FLAGS
   -g, --releaseGroup=<option>  (required) Name of a release group.
                                <options: client|server|azure|build-tools|gitrest|historian>
+  --outFile=<value>            Output file to write the list of packages to. If not specified, the list will be written
+                               to stdout.
   --tarball                    Return packed tarball names (without extension) instead of package names. @-signs will be
                                removed from the name, and slashes are replaced with dashes.
 

--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -16,6 +16,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules -- the policy-related stuff will eventually be moved into this package
 } from "@fluidframework/build-tools/dist/repoPolicyCheck/handlers/npmPackages";
 import { Package, PackageNamePolicyConfig } from "@fluidframework/build-tools";
+import { writeFileSync } from "node:fs";
 
 interface ListItem extends PnpmListEntry {
 	tarball?: string;
@@ -60,6 +61,11 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 				"Return packed tarball names (without extension) instead of package names. @-signs will be removed from the name, and slashes are replaced with dashes.",
 			default: false,
 		}),
+		outFile: Flags.string({
+			description:
+				"Output file to write the list of packages to. If not specified, the list will be written to stdout.",
+			required: false,
+		}),
 	};
 
 	public async run(): Promise<ListItem[]> {
@@ -101,8 +107,12 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 				return item;
 			});
 
-		for (const details of filtered) {
-			this.log(details.name);
+		const output = filtered.map((details) => details.name).join("\n");
+
+		if (this.flags.outFile === undefined) {
+			this.log(output);
+		} else {
+			writeFileSync(this.flags.outFile, output);
 		}
 
 		return filtered;

--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -61,10 +61,11 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 				"Return packed tarball names (without extension) instead of package names. @-signs will be removed from the name, and slashes are replaced with dashes.",
 			default: false,
 		}),
-		outFile: Flags.string({
+		outFile: Flags.file({
 			description:
 				"Output file to write the list of packages to. If not specified, the list will be written to stdout.",
 			required: false,
+			exists: false
 		}),
 	};
 

--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -65,7 +65,7 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 			description:
 				"Output file to write the list of packages to. If not specified, the list will be written to stdout.",
 			required: false,
-			exists: false
+			exists: false,
 		}),
 	};
 


### PR DESCRIPTION
Optional argument to write the output to a file instead of console.