### PR TITLE
Fix check policy done file when there are deleted files

### DIFF
--- a/build-tools/packages/build-tools/src/common/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/common/gitRepo.ts
@@ -208,11 +208,11 @@ export class GitRepo {
 	 * Returns an array containing all the modified files in the repo.
 	 */
 	public async getModifiedFiles(): Promise<string[]> {
-		const results = await this.exec(
-			`ls-files -mo --exclude-standard --deduplicate`,
-			`get modified files`,
-		);
-		return results.split("\n").filter((t) => t !== undefined && t !== "" && t !== null);
+		const results = await this.exec(`status --porcelain`, `get modified files`);
+		return results
+			.split("\n")
+			.filter((t) => t !== "" && !t.startsWith(" D "))
+			.map((t) => t.substring(3));
 	}
 
 	/**


### PR DESCRIPTION
`git ls-files -m` includes deleted files, which would cause the FlubCheckPolicyTask to failed in generate the done files trying to get the hash of a deleted files.  Use `git status --porcelain` and filter deleted files instead.  