### PR TITLE
fix(build-tools): run.js should set development: false

### DIFF
--- a/build-tools/packages/build-cli/bin/run.js
+++ b/build-tools/packages/build-cli/bin/run.js
@@ -7,5 +7,5 @@
 // eslint-disable-next-line unicorn/prefer-top-level-await
 (async () => {
 	const oclif = await import("@oclif/core");
-	await oclif.execute({ development: true, dir: __dirname });
+	await oclif.execute({ development: false, dir: __dirname });
 })();

--- a/build-tools/packages/readme-command/bin/run.js
+++ b/build-tools/packages/readme-command/bin/run.js
@@ -7,5 +7,5 @@
 // eslint-disable-next-line unicorn/prefer-top-level-await
 (async () => {
 	const oclif = await import("@oclif/core");
-	await oclif.execute({ development: true, dir: __dirname });
+	await oclif.execute({ development: false, dir: __dirname });
 })();

--- a/build-tools/packages/version-tools/bin/run.js
+++ b/build-tools/packages/version-tools/bin/run.js
@@ -7,5 +7,5 @@
 // eslint-disable-next-line unicorn/prefer-top-level-await
 (async () => {
 	const oclif = await import("@oclif/core");
-	await oclif.execute({ development: true, dir: __dirname });
+	await oclif.execute({ development: false, dir: __dirname });
 })();


### PR DESCRIPTION
Opened a PR against oclif as well: https://github.com/oclif/hello-world/pull/340