### PR TITLE
test(tree): add tree destruction test to forest test suite

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -122,8 +122,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 			},
 			destroy(detachedField: FieldKey, count: number): void {
 				this.forest.invalidateDependents();
-				const parent = this.getParent();
-				parent.mutableChunk.fields.delete(detachedField);
+				this.forest.roots.fields.delete(detachedField);
 			},
 			create(content: Delta.ProtoNodes, destination: FieldKey): void {
 				this.forest.invalidateDependents();

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -23,6 +23,10 @@ import {
 	ITreeCursor,
 	EmptyKey,
 	FieldUpPath,
+	DetachedFieldIndex,
+	ForestRootId,
+	DetachedField,
+	detachedFieldAsKey,
 } from "../core";
 import {
 	cursorToJsonObject,
@@ -32,7 +36,7 @@ import {
 	SchemaBuilder,
 	leaf,
 } from "../domains";
-import { JsonCompatible, brand, brandOpaque } from "../util";
+import { IdAllocator, JsonCompatible, brand, brandOpaque, idAllocatorFromMaxId } from "../util";
 import {
 	FieldKinds,
 	jsonableTreeFromCursor,
@@ -543,6 +547,41 @@ export function testForest(config: ForestTestConfiguration): void {
 				assert(reader.firstNode());
 				assert.equal(reader.value, 2);
 				assert.equal(reader.nextNode(), false);
+			});
+
+			it("delete", () => {
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
+				const content: JsonCompatible[] = [1, 2];
+				initializeForest(forest, content.map(singleJsonCursor));
+
+				const mark: Delta.Remove = {
+					type: Delta.MarkType.Remove,
+					count: 1,
+					detachId,
+				};
+				const detachedFieldIndex = new DetachedFieldIndex(
+					"test",
+					idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
+				);
+				const delta: Delta.Root = new Map([[rootFieldKey, [0, mark]]]);
+				applyTestDelta(delta, forest, detachedFieldIndex);
+
+				const detachedField: DetachedField = brand(
+					detachedFieldIndex.toFieldKey(0 as ForestRootId),
+				);
+				// `1` should be under the detached field
+				const reader = forest.allocateCursor();
+				moveToDetachedField(forest, reader, detachedField);
+				assert(reader.firstNode());
+				assert.equal(reader.value, 1);
+				assert.equal(reader.nextNode(), false);
+				reader.clear();
+
+				forest.acquireVisitor().destroy(detachedFieldAsKey(detachedField), 1);
+
+				// check the detached field no longer exists
+				const detachedCursor = forest.allocateCursor();
+				assert.throws(() => moveToDetachedField(forest, detachedCursor, detachedField));
 			});
 
 			it("a skip", () => {


### PR DESCRIPTION
## Description

Adds a test to the forest test suite to validate destroying a detached field.