### PR TITLE
test(tree): unskip undo tests

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
@@ -60,7 +60,6 @@ const testCases: {
 		editedState: ["C", "D"],
 	},
 	{
-		skip: true, // Blocked on #5263
 		name: "nested deletes",
 		edit: (actedOn) => {
 			const listNode: UpPath = {
@@ -82,7 +81,6 @@ const testCases: {
 		editedState: [],
 	},
 	{
-		skip: true, // Blocked on #5263
 		name: "move out under delete",
 		edit: (actedOn) => {
 			const listNode: UpPath = {


### PR DESCRIPTION
## Description

Tests can now be unskipped due to repair data being stored in the forest
