### PR TITLE
GC: Log inactive loaded events for DDS as well

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -110,12 +110,13 @@ export class GCTelemetryTracker {
 			return false;
 		}
 
-		// For sub data store (DDS) nodes, if they are changed or loaded, its data store will also be changed or loaded,
-		// so skip logging to make the telemetry less noisy.
-		if (nodeType === GCNodeType.SubDataStore && usageType !== "Revived") {
+		if (nodeType === GCNodeType.Other) {
 			return false;
 		}
-		if (nodeType === GCNodeType.Other) {
+
+		// For sub data store (DDS) nodes, if they are changed, its data store will also be changed,
+		// so skip logging to make the telemetry less noisy.
+		if (nodeType === GCNodeType.SubDataStore && usageType === "Changed") {
 			return false;
 		}
 

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -96,7 +96,7 @@ export class GCTelemetryTracker {
 
 	/**
 	 * Returns whether an event should be logged for a node that isn't active anymore. Some scenarios where we won't log:
-	 * 1. When a DDS is changed or loaded. The corresponding data store's event will be logged instead.
+	 * 1. When a DDS is changed. The corresponding data store's event will be logged instead.
 	 * 2. An event is logged only once per container instance per event per node.
 	 */
 	private shouldLogNonActiveEvent(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -40,6 +40,21 @@ import { FluidSerializer, parseHandles } from "@fluidframework/shared-object-bas
 import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils.js";
 
 /**
+ * We manufacture a handle to simulate a bug where an object is unrefenced in GC's view
+ * (and reminder, interactive clients never update their GC data after loading),
+ * but someone still has a handle to it.
+ *
+ * It's possible to achieve this truly with multiple clients where one revives it mid-session
+ * after it was unreferenced for the inactive timeout, but that's more complex to implement
+ * in a test and is no better than this approach
+ */
+function manufactureHandle<T>(handleContext: IFluidHandleContext, url: string): IFluidHandle<T> {
+	const serializer = new FluidSerializer(handleContext, () => {});
+	const handle: IFluidHandle<T> = parseHandles({ type: "__fluid_handle__", url }, serializer);
+	return handle;
+}
+
+/**
  * Validates this scenario: When a GC node (data store or attachment blob) becomes inactive, i.e, it has been
  * unreferenced for a certain amount of time, using the node results in an error telemetry.
  */
@@ -314,28 +329,68 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 			},
 		);
 
-		describe("Interactive (non-summarizer) clients", () => {
-			/**
-			 * We manufacture a handle to simulate a bug where an object is unrefenced in GC's view
-			 * (and reminder, interactive clients never update their GC data after loading),
-			 * but someone still has a handle to it.
-			 *
-			 * It's possible to achieve this truly with multiple clients where one revives it mid-session
-			 * after it was unreferenced for the inactive timeout, but that's more complex to implement
-			 * in a test and is no better than this approach
-			 */
-			function manufactureHandle<T>(
-				handleContext: IFluidHandleContext,
-				url: string,
-			): IFluidHandle<T> {
-				const serializer = new FluidSerializer(handleContext, () => {});
-				const handle: IFluidHandle<T> = parseHandles(
-					{ type: "__fluid_handle__", url },
-					serializer,
-				);
-				return handle;
-			}
+		itExpects(
+			"can generate events when unreferenced DDS is accessed after it's inactive",
+			[{ eventName: changedEvent }, { eventName: loadedEvent }],
+			async () => {
+				const summarizerRuntime = await createSummarizerClient({
+					...testContainerConfigWithThrowOption, // But summarizer should NOT throw
+					loaderProps: { logger: mockLogger },
+				});
+				const dataStore = await containerRuntime.createDataStore(TestDataObjectType);
+				const dataObject = (await dataStore.entryPoint.get()) as ITestDataObject;
+				const dataStoreUrl = dataObject.handle.absolutePath;
+				const ddsUrl = dataObject._root.handle.absolutePath;
 
+				defaultDataStore._root.set("dataStore1", dataObject.handle);
+				await provider.ensureSynchronized();
+
+				// Mark dataStore1 as unreferenced, send an op and load its DDS.
+				defaultDataStore._root.delete("dataStore1");
+				dataObject._root.set("key", "value2");
+				await provider.ensureSynchronized();
+				await summarizerRuntime.resolveHandle({ url: ddsUrl });
+
+				// Summarize and validate that no unreferenced errors were logged.
+				await summarize(summarizerRuntime);
+				validateNoInactiveEvents();
+
+				// Wait for inactive timeout. This will ensure that the unreferenced DDS is inactive.
+				await waitForInactiveTimeout();
+
+				// Make changes to the inactive data store and validate that we get the changedEvent.
+				dataObject._root.set("key", "value");
+				await provider.ensureSynchronized();
+				// Load the DDS and validate that we get loadedEvent.
+				const response = await summarizerRuntime.resolveHandle({ url: ddsUrl });
+				assert.equal(
+					response.status,
+					200,
+					"Loading the inactive object should succeed on summarizer despite throwOnInactiveLoad option",
+				);
+				await summarize(summarizerRuntime);
+				mockLogger.assertMatch(
+					[
+						{
+							eventName: changedEvent,
+							timeout: inactiveTimeoutMs,
+							id: { value: dataStoreUrl, tag: TelemetryDataTag.CodeArtifact },
+							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
+						},
+						{
+							eventName: loadedEvent,
+							timeout: inactiveTimeoutMs,
+							id: { value: ddsUrl, tag: TelemetryDataTag.CodeArtifact },
+							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
+						},
+					],
+					"changed and loaded events not generated as expected",
+					true /* inlineDetailsProp */,
+				);
+			},
+		);
+
+		describe("Interactive (non-summarizer) clients", () => {
 			/**
 			 * Our partners use ContainerRuntime.resolveHandle to issue requests. We can't easily call it directly,
 			 * but the test containers are wired up to route requests to this function.


### PR DESCRIPTION
When an inactive or sweep ready DDS is loaded without first loading its data store, inactive / sweep ready event is not logged. The reason is that the GC telemetry logic filters out DDS when logging these events to reduce too much telemetry. Also, in practice, DDSes are not loaded without first loading its data store.
However, it may be useful to log loaded events for DDS to cover all bases. Additionally, it can help build a timeline of when an inactive data store and its DDS are loaded.

This PR changes the logic to filter out only changed events for DDS. Those will first reach the data store and will be logged first anyway.

[AB#5336](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5336)