### PR TITLE
getVersions cleanup

### DIFF
--- a/packages/drivers/routerlicious-driver/src/gitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/gitManager.ts
@@ -16,7 +16,6 @@ export class GitManager implements IGitManager {
 	private readonly blobCache = new Map<string, resources.IBlob>();
 	private readonly commitCache = new Map<string, resources.ICommit>();
 	private readonly treeCache = new Map<string, resources.ITree>();
-	private readonly refCache = new Map<string, string>();
 
 	constructor(private readonly historian: IHistorian) {}
 
@@ -24,24 +23,9 @@ export class GitManager implements IGitManager {
 	 * Reads the object with the given ID. We defer to the client implementation to do the actual read.
 	 */
 	public async getCommits(
-		shaOrRef: string,
+		sha: string,
 		count: number,
 	): Promise<IR11sResponse<resources.ICommitDetails[]>> {
-		let sha: string | undefined = shaOrRef;
-
-		// See if the sha is really a ref and convert
-		if (this.refCache.has(shaOrRef)) {
-			sha = this.refCache.get(shaOrRef);
-
-			// Delete refcache after first use
-			this.refCache.delete(shaOrRef);
-
-			// If null is stored for the ref then there are no commits - return an empty array
-			if (!sha) {
-				return createR11sResponseFromContent([]);
-			}
-		}
-
 		// See if the commit sha is hashed and return it if so
 		const commit = this.commitCache.get(sha);
 		if (commit !== undefined) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3746,7 +3746,7 @@ export class ContainerRuntime
 		 * and then close as the current main client is likely to be re-elected as the parent summarizer again.
 		 */
 		if (!result.isSummaryTracked && result.isSummaryNewer) {
-			const fetchResult = await this.fetchSnapshotFromStorage(
+			const fetchResult = await this.fetchLatestSnapshotFromStorage(
 				summaryLogger,
 				{
 					eventName: "RefreshLatestSummaryAckFetch",
@@ -3802,7 +3802,7 @@ export class ContainerRuntime
 
 		// This is a performance optimization as the same parent is likely to be elected again, and would use its
 		// cache to fetch the snapshot instead of the network.
-		await this.fetchSnapshotFromStorage(
+		await this.fetchLatestSnapshotFromStorage(
 			summaryLogger,
 			{
 				eventName: "RefreshLatestSummaryFromServerFetch",
@@ -3828,11 +3828,11 @@ export class ContainerRuntime
 	}
 
 	/**
-	 * Downloads snapshot from storage with the given versionId or latest if versionId is null.
+	 * Downloads the latest snapshot from storage.
 	 * By default, it also closes the container after downloading the snapshot. However, this may be
 	 * overridden via options.
 	 */
-	private async fetchSnapshotFromStorage(
+	private async fetchLatestSnapshotFromStorage(
 		logger: ITelemetryLoggerExt,
 		event: ITelemetryGenericEvent,
 		readAndParseBlob: ReadAndParseBlob,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3754,7 +3754,6 @@ export class ContainerRuntime
 					targetSequenceNumber: summaryRefSeq,
 				},
 				readAndParseBlob,
-				null,
 			);
 
 			/**
@@ -3809,7 +3808,6 @@ export class ContainerRuntime
 				eventName: "RefreshLatestSummaryFromServerFetch",
 			},
 			readAndParseBlob,
-			null,
 		);
 
 		await this.closeStaleSummarizer("RefreshLatestSummaryFromServerFetch");
@@ -3838,7 +3836,6 @@ export class ContainerRuntime
 		logger: ITelemetryLoggerExt,
 		event: ITelemetryGenericEvent,
 		readAndParseBlob: ReadAndParseBlob,
-		versionId: string | null,
 	): Promise<{ snapshotTree: ISnapshotTree; versionId: string; latestSnapshotRefSeq: number }> {
 		return PerformanceEvent.timedExecAsync(
 			logger,
@@ -3860,10 +3857,10 @@ export class ContainerRuntime
 				const trace = Trace.start();
 
 				const versions = await this.storage.getVersions(
-					versionId,
+					null,
 					1,
 					"prefetchLatestSummaryBeforeClose",
-					versionId === null ? FetchSource.noCache : undefined,
+					FetchSource.noCache,
 				);
 				assert(
 					!!versions && !!versions[0],


### PR DESCRIPTION
I've been investigating an OCE issue where we're getting back an unexpected response from getVersions.  In my investigation I found a couple small/easy items to clean up that were red herrings, so doing that here.  Basically the caches are never populated, and we never call fetchSnapshotFromStorage with anything but a `null` versionId.