### PR TITLE
Fix 0x331 for rebasing a batch

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -2134,8 +2134,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			return false;
 		}
 
-		const pendingKeyMessageId = this.pendingKeys.get(op.key);
-		if (pendingKeyMessageId !== undefined) {
+		const pendingKeyMessageIds = this.pendingKeys.get(op.key);
+		if (pendingKeyMessageIds !== undefined) {
 			// Found an NACK op, clear it from the directory if the latest sequence number in the directory
 			// match the message's and don't process the op.
 			if (local) {
@@ -2143,14 +2143,13 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					localOpMetadata !== undefined && isKeyEditLocalOpMetadata(localOpMetadata),
 					0x011 /* pendingMessageId is missing from the local client's operation */,
 				);
-				const pendingMessageIds = this.pendingKeys.get(op.key);
+				// https://github.com/microsoft/FluidFramework/commit/5daae4110c7d77d2fe38f2fc16f4743adae05544#diff-5da3533fe8c2f92f839a9a3d55ee13909efd2bd614b44ed3057b7ce8b285b1f8R1447
 				assert(
-					pendingMessageIds !== undefined &&
-						pendingMessageIds[0] === localOpMetadata.pendingMessageId,
+					pendingKeyMessageIds[0] === localOpMetadata.pendingMessageId,
 					0x331 /* Unexpected pending message received */,
 				);
-				pendingMessageIds.shift();
-				if (pendingMessageIds.length === 0) {
+				pendingKeyMessageIds.shift();
+				if (pendingKeyMessageIds.length === 0) {
 					this.pendingKeys.delete(op.key);
 				}
 			}

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1821,7 +1821,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		// is already deleted, in which case we don't need to submit the op.
 		if (pendingMessageIds !== undefined) {
 			const index = pendingMessageIds.findIndex(
-				(i) => i === localOpMetadata.pendingMessageId,
+				(id) => id === localOpMetadata.pendingMessageId,
 			);
 			if (index === -1) {
 				return;
@@ -2146,7 +2146,6 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					localOpMetadata !== undefined && isKeyEditLocalOpMetadata(localOpMetadata),
 					0x011 /* pendingMessageId is missing from the local client's operation */,
 				);
-				// https://github.com/microsoft/FluidFramework/commit/5daae4110c7d77d2fe38f2fc16f4743adae05544#diff-5da3533fe8c2f92f839a9a3d55ee13909efd2bd614b44ed3057b7ce8b285b1f8R1447
 				assert(
 					pendingKeyMessageIds[0] === localOpMetadata.pendingMessageId,
 					0x331 /* Unexpected pending message received */,

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1819,11 +1819,14 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		const pendingMessageIds = this.pendingKeys.get(op.key);
 		// Only submit the op, if we have record for it, otherwise it is possible that the older instance
 		// is already deleted, in which case we don't need to submit the op.
-		if (
-			pendingMessageIds !== undefined &&
-			pendingMessageIds[0] === localOpMetadata.pendingMessageId
-		) {
-			pendingMessageIds.shift();
+		if (pendingMessageIds !== undefined) {
+			const index = pendingMessageIds.findIndex(
+				(i) => i === localOpMetadata.pendingMessageId,
+			);
+			if (index === -1) {
+				return;
+			}
+			pendingMessageIds.splice(index, 1);
 			if (pendingMessageIds.length === 0) {
 				this.pendingKeys.delete(op.key);
 			}

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -1221,7 +1221,7 @@ describeNoCompat("SharedDirectory", (getTestObjectProvider) => {
 		provider = getTestObjectProvider();
 	});
 
-	it.only("Rebasing batch doesn't hit 0x331", async () => {
+	it("Rebasing batch doesn't hit 0x331", async () => {
 		// Grouped batching is needed for rebasing to happen
 		const container = await provider.makeTestContainer(groupedBatchingContainerConfig);
 		const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");


### PR DESCRIPTION
Main issue is that we can resubmit batches before we receive acks from other batches. Thus, it results in ops being dropped because of the "if" in "SubDirectory.resubmitKeyMessage".

An example flow that hits the assert:

1. Connect container in read mode
2. Send batch of SubDirectory "sets" (pendingKeys = [0])
3. Send batch of SubDirectory "sets" (pendingKeys = [0, 1])
	- Let's say this batch gets rebased. Ops are not resubmitted because of the "if", but pendingKeys is still [0, 1]
4. Connect container in write mode
5. resubmit what we have in PendingStateManager, which is just the first batch (second batch was dropped on rebase)
6. Resubmit first batch of SubDirectory "sets" (pendingKeys = [1, 2])
7. Incoming message "0", ignored since it's remote
8. Incoming message "2", assert 0x331 hit


I believe "SubDirectory.resubmitKeyMessage" should check the whole pendingKeys array for a match, remove it from that index, and resubmit appropriately.

[AB#5741](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5741)