### PR TITLE
tree2: Setup "create" for recursive object schema

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -591,10 +591,15 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 type ExtractListItemType<List extends FlexList> = List extends FlexList<infer Item> ? Item : unknown;
 
 // @alpha
-export type FactoryObjectNodeSchema<TScope extends string, Name extends number | string, T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>> = FactoryTreeSchema<TreeNodeSchema<`${TScope}.${Name}`, {
+type FactoryObjectNodeSchema<TScope extends string, Name extends number | string, T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>> = FactoryTreeSchema<TreeNodeSchema<`${TScope}.${Name}`, {
     objectNodeFields: {
         [key in keyof T]: NormalizeField_2<T[key], Required_2>;
     };
+}>>;
+
+// @alpha
+type FactoryObjectNodeSchemaRecursive<TScope extends string, Name extends number | string, T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>> = FactoryTreeSchema<TreeNodeSchema<`${TScope}.${Name}`, {
+    objectNodeFields: T;
 }>>;
 
 // @alpha
@@ -945,7 +950,10 @@ declare namespace InternalTypes {
         Optional,
         NodeKeyFieldKind,
         Forbidden,
-        Sequence_2 as SequenceFieldKind
+        Sequence_2 as SequenceFieldKind,
+        FactoryObjectNodeSchema,
+        FactoryObjectNodeSchemaRecursive,
+        testRecursiveDomain
     }
 }
 export { InternalTypes }
@@ -1687,13 +1695,11 @@ export interface RangeUpPath<TUpPath extends UpPath = UpPath> extends FieldUpPat
 export function recordDependency(dependent: ObservingDependent | undefined, dependee: Dependee): void;
 
 // @alpha (undocumented)
-const recursiveObject: TreeNodeSchema<"Test Recursive Domain.object", {
-objectNodeFields: {
-readonly recursive: TreeFieldSchema<Optional, readonly [() => TreeNodeSchema<"Test Recursive Domain.object", any>]>;
+const recursiveObject: FactoryObjectNodeSchemaRecursive<"Test Recursive Domain", "object", {
+readonly recursive: TreeFieldSchema<Optional, readonly [() => FactoryObjectNodeSchemaRecursive<"Test Recursive Domain", "object", any>]>;
 readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", {
 leafValue: import("..").ValueSchema.Number;
 }>;
-};
 }>;
 
 // @alpha (undocumented)
@@ -1816,6 +1822,7 @@ export class SchemaBuilder<TScope extends string = string, TName extends string 
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", {
         leafValue: import("..").ValueSchema.Boolean;
     }>;
+    fixRecursiveReference<T extends AllowedTypes>(...types: T): void;
     // (undocumented)
     readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", {
         leafValue: import("..").ValueSchema.FluidHandle;
@@ -1846,6 +1853,8 @@ export class SchemaBuilder<TScope extends string = string, TName extends string 
     }>;
     // (undocumented)
     object<const Name extends TName, const T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>(name: Name, t: T): FactoryObjectNodeSchema<TScope, Name, T>;
+    // (undocumented)
+    objectRecursive<const Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): FactoryObjectNodeSchemaRecursive<TScope, Name, T>;
     static optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Optional, NormalizeAllowedTypes<T>>;
     readonly optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Optional, NormalizeAllowedTypes<T>>;
     static required: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Required_2, NormalizeAllowedTypes<T>>;
@@ -1890,7 +1899,7 @@ export class SchemaBuilderBase<TScope extends string, TDefaultKind extends Field
             [key in keyof T]: NormalizeField_2<T[key], TDefaultKind>;
         };
     }>;
-    objectRecursive<Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeNodeSchema<`${TScope}.${Name}`, {
+    objectRecursive<const Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>>(name: Name, t: T): TreeNodeSchema<`${TScope}.${Name}`, {
         objectNodeFields: T;
     }>;
     readonly scope: TScope;
@@ -2097,7 +2106,6 @@ declare namespace testRecursiveDomain {
         library
     }
 }
-export { testRecursiveDomain }
 
 // @alpha
 export function toDownPath(upPath: UpPath): DownPath;

--- a/experimental/dds/tree2/src/domains/index.ts
+++ b/experimental/dds/tree2/src/domains/index.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export { SchemaBuilder, FactoryObjectNodeSchema } from "./schemaBuilder";
+export {
+	SchemaBuilder,
+	FactoryObjectNodeSchema,
+	FactoryObjectNodeSchemaRecursive,
+} from "./schemaBuilder";
 
 export {
 	cursorToJsonObject,

--- a/experimental/dds/tree2/src/domains/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/domains/schemaBuilder.ts
@@ -372,7 +372,7 @@ export class SchemaBuilder<
 	public readonly null = leaf.null;
 
 	/**
-	 * Function which can be used for its compile time sid-effects to tweak the evaluation order of recursive types to make them compile.
+	 * Function which can be used for its compile time side-effects to tweak the evaluation order of recursive types to make them compile.
 	 * @remarks
 	 * Some related information in https://github.com/microsoft/TypeScript/issues/55758.
 	 *

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -10,7 +10,7 @@
  * Currently we do not have tooling in place to test this in our test suite, and exporting these types here is a temporary crutch to aid in diagnosing this issue.
  */
 
-import { AllowedTypes, FieldKinds, TreeFieldSchema } from "../feature-libraries";
+import { FieldKinds, TreeFieldSchema } from "../feature-libraries";
 import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../util";
 import { leaf } from "./leafDomain";
 import { SchemaBuilder } from "./schemaBuilder";
@@ -25,11 +25,8 @@ export const recursiveObject = builder.objectRecursive("object", {
 	number: leaf.number,
 });
 
-// Some related information in https://github.com/microsoft/TypeScript/issues/55758.
-function fixRecursiveReference<T extends AllowedTypes>(...types: T): void {}
-
 const recursiveReference = () => recursiveObject2;
-fixRecursiveReference(recursiveReference);
+builder.fixRecursiveReference(recursiveReference);
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaBuilderBase.ts
@@ -217,7 +217,7 @@ export class SchemaBuilderBase<
 	 * TODO: Make this work with ImplicitFieldSchema.
 	 */
 	public objectRecursive<
-		Name extends TName,
+		const Name extends TName,
 		const T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>,
 	>(name: Name, t: T): TreeNodeSchema<`${TScope}.${Name}`, { objectNodeFields: T }> {
 		return this.object(

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -128,9 +128,7 @@ export {
 	nodeKeyField,
 	nodeKeySchema,
 	leaf,
-	testRecursiveDomain,
 	SchemaBuilder,
-	FactoryObjectNodeSchema,
 } from "./domains";
 
 export {

--- a/experimental/dds/tree2/src/internal.ts
+++ b/experimental/dds/tree2/src/internal.ts
@@ -36,3 +36,9 @@ export {
 	Forbidden,
 	SequenceFieldKind,
 } from "./feature-libraries";
+
+export {
+	FactoryObjectNodeSchema,
+	FactoryObjectNodeSchemaRecursive,
+	testRecursiveDomain,
+} from "./domains";

--- a/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
@@ -296,7 +296,7 @@ describe("domains - SchemaBuilder", () => {
 
 /**
  * These build objects are intentionally not holding the data their types make them appear to have as part of a workaround for https://github.com/microsoft/TypeScript/issues/43826.
- * This makes testing that these factory function dod the correct thing a bit non-obvious:
+ * This makes testing that these factory function do the correct thing a bit non-obvious:
  */
 export function checkCreated<TSchema extends ObjectNodeSchema>(
 	created: SharedTreeObject<TSchema>,


### PR DESCRIPTION
## Description

Add SchemaBuilder support for factory functions for recursive structs.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
