### PR TITLE
tree2: Make getProxyForNode more type safe

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -22,6 +22,7 @@ import {
 	OptionalField,
 	RequiredField,
 	TreeNode,
+	Typed,
 	TypedField,
 	TypedNodeUnion,
 } from "../editableTreeTypes";
@@ -122,7 +123,7 @@ export function getProxyForField<TSchema extends TreeFieldSchema>(
 }
 
 export function getProxyForNode<TSchema extends TreeNodeSchema>(
-	treeNode: TreeNode,
+	treeNode: Typed<TSchema>,
 ): ProxyNode<TSchema> {
 	const schema = treeNode.schema;
 


### PR DESCRIPTION
## Description

getProxyForNode  was inferring the schema from the return type. This is dangerous since it makes the type the implementation is `as` casting to unrelated to the runtime value or input type. This means the implementation has no way to ensure the as cast is correct, and adding asserts for it is impossible since there is only compile time information.

A much safer approach is to constrain the input to be the desired type. This way if its invoked with the incorrect input type, it will fail to build instead of returning a type at runtime that does not match the compile time type. This PR adopts this safer approach.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
