### PR TITLE
tree2: Replace SchemaAware.Internal.TypedValue with TreeValue

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -30,7 +30,7 @@ export type AllowedTypeSet = Any | ReadonlySet<TreeNodeSchema>;
 
 // @alpha
 type AllowedTypesToTypedTrees<Mode extends ApiMode, T extends AllowedTypes> = [
-T extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Mode, Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<T>, readonly TreeNodeSchema[]>>> : UntypedApi<Mode>
+T extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray<Mode, Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<T>, readonly TreeNodeSchema[]>>> : UntypedApi<Mode>
 ][_InlineTrick];
 
 // @alpha
@@ -881,7 +881,7 @@ declare namespace InternalEditableTreeTypes {
     export {
         TypedFieldInner,
         UnboxFieldInner,
-        TypeArrayToTypedTreeArray,
+        TypeArrayToTypedTreeArray_2 as TypeArrayToTypedTreeArray,
         ObjectNodeFields,
         UnboxField,
         UnboxNode,
@@ -963,11 +963,10 @@ declare namespace InternalTypes_2 {
         EditableOptionalField,
         TypedField_2 as TypedField,
         UnbrandedName,
-        TypeArrayToTypedTreeArray_2 as TypeArrayToTypedTreeArray,
+        TypeArrayToTypedTreeArray,
         UntypedApi,
         EmptyObject,
         ValuesOf,
-        TypedValue,
         TypedValueOrUndefined,
         PrimitiveValueSchema,
         UntypedSequenceField,
@@ -1217,7 +1216,7 @@ export type LazyTreeNodeSchema = TreeNodeSchema | (() => TreeNodeSchema);
 
 // @alpha
 export interface Leaf<TSchema extends LeafSchema> extends TreeNode {
-    readonly value: SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>;
+    readonly value: TreeValue<TSchema["leafValue"]>;
 }
 
 // @alpha
@@ -1652,7 +1651,7 @@ export type ProxyField<TSchema extends TreeFieldSchema, API extends "javaScript"
 export type ProxyFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree", Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? never : Kind extends typeof FieldKinds.required ? ProxyNodeUnion<TTypes, API> : Kind extends typeof FieldKinds.optional ? ProxyNodeUnion<TTypes, API> | (Emptiness extends "notEmpty" ? never : undefined) : unknown;
 
 // @alpha
-export type ProxyNode<TSchema extends TreeNodeSchema, API extends "javaScript" | "sharedTree" = "sharedTree"> = TSchema extends LeafSchema ? SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]> : TSchema extends MapSchema ? API extends "sharedTree" ? SharedTreeMap<TSchema> : Map<string, ProxyField<TSchema["mapFields"], API>> : TSchema extends FieldNodeSchema ? API extends "sharedTree" ? SharedTreeList<TSchema["objectNodeFieldsObject"][""]["allowedTypes"], API> : readonly ProxyNodeUnion<TSchema["objectNodeFieldsObject"][""]["allowedTypes"], API>[] : TSchema extends ObjectNodeSchema ? SharedTreeObject<TSchema, API> : unknown;
+export type ProxyNode<TSchema extends TreeNodeSchema, API extends "javaScript" | "sharedTree" = "sharedTree"> = TSchema extends LeafSchema ? TreeValue<TSchema["leafValue"]> : TSchema extends MapSchema ? API extends "sharedTree" ? SharedTreeMap<TSchema> : Map<string, ProxyField<TSchema["mapFields"], API>> : TSchema extends FieldNodeSchema ? API extends "sharedTree" ? SharedTreeList<TSchema["objectNodeFieldsObject"][""]["allowedTypes"], API> : readonly ProxyNodeUnion<TSchema["objectNodeFieldsObject"][""]["allowedTypes"], API>[] : TSchema extends ObjectNodeSchema ? SharedTreeObject<TSchema, API> : unknown;
 
 // @alpha
 export type ProxyNodeUnion<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> = TTypes extends readonly [Any] ? unknown : {
@@ -2286,18 +2285,18 @@ export type TreeValue<TSchema extends ValueSchema = ValueSchema> = [
 ][_InlineTrick];
 
 // @alpha
-type TypeArrayToTypedTreeArray<T extends readonly TreeNodeSchema[]> = [
+type TypeArrayToTypedTreeArray<Mode extends ApiMode, T extends readonly TreeNodeSchema[]> = [
 T extends readonly [infer Head, ...infer Tail] ? [
-TypedNode<Assume<Head, TreeNodeSchema>>,
-...TypeArrayToTypedTreeArray<Assume<Tail, readonly TreeNodeSchema[]>>
+TypedNode_2<Assume<Head, TreeNodeSchema>, Mode>,
+...TypeArrayToTypedTreeArray<Mode, Assume<Tail, readonly TreeNodeSchema[]>>
 ] : []
 ][_InlineTrick];
 
 // @alpha
-type TypeArrayToTypedTreeArray_2<Mode extends ApiMode, T extends readonly TreeNodeSchema[]> = [
+type TypeArrayToTypedTreeArray_2<T extends readonly TreeNodeSchema[]> = [
 T extends readonly [infer Head, ...infer Tail] ? [
-TypedNode_2<Assume<Head, TreeNodeSchema>, Mode>,
-...TypeArrayToTypedTreeArray_2<Mode, Assume<Tail, readonly TreeNodeSchema[]>>
+TypedNode<Assume<Head, TreeNodeSchema>>,
+...TypeArrayToTypedTreeArray_2<Assume<Tail, readonly TreeNodeSchema[]>>
 ] : []
 ][_InlineTrick];
 
@@ -2336,7 +2335,7 @@ export type TypedNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSche
 type TypedNode_2<TSchema extends TreeNodeSchema, Mode extends ApiMode = ApiMode.Editable> = FlattenKeys<CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["objectNodeFieldsObject"]>, TSchema["leafValue"], TSchema["name"]>>;
 
 // @alpha
-export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray<Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>> : TreeNode;
+export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>> : TreeNode;
 
 // @alpha
 export interface TypedTreeChannel extends IChannel {
@@ -2362,16 +2361,7 @@ export interface TypedTreeOptions extends SharedTreeOptions {
 }
 
 // @alpha
-type TypedValue<TValue extends ValueSchema> = {
-    [ValueSchema.Number]: number;
-    [ValueSchema.String]: string;
-    [ValueSchema.Boolean]: boolean;
-    [ValueSchema.FluidHandle]: IFluidHandle;
-    [ValueSchema.Null]: null;
-}[TValue];
-
-// @alpha
-type TypedValueOrUndefined<TValue extends ValueSchema | undefined> = TValue extends ValueSchema ? TypedValue<TValue> : undefined;
+type TypedValueOrUndefined<TValue extends ValueSchema | undefined> = TValue extends ValueSchema ? TreeValue<TValue> : undefined;
 
 // @alpha
 export const typeNameSymbol: unique symbol;
@@ -2386,7 +2376,7 @@ type UnboxField<TSchema extends TreeFieldSchema, Emptiness extends "maybeEmpty" 
 type UnboxFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? Sequence<TTypes> : Kind extends typeof FieldKinds.required ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined) : Kind extends typeof FieldKinds.nodeKey ? NodeKeyField : unknown;
 
 // @alpha
-type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema ? SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["objectNodeFieldsObject"][""]> : TSchema extends ObjectNodeSchema ? ObjectNodeTyped<TSchema> : unknown;
+type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema ? TreeValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["objectNodeFieldsObject"][""]> : TSchema extends ObjectNodeSchema ? ObjectNodeTyped<TSchema> : unknown;
 
 // @alpha
 type UnboxNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [
@@ -2527,7 +2517,7 @@ export type ValueFromBranded<T extends BrandedType<any, string>> = T extends Bra
 
 // @alpha (undocumented)
 type ValuePropertyFromSchema<TSchema extends ValueSchema | undefined> = TSchema extends ValueSchema ? {
-    [valueSymbol]: TypedValue<TSchema>;
+    [valueSymbol]: TreeValue<TSchema>;
 } : EmptyObject;
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -419,7 +419,7 @@ export interface Leaf<TSchema extends LeafSchema> extends TreeNode {
 	/**
 	 * Value stored on this node.
 	 */
-	readonly value: SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>;
+	readonly value: TreeValue<TSchema["leafValue"]>;
 }
 
 /**
@@ -871,7 +871,7 @@ export type UnboxNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonl
  * @alpha
  */
 export type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema
-	? SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>
+	? TreeValue<TSchema["leafValue"]>
 	: TSchema extends MapSchema
 	? MapNode<TSchema>
 	: TSchema extends FieldNodeSchema

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyTree.ts
@@ -4,7 +4,6 @@
  */
 
 import { assert, unreachableCase } from "@fluidframework/core-utils";
-import * as SchemaAware from "../schema-aware";
 import {
 	Value,
 	Anchor,
@@ -20,6 +19,7 @@ import {
 	EmptyKey,
 	TreeNodeSchemaIdentifier,
 	forEachField,
+	TreeValue,
 } from "../../core";
 import { capitalize, disposeSymbol, fail, getOrCreate } from "../../util";
 import { ContextuallyTypedNodeData } from "../contextuallyTyped";
@@ -461,8 +461,8 @@ export class LazyLeaf<TSchema extends LeafSchema>
 		makePropertyEnumerableOwn(this, "value", LazyTreeNode.prototype);
 	}
 
-	public override get value(): SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]> {
-		return super.value as SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>;
+	public override get value(): TreeValue<TSchema["leafValue"]> {
+		return super.value as TreeValue<TSchema["leafValue"]>;
 	}
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { EditableTreeEvents, SchemaAware } from "../..";
+import { EditableTreeEvents } from "../..";
+import { TreeValue } from "../../../core";
 import { RestrictiveReadonlyRecord } from "../../../util";
 import { FieldKinds } from "../../default-field-kinds";
 import { FieldKind } from "../../modular-schema";
@@ -284,7 +285,7 @@ export type ProxyNode<
 	TSchema extends TreeNodeSchema,
 	API extends "javaScript" | "sharedTree" = "sharedTree",
 > = TSchema extends LeafSchema
-	? SchemaAware.InternalTypes.TypedValue<TSchema["leafValue"]>
+	? TreeValue<TSchema["leafValue"]>
 	: TSchema extends MapSchema
 	? API extends "sharedTree"
 		? SharedTreeMap<TSchema>

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/internal.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/internal.ts
@@ -21,7 +21,7 @@ export {
 	EmptyObject,
 } from "./schemaAware";
 
-export { ValuesOf, TypedValue, TypedValueOrUndefined } from "./schemaAwareUtil";
+export { ValuesOf, TypedValueOrUndefined } from "./schemaAwareUtil";
 
 export { PrimitiveValueSchema } from "../../core";
 

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { PrimitiveValueSchema, TreeNodeSchemaIdentifier, ValueSchema } from "../../core";
+import { PrimitiveValueSchema, TreeNodeSchemaIdentifier, TreeValue, ValueSchema } from "../../core";
 import {
 	ContextuallyTypedNodeData,
 	FluidSerializableReadOnly,
@@ -30,7 +30,7 @@ import {
 } from "../untypedTree";
 import { Assume, FlattenKeys, _InlineTrick } from "../../util";
 import { UntypedOptionalField, UntypedSequenceField, UntypedValueField } from "./partlyTyped";
-import { TypedValue, TypedValueOrUndefined } from "./schemaAwareUtil";
+import { TypedValueOrUndefined } from "./schemaAwareUtil";
 
 /**
  * Empty Object for use in type computations that should contribute no fields when `&`ed with another type.
@@ -45,7 +45,7 @@ export type EmptyObject = {};
  * @alpha
  */
 export type ValuePropertyFromSchema<TSchema extends ValueSchema | undefined> =
-	TSchema extends ValueSchema ? { [valueSymbol]: TypedValue<TSchema> } : EmptyObject;
+	TSchema extends ValueSchema ? { [valueSymbol]: TreeValue<TSchema> } : EmptyObject;
 
 /**
  * Different schema aware APIs that can be generated.

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAwareUtil.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAwareUtil.ts
@@ -3,40 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { Value, ValueSchema, PrimitiveValueSchema } from "../../core";
-import { areSafelyAssignable, isAssignableTo, requireTrue } from "../../util";
+import { ValueSchema, PrimitiveValueSchema, TreeValue } from "../../core";
+import { areSafelyAssignable, requireTrue } from "../../util";
 import { PrimitiveValue } from "../contextuallyTyped";
-
-/**
- * {@link ValueSchema} to allowed types for that schema.
- * @alpha
- */
-export type TypedValue<TValue extends ValueSchema> = {
-	[ValueSchema.Number]: number;
-	[ValueSchema.String]: string;
-	[ValueSchema.Boolean]: boolean;
-	[ValueSchema.FluidHandle]: IFluidHandle;
-	// eslint-disable-next-line @rushstack/no-new-null
-	[ValueSchema.Null]: null;
-}[TValue];
 
 /**
  * {@link ValueSchema} | undefined to allowed types for that schema.
  * @alpha
  */
 export type TypedValueOrUndefined<TValue extends ValueSchema | undefined> =
-	TValue extends ValueSchema ? TypedValue<TValue> : undefined;
+	TValue extends ValueSchema ? TreeValue<TValue> : undefined;
 
 {
-	type PrimitiveValue2 = TypedValue<PrimitiveValueSchema>;
+	type PrimitiveValue2 = TreeValue<PrimitiveValueSchema>;
 	type _check1 = requireTrue<areSafelyAssignable<PrimitiveValue, PrimitiveValue2>>;
-}
-
-{
-	type Value2 = TypedValue<ValueSchema>;
-	type _check2 = isAssignableTo<Value, Value2>;
-	type _check3 = isAssignableTo<Value2, Value>;
 }
 
 /**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -6,9 +6,7 @@
 import { strict as assert } from "assert";
 import { LeafSchema, TreeSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
-
-// eslint-disable-next-line import/no-internal-modules
-import { TypedValue } from "../../../feature-libraries/schema-aware/internal";
+import { TreeValue } from "../../../core";
 import { createTreeView, itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
@@ -328,8 +326,8 @@ describe("Object-like", () => {
 		describe("primitives", () => {
 			function check<const TSchema extends LeafSchema>(
 				schema: LeafSchema,
-				before: TypedValue<TSchema["leafValue"]>,
-				after: TypedValue<TSchema["leafValue"]>,
+				before: TreeValue<TSchema["leafValue"]>,
+				after: TreeValue<TSchema["leafValue"]>,
 			) {
 				describe(`required ${typeof before} `, () => {
 					itWithRoot(

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAwareSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAwareSimple.ts
@@ -15,12 +15,11 @@ import {
 	AllowedTypes,
 	InternalTypedSchemaTypes,
 } from "../../..";
-import { ValueSchema } from "../../../core";
+import { TreeValue, ValueSchema } from "../../../core";
 // eslint-disable-next-line import/no-internal-modules
 import { UntypedSequenceField } from "../../../feature-libraries/schema-aware/partlyTyped";
 
 import {
-	TypedValue,
 	TypedValueOrUndefined,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/schema-aware/schemaAwareUtil";
@@ -31,7 +30,7 @@ import { Assume, _InlineTrick } from "../../../util";
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ValuePropertyFromSchema<TSchema extends ValueSchema> = {
-	[valueSymbol]: TypedValue<TSchema>;
+	[valueSymbol]: TreeValue<TSchema>;
 };
 
 /**


### PR DESCRIPTION
## Description

Replace  Replace SchemaAware.Internal.TypedValue with TreeValue which is the same.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

