### PR TITLE
Adding verbose logging for the connect_document_success event

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -573,7 +573,7 @@ export class DocumentDeltaConnection
 
 				this.logger.sendTelemetryEvent(
 					{
-						eventName: "connect_document_success",
+						eventName: "ConnectDocumentSuccess",
 						pendingClientId: response.clientId,
 					},
 					undefined,

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -22,7 +22,7 @@ import {
 	ITokenClaims,
 	ScopeType,
 } from "@fluidframework/protocol-definitions";
-import { IDisposable, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { IDisposable, ITelemetryProperties, LogLevel } from "@fluidframework/core-interfaces";
 import {
 	ITelemetryLoggerExt,
 	extractLogSafeErrorProperties,
@@ -570,6 +570,15 @@ export class DocumentDeltaConnection
 						return;
 					}
 				}
+
+				this.logger.sendTelemetryEvent(
+					{
+						eventName: "connect_document_success",
+						pendingClientId: response.clientId,
+					},
+					undefined,
+					LogLevel.verbose,
+				);
 
 				this.checkpointSequenceNumber = response.checkpointSequenceNumber;
 


### PR DESCRIPTION
## Description

In order to get more information around the pending client Id for the connection before it is actually stored, we are logging this information as soon as it is available, in case the connection gets disconnected before we get any events of the form ConnectionStateChange_XXXXXXXX  (logConnectionStateChangeTelemetry). 
