### PR TITLE
refactor(ci): Extract common steps for perf tests to a template

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -30,7 +30,7 @@ steps:
   # Need to give this step a unique name because this template is used several times in the same pipeline.
   # If at some point this becomes hard to do, we can switch to using standard variables (vs output variables from
   # a step) so the step doesn't need a name. Need to be careful with the characters allowed in a step name.
-  name: localVariables_${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '_') }}
+  name: localVariables_${{ replace(replace(replace(parameters.testPackageName, '@', '' ), '/', '_'), '-', '_') }}
   inputs:
     targetType: 'inline'
     script: |

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -27,7 +27,10 @@ parameters:
 steps:
 - task: Bash@3
   displayName: Set local template variables
-  name: localVariables
+  # Need to give this step a unique name because this template is used several times in the same pipeline.
+  # If at some point this becomes hard to do, we can switch to using standard variables (vs output variables from
+  # a step) so the step doesn't need a name
+  name: localVariables_${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '-') }}
   inputs:
     targetType: 'inline'
     script: |

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -34,7 +34,13 @@ steps:
     # Using isOutput=true variables was too complicated/dirty.
     script: |
       echo "Setting local variables for yml template"
-      echo "##vso[task.setvariable variable=itpbip_sanitizedPackageName]${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '-') }}-?.?.?-*.tgz"
+
+      # Doing the character replacements with sed at runtime because using replace() in ADO template expression (which
+      # are evaluated at compile-time) causes some weird interactions if the value provided for testPackageName is only
+      # available at runtime. Also, using ! as separator instead of the usual / because forward slash is something we
+      # need to replace.
+      TEST_PACKAGE_NAME=$(echo "${{ parameters.testPackageName }}" | sed -r 's!@!!g' | sed -r 's!/!-!g')
+      echo "##vso[task.setvariable variable=itpbip_sanitizedPackageName]${TEST_PACKAGE_NAME}-?.?.?-*.tgz"
       echo "##vso[task.setvariable variable=itpbip_downloadPath]$(Pipeline.Workspace)/downloadedPackages"
 
 # Download package that has performance tests

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -27,16 +27,15 @@ parameters:
 steps:
 - task: Bash@3
   displayName: Set local template variables
-  # Need to give this step a unique name because this template is used several times in the same pipeline.
-  # If at some point this becomes hard to do, we can switch to using standard variables (vs output variables from
-  # a step) so the step doesn't need a name. Need to be careful with the characters allowed in a step name.
-  name: localVariables_${{ replace(replace(replace(parameters.testPackageName, '@', '' ), '/', '_'), '-', '_') }}
   inputs:
     targetType: 'inline'
+    # Using a prefix on these variables to try to make them unique to minimize risk of conflicts with variables that
+    # use the same name in the pipeline that includes this template.
+    # Using isOutput=true variables was too complicated/dirty.
     script: |
       echo "Setting local variables for yml template"
-      echo "##vso[task.setvariable variable=sanitizedPackageName;isOutput=true]${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '-') }}-?.?.?-*.tgz"
-      echo "##vso[task.setvariable variable=downloadPath;isOutput=true]$(Pipeline.Workspace)/downloadedPackages"
+      echo "##vso[task.setvariable variable=itpbip_sanitizedPackageName]${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '-') }}-?.?.?-*.tgz"
+      echo "##vso[task.setvariable variable=itpbip_downloadPath]$(Pipeline.Workspace)/downloadedPackages"
 
 # Download package that has performance tests
 - task: DownloadPipelineArtifact@2
@@ -53,8 +52,8 @@ steps:
     buildVersionToDownload: specific
     buildId: ${{ parameters.artifactBuildId }}
     artifact: pack
-    patterns: "**/$(localVariables.sanitizedPackageName)"
-    path: $(localVariables.downloadPath)
+    patterns: "**/$(itpbip_sanitizedPackageName)"
+    path: $(itpbip_downloadPath)
     # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
     # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
 
@@ -67,7 +66,7 @@ steps:
     script: |
       echo "Installing ${{ parameters.testPackageName }}"
 
-      TEST_PACKAGE_PATH_PATTERN=$(localVariables.downloadPath)/scoped/$(localVariables.sanitizedPackageName)
+      TEST_PACKAGE_PATH_PATTERN=$(itpbip_downloadPath)/scoped/$(itpbip_sanitizedPackageName)
       echo "Looking for tarball with pattern $TEST_PACKAGE_PATH_PATTERN :"
       ls -1 $TEST_PACKAGE_PATH_PATTERN
 

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# This template is intended to be used for common steps across stages of the test-perf-benchmarks.yml pipeline.
+# It downloads (from the artifacts produced by another pipeline) and installs a specified package that has performance tests.
+
+parameters:
+# Identifier for the pipeline that produced the artifact with the package to be installed.
+# Will be used for the 'pipeline' input for a DownloadPipelineArtifact task.
+- name: artifactPipeline
+  type: string
+
+# Identifier for the pipeline run that produced the artifact with the package to be installed.
+# Will be used for the 'buildId' input for a DownloadPipelineArtifact task.
+- name: artifactBuildId
+  type: string
+
+# Name of the package to be installed.
+- name: testPackageName
+  type: string
+
+# Path where the package should be installed. This template assumes an appropriate .npmrc file was already setup there
+# so dependencies can be resolved from our feeds.
+- name: installPath
+  type: string
+
+steps:
+- task: Bash@3
+  displayName: Set local template variables
+  name: localVariables
+  inputs:
+    targetType: 'inline'
+    script: |
+      echo "Setting local variables for yml template"
+      echo "##vso[task.setvariable variable=sanitizedPackageName;isOutput=true]${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '-') }}-?.?.?-*.tgz"
+      echo "##vso[task.setvariable variable=downloadPath;isOutput=true]$(Pipeline.Workspace)/downloadedPackages"
+
+# Download package that has performance tests
+- task: DownloadPipelineArtifact@2
+  displayName: Download package with perf tests
+  inputs:
+    # It seems there's a bug and preferTriggeringPipeline is not respected.
+    # We force the behavior by explicitly specifying:
+    # - buildVersionToDownload: specific
+    # - buildId: <the id of the triggering build>
+    # preferTriggeringPipeline: true
+    source: specific
+    project: internal
+    pipeline: ${{ parameters.artifactPipeline }}
+    buildVersionToDownload: specific
+    buildId: ${{ parameters.artifactBuildId }}
+    artifact: pack
+    patterns: "**/$(localVariables.sanitizedPackageName)"
+    path: $(localVariables.downloadPath)
+    # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
+    # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+
+# Install package that has performance tests
+- task: Bash@3
+  displayName: Install package with perf tests
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.installPath }}
+    script: |
+      echo "Installing ${{ parameters.testPackageName }}"
+
+      TEST_PACKAGE_PATH_PATTERN=$(localVariables.downloadPath)/scoped/$(localVariables.sanitizedPackageName)
+      echo "Looking for tarball with pattern $TEST_PACKAGE_PATH_PATTERN :"
+      ls -1 $TEST_PACKAGE_PATH_PATTERN
+
+      if [[ `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l` -eq 1 ]]; then
+        npm install $(ls $TEST_PACKAGE_PATH_PATTERN)
+      else
+        echo "##vso[task.logissue type=error]Test package '${{ parameters.testPackageName }}' not found, or more than one possible match found. See messages above."
+        exit -1
+      fi

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -29,8 +29,8 @@ steps:
   displayName: Set local template variables
   # Need to give this step a unique name because this template is used several times in the same pipeline.
   # If at some point this becomes hard to do, we can switch to using standard variables (vs output variables from
-  # a step) so the step doesn't need a name
-  name: localVariables_${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '-') }}
+  # a step) so the step doesn't need a name. Need to be careful with the characters allowed in a step name.
+  name: localVariables_${{ replace(replace(parameters.testPackageName, '@', '' ), '/', '_') }}
   inputs:
     targetType: 'inline'
     script: |

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -39,7 +39,7 @@ steps:
 
 # Download package that has performance tests
 - task: DownloadPipelineArtifact@2
-  displayName: Download package with perf tests
+  displayName: Download package with perf tests - ${{ parameters.testPackageName }}
   inputs:
     # It seems there's a bug and preferTriggeringPipeline is not respected.
     # We force the behavior by explicitly specifying:
@@ -59,7 +59,7 @@ steps:
 
 # Install package that has performance tests
 - task: Bash@3
-  displayName: Install package with perf tests
+  displayName: Install package with perf tests - ${{ parameters.testPackageName }}
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.installPath }}

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -1,13 +1,11 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-# NOTE: This template is specifically intended to be used for common steps required across different stages
+# This template is specifically intended to be used for common steps required across different stages
 # of test-perf-benchmarks.yml pipeline, and assumes it has access to variables that have been defined/imported
-# in that pipeline (whether globaly or in the stage/job definitions).
+# in that pipeline (whether globally or in the stage/job definitions).
 # It also downloads the test files artifact to a location that the test-perf-benchmarks.yml pipeline expects.
-
-# Some assumptions:
-# - The 'ado-feeds' variable group is imported
+# The first step tries to validate that all variables that this template expects to exist have values.
 
 steps:
 - task: Bash@3

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# NOTE: This template is specifically intended to be used for common steps required across different stages
+# of test-perf-benchmarks.yml pipeline, and assumes it has access to variables that have been defined/imported
+# in that pipeline (whether globaly or in the stage/job definitions).
+# It also downloads the test files artifact to a location that the test-perf-benchmarks.yml pipeline expects.
+
+# Some assumptions:
+# - The 'ado-feeds' variable group is imported
+
+steps:
+- task: Bash@3
+  displayName: Ensure expected variables are not empty
+  inputs:
+    targetType: 'inline'
+    script: |
+      if [ -z "$(testWorkspace)" ]; then
+        echo "##vso[task.logissue type=error;]Template expects the \"testWorkspace\" variable to have a value"
+        echo "##vso[task.complete result=Failed;]"
+      fi
+      if [ -z "$(artifactPipeline)" ]; then
+        echo "##vso[task.logissue type=error;]Template expects the \"artifactPipeline\" variable to have a value"
+        echo "##vso[task.complete result=Failed;]"
+      fi
+      if [ -z "$(artifactBuildId)" ]; then
+        echo "##vso[task.logissue type=error;]Template expects the \"artifactBuildId\" variable to have a value"
+        echo "##vso[task.complete result=Failed;]"
+      fi
+      if [ -z "$(ado-feeds-dev)" ]; then
+        echo "##vso[task.logissue type=error;]Template expects the \"ado-feeds-dev\" variable to have a value"
+        echo "##vso[task.complete result=Failed;]"
+      fi
+      if [ -z "$(ado-feeds-office)" ]; then
+        echo "##vso[task.logissue type=error;]Template expects the \"ado-feeds-office\" variable to have a value"
+        echo "##vso[task.complete result=Failed;]"
+      fi
+
+- template: include-telemetry-setup.yml
+  parameters:
+    devFeedUrl: $(ado-feeds-dev)
+    officeFeedUrl: $(ado-feeds-office)
+
+- task: Bash@3
+  displayName: Print parameter/variable values for troubleshooting
+  inputs:
+    targetType: 'inline'
+    script: |
+      echo "
+      Variables:
+        artifactPipeline=$(artifactPipeline)
+        artifactBuildId=$(artifactBuildId)
+        testWorkspace=$(testWorkspace)
+
+      Build Params
+        SourceBranch=$(Build.SourceBranch)
+      "
+
+# Download artifact with test files
+- task: DownloadPipelineArtifact@2
+  displayName: Download test files
+  inputs:
+    # It seems there's a bug and preferTriggeringPipeline is not respected.
+    # We force the behavior by explicitly specifying:
+    # - buildVersionToDownload: specific
+    # - buildId: <the id of the triggering build>
+    # preferTriggeringPipeline: true
+    source: specific
+    project: internal
+    pipeline: $(artifactPipeline)
+    buildVersionToDownload: specific
+    buildId: $(artifactBuildId)
+    artifact: test-files
+    path: $(Pipeline.Workspace)/test-files/
+    # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
+    # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+
+- task: Bash@3
+  displayName: Create test directory
+  inputs:
+    targetType: 'inline'
+    script: |
+      mkdir $(testWorkspace)
+
+- task: Bash@3
+  displayName: Initialize npmrc
+  inputs:
+    targetType: 'inline'
+    workingDirectory: $(testWorkspace)
+    # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
+    script: |
+      echo Initialize package
+      npm init --yes
+
+      echo Generating .npmrc
+      echo "registry=https://registry.npmjs.org" >> ./.npmrc
+      echo "always-auth=false" >> ./.npmrc
+
+      echo "@fluidframework:registry=$(ado-feeds-dev)" >> ./.npmrc
+      echo "@fluid-experimental:registry=$(ado-feeds-dev)" >> ./.npmrc
+      echo "@fluid-tools:registry=$(ado-feeds-dev)" >> ./.npmrc
+      echo "@fluid-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
+      echo "@fluid-private:registry=$(ado-feeds-dev)" >> ./.npmrc
+      echo "@ff-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
+      echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
+      echo "always-auth=true" >> ./.npmrc
+      cat .npmrc
+
+# Auth to internal feed
+- task: npmAuthenticate@0
+  displayName: 'npm authenticate (internal feed)'
+  inputs:
+    workingFile: $(testWorkspace)/.npmrc
+
+# Install aria-logger
+- task: Npm@1
+  displayName: 'npm install aria logger'
+  inputs:
+    workingDir: $(testWorkspace)
+    command: 'custom'
+    customCommand: 'install @ff-internal/aria-logger'
+    customRegistry: 'useNpmrc'

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -2,43 +2,39 @@
 # Licensed under the MIT License.
 
 # This template is specifically intended to be used for common steps required across different stages
-# of test-perf-benchmarks.yml pipeline, and assumes it has access to variables that have been defined/imported
-# in that pipeline (whether globally or in the stage/job definitions).
-# It also downloads the test files artifact to a location that the test-perf-benchmarks.yml pipeline expects.
-# The first step tries to validate that all variables that this template expects to exist have values.
+# of test-perf-benchmarks.yml pipeline. It performs some common setup that all stages need to do.
+
+parameters:
+# Identifier for the pipeline that produced the artifact with the test files.
+# Will be used for the 'pipeline' input for a DownloadPipelineArtifact task.
+- name: artifactPipeline
+  type: string
+
+# Identifier for the pipeline run that produced the artifact with the test files.
+# Will be used for the 'buildId' input for a DownloadPipelineArtifact task.
+- name: artifactBuildId
+  type: string
+
+# URL for the "Dev feed" in our ADO project.
+# All Fluid packages will be resolved from here when installing the dependencies for telemetry generator and aria-logger.
+- name: devFeedUrl
+  type: string
+
+# URL for the "Office feed" in our ADO project.
+# Packages in the @microsoft scope will be resolved from here when installing the dependencies for telemetry generator and aria-logger.
+- name: officeFeedUrl
+  type: string
+
+# Path where the packages with perf tests will be installed.
+# The template will create it, setup an .npmrc file so Fluid packages can be resolved from our Dev Feed, and install aria-logger in it.
+- name: testWorkspace
+  type: string
+
+# Path to the folder where the test files artifact should be downloaded.
+- name: testFilesPath
+  type: string
 
 steps:
-- task: Bash@3
-  displayName: Ensure expected variables are not empty
-  inputs:
-    targetType: 'inline'
-    script: |
-      if [ -z "$(testWorkspace)" ]; then
-        echo "##vso[task.logissue type=error;]Template expects the \"testWorkspace\" variable to have a value"
-        echo "##vso[task.complete result=Failed;]"
-      fi
-      if [ -z "$(artifactPipeline)" ]; then
-        echo "##vso[task.logissue type=error;]Template expects the \"artifactPipeline\" variable to have a value"
-        echo "##vso[task.complete result=Failed;]"
-      fi
-      if [ -z "$(artifactBuildId)" ]; then
-        echo "##vso[task.logissue type=error;]Template expects the \"artifactBuildId\" variable to have a value"
-        echo "##vso[task.complete result=Failed;]"
-      fi
-      if [ -z "$(ado-feeds-dev)" ]; then
-        echo "##vso[task.logissue type=error;]Template expects the \"ado-feeds-dev\" variable to have a value"
-        echo "##vso[task.complete result=Failed;]"
-      fi
-      if [ -z "$(ado-feeds-office)" ]; then
-        echo "##vso[task.logissue type=error;]Template expects the \"ado-feeds-office\" variable to have a value"
-        echo "##vso[task.complete result=Failed;]"
-      fi
-
-- template: include-telemetry-setup.yml
-  parameters:
-    devFeedUrl: $(ado-feeds-dev)
-    officeFeedUrl: $(ado-feeds-office)
-
 - task: Bash@3
   displayName: Print parameter/variable values for troubleshooting
   inputs:
@@ -46,13 +42,21 @@ steps:
     script: |
       echo "
       Variables:
-        artifactPipeline=$(artifactPipeline)
-        artifactBuildId=$(artifactBuildId)
-        testWorkspace=$(testWorkspace)
+        artifactBuildId=${{ parameters.artifactBuildId }}
+        artifactPipeline=${{ parameters.artifactPipeline }}
+        devFeedUrl=${{ parameters.devFeedUrl }}
+        officeFeedUrl=${{ parameters.officeFeedUrl }}
+        testFilesPath=${{ parameters.testFilesPath }}
+        testWorkspace=${{ parameters.testWorkspace }}
 
       Build Params
         SourceBranch=$(Build.SourceBranch)
       "
+
+- template: include-telemetry-setup.yml
+  parameters:
+    devFeedUrl: ${{ parameters.devFeedUrl }}
+    officeFeedUrl: ${{ parameters.officeFeedUrl }}
 
 # Download artifact with test files
 - task: DownloadPipelineArtifact@2
@@ -65,11 +69,11 @@ steps:
     # preferTriggeringPipeline: true
     source: specific
     project: internal
-    pipeline: $(artifactPipeline)
+    pipeline: ${{ parameters.artifactPipeline }}
     buildVersionToDownload: specific
-    buildId: $(artifactBuildId)
+    buildId: ${{ parameters.artifactBuildId }}
     artifact: test-files
-    path: $(Pipeline.Workspace)/test-files/
+    path: ${{ parameters.testFilesPath }}
     # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
     # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
 
@@ -78,14 +82,13 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      mkdir $(testWorkspace)
+      mkdir ${{ parameters.testWorkspace }}
 
 - task: Bash@3
   displayName: Initialize npmrc
   inputs:
     targetType: 'inline'
-    workingDirectory: $(testWorkspace)
-    # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
+    workingDirectory: ${{ parameters.testWorkspace }}
     script: |
       echo Initialize package
       npm init --yes
@@ -94,13 +97,13 @@ steps:
       echo "registry=https://registry.npmjs.org" >> ./.npmrc
       echo "always-auth=false" >> ./.npmrc
 
-      echo "@fluidframework:registry=$(ado-feeds-dev)" >> ./.npmrc
-      echo "@fluid-experimental:registry=$(ado-feeds-dev)" >> ./.npmrc
-      echo "@fluid-tools:registry=$(ado-feeds-dev)" >> ./.npmrc
-      echo "@fluid-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-      echo "@fluid-private:registry=$(ado-feeds-dev)" >> ./.npmrc
-      echo "@ff-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-      echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
+      echo "@fluidframework:registry=${{ parameters.devFeedUrl }}" >> ./.npmrc
+      echo "@fluid-experimental:registry=${{ parameters.devFeedUrl }}" >> ./.npmrc
+      echo "@fluid-tools:registry=${{ parameters.devFeedUrl }}" >> ./.npmrc
+      echo "@fluid-internal:registry=${{ parameters.devFeedUrl }}" >> ./.npmrc
+      echo "@fluid-private:registry=${{ parameters.devFeedUrl }}" >> ./.npmrc
+      echo "@ff-internal:registry=${{ parameters.devFeedUrl }}" >> ./.npmrc
+      echo "@microsoft:registry=${{ parameters.officeFeedUrl }}" >> ./.npmrc
       echo "always-auth=true" >> ./.npmrc
       cat .npmrc
 
@@ -108,13 +111,13 @@ steps:
 - task: npmAuthenticate@0
   displayName: 'npm authenticate (internal feed)'
   inputs:
-    workingFile: $(testWorkspace)/.npmrc
+    workingFile: ${{ parameters.testWorkspace }}/.npmrc
 
 # Install aria-logger
 - task: Npm@1
   displayName: 'npm install aria logger'
   inputs:
-    workingDir: $(testWorkspace)
+    workingDir: ${{ parameters.testWorkspace }}
     command: 'custom'
     customCommand: 'install @ff-internal/aria-logger'
     customRegistry: 'useNpmrc'

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -332,9 +332,6 @@ stages:
         - name: testPackage
           value: '@fluid-private/test-end-to-end-tests'
           readonly: true
-        - name: escapedTestPackage
-          value: ${{ replace(replace(variables.testPackage, '@', '' ), '/', '-') }}
-          readonly: true
       jobs:
       - job: perf_unit_tests_memory
         displayName: Perf unit tests - memory

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -333,8 +333,8 @@ stages:
           value: '@fluid-private/test-end-to-end-tests'
           readonly: true
       jobs:
-      - job: perf_unit_tests_memory
-        displayName: Perf unit tests - memory
+      - job: perf_e2e_tests
+        displayName: Perf e2e tests
         pool: ${{ parameters.poolBuild }}
         timeoutInMinutes: ${{ coalesce(endpointObject.timeoutInMinutes, 60) }}
         steps:
@@ -351,9 +351,11 @@ stages:
         # Download and install package with performance tests
         - template: templates/include-test-perf-benchmarks-install-package.yml
           parameters:
+            # Not sure why macro syntax $() for 'testPackage' doesn't work here, maybe because the template is parsed
+            # at "compile time"? The others are defined at the pipeline level so maybe that's why they work...?
             artifactBuildId: $(artifactBuildId)
             artifactPipeline: $(artifactPipeline)
-            testPackageName: $(testPackage)
+            testPackageName: ${{ variables.testPackage }}
             installPath: $(testWorkspace)
 
         - task: Bash@3

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -103,54 +103,16 @@ stages:
       # Run tests for each package that has them
       - ${{ each testPackage in parameters.executionTestPackages }}:
 
-        # Download package with performance tests
-        - task: DownloadPipelineArtifact@2
-          displayName: Download test package
-          inputs:
-            # It seems there's a bug and preferTriggeringPipeline is not respected.
-            # We force the behavior by explicitly specifying:
-            # - buildVersionToDownload: specific
-            # - buildId: <the id of the triggering build>
-            # preferTriggeringPipeline: true
-            source: specific
-            project: internal
-            pipeline: ${{ variables.artifactPipeline }}
-            buildVersionToDownload: specific
-            buildId: ${{ variables.artifactBuildId }}
-            artifact: pack
-            patterns: "**/${{ replace(replace(testPackage, '@', '' ), '/', '-') }}-?.?.?-*.tgz"
-            path: $(Pipeline.Workspace)/client/pack
-            # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
-            # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+        # Download and install package with performance tests
+        - template: include-test-perf-benchmarks-install-package.yml
+          parameters:
+            artifactBuildId: $(artifactBuildId)
+            artifactPipeline: $(artifactPipeline)
+            testPackageName: ${{ testPackage }}
+            installPath: $(testWorkspace)
 
-        # Install package with performance tests
-        - task: Bash@3
-          displayName: Install test package
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}
-            script: |
-              echo "Install ${{ testPackage }}"
-              TEST_PACKAGE_FILE_PATTERN=${{ replace(replace(testPackage, '@', '' ), '/', '-') }}-?.?.?-*.tgz
-              TEST_PACKAGE_PATH_PATTERN=$(Pipeline.Workspace)/client/pack/scoped/$TEST_PACKAGE_FILE_PATTERN
-
-              echo $TEST_PACKAGE_FILE_PATTERN
-              echo $TEST_PACKAGE_PATH_PATTERN
-
-              echo `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l`
-              echo `ls $TEST_PACKAGE_PATH_PATTERN`
-
-              if [[ `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l` -eq 1 ]]; then
-                TEST_PACKAGE_TGZ=`ls $TEST_PACKAGE_PATH_PATTERN`
-              else
-                ls -1 $TEST_PACKAGE_PATH_PATTERN
-                echo "##vso[task.logissue type=error]Test package '${{ testPackage }}' not found, or there are more then one found"
-                exit -1
-              fi
-
-              npm install $TEST_PACKAGE_TGZ
-
-        # Unpack test files
+        # The "npm pack"-ed package that we install doesn't have the test files.
+        # Unpack them "on top" of the package, where it was installed, so we can run its tests.
         - task: Bash@3
           displayName: Unpack test files
           inputs:
@@ -164,7 +126,8 @@ stages:
               mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
               mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
 
-        # Run tests
+        # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
+        # and run tests.
         - task: Bash@3
           displayName: Run execution-time tests
           inputs:
@@ -265,54 +228,16 @@ stages:
       # Run tests for each package that has them
       - ${{ each testPackage in parameters.memoryTestPackages }}:
 
-        # Download package with performance tests
-        - task: DownloadPipelineArtifact@2
-          displayName: Download test package
-          inputs:
-            # It seems there's a bug and preferTriggeringPipeline is not respected.
-            # We force the behavior by explicitly specifying:
-            # - buildVersionToDownload: specific
-            # - buildId: <the id of the triggering build>
-            # preferTriggeringPipeline: true
-            source: specific
-            project: internal
-            pipeline: ${{ variables.artifactPipeline }}
-            buildVersionToDownload: specific
-            buildId: ${{ variables.artifactBuildId }}
-            artifact: pack
-            patterns: "**/${{ replace(replace(testPackage, '@', '' ), '/', '-') }}-?.?.?-*.tgz"
-            path: $(Pipeline.Workspace)/client/pack
-            # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
-            # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+        # Download and install package with performance tests
+        - template: include-test-perf-benchmarks-install-package.yml
+          parameters:
+            artifactBuildId: $(artifactBuildId)
+            artifactPipeline: $(artifactPipeline)
+            testPackageName: ${{ testPackage }}
+            installPath: $(testWorkspace)
 
-        # Install package with performance tests
-        - task: Bash@3
-          displayName: Install test package
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}
-            script: |
-              echo "Install ${{ testPackage }}"
-              TEST_PACKAGE_FILE_PATTERN=${{ replace(replace(testPackage, '@', '' ), '/', '-') }}-?.?.?-*.tgz
-              TEST_PACKAGE_PATH_PATTERN=$(Pipeline.Workspace)/client/pack/scoped/$TEST_PACKAGE_FILE_PATTERN
-
-              echo $TEST_PACKAGE_FILE_PATTERN
-              echo $TEST_PACKAGE_PATH_PATTERN
-
-              echo `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l`
-              echo `ls $TEST_PACKAGE_PATH_PATTERN`
-
-              if [[ `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l` -eq 1 ]]; then
-                TEST_PACKAGE_TGZ=`ls $TEST_PACKAGE_PATH_PATTERN`
-              else
-                ls -1 $TEST_PACKAGE_PATH_PATTERN
-                echo "##vso[task.logissue type=error]Test package '${{ testPackage }}' not found, or there are more then one found"
-                exit -1
-              fi
-
-              npm install $TEST_PACKAGE_TGZ
-
-        # Unpack test files
+        # The "npm pack"-ed package that we install doesn't have the test files.
+        # Unpack them "on top" of the package, where it was installed, so we can run its tests.
         - task: Bash@3
           displayName: Unpack test files
           inputs:
@@ -326,7 +251,8 @@ stages:
               mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
               mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
 
-        # Run tests
+        # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
+        # and run tests.
         - task: Bash@3
           displayName: Run memory performance tests
           inputs:
@@ -425,52 +351,13 @@ stages:
             testFilesPath: $(testFilesPath)
             testWorkspace: $(testWorkspace)
 
-        # Download package with performance tests
-        - task: DownloadPipelineArtifact@2
-          displayName: Download test package
-          inputs:
-            # It seems there's a bug and preferTriggeringPipeline is not respected.
-            # We force the behavior by explicitly specifying:
-            # - buildVersionToDownload: specific
-            # - buildId: <the id of the triggering build>
-            # preferTriggeringPipeline: true
-            source: specific
-            project: internal
-            pipeline: ${{ variables.artifactPipeline }}
-            buildVersionToDownload: specific
-            buildId: ${{ variables.artifactBuildId }}
-            artifact: pack
-            patterns: "**/${{ variables.escapedTestPackage }}-?.?.?-*.tgz"
-            path: $(Pipeline.Workspace)/client/pack
-            # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
-            # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
-
-        # Install package with performance tests
-        - task: Bash@3
-          displayName: Install Test Package
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}
-            script: |
-              echo "Install ${{ variables.testPackage }}"
-              TEST_PACKAGE_FILE_PATTERN=${{ variables.escapedTestPackage }}-?.?.?-*.tgz
-              TEST_PACKAGE_PATH_PATTERN=$(Pipeline.Workspace)/client/pack/scoped/$TEST_PACKAGE_FILE_PATTERN
-
-              echo $TEST_PACKAGE_FILE_PATTERN
-              echo $TEST_PACKAGE_PATH_PATTERN
-
-              echo `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l`
-              echo `ls $TEST_PACKAGE_PATH_PATTERN`
-
-              if [[ `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l` -eq 1 ]]; then
-                TEST_PACKAGE_TGZ=`ls $TEST_PACKAGE_PATH_PATTERN`
-              else
-                ls -1 $TEST_PACKAGE_PATH_PATTERN
-                echo "##vso[task.logissue type=error]Test package '${{ variables.testPackage }}' not found, or there are more then one found"
-                exit -1
-              fi
-
-              npm install $TEST_PACKAGE_TGZ
+        # Download and install package with performance tests
+        - template: include-test-perf-benchmarks-install-package.yml
+          parameters:
+            artifactBuildId: $(artifactBuildId)
+            artifactPipeline: $(artifactPipeline)
+            testPackageName: $(testPackage)
+            installPath: $(testWorkspace)
 
         - task: Bash@3
           displayName: Prepare test package to run tests

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -114,7 +114,7 @@ stages:
         # The "npm pack"-ed package that we install doesn't have the test files.
         # Unpack them "on top" of the package, where it was installed, so we can run its tests.
         - task: Bash@3
-          displayName: Unpack test files
+          displayName: Unpack test files - ${{ testPackage }}
           inputs:
             targetType: 'inline'
             script: |
@@ -129,7 +129,7 @@ stages:
         # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
         # and run tests.
         - task: Bash@3
-          displayName: Run execution-time tests
+          displayName: Run execution-time tests - ${{ testPackage }}
           inputs:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -156,7 +156,7 @@ stages:
 
         # Consolidate output files
         - task: CopyFiles@2
-          displayName: Consolidate output files
+          displayName: Consolidate output files - ${{ testPackage }}
           inputs:
             sourceFolder: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/node_modules/@fluid-tools/benchmark/dist/.output/
             contents: '**'
@@ -164,7 +164,7 @@ stages:
 
         # Cleanup package
         - task: Bash@3
-          displayName: Cleanup package
+          displayName: Cleanup package - ${{ testPackage }}
           inputs:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
@@ -239,7 +239,7 @@ stages:
         # The "npm pack"-ed package that we install doesn't have the test files.
         # Unpack them "on top" of the package, where it was installed, so we can run its tests.
         - task: Bash@3
-          displayName: Unpack test files
+          displayName: Unpack test files - ${{ testPackage }}
           inputs:
             targetType: 'inline'
             script: |
@@ -254,7 +254,7 @@ stages:
         # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
         # and run tests.
         - task: Bash@3
-          displayName: Run memory performance tests
+          displayName: Run memory performance tests - ${{ testPackage }}
           inputs:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -266,7 +266,7 @@ stages:
 
         # Consolidate output files
         - task: CopyFiles@2
-          displayName: Consolidate output files
+          displayName: Consolidate output files - ${{ testPackage }}
           inputs:
             sourceFolder: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/.memoryTestsOutput
             contents: '**'
@@ -274,7 +274,7 @@ stages:
 
         # Cleanup package
         - task: Bash@3
-          displayName: 'Cleanup package'
+          displayName: Cleanup package - ${{ testPackage }}
           inputs:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
@@ -357,7 +357,7 @@ stages:
             installPath: $(testWorkspace)
 
         - task: Bash@3
-          displayName: Prepare test package to run tests
+          displayName: Prepare test package to run tests ${{ endpointObject.endpointName }}
           inputs:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -351,11 +351,9 @@ stages:
         # Download and install package with performance tests
         - template: templates/include-test-perf-benchmarks-install-package.yml
           parameters:
-            # Not sure why macro syntax $() for 'testPackage' doesn't work here, maybe because the template is parsed
-            # at "compile time"? The others are defined at the pipeline level so maybe that's why they work...?
             artifactBuildId: $(artifactBuildId)
             artifactPipeline: $(artifactPipeline)
-            testPackageName: ${{ variables.testPackage }}
+            testPackageName: $(testPackage)
             installPath: $(testWorkspace)
 
         - task: Bash@3

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -89,96 +89,12 @@ stages:
       - group: ado-feeds
 
       steps:
-      - template: templates/include-telemetry-setup.yml
-        parameters:
-          devFeedUrl: $(ado-feeds-dev)
-          officeFeedUrl: $(ado-feeds-office)
-
-      - task: Bash@3
-        displayName: Print parameter/variable values for troubleshooting
-        inputs:
-          targetType: 'inline'
-          script: |
-            echo "
-            Variables:
-              artifactPipeline=$(artifactPipeline)
-              artifactBuildId=$(artifactBuildId)
-              testWorkspace=$(testWorkspace)
-              absolutePathToTelemetryGenerator=$(absolutePathToTelemetryGenerator)
-
-            Build Params
-              SourceBranch=$(Build.SourceBranch)
-            "
-
-      # Download artifact with test files
-      - task: DownloadPipelineArtifact@2
-        displayName: Download test files
-        inputs:
-          # It seems there's a bug and preferTriggeringPipeline is not respected.
-          # We force the behavior by explicitly specifying:
-          # - buildVersionToDownload: specific
-          # - buildId: <the id of the triggering build>
-          # preferTriggeringPipeline: true
-          source: specific
-          project: internal
-          pipeline: ${{ variables.artifactPipeline }}
-          buildVersionToDownload: specific
-          buildId: ${{ variables.artifactBuildId }}
-          artifact: test-files
-          path: $(Pipeline.Workspace)/test-files/
-          # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
-          # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
-
-      - task: Bash@3
-        displayName: Create test directory
-        inputs:
-          targetType: 'inline'
-          script: |
-            mkdir $(testWorkspace)
-
-      - task: Bash@3
-        displayName: Initialize npmrc
-        inputs:
-          targetType: 'inline'
-          workingDirectory: $(testWorkspace)
-          # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
-          script: |
-            echo Initialize package
-            npm init --yes
-
-            echo Generating .npmrc
-            echo "registry=https://registry.npmjs.org" >> ./.npmrc
-            echo "always-auth=false" >> ./.npmrc
-
-            echo "@fluidframework:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-experimental:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-tools:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-private:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@ff-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
-            echo "always-auth=true" >> ./.npmrc
-            cat .npmrc
-
-      # Auth to internal feed
-      - task: npmAuthenticate@0
-        displayName: 'npm authenticate (internal feed)'
-        inputs:
-          workingFile: $(testWorkspace)/.npmrc
-
-      # Install aria-logger
-      - task: Npm@1
-        displayName: 'npm install aria logger'
-        inputs:
-          workingDir: $(testWorkspace)
-          command: 'custom'
-          customCommand: 'install @ff-internal/aria-logger'
-          customRegistry: 'useNpmrc'
+      - template: templates/include-test-perf-benchmarks.yml
 
       # Run tests for each package that has them
       - ${{ each testPackage in parameters.executionTestPackages }}:
 
-        # Download artifact for package to be tested
+        # Download package with performance tests
         - task: DownloadPipelineArtifact@2
           displayName: Download test package
           inputs:
@@ -198,7 +114,7 @@ stages:
             # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
             # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
 
-        # Install package to be tested
+        # Install package with performance tests
         - task: Bash@3
           displayName: Install test package
           inputs:
@@ -330,96 +246,12 @@ stages:
       - group: ado-feeds
 
       steps:
-      - template: templates/include-telemetry-setup.yml
-        parameters:
-          devFeedUrl: $(ado-feeds-dev)
-          officeFeedUrl: $(ado-feeds-office)
-
-      - task: Bash@3
-        displayName: Print parameter/variable values for troubleshooting
-        inputs:
-          targetType: 'inline'
-          script: |
-            echo "
-            Variables:
-              artifactPipeline=$(artifactPipeline)
-              artifactBuildId=$(artifactBuildId)
-              testWorkspace=$(testWorkspace)
-              absolutePathToTelemetryGenerator=$(absolutePathToTelemetryGenerator)
-
-            Build Params
-              SourceBranch=$(Build.SourceBranch)
-            "
-
-      # Download Artifact - Test Files
-      - task: DownloadPipelineArtifact@2
-        displayName: Download test files
-        inputs:
-          # It seems there's a bug and preferTriggeringPipeline is not respected.
-          # We force the behavior by explicitly specifying:
-          # - buildVersionToDownload: specific
-          # - buildId: <the id of the triggering build>
-          # preferTriggeringPipeline: true
-          source: specific
-          project: internal
-          pipeline: ${{ variables.artifactPipeline }}
-          buildVersionToDownload: specific
-          buildId: ${{ variables.artifactBuildId }}
-          artifact: test-files
-          path: $(Pipeline.Workspace)/test-files/
-          # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
-          # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
-
-      - task: Bash@3
-        displayName: Create test directory
-        inputs:
-          targetType: 'inline'
-          script: |
-            mkdir $(testWorkspace)
-
-      - task: Bash@3
-        displayName: Initialize npmrc
-        inputs:
-          targetType: 'inline'
-          workingDirectory: $(testWorkspace)
-          # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
-          script: |
-            echo Initialize package
-            npm init --yes
-
-            echo Generating .npmrc
-            echo "registry=https://registry.npmjs.org" >> ./.npmrc
-            echo "always-auth=false" >> ./.npmrc
-
-            echo "@fluidframework:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-experimental:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-tools:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@fluid-private:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@ff-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-            echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
-            echo "always-auth=true" >> ./.npmrc
-            cat .npmrc
-
-      # Auth to internal feed
-      - task: npmAuthenticate@0
-        displayName: 'npm authenticate (internal feed)'
-        inputs:
-          workingFile: $(testWorkspace)/.npmrc
-
-      # Install aria-logger
-      - task: Npm@1
-        displayName: 'npm install aria logger'
-        inputs:
-          workingDir: $(testWorkspace)
-          command: 'custom'
-          customCommand: 'install @ff-internal/aria-logger'
-          customRegistry: 'useNpmrc'
+      - template: templates/include-test-perf-benchmarks.yml
 
       # Run tests for each package that has them
       - ${{ each testPackage in parameters.memoryTestPackages }}:
 
-        # Download package artifacts
+        # Download package with performance tests
         - task: DownloadPipelineArtifact@2
           displayName: Download test package
           inputs:
@@ -439,7 +271,7 @@ stages:
             # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
             # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
 
-        # Install test package
+        # Install package with performance tests
         - task: Bash@3
           displayName: Install test package
           inputs:
@@ -572,28 +404,9 @@ stages:
         - group: ado-feeds
 
         steps:
-        - template: templates/include-telemetry-setup.yml
-          parameters:
-            devFeedUrl: $(ado-feeds-dev)
-            officeFeedUrl: $(ado-feeds-office)
+        - template: templates/include-test-perf-benchmarks.yml
 
-        - task: Bash@3
-          displayName: Print parameter/variable values for troubleshooting
-          inputs:
-            targetType: 'inline'
-            script: |
-              echo "
-              Variables:
-                artifactPipeline=$(artifactPipeline)
-                artifactBuildId=$(artifactBuildId)
-                testWorkspace=$(testWorkspace)
-                absolutePathToTelemetryGenerator=$(absolutePathToTelemetryGenerator)
-
-              Build Params
-                SourceBranch=$(Build.SourceBranch)
-              "
-
-        # Download test package
+        # Download package with performance tests
         - task: DownloadPipelineArtifact@2
           displayName: Download test package
           inputs:
@@ -613,53 +426,7 @@ stages:
             # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
             # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
 
-        - task: Bash@3
-          displayName: Create test directory
-          inputs:
-            targetType: 'inline'
-            script: |
-              mkdir $(testWorkspace)
-
-        - task: Bash@3
-          displayName: Initialize npmrc
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(testWorkspace)
-            # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
-            script: |
-              echo Initialize package
-              npm init --yes
-
-              echo Generating .npmrc
-              echo "registry=https://registry.npmjs.org" >> ./.npmrc
-              echo "always-auth=false" >> ./.npmrc
-
-              echo "@fluidframework:registry=$(ado-feeds-dev)" >> ./.npmrc
-              echo "@fluid-experimental:registry=$(ado-feeds-dev)" >> ./.npmrc
-              echo "@fluid-tools:registry=$(ado-feeds-dev)" >> ./.npmrc
-              echo "@fluid-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-              echo "@fluid-private:registry=$(ado-feeds-dev)" >> ./.npmrc
-              echo "@ff-internal:registry=$(ado-feeds-dev)" >> ./.npmrc
-              echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
-              echo "always-auth=true" >> ./.npmrc
-              cat .npmrc
-
-        # Auth to internal feed
-        - task: npmAuthenticate@0
-          displayName: 'npm authenticate (internal feed)'
-          inputs:
-            workingFile: $(testWorkspace)/.npmrc
-
-        # Install aria-logger
-        - task: Npm@1
-          displayName: 'npm install aria logger'
-          inputs:
-            workingDir: $(testWorkspace)
-            command: 'custom'
-            customCommand: 'install @ff-internal/aria-logger'
-            customRegistry: 'useNpmrc'
-
-        # Install e2e test package
+        # Install package with performance tests
         - task: Bash@3
           displayName: Install Test Package
           inputs:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -60,6 +60,9 @@ variables:
   - name: testWorkspace
     value: $(Pipeline.Workspace)/test
     readonly: true
+  - name: testFilesPath
+    value: $(Pipeline.Workspace)/test-files
+    readonly: true
   - name: artifactPipeline
     value: $(resources.pipeline.client.pipelineName)
     readonly: true
@@ -70,6 +73,7 @@ variables:
     value: $(Build.SourcesDirectory)/tools/telemetry-generator
     readonly: true
   - group: prague-key-vault
+  - group: ado-feeds
 
 lockBehavior: sequential
 stages:
@@ -85,11 +89,16 @@ stages:
     - job: perf_unit_tests_runtime
       displayName: Perf unit tests - runtime
       pool: ${{ parameters.poolBuild }}
-      variables:
-      - group: ado-feeds
-
       steps:
       - template: templates/include-test-perf-benchmarks.yml
+        parameters:
+          # ado-feeds-dev and ado-feeds-office come from the ado-feeds variable group
+          artifactBuildId: $(artifactBuildId)
+          artifactPipeline: $(artifactPipeline)
+          devFeedUrl: $(ado-feeds-dev)
+          officeFeedUrl: $(ado-feeds-office)
+          testFilesPath: $(testFilesPath)
+          testWorkspace: $(testWorkspace)
 
       # Run tests for each package that has them
       - ${{ each testPackage in parameters.executionTestPackages }}:
@@ -151,9 +160,9 @@ stages:
               TAR_FILE=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
               mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
-              tar -xvf $(Pipeline.Workspace)/test-files/$TAR_FILE.test-files.tar -C $(Pipeline.Workspace)/test-files
-              mv $(Pipeline.Workspace)/test-files/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
-              mv $(Pipeline.Workspace)/test-files/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
+              tar -xvf $(testFilesPath)/$TAR_FILE.test-files.tar -C $(testFilesPath)
+              mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
+              mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
 
         # Run tests
         - task: Bash@3
@@ -242,11 +251,16 @@ stages:
     - job: perf_unit_tests_memory
       displayName: Perf unit tests - memory
       pool: ${{ parameters.poolBuild }}
-      variables:
-      - group: ado-feeds
-
       steps:
       - template: templates/include-test-perf-benchmarks.yml
+        parameters:
+          # ado-feeds-dev and ado-feeds-office come from the ado-feeds variable group
+          artifactBuildId: $(artifactBuildId)
+          artifactPipeline: $(artifactPipeline)
+          devFeedUrl: $(ado-feeds-dev)
+          officeFeedUrl: $(ado-feeds-office)
+          testFilesPath: $(testFilesPath)
+          testWorkspace: $(testWorkspace)
 
       # Run tests for each package that has them
       - ${{ each testPackage in parameters.memoryTestPackages }}:
@@ -308,9 +322,9 @@ stages:
               TAR_FILE=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
               mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
-              tar -xvf $(Pipeline.Workspace)/test-files/$TAR_FILE.test-files.tar -C $(Pipeline.Workspace)/test-files
-              mv $(Pipeline.Workspace)/test-files/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
-              mv $(Pipeline.Workspace)/test-files/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
+              tar -xvf $(testFilesPath)/$TAR_FILE.test-files.tar -C $(testFilesPath)
+              mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
+              mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
 
         # Run tests
         - task: Bash@3
@@ -400,11 +414,16 @@ stages:
         displayName: Perf unit tests - memory
         pool: ${{ parameters.poolBuild }}
         timeoutInMinutes: ${{ coalesce(endpointObject.timeoutInMinutes, 60) }}
-        variables:
-        - group: ado-feeds
-
         steps:
         - template: templates/include-test-perf-benchmarks.yml
+          parameters:
+            # ado-feeds-dev and ado-feeds-office come from the ado-feeds variable group
+            artifactBuildId: $(artifactBuildId)
+            artifactPipeline: $(artifactPipeline)
+            devFeedUrl: $(ado-feeds-dev)
+            officeFeedUrl: $(ado-feeds-office)
+            testFilesPath: $(testFilesPath)
+            testWorkspace: $(testWorkspace)
 
         # Download package with performance tests
         - task: DownloadPipelineArtifact@2
@@ -615,12 +634,10 @@ stages:
     - job: upload_run_telemetry
       displayName: Upload pipeline run telemetry to Kusto
       pool: Small
-      variables:
-      - group: ado-feeds
-
       steps:
       - template: templates/include-telemetry-setup.yml
         parameters:
+          # ado-feeds-dev and ado-feeds-office come from the ado-feeds variable group
           devFeedUrl: $(ado-feeds-dev)
           officeFeedUrl: $(ado-feeds-office)
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -104,7 +104,7 @@ stages:
       - ${{ each testPackage in parameters.executionTestPackages }}:
 
         # Download and install package with performance tests
-        - template: include-test-perf-benchmarks-install-package.yml
+        - template: templates/include-test-perf-benchmarks-install-package.yml
           parameters:
             artifactBuildId: $(artifactBuildId)
             artifactPipeline: $(artifactPipeline)
@@ -229,7 +229,7 @@ stages:
       - ${{ each testPackage in parameters.memoryTestPackages }}:
 
         # Download and install package with performance tests
-        - template: include-test-perf-benchmarks-install-package.yml
+        - template: templates/include-test-perf-benchmarks-install-package.yml
           parameters:
             artifactBuildId: $(artifactBuildId)
             artifactPipeline: $(artifactPipeline)
@@ -349,7 +349,7 @@ stages:
             testWorkspace: $(testWorkspace)
 
         # Download and install package with performance tests
-        - template: include-test-perf-benchmarks-install-package.yml
+        - template: templates/include-test-perf-benchmarks-install-package.yml
           parameters:
             artifactBuildId: $(artifactBuildId)
             artifactPipeline: $(artifactPipeline)


### PR DESCRIPTION
## Description

Follow-up to https://github.com/microsoft/FluidFramework/pull/17923. With the changes there, the performance benchmarks pipeline acquired a lot of common steps across its stages, which this PR extracts into a couple of templates.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[Run of the Performance Benchmarks pipeline with these changes](https://dev.azure.com/fluidframework/internal/_build?definitionId=96&_a=summary) (msft internal).