### PR TITLE
Add 'after' support

### DIFF
--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -157,12 +157,16 @@ For example:
 {
 	"fluidBuild": {
 		"tasks": {
+         "build": ["...", "build:docs", "copy:docs"]
 			"tsc": ["...", "typetests:gen"], // Depends on "typetests:gen", including dependencies
 			// in default definition (i.e. "^tsc" in the above example)
 			"build:test": [
 				"@fluidframework/merge-tree#build:test" // Overrides default, depends only on "build:test" task
 				// in dependent package "@fluidframework/merge-tree"
 			],
+         "copy:docs": [
+            "after": [ "build:docs" ]                   // if "build:docs" is trigger, "copy:docs" only run after it
+         ],
 			"webpack": ["^tsc"] // Depends on `tsc` task of all of the dependent packages
 			// (if the task exists)
 		}

--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -157,7 +157,7 @@ For example:
 {
 	"fluidBuild": {
 		"tasks": {
-         "build": ["...", "build:docs", "copy:docs"]
+			"build": ["...", "build:docs", "copy:docs"],
 			"tsc": ["...", "typetests:gen"], // Depends on "typetests:gen", including dependencies
 			// in default definition (i.e. "^tsc" in the above example)
 			"build:test": [

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -20,6 +20,7 @@ import {
 	TaskDefinitionsOnDisk,
 	TaskConfig,
 	getTaskDefinitions,
+	normalizeGlobalTaskDefinitions,
 } from "../common/fluidTaskDefinitions";
 import registerDebug from "debug";
 
@@ -79,7 +80,7 @@ export class BuildPackage {
 	constructor(
 		public readonly buildContext: BuildContext,
 		public readonly pkg: Package,
-		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
+		globalTaskDefinitions: TaskDefinitions,
 	) {
 		this._taskDefinitions = getTaskDefinitions(
 			this.pkg.packageJson,
@@ -488,7 +489,7 @@ export class BuildGraph {
 
 	private getBuildPackage(
 		pkg: Package,
-		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
+		globalTaskDefinitions: TaskDefinitions,
 		pendingInitDep: BuildPackage[],
 	) {
 		let buildPackage = this.buildPackages.get(pkg);
@@ -511,9 +512,10 @@ export class BuildGraph {
 	private initializePackages(
 		packages: Map<string, Package>,
 		releaseGroupPackages: Package[],
-		globalTaskDefinitions: TaskDefinitionsOnDisk | undefined,
+		globalTaskDefinitionsOnDisk: TaskDefinitionsOnDisk | undefined,
 		getDepFilter: (pkg: Package) => (dep: Package) => boolean,
 	) {
+		const globalTaskDefinitions = normalizeGlobalTaskDefinitions(globalTaskDefinitionsOnDisk);
 		const pendingInitDep: BuildPackage[] = [];
 		for (const pkg of packages.values()) {
 			// Start with only matched packages

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -125,7 +125,7 @@ export class BuildPackage {
 			if (
 				// Only enable release group root script if it is explicitly defined, for places that don't use it yet
 				!isReleaseGroupRootScriptEnabled ||
-				// if there is no script or the script starts with "fluid-build", the use the default
+				// if there is no script or the script starts with "fluid-build", then use the default
 				script === undefined ||
 				script.startsWith("fluid-build ")
 			) {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -117,7 +117,9 @@ export abstract class LeafTask extends Task {
 				if (e[0] === this) {
 					// detected a cycle, convert into a message
 					throw new Error(
-						`Circular dependency: ${e.map((v) => v.nameColored).join("->")}`,
+						`Circular dependency in parent leaf tasks: ${e
+							.map((v) => v.nameColored)
+							.join("->")}`,
 					);
 				}
 			}
@@ -152,12 +154,12 @@ export abstract class LeafTask extends Task {
 		}
 		if (options.showExec) {
 			this.node.buildContext.taskStats.leafBuiltCount++;
-			const taskNum = this.node.buildContext.taskStats.leafBuiltCount
-				.toString()
-				.padStart(3, " ");
 			const totalTask =
 				this.node.buildContext.taskStats.leafTotalCount -
 				this.node.buildContext.taskStats.leafUpToDateCount;
+			const taskNum = this.node.buildContext.taskStats.leafBuiltCount
+				.toString()
+				.padStart(totalTask.toString().length, " ");
 			log(`[${taskNum}/${totalTask}] ${this.node.pkg.nameColored}: ${this.command}`);
 		}
 		const startTime = Date.now();
@@ -273,12 +275,12 @@ export abstract class LeafTask extends Task {
 			}
 
 			this.node.buildContext.taskStats.leafBuiltCount++;
-			const taskNum = this.node.buildContext.taskStats.leafBuiltCount
-				.toString()
-				.padStart(3, " ");
 			const totalTask =
 				this.node.buildContext.taskStats.leafTotalCount -
 				this.node.buildContext.taskStats.leafUpToDateCount;
+			const taskNum = this.node.buildContext.taskStats.leafBuiltCount
+				.toString()
+				.padStart(totalTask.toString().length, " ");
 			const elapsedTime = (Date.now() - startTime) / 1000;
 			const workerMsg = worker ? "[worker] " : "";
 			const suffix = this.isIncremental ? "" : " (non-incremental)";

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/task.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/task.ts
@@ -22,7 +22,7 @@ export interface TaskExec {
 
 export abstract class Task {
 	public dependentTasks?: Task[];
-	private _transitiveDependentLeafTasks?: LeafTask[];
+	private _transitiveDependentLeafTasks: LeafTask[] | undefined | null;
 	public static createTaskQueue(): AsyncPriorityQueue<TaskExec> {
 		return priorityQueue(async (taskExec: TaskExec) => {
 			const waitTime = (Date.now() - taskExec.queueTime) / 1000;
@@ -65,25 +65,47 @@ export abstract class Task {
 		// This function should only be called by task with task names
 		assert.notStrictEqual(this.taskName, undefined);
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this.dependentTasks = this.node.getDependentTasks(this, this.taskName!, pendingInitDep);
+		this.dependentTasks = this.node.getDependsOnTasks(this, this.taskName!, pendingInitDep);
 	}
 
 	protected get transitiveDependentLeafTask() {
-		if (this._transitiveDependentLeafTasks === undefined) {
-			const dependentTasks = this.dependentTasks;
-			if (dependentTasks) {
-				const s = new Set<LeafTask>();
-				for (const dependentTask of dependentTasks) {
-					dependentTask.transitiveDependentLeafTask.forEach((t) => s.add(t));
-					dependentTask.collectLeafTasks(s);
-				}
-				this._transitiveDependentLeafTasks = [...s.values()];
-			} else {
-				this._transitiveDependentLeafTasks = [];
-				assert.strictEqual(this.taskName, undefined);
-			}
+		if (this._transitiveDependentLeafTasks === null) {
+			// Circular dependency, start unrolling
+			throw [this];
 		}
-		return this._transitiveDependentLeafTasks;
+		try {
+			if (this._transitiveDependentLeafTasks === undefined) {
+				const dependentTasks = this.dependentTasks;
+				this._transitiveDependentLeafTasks = null;
+				if (dependentTasks) {
+					const s = new Set<LeafTask>();
+					for (const dependentTask of dependentTasks) {
+						dependentTask.transitiveDependentLeafTask.forEach((t) => s.add(t));
+						dependentTask.collectLeafTasks(s);
+					}
+					this._transitiveDependentLeafTasks = [...s.values()];
+				} else {
+					// Only unnamed sub task from a group task doesn't the dependentTasks initialized
+					this._transitiveDependentLeafTasks = [];
+					assert.strictEqual(this.taskName, undefined);
+				}
+			}
+			return this._transitiveDependentLeafTasks;
+		} catch (e) {
+			if (Array.isArray(e)) {
+				// Add to the dependency chain
+				e.push(this);
+				if (e[0] === this) {
+					// detected a cycle, convert into a message
+					throw new Error(
+						`Circular dependency in dependent tasks: ${e
+							.map((v) => v.nameColored)
+							.join("->")}`,
+					);
+				}
+			}
+			throw e;
+		}
 	}
 
 	public async run(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -229,7 +229,7 @@ function isFluidBuildEnabled(root: string, json: PackageJson) {
  */
 function hasTaskDependency(root: string, json: PackageJson, taskName: string, searchDep: string) {
 	const rootConfig = getFluidBuildConfig(root);
-	const taskDefinitions = getTaskDefinitions(json, rootConfig?.tasks);
+	const taskDefinitions = getTaskDefinitions(json, rootConfig?.tasks, false);
 	const seenDep = new Set<string>();
 	const pending: string[] = [];
 	if (taskDefinitions[taskName]) {

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -7,7 +7,10 @@ import path from "path";
 import * as JSON5 from "json5";
 import * as semver from "semver";
 import { Package, PackageJson, updatePackageJsonFile } from "../../common/npmPackage";
-import { getTaskDefinitions } from "../../common/fluidTaskDefinitions";
+import {
+	normalizeGlobalTaskDefinitions,
+	getTaskDefinitions,
+} from "../../common/fluidTaskDefinitions";
 import { getEsLintConfigFilePath } from "../../common/taskUtils";
 import { FluidRepo } from "../../common/fluidRepo";
 import { getFluidBuildConfig } from "../../common/fluidUtils";
@@ -229,7 +232,8 @@ function isFluidBuildEnabled(root: string, json: PackageJson) {
  */
 function hasTaskDependency(root: string, json: PackageJson, taskName: string, searchDep: string) {
 	const rootConfig = getFluidBuildConfig(root);
-	const taskDefinitions = getTaskDefinitions(json, rootConfig?.tasks, false);
+	const globalTaskDefinitions = normalizeGlobalTaskDefinitions(rootConfig?.tasks);
+	const taskDefinitions = getTaskDefinitions(json, globalTaskDefinitions, false);
 	const seenDep = new Set<string>();
 	const pending: string[] = [];
 	if (taskDefinitions[taskName]) {


### PR DESCRIPTION
Similar to 'before', 'after' will schedule the task to be executed after all the specified task is executed.

Also,
- Allow '#' and '^' expands on before (and after) just like `dependsOn`.
- Added more validation of task definitions
- Detect circular references of tasks
- Output padding based on the number of total tasks.
