### PR TITLE
fluid-build: simplify build graph creation

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -299,7 +299,7 @@ export class BuildPackage {
 					traceTaskDepTask(`${matchedTask.nameColored} -> ${task.nameColored}`);
 					// initializeDependentTask should have been called on all the task already
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					matchedTask.dependentTasks!.push(task);
+					matchedTask.dependentTasks.push(task);
 				}
 			}
 
@@ -318,7 +318,7 @@ export class BuildPackage {
 				});
 				// initializeDependentTask should have been called on all the task already
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				task.dependentTasks!.push(...matchedTasks);
+				task.dependentTasks.push(...matchedTasks);
 			}
 		});
 	}
@@ -374,6 +374,31 @@ export class BuildPackage {
 	}
 }
 
+/**
+ * BuildGraph is a representation of all the tasks and the dependent order
+ * specified by the task definitions.
+ *
+ * To create the graph:
+ * 1. Initialize BuildPackages
+ * 	  a. Create the BuildPackage nodes for packages that are matched (on the command line)
+ *       and then transitively create dependent packages as needed. Not all repo packages
+ *       will have a BuildPackage created.
+ *    b. Detect if there is a circular dependency by assign level to packages. The package
+ *       level has no other use currently.
+ * 2. Tasks and dependencies graph
+ *    a. Create the initial task specified on the command line.  Without --dep option, the
+ *       the initial task will only for created for matched BuildPackages. With --dep option
+ *       the initial task will be created for all instantiated BuildPackages (i.e. all the
+ *       package that is transitive dependencies of the matched BuildPackages).
+ *	  b. Transitively resolve and create dependent tasks starting from the initial tasks
+ *       based on the `dependsOn` specified in the TaskDefinitions
+ *    c. Resolve all `before` and `after` dependencies to tasks that is already instantiated.
+ * 	     `before` and `after` doesn't cause new task to be created, only match to existing tasks.
+ * 3. Initialize leaf dependency tasks to drive execution, resolving the group tasks dependencies.
+ * 4. Assign tasks weight to prioritize tasks based on how expansive the tasks depending on
+ *    this one will unblock.
+ *
+ */
 export class BuildGraph {
 	private matchedPackages = 0;
 	private readonly buildPackages = new Map<Package, BuildPackage>();

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -422,7 +422,7 @@ export abstract class TscDependentTask extends LeafWithDoneFileTask {
 	protected async getDoneFileContent() {
 		try {
 			const tsBuildInfoFiles: ITsBuildInfo[] = [];
-			const tscTasks = [...this.getDependentLeafTasks()].filter(
+			const tscTasks = [...this.allDependentTasks].filter(
 				(task) => task.executable === "tsc",
 			);
 			const ownTscTasks = tscTasks.filter((task) => task.package == this.package);


### PR DESCRIPTION
Group task are named symbolic node used by task definition as alias, multiple commands or redirect to other npm scripts (via npm run, concurrently or &&).   When driving execution, only leaf tasks has actions.  So after we create the dependencies graph of all the task, we need to resolve the group task node so that leaf task has direct dependencies to other leaf tasks.

This change avoids fully gather transitive dependencies for leaf tasks.  Instead, we just need to make sure that we can establish the leaf task relationship when it go thru a group tasks node. If the group task has any leaf subtask, we distribute dependent tasks to the subtask.  When there are no subtasks, return to the task that depends on the group task all the dependent tasks so that it can added as the dependent (bypassing the empty group task as the dependency.


Also,
- Shift the edge creation for sequential subtasks to earlier as dependentTasks so we don't have to resolve them into leaf task yet.
- Add comment on the high level description of the build graph creation.