### PR TITLE
experiment: alpha/beta types in a single package with export paths

### DIFF
--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -12,7 +12,7 @@ import {
 	TypedTreeChannel,
 	TypedTreeFactory,
 	// eslint-disable-next-line import/no-unresolved
-} from "@fluid-experimental/tree2";
+} from "@fluid-experimental/tree2/alpha";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { v4 as uuid } from "uuid";

--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -11,6 +11,7 @@ import {
 	Typed,
 	TypedTreeChannel,
 	TypedTreeFactory,
+	// eslint-disable-next-line import/no-unresolved
 } from "@fluid-experimental/tree2";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";

--- a/examples/apps/tree-comparison/tsconfig.json
+++ b/examples/apps/tree-comparison/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"compilerOptions": {
-		"module": "esnext",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"outDir": "lib",
 		"jsx": "react",
 		"types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer", "react"],

--- a/experimental/dds/tree2/api-extractor.esnext.json
+++ b/experimental/dds/tree2/api-extractor.esnext.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "./api-extractor.json",
+	"compiler": {
+		"tsconfigFilePath": "<projectFolder>/tsconfig.json"
+	},
+	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+	"dtsRollup": {
+		"enabled": true,
+		"alphaTrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-alpha.d.ts",
+		"betaTrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-beta.d.ts",
+		"publicTrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-public.d.ts",
+		"untrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-untrimmed.d.ts"
+	}
+}

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -14,11 +14,11 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/tree2-public.d.ts",
+				"types": "./lib/tree2-untrimmed.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/tree2-public.d.ts",
+				"types": "./dist/tree2-untrimmed.d.ts",
 				"default": "./dist/index.js"
 			}
 		},
@@ -45,16 +45,16 @@
 	},
 	"main": "dist/index.js",
 	"module": "lib/index.js",
-	"types": "dist/tree2-public.d.ts",
+	"types": "dist/tree2-untrimmed.d.ts",
 	"scripts": {
 		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js",
 		"bench:profile": "mocha --v8-prof --timeout 999999 --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:docs": "npm run build:docs:commonjs && npm run build:docs:esnext",
-		"build:docs:commonjs": "api-extractor run --local",
-		"build:docs:esnext": "api-extractor run --local --config api-extractor.esnext.json",
+		"build:docs": "npm run api-extractor:commonjs && npm run api-extractor:esnext",
+		"api-extractor:commonjs": "api-extractor run --local",
+		"api-extractor:esnext": "api-extractor run --local --config api-extractor.esnext.json",
 		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"ci:build:docs": "api-extractor run",
@@ -161,15 +161,9 @@
 	},
 	"build:docs": {
 		"dependsOn": [
-			"build:docs:commonjs",
-			"build:docs:esnext"
+			"api-extractor:commonjs",
+			"api-extractor:esnext"
 		],
 		"script": false
-	},
-	"build:docs:commonjs": [
-		"tsc"
-	],
-	"build:docs:esnext": [
-		"build:esnext"
-	]
+	}
 }

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -11,6 +11,38 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/tree2-untrimmed.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/tree2-untrimmed.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+    "./alpha": {
+			"import": {
+				"types": "./lib/tree2-alpha.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/tree2-alpha.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+    "./beta": {
+			"import": {
+				"types": "./lib/tree2-beta.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/tree2-beta.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
@@ -20,7 +52,9 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:docs": "api-extractor run --local",
+		"build:docs": "npm run build:docs:commonjs && npm run build:docs:esnext",
+		"build:docs:commonjs": "api-extractor run --local",
+		"build:docs:esnext": "api-extractor run --local --config api-extractor.esnext.json",
 		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"ci:build:docs": "api-extractor run",
@@ -124,5 +158,11 @@
 	"typeValidation": {
 		"disabled": true,
 		"broken": {}
-	}
+	},
+  "build:docs": {
+    "dependsOn": ["build:docs:commonjs", "build:docs:esnext"],
+    "script": false
+  },
+  "build:docs:commonjs": ["tsc"],
+  "build:docs:esnext": ["build:esnext"]
 }

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -14,15 +14,15 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/tree2-untrimmed.d.ts",
+				"types": "./lib/tree2-public.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/tree2-untrimmed.d.ts",
+				"types": "./dist/tree2-public.d.ts",
 				"default": "./dist/index.js"
 			}
 		},
-    "./alpha": {
+		"./alpha": {
 			"import": {
 				"types": "./lib/tree2-alpha.d.ts",
 				"default": "./lib/index.js"
@@ -32,7 +32,7 @@
 				"default": "./dist/index.js"
 			}
 		},
-    "./beta": {
+		"./beta": {
 			"import": {
 				"types": "./lib/tree2-beta.d.ts",
 				"default": "./lib/index.js"
@@ -45,7 +45,7 @@
 	},
 	"main": "dist/index.js",
 	"module": "lib/index.js",
-	"types": "dist/index.d.ts",
+	"types": "dist/tree2-public.d.ts",
 	"scripts": {
 		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js",
 		"bench:profile": "mocha --v8-prof --timeout 999999 --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",
@@ -159,10 +159,17 @@
 		"disabled": true,
 		"broken": {}
 	},
-  "build:docs": {
-    "dependsOn": ["build:docs:commonjs", "build:docs:esnext"],
-    "script": false
-  },
-  "build:docs:commonjs": ["tsc"],
-  "build:docs:esnext": ["build:esnext"]
+	"build:docs": {
+		"dependsOn": [
+			"build:docs:commonjs",
+			"build:docs:esnext"
+		],
+		"script": false
+	},
+	"build:docs:commonjs": [
+		"tsc"
+	],
+	"build:docs:esnext": [
+		"build:esnext"
+	]
 }

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -45,7 +45,7 @@
 	},
 	"main": "dist/index.js",
 	"module": "lib/index.js",
-	"types": "dist/tree2-untrimmed.d.ts",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js",
 		"bench:profile": "mocha --v8-prof --timeout 999999 --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const tscDependsOn = ["^tsc", "build:genver"];
+const tscDependsOn = ["^tsc", "^api-extractor:commonjs", "^api-extractor:esnext", "build:genver"];
 /**
  * The settings in this file configure the Fluid build tools, such as fluid-build and flub. Some settings apply to the
  * whole repo, while others apply only to the client release group.
@@ -38,9 +38,11 @@ module.exports = {
 		"build:genver": [],
 		"typetests:gen": ["^tsc", "build:genver"], // we may reexport type from dependent packages, needs to build them first.
 		"tsc": tscDependsOn,
-		"build:esnext": tscDependsOn,
+		"build:esnext": [...tscDependsOn],
 		"build:test": [...tscDependsOn, "typetests:gen", "tsc"],
 		"build:docs": [...tscDependsOn, "tsc"],
+		"api-extractor:commonjs": [...tscDependsOn, "tsc"],
+		"api-extractor:esnext": ["build:esnext"],
 		"ci:build:docs": [...tscDependsOn, "tsc"],
 		"depcruise": [],
 		"eslint": [...tscDependsOn, "commonjs"],


### PR DESCRIPTION
wip

## The scenario

We want to roll out some new APIs slowly over time. We intend to use the TSDoc `@alpha` and `@beta` tags to enable us to produce different types files that have some APIs trimmed out (this process is called "dts trimming").

However, there's only one `types` field in package.json, so we're stuck shipping different packages for different API types - e.g. an alpha-types package and a beta-types package, in addition to the standard package. While the user experience for customers isn't that bad, shipping different packages that differ only in superficial ways seems wasteful at best, and it also requires us to change packages in the CI pipeline far more than we do today. It would be far better if the package.json in the repo was almost exactly what we ship to npm.

## The concept

The idea is to use the `exports` field in package.json to output different paths that point to the same code, but different types. When importing from the package using a path like `import { API } from "@scope/package/beta";` the result would be the beta API, while the default path would omit those APIs.

## The exports field

Using this idea, the exports field for a CJS-and-ESM package would look something like this:

```json
"exports": {
  ".": {
    "import": {
      "types": "./lib/tree2-untrimmed.d.ts",
      "default": "./lib/index.js"
    },
    "require": {
      "types": "./dist/tree2-untrimmed.d.ts",
      "default": "./dist/index.js"
    }
  },
  "./alpha": {
    "import": {
      "types": "./lib/tree2-alpha.d.ts",
      "default": "./lib/index.js"
    },
    "require": {
      "types": "./dist/tree2-alpha.d.ts",
      "default": "./dist/index.js"
    }
  },
  "./beta": {
    "import": {
      "types": "./lib/tree2-beta.d.ts",
      "default": "./lib/index.js"
    },
    "require": {
      "types": "./dist/tree2-beta.d.ts",
      "default": "./dist/index.js"
    }
  }
},
```