### PR TITLE
App insights Namespace Filter

### DIFF
--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -33,7 +33,7 @@ export interface FluidAppInsightsLoggerConfig {
 // @public
 export interface NamespaceFilter {
     namespacePattern: string;
-    namespacePatternExceptions?: string[];
+    namespacePatternExceptions?: Set<string>;
 }
 
 export { TelemetryEventCategory }

--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -17,9 +17,9 @@ export interface CategoryFilter {
 // @public @sealed
 export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
     constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig);
-    send(event: ITelemetryBaseEvent): void;
     // (undocumented)
-    static sortTelemetryFilters(filters: TelemetryFilter[]): TelemetryFilter[];
+    get filters(): TelemetryFilter[];
+    send(event: ITelemetryBaseEvent): void;
 }
 
 // @public

--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -9,6 +9,11 @@ import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { TelemetryEventCategory } from '@fluidframework/telemetry-utils';
 
+// @public
+export interface CategoryFilter {
+    categories: TelemetryEventCategory[];
+}
+
 // @public @sealed
 export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
     constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig);
@@ -23,13 +28,15 @@ export interface FluidAppInsightsLoggerConfig {
     };
 }
 
+// @public
+export interface NamespaceFilter {
+    namespacePattern: string;
+    namespacePatternExceptions?: string[];
+}
+
 export { TelemetryEventCategory }
 
 // @public
-export interface TelemetryFilter {
-    categories?: TelemetryEventCategory[];
-    namespacePattern?: string;
-    namespacePatternExceptions?: string[];
-}
+export type TelemetryFilter = CategoryFilter | NamespaceFilter | (CategoryFilter & NamespaceFilter);
 
 ```

--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -27,7 +27,9 @@ export { TelemetryEventCategory }
 
 // @public
 export interface TelemetryFilter {
-    category: TelemetryEventCategory;
+    category?: TelemetryEventCategory;
+    namespacePattern?: string;
+    namespacePatternExceptions?: string[];
 }
 
 ```

--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -17,8 +17,6 @@ export interface CategoryFilter {
 // @public @sealed
 export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
     constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig);
-    // (undocumented)
-    get filters(): TelemetryFilter[];
     send(event: ITelemetryBaseEvent): void;
 }
 

--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -27,7 +27,7 @@ export { TelemetryEventCategory }
 
 // @public
 export interface TelemetryFilter {
-    category?: TelemetryEventCategory;
+    categories?: TelemetryEventCategory[];
     namespacePattern?: string;
     namespacePatternExceptions?: string[];
 }

--- a/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
+++ b/packages/framework/client-logger/app-insights-logger/api-report/app-insights-logger.api.md
@@ -18,6 +18,8 @@ export interface CategoryFilter {
 export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
     constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig);
     send(event: ITelemetryBaseEvent): void;
+    // (undocumented)
+    static sortTelemetryFilters(filters: TelemetryFilter[]): TelemetryFilter[];
 }
 
 // @public

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -31,10 +31,13 @@ export interface FluidAppInsightsLoggerConfig {
 		mode: "inclusive" | "exclusive";
 		/**
 		 * Controls the filtering of log events.
-		 * Leaving this undefined will be treated as an empty array.
+		 *
+		 * @remarks Leaving this undefined will be treated as an empty array.
 		 *
 		 * In order for the filters to be valid they must meet the following conditions:
+		 *
 		 * 1. There must not be any two filters with the same `namespacePattern`.
+		 *
 		 * 2. All {@link NamespaceFilter} must not have any defined `namespacePatternException` that is not a child of the parent `namespacePattern`
 		 */
 		filters?: TelemetryFilter[];
@@ -70,8 +73,8 @@ export interface NamespaceFilter {
 	/**
 	 * A list of namespace patterns to explicitly exclude from the filter.
 	 *
-	 * @example If you have a namespacePattern of "perf:latency" but want to exclude
-	 *
+	 * @example
+	 * If you have a namespacePattern of "perf:latency" but want to exclude
 	 * events from "perf:latency:ops", you would add "perf:latency:ops" to this list.
 	 */
 	namespacePatternExceptions?: Set<string>;
@@ -96,7 +99,8 @@ export interface NamespaceFilter {
  *
  * @public
  *
- * @example With the following configuration, an event `{ namespace: "A.B.C", categories: ["generic"] }` will not be sent despite matching the first, less specific filter because it did not match the second filter which was the most relevant and specific
+ * @example
+ * With the following configuration, an event `{ namespace: "A.B.C", categories: ["generic"] }` will not be sent despite matching the first, less specific filter because it did not match the second filter which was the most relevant and specific
  * ```
  * const logger = new FluidAppInsightsLogger(appInsightsClient, {
  *			filtering: {
@@ -203,7 +207,7 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 	 *
 	 * @param event - The telemetry event to check against the filters.
 	 *
-	 * @returns boolean `true` if the event matches any filter, otherwise `false`.
+	 * @returns `true` if the event matches any filter, otherwise `false`.
 	 */
 	private doesEventMatchFilter(event: ITelemetryBaseEvent): boolean {
 		for (const filter of this.config.filtering.filters ?? []) {
@@ -271,7 +275,7 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 	/**
 	 * Checks an array of telemetry filters for any issues, merges redundant filters, and returns a fully validated array.
 	 *
-	 * @throws - an Error if there are two filters with duplicate namespace patterns or a filter with a pattern exception that is not a child of the parent pattern.
+	 * @throws An Error if there are two filters with duplicate namespace patterns or a filter with a pattern exception that is not a child of the parent pattern.
 	 */
 	private validateFilters(filters: TelemetryFilter[]): void {
 		const uniqueFilterNamespaces = new Set<string>();

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -40,7 +40,7 @@ export interface FluidAppInsightsLoggerConfig {
 /**
  * Object used with an {@link FluidAppInsightsLoggerConfig}
  * to define a filter with logic for matching it to telemetry events.
- * Filters can include either a category, namespace or both types of filters; A valid filter must have at least one defined.
+ * Filters can include either a category, namespace or both types of filters; a valid filter must have at least one defined.
  *
  * @public
  */

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -127,15 +127,17 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 		return shouldSendEvent;
 	}
 
-	// private doesEventMatchFilter(event: ITelemetryBaseEvent): boolean {
-	// 	for (const filter of this.config.filtering.filters ?? []) {
-	// 		if (filter.category === event.category) {
-	// 			return true;
-	// 		}
-	// 	}
-	// 	return false;
-	// }
-
+	/**
+	 * Checks if a given {@link ITelemetryBaseEvent} conforms to any of the provided {@link TelemetryFilter} rules.
+	 *
+	 * - If a {@link TelemetryFilter} specifies both a `category` and a `namespace`, the event must match both.
+	 * - If only a `category` or `namespace` is provided, the event should match either one of them.
+	 * - If a `namespace` pattern exception is specified in the {@link TelemetryFilter}, the event should not match the exception pattern.
+	 *
+	 * @param event - The telemetry event to check against the filters.
+	 *
+	 * @returns boolean `true` if the event matches any filter, otherwise `false`.
+	 */
 	private doesEventMatchFilter(event: ITelemetryBaseEvent): boolean {
 		for (const filter of this.config.filtering.filters ?? []) {
 			let matches = true;

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -74,7 +74,7 @@ export interface NamespaceFilter {
 	 *
 	 * events from "perf:latency:ops", you would add "perf:latency:ops" to this list.
 	 */
-	namespacePatternExceptions?: string[];
+	namespacePatternExceptions?: Set<string>;
 }
 
 /**
@@ -276,19 +276,11 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 					uniqueFilterNamespaces.add(filter.namespacePattern);
 				}
 
-				const uniqueFilterNamespaceExceptions = new Set<string>();
 				for (const patternException of filter.namespacePatternExceptions ?? []) {
 					if (!patternException.startsWith(filter.namespacePattern)) {
 						throw new Error(
 							"Cannot have a namespace pattern exception that is not a child of the parent namespace",
 						);
-					}
-					if (uniqueFilterNamespaceExceptions.has(patternException)) {
-						throw new Error(
-							"Cannot have duplicate namespace pattern exception filters",
-						);
-					} else {
-						uniqueFilterNamespaceExceptions.add(patternException);
 					}
 				}
 				validatedFilters.push(filter);

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -207,14 +207,18 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 	 */
 	private doesEventMatchFilter(event: ITelemetryBaseEvent): boolean {
 		for (const filter of this.config.filtering.filters ?? []) {
-			if ("namespacePattern" in filter) {
+			if ("namespacePattern" in filter && filter.namespacePattern !== undefined) {
 				if (event.eventName.startsWith(filter.namespacePattern)) {
 					// Found matching namespace pattern, since filters are ordered in most specific first,
 					// this is the most specific, relevant matching filter for the event.
 
 					// By default, if no categories are defined then any category is a valid match.
 					let doesFilterCategoriesMatch = true;
-					if ("categories" in filter && filter.categories.length > 0) {
+					if (
+						"categories" in filter &&
+						filter.categories !== undefined &&
+						filter.categories.length > 0
+					) {
 						doesFilterCategoriesMatch = false;
 						const matchingCategory = filter.categories.find(
 							(category) => category === event.category,
@@ -239,7 +243,11 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 				}
 			}
 			// Filter only has categories defined
-			else if ("categories" in filter && filter.categories.length > 0) {
+			else if (
+				"categories" in filter &&
+				filter.categories !== undefined &&
+				filter.categories.length > 0
+			) {
 				const doesFilterCategoriesMatch = filter.categories.find(
 					(category) => category === event.category,
 				);
@@ -283,9 +291,9 @@ export class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 						);
 					}
 				}
-			} else if ("categories" in filter) {
+			} else if ("categories" in filter && filter.categories !== undefined) {
 				// These are filters that only contain "categories". For the purpose of this validation logic, we are treating filters
-				// that does not contain a defined namespace as the the same as a blank "" namespace (which will match any event).
+				// that does not contain a defined namespace as the the same as a blank "" namespace pattern (which will match any event).
 				if (uniqueFilterNamespaces.has("")) {
 					throw new Error("Cannot have multiple filters that only define categories");
 				}

--- a/packages/framework/client-logger/app-insights-logger/src/index.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/index.ts
@@ -9,7 +9,12 @@
  * @packageDocumentation
  */
 
-export type { FluidAppInsightsLoggerConfig, TelemetryFilter } from "./fluidAppInsightsLogger";
+export type {
+	FluidAppInsightsLoggerConfig,
+	TelemetryFilter,
+	CategoryFilter,
+	NamespaceFilter,
+} from "./fluidAppInsightsLogger";
 
 export { FluidAppInsightsLogger } from "./fluidAppInsightsLogger";
 

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -60,7 +60,10 @@ describe("FluidAppInsightsLogger", () => {
 				],
 			},
 		};
-		assert.throws(() => new FluidAppInsightsLogger(appInsightsClient, invalidConfig));
+		assert.throws(
+			() => new FluidAppInsightsLogger(appInsightsClient, invalidConfig),
+			new Error("Cannot have duplicate namespace pattern filters"),
+		);
 	});
 
 	it("constructor() throws error when filter config with namespace pattern exception that is not part of the parent pattern is provided", () => {
@@ -75,7 +78,12 @@ describe("FluidAppInsightsLogger", () => {
 				],
 			},
 		};
-		assert.throws(() => new FluidAppInsightsLogger(appInsightsClient, invalidConfig));
+		assert.throws(
+			() => new FluidAppInsightsLogger(appInsightsClient, invalidConfig),
+			new Error(
+				"Cannot have a namespace pattern exception that is not a child of the parent namespace",
+			),
+		);
 	});
 
 	it("constructor() throws error when multiple filters that only define categories are provided", () => {
@@ -92,7 +100,10 @@ describe("FluidAppInsightsLogger", () => {
 				],
 			},
 		};
-		assert.throws(() => new FluidAppInsightsLogger(appInsightsClient, invalidConfig));
+		assert.throws(
+			() => new FluidAppInsightsLogger(appInsightsClient, invalidConfig),
+			new Error("Cannot have multiple filters that only define categories"),
+		);
 	});
 });
 

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -7,19 +7,28 @@ import { strict as assert } from "node:assert";
 import { ApplicationInsights, type IEventTelemetry } from "@microsoft/applicationinsights-web";
 import type Sinon from "sinon";
 import { assert as sinonAssert, spy } from "sinon";
-import { FluidAppInsightsLogger } from "../fluidAppInsightsLogger";
+import {
+	FluidAppInsightsLogger,
+	type TelemetryFilter,
+	type FluidAppInsightsLoggerConfig,
+} from "../fluidAppInsightsLogger";
 
 describe("FluidAppInsightsLogger", () => {
-	it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
-		const appInsightsClient = new ApplicationInsights({
+	let appInsightsClient: ApplicationInsights;
+	let trackEventSpy: Sinon.SinonSpy;
+
+	beforeEach(() => {
+		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
 					// (this is an example string)
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
-		const trackEventSpy = spy(appInsightsClient, "trackEvent");
+		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
 
+	it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
 		const logger = new FluidAppInsightsLogger(appInsightsClient);
 
 		const mockTelemetryEvent = {
@@ -35,6 +44,30 @@ describe("FluidAppInsightsLogger", () => {
 		};
 
 		sinonAssert.calledWith(trackEventSpy, expectedAppInsightsEvent);
+	});
+
+	it("constructor() throws error when invalid filter config is provided", () => {
+		// Invalid filter with no namepsace or category defined
+		assert.throws(
+			() =>
+				new FluidAppInsightsLogger(appInsightsClient, {
+					filtering: {
+						mode: "exclusive",
+						filters: [
+							{
+								namespacePattern: "perf.latency.*",
+							},
+							{
+								category: "error",
+								namespacePattern: "perf.latency.*",
+							},
+							{
+								// Empty config
+							},
+						],
+					},
+				}),
+		);
 	});
 });
 
@@ -90,9 +123,29 @@ describe("Telemetry Filter - filter mode", () => {
 	});
 });
 
-describe("Telemetry Filter - Category filtering", () => {
+describe("Telemetry Filter - Category Filtering", () => {
 	let appInsightsClient: ApplicationInsights;
 	let trackEventSpy: Sinon.SinonSpy;
+	const configFilters: TelemetryFilter[] = [
+		{
+			category: "performance",
+		},
+		{
+			category: "generic",
+		},
+	];
+	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		filtering: {
+			mode: "exclusive",
+			filters: configFilters,
+		},
+	};
+	const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		filtering: {
+			mode: "inclusive",
+			filters: configFilters,
+		},
+	};
 
 	beforeEach(() => {
 		appInsightsClient = new ApplicationInsights({
@@ -105,104 +158,449 @@ describe("Telemetry Filter - Category filtering", () => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	it("exclusive filter mode sends ALL events except those that match category filters", () => {
-		const logger = new FluidAppInsightsLogger(appInsightsClient, {
-			filtering: {
-				mode: "exclusive",
-				filters: [
-					{
-						category: "performance",
-					},
-					{
-						category: "generic",
-					},
-				],
-			},
-		});
-
-		const errorCategoryEvent = {
-			category: "error",
-			eventName: "errorCategoryEventName",
-		};
-		const perfCategoryEvent = {
+	it("exclusive filter mode DOES NOT SEND events that DO MATCH with one of multiple category filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be excluded - match with category filter
+		const event1 = {
 			category: "performance",
-			eventName: "perfCategoryEventName",
+			eventName: "perf:latency:ops",
 		};
-		const genericCategoryEvent = {
+		// should be excluded - match with second category filter
+		const event2 = {
 			category: "generic",
-			eventName: "genericCategoryEventName",
+			eventName: "perf:memory:container",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+
+	it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple category filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be included - does not match any category filter
+		const event = {
+			category: "error",
+			eventName: "perf:runtime:container",
 		};
 
-		logger.send(perfCategoryEvent);
-		logger.send(errorCategoryEvent);
-		logger.send(genericCategoryEvent);
+		logger.send(event);
 
-		const expectedSentEventCount = 1;
 		const expectedAppInsightsSentEvent: IEventTelemetry = {
-			name: errorCategoryEvent.eventName,
+			name: event.eventName,
 			properties: {
-				...errorCategoryEvent,
+				...event,
 			},
 		};
-		sinonAssert.callCount(trackEventSpy, expectedSentEventCount);
+		sinonAssert.callCount(trackEventSpy, 1);
 		for (const call of trackEventSpy.getCalls()) {
 			sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
 		}
 	});
 
-	it("inclusive filter mode sends NO events except those that match category filters", () => {
-		const logger = new FluidAppInsightsLogger(appInsightsClient, {
-			filtering: {
-				mode: "inclusive",
-				filters: [
-					{
-						category: "performance",
-					},
-					{
-						category: "generic",
-					},
-				],
+	// ------------------------------------------------------------------------------------
+
+	it("inclusive filter mode DOES SEND events that DO MATCH with one of multiple category filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be included - match with category filter
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency:ops",
+		};
+		// should be included - match with second category filter
+		const event2 = {
+			category: "generic",
+			eventName: "perf:memory:container",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 2);
+	});
+
+	it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple category filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be excluded - does not match any category filter
+		const event = {
+			category: "error",
+			eventName: "perf:runtime:container",
+		};
+
+		logger.send(event);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+});
+
+describe("Telemetry Filter - Namespace Filtering", () => {
+	let appInsightsClient: ApplicationInsights;
+	let trackEventSpy: Sinon.SinonSpy;
+	const configFilters: TelemetryFilter[] = [
+		{
+			namespacePattern: "perf:latency*",
+			namespacePatternExceptions: ["perf:latency:ops*"],
+		},
+		{
+			namespacePattern: "perf:memory*",
+			namespacePatternExceptions: ["perf:memory:container*"],
+		},
+	];
+	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		filtering: {
+			mode: "exclusive",
+			filters: configFilters,
+		},
+	};
+	const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		filtering: {
+			mode: "inclusive",
+			filters: configFilters,
+		},
+	};
+
+	beforeEach(() => {
+		appInsightsClient = new ApplicationInsights({
+			config: {
+				connectionString:
+					// (this is an example string)
+					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
 
-		const errorCategoryEvent = {
-			category: "error",
-			eventName: "errorCategoryEventName",
-		};
-		const perfCategoryEvent = {
+	it("exclusive filter mode DOES NOT SEND events that PARITALLY MATCH with one of multiple namespace filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be excluded - partial match with namespace filter
+		const event1 = {
 			category: "performance",
-			eventName: "perfCategoryEventName",
+			eventName: "perf:latency:signals",
 		};
-		const genericCategoryEvent = {
-			category: "generic",
-			eventName: "genericCategoryEventName",
+		// should be excluded - partial match with second namespace filter
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory:ops:summary",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+
+	it("exclusive filter mode DOES NOT SEND events that PERFECTLY MATCH with one of multiple namespace filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be excluded - perfect match with namespace filter
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency",
+		};
+		// should be excluded - perfect match with second namespace filter
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+
+	it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be included - does not match any namespace filter
+		const event = {
+			category: "performance",
+			eventName: "perf:runtime:container",
 		};
 
-		logger.send(perfCategoryEvent);
-		logger.send(errorCategoryEvent);
-		logger.send(genericCategoryEvent);
+		logger.send(event);
 
-		const expectedSentEventCount = 2;
-		sinonAssert.callCount(trackEventSpy, expectedSentEventCount);
+		const expectedAppInsightsSentEvent: IEventTelemetry = {
+			name: event.eventName,
+			properties: {
+				...event,
+			},
+		};
+		sinonAssert.callCount(trackEventSpy, 1);
+		for (const call of trackEventSpy.getCalls()) {
+			sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
+		}
+	});
 
-		const actualSentPerfEvents = trackEventSpy.getCalls().filter((call) =>
+	it("exclusive filter mode DOES SEND events that PARITALLY MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be included - partial match with namespace filter but also partially matches namespace pattern exception
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency:ops:roundTripTime",
+		};
+		// should be included - partial match with second namespace filter but also partially matches namespace pattern exception
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory:container:summary",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 2);
+	});
+
+	it("exclusive filter mode DOES SEND events that PERFECTLY MATCH with one of multiple namespace filters if they also perfectly match with a namespace exception", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+		// should be included - partial match with namespace filter but also perfectly matches namespace pattern exception
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency:ops",
+		};
+		// should be included - partial match with second namespace filter but also perfectly matches namespace pattern exception
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory:container",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 2);
+	});
+
+	// ------------------------------------------------------------------------------------
+
+	it("inclusive filter mode DOES SEND events that PARITALLY MATCH with one of multiple namespace filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be included - partial match with namespace filter
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency:signals",
+		};
+		// should be included - partial match with second namespace filter
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory:ops:summary",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 2);
+	});
+
+	it("inclusive filter mode DOES SEND events that PERFECTLY MATCH with one of multiple namespace filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be included - perfect match with namespace filter
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency",
+		};
+		// should be included - perfect match with second namespace filter
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 2);
+	});
+
+	it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be excluded - does not match any namespace filter
+		const event = {
+			category: "performance",
+			eventName: "perf:runtime:container",
+		};
+
+		logger.send(event);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+
+	it("inclusive filter mode DOES NOT SEND events that PARITALLY MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be excluded - partial match with namespace filter but also partially matches namespace pattern exception
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency:ops:roundTripTime",
+		};
+		// should be excluded - partial match with second namespace filter but also partially matches namespace pattern exception
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory:container:summary",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+
+	it("inclusive filter mode DOES NOT SEND events that PERFECTLY MATCH with one of multiple namespace filters if they also perfectly match with a namespace exception", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+		// should be excluded - partial match with namespace filter but also perfectly matches namespace pattern exception
+		const event1 = {
+			category: "performance",
+			eventName: "perf:latency:ops",
+		};
+		// should be excluded - partial match with second namespace filter but also perfectly matches namespace pattern exception
+		const event2 = {
+			category: "performance",
+			eventName: "perf:memory:container",
+		};
+		logger.send(event1);
+		logger.send(event2);
+		sinonAssert.callCount(trackEventSpy, 0);
+	});
+});
+
+describe("Telemetry Filter - Category & Namespace Combination Filtering", () => {
+	let appInsightsClient: ApplicationInsights;
+	let trackEventSpy: Sinon.SinonSpy;
+	const configFilters: TelemetryFilter[] = [
+		{
+			category: "performance",
+			namespacePattern: "perf:latency*",
+			namespacePatternExceptions: ["perf:latency:ops*"],
+		},
+	];
+	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		filtering: {
+			mode: "exclusive",
+			filters: configFilters,
+		},
+	};
+	const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		filtering: {
+			mode: "inclusive",
+			filters: configFilters,
+		},
+	};
+
+	beforeEach(() => {
+		appInsightsClient = new ApplicationInsights({
+			config: {
+				connectionString:
+					// (this is an example string)
+					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
+			},
+		});
+		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
+
+	it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+
+		// should be included - does not match any filter
+		const event1 = {
+			category: "error",
+			eventName: "perf:runtime:container",
+		};
+
+		// should be included - only partial matches namespace filter but not category
+		const event2 = {
+			category: "error",
+			eventName: "perf:latency:ops:delta",
+		};
+
+		// should be included - partial namespace match and category match but also matches exception.
+		const event3 = {
+			category: "performance",
+			eventName: "perf:latency:ops:delta",
+		};
+
+		// should be excluded - perfect namespace and category match.
+		const event4 = {
+			category: "performance",
+			eventName: "perf:latency",
+		};
+
+		// should be excluded - partial namespace match and category match.
+		const event5 = {
+			category: "performance",
+			eventName: "perf:latency:container:syncTime",
+		};
+
+		logger.send(event1);
+		logger.send(event2);
+		logger.send(event3);
+		logger.send(event4);
+		logger.send(event5);
+
+		const actualSentEvent1 = trackEventSpy.getCalls().filter((call) =>
 			call.calledWithExactly({
-				name: perfCategoryEvent.eventName,
+				name: event1.eventName,
 				properties: {
-					...perfCategoryEvent,
+					...event1,
 				},
 			}),
 		);
-		const actualSentGenericEvents = trackEventSpy.getCalls().filter((call) =>
+		const actualSentEvent2 = trackEventSpy.getCalls().filter((call) =>
 			call.calledWithExactly({
-				name: genericCategoryEvent.eventName,
+				name: event2.eventName,
 				properties: {
-					...genericCategoryEvent,
+					...event2,
+				},
+			}),
+		);
+		const actualSentEvent3 = trackEventSpy.getCalls().filter((call) =>
+			call.calledWithExactly({
+				name: event3.eventName,
+				properties: {
+					...event3,
 				},
 			}),
 		);
 
-		assert.strictEqual(actualSentPerfEvents.length, 1);
-		assert.strictEqual(actualSentGenericEvents.length, 1);
+		sinonAssert.callCount(trackEventSpy, 3);
+		assert.strictEqual(actualSentEvent1.length, 1);
+		assert.strictEqual(actualSentEvent2.length, 1);
+		assert.strictEqual(actualSentEvent3.length, 1);
+	});
+
+	it("inclusive filter mode DOES SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
+		const logger = new FluidAppInsightsLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+
+		// should be excluded - does not match any filter
+		const event1 = {
+			category: "error",
+			eventName: "perf:runtime:container",
+		};
+
+		// should be excluded - only partial matches namespace filter but not category
+		const event2 = {
+			category: "error",
+			eventName: "perf:latency:ops:delta",
+		};
+
+		// should be excluded - partial namespace match and category match but also matches exception.
+		const event3 = {
+			category: "performance",
+			eventName: "perf:latency:ops:delta",
+		};
+
+		// should be included - perfect namespace and category match.
+		const event4 = {
+			category: "performance",
+			eventName: "perf:latency",
+		};
+
+		// should be included - partial namespace match and category match.
+		const event5 = {
+			category: "performance",
+			eventName: "perf:latency:container:syncTime",
+		};
+
+		logger.send(event1);
+		logger.send(event2);
+		logger.send(event3);
+		logger.send(event4);
+		logger.send(event5);
+
+		const actualSentEvent4 = trackEventSpy.getCalls().filter((call) =>
+			call.calledWithExactly({
+				name: event4.eventName,
+				properties: {
+					...event4,
+				},
+			}),
+		);
+		const actualSentEvent5 = trackEventSpy.getCalls().filter((call) =>
+			call.calledWithExactly({
+				name: event4.eventName,
+				properties: {
+					...event4,
+				},
+			}),
+		);
+
+		sinonAssert.callCount(trackEventSpy, 2);
+		assert.strictEqual(actualSentEvent4.length, 1);
+		assert.strictEqual(actualSentEvent5.length, 1);
 	});
 });

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -70,7 +70,7 @@ describe("FluidAppInsightsLogger", () => {
 				filters: [
 					{
 						namespacePattern: "A:B:C",
-						namespacePatternExceptions: ["D:C:A"],
+						namespacePatternExceptions: new Set(["D:C:A"]),
 					},
 				],
 			},
@@ -378,11 +378,11 @@ describe("Telemetry Filter - Namespace Filtering", () => {
 	const configFilters: TelemetryFilter[] = [
 		{
 			namespacePattern: namespaceFilterPattern1,
-			namespacePatternExceptions: [namespaceFilterPattern1Exception],
+			namespacePatternExceptions: new Set([namespaceFilterPattern1Exception]),
 		},
 		{
 			namespacePattern: namespaceFilterPattern2,
-			namespacePatternExceptions: [namespaceFilterPattern2Exception],
+			namespacePatternExceptions: new Set([namespaceFilterPattern2Exception]),
 		},
 	];
 	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
@@ -612,7 +612,7 @@ describe("Telemetry Filter - Category & Namespace Combination Filtering", () => 
 		{
 			categories: ["performance"],
 			namespacePattern: "perf:latency",
-			namespacePatternExceptions: ["perf:latency:ops"],
+			namespacePatternExceptions: new Set(["perf:latency:ops"]),
 		},
 	];
 	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -45,30 +45,6 @@ describe("FluidAppInsightsLogger", () => {
 
 		sinonAssert.calledWith(trackEventSpy, expectedAppInsightsEvent);
 	});
-
-	it("constructor() throws error when invalid filter config is provided", () => {
-		// Invalid filter with no namepsace or category defined
-		assert.throws(
-			() =>
-				new FluidAppInsightsLogger(appInsightsClient, {
-					filtering: {
-						mode: "exclusive",
-						filters: [
-							{
-								namespacePattern: "perf.latency",
-							},
-							{
-								categories: ["error"],
-								namespacePattern: "perf.latency",
-							},
-							{
-								// Empty config
-							},
-						],
-					},
-				}),
-		);
-	});
 });
 
 describe("Telemetry Filter - filter mode", () => {


### PR DESCRIPTION
## Description
Adds namespace filters and namespace exceptions to App Insights Fluid Telemetry Logger. This updates the logic of the filter to be as such:
- If a `TelemetryFilter` specifies both a `category` and a `namespace`, the event must match both.
- If only a `category` or `namespace` is provided, the event should match either one of them.
- If a `namespace` pattern exception is specified in the `TelemetryFilter`, the event should not match the exception pattern.

Additionally, Tests were revamped to include more consistency, distinctly cover more edge cases and be easier to follow.

## Reviewer Guidance