### PR TITLE
feat(tree2): add destruction to Delta format and visit

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -425,6 +425,7 @@ declare namespace Delta {
         FieldMap,
         DetachedNodeChanges,
         DetachedNodeBuild,
+        DetachedNodeDestruction,
         DetachedNodeRename,
         FieldChanges
     }
@@ -472,6 +473,14 @@ interface DetachedNodeBuild<TTree = ProtoNode> {
 interface DetachedNodeChanges<TTree = ProtoNode> {
     // (undocumented)
     readonly fields: FieldMap<TTree>;
+    // (undocumented)
+    readonly id: DetachedNodeId;
+}
+
+// @alpha
+interface DetachedNodeDestruction {
+    // (undocumented)
+    readonly count: number;
     // (undocumented)
     readonly id: DetachedNodeId;
 }
@@ -627,6 +636,7 @@ export interface FieldAnchor {
 // @alpha
 interface FieldChanges<TTree = ProtoNode> {
     readonly build?: readonly DetachedNodeBuild<TTree>[];
+    readonly destroy?: readonly DetachedNodeDestruction[];
     readonly global?: readonly DetachedNodeChanges<TTree>[];
     readonly local?: readonly Mark<TTree>[];
     readonly rename?: readonly DetachedNodeRename[];

--- a/experimental/dds/tree2/src/core/tree/delta.ts
+++ b/experimental/dds/tree2/src/core/tree/delta.ts
@@ -148,12 +148,21 @@ export interface DetachedNodeChanges<TTree = ProtoNode> {
 }
 
 /**
- * Represents the creation of a detached node
+ * Represents the creation of detached nodes
  * @alpha
  */
 export interface DetachedNodeBuild<TTree = ProtoNode> {
 	readonly id: DetachedNodeId;
 	readonly trees: readonly TTree[];
+}
+
+/**
+ * Represents the destruction of detached nodes
+ * @alpha
+ */
+export interface DetachedNodeDestruction {
+	readonly id: DetachedNodeId;
+	readonly count: number;
 }
 
 /**
@@ -181,13 +190,30 @@ export interface FieldChanges<TTree = ProtoNode> {
 	/**
 	 * Changes to apply to detached nodes.
 	 * The ordering has no significance.
+	 *
+	 * Nested changes for a root that is undergoing a rename should be listed under the starting name.
+	 * For example, if one wishes to change a tree which is being renamed from ID A to ID B,
+	 * then the changes should be listed under ID A.
 	 */
 	readonly global?: readonly DetachedNodeChanges<TTree>[];
 	/**
 	 * New detached nodes to be constructed.
 	 * The ordering has no significance.
+	 *
+	 * Build instructions for a root that is undergoing a rename should be listed under the starting name.
+	 * For example, if one wishes to build a tree which is being renamed from ID A to ID B,
+	 * then the build should be listed under ID A.
 	 */
 	readonly build?: readonly DetachedNodeBuild<TTree>[];
+	/**
+	 * New detached nodes to be constructed.
+	 * The ordering has no significance.
+	 *
+	 * Destruction instructions for a root that is undergoing a rename should be listed under the final name.
+	 * For example, if one wishes to destroy a tree which is being renamed from ID A to ID B,
+	 * then the destruction should be listed under ID B.
+	 */
+	readonly destroy?: readonly DetachedNodeDestruction[];
 	/**
 	 * Detached whose associated ID needs to be updated.
 	 * The ordering has no significance.

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -325,8 +325,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			assert(forest.anchors.isEmpty());
 		});
 
-		// Not testable until node destruction is implemented
-		it.skip("using an anchor that went away returns NotFound", () => {
+		it("using an anchor that went away returns NotFound", () => {
 			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 
 			initializeForest(forest, [singleJsonCursor([1, 2])]);
@@ -340,7 +339,9 @@ export function testForest(config: ForestTestConfiguration): void {
 			cursor.clear();
 
 			const mark: Delta.Mark = { count: 1, detach: detachId };
-			const delta: Delta.Root = new Map([[rootFieldKey, { local: [mark] }]]);
+			const delta: Delta.Root = new Map([
+				[rootFieldKey, { local: [mark], destroy: [{ id: detachId, count: 1 }] }],
+			]);
 			applyTestDelta(delta, forest);
 			applyTestDelta(delta, forest.anchors);
 


### PR DESCRIPTION
Adds the ability to convey the destruction of detached fields in the `Delta` format.
Updates the `visitDelta` function so that it communicates destructions to the visitor.