### PR TITLE
Better separate schema from DataObject

### DIFF
--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -5,7 +5,6 @@
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import {
-	AllowedUpdateType,
 	ForestType,
 	ISharedTree,
 	ISharedTreeView,
@@ -13,7 +12,7 @@ import {
 	typeboxValidator,
 } from "@fluid-experimental/tree2";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { Inventory, schema } from "./schema";
+import { Inventory, treeConfiguration } from "./schema";
 
 const treeKey = "tree";
 
@@ -23,45 +22,31 @@ const factory = new SharedTreeFactory({
 });
 
 export class InventoryList extends DataObject {
-	private _tree?: ISharedTree;
-	private _view?: ISharedTreeView;
+	#tree?: ISharedTree;
+	#view?: ISharedTreeView;
 
 	public get inventory(): Inventory {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this._view!.root2(schema);
+		if (this.#view === undefined)
+			throw new Error("view should be initialized by hasInitialized");
+		return this.#view.root2(treeConfiguration.schema);
 	}
 
 	protected async initializingFirstTime() {
-		this._tree = this.runtime.createChannel(undefined, factory.type) as ISharedTree;
-		this.root.set(treeKey, this._tree.handle);
+		this.#tree = this.runtime.createChannel(undefined, factory.type) as ISharedTree;
+		this.root.set(treeKey, this.#tree.handle);
 	}
 
 	protected async initializingFromExisting() {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- map populated on creation by 'initializingFirstTime'.
-		this._tree = await this.root.get<IFluidHandle<ISharedTree>>(treeKey)!.get();
+		const handle = this.root.get<IFluidHandle<ISharedTree>>(treeKey);
+		if (handle === undefined)
+			throw new Error("map should be populated on creation by 'initializingFirstTime'");
+		this.#tree = await handle.get();
 	}
 
 	protected async hasInitialized() {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- field initialized by initializing* methods.
-		this._view = this._tree!.schematizeView({
-			initialTree: {
-				// TODO: FieldNodes should not require wrapper object
-				parts: {
-					"": [
-						{
-							name: "nut",
-							quantity: 0,
-						},
-						{
-							name: "bolt",
-							quantity: 0,
-						},
-					],
-				},
-			},
-			allowedSchemaModifications: AllowedUpdateType.None,
-			schema,
-		});
+		if (this.#tree === undefined)
+			throw new Error("tree should be initialized by initializing* methods");
+		this.#view = this.#tree.schematizeView(treeConfiguration);
 	}
 }
 

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -12,7 +12,7 @@ import {
 
 const builder = new SchemaBuilder({ scope: "com.contoso.app.inventory" });
 
-export type Part = ProxyNode<typeof Inventory>;
+export type Part = ProxyNode<typeof Part>;
 export const Part = builder.object("Part", {
 	name: builder.string,
 	quantity: builder.number,

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -3,21 +3,42 @@
  * Licensed under the MIT License.
  */
 
-import { ProxyNode, SchemaBuilder } from "@fluid-experimental/tree2";
+import {
+	AllowedUpdateType,
+	InitializeAndSchematizeConfiguration,
+	ProxyNode,
+	SchemaBuilder,
+} from "@fluid-experimental/tree2";
 
-const builder = new SchemaBuilder({
-	scope: "com.contoso.app.inventory",
-});
+const builder = new SchemaBuilder({ scope: "com.contoso.app.inventory" });
 
-export const part = builder.object("Part", {
+export type Part = ProxyNode<typeof Inventory>;
+export const Part = builder.object("Part", {
 	name: builder.string,
 	quantity: builder.number,
 });
 
-export const inventory = builder.object("Inventory", {
-	parts: builder.list(part),
+export type Inventory = ProxyNode<typeof Inventory>;
+export const Inventory = builder.object("Inventory", {
+	parts: builder.list(Part),
 });
 
-export const schema = builder.intoSchema(inventory);
-
-export type Inventory = ProxyNode<typeof inventory>;
+export const treeConfiguration = {
+	schema: builder.intoSchema(Inventory),
+	allowedSchemaModifications: AllowedUpdateType.None,
+	initialTree: {
+		parts: {
+			// TODO: FieldNodes should not require wrapper object
+			"": [
+				{
+					name: "nut",
+					quantity: 0,
+				},
+				{
+					name: "bolt",
+					quantity: 0,
+				},
+			],
+		},
+	},
+} satisfies InitializeAndSchematizeConfiguration;


### PR DESCRIPTION
## Description

Split application schema specific stuff out of the DataObject implementation.
Make the data-object do its type narrowing with exceptions instead of linter suppression and "!" so it its wrong (or breaks in the future, for example when someone is playing with the example) it will error instead of silently passing along the incorrectly typed value.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

