### PR TITLE
tree2: Remove many uses of deprecated ISharedTree.view

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -52,9 +52,12 @@ const childrenFieldKey: FieldKey = brand("children");
 /*
  * Updates the given `tree` to the given `schema` and inserts `state` as its root.
  */
-function initializeTestTree(tree: ISharedTree, state: JsonableTree = initialTestJsonTree) {
+function initializeTestTree(
+	tree: ISharedTree,
+	state: JsonableTree = initialTestJsonTree,
+): ISharedTreeView {
 	const writeCursor = singleTextCursor(state);
-	tree.schematize({
+	return tree.schematizeView({
 		allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 		initialTree: [writeCursor],
 		schema: fullSchemaData,
@@ -434,7 +437,7 @@ describe("Op Size", () => {
 		function benchmarkOps(transactionStyle: TransactionStyle, percentile: number): void {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
 			initializeOpDataCollection(tree);
-			initializeTestTree(tree);
+			const view = initializeTestTree(tree);
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 			const jsonNode = createTreeWithSize(
 				getSuccessfulOpByteSize(Operation.Insert, transactionStyle, percentile),
@@ -443,8 +446,9 @@ describe("Op Size", () => {
 				transactionStyle === TransactionStyle.Individual
 					? insertNodesWithIndividualTransactions
 					: insertNodesWithSingleTransaction;
-			apply(tree.view, jsonNode, BENCHMARK_NODE_COUNT);
-			assertChildNodeCount(tree.view, BENCHMARK_NODE_COUNT);
+
+			apply(view, jsonNode, BENCHMARK_NODE_COUNT);
+			assertChildNodeCount(view, BENCHMARK_NODE_COUNT);
 		}
 
 		for (const { description, style, extraDescription } of styles) {
@@ -467,14 +471,14 @@ describe("Op Size", () => {
 				transactionStyle,
 				percentile,
 			);
-			initializeTestTree(tree, createInitialTree(100, childByteSize));
+			const view = initializeTestTree(tree, createInitialTree(100, childByteSize));
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 			if (transactionStyle === TransactionStyle.Individual) {
-				deleteNodesWithIndividualTransactions(tree.view, 100, 1);
+				deleteNodesWithIndividualTransactions(view, 100, 1);
 			} else {
-				deleteNodesWithSingleTransaction(tree.view, 100);
+				deleteNodesWithSingleTransaction(view, 100);
 			}
-			assertChildNodeCount(tree.view, 0);
+			assertChildNodeCount(view, 0);
 		}
 
 		for (const { description, style, extraDescription } of styles) {
@@ -497,17 +501,17 @@ describe("Op Size", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "test");
 			initializeOpDataCollection(tree);
 			// Note that the child node byte size for the initial tree here should be arbitrary.
-			initializeTestTree(tree, createInitialTree(BENCHMARK_NODE_COUNT, 1000));
+			const view = initializeTestTree(tree, createInitialTree(BENCHMARK_NODE_COUNT, 1000));
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 			const editPayload = createStringFromLength(
 				getSuccessfulOpByteSize(Operation.Edit, transactionStyle, percentile),
 			);
 			if (transactionStyle === TransactionStyle.Individual) {
-				editNodesWithIndividualTransactions(tree.view, BENCHMARK_NODE_COUNT, editPayload);
+				editNodesWithIndividualTransactions(view, BENCHMARK_NODE_COUNT, editPayload);
 			} else {
-				editNodesWithSingleTransaction(tree.view, BENCHMARK_NODE_COUNT, editPayload);
+				editNodesWithSingleTransaction(view, BENCHMARK_NODE_COUNT, editPayload);
 			}
-			expectChildrenValues(tree.view, editPayload, BENCHMARK_NODE_COUNT);
+			expectChildrenValues(view, editPayload, BENCHMARK_NODE_COUNT);
 		}
 
 		for (const { description, style, extraDescription } of styles) {
@@ -577,10 +581,13 @@ describe("Op Size", () => {
 					TransactionStyle.Individual,
 					percentile,
 				);
-				initializeTestTree(tree, createInitialTree(deleteNodeCount, childByteSize));
+				const view = initializeTestTree(
+					tree,
+					createInitialTree(deleteNodeCount, childByteSize),
+				);
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				deleteNodesWithIndividualTransactions(tree.view, deleteNodeCount, 1);
-				assertChildNodeCount(tree.view, 0);
+				deleteNodesWithIndividualTransactions(view, deleteNodeCount, 1);
+				assertChildNodeCount(view, 0);
 
 				// insert
 				const insertChildNode = createTreeWithSize(
@@ -590,8 +597,8 @@ describe("Op Size", () => {
 						percentile,
 					),
 				);
-				insertNodesWithIndividualTransactions(tree.view, insertChildNode, insertNodeCount);
-				assertChildNodeCount(tree.view, insertNodeCount);
+				insertNodesWithIndividualTransactions(view, insertChildNode, insertNodeCount);
+				assertChildNodeCount(view, insertNodeCount);
 
 				// edit
 				// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
@@ -599,7 +606,7 @@ describe("Op Size", () => {
 					const remainder = editNodeCount - insertNodeCount;
 					saveAndResetCurrentOps();
 					insertNodesWithIndividualTransactions(
-						tree.view,
+						view,
 						createTreeWithSize(childByteSize),
 						remainder,
 					);
@@ -612,8 +619,8 @@ describe("Op Size", () => {
 						percentile,
 					),
 				);
-				editNodesWithIndividualTransactions(tree.view, editNodeCount, editPayload);
-				expectChildrenValues(tree.view, editPayload, editNodeCount);
+				editNodesWithIndividualTransactions(view, editNodeCount, editPayload);
+				expectChildrenValues(view, editPayload, editNodeCount);
 			};
 
 			for (const distribution of distributions) {
@@ -657,17 +664,20 @@ describe("Op Size", () => {
 					TransactionStyle.Single,
 					percentile,
 				);
-				initializeTestTree(tree, createInitialTree(deleteNodeCount, childByteSize));
+				const view = initializeTestTree(
+					tree,
+					createInitialTree(deleteNodeCount, childByteSize),
+				);
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				deleteNodesWithSingleTransaction(tree.view, deleteNodeCount);
-				assertChildNodeCount(tree.view, 0);
+				deleteNodesWithSingleTransaction(view, deleteNodeCount);
+				assertChildNodeCount(view, 0);
 
 				// insert
 				const insertChildNode = createTreeWithSize(
 					getSuccessfulOpByteSize(Operation.Insert, TransactionStyle.Single, percentile),
 				);
-				insertNodesWithSingleTransaction(tree.view, insertChildNode, insertNodeCount);
-				assertChildNodeCount(tree.view, insertNodeCount);
+				insertNodesWithSingleTransaction(view, insertChildNode, insertNodeCount);
+				assertChildNodeCount(view, insertNodeCount);
 
 				// edit
 				// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
@@ -676,7 +686,7 @@ describe("Op Size", () => {
 					const remainder = editNodeCount - insertNodeCount;
 					saveAndResetCurrentOps();
 					insertNodesWithIndividualTransactions(
-						tree.view,
+						view,
 						createTreeWithSize(childByteSize),
 						remainder,
 					);
@@ -685,8 +695,8 @@ describe("Op Size", () => {
 				const editPayload = createStringFromLength(
 					getSuccessfulOpByteSize(Operation.Edit, TransactionStyle.Single, percentile),
 				);
-				editNodesWithSingleTransaction(tree.view, editNodeCount, editPayload);
-				expectChildrenValues(tree.view, editPayload, editNodeCount);
+				editNodesWithSingleTransaction(view, editNodeCount, editPayload);
+				expectChildrenValues(view, editPayload, editNodeCount);
 			};
 
 			for (const distribution of distributions) {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -1094,11 +1094,12 @@ describe("SharedTree", () => {
 	describe("Rebasing", () => {
 		it("rebases stashed ops with prior state present", async () => {
 			const provider = await TestTreeProvider.create(2);
-			const view1 = provider.trees[0].schematizeView({
+			const config = {
 				initialTree: ["a"],
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
-			});
+			};
+			const view1 = provider.trees[0].schematizeView(config);
 			await provider.ensureSynchronized();
 
 			const pausedContainer: IContainerExperimental = provider.containers[0];
@@ -1120,7 +1121,7 @@ describe("SharedTree", () => {
 			const tree = await dataStore.getSharedObject<ISharedTree>("TestSharedTree");
 			await waitForContainerConnection(loadedContainer, true);
 			await provider.ensureSynchronized();
-			validateRootField(tree.view, ["d", "a", "b", "c"]);
+			validateRootField(tree.schematizeView(config), ["d", "a", "b", "c"]);
 			validateRootField(otherLoadedTree, ["d", "a", "b", "c"]);
 		});
 	});

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -221,9 +221,12 @@ export function generateTestTrees() {
 					"test",
 				);
 
-				baseTree.view.storedSchema.update(jsonSequenceRootSchema);
+				const tree1 = baseTree.schematizeView({
+					allowedSchemaModifications: AllowedUpdateType.None,
+					schema: jsonSequenceRootSchema,
+					initialTree: [],
+				});
 
-				const tree1 = baseTree.view;
 				const tree2 = tree1.fork();
 				insert(tree1, 0, "y");
 				tree2.rebaseOnto(tree1);


### PR DESCRIPTION
## Description

Removes many uses of deprecated ISharedTree.view from tests.

The remaining usages are mainly in fuzz tests and will be removed separately.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

