### PR TITLE
tree2: Allow comparing tree content without a view schema

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1026,6 +1026,7 @@ export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : fals
 
 // @alpha
 export interface ISharedTree extends ISharedObject, TypedTreeChannel {
+    contentSnapshot(): TreeSnapshot;
     schematizeView<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
     // @deprecated
     readonly view: ISharedTreeView;
@@ -2186,6 +2187,12 @@ export interface TreeSchema<out T extends TreeFieldSchema = TreeFieldSchema> ext
 type TreeSchemaSpecification = [
 FlattenKeys<(ObjectSchemaSpecification | MapSchemaSpecification | LeafSchemaSpecification) & Partial<ObjectSchemaSpecification & MapSchemaSpecification & LeafSchemaSpecification>>
 ][_InlineTrick];
+
+// @alpha
+export interface TreeSnapshot {
+    readonly schema: TreeStoredSchema;
+    readonly tree: JsonableTree[];
+}
 
 // @alpha
 export enum TreeStatus {

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1026,7 +1026,7 @@ export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : fals
 
 // @alpha
 export interface ISharedTree extends ISharedObject, TypedTreeChannel {
-    contentSnapshot(): TreeSnapshot;
+    contentSnapshot(): SharedTreeContentSnapshot;
     schematizeView<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
     // @deprecated
     readonly view: ISharedTreeView;
@@ -1939,6 +1939,12 @@ export interface SequenceFieldEditBuilder {
 }
 
 // @alpha
+export interface SharedTreeContentSnapshot {
+    readonly schema: TreeStoredSchema;
+    readonly tree: JsonableTree[];
+}
+
+// @alpha
 export class SharedTreeFactory implements IChannelFactory {
     constructor(options?: SharedTreeOptions);
     // (undocumented)
@@ -2187,12 +2193,6 @@ export interface TreeSchema<out T extends TreeFieldSchema = TreeFieldSchema> ext
 type TreeSchemaSpecification = [
 FlattenKeys<(ObjectSchemaSpecification | MapSchemaSpecification | LeafSchemaSpecification) & Partial<ObjectSchemaSpecification & MapSchemaSpecification & LeafSchemaSpecification>>
 ][_InlineTrick];
-
-// @alpha
-export interface TreeSnapshot {
-    readonly schema: TreeStoredSchema;
-    readonly tree: JsonableTree[];
-}
 
 // @alpha
 export enum TreeStatus {

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -95,7 +95,12 @@ export {
 	prefixFieldPath,
 	CursorWithNode,
 } from "./treeCursorUtils";
-export { singleTextCursor, jsonableTreeFromCursor } from "./treeTextCursor";
+export {
+	singleTextCursor,
+	jsonableTreeFromCursor,
+	jsonableTreeFromFieldCursor,
+	jsonableTreeFromForest,
+} from "./treeTextCursor";
 
 // Split this up into separate import and export for compatibility with API-Extractor.
 import * as SequenceField from "./sequence-field";

--- a/experimental/dds/tree2/src/feature-libraries/treeTextCursor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/treeTextCursor.ts
@@ -13,6 +13,8 @@ import {
 	mapCursorField,
 	ITreeCursorSynchronous,
 	setGenericTreeField,
+	IForestSubscription,
+	moveToDetachedField,
 } from "../core";
 import { CursorAdapter, singleStackTreeCursor } from "./treeCursorUtils";
 
@@ -75,4 +77,26 @@ export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree {
 		setGenericTreeField(node, cursor.getFieldKey(), field);
 	}
 	return node;
+}
+
+/**
+ * Extract a JsonableTree from the contents of the given ITreeCursor's current node.
+ */
+export function jsonableTreeFromFieldCursor(cursor: ITreeCursor): JsonableTree[] {
+	assert(cursor.mode === CursorLocationType.Fields, "must start at field");
+	return mapCursorField(cursor, jsonableTreeFromCursor);
+}
+
+/**
+ * Copy forest content into a JsonableTree.
+ * @remarks
+ * This is not a time or memory efficient way to pass around forest content:
+ * its intended for debugging and testing purposes when forest content is needed in a human readable serializable format.
+ */
+export function jsonableTreeFromForest(forest: IForestSubscription): JsonableTree[] {
+	const readCursor = forest.allocateCursor();
+	moveToDetachedField(forest, readCursor);
+	const jsonable = jsonableTreeFromFieldCursor(readCursor);
+	readCursor.free();
+	return jsonable;
 }

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -308,7 +308,7 @@ export {
 	TypedTreeFactory,
 	TypedTreeOptions,
 	TypedTreeChannel,
-	TreeSnapshot,
+	SharedTreeContentSnapshot,
 } from "./shared-tree";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec";

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -308,6 +308,7 @@ export {
 	TypedTreeFactory,
 	TypedTreeOptions,
 	TypedTreeChannel,
+	TreeSnapshot,
 } from "./shared-tree";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec";

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -9,7 +9,7 @@ export {
 	SharedTreeOptions,
 	SharedTree,
 	ForestType,
-	TreeSnapshot,
+	SharedTreeContentSnapshot,
 } from "./sharedTree";
 
 export {

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -9,6 +9,7 @@ export {
 	SharedTreeOptions,
 	SharedTree,
 	ForestType,
+	TreeSnapshot,
 } from "./sharedTree";
 
 export {

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -60,7 +60,7 @@ export interface TreeSnapshot {
 	 * The schema stored in the document.
 	 *
 	 * @remarks
-	 * Edits to the schema (by this or other clients) can change this: this is only a snapshot of a point in time.
+	 * Edits to the schema can mutate the schema stored of the tree which took this snapshot (but this snapshot will remain the same)
 	 * This is mainly useful for debugging cases where schematize reports an incompatible view schema.
 	 */
 	readonly schema: TreeStoredSchema;

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -53,9 +53,11 @@ import {
 
 /**
  * Copy of data from an {@link ISharedTree} at some point in time.
+ * @remarks
+ * This is unrelated to Fluids concept of "snapshots".
  * @alpha
  */
-export interface TreeSnapshot {
+export interface SharedTreeContentSnapshot {
 	/**
 	 * The schema stored in the document.
 	 *
@@ -93,7 +95,7 @@ export interface ISharedTree extends ISharedObject, TypedTreeChannel {
 	 *
 	 * This does not include everything that is included in a tree summary, since information about how to merge future edits is omitted.
 	 */
-	contentSnapshot(): TreeSnapshot;
+	contentSnapshot(): SharedTreeContentSnapshot;
 
 	/**
 	 * Takes in a tree and returns a view of it that conforms to the view schema.
@@ -182,7 +184,7 @@ export class SharedTree
 		});
 	}
 
-	public contentSnapshot(): TreeSnapshot {
+	public contentSnapshot(): SharedTreeContentSnapshot {
 		const cursor = this.view.forest.allocateCursor();
 		try {
 			moveToDetachedField(this.view.forest, cursor);

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -88,7 +88,7 @@ export interface ISharedTree extends ISharedObject, TypedTreeChannel {
 
 	/**
 	 * Provides a copy of the current content of the tree.
-	 * This can be useful for inspecting the tree when no suable view schema is available.
+	 * This can be useful for inspecting the tree when no suitable view schema is available.
 	 * This is only intended for use in testing and exceptional code paths: it is not performant.
 	 *
 	 * This does not include everything that is included in a tree summary, since information about how to merge future edits is omitted.

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -27,6 +27,7 @@ import {
 	TestTreeProviderLite,
 	createTestUndoRedoStacks,
 	emptyJsonSequenceConfig,
+	expectSchemaEqual,
 	initializeTestTree,
 	jsonSequenceRootSchema,
 	toJsonableTree,
@@ -114,6 +115,29 @@ describe("SharedTree", () => {
 		root.content = 2;
 		assert(leafNode.treeStatus() !== TreeStatus.InDocument);
 		assert.equal(root.content, 2);
+	});
+
+	it("contentSnapshot", () => {
+		const factory = new SharedTreeFactory();
+		const sharedTree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
+		{
+			const snapshot = sharedTree.contentSnapshot();
+			assert.deepEqual(snapshot.tree, []);
+			expectSchemaEqual(snapshot.schema, {
+				rootFieldSchema: storedEmptyFieldSchema,
+				treeSchema: new Map(),
+			});
+		}
+		sharedTree.schematize({
+			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
+			initialTree: [1],
+			schema: jsonSequenceRootSchema,
+		});
+		{
+			const snapshot = sharedTree.contentSnapshot();
+			assert.deepEqual(snapshot.tree, [{ type: leaf.number.name, value: 1 }]);
+			expectSchemaEqual(snapshot.schema, jsonSequenceRootSchema);
+		}
 	});
 
 	it("can be connected to another tree", async () => {

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -42,7 +42,7 @@ import {
 	InitializeAndSchematizeConfiguration,
 	ISharedTreeBranchView,
 	runSynchronous,
-	TreeSnapshot,
+	SharedTreeContentSnapshot,
 } from "../shared-tree";
 import {
 	Any,
@@ -578,8 +578,8 @@ export function validateViewConsistency(
 }
 
 export function validateSnapshotConsistency(
-	treeA: TreeSnapshot,
-	treeB: TreeSnapshot,
+	treeA: SharedTreeContentSnapshot,
+	treeB: SharedTreeContentSnapshot,
 	idDifferentiator: string | undefined = undefined,
 ): void {
 	assert.deepEqual(

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -42,6 +42,7 @@ import {
 	InitializeAndSchematizeConfiguration,
 	ISharedTreeBranchView,
 	runSynchronous,
+	TreeSnapshot,
 } from "../shared-tree";
 import {
 	Any,
@@ -62,6 +63,7 @@ import {
 	revisionMetadataSourceFromInfo,
 	singleTextCursor,
 	TypedField,
+	jsonableTreeFromForest,
 } from "../feature-libraries";
 import {
 	Delta,
@@ -83,7 +85,6 @@ import {
 	FieldUpPath,
 	TreeNodeSchemaIdentifier,
 	TreeNodeStoredSchema,
-	IForestSubscription,
 	InMemoryStoredSchemaRepository,
 	initializeForest,
 	AllowedUpdateType,
@@ -526,9 +527,17 @@ export function validateTree(tree: ISharedTreeView, expected: JsonableTree[]): v
 
 const schemaCodec = makeSchemaCodec({ jsonValidator: typeboxValidator });
 
+/**
+ * This does NOT check that the trees have the same edits, same edit manager state or anything like that.
+ * This ONLY checks if the content of the forest of the main branch of the trees match.
+ */
 export function validateTreeConsistency(treeA: ISharedTree, treeB: ISharedTree): void {
 	// TODO: validate other aspects of these trees are consistent, for example their collaboration window information.
-	validateViewConsistency(treeA.view, treeB.view, `id: ${treeA.id} vs id: ${treeB.id}`);
+	validateSnapshotConsistency(
+		treeA.contentSnapshot(),
+		treeB.contentSnapshot(),
+		`id: ${treeA.id} vs id: ${treeB.id}`,
+	);
 }
 
 function contentToJsonableTree(content: TreeContent): JsonableTree[] {
@@ -541,7 +550,19 @@ function contentToJsonableTree(content: TreeContent): JsonableTree[] {
 
 export function validateTreeContent(tree: ISharedTreeView, content: TreeContent): void {
 	assert.deepEqual(toJsonableTree(tree), contentToJsonableTree(content));
-	assert.deepEqual(schemaCodec.encode(tree.storedSchema), schemaCodec.encode(content.schema));
+	expectSchemaEqual(tree.storedSchema, content.schema);
+}
+
+export function expectSchemaEqual(
+	a: TreeStoredSchema,
+	b: TreeStoredSchema,
+	idDifferentiator: string | undefined = undefined,
+): void {
+	assert.deepEqual(
+		schemaCodec.encode(a),
+		schemaCodec.encode(b),
+		`Inconsistent schema: ${idDifferentiator}`,
+	);
 }
 
 export function validateViewConsistency(
@@ -549,16 +570,24 @@ export function validateViewConsistency(
 	treeB: ISharedTreeView,
 	idDifferentiator: string | undefined = undefined,
 ): void {
+	validateSnapshotConsistency(
+		{ tree: toJsonableTree(treeA), schema: treeA.storedSchema },
+		{ tree: toJsonableTree(treeB), schema: treeB.storedSchema },
+		idDifferentiator,
+	);
+}
+
+export function validateSnapshotConsistency(
+	treeA: TreeSnapshot,
+	treeB: TreeSnapshot,
+	idDifferentiator: string | undefined = undefined,
+): void {
 	assert.deepEqual(
-		toJsonableTree(treeA),
-		toJsonableTree(treeB),
+		treeA.tree,
+		treeB.tree,
 		`Inconsistent json representation: ${idDifferentiator}`,
 	);
-	assert.deepEqual(
-		schemaCodec.encode(treeA.storedSchema),
-		schemaCodec.encode(treeB.storedSchema),
-		`Inconsistent schema: ${idDifferentiator}`,
-	);
+	expectSchemaEqual(treeA.schema, treeB.schema, idDifferentiator);
 }
 
 export function viewWithContent(
@@ -639,14 +668,6 @@ export function makeTreeFromJson(json: JsonCompatible[] | JsonCompatible): IShar
 
 export function toJsonableTree(tree: ISharedTreeView): JsonableTree[] {
 	return jsonableTreeFromForest(tree.forest);
-}
-
-export function jsonableTreeFromForest(forest: IForestSubscription): JsonableTree[] {
-	const readCursor = forest.allocateCursor();
-	moveToDetachedField(forest, readCursor);
-	const jsonable = mapCursorField(readCursor, jsonableTreeFromCursor);
-	readCursor.free();
-	return jsonable;
 }
 
 /**


### PR DESCRIPTION
## Description

Access to ISharedTreeViews without a view schema is deprecated.

This change provides access to schema and tree content in a way suitable for debugging and testing/comparing trees without requiring a view schema.

The test utilities used have been updated to leverage this, to reduce dependency on the deprecated ISharedTree.view.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

