### PR TITLE
experiment: Use pathed exports for internal APIs

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const tscDependsOn = ["^tsc", "build:genver"];
+const tscDependsOn = ["^tsc", "^api-extractor:commonjs", "^api-extractor:esnext", "build:genver"];
 /**
  * The settings in this file configure the Fluid build tools, such as fluid-build and flub. Some settings apply to the
  * whole repo, while others apply only to the client release group.
@@ -38,9 +38,11 @@ module.exports = {
 		"build:genver": [],
 		"typetests:gen": ["^tsc", "build:genver"], // we may reexport type from dependent packages, needs to build them first.
 		"tsc": tscDependsOn,
-		"build:esnext": tscDependsOn,
+		"build:esnext": [...tscDependsOn],
 		"build:test": [...tscDependsOn, "typetests:gen", "tsc"],
 		"build:docs": [...tscDependsOn, "tsc"],
+		"api-extractor:commonjs": [...tscDependsOn, "tsc"],
+		"api-extractor:esnext": ["build:esnext"],
 		"ci:build:docs": [...tscDependsOn, "tsc"],
 		"depcruise": [],
 		"eslint": [...tscDependsOn, "commonjs"],

--- a/packages/tools/devtools/devtools-core/api-extractor.esnext.json
+++ b/packages/tools/devtools/devtools-core/api-extractor.esnext.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "./api-extractor.json",
+	"compiler": {
+		"tsconfigFilePath": "<projectFolder>/tsconfig.json"
+	},
+	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+	"dtsRollup": {
+		"enabled": true,
+		"alphaTrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-alpha.d.ts",
+		"betaTrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-beta.d.ts",
+		"publicTrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-public.d.ts",
+		"untrimmedFilePath": "<projectFolder>/lib/<unscopedPackageName>-untrimmed.d.ts"
+	}
+}

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -22,26 +22,6 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./beta": {
-			"import": {
-				"types": "./lib/devtools-core-beta.d.ts",
-				"default": "./lib/index.js"
-			},
-			"require": {
-				"types": "./dist/devtools-core-beta.d.ts",
-				"default": "./dist/index.js"
-			}
-		},
-		"./alpha": {
-			"import": {
-				"types": "./lib/devtools-core-alpha.d.ts",
-				"default": "./lib/index.js"
-			},
-			"require": {
-				"types": "./dist/devtools-core-alpha.d.ts",
-				"default": "./dist/index.js"
-			}
-		},
 		"./internal": {
 			"import": {
 				"types": "./lib/devtools-core-untrimmed.d.ts",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -11,14 +11,58 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/devtools-core-public.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/devtools-core-public.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+		"./beta": {
+			"import": {
+				"types": "./lib/devtools-core-beta.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/devtools-core-beta.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+		"./alpha": {
+			"import": {
+				"types": "./lib/devtools-core-alpha.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/devtools-core-alpha.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+		"./internal": {
+			"import": {
+				"types": "./lib/devtools-core-untrimmed.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/devtools-core-untrimmed.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
 	"main": "dist/index.js",
 	"module": "lib/index.js",
-	"types": "dist/index.d.ts",
+	"types": "dist/devtools-core-public.d.ts",
 	"scripts": {
+		"api-extractor:commonjs": "api-extractor run --local",
+		"api-extractor:esnext": "api-extractor run --local --config api-extractor.esnext.json",
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:docs": "api-extractor run --local",
+		"build:docs": "npm run api-extractor:commonjs && npm run api-extractor:esnext",
 		"build:esnext": "tsc --project ./tsconfig.esnext.json",
 		"build:genver": "gen-version",
 		"ci:build:docs": "api-extractor run",

--- a/packages/tools/devtools/devtools-example/tsconfig.json
+++ b/packages/tools/devtools/devtools-example/tsconfig.json
@@ -4,6 +4,7 @@
 		"rootDir": "src",
 		"outDir": "dist",
 		"module": "ESNext",
+		"moduleResolution": "node16",
 		"composite": true,
 		"jsx": "react",
 		"types": ["jest", "node", "puppeteer", "jest-environment-puppeteer"],

--- a/packages/tools/devtools/devtools-view/.eslintrc.cjs
+++ b/packages/tools/devtools/devtools-view/.eslintrc.cjs
@@ -34,6 +34,10 @@ module.exports = {
 				allow: [
 					// Allow use of unstable API
 					"@fluentui/react-components/unstable",
+
+					// Allow use of internal API
+					"@fluid-experimental/devtools-core/internal",
+					"*/index.js",
 				],
 			},
 		],
@@ -70,8 +74,42 @@ module.exports = {
 		},
 	],
 	settings: {
-		react: {
+		"react": {
 			version: "detect",
+		},
+		"import/extensions": [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+		"import/parsers": {
+			"@typescript-eslint/parser": [".ts", ".tsx", ".d.ts"],
+		},
+		"import/resolver": {
+			node: {
+				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+			},
+			typescript: {
+				alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+
+				// Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
+
+				// use <root>/path/to/folder/tsconfig.json
+				// "project": "path/to/folder",
+
+				// Multiple tsconfigs (Useful for monorepos)
+
+				// use a glob pattern
+				// "project": "packages/*/tsconfig.json",
+
+				// use an array
+				// "project": [
+				//   "packages/module-a/tsconfig.json",
+				//   "packages/module-b/tsconfig.json"
+				// ],
+
+				// use an array of glob patterns
+				// "project": [
+				//   "packages/*/tsconfig.json",
+				//   "other-packages/*/tsconfig.json"
+				// ]
+			},
 		},
 	},
 };

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -13,6 +13,20 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"type": "module",
+	"exports": {
+		".": {
+			"default": {
+				"types": "./dist/devtools-view-public.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+		"./internal": {
+			"default": {
+				"types": "./dist/devtools-view-untrimmed.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -95,11 +109,11 @@
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",
 		"eslint-config-prettier": "~9.0.0",
+		"eslint-import-resolver-typescript": "^3.6.1",
+		"eslint-plugin-import": "~2.28.1",
 		"eslint-plugin-jest": "~27.4.2",
 		"eslint-plugin-react": "~7.33.2",
 		"eslint-plugin-react-hooks": "~4.6.0",
-		"eslint-plugin-import": "~2.28.1",
-		"eslint-import-resolver-typescript": "^3.6.1",
 		"globby": "^13.2.2",
 		"jest": "^29.6.2",
 		"jest-junit": "^10.0.0",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -98,6 +98,8 @@
 		"eslint-plugin-jest": "~27.4.2",
 		"eslint-plugin-react": "~7.33.2",
 		"eslint-plugin-react-hooks": "~4.6.0",
+		"eslint-plugin-import": "~2.28.1",
+		"eslint-import-resolver-typescript": "^3.6.1",
 		"globby": "^13.2.2",
 		"jest": "^29.6.2",
 		"jest-junit": "^10.0.0",

--- a/packages/tools/devtools/devtools-view/src/Audience.ts
+++ b/packages/tools/devtools/devtools-view/src/Audience.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { type IClient } from "@fluidframework/protocol-definitions";
-import { type AudienceClientMetadata } from "@fluid-experimental/devtools-core";
+import { type AudienceClientMetadata } from "@fluid-experimental/devtools-core/internal";
 
 /**
  * Represents a single audience user, aggregating their client connections.

--- a/packages/tools/devtools/devtools-view/src/ContainerFeatureFlagHelper.ts
+++ b/packages/tools/devtools/devtools-view/src/ContainerFeatureFlagHelper.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { type ContainerDevtoolsFeatureFlags } from "@fluid-experimental/devtools-core";
+import { type ContainerDevtoolsFeatureFlags } from "@fluid-experimental/devtools-core/internal";
 import React from "react";
 
 /**

--- a/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsPanel.tsx
@@ -4,10 +4,10 @@
  */
 import React from "react";
 
-import { type IMessageRelay } from "@fluid-experimental/devtools-core";
+import { type IMessageRelay } from "@fluid-experimental/devtools-core/internal";
 import { type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { DevtoolsView } from "./DevtoolsView";
-import { MessageRelayContext } from "./MessageRelayContext";
+import { DevtoolsView } from "./DevtoolsView.js";
+import { MessageRelayContext } from "./MessageRelayContext.js";
 
 /**
  * {@link DevtoolsPanel} input props.

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -28,7 +28,7 @@ import {
 	type HasContainerKey,
 	type InboundHandlers,
 	type ISourcedDevtoolsMessage,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 
 import {
 	ContainerDevtoolsView,
@@ -40,15 +40,16 @@ import {
 	SettingsView,
 	TelemetryView,
 	Waiting,
-} from "./components";
-import { useMessageRelay } from "./MessageRelayContext";
+	// eslint-disable-next-line import/no-internal-modules
+} from "./components/index.js";
+import { useMessageRelay } from "./MessageRelayContext.js";
 import {
 	ConsoleVerboseLogger,
 	LoggerContext,
 	TelemetryOptInLogger,
 	useLogger,
-} from "./TelemetryUtils";
-import { getFluentUIThemeToUse, ThemeContext } from "./ThemeHelper";
+} from "./TelemetryUtils.js";
+import { getFluentUIThemeToUse, ThemeContext } from "./ThemeHelper.js";
 
 const loggingContext = "INLINE(DevtoolsView)";
 

--- a/packages/tools/devtools/devtools-view/src/MessageRelayContext.ts
+++ b/packages/tools/devtools/devtools-view/src/MessageRelayContext.ts
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { type IMessageRelay } from "@fluid-experimental/devtools-core";
+import { type IMessageRelay } from "@fluid-experimental/devtools-core/internal";
 
 /**
  * Context for accessing a shared {@link @fluid-experimental/devtools-core#IMessageRelay} for communicating with the webpage.

--- a/packages/tools/devtools/devtools-view/src/WindowMessageRelay.ts
+++ b/packages/tools/devtools/devtools-view/src/WindowMessageRelay.ts
@@ -11,7 +11,7 @@ import {
 	type IMessageRelayEvents,
 	isDevtoolsMessage,
 	devtoolsMessageSource,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 
 /**
  * Message relay used by a devtools view rendered in the same page as the application to communicate with the

--- a/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
@@ -22,10 +22,10 @@ import {
 	ArrowExitRegular,
 } from "@fluentui/react-icons";
 
-import { ThemeOption, useThemeContext } from "../ThemeHelper";
-import { clientIdTooltipText } from "./TooltipTexts";
-import { type TransformedAudienceHistoryData } from "./AudienceView";
-import { LabelCellLayout } from "./utility-components";
+import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
+import { clientIdTooltipText } from "./TooltipTexts.js";
+import { type TransformedAudienceHistoryData } from "./AudienceView.js";
+import { LabelCellLayout } from "./utility-components/index.js";
 
 const audienceStyles = makeStyles({
 	joined: {

--- a/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
@@ -16,15 +16,15 @@ import {
 } from "@fluentui/react-components";
 import { EditRegular, Search12Regular, Person12Regular } from "@fluentui/react-icons";
 
-import { ThemeContext, ThemeOption } from "../ThemeHelper";
+import { ThemeContext, ThemeOption } from "../ThemeHelper.js";
 import {
 	clientIdTooltipText,
 	userIdTooltipText,
 	clientModeTooltipText,
 	clientScopesTooltipText,
-} from "./TooltipTexts";
-import { type TransformedAudienceStateData } from "./AudienceView";
-import { LabelCellLayout } from "./utility-components";
+} from "./TooltipTexts.js";
+import { type TransformedAudienceStateData } from "./AudienceView.js";
+import { LabelCellLayout } from "./utility-components/index.js";
 
 const audienceStateStyle = makeStyles({
 	currentUser: {

--- a/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
@@ -11,12 +11,12 @@ import {
 	type HasContainerKey,
 	type IDevtoolsMessage,
 	type InboundHandlers,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 import { type IClient } from "@fluidframework/protocol-definitions";
-import { useMessageRelay } from "../MessageRelayContext";
-import { AudienceStateTable } from "./AudienceStateTable";
-import { AudienceHistoryTable } from "./AudienceHistoryTable";
-import { Waiting } from "./Waiting";
+import { useMessageRelay } from "../MessageRelayContext.js";
+import { AudienceStateTable } from "./AudienceStateTable.js";
+import { AudienceHistoryTable } from "./AudienceHistoryTable.js";
+import { Waiting } from "./Waiting.js";
 
 // TODOs:
 // - Special annotation for the member elected as the summarizer

--- a/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
@@ -21,17 +21,17 @@ import {
 	type ISourcedDevtoolsMessage,
 	type InboundHandlers,
 	handleIncomingMessage,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 import React from "react";
 
-import { useMessageRelay } from "../MessageRelayContext";
-import { ContainerFeatureFlagContext } from "../ContainerFeatureFlagHelper";
-import { useLogger } from "../TelemetryUtils";
-import { AudienceView } from "./AudienceView";
-import { ContainerHistoryView } from "./ContainerHistoryView";
-import { ContainerSummaryView } from "./ContainerSummaryView";
-import { DataObjectsView } from "./DataObjectsView";
-import { Waiting } from "./Waiting";
+import { useMessageRelay } from "../MessageRelayContext.js";
+import { ContainerFeatureFlagContext } from "../ContainerFeatureFlagHelper.js";
+import { useLogger } from "../TelemetryUtils.js";
+import { AudienceView } from "./AudienceView.js";
+import { ContainerHistoryView } from "./ContainerHistoryView.js";
+import { ContainerSummaryView } from "./ContainerSummaryView.js";
+import { DataObjectsView } from "./DataObjectsView.js";
+import { Waiting } from "./Waiting.js";
 
 // TODOs:
 // - Allow consumers to specify additional tabs / views for list of inner app view options.

--- a/packages/tools/devtools/devtools-view/src/components/ContainerHistoryLog.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerHistoryLog.tsx
@@ -22,10 +22,10 @@ import {
 	Attach20Regular,
 	LockClosed20Filled,
 } from "@fluentui/react-icons";
-import { type ConnectionStateChangeLogEntry } from "@fluid-experimental/devtools-core";
+import { type ConnectionStateChangeLogEntry } from "@fluid-experimental/devtools-core/internal";
 
-import { ThemeContext, ThemeOption } from "../ThemeHelper";
-import { LabelCellLayout } from "./utility-components";
+import { ThemeContext, ThemeOption } from "../ThemeHelper.js";
+import { LabelCellLayout } from "./utility-components/index.js";
 
 /**
  * Returns the text color based on the current color theme of the devtools.

--- a/packages/tools/devtools/devtools-view/src/components/ContainerHistoryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerHistoryView.tsx
@@ -12,10 +12,10 @@ import {
 	type HasContainerKey,
 	type ISourcedDevtoolsMessage,
 	type InboundHandlers,
-} from "@fluid-experimental/devtools-core";
-import { useMessageRelay } from "../MessageRelayContext";
-import { ContainerHistoryLog } from "./ContainerHistoryLog";
-import { Waiting } from "./Waiting";
+} from "@fluid-experimental/devtools-core/internal";
+import { useMessageRelay } from "../MessageRelayContext.js";
+import { ContainerHistoryLog } from "./ContainerHistoryLog.js";
+import { Waiting } from "./Waiting.js";
 
 /**
  * {@link ContainerHistoryView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -39,15 +39,19 @@ import {
 	type IMessageRelay,
 	type InboundHandlers,
 	type ISourcedDevtoolsMessage,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 
-import { useLogger } from "../TelemetryUtils";
-import { connectionStateToString } from "../Utilities";
-import { useMessageRelay } from "../MessageRelayContext";
-import { Waiting } from "./Waiting";
-import { clientIdTooltipText, containerStatusTooltipText, userIdTooltipText } from "./TooltipTexts";
+import { useLogger } from "../TelemetryUtils.js";
+import { connectionStateToString } from "../Utilities.js";
+import { useMessageRelay } from "../MessageRelayContext.js";
+import { Waiting } from "./Waiting.js";
+import {
+	clientIdTooltipText,
+	containerStatusTooltipText,
+	userIdTooltipText,
+} from "./TooltipTexts.js";
 
 /**
  * {@link ContainerSummaryView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/DataObjectsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/DataObjectsView.tsx
@@ -13,11 +13,11 @@ import {
 	type ISourcedDevtoolsMessage,
 	type InboundHandlers,
 	type RootHandleNode,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 
-import { useMessageRelay } from "../MessageRelayContext";
-import { TreeDataView } from "./data-visualization";
-import { Waiting } from "./Waiting";
+import { useMessageRelay } from "../MessageRelayContext.js";
+import { TreeDataView } from "./data-visualization/index.js";
+import { Waiting } from "./Waiting.js";
 
 const loggingContext = "INLINE(VIEW)";
 

--- a/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { Body1, Body1Strong, Subtitle1, makeStyles } from "@fluentui/react-components";
-import { DynamicComposedChart } from "./graphs";
+import { DynamicComposedChart } from "./graphs/index.js";
 
 const useStyles = makeStyles({
 	flexColumn: {

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -15,8 +15,8 @@ import {
 	webLightTheme,
 } from "@fluentui/react-components";
 
-import { ThemeOption, useThemeContext } from "../ThemeHelper";
-import { useTelemetryOptIn } from "../TelemetryUtils";
+import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
+import { useTelemetryOptIn } from "../TelemetryUtils.js";
 
 const useStyles = makeStyles({
 	root: {

--- a/packages/tools/devtools/devtools-view/src/components/TelemetryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TelemetryView.tsx
@@ -34,12 +34,12 @@ import {
 	type ITimestampedTelemetryEvent,
 	TelemetryHistory,
 	TelemetryEvent,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 
-import { useMessageRelay } from "../MessageRelayContext";
-import { useLogger } from "../TelemetryUtils";
-import { ThemeOption, useThemeContext } from "../ThemeHelper";
-import { Waiting } from "./Waiting";
+import { useMessageRelay } from "../MessageRelayContext.js";
+import { useLogger } from "../TelemetryUtils.js";
+import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
+import { Waiting } from "./Waiting.js";
 
 /**
  * Set the default displayed size to 100.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/CommonInterfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type VisualNode, type VisualNodeBase } from "@fluid-experimental/devtools-core";
+import { type VisualNode, type VisualNodeBase } from "@fluid-experimental/devtools-core/internal";
 import { type Serializable } from "@fluidframework/datastore-definitions";
 
 /**

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/EditableView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/EditableView.tsx
@@ -22,12 +22,12 @@ import {
 	EditType,
 	type FluidObjectValueNode,
 	type HasContainerKey,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 
 import { type Serializable } from "@fluidframework/datastore-definitions";
-import { useMessageRelay } from "../../MessageRelayContext";
-import { TreeHeader } from "./TreeHeader";
-import { type HasLabel } from "./CommonInterfaces";
+import { useMessageRelay } from "../../MessageRelayContext.js";
+import { TreeHeader } from "./TreeHeader.js";
+import { type HasLabel } from "./CommonInterfaces.js";
 
 /**
  * Input to {@link EditableView}

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
@@ -14,13 +14,13 @@ import {
 	type HasContainerKey,
 	type HasFluidObjectId,
 	type FluidObjectNode,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 
-import { useMessageRelay } from "../../MessageRelayContext";
-import { type HasLabel } from "./CommonInterfaces";
-import { TreeDataView } from "./TreeDataView";
-import { TreeItem } from "./TreeItem";
-import { TreeHeader } from "./TreeHeader";
+import { useMessageRelay } from "../../MessageRelayContext.js";
+import { type HasLabel } from "./CommonInterfaces.js";
+import { TreeDataView } from "./TreeDataView.js";
+import { TreeItem } from "./TreeItem.js";
+import { TreeHeader } from "./TreeHeader.js";
 
 const loggingContext = "EXTENSION(HandleView)";
 

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidTreeView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidTreeView.tsx
@@ -4,12 +4,15 @@
  */
 import React from "react";
 
-import { type HasContainerKey, type FluidObjectTreeNode } from "@fluid-experimental/devtools-core";
+import {
+	type HasContainerKey,
+	type FluidObjectTreeNode,
+} from "@fluid-experimental/devtools-core/internal";
 
-import { type DataVisualizationTreeProps } from "./CommonInterfaces";
-import { TreeDataView } from "./TreeDataView";
-import { TreeHeader } from "./TreeHeader";
-import { TreeItem } from "./TreeItem";
+import { type DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { TreeDataView } from "./TreeDataView.js";
+import { TreeHeader } from "./TreeHeader.js";
+import { TreeItem } from "./TreeItem.js";
 
 /**
  * {@link TreeView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidValueView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidValueView.tsx
@@ -4,13 +4,16 @@
  */
 import React from "react";
 
-import type { FluidObjectValueNode, HasContainerKey } from "@fluid-experimental/devtools-core";
-import { useContainerFeaturesContext } from "../../ContainerFeatureFlagHelper";
-import { EditableView } from "./EditableView";
+import type {
+	FluidObjectValueNode,
+	HasContainerKey,
+} from "@fluid-experimental/devtools-core/internal";
+import { useContainerFeaturesContext } from "../../ContainerFeatureFlagHelper.js";
+import { EditableView } from "./EditableView.js";
 
-import type { DataVisualizationTreeProps } from "./CommonInterfaces";
-import { TreeItem } from "./TreeItem";
-import { TreeHeader } from "./TreeHeader";
+import type { DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { TreeItem } from "./TreeItem.js";
+import { TreeHeader } from "./TreeHeader.js";
 
 /**
  * {@link ValueView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeDataView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeDataView.tsx
@@ -4,16 +4,16 @@
  */
 import React from "react";
 
-import { type HasContainerKey, VisualNodeKind } from "@fluid-experimental/devtools-core";
+import { type HasContainerKey, VisualNodeKind } from "@fluid-experimental/devtools-core/internal";
 
-import { type DataVisualizationTreeProps } from "./CommonInterfaces";
-import { FluidHandleView } from "./FluidHandleView";
-import { TreeView } from "./TreeView";
-import { FluidTreeView } from "./FluidTreeView";
-import { ValueView } from "./ValueView";
-import { FluidValueView } from "./FluidValueView";
-import { UnknownFluidObjectView } from "./UnknownFluidObjectView";
-import { UnknownDataView } from "./UnknownDataView";
+import { type DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { FluidHandleView } from "./FluidHandleView.js";
+import { TreeView } from "./TreeView.js";
+import { FluidTreeView } from "./FluidTreeView.js";
+import { ValueView } from "./ValueView.js";
+import { FluidValueView } from "./FluidValueView.js";
+import { UnknownFluidObjectView } from "./UnknownFluidObjectView.js";
+import { UnknownDataView } from "./UnknownDataView.js";
 
 /**
  * {@link TreeDataView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
@@ -5,8 +5,8 @@
 import React from "react";
 import { tokens } from "@fluentui/react-components";
 
-import { ThemeContext, ThemeOption } from "../../ThemeHelper";
-import { type HasLabel } from "./CommonInterfaces";
+import { ThemeContext, ThemeOption } from "../../ThemeHelper.js";
+import { type HasLabel } from "./CommonInterfaces.js";
 
 /**
  * Input props to {@link TreeHeader}

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeView.tsx
@@ -5,12 +5,15 @@
 
 import React from "react";
 
-import { type HasContainerKey, type VisualTreeNode } from "@fluid-experimental/devtools-core";
+import {
+	type HasContainerKey,
+	type VisualTreeNode,
+} from "@fluid-experimental/devtools-core/internal";
 
-import { type DataVisualizationTreeProps } from "./CommonInterfaces";
-import { TreeDataView } from "./TreeDataView";
-import { TreeHeader } from "./TreeHeader";
-import { TreeItem } from "./TreeItem";
+import { type DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { TreeDataView } from "./TreeDataView.js";
+import { TreeHeader } from "./TreeHeader.js";
+import { TreeItem } from "./TreeItem.js";
 
 /**
  * {@link TreeView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownDataView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownDataView.tsx
@@ -4,11 +4,11 @@
  */
 import React from "react";
 
-import { type UnknownObjectNode } from "@fluid-experimental/devtools-core";
+import { type UnknownObjectNode } from "@fluid-experimental/devtools-core/internal";
 
-import { type DataVisualizationTreeProps } from "./CommonInterfaces";
-import { TreeHeader } from "./TreeHeader";
-import { TreeItem } from "./TreeItem";
+import { type DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { TreeHeader } from "./TreeHeader.js";
+import { TreeItem } from "./TreeItem.js";
 
 /**
  * {@link UnknownDataView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownFluidObjectView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/UnknownFluidObjectView.tsx
@@ -4,11 +4,11 @@
  */
 import React from "react";
 
-import { type FluidUnknownObjectNode } from "@fluid-experimental/devtools-core";
+import { type FluidUnknownObjectNode } from "@fluid-experimental/devtools-core/internal";
 
-import { type DataVisualizationTreeProps } from "./CommonInterfaces";
-import { TreeHeader } from "./TreeHeader";
-import { TreeItem } from "./TreeItem";
+import { type DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { TreeHeader } from "./TreeHeader.js";
+import { TreeItem } from "./TreeItem.js";
 
 /**
  * {@link UnknownFluidObjectView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/ValueView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/ValueView.tsx
@@ -4,11 +4,11 @@
  */
 import React from "react";
 
-import { type ValueNodeBase } from "@fluid-experimental/devtools-core";
+import { type ValueNodeBase } from "@fluid-experimental/devtools-core/internal";
 
-import { type DataVisualizationTreeProps } from "./CommonInterfaces";
-import { TreeHeader } from "./TreeHeader";
-import { TreeItem } from "./TreeItem";
+import { type DataVisualizationTreeProps } from "./CommonInterfaces.js";
+import { TreeHeader } from "./TreeHeader.js";
+import { TreeItem } from "./TreeItem.js";
 
 /**
  * {@link ValueView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/index.ts
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/index.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-export type { FluidHandleViewProps } from "./FluidHandleView";
-export { FluidHandleView } from "./FluidHandleView";
-export type { FluidTreeViewProps } from "./FluidTreeView";
-export { FluidTreeView } from "./FluidTreeView";
-export type { FluidValueViewProps } from "./FluidValueView";
-export { FluidValueView } from "./FluidValueView";
-export type { TreeDataViewProps } from "./TreeDataView";
-export { TreeDataView } from "./TreeDataView";
-export type { TreeHeaderProps } from "./TreeHeader";
-export { TreeHeader } from "./TreeHeader";
-export type { TreeViewProps } from "./TreeView";
-export { TreeView } from "./TreeView";
-export type { UnknownDataViewProps } from "./UnknownDataView";
-export { UnknownDataView } from "./UnknownDataView";
-export type { UnknownFluidObjectViewProps } from "./UnknownFluidObjectView";
-export { UnknownFluidObjectView } from "./UnknownFluidObjectView";
-export type { ValueViewProps } from "./ValueView";
-export { ValueView } from "./ValueView";
+export type { FluidHandleViewProps } from "./FluidHandleView.js";
+export { FluidHandleView } from "./FluidHandleView.js";
+export type { FluidTreeViewProps } from "./FluidTreeView.js";
+export { FluidTreeView } from "./FluidTreeView.js";
+export type { FluidValueViewProps } from "./FluidValueView.js";
+export { FluidValueView } from "./FluidValueView.js";
+export type { TreeDataViewProps } from "./TreeDataView.js";
+export { TreeDataView } from "./TreeDataView.js";
+export type { TreeHeaderProps } from "./TreeHeader.js";
+export { TreeHeader } from "./TreeHeader.js";
+export type { TreeViewProps } from "./TreeView.js";
+export { TreeView } from "./TreeView.js";
+export type { UnknownDataViewProps } from "./UnknownDataView.js";
+export { UnknownDataView } from "./UnknownDataView.js";
+export type { UnknownFluidObjectViewProps } from "./UnknownFluidObjectView.js";
+export { UnknownFluidObjectView } from "./UnknownFluidObjectView.js";
+export type { ValueViewProps } from "./ValueView.js";
+export { ValueView } from "./ValueView.js";

--- a/packages/tools/devtools/devtools-view/src/components/graphs/DynamicComposedChart.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/graphs/DynamicComposedChart.tsx
@@ -23,7 +23,7 @@ import {
 	XAxis,
 	YAxis,
 } from "recharts";
-import { ThemeOption, useThemeContext } from "../../ThemeHelper";
+import { ThemeOption, useThemeContext } from "../../ThemeHelper.js";
 
 /**
  * Data To be rendered with Op Latency Graph

--- a/packages/tools/devtools/devtools-view/src/components/graphs/index.ts
+++ b/packages/tools/devtools/devtools-view/src/components/graphs/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export type { DynamicComposedChartProps, GraphDataSet } from "./DynamicComposedChart";
-export { DynamicComposedChart } from "./DynamicComposedChart";
+export type { DynamicComposedChartProps, GraphDataSet } from "./DynamicComposedChart.js";
+export { DynamicComposedChart } from "./DynamicComposedChart.js";

--- a/packages/tools/devtools/devtools-view/src/components/index.ts
+++ b/packages/tools/devtools/devtools-view/src/components/index.ts
@@ -6,20 +6,21 @@
 // All of the components in this directory are intended to be used within this package,
 // so we will export * here
 /* eslint-disable no-restricted-syntax */
+/* eslint-disable import/no-internal-modules */
 
-export * from "./data-visualization";
+export * from "./data-visualization/index.js";
 
-export * from "./AudienceHistoryTable";
-export * from "./AudienceView";
-export * from "./ContainerDevtoolsView";
-export * from "./ContainerHistoryView";
-export * from "./ContainerSummaryView";
-export * from "./LandingView";
-export * from "./Menu";
-export * from "./NoDevtoolsErrorBar";
-export * from "./TelemetryView";
-export * from "./SettingsView";
-export * from "./OpLatencyView";
-export * from "./Waiting";
+export * from "./AudienceHistoryTable.js";
+export * from "./AudienceView.js";
+export * from "./ContainerDevtoolsView.js";
+export * from "./ContainerHistoryView.js";
+export * from "./ContainerSummaryView.js";
+export * from "./LandingView.js";
+export * from "./Menu.js";
+export * from "./NoDevtoolsErrorBar.js";
+export * from "./TelemetryView.js";
+export * from "./SettingsView.js";
+export * from "./OpLatencyView.js";
+export * from "./Waiting.js";
 
 /* eslint-enable no-restricted-syntax */

--- a/packages/tools/devtools/devtools-view/src/components/utility-components/index.ts
+++ b/packages/tools/devtools/devtools-view/src/components/utility-components/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export type { LabelCellLayoutProps } from "./LabelCellLayout";
-export { LabelCellLayout } from "./LabelCellLayout";
+export type { LabelCellLayoutProps } from "./LabelCellLayout.js";
+export { LabelCellLayout } from "./LabelCellLayout.js";

--- a/packages/tools/devtools/devtools-view/src/index.ts
+++ b/packages/tools/devtools/devtools-view/src/index.ts
@@ -16,10 +16,10 @@
  * @packageDocumentation
  */
 
-export type { DevtoolsPanelProps } from "./DevtoolsPanel";
-export { DevtoolsPanel } from "./DevtoolsPanel";
-export { WindowMessageRelay } from "./WindowMessageRelay";
+export type { DevtoolsPanelProps } from "./DevtoolsPanel.js";
+export { DevtoolsPanel } from "./DevtoolsPanel.js";
+export { WindowMessageRelay } from "./WindowMessageRelay.js";
 
 // Convenience re-exports
-export type { IMessageRelay } from "@fluid-experimental/devtools-core";
+export type { IMessageRelay } from "@fluid-experimental/devtools-core/internal";
 export type { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";

--- a/packages/tools/devtools/devtools-view/src/screenshot-tests/Screenshot.test.ts
+++ b/packages/tools/devtools/devtools-view/src/screenshot-tests/Screenshot.test.ts
@@ -18,6 +18,7 @@ import { simpleGit, pathspec } from "simple-git";
 import { ThemeOption } from "../ThemeHelper.js";
 
 const { default: chalk } = chalkLib;
+
 /**
  * Viewport configuration for running a screenshot test.
  */

--- a/packages/tools/devtools/devtools-view/src/screenshot-tests/Screenshot.test.ts
+++ b/packages/tools/devtools/devtools-view/src/screenshot-tests/Screenshot.test.ts
@@ -9,14 +9,15 @@ import { decodeComponentId, type RPCs } from "@previewjs/api";
 import { createChromelessWorkspace } from "@previewjs/chromeless";
 import reactPlugin from "@previewjs/plugin-react";
 import { expect } from "chai";
-import chalk from "chalk";
+import { default as chalkLib } from "chalk";
 import { run } from "mocha";
 import { globby } from "globby";
 import { chromium } from "playwright";
 import { simpleGit, pathspec } from "simple-git";
 
-import { ThemeOption } from "../ThemeHelper";
+import { ThemeOption } from "../ThemeHelper.js";
 
+const { default: chalk } = chalkLib;
 /**
  * Viewport configuration for running a screenshot test.
  */

--- a/packages/tools/devtools/devtools-view/src/screenshot-tests/ScreenshotTestUtilities.tsx
+++ b/packages/tools/devtools/devtools-view/src/screenshot-tests/ScreenshotTestUtilities.tsx
@@ -8,10 +8,10 @@ import React from "react";
 
 import { createChildLogger } from "@fluidframework/telemetry-utils";
 
-import { MockMessageRelay } from "../test/MockMessageRelay";
-import { MessageRelayContext } from "../MessageRelayContext";
-import { LoggerContext } from "../TelemetryUtils";
-import { getFluentUIThemeToUse } from "../ThemeHelper";
+import { MockMessageRelay } from "../test/MockMessageRelay.js";
+import { MessageRelayContext } from "../MessageRelayContext.js";
+import { LoggerContext } from "../TelemetryUtils.js";
+import { getFluentUIThemeToUse } from "../ThemeHelper.js";
 
 /**
  * {@link TestContexts} input props.

--- a/packages/tools/devtools/devtools-view/src/screenshot-tests/stories/AudienceHistoryTable.stories.tsx
+++ b/packages/tools/devtools/devtools-view/src/screenshot-tests/stories/AudienceHistoryTable.stories.tsx
@@ -4,8 +4,8 @@
  */
 
 // PreviewJS doesn't handle roll-up modules correctly. Must import directly from component module.
-import { AudienceHistoryTable } from "../../components/AudienceHistoryTable";
-import { testContextDecorator } from "../ScreenshotTestUtilities";
+import { AudienceHistoryTable } from "../../components/AudienceHistoryTable.js";
+import { testContextDecorator } from "../ScreenshotTestUtilities.js";
 
 export default {
 	title: "AudienceHistoryTable",

--- a/packages/tools/devtools/devtools-view/src/screenshot-tests/stories/TreeHeader.stories.tsx
+++ b/packages/tools/devtools/devtools-view/src/screenshot-tests/stories/TreeHeader.stories.tsx
@@ -4,8 +4,8 @@
  */
 
 // PreviewJS doesn't handle roll-up modules correctly. Must import directly from component module.
-import { TreeHeader } from "../../components/data-visualization/TreeHeader";
-import { testContextDecorator } from "../ScreenshotTestUtilities";
+import { TreeHeader } from "../../components/data-visualization/TreeHeader.js";
+import { testContextDecorator } from "../ScreenshotTestUtilities.js";
 
 export default {
 	title: "TreeHeader",

--- a/packages/tools/devtools/devtools-view/src/screenshot-tests/stories/Waiting.stories.tsx
+++ b/packages/tools/devtools/devtools-view/src/screenshot-tests/stories/Waiting.stories.tsx
@@ -4,8 +4,8 @@
  */
 
 // PreviewJS doesn't handle roll-up modules correctly. Must import directly from component module.
-import { Waiting } from "../../components/Waiting";
-import { testContextDecorator } from "../ScreenshotTestUtilities";
+import { Waiting } from "../../components/Waiting.js";
+import { testContextDecorator } from "../ScreenshotTestUtilities.js";
 
 export default {
 	title: "Waiting",

--- a/packages/tools/devtools/devtools-view/src/test/AudienceHistoryTable.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/AudienceHistoryTable.test.tsx
@@ -9,7 +9,8 @@ import React from "react";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
-import { AudienceHistoryTable, type TransformedAudienceHistoryData } from "../components";
+// eslint-disable-next-line import/no-internal-modules
+import { AudienceHistoryTable, type TransformedAudienceHistoryData } from "../components/index.js";
 
 describe("AudienceHistoryTable component tests", () => {
 	async function getTableBodyRows(): Promise<HTMLCollection> {

--- a/packages/tools/devtools/devtools-view/src/test/DynamicComposedChart.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/DynamicComposedChart.test.tsx
@@ -10,7 +10,7 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
 // eslint-disable-next-line import/no-internal-modules
-import { DynamicComposedChart, type GraphDataSet } from "../components/graphs";
+import { DynamicComposedChart, type GraphDataSet } from "../components/graphs/index.js";
 
 // ResizeObserver is a hook used by Recharts that needs to be mocked for unit tests to function.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any

--- a/packages/tools/devtools/devtools-view/src/test/MockMessageRelay.ts
+++ b/packages/tools/devtools/devtools-view/src/test/MockMessageRelay.ts
@@ -7,7 +7,7 @@ import {
 	type IMessageRelay,
 	type IMessageRelayEvents,
 	type IDevtoolsMessage,
-} from "@fluid-experimental/devtools-core";
+} from "@fluid-experimental/devtools-core/internal";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 
 /**

--- a/packages/tools/devtools/devtools-view/src/test/NoDevtoolsErrorBar.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/NoDevtoolsErrorBar.test.tsx
@@ -10,7 +10,8 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { coreErrorMessage, docsLinkUrl, NoDevtoolsErrorBar } from "../components";
+// eslint-disable-next-line import/no-internal-modules
+import { coreErrorMessage, docsLinkUrl, NoDevtoolsErrorBar } from "../components/index.js";
 
 describe("NoDevtoolsErrorBar component tests", () => {
 	it("Displays expected text and contains expected link", async (): Promise<void> => {
@@ -28,7 +29,8 @@ describe("NoDevtoolsErrorBar component tests", () => {
 		render(<NoDevtoolsErrorBar dismiss={dismiss} retrySearch={(): void => {}} />);
 
 		const dismissButton = await screen.findByRole("button"); // Dismiss button is first button rendered
-		await userEvent.click(dismissButton);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+		await (userEvent as any).click(dismissButton);
 		expect(dismiss).toHaveBeenCalled();
 	});
 
@@ -37,7 +39,8 @@ describe("NoDevtoolsErrorBar component tests", () => {
 		render(<NoDevtoolsErrorBar dismiss={(): void => {}} retrySearch={retrySearch} />);
 
 		const retrySearchButton = await screen.findByTestId("retry-search-button");
-		await userEvent.click(retrySearchButton);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+		await (userEvent as any).click(retrySearchButton);
 		expect(retrySearch).toHaveBeenCalled();
 	});
 });

--- a/packages/tools/devtools/devtools-view/src/test/OpLatencyView.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/OpLatencyView.test.tsx
@@ -9,7 +9,8 @@ import React from "react";
 import "@testing-library/jest-dom";
 import { render, screen, within } from "@testing-library/react";
 
-import { OpLatencyView } from "../components";
+// eslint-disable-next-line import/no-internal-modules
+import { OpLatencyView } from "../components/index.js";
 
 // ResizeObserver is a hook used by Recharts that needs to be mocked for unit tests to function.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any

--- a/packages/tools/devtools/devtools-view/src/test/VisualTree.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/VisualTree.test.tsx
@@ -18,10 +18,11 @@ import {
 	type FluidUnknownObjectNode,
 	type UnknownObjectNode,
 	VisualNodeKind,
-} from "@fluid-experimental/devtools-core";
-import { UnknownDataView, FluidTreeView, UnknownFluidObjectView } from "../components";
-import { MessageRelayContext } from "../MessageRelayContext";
-import { MockMessageRelay } from "./MockMessageRelay";
+} from "@fluid-experimental/devtools-core/internal";
+// eslint-disable-next-line import/no-internal-modules
+import { UnknownDataView, FluidTreeView, UnknownFluidObjectView } from "../components/index.js";
+import { MessageRelayContext } from "../MessageRelayContext.js";
+import { MockMessageRelay } from "./MockMessageRelay.js";
 
 const testContainerKey = "test-container-key";
 const testFluidObjectId = "test-fluid-object-id";
@@ -120,7 +121,8 @@ describe("VisualTreeView component tests", () => {
 
 		// TODO: Loop the expand button for n-amount of times.
 		const expandButton = await screen.findByTestId("tree-button");
-		await userEvent.click(expandButton);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+		await (userEvent as any).click(expandButton);
 
 		await screen.findByText(/test-node-key/);
 

--- a/packages/tools/devtools/devtools-view/src/test/Waiting.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/Waiting.test.tsx
@@ -7,7 +7,8 @@ import React from "react";
 
 import { render, screen } from "@testing-library/react";
 
-import { Waiting, defaultWaitingLabel } from "../components";
+// eslint-disable-next-line import/no-internal-modules
+import { Waiting, defaultWaitingLabel } from "../components/index.js";
 
 describe("Waiting component tests", () => {
 	it("Displays default label when a label is not specified", async (): Promise<void> => {

--- a/packages/tools/devtools/devtools-view/tsconfig.json
+++ b/packages/tools/devtools/devtools-view/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"compilerOptions": {
 		"module": "esnext",
+		"moduleResolution": "node16",
 		"lib": ["ESNext", "DOM"],
 		"rootDir": "src",
 		"outDir": "dist",

--- a/packages/tools/devtools/devtools/tsconfig.json
+++ b/packages/tools/devtools/devtools/tsconfig.json
@@ -5,6 +5,7 @@
 		"outDir": "dist",
 		"composite": true,
 		"types": ["chai", "mocha"],
+		"moduleResolution": "node16",
 	},
 	"include": ["src/**/*"],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8076,7 +8076,7 @@ importers:
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
     devDependencies:
       '@fluidframework/build-common': 2.0.2
-      '@fluidframework/build-tools': 0.26.0-203096
+      '@fluidframework/build-tools': 0.26.0-203096_@types+node@16.18.58
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
@@ -10745,6 +10745,8 @@ importers:
       cross-env: ^7.0.3
       eslint: ~8.50.0
       eslint-config-prettier: ~9.0.0
+      eslint-import-resolver-typescript: ^3.6.1
+      eslint-plugin-import: ~2.28.1
       eslint-plugin-jest: ~27.4.2
       eslint-plugin-react: ~7.33.2
       eslint-plugin-react-hooks: ~4.6.0
@@ -10790,7 +10792,7 @@ importers:
     devDependencies:
       '@fluidframework/build-common': 2.0.2
       '@fluidframework/build-tools': 0.26.0-203096_@types+node@16.18.58
-      '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
+      '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
       '@fluidframework/test-runtime-utils': link:../../../runtime/test-runtime-utils
@@ -10817,6 +10819,8 @@ importers:
       cross-env: 7.0.3
       eslint: 8.50.0
       eslint-config-prettier: 9.0.0_eslint@8.50.0
+      eslint-import-resolver-typescript: 3.6.1_mc36sq7crv2v5vtlozlclqwu5e
+      eslint-plugin-import: 2.28.1_rdoeqvzpa2jmvnyuviohvk2bau
       eslint-plugin-jest: 27.4.2_6qqm6drbyi4cpw3yzxwfwf3ppm
       eslint-plugin-react: 7.33.2_eslint@8.50.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.50.0


### PR DESCRIPTION
This PR is an experiment in using the exports field to provide an explicit entrypoint to use for internal purposes, separate from the package's public API. I used the devtools packages as a testbed.

The devtools-view package required the most changes. It is an ESM-only package (`type: module` in package.json), so when I switched the moduleResolution to node16, I had to update all the imports to add file extensions. I also had to update the chalk import. This might be alleviated by updating to a more recent version of chalk that is ESM-only, but that will cause other problems.

Switching to CJS by removing the `type: module` setting in package.json alleviates some problems, but causes others, because some of the dependencies are also ESM-only. That would require switching to dynamic imports for those packages, which is a decision best left to the code owners.

I wasn't able to get devtools-view to compile because of a react thing I don't understand. The problem is with a dependency whose most recent version is 3 years old, so the simplest solution might be to find a new dependency.