### PR TITLE
GC: Refactor GC tombstone configs initialization to be in one place in garbage collector

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -140,7 +140,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     ensureNoDataModelChanges<T>(callback: () => T): T;
     // (undocumented)
     get flushMode(): FlushMode;
-    readonly gcTombstoneEnforcementAllowed: boolean;
+    get gcThrowOnTombstoneLoad(): boolean;
+    get gcThrowOnTombstoneUsage(): boolean;
+    get gcTombstoneEnforcementAllowed(): boolean;
     // (undocumented)
     readonly getAbsoluteUrl: (relativeUrl: string) => Promise<string | undefined>;
     getAliasedDataStoreEntryPoint(alias: string): Promise<IFluidHandle<FluidObject> | undefined>;

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -109,6 +109,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_ContainerRuntime": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1141,17 +1141,17 @@ export class ContainerRuntime
 
 	/** If false, loading or using a Tombstoned object should merely log, not fail */
 	public get gcTombstoneEnforcementAllowed(): boolean {
-		return this.garbageCollector.gcTombstoneEnforcementAllowed;
+		return this.garbageCollector.tombstoneEnforcementAllowed;
 	}
 
 	/** If true, throw an error when a tombstone data store is retrieved */
 	public get gcThrowOnTombstoneLoad(): boolean {
-		return this.garbageCollector.gcThrowOnTombstoneLoad;
+		return this.garbageCollector.throwOnTombstoneLoad;
 	}
 
 	/** If true, throw an error when a tombstone data store is used. */
 	public get gcThrowOnTombstoneUsage(): boolean {
-		return this.garbageCollector.gcThrowOnTombstoneUsage;
+		return this.garbageCollector.throwOnTombstoneUsage;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -166,7 +166,6 @@ import {
 	IGarbageCollector,
 	IGCRuntimeOptions,
 	IGCStats,
-	shouldAllowGcTombstoneEnforcement,
 	trimLeadingAndTrailingSlashes,
 } from "./gc";
 import { channelToDataStore, IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
@@ -1140,10 +1139,20 @@ export class ContainerRuntime
 	 */
 	private nextSummaryNumber: number;
 
-	/**
-	 * If false, loading or using a Tombstoned object should merely log, not fail
-	 */
-	public readonly gcTombstoneEnforcementAllowed: boolean;
+	/** If false, loading or using a Tombstoned object should merely log, not fail */
+	public get gcTombstoneEnforcementAllowed(): boolean {
+		return this.garbageCollector.gcTombstoneEnforcementAllowed;
+	}
+
+	/** If true, throw an error when a tombstone data store is retrieved */
+	public get gcThrowOnTombstoneLoad(): boolean {
+		return this.garbageCollector.gcThrowOnTombstoneLoad;
+	}
+
+	/** If true, throw an error when a tombstone data store is used. */
+	public get gcThrowOnTombstoneUsage(): boolean {
+		return this.garbageCollector.gcThrowOnTombstoneUsage;
+	}
 
 	/**
 	 * GUID to identify a document in telemetry
@@ -1289,11 +1298,6 @@ export class ContainerRuntime
 		// Note that we only need to pull the *initial* connected state from the context.
 		// Later updates come through calls to setConnectionState.
 		this._connected = connected;
-
-		this.gcTombstoneEnforcementAllowed = shouldAllowGcTombstoneEnforcement(
-			metadata?.gcFeatureMatrix?.tombstoneGeneration /* persisted */,
-			this.runtimeOptions.gcOptions[gcTombstoneGenerationOptionName] /* current */,
-		);
 
 		this.mc.logger.sendTelemetryEvent({
 			eventName: "GCFeatureMatrix",

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -78,7 +78,7 @@ import {
 	summarizerClientType,
 } from "./summary";
 import { ContainerRuntime } from "./containerRuntime";
-import { sendGCUnexpectedUsageEvent, throwOnTombstoneUsageKey } from "./gc";
+import { sendGCUnexpectedUsageEvent } from "./gc";
 
 function createAttributes(
 	pkg: readonly string[],
@@ -326,10 +326,7 @@ export abstract class FluidDataStoreContext
 		);
 
 		// Tombstone should only throw when the feature flag is enabled and the client isn't a summarizer
-		this.throwOnTombstoneUsage =
-			this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
-			this._containerRuntime.gcTombstoneEnforcementAllowed &&
-			this.clientDetails.type !== summarizerClientType;
+		this.throwOnTombstoneUsage = this._containerRuntime.gcThrowOnTombstoneUsage;
 
 		// By default, a data store can log maximum 10 local changes telemetry in summarizer.
 		this.localChangesTelemetryCount =

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -325,7 +325,6 @@ export abstract class FluidDataStoreContext
 			this.mc.logger,
 		);
 
-		// Tombstone should only throw when the feature flag is enabled and the client isn't a summarizer
 		this.throwOnTombstoneUsage = this._containerRuntime.gcThrowOnTombstoneUsage;
 
 		// By default, a data store can log maximum 10 local changes telemetry in summarizer.

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -113,6 +113,19 @@ export class GarbageCollector implements IGarbageCollector {
 	private readonly summaryStateTracker: GCSummaryStateTracker;
 	private readonly telemetryTracker: GCTelemetryTracker;
 
+	/** If false, loading or using a Tombstoned object should merely log, not fail */
+	public get gcTombstoneEnforcementAllowed(): boolean {
+		return this.configs.gcTombstoneEnforcementAllowed;
+	}
+	/** If true, throw an error when a tombstone data store is retrieved */
+	public get gcThrowOnTombstoneLoad(): boolean {
+		return this.configs.gcThrowOnTombstoneLoad;
+	}
+	/** If true, throw an error when a tombstone data store is used. */
+	public get gcThrowOnTombstoneUsage(): boolean {
+		return this.configs.gcThrowOnTombstoneUsage;
+	}
+
 	/** For a given node path, returns the node's package path. */
 	private readonly getNodePackagePath: (
 		nodePath: string,
@@ -176,7 +189,6 @@ export class GarbageCollector implements IGarbageCollector {
 			this.mc,
 			this.configs,
 			this.isSummarizerClient,
-			this.runtime.gcTombstoneEnforcementAllowed,
 			createParams.createContainerMetadata,
 			(nodeId: string) => this.runtime.getNodeType(nodeId),
 			(nodeId: string) => this.unreferencedNodesState.get(nodeId),
@@ -892,7 +904,7 @@ export class GarbageCollector implements IGarbageCollector {
 		// We may throw when loading an Inactive object, depending on these preconditions
 		const shouldThrowOnInactiveLoad =
 			!this.isSummarizerClient &&
-			this.configs.throwOnInactiveLoad === true &&
+			this.configs.gcThrowOnInactiveLoad === true &&
 			requestHeaders?.[AllowInactiveRequestHeaderKey] !== true;
 		const state = this.unreferencedNodesState.get(nodePath)?.state;
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -114,16 +114,16 @@ export class GarbageCollector implements IGarbageCollector {
 	private readonly telemetryTracker: GCTelemetryTracker;
 
 	/** If false, loading or using a Tombstoned object should merely log, not fail */
-	public get gcTombstoneEnforcementAllowed(): boolean {
-		return this.configs.gcTombstoneEnforcementAllowed;
+	public get tombstoneEnforcementAllowed(): boolean {
+		return this.configs.tombstoneEnforcementAllowed;
 	}
 	/** If true, throw an error when a tombstone data store is retrieved */
-	public get gcThrowOnTombstoneLoad(): boolean {
-		return this.configs.gcThrowOnTombstoneLoad;
+	public get throwOnTombstoneLoad(): boolean {
+		return this.configs.throwOnTombstoneLoad;
 	}
-	/** If true, throw an error when a tombstone data store is used. */
-	public get gcThrowOnTombstoneUsage(): boolean {
-		return this.configs.gcThrowOnTombstoneUsage;
+	/** If true, throw an error when a tombstone data store is used */
+	public get throwOnTombstoneUsage(): boolean {
+		return this.configs.throwOnTombstoneUsage;
 	}
 
 	/** For a given node path, returns the node's package path. */
@@ -904,7 +904,7 @@ export class GarbageCollector implements IGarbageCollector {
 		// We may throw when loading an Inactive object, depending on these preconditions
 		const shouldThrowOnInactiveLoad =
 			!this.isSummarizerClient &&
-			this.configs.gcThrowOnInactiveLoad === true &&
+			this.configs.throwOnInactiveLoad === true &&
 			requestHeaders?.[AllowInactiveRequestHeaderKey] !== true;
 		const state = this.unreferencedNodesState.get(nodePath)?.state;
 

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -24,8 +24,10 @@ import {
 	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
+	throwOnTombstoneLoadKey,
+	throwOnTombstoneUsageKey,
 } from "./gcDefinitions";
-import { getGCVersion, shouldAllowGcSweep } from "./gcHelpers";
+import { getGCVersion, shouldAllowGcSweep, shouldAllowGcTombstoneEnforcement } from "./gcHelpers";
 
 /**
  * Generates configurations for the Garbage Collector that it uses to determine what to run and how.
@@ -42,6 +44,7 @@ export function generateGCConfigs(
 		gcOptions: IGCRuntimeOptions;
 		metadata: IContainerRuntimeMetadata | undefined;
 		existing: boolean;
+		isSummarizerClient: boolean;
 	},
 ): IGarbageCollectorConfigs {
 	let gcEnabled: boolean;
@@ -152,8 +155,6 @@ export function generateGCConfigs(
 		throw new UsageError("inactive timeout should not be greater than the sweep timeout");
 	}
 
-	const throwOnInactiveLoad: boolean | undefined = createParams.gcOptions.throwOnInactiveLoad;
-
 	// Whether we are running in test mode. In this mode, unreferenced nodes are immediately deleted.
 	const testMode =
 		mc.config.getBoolean(gcTestModeKey) ?? createParams.gcOptions.runGCInTestMode === true;
@@ -161,6 +162,20 @@ export function generateGCConfigs(
 	// via feature flags.
 	const tombstoneMode = !shouldRunSweep && mc.config.getBoolean(disableTombstoneKey) !== true;
 	const runFullGC = createParams.gcOptions.runFullGC;
+
+	const gcThrowOnInactiveLoad: boolean | undefined = createParams.gcOptions.throwOnInactiveLoad;
+	const gcTombstoneEnforcementAllowed = shouldAllowGcTombstoneEnforcement(
+		createParams.metadata?.gcFeatureMatrix?.tombstoneGeneration /* persisted */,
+		createParams.gcOptions[gcTombstoneGenerationOptionName] /* current */,
+	);
+	const gcThrowOnTombstoneLoad =
+		mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
+		gcTombstoneEnforcementAllowed &&
+		!createParams.isSummarizerClient;
+	const gcThrowOnTombstoneUsage =
+		mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
+		gcTombstoneEnforcementAllowed &&
+		!createParams.isSummarizerClient;
 
 	return {
 		gcEnabled,
@@ -173,10 +188,13 @@ export function generateGCConfigs(
 		sessionExpiryTimeoutMs,
 		sweepTimeoutMs,
 		inactiveTimeoutMs,
-		throwOnInactiveLoad,
 		persistedGcFeatureMatrix,
 		gcVersionInBaseSnapshot,
 		gcVersionInEffect,
+		gcThrowOnInactiveLoad,
+		gcTombstoneEnforcementAllowed,
+		gcThrowOnTombstoneLoad,
+		gcThrowOnTombstoneUsage,
 	};
 }
 

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -163,18 +163,18 @@ export function generateGCConfigs(
 	const tombstoneMode = !shouldRunSweep && mc.config.getBoolean(disableTombstoneKey) !== true;
 	const runFullGC = createParams.gcOptions.runFullGC;
 
-	const gcThrowOnInactiveLoad: boolean | undefined = createParams.gcOptions.throwOnInactiveLoad;
-	const gcTombstoneEnforcementAllowed = shouldAllowGcTombstoneEnforcement(
+	const throwOnInactiveLoad: boolean | undefined = createParams.gcOptions.throwOnInactiveLoad;
+	const tombstoneEnforcementAllowed = shouldAllowGcTombstoneEnforcement(
 		createParams.metadata?.gcFeatureMatrix?.tombstoneGeneration /* persisted */,
 		createParams.gcOptions[gcTombstoneGenerationOptionName] /* current */,
 	);
-	const gcThrowOnTombstoneLoad =
+	const throwOnTombstoneLoad =
 		mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
-		gcTombstoneEnforcementAllowed &&
+		tombstoneEnforcementAllowed &&
 		!createParams.isSummarizerClient;
-	const gcThrowOnTombstoneUsage =
+	const throwOnTombstoneUsage =
 		mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
-		gcTombstoneEnforcementAllowed &&
+		tombstoneEnforcementAllowed &&
 		!createParams.isSummarizerClient;
 
 	return {
@@ -191,10 +191,10 @@ export function generateGCConfigs(
 		persistedGcFeatureMatrix,
 		gcVersionInBaseSnapshot,
 		gcVersionInEffect,
-		gcThrowOnInactiveLoad,
-		gcTombstoneEnforcementAllowed,
-		gcThrowOnTombstoneLoad,
-		gcThrowOnTombstoneUsage,
+		throwOnInactiveLoad,
+		tombstoneEnforcementAllowed,
+		throwOnTombstoneLoad,
+		throwOnTombstoneUsage,
 	};
 }
 

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -204,11 +204,11 @@ export interface IGarbageCollector {
 	/** The count of data stores whose GC state updated since the last summary. */
 	readonly updatedDSCountSinceLastSummary: number;
 	/** Tells whether tombstone feature is enabled and enforced. */
-	readonly gcTombstoneEnforcementAllowed: boolean;
+	readonly tombstoneEnforcementAllowed: boolean;
 	/** Tells whether loading a tombstone object should fail or merely log. */
-	readonly gcThrowOnTombstoneLoad: boolean;
+	readonly throwOnTombstoneLoad: boolean;
 	/** Tells whether using a tombstone object should fail or merely log. */
-	readonly gcThrowOnTombstoneUsage: boolean;
+	readonly throwOnTombstoneUsage: boolean;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */
@@ -352,13 +352,13 @@ export interface IGarbageCollectorConfigs {
 	/** The current version of GC data in the running code */
 	readonly gcVersionInEffect: GCVersion;
 	/** It is easier for users to diagnose InactiveObject usage if we throw on load, which this option enables */
-	readonly gcThrowOnInactiveLoad: boolean | undefined;
+	readonly throwOnInactiveLoad: boolean | undefined;
 	/** If false, loading or using a Tombstoned object should merely log, not fail */
-	readonly gcTombstoneEnforcementAllowed: boolean;
+	readonly tombstoneEnforcementAllowed: boolean;
 	/** If true, throw an error when a tombstone data store is retrieved */
-	readonly gcThrowOnTombstoneLoad: boolean;
+	readonly throwOnTombstoneLoad: boolean;
 	/** If true, throw an error when a tombstone data store is used. */
-	readonly gcThrowOnTombstoneUsage: boolean;
+	readonly throwOnTombstoneUsage: boolean;
 }
 
 /** The state of node that is unreferenced. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -193,8 +193,6 @@ export interface IGarbageCollectionRuntime {
 	getNodeType(nodePath: string): GCNodeType;
 	/** Called when the runtime should close because of an error. */
 	closeFn: (error?: ICriticalContainerError) => void;
-	/** If false, loading or using a Tombstoned object should merely log, not fail */
-	gcTombstoneEnforcementAllowed: boolean;
 }
 
 /** Defines the contract for the garbage collector. */
@@ -205,6 +203,12 @@ export interface IGarbageCollector {
 	readonly summaryStateNeedsReset: boolean;
 	/** The count of data stores whose GC state updated since the last summary. */
 	readonly updatedDSCountSinceLastSummary: number;
+	/** Tells whether tombstone feature is enabled and enforced. */
+	readonly gcTombstoneEnforcementAllowed: boolean;
+	/** Tells whether loading a tombstone object should fail or merely log. */
+	readonly gcThrowOnTombstoneLoad: boolean;
+	/** Tells whether using a tombstone object should fail or merely log. */
+	readonly gcThrowOnTombstoneUsage: boolean;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */
@@ -332,8 +336,6 @@ export interface IGarbageCollectorConfigs {
 	readonly sweepTimeoutMs: number | undefined;
 	/** The time after which an unreferenced node is inactive. */
 	readonly inactiveTimeoutMs: number;
-	/** It is easier for users to diagnose InactiveObject usage if we throw on load, which this option enables */
-	readonly throwOnInactiveLoad: boolean | undefined;
 	/** Tracks whether GC should run in test mode. In this mode, unreferenced objects are deleted immediately. */
 	readonly testMode: boolean;
 	/**
@@ -349,6 +351,14 @@ export interface IGarbageCollectorConfigs {
 	readonly gcVersionInBaseSnapshot: GCVersion | undefined;
 	/** The current version of GC data in the running code */
 	readonly gcVersionInEffect: GCVersion;
+	/** It is easier for users to diagnose InactiveObject usage if we throw on load, which this option enables */
+	readonly gcThrowOnInactiveLoad: boolean | undefined;
+	/** If false, loading or using a Tombstoned object should merely log, not fail */
+	readonly gcTombstoneEnforcementAllowed: boolean;
+	/** If true, throw an error when a tombstone data store is retrieved */
+	readonly gcThrowOnTombstoneLoad: boolean;
+	/** If true, throw an error when a tombstone data store is used. */
+	readonly gcThrowOnTombstoneUsage: boolean;
 }
 
 /** The state of node that is unreferenced. */

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -80,7 +80,7 @@ export class GCTelemetryTracker {
 		private readonly mc: MonitoringContext,
 		private readonly configs: Pick<
 			IGarbageCollectorConfigs,
-			"inactiveTimeoutMs" | "sweepTimeoutMs" | "gcTombstoneEnforcementAllowed"
+			"inactiveTimeoutMs" | "sweepTimeoutMs" | "tombstoneEnforcementAllowed"
 		>,
 		private readonly isSummarizerClient: boolean,
 		private readonly createContainerMetadata: ICreateContainerMetadata,
@@ -183,7 +183,7 @@ export class GCTelemetryTracker {
 					eventName: `GC_Tombstone_${nodeType}_Revived`,
 					category: "generic",
 					...tagCodeArtifacts({ url: id }),
-					gcTombstoneEnforcementAllowed: this.configs.gcTombstoneEnforcementAllowed,
+					gcTombstoneEnforcementAllowed: this.configs.tombstoneEnforcementAllowed,
 				},
 				undefined /* packagePath */,
 			);

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -80,10 +80,9 @@ export class GCTelemetryTracker {
 		private readonly mc: MonitoringContext,
 		private readonly configs: Pick<
 			IGarbageCollectorConfigs,
-			"inactiveTimeoutMs" | "sweepTimeoutMs"
+			"inactiveTimeoutMs" | "sweepTimeoutMs" | "gcTombstoneEnforcementAllowed"
 		>,
 		private readonly isSummarizerClient: boolean,
-		private readonly gcTombstoneEnforcementAllowed: boolean,
 		private readonly createContainerMetadata: ICreateContainerMetadata,
 		private readonly getNodeType: (nodeId: string) => GCNodeType,
 		private readonly getNodeStateTracker: (
@@ -184,7 +183,7 @@ export class GCTelemetryTracker {
 					eventName: `GC_Tombstone_${nodeType}_Revived`,
 					category: "generic",
 					...tagCodeArtifacts({ url: id }),
-					gcTombstoneEnforcementAllowed: this.gcTombstoneEnforcementAllowed,
+					gcTombstoneEnforcementAllowed: this.configs.gcTombstoneEnforcementAllowed,
 				},
 				undefined /* packagePath */,
 			);

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -31,15 +31,11 @@ export {
 	stableGCVersion,
 	disableAttachmentBlobSweepKey,
 	disableDatastoreSweepKey,
-	throwOnTombstoneLoadKey,
-	throwOnTombstoneUsageKey,
 	UnreferencedState,
 } from "./gcDefinitions";
 export {
 	cloneGCData,
 	concatGarbageCollectionStates,
-	shouldAllowGcTombstoneEnforcement,
-	shouldAllowGcSweep,
 	trimLeadingAndTrailingSlashes,
 	unpackChildNodesGCDetails,
 } from "./gcHelpers";

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -93,6 +93,7 @@ export class MockRuntime
 	}
 
 	public gcTombstoneEnforcementAllowed: boolean = true;
+	public gcThrowOnTombstoneLoad: boolean = false;
 
 	public get storage() {
 		return (this.attachState === AttachState.Detached

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -123,7 +123,6 @@ describe("Garbage Collection Tests", () => {
 			getNodeType,
 			getCurrentReferenceTimestampMs: () => Date.now(),
 			closeFn,
-			gcTombstoneEnforcementAllowed: true,
 		};
 
 		let metadata = createParams.metadata;

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -116,7 +116,6 @@ describe("Garbage Collection configurations", () => {
 			getNodeType,
 			getCurrentReferenceTimestampMs: () => Date.now(),
 			closeFn,
-			gcTombstoneEnforcementAllowed: true,
 		};
 
 		return GarbageCollector.create({

--- a/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
@@ -4,7 +4,9 @@
  */
 
 import { strict as assert } from "assert";
-import { shouldAllowGcTombstoneEnforcement, GCFeatureMatrix, shouldAllowGcSweep } from "../../gc";
+import { GCFeatureMatrix } from "../../gc";
+// eslint-disable-next-line import/no-internal-modules
+import { shouldAllowGcSweep, shouldAllowGcTombstoneEnforcement } from "../../gc/gcHelpers";
 
 describe("Garbage Collection Helpers Tests", () => {
 	describe("shouldAllowGcTombstoneEnforcement", () => {

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -71,9 +71,12 @@ describe("GC Telemetry Tracker", () => {
 		};
 		const tracker = new GCTelemetryTracker(
 			mc,
-			{ inactiveTimeoutMs, sweepTimeoutMs: enableSweep ? sweepTimeoutMs : undefined },
+			{
+				inactiveTimeoutMs,
+				sweepTimeoutMs: enableSweep ? sweepTimeoutMs : undefined,
+				gcTombstoneEnforcementAllowed: false,
+			},
 			isSummarizerClient,
-			false /* gcTombstoneEnforcementAllowed */,
 			{ createContainerRuntimeVersion: pkgVersion },
 			getNodeType,
 			(nodeId: string) => unreferencedNodesState.get(nodeId),

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -74,7 +74,7 @@ describe("GC Telemetry Tracker", () => {
 			{
 				inactiveTimeoutMs,
 				sweepTimeoutMs: enableSweep ? sweepTimeoutMs : undefined,
-				gcTombstoneEnforcementAllowed: false,
+				tombstoneEnforcementAllowed: false,
 			},
 			isSummarizerClient,
 			{ createContainerRuntimeVersion: pkgVersion },

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -151,6 +151,7 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*


### PR DESCRIPTION
This PR moves the gc tomsbtone configs initalization into one place in garbage collector configs. Currently, the same configs are initialized in DataStores, DataStoreContext and GarbageCollector making it possible for them to get out of sync. Also, changing it requires changing them everywhere making changes more complex and prone to errors.