### PR TITLE
[Port v2int 7.1] Fix grouped batching asserts

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1819,11 +1819,14 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		const pendingMessageIds = this.pendingKeys.get(op.key);
 		// Only submit the op, if we have record for it, otherwise it is possible that the older instance
 		// is already deleted, in which case we don't need to submit the op.
-		if (
-			pendingMessageIds !== undefined &&
-			pendingMessageIds[0] === localOpMetadata.pendingMessageId
-		) {
-			pendingMessageIds.shift();
+		if (pendingMessageIds !== undefined) {
+			const index = pendingMessageIds.findIndex(
+				(id) => id === localOpMetadata.pendingMessageId,
+			);
+			if (index === -1) {
+				return;
+			}
+			pendingMessageIds.splice(index, 1);
 			if (pendingMessageIds.length === 0) {
 				this.pendingKeys.delete(op.key);
 			}
@@ -2134,8 +2137,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			return false;
 		}
 
-		const pendingKeyMessageId = this.pendingKeys.get(op.key);
-		if (pendingKeyMessageId !== undefined) {
+		const pendingKeyMessageIds = this.pendingKeys.get(op.key);
+		if (pendingKeyMessageIds !== undefined) {
 			// Found an NACK op, clear it from the directory if the latest sequence number in the directory
 			// match the message's and don't process the op.
 			if (local) {
@@ -2143,14 +2146,12 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					localOpMetadata !== undefined && isKeyEditLocalOpMetadata(localOpMetadata),
 					0x011 /* pendingMessageId is missing from the local client's operation */,
 				);
-				const pendingMessageIds = this.pendingKeys.get(op.key);
 				assert(
-					pendingMessageIds !== undefined &&
-						pendingMessageIds[0] === localOpMetadata.pendingMessageId,
+					pendingKeyMessageIds[0] === localOpMetadata.pendingMessageId,
 					0x331 /* Unexpected pending message received */,
 				);
-				pendingMessageIds.shift();
-				if (pendingMessageIds.length === 0) {
+				pendingKeyMessageIds.shift();
+				if (pendingKeyMessageIds.length === 0) {
 					this.pendingKeys.delete(op.key);
 				}
 			}

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -323,7 +323,8 @@ export class ConsensusRegisterCollection<T>
 			);
 		} else if (data.versions.length > 0) {
 			assert(
-				sequenceNumber > data.versions[data.versions.length - 1].sequenceNumber,
+				// seqNum should always be increasing, except for the case of grouped batches (seqNum will be the same)
+				sequenceNumber >= data.versions[data.versions.length - 1].sequenceNumber,
 				0x071 /* "Versions should naturally be ordered by sequenceNumber" */,
 			);
 		}

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -621,7 +621,8 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 							m.minimumSequenceNumber < collabWindow.minSeq ||
 							m.referenceSequenceNumber < collabWindow.minSeq ||
 							m.sequenceNumber <= collabWindow.minSeq ||
-							m.sequenceNumber <= collabWindow.currentSeq
+							// sequenceNumber could be the same if messages are part of a grouped batch
+							m.sequenceNumber < collabWindow.currentSeq
 						) {
 							throw new Error(
 								`Invalid catchup operations in snapshot: ${JSON.stringify({

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -14,14 +14,20 @@ import {
 	DataObjectFactoryType,
 	ChannelFactoryRegistry,
 	ITestFluidObject,
+	createSummarizer,
+	summarizeNow,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-internal/test-version-utils";
+import { describeFullCompat, describeNoCompat } from "@fluid-internal/test-version-utils";
 
 const stringId = "sharedStringKey";
 const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
 const testContainerConfig: ITestContainerConfig = {
 	fluidDataObjectType: DataObjectFactoryType.Test,
 	registry,
+};
+const groupedBatchingContainerConfig: ITestContainerConfig = {
+	...testContainerConfig,
+	runtimeOptions: { enableGroupedBatching: true },
 };
 
 describeFullCompat("SharedString", (getTestObjectProvider) => {
@@ -116,5 +122,67 @@ describeFullCompat("SharedString", (getTestObjectProvider) => {
 		assert.equal(detachedString1.isAttached(), true, "detachedString1 should be attached");
 		assert.equal(detachedString2.isAttached(), true, "detachedString2 should be attached");
 		assert.equal(sharedString1.isAttached(), true, "sharedString1 should be attached");
+	});
+});
+
+describeNoCompat("SharedString grouped batching", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	beforeEach(() => {
+		provider = getTestObjectProvider();
+	});
+
+	it("can load summarized grouped batch at min seqnum", async () => {
+		const container1 = await provider.makeTestContainer(groupedBatchingContainerConfig);
+		const dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+		const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+
+		const text = "syncSharedString";
+		dataObject1.context.containerRuntime.orderSequentially(() => {
+			for (let i = 0; i < text.length; i++) {
+				sharedString1.insertText(i, text.charAt(i));
+			}
+		});
+
+		// Grouped batch should be min seqnum
+		await provider.ensureSynchronized();
+
+		sharedString1.insertText(0, "a");
+		await provider.ensureSynchronized();
+		const { summarizer } = await createSummarizer(provider, container1, testContainerConfig);
+		await summarizeNow(summarizer);
+
+		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+		const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+
+		// These calls ensures assert 0x072 isn't hit
+		sharedString2.insertText(0, "a");
+		await provider.ensureSynchronized();
+	});
+
+	it("can load summarized grouped batch", async () => {
+		const container1 = await provider.makeTestContainer(groupedBatchingContainerConfig);
+		const dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+		const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+
+		const text = "syncSharedString";
+		dataObject1.context.containerRuntime.orderSequentially(() => {
+			for (let i = 0; i < text.length; i++) {
+				sharedString1.insertText(i, text.charAt(i));
+			}
+		});
+
+		// Summarize grouped batch
+		await provider.ensureSynchronized();
+		const { summarizer } = await createSummarizer(provider, container1, testContainerConfig);
+		await summarizeNow(summarizer);
+
+		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+		const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+
+		// These calls ensures assert 0x072 isn't hit
+		sharedString2.insertText(0, "a");
+		await provider.ensureSynchronized();
 	});
 });


### PR DESCRIPTION
These asserts are currently blocking the rollout of the grouped batching feature.

[0x071](https://github.com/microsoft/FluidFramework/pull/17836)
[0x072](https://github.com/microsoft/FluidFramework/pull/17775)
[0x331](https://github.com/microsoft/FluidFramework/pull/17913)