### PR TITLE
chore(merge-tree): deprecations for 17790

### DIFF
--- a/.changeset/eight-lions-change.md
+++ b/.changeset/eight-lions-change.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/merge-tree": minor
+---
+
+Deprecate BaseSegment.ack, Client, CollaborationWindow, compareNumbers, compareStrings, createAnnotateMarkerOp, createAnnotateRangeOp, createInsertOp, createInsertSegmentOp, createRemoveRangeOp, IConsensusInfo, IConsensusValue, IMarkerModifiedAction, IMergeTreeTextHelper, ISegment.ack, LocalClientId, MergeTreeDeltaCallback, MergeTreeMaintenanceCallback, NonCollabClient, SegmentAccumulator, SegmentGroup, SegmentGroupCollection.dequeue, SegmentGroupCollection.enqueue, SegmentGroupCollection.pop, SortedSegmentSet, SortedSegmentSetItem, SortedSet, toRemovalInfo, TreeMaintenanceSequenceNumber, UnassignedSequenceNumber, UniversalSequenceNumber
+
+This functionality was not intended for export and will be removed in a future release.

--- a/examples/data-objects/prosemirror/src/fluidBridge.ts
+++ b/examples/data-objects/prosemirror/src/fluidBridge.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { assert } from "@fluidframework/core-utils";

--- a/examples/data-objects/prosemirror/src/fluidCollabManager.ts
+++ b/examples/data-objects/prosemirror/src/fluidCollabManager.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { EventEmitter } from "events";
 import { assert } from "@fluidframework/core-utils";
 import { ILoader } from "@fluidframework/container-definitions";
 import {
-	// eslint-disable-next-line import/no-deprecated
 	createGroupOp,
 	createRemoveRangeOp,
 	Marker,
@@ -292,10 +292,8 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 						operations = operations.concat(sliceOperations);
 					}
 
-					/* eslint-disable import/no-deprecated */
 					const groupOp = createGroupOp(...operations);
 					this.text.groupOperation(groupOp);
-					/* eslint-enable import/no-deprecated */
 
 					break;
 				}
@@ -358,10 +356,8 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 						operations = operations.concat(sliceOperations);
 					}
 
-					/* eslint-disable import/no-deprecated */
 					const groupOp = createGroupOp(...operations);
 					this.text.groupOperation(groupOp);
-					/* eslint-enable import/no-deprecated */
 
 					break;
 				}

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import { IEvent, IFluidHandle } from "@fluidframework/core-interfaces";
 import {
@@ -21,10 +23,8 @@ import {
 	PropertySet,
 	ReferencePosition,
 	ReferenceType,
-	// eslint-disable-next-line import/no-deprecated
 	refGetRangeLabels,
 	refGetTileLabels,
-	// eslint-disable-next-line import/no-deprecated
 	refHasRangeLabels,
 	reservedMarkerIdKey,
 	reservedRangeLabelsKey,
@@ -87,13 +87,9 @@ export const getDocSegmentKind = (segment: ISegment): DocSegmentKind => {
 		switch (markerType) {
 			case ReferenceType.Tile:
 			case ReferenceType.Tile | ReferenceType.NestBegin:
-				// eslint-disable-next-line import/no-deprecated
 				const hasRangeLabels = refHasRangeLabels(segment);
 				const kind = (
-					hasRangeLabels
-						? // eslint-disable-next-line import/no-deprecated
-						  refGetRangeLabels(segment)[0]
-						: refGetTileLabels(segment)[0]
+					hasRangeLabels ? refGetRangeLabels(segment)[0] : refGetTileLabels(segment)[0]
 				) as DocSegmentKind;
 
 				assert(tilesAndRanges.has(kind), `Unknown tile/range label.`);
@@ -108,7 +104,6 @@ export const getDocSegmentKind = (segment: ISegment): DocSegmentKind => {
 				// Ensure that 'nestEnd' range label matches the 'beginTags' range label (otherwise it
 				// will not close the range.)
 				assert(
-					// eslint-disable-next-line import/no-deprecated
 					refGetRangeLabels(segment)[0] === DocSegmentKind.beginTags,
 					`Unknown refType '${markerType}'.`,
 				);

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import { createChildLogger } from "@fluidframework/telemetry-utils";
 import {

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -211,19 +211,19 @@ export class CollaborationWindow {
 // @public @deprecated (undocumented)
 export function combine(combiningInfo: ICombiningOp, currentValue: any, newValue: any, seq?: number): any;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const compareNumbers: (a: number, b: number) => number;
 
 // @public (undocumented)
 export function compareReferencePositions(a: ReferencePosition, b: ReferencePosition): number;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const compareStrings: (a: string, b: string) => number;
 
 // @internal (undocumented)
 export type ConflictAction<TKey, TData> = (key: TKey, currentKey: TKey, data: TData, currentData: TData) => QProperty<TKey, TData>;
 
-// @public
+// @public @deprecated
 export function createAnnotateMarkerOp(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
 
 // @public
@@ -344,7 +344,7 @@ export interface ICombiningOp {
     name: string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IConsensusInfo {
     // (undocumented)
     callback: (m: Marker) => void;
@@ -352,7 +352,7 @@ export interface IConsensusInfo {
     marker: Marker;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IConsensusValue {
     // (undocumented)
     seq: number;
@@ -392,7 +392,7 @@ export interface IMarkerDef {
     refType?: ReferenceType;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IMarkerModifiedAction {
     // (undocumented)
     (marker: Marker): void;
@@ -631,7 +631,7 @@ export interface KeyComparer<TKey> {
     (a: TKey, b: TKey): number;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const LocalClientId = -1;
 
 // @public
@@ -746,7 +746,7 @@ export class MergeNode implements IMergeNodeCommon {
     ordinal: string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type MergeTreeDeltaCallback = (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs) => void;
 
 // @public (undocumented)
@@ -779,7 +779,7 @@ export const MergeTreeDeltaType: {
 // @public (undocumented)
 export type MergeTreeDeltaType = (typeof MergeTreeDeltaType)[keyof typeof MergeTreeDeltaType];
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type MergeTreeMaintenanceCallback = (MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs, opArgs: IMergeTreeDeltaOpArgs | undefined) => void;
 
 // @public
@@ -806,7 +806,7 @@ export interface MergeTreeRevertibleDriver {
 // @public (undocumented)
 export function minReferencePosition<T extends ReferencePosition>(a: T, b: T): T;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const NonCollabClient = -2;
 
 // @public (undocumented)
@@ -1005,7 +1005,7 @@ export const reservedTileLabelsKey = "referenceTileLabels";
 // @alpha (undocumented)
 export function revertMergeTreeDeltaRevertibles(driver: MergeTreeRevertibleDriver, revertibles: MergeTreeDeltaRevertible[]): void;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface SegmentAccumulator {
     // (undocumented)
     segments: ISegment[];
@@ -1201,7 +1201,7 @@ export class TrackingGroupCollection {
     unlink(trackingGroup: ITrackingGroup): boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const TreeMaintenanceSequenceNumber = -2;
 
 // @public (undocumented)

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -35,7 +35,7 @@ export interface AttributionPolicy {
 
 // @public (undocumented)
 export abstract class BaseSegment extends MergeNode implements ISegment {
-    // (undocumented)
+    // @deprecated (undocumented)
     ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean;
     // (undocumented)
     addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow, rollback?: PropertiesRollback): PropertySet | undefined;
@@ -87,7 +87,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     abstract readonly type: string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class Client extends TypedEventEmitter<IClientEvents> {
     constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryLoggerExt, options?: PropertySet);
     // (undocumented)
@@ -192,7 +192,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 // @public @deprecated (undocumented)
 export function clone<T>(extension: MapLike<T> | undefined): MapLike<T> | undefined;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class CollaborationWindow {
     // (undocumented)
     clientId: number;
@@ -226,7 +226,7 @@ export type ConflictAction<TKey, TData> = (key: TKey, currentKey: TKey, data: TD
 // @public @deprecated
 export function createAnnotateMarkerOp(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
 
-// @public
+// @public @deprecated
 export function createAnnotateRangeOp(start: number, end: number, props: PropertySet, combiningOp: ICombiningOp | undefined): IMergeTreeAnnotateMsg;
 
 // @public (undocumented)
@@ -238,16 +238,16 @@ export function createGroupOp(...ops: IMergeTreeDeltaOp[]): IMergeTreeGroupMsg;
 // @alpha (undocumented)
 export function createInsertOnlyAttributionPolicy(): AttributionPolicy;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createInsertOp(pos: number, segSpec: any): IMergeTreeInsertMsg;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createInsertSegmentOp(pos: number, segment: ISegment): IMergeTreeInsertMsg;
 
 // @public @deprecated (undocumented)
 export function createMap<T>(): MapLike<T>;
 
-// @public
+// @public @deprecated
 export function createRemoveRangeOp(start: number, end: number): IMergeTreeRemoveMsg;
 
 // @public (undocumented)
@@ -531,7 +531,7 @@ export interface IMergeTreeSegmentDelta {
     segment: ISegment;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IMergeTreeTextHelper {
     // (undocumented)
     getText(refSeq: number, clientId: number, placeholder: string, start?: number, end?: number): string;
@@ -570,6 +570,7 @@ export interface IRemovalInfo {
 
 // @public
 export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
+    // @deprecated
     ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean;
     // (undocumented)
     addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow, rollback?: PropertiesRollback): PropertySet | undefined;
@@ -1011,7 +1012,7 @@ export interface SegmentAccumulator {
     segments: ISegment[];
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface SegmentGroup {
     // (undocumented)
     localSeq: number;
@@ -1028,13 +1029,13 @@ export class SegmentGroupCollection {
     constructor(segment: ISegment);
     // (undocumented)
     copyTo(segment: ISegment): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     dequeue(): SegmentGroup | undefined;
     // (undocumented)
     get empty(): boolean;
-    // (undocumented)
+    // @deprecated (undocumented)
     enqueue(segmentGroup: SegmentGroup): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     pop?(): SegmentGroup | undefined;
     // (undocumented)
     get size(): number;
@@ -1076,7 +1077,7 @@ export interface SortedDictionary<TKey, TData> extends Dictionary<TKey, TData> {
     min(): Property<TKey, TData> | undefined;
 }
 
-// @public
+// @public @deprecated
 export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends SortedSet<T, string> {
     // (undocumented)
     protected findItemPosition(item: T): {
@@ -1087,12 +1088,12 @@ export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends
     protected getKey(item: T): string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SortedSegmentSetItem = ISegment | LocalReferencePosition | {
     readonly segment: ISegment;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export abstract class SortedSet<T, U extends string | number> {
     // (undocumented)
     addOrUpdate(newItem: T, update?: (existingItem: T, newItem: T) => void): void;
@@ -1163,7 +1164,7 @@ export class TextSegment extends BaseSegment {
     readonly type = "TextSegment";
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function toRemovalInfo(maybe: Partial<IRemovalInfo> | undefined): IRemovalInfo | undefined;
 
 // @public (undocumented)
@@ -1204,10 +1205,10 @@ export class TrackingGroupCollection {
 // @public @deprecated (undocumented)
 export const TreeMaintenanceSequenceNumber = -2;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const UnassignedSequenceNumber = -1;
 
-// @public
+// @public @deprecated
 export const UniversalSequenceNumber = 0;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
+++ b/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
+/* eslint-disable import/no-deprecated */
+
 import { IIntegerRange } from "./base";
 import { ISegment } from "./mergeTreeNodes";
 import { MergeTree } from "./mergeTree";
@@ -45,9 +46,7 @@ export class MergeTreeTextHelper implements IMergeTreeTextHelper {
 		end: number | undefined,
 		refSeq: number,
 		clientId: number,
-		// eslint-disable-next-line import/no-deprecated
 	): IIntegerRange {
-		// eslint-disable-next-line import/no-deprecated
 		const range: IIntegerRange = {
 			end: end ?? this.mergeTree.getLength(refSeq, clientId),
 			start: start ?? 0,

--- a/packages/dds/merge-tree/src/attributionPolicy.ts
+++ b/packages/dds/merge-tree/src/attributionPolicy.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import { AttributionKey } from "@fluidframework/runtime-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -96,6 +96,9 @@ export interface IClientEvents {
 	);
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export class Client extends TypedEventEmitter<IClientEvents> {
 	public longClientId: string | undefined;
 

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { IFluidHandle, type IEventThisPlaceHolder } from "@fluidframework/core-interfaces";
@@ -16,7 +17,6 @@ import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { ITelemetryLoggerExt, LoggingError, UsageError } from "@fluidframework/telemetry-utils";
-// eslint-disable-next-line import/no-deprecated
 import { IIntegerRange } from "./base";
 import { List, RedBlackTree } from "./collections";
 import { UnassignedSequenceNumber, UniversalSequenceNumber } from "./constants";
@@ -38,7 +38,6 @@ import {
 import {
 	createAnnotateMarkerOp,
 	createAnnotateRangeOp,
-	// eslint-disable-next-line import/no-deprecated
 	createGroupOp,
 	createInsertSegmentOp,
 	createRemoveRangeOp,
@@ -48,7 +47,6 @@ import {
 	IJSONSegment,
 	IMergeTreeAnnotateMsg,
 	IMergeTreeDeltaOp,
-	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeGroupMsg,
 	IMergeTreeInsertMsg,
 	IMergeTreeRemoveMsg,
@@ -62,7 +60,6 @@ import { SnapshotLegacy } from "./snapshotlegacy";
 import { SnapshotLoader } from "./snapshotLoader";
 import { IMergeTreeTextHelper } from "./textSegment";
 import { SnapshotV1 } from "./snapshotV1";
-// eslint-disable-next-line import/no-deprecated
 import { ReferencePosition, RangeStackMap, DetachedReferencePosition } from "./referencePositions";
 import { MergeTree } from "./mergeTree";
 import { MergeTreeTextHelper } from "./MergeTreeTextHelper";
@@ -539,7 +536,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	private getValidOpRange(
 		op: IMergeTreeAnnotateMsg | IMergeTreeInsertMsg | IMergeTreeRemoveMsg,
 		clientArgs: IMergeTreeClientSequenceArgs,
-		// eslint-disable-next-line import/no-deprecated
 	): IIntegerRange {
 		let start: number | undefined = op.pos1;
 		if (start === undefined && op.relativePos1) {
@@ -600,7 +596,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		}
 
 		// start and end are guaranteed to be non-null here, otherwise we throw above.
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions, import/no-deprecated
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return { start, end } as IIntegerRange;
 	}
 
@@ -841,7 +837,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	}
 
 	public applyStashedOp(op: IMergeTreeDeltaOp): SegmentGroup;
-	// eslint-disable-next-line import/no-deprecated
 	public applyStashedOp(op: IMergeTreeGroupMsg): SegmentGroup[];
 	public applyStashedOp(op: IMergeTreeOp): SegmentGroup | SegmentGroup[];
 	public applyStashedOp(op: IMergeTreeOp): SegmentGroup | SegmentGroup[] {
@@ -939,7 +934,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 			if (Array.isArray(segmentGroup)) {
 				if (segmentGroup.length === 0) {
 					// sometimes we rebase to an empty op
-					// eslint-disable-next-line import/no-deprecated
 					return createGroupOp();
 				}
 				firstGroup = segmentGroup[0];
@@ -994,7 +988,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 			);
 			opList.push(...this.resetPendingDeltaToOps(resetOp, segmentGroup));
 		}
-		// eslint-disable-next-line import/no-deprecated
 		return opList.length === 1 ? opList[0] : createGroupOp(...opList);
 	}
 
@@ -1056,7 +1049,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	/**
 	 * @deprecated this functionality is no longer supported and will be removed
 	 */
-	// eslint-disable-next-line import/no-deprecated
 	getStackContext(startPos: number, rangeLabels: string[]): RangeStackMap {
 		return this._mergeTree.getStackContext(
 			startPos,
@@ -1070,7 +1062,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		return segWindow.collaborating ? UnassignedSequenceNumber : UniversalSequenceNumber;
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	localTransaction(groupOp: IMergeTreeGroupMsg) {
 		for (const op of groupOp.ops) {
 			const opArgs: IMergeTreeDeltaOpArgs = {

--- a/packages/dds/merge-tree/src/constants.ts
+++ b/packages/dds/merge-tree/src/constants.ts
@@ -10,6 +10,18 @@
 
 export const UniversalSequenceNumber = 0;
 export const UnassignedSequenceNumber = -1;
+
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export const TreeMaintenanceSequenceNumber = -2;
+
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export const LocalClientId = -1;
+
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export const NonCollabClient = -2;

--- a/packages/dds/merge-tree/src/constants.ts
+++ b/packages/dds/merge-tree/src/constants.ts
@@ -6,9 +6,14 @@
 /**
  * Sequence numbers for shared segments start at 1 or greater.  Every segment marked
  * with sequence number zero will be counted as part of the requested string.
+ *
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
  */
-
 export const UniversalSequenceNumber = 0;
+
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export const UnassignedSequenceNumber = -1;
 
 /**

--- a/packages/dds/merge-tree/src/endOfTreeSegment.ts
+++ b/packages/dds/merge-tree/src/endOfTreeSegment.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import { LocalClientId } from "./constants";
 import { LocalReferenceCollection } from "./localReference";

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -5,13 +5,12 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/prefer-optional-chain, no-bitwise */
 
 import { assert } from "@fluidframework/core-utils";
 import { DataProcessingError, UsageError } from "@fluidframework/telemetry-utils";
 import { IAttributionCollectionSerializer } from "./attributionCollection";
-// eslint-disable-next-line import/no-deprecated
 import { Comparer, Heap, List, ListNode, Stack } from "./collections";
 import {
 	LocalClientId,
@@ -38,7 +37,6 @@ import {
 	IncrementalExecOp,
 	IncrementalMapState,
 	InsertContext,
-	// eslint-disable-next-line import/no-deprecated
 	internedSpaces,
 	IRemovalInfo,
 	ISegment,
@@ -70,17 +68,13 @@ import {
 	ReferenceType,
 } from "./ops";
 import { PartialSequenceLengths } from "./partialLengths";
-// eslint-disable-next-line import/no-deprecated
 import { createMap, extend, MapLike, PropertySet } from "./properties";
 import {
 	refTypeIncludesFlag,
 	ReferencePosition,
 	DetachedReferencePosition,
-	// eslint-disable-next-line import/no-deprecated
 	RangeStackMap,
-	// eslint-disable-next-line import/no-deprecated
 	refHasRangeLabel,
-	// eslint-disable-next-line import/no-deprecated
 	refGetRangeLabels,
 	refGetTileLabels,
 	refHasTileLabel,
@@ -145,17 +139,14 @@ interface IReferenceSearchInfo {
 interface IMarkerSearchRangeInfo {
 	mergeTree: MergeTree;
 	rangeLabels: string[];
-	// eslint-disable-next-line import/no-deprecated
 	stacks: RangeStackMap;
 }
 
 function applyLeafRangeMarker(marker: Marker, searchInfo: IMarkerSearchRangeInfo) {
 	for (const rangeLabel of searchInfo.rangeLabels) {
-		// eslint-disable-next-line import/no-deprecated
 		if (refHasRangeLabel(marker, rangeLabel)) {
 			let currentStack = searchInfo.stacks[rangeLabel];
 			if (currentStack === undefined) {
-				// eslint-disable-next-line import/no-deprecated
 				currentStack = new Stack<Marker>();
 				searchInfo.stacks[rangeLabel] = currentStack;
 			}
@@ -268,8 +259,6 @@ function addTileIfNotPresent(tile: ReferencePosition, tiles: object) {
 		}
 	}
 }
-
-// eslint-disable-next-line import/no-deprecated
 function applyStackDelta(currentStackMap: RangeStackMap, deltaStackMap: RangeStackMap) {
 	// eslint-disable-next-line guard-for-in, no-restricted-syntax
 	for (const label in deltaStackMap) {
@@ -277,7 +266,6 @@ function applyStackDelta(currentStackMap: RangeStackMap, deltaStackMap: RangeSta
 		if (!deltaStack.empty()) {
 			let currentStack = currentStackMap[label];
 			if (currentStack === undefined) {
-				// eslint-disable-next-line import/no-deprecated
 				currentStack = new Stack<ReferencePosition>();
 				currentStackMap[label] = currentStack;
 			}
@@ -287,8 +275,6 @@ function applyStackDelta(currentStackMap: RangeStackMap, deltaStackMap: RangeSta
 		}
 	}
 }
-
-// eslint-disable-next-line import/no-deprecated
 function applyRangeReference(stack: Stack<ReferencePosition>, delta: ReferencePosition) {
 	if (refTypeIncludesFlag(delta, ReferenceType.NestBegin)) {
 		stack.push(delta);
@@ -320,13 +306,11 @@ function addNodeReferences(
 	node: IMergeNode,
 	rightmostTiles: MapLike<ReferencePosition>,
 	leftmostTiles: MapLike<ReferencePosition>,
-	// eslint-disable-next-line import/no-deprecated
 	rangeStacks: RangeStackMap,
 ) {
 	function updateRangeInfo(label: string, refPos: ReferencePosition) {
 		let stack = rangeStacks[label];
 		if (stack === undefined) {
-			// eslint-disable-next-line import/no-deprecated
 			stack = new Stack<ReferencePosition>();
 			rangeStacks[label] = stack;
 		}
@@ -347,7 +331,6 @@ function addNodeReferences(
 					addTileIfNotPresent(segment, leftmostTiles);
 				}
 				if (segment.refType & (ReferenceType.NestBegin | ReferenceType.NestEnd)) {
-					// eslint-disable-next-line import/no-deprecated
 					const rangeLabels = refGetRangeLabels(segment);
 					if (rangeLabels) {
 						for (const label of rangeLabels) {
@@ -368,7 +351,6 @@ function addNodeReferences(
 							addTileIfNotPresent(lref, leftmostTiles);
 						}
 						if (lref.refType & (ReferenceType.NestBegin | ReferenceType.NestEnd)) {
-							// eslint-disable-next-line import/no-deprecated
 							for (const label of refGetRangeLabels(lref)!) {
 								updateRangeInfo(label, lref);
 							}
@@ -380,7 +362,6 @@ function addNodeReferences(
 	} else {
 		const block = <IHierBlock>node;
 		applyStackDelta(rangeStacks, block.rangeStacks);
-		// eslint-disable-next-line import/no-deprecated
 		extend(rightmostTiles, block.rightmostTiles);
 		extendIfUndefined(leftmostTiles, block.leftmostTiles);
 	}
@@ -400,16 +381,12 @@ function extendIfUndefined<T>(base: MapLike<T>, extension: MapLike<T> | undefine
 class HierMergeBlock extends MergeBlock implements IHierBlock {
 	public rightmostTiles: MapLike<ReferencePosition>;
 	public leftmostTiles: MapLike<ReferencePosition>;
-	// eslint-disable-next-line import/no-deprecated
 	public rangeStacks: MapLike<Stack<ReferencePosition>>;
 
 	constructor(childCount: number) {
 		super(childCount);
-		// eslint-disable-next-line import/no-deprecated
 		this.rightmostTiles = createMap<ReferencePosition>();
-		// eslint-disable-next-line import/no-deprecated
 		this.leftmostTiles = createMap<ReferencePosition>();
-		// eslint-disable-next-line import/no-deprecated
 		this.rangeStacks = createMap<Stack<ReferencePosition>>();
 	}
 
@@ -422,7 +399,6 @@ class HierMergeBlock extends MergeBlock implements IHierBlock {
 		// eslint-disable-next-line guard-for-in, no-restricted-syntax
 		for (const key in this.rangeStacks) {
 			const stack = this.rangeStacks[key];
-			// eslint-disable-next-line import/no-deprecated
 			strbuf += internedSpaces(indentCount);
 			strbuf += `${key}: `;
 			for (const item of stack.items) {
@@ -1323,7 +1299,6 @@ export class MergeTree {
 	public getStackContext(startPos: number, clientId: number, rangeLabels: string[]) {
 		const searchInfo: IMarkerSearchRangeInfo = {
 			mergeTree: this,
-			// eslint-disable-next-line import/no-deprecated
 			stacks: createMap<Stack<Marker>>(),
 			rangeLabels,
 		};
@@ -2602,9 +2577,7 @@ export class MergeTree {
 		let len: number | undefined;
 		const hierBlock = block.hierBlock();
 		if (hierBlock) {
-			// eslint-disable-next-line import/no-deprecated
 			hierBlock.rightmostTiles = createMap<Marker>();
-			// eslint-disable-next-line import/no-deprecated
 			hierBlock.leftmostTiles = createMap<Marker>();
 			hierBlock.rangeStacks = {};
 		}
@@ -2686,7 +2659,6 @@ export class MergeTree {
 		this.nodeMap(refSeq, clientId, handler, accum, undefined, start, end);
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public incrementalBlockMap<TContext>(stateStack: Stack<IncrementalMapState<TContext>>) {
 		while (!stateStack.empty()) {
 			// We already check the stack is not empty

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -92,6 +92,9 @@ export interface IMergeTreeClientSequenceArgs {
 	readonly sequenceNumber: number;
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export type MergeTreeDeltaCallback = (
 	opArgs: IMergeTreeDeltaOpArgs,
 	deltaArgs: IMergeTreeDeltaCallbackArgs,
@@ -101,6 +104,9 @@ export type MergeTreeDeltaCallback = (
 export interface IMergeTreeMaintenanceCallbackArgs
 	extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> {}
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export type MergeTreeMaintenanceCallback = (
 	MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs,
 	opArgs: IMergeTreeDeltaOpArgs | undefined,

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -4,8 +4,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-
-/* eslint-disable @typescript-eslint/prefer-optional-chain */
+/* eslint-disable import/no-deprecated */
 
 import { assert } from "@fluidframework/core-utils";
 import { AttributionKey } from "@fluidframework/runtime-definitions";
@@ -17,14 +16,11 @@ import { TrackingGroupCollection } from "./mergeTreeTracking";
 import { ICombiningOp, IJSONSegment, IMarkerDef, MergeTreeDeltaType, ReferenceType } from "./ops";
 import { computeHierarchicalOrdinal } from "./ordinal";
 import { PartialSequenceLengths } from "./partialLengths";
-// eslint-disable-next-line import/no-deprecated
 import { clone, createMap, MapLike, PropertySet } from "./properties";
 import {
 	refTypeIncludesFlag,
-	// eslint-disable-next-line import/no-deprecated
 	RangeStackMap,
 	ReferencePosition,
-	// eslint-disable-next-line import/no-deprecated
 	refGetRangeLabels,
 	refGetTileLabels,
 } from "./referencePositions";
@@ -93,7 +89,6 @@ export interface IHierBlock extends IMergeBlock {
 	hierToString(indentCount: number): string;
 	rightmostTiles: MapLike<ReferencePosition>;
 	leftmostTiles: MapLike<ReferencePosition>;
-	// eslint-disable-next-line import/no-deprecated
 	rangeStacks: RangeStackMap;
 }
 
@@ -232,6 +227,9 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
 	ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean;
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export interface IMarkerModifiedAction {
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
 	(marker: Marker): void;
@@ -439,7 +437,6 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 		rollback: PropertiesRollback = PropertiesRollback.None,
 	) {
 		this.propertyManager ??= new PropertiesManager();
-		// eslint-disable-next-line import/no-deprecated
 		this.properties ??= createMap<any>();
 		return this.propertyManager.addProperties(
 			this.properties,
@@ -462,7 +459,6 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 	protected cloneInto(b: ISegment) {
 		b.clientId = this.clientId;
 		// TODO: deep clone properties
-		// eslint-disable-next-line import/no-deprecated
 		b.properties = clone(this.properties);
 		b.removedClientIds = this.removedClientIds?.slice();
 		// TODO: copy removed client overlap and branch removal info
@@ -724,8 +720,14 @@ export class CollaborationWindow {
 	}
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export const compareNumbers = (a: number, b: number) => a - b;
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export const compareStrings = (a: string, b: string) => a.localeCompare(b);
 
 const indentStrings = ["", " ", "  "];
@@ -742,11 +744,17 @@ export function internedSpaces(n: number) {
 	return indentStrings[n];
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export interface IConsensusInfo {
 	marker: Marker;
 	callback: (m: Marker) => void;
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export interface SegmentAccumulator {
 	segments: ISegment[];
 }
@@ -791,7 +799,6 @@ export function debugMarkerToString(marker: Marker): string {
 			lbuf += tileLabel;
 		}
 	}
-	// eslint-disable-next-line import/no-deprecated
 	const rangeLabels = refGetRangeLabels(marker);
 	if (rangeLabels) {
 		let rangeKind = "begin";

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -113,6 +113,9 @@ export interface IRemovalInfo {
 	removedClientIds: number[];
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export function toRemovalInfo(maybe: Partial<IRemovalInfo> | undefined): IRemovalInfo | undefined {
 	if (maybe?.removedClientIds !== undefined && maybe?.removedSeq !== undefined) {
 		return maybe as IRemovalInfo;
@@ -223,6 +226,8 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
 	 * @throws - error if the segment state doesn't match segment group or op.
 	 * E.g. if the segment group is not first in the pending queue, or
 	 * an inserted segment does not have unassigned sequence number.
+	 *
+	 * @deprecated This functionality was not meant to be exported and will be removed in a future release
 	 */
 	ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean;
 }
@@ -343,6 +348,9 @@ export interface SearchResult {
 	pos: number;
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export interface SegmentGroup {
 	segments: ISegment[];
 	previousProps?: PropertySet[];
@@ -479,6 +487,9 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 
 	public abstract toJSONObject(): any;
 
+	/**
+	 * @deprecated This functionality was not meant to be exported and will be removed in a future release
+	 */
 	public ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean {
 		const currentSegmentGroup = this.segmentGroups.dequeue();
 		assert(
@@ -701,6 +712,9 @@ export class IncrementalMapState<TContext> {
 	) {}
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export class CollaborationWindow {
 	clientId = LocalClientId;
 	collaborating = false;

--- a/packages/dds/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/dds/merge-tree/src/mergeTreeTracking.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { LocalReferencePosition } from "./localReference";
 import { ISegment } from "./mergeTreeNodes";
 import { SortedSegmentSet } from "./sortedSegmentSet";

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -51,6 +51,8 @@ export function createAnnotateMarkerOp(
  * @param props - The properties to annotate the range with
  * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.
  * @returns The annotate op
+ *
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
  */
 export function createAnnotateRangeOp(
 	start: number,
@@ -72,6 +74,8 @@ export function createAnnotateRangeOp(
  *
  * @param start - The inclusive start of the range to remove
  * @param end - The exclusive end of the range to remove
+ *
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
  */
 export function createRemoveRangeOp(start: number, end: number): IMergeTreeRemoveMsg {
 	return {
@@ -85,11 +89,16 @@ export function createRemoveRangeOp(start: number, end: number): IMergeTreeRemov
  *
  * @param pos - The position to insert the segment at
  * @param segment - The segment to insert
+ *
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
  */
 export function createInsertSegmentOp(pos: number, segment: ISegment): IMergeTreeInsertMsg {
 	return createInsertOp(pos, segment.toJSONObject());
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export function createInsertOp(pos: number, segSpec: any): IMergeTreeInsertMsg {
 	return {
 		pos1: pos,

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -22,6 +22,8 @@ import { PropertySet } from "./properties";
  * @param props - The properties to annotate the marker with
  * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.
  * @returns The annotate op
+ *
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
  */
 export function createAnnotateMarkerOp(
 	marker: Marker,

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import { Property, RedBlackTree } from "./collections";
 import { UnassignedSequenceNumber } from "./constants";

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -16,6 +16,9 @@ export type PropertySet = MapLike<any>;
 
 // Assume these are created with Object.create(null)
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export interface IConsensusValue {
 	seq: number;
 	value: any;

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { UsageError } from "@fluidframework/telemetry-utils";
 import { List } from "./collections";
@@ -13,7 +15,6 @@ import { IMergeLeaf, ISegment, toRemovalInfo } from "./mergeTreeNodes";
 import { depthFirstNodeWalk } from "./mergeTreeNodeWalk";
 import { ITrackingGroup, Trackable, UnorderedTrackingGroup } from "./mergeTreeTracking";
 import { IJSONSegment, MergeTreeDeltaType, ReferenceType } from "./ops";
-// eslint-disable-next-line import/no-deprecated
 import { matchProperties, PropertySet } from "./properties";
 import { DetachedReferencePosition } from "./referencePositions";
 import { MergeTree, findRootMergeBlock } from "./mergeTree";
@@ -173,7 +174,6 @@ function appendLocalAnnotateToRevertibles(
 		if (propertyDeltas) {
 			if (
 				last?.operation === MergeTreeDeltaType.ANNOTATE &&
-				// eslint-disable-next-line import/no-deprecated
 				matchProperties(last?.propertyDeltas, propertyDeltas)
 			) {
 				last.trackingGroup.link(ds.segment);

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { List, walkList } from "./collections";
 import { ISegment, SegmentGroup } from "./mergeTreeNodes";
 
@@ -21,15 +23,24 @@ export class SegmentGroupCollection {
 		return this.segmentGroups.empty;
 	}
 
+	/**
+	 * @deprecated This functionality was not meant to be exported and will be removed in a future release
+	 */
 	public enqueue(segmentGroup: SegmentGroup) {
 		this.segmentGroups.push(segmentGroup);
 		segmentGroup.segments.push(this.segment);
 	}
 
+	/**
+	 * @deprecated This functionality was not meant to be exported and will be removed in a future release
+	 */
 	public dequeue(): SegmentGroup | undefined {
 		return this.segmentGroups.shift()?.data;
 	}
 
+	/**
+	 * @deprecated This functionality was not meant to be exported and will be removed in a future release
+	 */
 	public pop?(): SegmentGroup | undefined {
 		return this.segmentGroups.pop ? this.segmentGroups.pop()?.data : undefined;
 	}

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { assert } from "@fluidframework/core-utils";
 import { UnassignedSequenceNumber, UniversalSequenceNumber } from "./constants";
 import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";
-// eslint-disable-next-line import/no-deprecated
 import { combine, createMap, MapLike, PropertySet } from "./properties";
 
 export enum PropertiesRollback {
@@ -66,7 +66,6 @@ export class PropertiesManager {
 		collaborating: boolean = false,
 		rollback: PropertiesRollback = PropertiesRollback.None,
 	): PropertySet | undefined {
-		// eslint-disable-next-line import/no-deprecated
 		this.pendingKeyUpdateCount ??= createMap<number>();
 
 		// There are outstanding local rewrites, so block all non-local changes
@@ -143,8 +142,7 @@ export class PropertiesManager {
 			// The delta should be null if undefined, as that's how we encode delete
 			deltas[key] = previousValue === undefined ? null : previousValue;
 			const newValue = combiningOp
-				? // eslint-disable-next-line import/no-deprecated
-				  combine(combiningOp, previousValue, undefined, seq)
+				? combine(combiningOp, previousValue, undefined, seq)
 				: newProps[key];
 			if (newValue === null) {
 				// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
@@ -163,7 +161,7 @@ export class PropertiesManager {
 		newManager: PropertiesManager,
 	): PropertySet | undefined {
 		if (oldProps) {
-			// eslint-disable-next-line no-param-reassign, import/no-deprecated
+			// eslint-disable-next-line no-param-reassign
 			newProps ??= createMap<any>();
 			if (!newManager) {
 				throw new Error("Must provide new PropertyManager");
@@ -172,7 +170,6 @@ export class PropertiesManager {
 				newProps[key] = oldProps[key];
 			}
 			newManager.pendingRewriteCount = this.pendingRewriteCount;
-			// eslint-disable-next-line import/no-deprecated
 			newManager.pendingKeyUpdateCount = createMap<number>();
 			for (const key of Object.keys(this.pendingKeyUpdateCount!)) {
 				newManager.pendingKeyUpdateCount[key] = this.pendingKeyUpdateCount![key];

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { bufferToString } from "@fluid-internal/client-utils";

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
@@ -13,7 +15,6 @@ import { AttributionKey, ISummaryTreeWithStats } from "@fluidframework/runtime-d
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { UnassignedSequenceNumber } from "./constants";
 import { ISegment } from "./mergeTreeNodes";
-// eslint-disable-next-line import/no-deprecated
 import { matchProperties, PropertySet } from "./properties";
 import {
 	IJSONSegmentWithMergeInfo,
@@ -238,7 +239,6 @@ export class SnapshotV1 {
 					prev = segment;
 				} else if (
 					prev.canAppend(segment) &&
-					// eslint-disable-next-line import/no-deprecated
 					matchProperties(prev.properties, segment.properties)
 				) {
 					// We have a compatible pair.  Replace `prev` with the coalesced segment.  Clone to avoid

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
@@ -14,7 +15,6 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { NonCollabClient, UnassignedSequenceNumber } from "./constants";
 import { ISegment } from "./mergeTreeNodes";
-// eslint-disable-next-line import/no-deprecated
 import { matchProperties } from "./properties";
 import {
 	JsonSegmentSpecs,
@@ -217,7 +217,6 @@ export class SnapshotLegacy {
 			) {
 				if (
 					prev?.canAppend(segment) &&
-					// eslint-disable-next-line import/no-deprecated
 					matchProperties(prev.properties, segment.properties)
 				) {
 					prev = prev.clone();

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -3,14 +3,20 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { LocalReferencePosition } from "./localReference";
 import { ISegment } from "./mergeTreeNodes";
 import { SortedSet } from "./sortedSet";
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export type SortedSegmentSetItem =
 	| ISegment
 	| LocalReferencePosition
 	| { readonly segment: ISegment };
+
 /**
  * Stores a unique and sorted set of segments, or objects with segments
  *
@@ -20,6 +26,8 @@ export type SortedSegmentSetItem =
  * segments ordered by their ordinals will always have the same order even if the ordinal values on
  * the segments changes. This invariant allows us to ensure the segments stay
  * ordered and unique, and that new segments can be inserted into that order.
+ *
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
  */
 export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends SortedSet<
 	T,

--- a/packages/dds/merge-tree/src/sortedSet.ts
+++ b/packages/dds/merge-tree/src/sortedSet.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export abstract class SortedSet<T, U extends string | number> {
 	protected abstract getKey(t: T): U;
 

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -114,6 +114,9 @@ export class TextSegment extends BaseSegment {
 	}
 }
 
+/**
+ * @deprecated This functionality was not meant to be exported and will be removed in a future release
+ */
 export interface IMergeTreeTextHelper {
 	getText(
 		refSeq: number,

--- a/packages/dds/merge-tree/src/zamboni.ts
+++ b/packages/dds/merge-tree/src/zamboni.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { UnassignedSequenceNumber } from "./constants";
@@ -16,7 +17,6 @@ import {
 	seqLTE,
 	toRemovalInfo,
 } from "./mergeTreeNodes";
-// eslint-disable-next-line import/no-deprecated
 import { matchProperties } from "./properties";
 
 export const zamboniSegmentsMax = 2;
@@ -167,7 +167,6 @@ function scourNode(node: IMergeBlock, holdNodes: IMergeNode[], mergeTree: MergeT
 				const segmentHasPositiveLength = (mergeTree.localNetLength(segment) ?? 0) > 0;
 				const canAppend =
 					prevSegment?.canAppend(segment) &&
-					// eslint-disable-next-line import/no-deprecated
 					matchProperties(prevSegment.properties, segment.properties) &&
 					prevSegment.trackingCollection.matches(segment.trackingCollection) &&
 					segmentHasPositiveLength;

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
 /* eslint-disable no-bitwise */
 
 import {

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -2,6 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable import/no-deprecated */
 /* eslint-disable no-bitwise */
 
 import { assert, unreachableCase } from "@fluidframework/core-utils";

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -2,6 +2,9 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable import/no-deprecated */
+
 import { assert, Deferred } from "@fluidframework/core-utils";
 import { bufferToString } from "@fluid-internal/client-utils";
 import { LoggingError, createChildLogger } from "@fluidframework/telemetry-utils";
@@ -14,7 +17,6 @@ import {
 import {
 	Client,
 	createAnnotateRangeOp,
-	// eslint-disable-next-line import/no-deprecated
 	createGroupOp,
 	createInsertOp,
 	createRemoveRangeOp,
@@ -29,7 +31,6 @@ import {
 	ISegment,
 	ISegmentAction,
 	LocalReferencePosition,
-	// eslint-disable-next-line import/no-deprecated
 	matchProperties,
 	MergeTreeDeltaType,
 	PropertySet,
@@ -153,7 +154,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 					if (
 						lastAnnotate &&
 						lastAnnotate.pos2 === r.position &&
-						// eslint-disable-next-line import/no-deprecated
 						matchProperties(lastAnnotate.props, props)
 					) {
 						lastAnnotate.pos2 += r.segment.cachedLength;
@@ -764,7 +764,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 				stashMessage = {
 					...message,
 					referenceSequenceNumber: stashMessage.sequenceNumber - 1,
-					// eslint-disable-next-line import/no-deprecated
 					contents: ops.length !== 1 ? createGroupOp(...ops) : ops[0],
 				};
 			}

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable import/no-deprecated */
+
 import { assert } from "@fluidframework/core-utils";
 import {
 	Client,


### PR DESCRIPTION
To avoid large merge conflicts and cluttering code in main with superfluous inline ignores, this change adds file-wide ignores for deprecation warnings. These ignores will be removed in the associated PR into next, so they will be short lived. I think this is a sane tradeoff.

It also avoids deprecating the `@internal` APIs to avoid code churn in too many files. These APIs have been verified to not be found in at least one partner's codebase, so should be relatively safe to mark `@internal` without following the deprecation cycle. 