### PR TITLE
Add logging for connection being setup and address possibility of the Connection Manager being disposed before new connection setup

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -587,7 +587,7 @@ export class ConnectionManager implements IConnectionManager {
 				}
 				this.logger.sendTelemetryEvent(
 					{
-						eventName: "ConnectedToDeltaStream",
+						eventName: "ConnectionReceived",
 						connected: connection !== undefined && connection.disposed === false,
 					},
 					undefined,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -694,14 +694,6 @@ export class ConnectionManager implements IConnectionManager {
 			return;
 		}
 
-		this.logger.sendTelemetryEvent(
-			{
-				eventName: "SettingUpNewConnection",
-				connected: connection !== undefined && connection.disposed === false,
-			},
-			undefined,
-			LogLevel.verbose,
-		);
 		this.setupNewSuccessfulConnection(connection, requestedMode, reason);
 	}
 


### PR DESCRIPTION


## Description
Latest event (fluid:telemetry:RouterliciousDriver:DeltaConnection:ConnectDocumentSuccess) to try to address the NoJoinOps happening in tinylicious seems to indicate a new client is added, join op is sent over the wire but there is no additional logging for that clientid. The current theory is the connection manager being disposed of while waiting for the await docService.connectToDeltaStream to return. We are also adding additional verbose logs to better understand if it still happens.
