### PR TITLE
Perf benchmarks: Make sure config files to skip drivers are enforced even on setup

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/LoadDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/LoadDocument.all.spec.ts
@@ -22,6 +22,12 @@ describeE2EDocRun("Load Document", (getTestObjectProvider, getDocumentInfo) => {
 	before(async () => {
 		provider = getTestObjectProvider();
 		const docData = getDocumentInfo(); // returns the type of document to be processed.
+		if (
+			docData.supportedEndpoints &&
+			!docData.supportedEndpoints?.includes(provider.driver.type)
+		) {
+			return;
+		}
 		documentWrapper = createDocument({
 			testName: `Load Document - ${docData.testTitle}`,
 			provider,

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -24,6 +24,12 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 	before(async () => {
 		provider = getTestObjectProvider();
 		const docData = getDocumentInfo(); // returns the type of document to be processed.
+		if (
+			docData.supportedEndpoints &&
+			!docData.supportedEndpoints?.includes(provider.driver.type)
+		) {
+			return;
+		}
 		documentWrapper = createDocument({
 			testName: `${scenarioTitle} - ${docData.testTitle}`,
 			provider,


### PR DESCRIPTION


## Description
The initial implementation of the performance runs would skip drivers only on the load and summarize events but would still run once during initial setup. AFR is timing out even on that step for Matrix tests. In order to avoid this timeout, we are now enforcing the skip even during the initial setup. 