### PR TITLE
Log ALL verbose events on stress test runs

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -108,7 +108,8 @@ async function main() {
 			driverEndpointName: endpoint,
 			profile: profileName,
 		},
-		random.pick([LogLevel.verbose, LogLevel.default]),
+		// Turn on verbose events for ALL stress test runs.
+		random.pick([LogLevel.verbose]),
 	);
 
 	// this will enabling capturing the full stack for errors


### PR DESCRIPTION

## Description

In order to better understand the scenarios where T9S is triggering NoJoinOps due to clients disappearing, we need the verbose logs to be logged for all the containers and not in 50% of them. When we have a fix for it or If the amount of space on Kusto increases dramatically we might re-visit and go back to 50%. 