### PR TITLE
Fix grouped batching mocks for fuzz testing

### DIFF
--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -201,10 +201,10 @@ export class MockContainerRuntime {
 			localOpMetadata,
 		};
 
+		this.clientSequenceNumber++;
 		switch (this.runtimeOptions.flushMode) {
 			case FlushMode.Immediate: {
 				this.submitInternal(message);
-				this.clientSequenceNumber++;
 				break;
 			}
 
@@ -278,13 +278,6 @@ export class MockContainerRuntime {
 		this.deltaManager.minimumSequenceNumber = message.minimumSequenceNumber;
 		const [local, localOpMetadata] = this.processInternal(message);
 		this.dataStoreRuntime.process(message, local, localOpMetadata);
-
-		if (this.runtimeOptions.enableGroupedBatching) {
-			// If the grouped batching scenario is enabled, we need to advance the
-			// client sequence number when we process a remote op. Sending ops will
-			// not increment this value.
-			this.clientSequenceNumber++;
-		}
 	}
 
 	protected addPendingMessage(
@@ -306,10 +299,10 @@ export class MockContainerRuntime {
 		if (local) {
 			const pendingMessage = this.pendingMessages.shift();
 			assert(
-				pendingMessage?.clientSequenceNumber === message.clientSequenceNumber,
-				"Unexpected client sequence number from message",
+				JSON.stringify(pendingMessage?.content) === JSON.stringify(message.contents),
+				"Unexpected message",
 			);
-			localOpMetadata = pendingMessage.localOpMetadata;
+			localOpMetadata = pendingMessage?.localOpMetadata;
 		}
 		return [local, localOpMetadata];
 	}

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -204,7 +204,7 @@ export class MockContainerRuntime {
 		this.clientSequenceNumber++;
 		switch (this.runtimeOptions.flushMode) {
 			case FlushMode.Immediate: {
-				this.submitInternal(message, this.clientSequenceNumber);
+				this.submitInternal(message, clientSequenceNumber);
 				break;
 			}
 

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -279,7 +279,7 @@ export class MockContainerRuntime {
 			referenceSequenceNumber: this.referenceSequenceNumber,
 			type: MessageType.Operation,
 		});
-		this.addPendingMessage(message.content, message.localOpMetadata, this.clientSequenceNumber);
+		this.addPendingMessage(message.content, message.localOpMetadata, clientSequenceNumber);
 	}
 
 	public process(message: ISequencedDocumentMessage) {
@@ -309,10 +309,10 @@ export class MockContainerRuntime {
 		if (local) {
 			const pendingMessage = this.pendingMessages.shift();
 			assert(
-				JSON.stringify(pendingMessage?.content) === JSON.stringify(message.contents),
+				pendingMessage?.clientSequenceNumber === message.clientSequenceNumber,
 				"Unexpected message",
 			);
-			localOpMetadata = pendingMessage?.localOpMetadata;
+			localOpMetadata = pendingMessage.localOpMetadata;
 		}
 		return [local, localOpMetadata];
 	}


### PR DESCRIPTION
## Description

Related to ADO:6011. Also, it was brought to my attention by @clarenceli-msft.

The issues here were:
- `this.clientSequenceNumber` was only incremented at read time when grouped batching was enabled. This means that that when batches are ungrouped, there can be two messages with the same client sequence number, same sequence number and different content.
- grouped batching uses fake client sequence numbers, just to differentiate between messages within the same batch.