### PR TITLE
tree2: Add API to encode schema for snapshotting

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -592,6 +592,9 @@ export const EmptyKey: FieldKey;
 type EmptyObject = {};
 
 // @alpha
+export function encodeTreeSchema(schema: TreeStoredSchema): JsonCompatible;
+
+// @alpha
 export type Events<E> = {
     [P in (string | symbol) & keyof E as IsEvent<E[P]> extends true ? P : never]: E[P];
 };

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -85,7 +85,7 @@ export { ForestSummarizer } from "./forestSummarizer";
 export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";
 export { MemoizedIdRangeAllocator, IdRange } from "./memoizedIdRangeAllocator";
 export { buildForest } from "./object-forest";
-export { SchemaSummarizer, SchemaEditor } from "./schemaSummarizer";
+export { SchemaSummarizer, SchemaEditor, encodeTreeSchema } from "./schemaSummarizer";
 // This is exported because its useful for doing comparisons of schema in tests.
 export { makeSchemaCodec } from "./schemaIndexFormat";
 export {

--- a/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
@@ -79,7 +79,7 @@ const Versioned = Type.Object({
 });
 type Versioned = Static<typeof Versioned>;
 
-function encodeRepo(repo: TreeStoredSchema): Format {
+export function encodeRepo(repo: TreeStoredSchema): Format {
 	const treeSchema: TreeSchemaFormat[] = [];
 	const rootFieldSchema = encodeField(repo.rootFieldSchema);
 	for (const [name, schema] of repo.treeSchema) {

--- a/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaSummarizer.ts
@@ -32,8 +32,8 @@ import {
 	SchemaEvents,
 } from "../core";
 import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
-import { isJsonObject, JsonCompatibleReadOnly } from "../util";
-import { makeSchemaCodec, Format } from "./schemaIndexFormat";
+import { isJsonObject, JsonCompatible, JsonCompatibleReadOnly } from "../util";
+import { makeSchemaCodec, Format, encodeRepo } from "./schemaIndexFormat";
 
 /**
  * The storage key for the blob in the summary containing schema data
@@ -240,4 +240,21 @@ export class SchemaEditor<TRepository extends StoredSchemaRepository>
 
 		return undefined;
 	}
+}
+
+/**
+ * Dumps schema into a deterministic JSON compatible semi-human readable but unspecified format.
+ *
+ * @remarks
+ * This can be used to help inspect schema for debugging, and to save a snapshot of schema to help detect and review changes to an applications schema.
+ *
+ * This format may change across major versions of this package: such changes are considered breaking.
+ * Beyond that, no compatibility guarantee is provided for this format: it should never be relied upon to load data, it should only be used for comparing outputs from this function.
+ * @privateRemarks
+ * This currently uses the schema summary format, but that could be changed to something more human readable (particularly if the encoded format becomes less human readable).
+ * This intentionally does not leak the format types in the API.
+ * @alpha
+ */
+export function encodeTreeSchema(schema: TreeStoredSchema): JsonCompatible {
+	return encodeRepo(schema);
 }

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -289,6 +289,7 @@ export {
 	SharedTreeObjectFactory,
 	SchemaCollection,
 	FactoryTreeSchema,
+	encodeTreeSchema,
 } from "./feature-libraries";
 
 export {

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaSummarizer.spec..ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaSummarizer.spec..ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+	encodeTreeSchema,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../feature-libraries/schemaSummarizer";
+import { storedEmptyFieldSchema } from "../../core";
+import { jsonSequenceRootSchema } from "../utils";
+
+describe("schemaSummarizer", () => {
+	describe("encodeTreeSchema", () => {
+		it("empty", () => {
+			const encoded = encodeTreeSchema({
+				rootFieldSchema: storedEmptyFieldSchema,
+				treeSchema: new Map(),
+			});
+			const snapshot = {};
+			assert.deepEqual(encoded, snapshot);
+		});
+	});
+
+	it("simple", () => {
+		const encoded = encodeTreeSchema(jsonSequenceRootSchema);
+		const snapshot = {};
+		assert.deepEqual(encoded, snapshot);
+	});
+});

--- a/experimental/dds/tree2/src/test/feature-libraries/schemaSummarizer.spec..ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schemaSummarizer.spec..ts
@@ -19,14 +19,101 @@ describe("schemaSummarizer", () => {
 				rootFieldSchema: storedEmptyFieldSchema,
 				treeSchema: new Map(),
 			});
-			const snapshot = {};
+			const snapshot = {
+				rootFieldSchema: {
+					kind: "Forbidden",
+				},
+				treeSchema: [],
+				version: "1.0.0",
+			};
 			assert.deepEqual(encoded, snapshot);
 		});
-	});
 
-	it("simple", () => {
-		const encoded = encodeTreeSchema(jsonSequenceRootSchema);
-		const snapshot = {};
-		assert.deepEqual(encoded, snapshot);
+		it("simple", () => {
+			const encoded = encodeTreeSchema(jsonSequenceRootSchema);
+			const snapshot = {
+				rootFieldSchema: {
+					kind: "Sequence",
+					types: [
+						"com.fluidframework.json.object",
+						"com.fluidframework.json.array",
+						"com.fluidframework.leaf.number",
+						"com.fluidframework.leaf.boolean",
+						"com.fluidframework.leaf.string",
+						"com.fluidframework.leaf.null",
+					],
+				},
+				treeSchema: [
+					{
+						leafValue: undefined,
+						mapFields: undefined,
+						name: "com.fluidframework.json.array",
+						objectNodeFields: [
+							{
+								kind: "Sequence",
+								name: "",
+								types: [
+									"com.fluidframework.json.object",
+									"com.fluidframework.json.array",
+									"com.fluidframework.leaf.number",
+									"com.fluidframework.leaf.boolean",
+									"com.fluidframework.leaf.string",
+									"com.fluidframework.leaf.null",
+								],
+							},
+						],
+					},
+					{
+						leafValue: undefined,
+						mapFields: {
+							kind: "Optional",
+							types: [
+								"com.fluidframework.json.object",
+								"com.fluidframework.json.array",
+								"com.fluidframework.leaf.number",
+								"com.fluidframework.leaf.boolean",
+								"com.fluidframework.leaf.string",
+								"com.fluidframework.leaf.null",
+							],
+						},
+						name: "com.fluidframework.json.object",
+						objectNodeFields: [],
+					},
+					{
+						leafValue: 2,
+						mapFields: undefined,
+						name: "com.fluidframework.leaf.boolean",
+						objectNodeFields: [],
+					},
+					{
+						leafValue: 3,
+						mapFields: undefined,
+						name: "com.fluidframework.leaf.handle",
+						objectNodeFields: [],
+					},
+					{
+						leafValue: 4,
+						mapFields: undefined,
+						name: "com.fluidframework.leaf.null",
+						objectNodeFields: [],
+					},
+					{
+						leafValue: 0,
+						mapFields: undefined,
+						name: "com.fluidframework.leaf.number",
+						objectNodeFields: [],
+					},
+					{
+						leafValue: 1,
+						mapFields: undefined,
+						name: "com.fluidframework.leaf.string",
+						objectNodeFields: [],
+					},
+				],
+				version: "1.0.0",
+			};
+
+			assert.deepEqual(encoded, snapshot);
+		});
 	});
 });


### PR DESCRIPTION
## Description

Expose an API which can be used to dump schema to text or json.
This is useful for inspecting schema for debugging purposes, as well as for making tests which snapshot an app's schema so they can review any changes which would impact the stored schema in a single place.

Combined with https://github.com/microsoft/FluidFramework/pull/17944 this provides a fully JSON compatible view of the content in a tree, suitable for testing and debugging.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
