### PR TITLE
fix(tree): insert* and move* should accept proxy API types

### DIFF
--- a/experimental/dds/tree2/.dependency-cruiser-known-violations.json
+++ b/experimental/dds/tree2/.dependency-cruiser-known-violations.json
@@ -490,5 +490,25 @@
 			"src/feature-libraries/editable-tree/editableField.ts",
 			"src/feature-libraries/editable-tree-2/index.ts"
 		]
+	},
+	{
+		"type": "cycle",
+		"from": "src/feature-libraries/editable-tree-2/index.ts",
+		"to": "src/feature-libraries/editable-tree-2/proxies/index.ts",
+		"rule": {
+			"severity": "error",
+			"name": "no-circular"
+		},
+		"cycle": [
+			"src/feature-libraries/editable-tree-2/proxies/index.ts",
+			"src/feature-libraries/editable-tree-2/proxies/node.ts",
+			"src/feature-libraries/editable-tree-2/proxies/proxies.ts",
+			"src/feature-libraries/editable-tree-2/lazyTree.ts",
+			"src/feature-libraries/editable-tree-2/lazyField.ts",
+			"src/feature-libraries/contextuallyTyped.ts",
+			"src/feature-libraries/editable-tree/index.ts",
+			"src/feature-libraries/editable-tree/editableField.ts",
+			"src/feature-libraries/editable-tree-2/index.ts"
+		]
 	}
 ]

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -30,7 +30,7 @@ export type AllowedTypeSet = Any | ReadonlySet<TreeNodeSchema>;
 
 // @alpha
 type AllowedTypesToTypedTrees<Mode extends ApiMode, T extends AllowedTypes> = [
-T extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Mode, Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<T>, readonly TreeNodeSchema[]>>> : UntypedApi<Mode>
+T extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray<Mode, Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<T>, readonly TreeNodeSchema[]>>> : UntypedApi<Mode>
 ][_InlineTrick];
 
 // @alpha
@@ -885,7 +885,7 @@ declare namespace InternalEditableTreeTypes {
     export {
         TypedFieldInner,
         UnboxFieldInner,
-        TypeArrayToTypedTreeArray,
+        TypeArrayToTypedTreeArray_2 as TypeArrayToTypedTreeArray,
         ObjectNodeFields,
         UnboxField,
         UnboxNode,
@@ -970,7 +970,7 @@ declare namespace InternalTypes_2 {
         EditableOptionalField,
         TypedField_2 as TypedField,
         UnbrandedName,
-        TypeArrayToTypedTreeArray_2 as TypeArrayToTypedTreeArray,
+        TypeArrayToTypedTreeArray,
         UntypedApi,
         EmptyObject,
         ValuesOf,
@@ -1952,14 +1952,15 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha
 export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> extends ReadonlyArray<ProxyNodeUnion<TTypes, API>> {
-    insertAt(index: number, value: Iterable<FlexibleNodeContent<TTypes>>): void;
-    insertAtEnd(value: Iterable<FlexibleNodeContent<TTypes>>): void;
-    insertAtStart(value: Iterable<FlexibleNodeContent<TTypes>>): void;
+    insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes>>): void;
+    insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes>>): void;
+    insertAtStart(value: Iterable<ProxyNodeUnion<TTypes>>): void;
     moveToEnd(sourceStart: number, sourceEnd: number): void;
-    moveToEnd<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>): void;
+    moveToEnd<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>): void;
     moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+    moveToIndex<TTypesSource extends AllowedTypes>(index: number, sourceStart: number, sourceEnd: number, source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>): void;
     moveToStart(sourceStart: number, sourceEnd: number): void;
-    moveToStart<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>): void;
+    moveToStart<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>): void;
     removeAt(index: number): void;
     removeRange(start?: number, end?: number): void;
 }
@@ -2220,18 +2221,18 @@ export type TreeValue<TSchema extends ValueSchema = ValueSchema> = [
 ][_InlineTrick];
 
 // @alpha
-type TypeArrayToTypedTreeArray<T extends readonly TreeNodeSchema[]> = [
+type TypeArrayToTypedTreeArray<Mode extends ApiMode, T extends readonly TreeNodeSchema[]> = [
 T extends readonly [infer Head, ...infer Tail] ? [
-TypedNode<Assume<Head, TreeNodeSchema>>,
-...TypeArrayToTypedTreeArray<Assume<Tail, readonly TreeNodeSchema[]>>
+TypedNode_2<Assume<Head, TreeNodeSchema>, Mode>,
+...TypeArrayToTypedTreeArray<Mode, Assume<Tail, readonly TreeNodeSchema[]>>
 ] : []
 ][_InlineTrick];
 
 // @alpha
-type TypeArrayToTypedTreeArray_2<Mode extends ApiMode, T extends readonly TreeNodeSchema[]> = [
+type TypeArrayToTypedTreeArray_2<T extends readonly TreeNodeSchema[]> = [
 T extends readonly [infer Head, ...infer Tail] ? [
-TypedNode_2<Assume<Head, TreeNodeSchema>, Mode>,
-...TypeArrayToTypedTreeArray_2<Mode, Assume<Tail, readonly TreeNodeSchema[]>>
+TypedNode<Assume<Head, TreeNodeSchema>>,
+...TypeArrayToTypedTreeArray_2<Assume<Tail, readonly TreeNodeSchema[]>>
 ] : []
 ][_InlineTrick];
 
@@ -2270,7 +2271,7 @@ export type TypedNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSche
 type TypedNode_2<TSchema extends TreeNodeSchema, Mode extends ApiMode = ApiMode.Editable> = FlattenKeys<CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["objectNodeFieldsObject"]>, TSchema["leafValue"], TSchema["name"]>>;
 
 // @alpha
-export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray<Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>> : TreeNode;
+export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>> : TreeNode;
 
 // @alpha
 export interface TypedTreeChannel extends IChannel {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -340,7 +340,7 @@ export class LazySequence<TTypes extends AllowedTypes>
 		assertValidRangeIndices(sourceStart, sourceEnd, sourceField);
 		if (this.schema.types !== undefined && sourceField !== this) {
 			for (let i = sourceStart; i < sourceEnd; i++) {
-				const sourceNode = sourceField.at(sourceStart);
+				const sourceNode = sourceField.boxedAt(sourceStart);
 				if (!this.schema.types.has(sourceNode.schema.name)) {
 					throw new Error("Type in source sequence is not allowed in destination.");
 				}
@@ -349,7 +349,12 @@ export class LazySequence<TTypes extends AllowedTypes>
 		const count = sourceEnd - sourceStart;
 		let destinationIndex = index;
 		if (sourceField === this) {
-			destinationIndex -= count;
+			if (destinationIndex > sourceStart) {
+				destinationIndex =
+					destinationIndex < sourceEnd
+						? sourceStart // distination overlaps with source range -> slide to left
+						: (destinationIndex -= count); // destination after source range -> subtract count
+			}
 		}
 		assertValidIndex(destinationIndex, this, true);
 		const sourceFieldPath = sourceField.getFieldPath();

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -28,9 +28,11 @@ import {
 import { LazySequence } from "../lazyField";
 import { FieldKey } from "../../../core";
 import { LazyObjectNode, getBoxedField } from "../lazyTree";
+import { ContextuallyTypedNodeData } from "../../contextuallyTyped";
 import {
 	ProxyField,
 	ProxyNode,
+	ProxyNodeUnion,
 	SharedTreeList,
 	SharedTreeObject,
 	getTreeNode,
@@ -330,6 +332,17 @@ function asIndex(key: string | symbol, length: number) {
 	}
 }
 
+function mapInput(
+	iterable: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
+): Iterable<ContextuallyTypedNodeData> {
+	return [...iterable].map(
+		(item) =>
+			(item !== null && typeof item === "object"
+				? getFactoryContent(item) ?? item
+				: item) as ContextuallyTypedNodeData,
+	);
+}
+
 export function createListProxy<TTypes extends AllowedTypes>(
 	treeNode: TreeNode,
 ): SharedTreeList<TTypes> {
@@ -346,6 +359,78 @@ export function createListProxy<TTypes extends AllowedTypes>(
 			set() {},
 			enumerable: false,
 			configurable: false,
+		},
+		insertAt: {
+			value(
+				this: object,
+				index: number,
+				value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>,
+			): void {
+				getField(this).insertAt(index, mapInput(value));
+			},
+		},
+		insertAtStart: {
+			value(this: object, value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void {
+				getField(this).insertAtStart(mapInput(value));
+			},
+		},
+		insertAtEnd: {
+			value(this: object, value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void {
+				getField(this).insertAtEnd(mapInput(value));
+			},
+		},
+		removeAt: {
+			value(this: object, index: number): void {
+				getField(this).removeAt(index);
+			},
+		},
+		removeRange: {
+			value(this: object, start?: number, end?: number): void {
+				getField(this).removeRange(start, end);
+			},
+		},
+		moveToStart: {
+			value(
+				this: object,
+				sourceStart: number,
+				sourceEnd: number,
+				source?: SharedTreeList<AllowedTypes>,
+			): void {
+				if (source !== undefined) {
+					getField(this).moveToStart(sourceStart, sourceEnd, getField(source));
+				} else {
+					getField(this).moveToStart(sourceStart, sourceEnd);
+				}
+			},
+		},
+		moveToEnd: {
+			value(
+				this: object,
+				sourceStart: number,
+				sourceEnd: number,
+				source?: SharedTreeList<AllowedTypes>,
+			): void {
+				if (source !== undefined) {
+					getField(this).moveToEnd(sourceStart, sourceEnd, getField(source));
+				} else {
+					getField(this).moveToEnd(sourceStart, sourceEnd);
+				}
+			},
+		},
+		moveToIndex: {
+			value(
+				this: object,
+				index: number,
+				sourceStart: number,
+				sourceEnd: number,
+				source?: SharedTreeList<AllowedTypes>,
+			): void {
+				if (source !== undefined) {
+					getField(this).moveToIndex(index, sourceStart, sourceEnd, getField(source));
+				} else {
+					getField(this).moveToIndex(index, sourceStart, sourceEnd);
+				}
+			},
 		},
 	});
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -204,49 +204,146 @@ export function createObjectProxy<TSchema extends ObjectNodeSchema, TTypes exten
 	return proxy;
 }
 
-const getField = <TTypes extends AllowedTypes>(target: object) => {
-	const treeNode = getTreeNode(target) as FieldNode<FieldNodeSchema>;
+/**
+ * Given the a list proxy, returns it's underlying LazySequence field.
+ */
+const getSequenceField = <TTypes extends AllowedTypes>(
+	list: SharedTreeList<AllowedTypes, "javaScript">,
+) => {
+	const treeNode = getTreeNode(list) as FieldNode<FieldNodeSchema>;
 	const field = treeNode.content;
 	return field as LazySequence<TTypes>;
 };
 
+// Converts a proxy union to contextually typed data, extracting factory content if necessary.
+const asContextuallyTypedData = (value: ProxyNodeUnion<AllowedTypes, "javaScript">) =>
+	(value === null || typeof value !== "object"
+		? value // Return primitives as-is
+		: getFactoryContent(value) ?? value) as ContextuallyTypedNodeData; // Otherwise extract factory content (if necessary).
+
+// Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
+// typed data prior to forwarding to 'LazySequence.insert*()'.
+function itemsAsContextuallyTyped(
+	iterable: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
+): Iterable<ContextuallyTypedNodeData> {
+	// If the iterable is not already an array, copy it into an array to use '.map()' below.
+	const asArray = Array.isArray(iterable) ? iterable : Array.from(iterable);
+
+	return asArray.map(asContextuallyTypedData);
+}
+
 // TODO: Experiment with alternative dispatch methods to see if we can improve performance.
 
-// For brevity, the current implementation dynamically builds a property descriptor map from a list of
-// functions we want to re-expose via the proxy.
+/** PropertyDescriptorMap used to build the prototype for our dispatch object. */
+const prototypeProperties: PropertyDescriptorMap = {
+	// We manually add [Symbol.iterator] to the dispatch map rather than use '[fn.name] = fn' as
+	// above because 'Array.prototype[Symbol.iterator].name' returns "values" (i.e., Symbol.iterator
+	// is an alias for the '.values()' function.)
+	[Symbol.iterator]: {
+		value: Array.prototype[Symbol.iterator],
+	},
+	insertAt: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			index: number,
+			value: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
+		): void {
+			getSequenceField(this).insertAt(index, itemsAsContextuallyTyped(value));
+		},
+	},
+	insertAtStart: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			value: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
+		): void {
+			getSequenceField(this).insertAtStart(itemsAsContextuallyTyped(value));
+		},
+	},
+	insertAtEnd: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			value: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
+		): void {
+			getSequenceField(this).insertAtEnd(itemsAsContextuallyTyped(value));
+		},
+	},
+	removeAt: {
+		value(this: SharedTreeList<AllowedTypes, "javaScript">, index: number): void {
+			getSequenceField(this).removeAt(index);
+		},
+	},
+	removeRange: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			start?: number,
+			end?: number,
+		): void {
+			getSequenceField(this).removeRange(start, end);
+		},
+	},
+	moveToStart: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			sourceStart: number,
+			sourceEnd: number,
+			source?: SharedTreeList<AllowedTypes>,
+		): void {
+			if (source !== undefined) {
+				getSequenceField(this).moveToStart(
+					sourceStart,
+					sourceEnd,
+					getSequenceField(source),
+				);
+			} else {
+				getSequenceField(this).moveToStart(sourceStart, sourceEnd);
+			}
+		},
+	},
+	moveToEnd: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			sourceStart: number,
+			sourceEnd: number,
+			source?: SharedTreeList<AllowedTypes>,
+		): void {
+			if (source !== undefined) {
+				getSequenceField(this).moveToEnd(sourceStart, sourceEnd, getSequenceField(source));
+			} else {
+				getSequenceField(this).moveToEnd(sourceStart, sourceEnd);
+			}
+		},
+	},
+	moveToIndex: {
+		value(
+			this: SharedTreeList<AllowedTypes, "javaScript">,
+			index: number,
+			sourceStart: number,
+			sourceEnd: number,
+			source?: SharedTreeList<AllowedTypes>,
+		): void {
+			if (source !== undefined) {
+				getSequenceField(this).moveToIndex(
+					index,
+					sourceStart,
+					sourceEnd,
+					getSequenceField(source),
+				);
+			} else {
+				getSequenceField(this).moveToIndex(index, sourceStart, sourceEnd);
+			}
+		},
+	},
+};
 
-const staticDispatchMap: PropertyDescriptorMap = {};
-
-// TODO: Historically I've been impressed by V8's ability to inline compositions of functions, but it's
-// still worth seeing if manually inlining 'thisContext' can improve performance.
-
-/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/unbound-method */
-
-/**
- * Adds a PropertyDescriptor for the given function to the 'staticDispatchMap'.  The 'thisContext' function
- * receives the original 'this' argument (which is the proxy) and returns the desired 'this' context
- * for the function call.  (We use 'thisContext' to redirect calls to the underlying LazySequence.)
- */
-function addDescriptor(
-	map: PropertyDescriptorMap,
-	fn: Function,
-	thisContext: (self: object) => object,
-) {
-	map[fn.name] = {
-		get: () =>
-			function (this: any, ...args: any[]) {
-				return fn.apply(thisContext(this), args) as unknown;
-			},
-		enumerable: false,
-		configurable: false,
-	};
-}
 
 // For compatibility, we are initially implement 'readonly T[]' by applying the Array.prototype methods
 // to the list proxy.  Over time, we should replace these with efficient implementations on LazySequence
 // to avoid re-entering the proxy as these methods access 'length' and the indexed properties.
 //
+// For brevity, the current implementation dynamically builds a property descriptor map from a list of
+// Array functions we want to re-expose via the proxy.
+
 // TODO: This assumes 'Function.name' matches the property name on 'Array.prototype', which may be
 // dubious across JS engines.
 [
@@ -286,35 +383,12 @@ function addDescriptor(
 	// Array.prototype.unshift,
 	Array.prototype.values,
 ].forEach((fn) => {
-	addDescriptor(staticDispatchMap, fn, (proxy) => proxy);
+	prototypeProperties[fn.name] = { value: fn };
 });
-
-// These are methods implemented by LazySequence that we expose through the proxy.
-[
-	LazySequence.prototype.insertAt,
-	LazySequence.prototype.removeAt,
-	LazySequence.prototype.insertAtStart,
-	LazySequence.prototype.insertAtEnd,
-	LazySequence.prototype.removeRange,
-	LazySequence.prototype.moveToStart,
-	LazySequence.prototype.moveToEnd,
-	LazySequence.prototype.moveToIndex,
-].forEach((fn) => {
-	addDescriptor(staticDispatchMap, fn, getField);
-});
-
-// [Symbol.iterator] is an alias for 'Array.prototype.values', as 'Function.name' returns 'values'.
-staticDispatchMap[Symbol.iterator] = {
-	value: Array.prototype[Symbol.iterator],
-	writable: false,
-	enumerable: false,
-	configurable: false,
-};
 
 /* eslint-enable @typescript-eslint/unbound-method */
-/* eslint-enable @typescript-eslint/ban-types */
 
-const prototype = Object.create(Object.prototype, staticDispatchMap);
+const prototype = Object.create(Object.prototype, prototypeProperties);
 
 /**
  * Helper to coerce property keys to integer indexes (or undefined if not an in-range integer).
@@ -332,17 +406,6 @@ function asIndex(key: string | symbol, length: number) {
 	}
 }
 
-function mapInput(
-	iterable: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
-): Iterable<ContextuallyTypedNodeData> {
-	return [...iterable].map(
-		(item) =>
-			(item !== null && typeof item === "object"
-				? getFactoryContent(item) ?? item
-				: item) as ContextuallyTypedNodeData,
-	);
-}
-
 export function createListProxy<TTypes extends AllowedTypes>(
 	treeNode: TreeNode,
 ): SharedTreeList<TTypes> {
@@ -353,84 +416,12 @@ export function createListProxy<TTypes extends AllowedTypes>(
 	// Properties normally inherited from 'Array.prototype' are surfaced via the prototype chain.
 	const dispatch = Object.create(prototype, {
 		length: {
-			get(this: object) {
-				return getField(this).length;
+			get(this: SharedTreeList<AllowedTypes, "javaScript">) {
+				return getSequenceField(this).length;
 			},
 			set() {},
 			enumerable: false,
 			configurable: false,
-		},
-		insertAt: {
-			value(
-				this: object,
-				index: number,
-				value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>,
-			): void {
-				getField(this).insertAt(index, mapInput(value));
-			},
-		},
-		insertAtStart: {
-			value(this: object, value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void {
-				getField(this).insertAtStart(mapInput(value));
-			},
-		},
-		insertAtEnd: {
-			value(this: object, value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void {
-				getField(this).insertAtEnd(mapInput(value));
-			},
-		},
-		removeAt: {
-			value(this: object, index: number): void {
-				getField(this).removeAt(index);
-			},
-		},
-		removeRange: {
-			value(this: object, start?: number, end?: number): void {
-				getField(this).removeRange(start, end);
-			},
-		},
-		moveToStart: {
-			value(
-				this: object,
-				sourceStart: number,
-				sourceEnd: number,
-				source?: SharedTreeList<AllowedTypes>,
-			): void {
-				if (source !== undefined) {
-					getField(this).moveToStart(sourceStart, sourceEnd, getField(source));
-				} else {
-					getField(this).moveToStart(sourceStart, sourceEnd);
-				}
-			},
-		},
-		moveToEnd: {
-			value(
-				this: object,
-				sourceStart: number,
-				sourceEnd: number,
-				source?: SharedTreeList<AllowedTypes>,
-			): void {
-				if (source !== undefined) {
-					getField(this).moveToEnd(sourceStart, sourceEnd, getField(source));
-				} else {
-					getField(this).moveToEnd(sourceStart, sourceEnd);
-				}
-			},
-		},
-		moveToIndex: {
-			value(
-				this: object,
-				index: number,
-				sourceStart: number,
-				sourceEnd: number,
-				source?: SharedTreeList<AllowedTypes>,
-			): void {
-				if (source !== undefined) {
-					getField(this).moveToIndex(index, sourceStart, sourceEnd, getField(source));
-				} else {
-					getField(this).moveToIndex(index, sourceStart, sourceEnd);
-				}
-			},
 		},
 	});
 
@@ -441,7 +432,7 @@ export function createListProxy<TTypes extends AllowedTypes>(
 	// requirements without use of Array[Symbol.species], which is potentially on a path ot deprecation.
 	return new Proxy<SharedTreeList<TTypes>>([] as any, {
 		get: (target, key) => {
-			const field = getField(dispatch);
+			const field = getSequenceField(dispatch);
 			const maybeIndex = asIndex(key, field.length);
 
 			// TODO: Ideally, we would return leaves without first boxing them.  However, this is not
@@ -462,19 +453,19 @@ export function createListProxy<TTypes extends AllowedTypes>(
 			return false;
 		},
 		has: (target, key) => {
-			const field = getField(dispatch);
+			const field = getSequenceField(dispatch);
 			const maybeIndex = asIndex(key, field.length);
 			return maybeIndex !== undefined || Reflect.has(dispatch, key);
 		},
 		ownKeys: (target) => {
-			const field = getField(dispatch);
+			const field = getSequenceField(dispatch);
 
 			// TODO: Would a lazy iterator to produce the indexes work / be more efficient?
 			// TODO: Need to surface 'Symbol.isConcatSpreadable' as an own key.
 			return Array.from({ length: field.length }, (_, index) => `${index}`).concat("length");
 		},
 		getOwnPropertyDescriptor: (target, key) => {
-			const field = getField(dispatch);
+			const field = getSequenceField(dispatch);
 			const maybeIndex = asIndex(key, field.length);
 			if (maybeIndex !== undefined) {
 				// To satisfy 'deepEquals' level scrutiny, the property descriptor for indexed properties must
@@ -492,7 +483,7 @@ export function createListProxy<TTypes extends AllowedTypes>(
 				// To satisfy 'deepEquals' level scrutiny, the property descriptor for 'length' must be a simple
 				// value property (as opposed to using getter) and be declared writable / non-configurable.
 				return {
-					value: getField(dispatch).length,
+					value: getSequenceField(dispatch).length,
 					writable: true,
 					enumerable: false,
 					configurable: false,

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -19,13 +19,7 @@ import {
 	TreeNodeSchema,
 	TreeSchema,
 } from "../../typed-schema";
-import {
-	CheckTypesOverlap,
-	FlexibleNodeContent,
-	Sequence,
-	AssignableFieldKinds,
-	TreeNode,
-} from "../editableTreeTypes";
+import { CheckTypesOverlap, AssignableFieldKinds, TreeNode } from "../editableTreeTypes";
 
 /**
  * An object-like SharedTree node. Includes objects, lists, and maps.
@@ -50,21 +44,21 @@ export interface SharedTreeList<
 	 * @param value - The content to insert.
 	 * @throws Throws if any of the input indices are invalid.
 	 */
-	insertAt(index: number, value: Iterable<FlexibleNodeContent<TTypes>>): void;
+	insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes>>): void;
 
 	/**
 	 * Inserts new item(s) at the start of the sequence.
 	 * @param value - The content to insert.
 	 * @throws Throws if any of the input indices are invalid.
 	 */
-	insertAtStart(value: Iterable<FlexibleNodeContent<TTypes>>): void;
+	insertAtStart(value: Iterable<ProxyNodeUnion<TTypes>>): void;
 
 	/**
 	 * Inserts new item(s) at the end of the sequence.
 	 * @param value - The content to insert.
 	 * @throws Throws if any of the input indices are invalid.
 	 */
-	insertAtEnd(value: Iterable<FlexibleNodeContent<TTypes>>): void;
+	insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes>>): void;
 
 	/**
 	 * Removes the item at the specified location.
@@ -104,7 +98,7 @@ export interface SharedTreeList<
 	moveToStart<TTypesSource extends AllowedTypes>(
 		sourceStart: number,
 		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>,
 	): void;
 
 	/**
@@ -129,7 +123,7 @@ export interface SharedTreeList<
 	moveToEnd<TTypesSource extends AllowedTypes>(
 		sourceStart: number,
 		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>,
 	): void;
 
 	/**
@@ -143,24 +137,22 @@ export interface SharedTreeList<
 	 */
 	moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
 
-	// TODO: Should accept a proxy rather than sequence field as source.
-
-	// /**
-	//  * Moves the specified items to the desired location within the sequence.
-	//  * @param index - The index to move the items to.
-	//  * @param sourceStart - The starting index of the range to move (inclusive).
-	//  * @param sourceEnd - The ending index of the range to move (exclusive)
-	//  * @param source - The source sequence to move items out of.
-	//  * @throws Throws if the types of any of the items being moved are not allowed in the destination sequence or if the input indices are invalid.
-	//  * @remarks
-	//  * All indices are relative to the sequence excluding the nodes being moved.
-	//  */
-	// moveToIndex<TTypesSource extends AllowedTypes>(
-	// 	index: number,
-	// 	sourceStart: number,
-	// 	sourceEnd: number,
-	// 	source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
-	// ): void;
+	/**
+	 * Moves the specified items to the desired location within the sequence.
+	 * @param index - The index to move the items to.
+	 * @param sourceStart - The starting index of the range to move (inclusive).
+	 * @param sourceEnd - The ending index of the range to move (exclusive)
+	 * @param source - The source sequence to move items out of.
+	 * @throws Throws if the types of any of the items being moved are not allowed in the destination sequence or if the input indices are invalid.
+	 * @remarks
+	 * All indices are relative to the sequence excluding the nodes being moved.
+	 */
+	moveToIndex<TTypesSource extends AllowedTypes>(
+		index: number,
+		sourceStart: number,
+		sourceEnd: number,
+		source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>,
+	): void;
 }
 
 /**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -64,7 +64,7 @@ describe("SharedTreeObject", () => {
 		polyChild: [numberChild, stringChild],
 		polyValueChild: [sb.number, numberChild],
 		// map: sb.map("map", sb.optional(leaf.string)), // TODO Test Maps
-		list: sb.fieldNode("list", sb.sequence(numberChild)),
+		list: sb.list(numberChild),
 	});
 
 	const schema = sb.intoSchema(parentSchema);
@@ -128,4 +128,43 @@ describe("SharedTreeObject", () => {
 			}
 		},
 	);
+});
+
+describe("SharedTreeList", () => {
+	const sb = new SchemaBuilder({
+		scope: "test",
+	});
+
+	const objectSchema = sb.object("parent", {
+		listA: sb.list(sb.string),
+		listB: sb.list(sb.string),
+	});
+
+	const schema = sb.intoSchema(objectSchema);
+
+	const initialTree = {
+		listA: ["a0", "a1"],
+		listB: ["b0", "b1"],
+	};
+
+	itWithRoot("can move an element between lists", schema, initialTree, (root) => {
+		root.listB.moveToIndex(1, 0, 1, root.listA);
+		assert.deepEqual(root.listB, ["b0, a0, a1, b1"]);
+	});
+});
+
+describe("SharedTreeList", () => {
+	const sb = new SchemaBuilder({
+		scope: "test",
+	});
+
+	const objectSchema = sb.object("object", {});
+	const listSchema = sb.list(objectSchema);
+	const schema = sb.intoSchema(listSchema);
+
+	itWithRoot("can move an element between lists", schema, [], (root) => {
+		root.insertAtStart([objectSchema.create({})]);
+		root.insertAtEnd([objectSchema.create({})]);
+		root.insertAtEnd([objectSchema.create({})]);
+	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { SchemaBuilder } from "../../../domains";
 import { node, typeNameSymbol } from "../../../feature-libraries";
-import { itWithRoot } from "./utils";
+import { itWithRoot, pretty } from "./utils";
 
 describe("SharedTree proxies", () => {
 	const sb = new SchemaBuilder({
@@ -131,40 +131,151 @@ describe("SharedTreeObject", () => {
 });
 
 describe("SharedTreeList", () => {
-	const sb = new SchemaBuilder({
-		scope: "test",
+	describe("inserting nodes created by factory", () => {
+		const _ = new SchemaBuilder({ scope: "test" });
+		const obj = _.object("Obj", { id: _.string });
+		const schema = _.intoSchema(_.list(obj));
+
+		itWithRoot("insertAtStart()", schema, [{ id: "B" }], (list) => {
+			assert.deepEqual(list, [{ id: "B" }]);
+			const newItem = obj.create({ id: "A" });
+			list.insertAtStart([newItem]);
+			assert.deepEqual(list, [{ id: "A" }, { id: "B" }]);
+		});
+
+		itWithRoot("insertAtEnd()", schema, [{ id: "A" }], (list) => {
+			assert.deepEqual(list, [{ id: "A" }]);
+			const newItem = obj.create({ id: "B" });
+			list.insertAtEnd([newItem]);
+			assert.deepEqual(list, [{ id: "A" }, { id: "B" }]);
+		});
+
+		itWithRoot("insertAt()", schema, [{ id: "A" }, { id: "C" }], (list) => {
+			assert.deepEqual(list, [{ id: "A" }, { id: "C" }]);
+			const newItem = obj.create({ id: "B" });
+			list.insertAt(1, [newItem]);
+			assert.deepEqual(list, [{ id: "A" }, { id: "B" }, { id: "C" }]);
+		});
 	});
 
-	const objectSchema = sb.object("parent", {
-		listA: sb.list(sb.string),
-		listB: sb.list(sb.string),
+	describe("removing items", () => {
+		const _ = new SchemaBuilder({ scope: "test" });
+		const schema = _.intoSchema(_.list(_.number));
+
+		itWithRoot("removeAt()", schema, [0, 1, 2], (list) => {
+			assert.deepEqual(list, [0, 1, 2]);
+			list.removeAt(1);
+			assert.deepEqual(list, [0, 2]);
+		});
+
+		itWithRoot("removeRange()", schema, [0, 1, 2, 3], (list) => {
+			assert.deepEqual(list, [0, 1, 2, 3]);
+			list.removeRange(/* start: */ 1, /* end: */ 3);
+			assert.deepEqual(list, [0, 3]);
+		});
 	});
 
-	const schema = sb.intoSchema(objectSchema);
+	describe("moving items", () => {
+		describe("within the same list", () => {
+			const _ = new SchemaBuilder({ scope: "test" });
+			const schema = _.intoSchema(_.list(_.number));
+			const initialTree = [0, 1, 2, 3];
 
-	const initialTree = {
-		listA: ["a0", "a1"],
-		listB: ["b0", "b1"],
-	};
+			itWithRoot("moveToStart()", schema, initialTree, (list) => {
+				assert.deepEqual(list, [0, 1, 2, 3]);
+				list.moveToStart(/* sourceStart: */ 1, /* sourceEnd: */ 3);
+				assert.deepEqual(list, [1, 2, 0, 3]);
+			});
 
-	itWithRoot("can move an element between lists", schema, initialTree, (root) => {
-		root.listB.moveToIndex(1, 0, 1, root.listA);
-		assert.deepEqual(root.listB, ["b0, a0, a1, b1"]);
-	});
-});
+			itWithRoot("moveToEnd()", schema, initialTree, (list) => {
+				assert.deepEqual(list, [0, 1, 2, 3]);
+				list.moveToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 3);
+				assert.deepEqual(list, [0, 3, 1, 2]);
+			});
 
-describe("SharedTreeList", () => {
-	const sb = new SchemaBuilder({
-		scope: "test",
-	});
+			describe("moveToIndex()", () => {
+				function check(index: number, start: number, end: number) {
+					const expected = initialTree.slice(0);
+					// Remove the moved items from [start..end).
+					const moved = expected.splice(start, /* deleteCount: */ end - start);
+					// Re-insert the moved items, adjusting index as necessary.
+					expected.splice(
+						index <= start
+							? index // If the index is <= start, it is unmodified
+							: index >= end
+							? index - moved.length // If the index is >= end, subtract the number of moved items.
+							: start, // If the index is inside the moved window, slide it left to the starting position.
+						/* deleteCount: */ 0,
+						...moved,
+					);
 
-	const objectSchema = sb.object("object", {});
-	const listSchema = sb.list(objectSchema);
-	const schema = sb.intoSchema(listSchema);
+					itWithRoot(
+						`${pretty(
+							initialTree,
+						)}.moveToStart(dest: ${index}, start: ${start}, end: ${end}) -> ${pretty(
+							expected,
+						)}`,
+						schema,
+						initialTree,
+						(list) => {
+							assert.deepEqual(list, initialTree);
+							list.moveToIndex(index, start, end);
+							assert.deepEqual(list, expected);
+						},
+					);
+				}
 
-	itWithRoot("can move an element between lists", schema, [], (root) => {
-		root.insertAtStart([objectSchema.create({})]);
-		root.insertAtEnd([objectSchema.create({})]);
-		root.insertAtEnd([objectSchema.create({})]);
+				for (let start = 0; start < initialTree.length; start++) {
+					// TODO: Empty moves should be allowed.
+					for (let end = start + 1; end <= initialTree.length; end++) {
+						for (let index = 0; index <= initialTree.length; index++) {
+							check(index, start, end);
+						}
+					}
+				}
+			});
+		});
+
+		describe("between different lists", () => {
+			const _ = new SchemaBuilder({
+				scope: "test",
+			});
+
+			const objectSchema = _.object("parent", {
+				listA: _.list(_.string),
+				listB: _.list(_.string),
+			});
+
+			const schema = _.intoSchema(objectSchema);
+
+			const initialTree = {
+				listA: ["a0", "a1"],
+				listB: ["b0", "b1"],
+			};
+
+			itWithRoot("moveToStart()", schema, initialTree, ({ listA, listB }) => {
+				assert.deepEqual(listA, ["a0", "a1"]);
+				assert.deepEqual(listB, ["b0", "b1"]);
+				listB.moveToStart(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
+				assert.deepEqual(listA, ["a1"]);
+				assert.deepEqual(listB, ["a0", "b0", "b1"]);
+			});
+
+			itWithRoot("moveToEnd()", schema, initialTree, ({ listA, listB }) => {
+				assert.deepEqual(listA, ["a0", "a1"]);
+				assert.deepEqual(listB, ["b0", "b1"]);
+				listB.moveToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
+				assert.deepEqual(listA, ["a1"]);
+				assert.deepEqual(listB, ["b0", "b1", "a0"]);
+			});
+
+			itWithRoot("moveToIndex()", schema, initialTree, ({ listA, listB }) => {
+				assert.deepEqual(listA, ["a0", "a1"]);
+				assert.deepEqual(listB, ["b0", "b1"]);
+				listB.moveToIndex(/* index: */ 1, /* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
+				assert.deepEqual(listA, ["a1"]);
+				assert.deepEqual(listB, ["b0", "a0", "b1"]);
+			});
+		});
 	});
 });


### PR DESCRIPTION
SharedListNode.insert*() needed adjustment to accept the new factory-created content.
SharedListNode.move*() needed adjustment to accept to accept a SharedListNode as source.

Testing also uncovered and fixed a couple of minor bugs in the move implementation:
* Use 'boxedAt()' when validating that the items in the source list comply with the destination type.
* The adjustment of the destination index wasn't quite right.