### PR TITLE
Fix the logic of undelete subdir trees iteratively

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -2447,10 +2447,11 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	}
 
 	private undeleteSubDirectoryTree(directory: SubDirectory): void {
-		// Restore deleted subdirectory tree. This will unmark "deleted" from the subdirectories from bottom to top.
-		for (const [_, subDirectory] of this._subdirectories.entries()) {
-			this.undeleteSubDirectoryTree(subDirectory);
-		}
+		// Restore deleted subdirectory tree. Need to undispose the current directory first, then get access to the iterator.
+		// This will unmark "deleted" from the subdirectories from top to bottom.
 		directory.undispose();
+		for (const [_, subDirectory] of directory.subdirectories()) {
+			this.undeleteSubDirectoryTree(subDirectory as SubDirectory);
+		}
 	}
 }

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -1213,6 +1213,33 @@ describeNoCompat("SharedDirectory orderSequentially", (getTestObjectProvider) =>
 		assert.equal(changedEventData[1].key, "key2");
 		assert.equal(changedEventData[1].previousValue, undefined);
 	});
+
+	it("Should rollback deleted subdirectory when multiple subdirectories exist", () => {
+		let error: Error | undefined;
+
+		sharedDir.createSubDirectory("dir2");
+		sharedDir.createSubDirectory("dir3");
+		sharedDir.createSubDirectory("dir1");
+
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedDir.deleteSubDirectory("dir3");
+				throw new Error("callback failure");
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		// rollback
+		assert.equal(sharedDir.countSubDirectory(), 3);
+		assert.equal(subDirCreatedEventData.length, 4);
+		assert.deepStrictEqual(subDirCreatedEventData, ["dir2", "dir3", "dir1", "dir3"]);
+		assert.equal(subDirDeletedEventData.length, 1);
+		assert.equal(subDirDeletedEventData[0], "dir3");
+	});
 });
 
 describeNoCompat("SharedDirectory", (getTestObjectProvider) => {


### PR DESCRIPTION
The previous `undeleteSubDirectoryTree` could become indefinitely trapped in the root directory when iterating the disposed subdirectories, resulting in the "maximum call stack size exceeded" error (infinite loop) when rolling-back a deletion, given multiple subdirectories exists under the root.

Update the logic to make it undelete the subdirectories iteratively, and add an additional e2e test for more comprehensive coverage.

[AB#6054](https://dev.azure.com/fluidframework/internal/_workitems/edit/6054)
