### PR TITLE
Shared directory fuzz tests with rebasing can be more aggressive

### DIFF
--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -366,9 +366,12 @@ describe("SharedDirectory fuzz Create/Delete concentrated", () => {
 				maxNumberOfClients: 3,
 				clientAddProbability: 0.08,
 			},
-			defaultTestCount: 25,
-			// Seeds 30, 50, 133, 137, 144, 177, 195, 196 fail only when rebaseProbability is non-zero ADO:6044
-			skip: [4, 8, 19],
+			defaultTestCount: 200,
+			// The seeds below fail only when rebaseProbability is non-zero ADO:6044
+			skip: [
+				4, 6, 8, 19, 48, 82, 83, 87, 94, 95, 110, 118, 123, 138, 154, 159, 180, 181, 190,
+				195,
+			],
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 21,
 			saveFailures: {
@@ -397,7 +400,7 @@ describe("SharedDirectory fuzz", () => {
 			maxNumberOfClients: Number.MAX_SAFE_INTEGER,
 			clientAddProbability: 0.08,
 		},
-		defaultTestCount: 200,
+		defaultTestCount: 25,
 		// Uncomment this line to replay a specific seed from its failure file:
 		// replay: 0,
 		saveFailures: { directory: dirPath.join(__dirname, "../../../src/test/mocha/results/2") },
@@ -424,7 +427,7 @@ describe("SharedDirectory fuzz", () => {
 				clientAddProbability: 0.08,
 			},
 			defaultTestCount: 200,
-			// Seeds 30, 50, 133, 137, 144, 177, 195, 196 fail only when rebaseProbability is non-zero ADO:6044
+			// The seeds below fail only when rebaseProbability is non-zero ADO:6044
 			skip: [30, 50, 133, 137, 144, 177, 195, 196],
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 0,

--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -404,10 +404,11 @@ describe("SharedDirectory fuzz", () => {
 		{ ...model, workloadName: "default directory 2 with rebasing" },
 		{
 			validationStrategy: {
-				type: "fixedInterval",
-				interval: defaultOptions.validateInterval,
+				type: "random",
+				probability: 0.4,
 			},
-			rebaseProbability: 0.15,
+			rebaseProbability: 0.2,
+			reconnectProbability: 0.5,
 			containerRuntimeOptions: {
 				flushMode: FlushMode.TurnBased,
 				enableGroupedBatching: true,
@@ -419,7 +420,7 @@ describe("SharedDirectory fuzz", () => {
 				maxNumberOfClients: Number.MAX_SAFE_INTEGER,
 				clientAddProbability: 0.08,
 			},
-			defaultTestCount: 25,
+			defaultTestCount: 200,
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 0,
 			saveFailures: {

--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -352,10 +352,11 @@ describe("SharedDirectory fuzz Create/Delete concentrated", () => {
 		{ ...model, workloadName: "default directory 1 with rebasing" },
 		{
 			validationStrategy: {
-				type: "fixedInterval",
-				interval: defaultOptions.validateInterval,
+				type: "random",
+				probability: 0.4,
 			},
-			rebaseProbability: 0.15,
+			rebaseProbability: 0.2,
+			reconnectProbability: 0.5,
 			containerRuntimeOptions: {
 				flushMode: FlushMode.TurnBased,
 				enableGroupedBatching: true,
@@ -366,6 +367,8 @@ describe("SharedDirectory fuzz Create/Delete concentrated", () => {
 				clientAddProbability: 0.08,
 			},
 			defaultTestCount: 25,
+			// Seeds 30, 50, 133, 137, 144, 177, 195, 196 fail only when rebaseProbability is non-zero ADO:6044
+			skip: [4, 8, 19],
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 21,
 			saveFailures: {
@@ -394,7 +397,7 @@ describe("SharedDirectory fuzz", () => {
 			maxNumberOfClients: Number.MAX_SAFE_INTEGER,
 			clientAddProbability: 0.08,
 		},
-		defaultTestCount: 25,
+		defaultTestCount: 200,
 		// Uncomment this line to replay a specific seed from its failure file:
 		// replay: 0,
 		saveFailures: { directory: dirPath.join(__dirname, "../../../src/test/mocha/results/2") },

--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -421,6 +421,8 @@ describe("SharedDirectory fuzz", () => {
 				clientAddProbability: 0.08,
 			},
 			defaultTestCount: 200,
+			// Seeds 30, 50, 133, 137, 144, 177, 195, 196 fail only when rebaseProbability is non-zero ADO:6044
+			skip: [30, 50, 133, 137, 144, 177, 195, 196],
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 0,
 			saveFailures: {


### PR DESCRIPTION
## Description

Adjusting the shared directory fuzz test parameters so that it catches issues [like the 0x331](https://github.com/microsoft/FluidFramework/pull/17913) which was missed by these tests..
