### PR TITLE
Add pending batch with rebasing tests for DDSes

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -26,17 +26,12 @@ import {
 } from "@fluidframework/test-utils";
 import { describeFullCompat, describeNoCompat } from "@fluid-internal/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { FlushMode } from "@fluidframework/runtime-definitions";
 
 const directoryId = "directoryKey";
 const registry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
 const testContainerConfig: ITestContainerConfig = {
 	fluidDataObjectType: DataObjectFactoryType.Test,
 	registry,
-};
-const groupedBatchingContainerConfig: ITestContainerConfig = {
-	...testContainerConfig,
-	runtimeOptions: { enableGroupedBatching: true, flushMode: FlushMode.Immediate },
 };
 
 describeFullCompat("SharedDirectory", (getTestObjectProvider) => {
@@ -1212,34 +1207,5 @@ describeNoCompat("SharedDirectory orderSequentially", (getTestObjectProvider) =>
 		assert.equal(changedEventData.length, 2);
 		assert.equal(changedEventData[1].key, "key2");
 		assert.equal(changedEventData[1].previousValue, undefined);
-	});
-});
-
-describeNoCompat("SharedDirectory", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	beforeEach(() => {
-		provider = getTestObjectProvider();
-	});
-
-	it("Rebasing batch doesn't hit 0x331", async () => {
-		// Grouped batching is needed for rebasing to happen
-		const container = await provider.makeTestContainer(groupedBatchingContainerConfig);
-		const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-		const sharedDir = await dataObject.getSharedObject<SharedDirectory>(directoryId);
-		const containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
-
-		const key = "testKey";
-		sharedDir.set(key, true);
-
-		containerRuntime.orderSequentially(() => {
-			// Need to do this inside orderSequentially
-			containerRuntime.ensureNoDataModelChanges(() => {
-				sharedDir.set(key, false);
-			});
-		});
-
-		await provider.ensureSynchronized();
-
-		assert.strictEqual(sharedDir.get(key), false);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -84,18 +84,18 @@ describeNoCompat("Op reentry and rebasing during pending batches", (getTestObjec
 	const key = "testKey";
 	interface PartialBatchTest {
 		name: string;
-		initialCallback: () => void;
-		reentrantCallback: () => void;
+		initial: () => void;
+		reentrant: () => void;
 		assertion: () => void;
 	}
 
 	const tests: PartialBatchTest[] = [];
 	tests.push({
 		name: "SharedDirectory",
-		initialCallback: () => {
+		initial: () => {
 			sharedDirectory1.set(key, true);
 		},
-		reentrantCallback: () => {
+		reentrant: () => {
 			sharedDirectory1.set(key, false);
 		},
 		assertion: () => {
@@ -107,18 +107,16 @@ describeNoCompat("Op reentry and rebasing during pending batches", (getTestObjec
 	tests.forEach((test) => {
 		it(`Pending batches with reentry - ${test.name}`, async function () {
 			await setupContainers();
-
 			const containerRuntime = dataObject1.context.containerRuntime as ContainerRuntime;
 
-			test.initialCallback();
+			test.initial();
 			containerRuntime.orderSequentially(() => {
 				containerRuntime.ensureNoDataModelChanges(() => {
-					test.reentrantCallback();
+					test.reentrant();
 				});
 			});
 
 			await provider.ensureSynchronized();
-
 			test.assertion();
 		});
 	});

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -1,0 +1,125 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { SharedDirectory, SharedMap } from "@fluidframework/map";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+	ChannelFactoryRegistry,
+	DataObjectFactoryType,
+	ITestContainerConfig,
+	ITestFluidObject,
+	ITestObjectProvider,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { SharedString } from "@fluidframework/sequence";
+import { IContainer } from "@fluidframework/container-definitions";
+import { FlushMode } from "@fluidframework/runtime-definitions";
+import { SharedCell } from "@fluidframework/cell";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
+
+describeNoCompat("Op reentry and rebasing during pending batches", (getTestObjectProvider) => {
+	const mapId = "mapKey";
+	const sharedStringId = "sharedStringKey";
+	const sharedDirectoryId = "sharedDirectoryKey";
+	const sharedCellId = "sharedCellKey";
+
+	const registry: ChannelFactoryRegistry = [
+		[mapId, SharedMap.getFactory()],
+		[sharedStringId, SharedString.getFactory()],
+		[sharedDirectoryId, SharedDirectory.getFactory()],
+		[sharedCellId, SharedCell.getFactory()],
+	];
+	const testContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry,
+	};
+	let provider: ITestObjectProvider;
+	let container1: IContainer;
+	let container2: IContainer;
+	let dataObject1: ITestFluidObject;
+	let dataObject2: ITestFluidObject;
+	let sharedMap1: SharedMap;
+	let sharedMap2: SharedMap;
+	let sharedString1: SharedString;
+	let sharedString2: SharedString;
+	let sharedDirectory1: SharedDirectory;
+	let sharedDirectory2: SharedDirectory;
+	let sharedCell1: SharedCell;
+	let sharedCell2: SharedCell;
+
+	beforeEach(async () => {
+		provider = getTestObjectProvider();
+	});
+
+	const setupContainers = async () => {
+		const configWithFeatureGates = {
+			...testContainerConfig,
+			runtimeOptions: { enableGroupedBatching: true, flushMode: FlushMode.Immediate },
+		};
+		container1 = await provider.makeTestContainer(configWithFeatureGates);
+		container2 = await provider.loadTestContainer(configWithFeatureGates);
+
+		dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+		dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+
+		sharedMap1 = await dataObject1.getSharedObject<SharedMap>(mapId);
+		sharedMap2 = await dataObject2.getSharedObject<SharedMap>(mapId);
+
+		sharedString1 = await dataObject1.getSharedObject<SharedString>(sharedStringId);
+		sharedString2 = await dataObject2.getSharedObject<SharedString>(sharedStringId);
+
+		sharedDirectory1 = await dataObject1.getSharedObject<SharedDirectory>(sharedDirectoryId);
+		sharedDirectory2 = await dataObject2.getSharedObject<SharedDirectory>(sharedDirectoryId);
+
+		sharedCell1 = await dataObject1.getSharedObject<SharedCell>(sharedCellId);
+		sharedCell2 = await dataObject2.getSharedObject<SharedCell>(sharedCellId);
+
+		await provider.ensureSynchronized();
+	};
+
+	const key = "testKey";
+	interface PartialBatchTest {
+		name: string;
+		initialCallback: () => void;
+		reentrantCallback: () => void;
+		assertion: () => void;
+	}
+
+	const tests: PartialBatchTest[] = [];
+	tests.push({
+		name: "SharedDirectory",
+		initialCallback: () => {
+			sharedDirectory1.set(key, true);
+		},
+		reentrantCallback: () => {
+			sharedDirectory1.set(key, false);
+		},
+		assertion: () => {
+			assert.strictEqual(sharedDirectory1.get(key), false);
+			assert.strictEqual(sharedDirectory2.get(key), false);
+		},
+	});
+
+	tests.forEach((test) => {
+		it(`Pending batches with reentry - ${test.name}`, async function () {
+			await setupContainers();
+
+			const containerRuntime = dataObject1.context.containerRuntime as ContainerRuntime;
+
+			test.initialCallback();
+			containerRuntime.orderSequentially(() => {
+				containerRuntime.ensureNoDataModelChanges(() => {
+					test.reentrantCallback();
+				});
+			});
+
+			await provider.ensureSynchronized();
+
+			test.assertion();
+		});
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -145,12 +145,15 @@ describeNoCompat("Op reentry and rebasing during pending batches", (getTestObjec
 		},
 	].forEach((test) => {
 		/**
-		 * The test exercises a less frequent but possibly problematic scenario with grouped batching and rebasing:
-		 * - the DDS receives some changes in a batch
-		 * - the changes are 'pending' (they have been submitted not acknowledged)
-		 * - while these changes are pending, the runtime creates a new batch of changes for the DDS
-		 * - due to reentrancy, the latest batch gets rebased and resubmitted to the DDS
-		 * - as there is already a pending batch in the DDSs buffer, this rebased batch may be deemed unexpected by the DDS resubmit flow
+		 * The test exercises a less frequent but possibly problematic scenario with grouped batching and rebasing,
+		 * in which:
+		 * - the container is in read mode
+		 * - a batch with ops changing a DDS is created
+		 * - another batch is created and because it has reentrant ops, it gets rebased
+		 * - the container connects to write mode due to its pending changes
+		 * - the batches inside the PendingStateManager are resubmitted
+		 * - the DDS must be able to receive the ops, reconcile its internal state  and reconstruct the
+		 * original changes from both batches in the expected order
 		 */
 		it(`Pending batches with reentry - ${test.name}`, async function () {
 			await setupContainers();

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -22,25 +22,15 @@ import { SharedCell } from "@fluidframework/cell";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { SharedCounter } from "@fluidframework/counter";
 import { SharedMatrix } from "@fluidframework/matrix";
-import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
 
 describeNoCompat("Op reentry and rebasing during pending batches", (getTestObjectProvider) => {
-	const mapId = "mapKey";
-	const sharedStringId = "sharedStringKey";
-	const sharedDirectoryId = "sharedDirectoryKey";
-	const sharedCellId = "sharedCellKey";
-	const sharedCounterId = "sharedCounterKey";
-	const sharedMatrixId = "sharedMatrixKey";
-	const consensusRegisterCollectionId = "consensusRegisterCollectionKey";
-
 	const registry: ChannelFactoryRegistry = [
-		[mapId, SharedMap.getFactory()],
-		[sharedStringId, SharedString.getFactory()],
-		[sharedDirectoryId, SharedDirectory.getFactory()],
-		[sharedCellId, SharedCell.getFactory()],
-		[sharedCounterId, SharedCounter.getFactory()],
-		[sharedMatrixId, SharedMatrix.getFactory()],
-		[consensusRegisterCollectionId, ConsensusRegisterCollection.getFactory()],
+		["map", SharedMap.getFactory()],
+		["sharedString", SharedString.getFactory()],
+		["sharedDirectory", SharedDirectory.getFactory()],
+		["sharedCell", SharedCell.getFactory()],
+		["sharedCounter", SharedCounter.getFactory()],
+		["sharedMatrix", SharedMatrix.getFactory()],
 	];
 	const testContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
@@ -67,12 +57,12 @@ describeNoCompat("Op reentry and rebasing during pending batches", (getTestObjec
 		};
 		container = await provider.makeTestContainer(configWithFeatureGates);
 		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-		sharedMap = await dataObject.getSharedObject<SharedMap>(mapId);
-		sharedString = await dataObject.getSharedObject<SharedString>(sharedStringId);
-		sharedDirectory = await dataObject.getSharedObject<SharedDirectory>(sharedDirectoryId);
-		sharedCell = await dataObject.getSharedObject<SharedCell>(sharedCellId);
-		sharedCounter = await dataObject.getSharedObject<SharedCounter>(sharedCounterId);
-		sharedMatrix = await dataObject.getSharedObject<SharedMatrix>(sharedMatrixId);
+		sharedMap = await dataObject.getSharedObject<SharedMap>("map");
+		sharedString = await dataObject.getSharedObject<SharedString>("sharedString");
+		sharedDirectory = await dataObject.getSharedObject<SharedDirectory>("sharedDirectory");
+		sharedCell = await dataObject.getSharedObject<SharedCell>("sharedCell");
+		sharedCounter = await dataObject.getSharedObject<SharedCounter>("sharedCounter");
+		sharedMatrix = await dataObject.getSharedObject<SharedMatrix>("sharedMatrix");
 
 		await provider.ensureSynchronized();
 	};


### PR DESCRIPTION
## Description

ADO:6016 - Hunt down instances of 0x331.

The problematic pattern is described [here](https://github.com/microsoft/FluidFramework/pull/17913) for SharedDirectory.

