### PR TITLE
refactor(ci): Use telemetry-generator-setup template when uploading bundle size measurements

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -463,7 +463,7 @@ stages:
                   echo "Writing the following performance tests results to Aria/Kusto"
                   echo "Report Size:"
                   ls -la '../../examples/utils/bundle-size-tests/bundleAnalysis/report.json';
-                  node --require @ff-internal/aria-logger bin/run --handlerModule dist/handlers/bundleSizeHandler.js --dir '../../artifacts/bundleAnalysis/@fluid-example/bundle-size-tests';
+                  node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/bundleSizeHandler.js --dir '../../artifacts/bundleAnalysis/@fluid-example/bundle-size-tests';
 
         # Docs
         - ${{ if ne(parameters.taskBuildDocs, false) }}:
@@ -586,7 +586,7 @@ stages:
               pwd;
               ls -laR $(pipelineTelemetryWorkdir)/timingOutput/output.json;
               cat $(pipelineTelemetryWorkdir)/timingOutput/output.json;
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(Build.SourcesDirectory)/tools/telemetry-generator/dist/handlers/stageTimingRetriever.js --dir '$(pipelineTelemetryWorkdir)/timingOutput/';
+              node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/stageTimingRetriever.js --dir '$(pipelineTelemetryWorkdir)/timingOutput/';
           env:
             BUILD_ID: $(Build.BuildId)
             ADO_API_TOKEN: $(System.AccessToken)

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -437,7 +437,7 @@ stages:
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run bundle-analysis:run'
 
-          - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
             - task: Bash@3
               displayName: 'List report.json'
               inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -437,7 +437,7 @@ stages:
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run bundle-analysis:run'
 
-          - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
+          - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             - task: Bash@3
               displayName: 'List report.json'
               inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -570,6 +570,7 @@ stages:
           parameters:
             devFeedUrl: $(ado-feeds-dev)
             officeFeedUrl: $(ado-feeds-office)
+            isCheckoutNeeded: true
 
         - task: Bash@3
           displayName: Retrieve buildId results

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -146,6 +146,8 @@ variables:
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
       nonScopedPackages: ${{ parameters.nonScopedPackages }}
+  # Absolute path to the folder that contains the source code for the telemetry-generator package, which is used in a few
+  # places in the pipeline to push custom telemetry to Kusto.
   - name: absolutePathToTelemetryGenerator
     value:  $(Build.SourcesDirectory)/tools/telemetry-generator
     readonly: true

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -146,7 +146,7 @@ variables:
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
       nonScopedPackages: ${{ parameters.nonScopedPackages }}
-  - name: toolAbsolutePath
+  - name: absolutePathToTelemetryGenerator
     value:  $(Build.SourcesDirectory)/tools/telemetry-generator
     readonly: true
   - group: ado-feeds
@@ -208,7 +208,7 @@ stages:
                 TestCoverage=$(testCoverage)
 
               Variables:
-                toolAbsolutePath=$(toolAbsolutePath)
+                absolutePathToTelemetryGenerator=$(absolutePathToTelemetryGenerator)
                 BuildReason=$(variables['Build.Reason'])
 
               Publish Parameters:
@@ -438,81 +438,32 @@ stages:
               customCommand: 'run bundle-analysis:run'
 
           - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
-            # Auth to internal feed
             - task: Bash@3
-              name: Initialize
-              displayName: Initialize .npmrc for telemetry logger
-              inputs:
-                targetType: 'inline'
-                workingDirectory: ${{ variables.toolAbsolutePath }}
-                # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
-                script: |
-                  echo Initialize package
-                  npm init --yes
-
-                  echo Generating .npmrc
-                  echo "registry=https://registry.npmjs.org" >> ./.npmrc
-                  echo "always-auth=false" >> ./.npmrc
-
-                  echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
-                  echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
-
-                  # This is confusing, but we are using the .npmrc here to load dependencies from different feeds. These
-                  # scopes must be loaded from the "dev" feed because that is the only place they are published. Ideally
-                  # this logic will be centralized outside of CI in the future.
-                  echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-                  echo "@fluid-private:registry=${{ variables.devFeed }}" >> ./.npmrc
-
-                  # This scope must be loaded from the "build" feed
-                  echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc
-
-                  # This scope must be loaded from the internal Office feed
-                  echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
-
-                  echo "always-auth=true" >> ./.npmrc
-                  cat .npmrc
-
-            - task: npmAuthenticate@0
-              displayName: 'npm authenticate (internal feed)'
-              inputs:
-                workingFile: ${{ variables.toolAbsolutePath }}/.npmrc
-
-            - task: Bash@3
-              displayName: 'List report.json and .npmrc'
+              displayName: 'List report.json'
               inputs:
                 targetType: 'inline'
                 workingDirectory:  ${{ parameters.buildDirectory }}
                 script: |
-                  echo "Build Directory is ${{ parameters.buildDirectory }}"
-                  ls -la '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis/@fluid-example/bundle-size-tests';
-                  cat '${{ variables.toolAbsolutePath }}/.npmrc';
+                  echo "Build Directory is ${{ parameters.buildDirectory }}";
+                  BUNDLE_SIZE_TESTS_DIR="${{ parameters.buildDirectory }}/artifacts/bundleAnalysis/@fluid-example/bundle-size-tests";
+                  echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
+                  ls -la '$BUNDLE_SIZE_TESTS_DIR';
 
-            - task: Bash@3
-              displayName: 'Prepare telemetry-generator for bundle size'
-              inputs:
-                targetType: 'inline'
-                workingDirectory:  ${{ variables.toolAbsolutePath }}
-                script: |
-                  ls -la '${{ variables.toolAbsolutePath }}';
-                  ls -la '${{ parameters.buildDirectory }}';
-                  npm install @ff-internal/aria-logger;
-                  npm i;
-                  npm run build:compile;
+            - template: include-telemetry-setup.yml
+              parameters:
+                devFeedUrl: $(ado-feeds-dev)
+                officeFeedUrl: $(ado-feeds-office)
 
             - task: Bash@3
               displayName: Write bundle sizes measurements to Aria/Kusto
               inputs:
                 targetType: 'inline'
-                workingDirectory: ${{ variables.toolAbsolutePath }}
+                workingDirectory: $(absolutePathToTelemetryGenerator)
                 script: |
                   echo "Writing the following performance tests results to Aria/Kusto"
                   echo "Report Size:"
                   ls -la '../../examples/utils/bundle-size-tests/bundleAnalysis/report.json';
-                  echo "Tools Path:"
-                  ls -la '../../tools/telemetry-generator/dist/handlers';
-                  node --require @ff-internal/aria-logger bin/run --handlerModule $(Build.SourcesDirectory)/tools/telemetry-generator/dist/handlers/bundleSizeHandler.js --dir '../../artifacts/bundleAnalysis/@fluid-example/bundle-size-tests';
-                  echo "Removing .npmrc"
-                  rm ../../tools/telemetry-generator/.npmrc;
+                  node --require @ff-internal/aria-logger bin/run --handlerModule dist/handlers/bundleSizeHandler.js --dir '../../artifacts/bundleAnalysis/@fluid-example/bundle-size-tests';
 
         # Docs
         - ${{ if ne(parameters.taskBuildDocs, false) }}:
@@ -624,7 +575,7 @@ stages:
           displayName: Retrieve buildId results
           inputs:
             targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
+            workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
               echo "Creating output folder ..."
               mkdir -p $(pipelineTelemetryWorkdir)/timingOutput

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -447,7 +447,7 @@ stages:
                   echo "Build Directory is ${{ parameters.buildDirectory }}";
                   BUNDLE_SIZE_TESTS_DIR="${{ parameters.buildDirectory }}/artifacts/bundleAnalysis/@fluid-example/bundle-size-tests";
                   echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
-                  ls -la '$BUNDLE_SIZE_TESTS_DIR';
+                  ls -la $BUNDLE_SIZE_TESTS_DIR;
 
             - template: include-telemetry-setup.yml
               parameters:

--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -23,10 +23,17 @@ parameters:
 - name: officeFeedUrl
   type: string
 
+# If the template should try to checkout the repo. If the job that includes this template already has steps to check out
+# the repo for other purposes, this should be set to false.
+- name: isCheckoutNeeded
+  type: boolean
+  default: false
+
 steps:
-# Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.
-- checkout: self
-  clean: true
+- ${{ if eq(parameters.isCheckoutNeeded, true) }}:
+  # Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.
+  - checkout: self
+    clean: true
 
 - template: include-use-node-version.yml
 

--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -4,14 +4,13 @@
 # include-use-node-version template to use a specific node version
 
 parameters:
-# The node version required. The version must already be installed in the image. 
+# The node version required. The version must already be installed in the image.
 - name: version
   type: string
   default: '18.17.1'
 
 steps:
 - task: Bash@3
-  name: SetNodeVersion
   displayName: Set node version
   inputs:
     targetType: 'inline'

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -93,6 +93,7 @@ stages:
         parameters:
           devFeedUrl: $(ado-feeds-dev)
           officeFeedUrl: $(ado-feeds-office)
+          isCheckoutNeeded: true
 
       - task: Bash@3
         displayName: Print parameter/variable values for troubleshooting
@@ -334,6 +335,7 @@ stages:
         parameters:
           devFeedUrl: $(ado-feeds-dev)
           officeFeedUrl: $(ado-feeds-office)
+          isCheckoutNeeded: true
 
       - task: Bash@3
         displayName: Print parameter/variable values for troubleshooting
@@ -576,6 +578,7 @@ stages:
           parameters:
             devFeedUrl: $(ado-feeds-dev)
             officeFeedUrl: $(ado-feeds-office)
+            isCheckoutNeeded: true
 
         - task: Bash@3
           displayName: Print parameter/variable values for troubleshooting
@@ -856,6 +859,7 @@ stages:
         parameters:
           devFeedUrl: $(ado-feeds-dev)
           officeFeedUrl: $(ado-feeds-office)
+          isCheckoutNeeded: true
 
       - task: Bash@3
         displayName: Retrieve and Upload pipeline run stats to Kusto

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -157,6 +157,7 @@ stages:
         parameters:
           devFeedUrl: $(ado-feeds-dev)
           officeFeedUrl: $(ado-feeds-office)
+          isCheckoutNeeded: true
       - task: Bash@3
         displayName: Retrieve buildId results
         inputs:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -183,6 +183,7 @@ stages:
         parameters:
           devFeedUrl: $(ado-feeds-dev)
           officeFeedUrl: $(ado-feeds-office)
+          isCheckoutNeeded: true
       - task: Bash@3
         displayName: Retrieve buildId results
         env:


### PR DESCRIPTION
## Description

Leverage the template to set up the telemetry-generator tool instead of doing it by hand.

Small updates along the way, explained in comments below.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Validated with a [run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=205258&view=results) for a test/ branch at commit [29b55d6](https://github.com/microsoft/FluidFramework/pull/17990/commits/29b55d65786d32fc77bb49ae5d8c656eb6dbaf3c), and confirmed the bundle size measurements made it to Kusto.