### PR TITLE
tree2: Improve strong typing

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -159,7 +159,7 @@ type ArrayToUnion<T extends readonly unknown[]> = T extends readonly (infer TVal
 export type AssignableFieldKinds = typeof FieldKinds.optional | typeof FieldKinds.required;
 
 // @alpha
-type Assume<TInput, TAssumeToBe> = TInput extends TAssumeToBe ? TInput : TAssumeToBe;
+type Assume<TInput, TAssumeToBe> = [TInput] extends [TAssumeToBe] ? TInput : TAssumeToBe;
 
 // @alpha
 export interface BatchBindingContext extends BindingContext {
@@ -696,7 +696,7 @@ export interface FieldMapObject<TChild> {
 }
 
 // @alpha
-export interface FieldNode<TSchema extends FieldNodeSchema> extends TreeNode {
+export interface FieldNode<in out TSchema extends FieldNodeSchema> extends TreeNode {
     readonly boxedContent: TypedField<TSchema["objectNodeFieldsObject"][""]>;
     readonly content: UnboxField<TSchema["objectNodeFieldsObject"][""]>;
 }
@@ -724,6 +724,14 @@ export interface FieldUpPath<TUpPath extends UpPath = UpPath> {
     readonly field: FieldKey;
     readonly parent: TUpPath | undefined;
 }
+
+// @alpha
+type FixedSizeTypeArrayToTypedTree<T extends readonly TreeNodeSchema[]> = [
+T extends readonly [infer Head, ...infer Tail] ? [
+TypedNode<Assume<Head, TreeNodeSchema>>,
+...FixedSizeTypeArrayToTypedTree<Assume<Tail, readonly TreeNodeSchema[]>>
+] : []
+][_InlineTrick];
 
 // @alpha
 type FlattenKeys<T> = [{
@@ -904,6 +912,10 @@ declare namespace InternalEditableTreeTypes {
         UnboxNode,
         UnboxNodeUnion,
         NodeKeyField,
+        IsArrayOfOne,
+        UnknownUnboxed,
+        FixedSizeTypeArrayToTypedTree,
+        TypedNodeUnionHelper,
         NodeKeys
     }
 }
@@ -1023,7 +1035,10 @@ interface Invariant<in out T> extends Contravariant<T>, Covariant<T> {
 }
 
 // @alpha
-type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
+type isAny<T> = boolean extends (T extends never ? true : false) ? true : false;
+
+// @alpha
+type IsArrayOfOne<T extends readonly unknown[]> = T["length"] extends 1 ? true : 1 extends T["length"] ? boolean : false;
 
 // @alpha
 export function isContextuallyTypedNodeDataObject(data: ContextuallyTypedNodeData | undefined): data is ContextuallyTypedNodeDataObject;
@@ -1228,7 +1243,7 @@ type LazyItem<Item = unknown> = Item | (() => Item);
 export type LazyTreeNodeSchema = TreeNodeSchema | (() => TreeNodeSchema);
 
 // @alpha
-export interface Leaf<TSchema extends LeafSchema> extends TreeNode {
+export interface Leaf<in out TSchema extends LeafSchema> extends TreeNode {
     readonly value: TreeValue<TSchema["leafValue"]>;
 }
 
@@ -1297,7 +1312,7 @@ interface MakeNominal {
 type MapFieldSchema = TreeFieldSchema<typeof FieldKinds.optional | typeof FieldKinds.sequence>;
 
 // @alpha
-export interface MapNode<TSchema extends MapSchema> extends TreeNode {
+export interface MapNode<in out TSchema extends MapSchema> extends TreeNode {
     [boxedIterator](): IterableIterator<TypedField<TSchema["mapFields"]>>;
     // (undocumented)
     [Symbol.iterator](): IterableIterator<[FieldKey, UnboxField<TSchema["mapFields"], "notEmpty">]>;
@@ -1484,7 +1499,7 @@ export interface ObjectNode extends TreeNode {
 }
 
 // @alpha
-type ObjectNodeFields<TFields extends RestrictiveReadonlyRecord<string, TreeFieldSchema>> = {
+type ObjectNodeFields<TFields extends RestrictiveReadonlyRecord<string, TreeFieldSchema>> = FlattenKeys<{
     readonly [key in keyof TFields as `boxed${Capitalize<key & string>}`]: TypedField<TFields[key]>;
 } & {
     readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? never : key]: UnboxField<TFields[key]>;
@@ -1492,7 +1507,7 @@ type ObjectNodeFields<TFields extends RestrictiveReadonlyRecord<string, TreeFiel
     -readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? key : never]: UnboxField<TFields[key]>;
 } & {
     readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? `set${Capitalize<key & string>}` : never]: (content: FlexibleFieldContent<TFields[key]>) => void;
-};
+}>;
 
 // @alpha
 export type ObjectNodeSchema = TreeNodeSchema & {
@@ -1500,7 +1515,7 @@ export type ObjectNodeSchema = TreeNodeSchema & {
 };
 
 // @alpha
-export type ObjectNodeTyped<TSchema extends ObjectNodeSchema> = ObjectNode & ObjectNodeFields<TSchema["objectNodeFieldsObject"]>;
+export type ObjectNodeTyped<TSchema extends ObjectNodeSchema> = ObjectNodeSchema extends TSchema ? ObjectNode : ObjectNode & ObjectNodeFields<TSchema["objectNodeFieldsObject"]>;
 
 // @alpha
 interface ObjectSchemaSpecification {
@@ -1915,7 +1930,7 @@ export interface SchemaValidationFunction<Schema extends TSchema> {
 }
 
 // @alpha
-export interface Sequence<TTypes extends AllowedTypes> extends TreeField {
+export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField {
     // (undocumented)
     [boxedIterator](): IterableIterator<TypedNodeUnion<TTypes>>;
     // (undocumented)
@@ -2064,7 +2079,7 @@ export enum TransactionResult {
 }
 
 // @alpha
-export interface Tree<TSchema = unknown> {
+export interface Tree<out TSchema = unknown> {
     [boxedIterator](): IterableIterator<Tree>;
     readonly context: TreeContext;
     readonly schema: TSchema;
@@ -2250,10 +2265,7 @@ TypedNode_2<Assume<Head, TreeNodeSchema>, Mode>,
 
 // @alpha
 type TypeArrayToTypedTreeArray_2<T extends readonly TreeNodeSchema[]> = [
-T extends readonly [infer Head, ...infer Tail] ? [
-TypedNode<Assume<Head, TreeNodeSchema>>,
-...TypeArrayToTypedTreeArray_2<Assume<Tail, readonly TreeNodeSchema[]>>
-] : []
+ArrayHasFixedLength<T> extends false ? T extends readonly (infer InnerT)[] ? [TypedNode<Assume<InnerT, TreeNodeSchema>>] : never : FixedSizeTypeArrayToTypedTree<T>
 ][_InlineTrick];
 
 // @alpha
@@ -2291,7 +2303,10 @@ export type TypedNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSche
 type TypedNode_2<TSchema extends TreeNodeSchema, Mode extends ApiMode = ApiMode.Editable> = FlattenKeys<CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["objectNodeFieldsObject"]>, TSchema["leafValue"], TSchema["name"]>>;
 
 // @alpha
-export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Assume<InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>> : TreeNode;
+export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema> ? TypedNodeUnionHelper<TTypes> : TreeNode;
+
+// @alpha
+type TypedNodeUnionHelper<TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema>> = InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Assume<InternalTypedSchemaTypes.FlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>>;
 
 // @alpha
 export interface TypedTreeChannel extends IChannel {
@@ -2332,12 +2347,12 @@ type UnboxField<TSchema extends TreeFieldSchema, Emptiness extends "maybeEmpty" 
 type UnboxFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? Sequence<TTypes> : Kind extends typeof FieldKinds.required ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined) : Kind extends typeof FieldKinds.nodeKey ? NodeKeyField : unknown;
 
 // @alpha
-type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema ? TreeValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["objectNodeFieldsObject"][""]> : TSchema extends ObjectNodeSchema ? ObjectNodeTyped<TSchema> : unknown;
+type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema ? TreeValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["objectNodeFieldsObject"][""]> : TSchema extends ObjectNodeSchema ? ObjectNodeTyped<TSchema> : UnknownUnboxed;
 
 // @alpha
 type UnboxNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [
 InternalTypedSchemaTypes.LazyItem<infer InnerType>
-] ? InnerType extends TreeNodeSchema ? UnboxNode<InnerType> : TypedNodeUnion<TTypes> : TypedNodeUnion<TTypes>;
+] ? InnerType extends TreeNodeSchema ? UnboxNode<InnerType> : InnerType extends Any ? TreeNode : unknown : boolean extends IsArrayOfOne<TTypes> ? UnknownUnboxed : TypedNodeUnion<TTypes>;
 
 // @alpha
 type Unbrand<T, B> = T extends infer S & B ? S : T;
@@ -2352,6 +2367,9 @@ type UnbrandList<T extends unknown[], B> = T extends [infer Head, ...infer Tail]
 
 // @alpha
 export type Unenforced<_DesiredExtendsConstraint> = unknown;
+
+// @alpha
+type UnknownUnboxed = TreeValue | TreeNode | TreeField;
 
 // @alpha
 type UntypedApi<Mode extends ApiMode> = {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -778,7 +778,7 @@ export type TypedNodeUnion<TTypes extends AllowedTypes> =
 		: TreeNode;
 
 /**
- * Helper for implementing TypedNodeUnionHelper.
+ * Helper for implementing TypedNodeUnion.
  * @privateRemarks
  * Inlining this into TypedNodeUnion causes it to not compile.
  * The reason for this us unknown, but splitting it out fixed it.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/internal.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/internal.ts
@@ -14,6 +14,10 @@ export {
 	UnboxNode,
 	UnboxNodeUnion,
 	NodeKeyField,
+	IsArrayOfOne,
+	UnknownUnboxed,
+	FixedSizeTypeArrayToTypedTree,
+	TypedNodeUnionHelper,
 } from "./editableTreeTypes";
 
 export { NodeKeys } from "./nodeKeys";

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/index.ts
@@ -37,7 +37,7 @@ export {
 	schemaLintDefault,
 } from "./schemaCollection";
 
-export { FlexList, markEager } from "./flexList";
+export { FlexList, markEager, ArrayHasFixedLength } from "./flexList";
 
 // Below here are things that are used by the above, but not part of the desired API surface.
 import * as InternalTypedSchemaTypes from "./internal";

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
@@ -18,11 +18,15 @@ import {
 	MapNode,
 	TypedField,
 	boxedIterator,
+	ObjectNode,
+	IsArrayOfOne,
+	UnknownUnboxed,
+	TypeArrayToTypedTreeArray,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/editable-tree-2/editableTreeTypes";
-import { jsonSequenceRootSchema } from "../../utils";
 import {
 	areSafelyAssignable,
+	Assume,
 	isAssignableTo,
 	requireAssignableTo,
 	requireFalse,
@@ -38,16 +42,43 @@ import {
 	ObjectNodeSchema,
 	TreeNodeSchema,
 	TreeFieldSchema,
+	AllowedTypes,
+	InternalTypedSchemaTypes,
 } from "../../../feature-libraries";
 
 describe("editableTreeTypes", () => {
+	/**
+	 * Example showing narrowing and exhaustive matches.
+	 */
+	function exhaustiveMatchSimple(root: TreeField): void {
+		const schema = SchemaBuilder.required([() => leaf.number, leaf.string]);
+		assert(root.is(schema));
+		const tree = root.boxedContent;
+		if (tree.is(leaf.number)) {
+			const n: number = tree.value;
+		} else if (tree.is(leaf.string)) {
+			const s: string = tree.value;
+		} else {
+			// Proves at compile time exhaustive match checking works, and tree is typed `never`.
+			unreachableCase(tree);
+		}
+	}
+
 	/**
 	 * Example showing the node kinds used in the json domain (everything except structs),
 	 * including narrowing and exhaustive matches.
 	 */
 	function jsonExample(root: TreeField): void {
-		assert(root.is(jsonSequenceRootSchema.rootFieldSchema));
-		for (const tree of root) {
+		// Rather than using jsonSequenceRootSchema.rootFieldSchema, recreate an equivalent schema.
+		// Doing this avoids a compile error (but not an intellisense error) on unreachableCase below.
+		// This has not be fully root caused, but it likely due to to schema d.ts files for recursive types containing `any` due to:
+		// https://github.com/microsoft/TypeScript/issues/55832
+		const jsonPrimitives = [...leaf.primitives, leaf.null] as const;
+		const jsonRoot2 = [() => jsonObject, () => jsonArray, ...jsonPrimitives] as const;
+		const schema = SchemaBuilder.sequence(jsonRoot2);
+
+		assert(root.is(schema));
+		for (const tree of root[boxedIterator]()) {
 			if (tree.is(leaf.boolean)) {
 				const b: boolean = tree.value;
 			} else if (tree.is(leaf.number)) {
@@ -111,13 +142,13 @@ describe("editableTreeTypes", () => {
 			mixed.polymorphic;
 
 		// Fully boxed, including the value field.
-		const boxedPolymorphic: RequiredField<[typeof leaf.number, typeof leaf.string]> =
+		const boxedPolymorphic: RequiredField<readonly [typeof leaf.number, typeof leaf.string]> =
 			mixed.boxedPolymorphic;
 
 		const optionalLeaf: number | undefined = mixed.optionalLeaf;
 		const boxedOptionalLeaf: TypedNode<typeof leaf.number> | undefined =
 			mixed.boxedOptionalLeaf.boxedContent;
-		const sequence: Sequence<[typeof leaf.number]> = mixed.sequence;
+		const sequence: Sequence<readonly [typeof leaf.number]> = mixed.sequence;
 
 		const child: number = sequence.at(0);
 		const childBoxed: TypedNode<typeof leaf.number> = sequence.boxedAt(0);
@@ -235,6 +266,21 @@ describe("editableTreeTypes", () => {
 		}
 	}
 
+	// TypeArrayToTypedTreeArray
+	{
+		// Direct
+		{
+			type UnionBasic1 = TypeArrayToTypedTreeArray<[typeof basicStruct]>;
+			type _1 = requireTrue<areSafelyAssignable<UnionBasic1, [BasicStruct]>>;
+		}
+
+		// Type-Erased
+		{
+			type Result = TypeArrayToTypedTreeArray<TreeNodeSchema[]>;
+			type _1 = requireTrue<areSafelyAssignable<Result, [TreeNode]>>;
+		}
+	}
+
 	// TypedNodeUnion
 	{
 		// Any
@@ -274,6 +320,35 @@ describe("editableTreeTypes", () => {
 				areSafelyAssignable<TypedNodeUnion<[() => typeof recursiveStruct]>, Recursive>
 			>;
 		}
+		// Type-Erased
+		{
+			type _1 = requireTrue<areSafelyAssignable<TypedNodeUnion<[TreeNodeSchema]>, TreeNode>>;
+			type _2 = requireTrue<
+				areSafelyAssignable<TypedNodeUnion<[ObjectNodeSchema]>, ObjectNode>
+			>;
+			type _3 = requireTrue<
+				areSafelyAssignable<TypedNodeUnion<[TreeNodeSchema, TreeNodeSchema]>, TreeNode>
+			>;
+			type _4 = requireTrue<areSafelyAssignable<TypedNodeUnion<[Any]>, TreeNode>>;
+			type y = InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TreeNodeSchema[]>;
+
+			type _5 = requireTrue<areSafelyAssignable<TypedNodeUnion<TreeNodeSchema[]>, TreeNode>>;
+			type _6 = requireTrue<areSafelyAssignable<TypedNodeUnion<AllowedTypes>, TreeNode>>;
+
+			type TypedNodeUnion2<TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema>> =
+				InternalTypedSchemaTypes.ArrayToUnion<
+					TypeArrayToTypedTreeArray<
+						Assume<
+							InternalTypedSchemaTypes.ConstantFlexListToNonLazyArray<TTypes>,
+							readonly TreeNodeSchema[]
+						>
+					>
+				>;
+
+			type x = TypedNodeUnion2<TreeNodeSchema[]>;
+
+			type z = InternalTypedSchemaTypes.ArrayToUnion<[TreeNode]>;
+		}
 	}
 
 	// UnboxNodeUnion
@@ -306,9 +381,9 @@ describe("editableTreeTypes", () => {
 		// Unboxed FieldNode
 		{
 			type UnboxedFieldNode = UnboxNodeUnion<[typeof basicFieldNode]>;
-			// TODO: areSafelyAssignable doesn't seem to work in this case. Revisit this once on TS 5 and TypeCheck is updated for it.
-			type _1 = requireAssignableTo<UnboxedFieldNode, TreeNode | undefined>;
-			type _2 = requireAssignableTo<TreeNode | undefined, UnboxedFieldNode>;
+			type _1 = requireTrue<areSafelyAssignable<TreeNode | undefined, UnboxedFieldNode>>;
+			// @ts-expect-error union can unbox to undefined
+			type _2 = requireAssignableTo<UnboxedFieldNode, TreeNode>;
 		}
 		// Recursive
 		{
@@ -322,5 +397,40 @@ describe("editableTreeTypes", () => {
 				areSafelyAssignable<UnboxNodeUnion<[() => typeof recursiveStruct]>, Recursive>
 			>;
 		}
+		// Type-Erased
+		{
+			type _1 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<[TreeNodeSchema]>, UnknownUnboxed>
+			>;
+			type _2 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<[ObjectNodeSchema]>, ObjectNode>
+			>;
+			type _3 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<[TreeNodeSchema, TreeNodeSchema]>, TreeNode>
+			>;
+			type _4 = requireTrue<areSafelyAssignable<UnboxNodeUnion<[Any]>, TreeNode>>;
+			type _5 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<TreeNodeSchema[]>, UnknownUnboxed>
+			>;
+			type _6 = requireTrue<
+				areSafelyAssignable<UnboxNodeUnion<AllowedTypes>, UnknownUnboxed>
+			>;
+		}
+
+		// Generic
+		// eslint-disable-next-line no-inner-declarations
+		function genericTest<T extends AllowedTypes>(t: T) {
+			type Unboxed = UnboxNodeUnion<T>;
+			// @ts-expect-error union can unbox to undefined or a sequence
+			type _1 = requireAssignableTo<Unboxed, TreeNode>;
+		}
+	}
+
+	// IsArrayOfOne
+	{
+		type _1 = requireFalse<IsArrayOfOne<[TreeNodeSchema, TreeNodeSchema]>>;
+		type _2 = requireFalse<IsArrayOfOne<[]>>;
+		type _3 = requireTrue<areSafelyAssignable<IsArrayOfOne<AllowedTypes>, boolean>>;
+		type _4 = requireTrue<IsArrayOfOne<[Any]>>;
 	}
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { EmptyKey, Value, FieldKey, rootFieldKey, JsonableTree } from "../../../core";
-import { brand, clone, fail, isAssignableTo, requireTrue } from "../../../util";
+import { brand, clone, fail, requireAssignableTo } from "../../../util";
 import {
 	EditableTree,
 	EditableField,
@@ -24,7 +24,6 @@ import {
 	getPrimaryField,
 	ContextuallyTypedNodeData,
 	ContextuallyTypedNodeDataObject,
-	MarkedArrayLike,
 	parentField,
 	contextSymbol,
 	TreeFieldSchema,
@@ -609,21 +608,13 @@ describe("editable-tree: read-only", () => {
 
 // This is only to cover the type checking, consider as a helper to properly define the contextually typed API
 {
-	type _checkTree = requireTrue<isAssignableTo<EditableTree, ContextuallyTypedNodeDataObject>>;
-	type _checkUnwrappedTree = requireTrue<
-		isAssignableTo<UnwrappedEditableTree, ContextuallyTypedNodeData>
+	type _checkTree = requireAssignableTo<EditableTree, ContextuallyTypedNodeDataObject>;
+	type _checkUnwrappedTree = requireAssignableTo<
+		UnwrappedEditableTree,
+		ContextuallyTypedNodeData
 	>;
-	type _checkField = requireTrue<
-		isAssignableTo<ContextuallyTypedNodeData | undefined, UnwrappedEditableField>
+	type _checkUnwrappedField = requireAssignableTo<
+		UnwrappedEditableField,
+		ContextuallyTypedNodeData | undefined
 	>;
-	const x: ContextuallyTypedNodeDataObject = 0 as any as EditableTree;
-	const xx: MarkedArrayLike<ContextuallyTypedNodeData> = 0 as any as EditableField;
-
-	// TODO: there seems to be a bug in TypeCheck library, since
-	// this should fail, but it does not (undefined should break it).
-	type _checkFail = requireTrue<
-		isAssignableTo<UnwrappedEditableField, ContextuallyTypedNodeData>
-	>;
-	// This does fail, but it should check the same as the above
-	// const _dummyValue: ContextuallyTypedNodeData = 0 as any as UnwrappedEditableField;
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/flexList.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/flexList.spec.ts
@@ -18,7 +18,7 @@ import {
 	// Allow importing from this specific file which is being tested:
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../../feature-libraries/typed-schema/flexList";
-import { requireAssignableTo, requireFalse, requireTrue } from "../../../util";
+import { areSafelyAssignable, requireAssignableTo, requireFalse, requireTrue } from "../../../util";
 
 // Test ArrayHasFixedLength
 {
@@ -76,6 +76,18 @@ import { requireAssignableTo, requireFalse, requireTrue } from "../../../util";
 
 	type e = FlexListToLazyArray<readonly [2]>;
 	type checkE = requireAssignableTo<e, [() => 2]>;
+}
+
+// Test FlexListToNonLazyArray
+{
+	type a = FlexListToNonLazyArray<number[]>;
+	type checkA = requireTrue<areSafelyAssignable<a, readonly number[]>>;
+
+	type b = FlexListToNonLazyArray<[]>;
+	type checkB = requireTrue<areSafelyAssignable<b, []>>;
+
+	type c = FlexListToNonLazyArray<[() => 5, 6, () => 7]>;
+	type checkC = requireTrue<areSafelyAssignable<c, [5, 6, 7]>>;
 }
 
 describe("FlexList", () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/typedSchema/typeUtils.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/typedSchema/typeUtils.spec.ts
@@ -35,6 +35,8 @@ import {
 	type check1_ = requireTrue<areSafelyAssignable<ArrayToUnion<[1]>, 1>>;
 	type Case2 = ArrayToUnion<[1, 2]>;
 	type check2_ = requireTrue<areSafelyAssignable<Case2, 1 | 2>>;
+	type Case3 = ArrayToUnion<number[]>;
+	type check3_ = requireTrue<areSafelyAssignable<Case3, number>>;
 }
 
 // Test Unbrand

--- a/experimental/dds/tree2/src/util/typeCheck.ts
+++ b/experimental/dds/tree2/src/util/typeCheck.ts
@@ -150,7 +150,7 @@ export type requireFalse<_X extends false> = true;
  *
  * @privateRemarks
  * Use of [] in the extends clause prevents unions from being distributed over this conditional and returning `boolean` in some cases.
- * @see [distributive-conditional-types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) for details.
+ * @see {@link https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types | distributive-conditional-types} for details.
  * @alpha
  */
 export type isAssignableTo<Source, Destination> = [Source] extends [Destination] ? true : false;

--- a/experimental/dds/tree2/src/util/typeCheck.ts
+++ b/experimental/dds/tree2/src/util/typeCheck.ts
@@ -148,13 +148,12 @@ export type requireFalse<_X extends false> = true;
 /**
  * Returns a type parameter that is true iff Source is assignable to Destination.
  *
+ * @privateRemarks
+ * Use of [] in the extends clause prevents unions from being distributed over this conditional and returning `boolean` in some cases.
+ * @see [distributive-conditional-types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) for details.
  * @alpha
  */
-export type isAssignableTo<Source, Destination> = isAny<Source> extends true
-	? true
-	: Source extends Destination
-	? true
-	: false;
+export type isAssignableTo<Source, Destination> = [Source] extends [Destination] ? true : false;
 
 /**
  * Returns a type parameter that is true iff Subset is a strict subset of Superset.
@@ -189,10 +188,13 @@ export type eitherIsAny<A, B> = true extends isAny<A> | isAny<B> ? true : false;
 /**
  * Returns a type parameter that is true iff T is any.
  *
+ * @privateRemarks
+ * Only `never` is assignable to `never` (`any` isn't),
+ * but `any` distributes over the `extends` here while nothing else should.
+ * This can be used to detect `any`.
  * @alpha
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
+export type isAny<T> = boolean extends (T extends never ? true : false) ? true : false;
 
 /**
  * Compile time assert that A is assignable to (extends) B.

--- a/experimental/dds/tree2/src/util/typeCheckTests.ts
+++ b/experimental/dds/tree2/src/util/typeCheckTests.ts
@@ -205,6 +205,9 @@ export type EnforceTypeCheckTests =
 	| requireFalse<isAny<never>>
 	| requireFalse<isAny<{}>>
 	| requireFalse<isAny<boolean>>
+	| requireFalse<isAny<number | undefined>>
+	| requireFalse<isAny<1 & "x">>
+	| requireFalse<isAny<(1 & 2) | {}>>
 
 	// test isStrictSubset
 	| requireTrue<isStrictSubset<1, 1 | 2>>
@@ -222,6 +225,10 @@ export type EnforceTypeCheckTests =
 type _falseIsTrue = requireTrue<false>;
 // @ts-expect-error negative test
 type _trueIsFalse = requireFalse<true>;
+// @ts-expect-error negative test
+type _booleanIsTrue = requireTrue<boolean>;
+// @ts-expect-error negative test
+type _booleanIsFalse = requireFalse<boolean>;
 // @ts-expect-error negative test
 type _emptyNotAssignable = requireFalse<isAssignableTo<Empty1, Empty2>>;
 // @ts-expect-error negative test

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -303,7 +303,7 @@ export function assertNonNegativeSafeInteger(index: number) {
  *
  * @alpha
  */
-export type Assume<TInput, TAssumeToBe> = TInput extends TAssumeToBe ? TInput : TAssumeToBe;
+export type Assume<TInput, TAssumeToBe> = [TInput] extends [TAssumeToBe] ? TInput : TAssumeToBe;
 
 /**
  * The counter used to generate deterministic stable ids for testing purposes.


### PR DESCRIPTION
## Description

A few places in the tree codebase included conditional types which did not take into account that sometimes conditionals are distributive (when given unions) and sometimes they aren't (ex: when given types containing unions). See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types for some more information.

This lead to some bugs in the TypeCheck library, as well as some bugs in ediableTreeTypes.

Specifically unboxing APIs's implementations type checked such that cases which might not unbox never unbox. Then when called in cases which unbox, they could have uncaught errors in the implementation where it incorrectly assumed it would get boxed nodes.

There were also some similar mishandlings of generic cases in a few other places, and additional tests for these cases were added.

## Breaking Changes

No correct code following our strong typing schema aware conventions should have been broken, but some types are now more strict.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

