### PR TITLE
Use new ST API surface in tree-comparison demo

### DIFF
--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -196,7 +196,7 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 			}
 
 			// Search for deleted inventory items to update our collection
-			const currentInventoryIds = [...this.inventoryItemList].map((inventoryItemNode) => {
+			const currentInventoryIds = this.inventoryItemList.map((inventoryItemNode) => {
 				return inventoryItemNode.id;
 			});
 			for (const trackedItemId of this._inventoryItems.keys()) {

--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -6,11 +6,12 @@
 import {
 	AllowedUpdateType,
 	ForestType,
+	ISharedTree,
+	node,
+	ProxyNode,
 	SchemaBuilder,
+	SharedTreeFactory,
 	typeboxValidator,
-	Typed,
-	TypedTreeChannel,
-	TypedTreeFactory,
 } from "@fluid-experimental/tree2";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -31,24 +32,22 @@ const inventoryItemSchema = builder.object("Contoso:InventoryItem-1.0.0", {
 	// The number in stock
 	quantity: builder.number,
 });
-type InventoryItemNode = Typed<typeof inventoryItemSchema>;
+type InventoryItemNode = ProxyNode<typeof inventoryItemSchema>;
 
-// TODO: Convert this to use builder.list() rather than builder.sequence when ready.
+const inventoryItemList = builder.list(inventoryItemSchema);
+type InventoryItemList = ProxyNode<typeof inventoryItemList>;
+
 const inventorySchema = builder.object("Contoso:Inventory-1.0.0", {
-	inventoryItems: builder.sequence(inventoryItemSchema),
+	inventoryItemList,
 });
-type InventoryNode = Typed<typeof inventorySchema>;
 
 // This call finalizes the schema into an object we can pass to schematize.
 const schema = builder.intoSchema(inventorySchema);
 
-const newTreeFactory = new TypedTreeFactory({
+const newTreeFactory = new SharedTreeFactory({
 	jsonValidator: typeboxValidator,
 	// For now, ignore the forest argument - I think it's probably going away once the optimized one is ready anyway?  AB#6013
 	forest: ForestType.Reference,
-	// For now, ignore the subtype.  However, be aware that it is written into the document and so must remain consistent
-	// in order to load existing documents.  AB#6014
-	subtype: "InventoryList",
 });
 
 const sharedTreeKey = "sharedTree";
@@ -71,7 +70,7 @@ class NewTreeInventoryItem extends TypedEmitter<IInventoryItemEvents> implements
 	public set quantity(newQuantity: number) {
 		// Note that modifying the content here is actually changing the data stored in the SharedTree legitimately
 		// (i.e. results in an op sent and changes reflected on all clients).  AB#5970
-		this._inventoryItemNode.boxedQuantity.content = newQuantity;
+		this._inventoryItemNode.quantity = newQuantity;
 	}
 	public constructor(
 		private readonly _inventoryItemNode: InventoryItemNode,
@@ -80,7 +79,8 @@ class NewTreeInventoryItem extends TypedEmitter<IInventoryItemEvents> implements
 		super();
 		// Note that this is not a normal Node EventEmitter and functions differently.  There is no "off" method,
 		// but instead "on" returns a callback to unregister the event.  AB#5973
-		this._unregisterChangingEvent = this._inventoryItemNode.on("changing", () => {
+		// node.on() is the way to register events on the inventory item (the first argument).  AB#6051
+		this._unregisterChangingEvent = node.on(this._inventoryItemNode, "changing", () => {
 			this.emit("quantityChanged");
 		});
 	}
@@ -93,24 +93,24 @@ class NewTreeInventoryItem extends TypedEmitter<IInventoryItemEvents> implements
 }
 
 export class NewTreeInventoryList extends DataObject implements IInventoryList {
-	private _sharedTree: TypedTreeChannel | undefined;
-	private get sharedTree(): TypedTreeChannel {
+	private _sharedTree: ISharedTree | undefined;
+	private get sharedTree(): ISharedTree {
 		if (this._sharedTree === undefined) {
 			throw new Error("Not initialized properly");
 		}
 		return this._sharedTree;
 	}
-	private _inventory: InventoryNode | undefined;
-	private get inventory(): InventoryNode {
-		if (this._inventory === undefined) {
+	private _inventoryItemList: InventoryItemList | undefined;
+	private get inventoryItemList(): InventoryItemList {
+		if (this._inventoryItemList === undefined) {
 			throw new Error("Not initialized properly");
 		}
-		return this._inventory;
+		return this._inventoryItemList;
 	}
 	private readonly _inventoryItems = new Map<string, NewTreeInventoryItem>();
 
 	public readonly addItem = (name: string, quantity: number) => {
-		this.inventory.inventoryItems.insertAtEnd([
+		this.inventoryItemList.insertAtEnd([
 			{
 				// In a real-world scenario, this is probably a known unique inventory ID (rather than
 				// randomly generated).  Randomly generating here just for convenience.
@@ -129,7 +129,7 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 		this._sharedTree = this.runtime.createChannel(
 			undefined,
 			newTreeFactory.type,
-		) as TypedTreeChannel;
+		) as ISharedTree;
 		this.root.set(sharedTreeKey, this._sharedTree.handle);
 		// Convenient repro for bug AB#5975
 		// const retrievedSharedTree = await this._sharedTree.handle.get();
@@ -142,43 +142,49 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 	// This would usually live in hasInitialized - I'm using initializingFromExisting here due to bug AB#5975.
 	protected async initializingFromExisting(): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this._sharedTree = await this.root
-			.get<IFluidHandle<TypedTreeChannel>>(sharedTreeKey)!
-			.get();
+		this._sharedTree = await this.root.get<IFluidHandle<ISharedTree>>(sharedTreeKey)!.get();
 	}
 
 	protected async hasInitialized(): Promise<void> {
 		// Note that although we always pass initialTree, it's only actually used on the first load and
 		// is ignored on subsequent loads.  AB#5974
-		// Note that because we passed an "object" to the toDocumentSchema() call (rather than a RequiredField),
-		// that call will automatically generate and wrap our object in a RequiredField.  That automatically
-		// generated RequiredField is what we get back from the .schematize() call.  So to get back to our
-		// object type we need to get the .content off of the return value of .schematize().
-		this._inventory = this.sharedTree.schematize({
-			initialTree: {
-				inventoryItems: [
-					{
-						id: uuid(),
-						name: "nut",
-						quantity: 0,
+		// The schematizeView() call does a few things:
+		// 1. On first load, stamps the schema we defined above on the tree (permanently).
+		// 2. On first load, inserts the initial data we define in the initialTree.
+		// 3. On all loads, gets an (untyped) view of the data (the contents can't be accessed directly from the sharedTree).
+		// Then the root2() call applies a typing to the untyped view based on our schema.  After that we can actually
+		// reach in and grab the inventoryItems list.
+		this._inventoryItemList = this.sharedTree
+			.schematizeView({
+				initialTree: {
+					inventoryItemList: {
+						// TODO: The list type unfortunately needs this "" key for now, but it's supposed to go away soon.
+						"": [
+							{
+								id: uuid(),
+								name: "nut",
+								quantity: 0,
+							},
+							{
+								id: uuid(),
+								name: "bolt",
+								quantity: 0,
+							},
+						],
 					},
-					{
-						id: uuid(),
-						name: "bolt",
-						quantity: 0,
-					},
-				],
-			},
-			allowedSchemaModifications: AllowedUpdateType.None,
-			schema,
-		}).content;
+				},
+				allowedSchemaModifications: AllowedUpdateType.None,
+				schema,
+			})
+			.root2(schema).inventoryItemList;
 		// afterChange will fire for any change of any type anywhere in the subtree.  In this application we expect
 		// three types of tree changes that will trigger this handler - add items, delete items, change item quantities.
 		// Since "afterChange" doesn't provide event args, we need to scan the tree and compare it to our InventoryItems
 		// to find what changed.  We'll intentionally ignore the quantity changes here, which are instead handled by
 		// "changing" listeners on each individual item node.
-		this.inventory.context.on("afterChange", () => {
-			for (const inventoryItemNode of this.inventory.inventoryItems) {
+		// node.on() is the way to register events on the list (the first argument).  AB#6051
+		node.on(this.inventoryItemList, "afterChange", () => {
+			for (const inventoryItemNode of this.inventoryItemList) {
 				// If we're not currently tracking some item in the tree, then it must have been
 				// added in this change.
 				if (!this._inventoryItems.has(inventoryItemNode.id)) {
@@ -190,11 +196,9 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 			}
 
 			// Search for deleted inventory items to update our collection
-			const currentInventoryIds = [...this.inventory.inventoryItems].map(
-				(inventoryItemNode) => {
-					return inventoryItemNode.id;
-				},
-			);
+			const currentInventoryIds = [...this.inventoryItemList].map((inventoryItemNode) => {
+				return inventoryItemNode.id;
+			});
 			for (const trackedItemId of this._inventoryItems.keys()) {
 				// If the tree doesn't contain the id of an item we're tracking, then it must have
 				// been deleted in this change.
@@ -206,7 +210,7 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 		});
 
 		// Last step of initializing is to populate our map of InventoryItems.
-		for (const inventoryItemNode of this.inventory.inventoryItems) {
+		for (const inventoryItemNode of this.inventoryItemList) {
 			const inventoryItem = this.makeInventoryItemFromInventoryItemNode(inventoryItemNode);
 			this._inventoryItems.set(inventoryItemNode.id, inventoryItem);
 		}
@@ -216,11 +220,9 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 		inventoryItemNode: InventoryItemNode,
 	): NewTreeInventoryItem {
 		const removeItemFromTree = () => {
-			// Although it's possible to remove a node from the tree without the parent reference, it gets a little messy:
-			// (inventoryItemNode.parentField.parent as any).removeAt(inventoryItemNode.parentField.index);
-			// So for now we'll pass in the delete capability as a callback to withold this.inventory access from the
+			// We pass in the delete capability as a callback to withold this.inventory access from the
 			// inventory items.  AB#6015
-			this.inventory.inventoryItems.removeAt(inventoryItemNode.parentField.index);
+			this.inventoryItemList.removeAt(this.inventoryItemList.indexOf(inventoryItemNode));
 		};
 		const inventoryItem = new NewTreeInventoryItem(inventoryItemNode, removeItemFromTree);
 		return inventoryItem;


### PR DESCRIPTION
@DLehenbauer walked me through some changes to the SharedTree API surface and we updated the tree-comparison demo accordingly.  Quick overview:
1. Use`SharedTreeFactory` and `ISharedTree` to access root2 (`TypedTreeFactory` and `TypedTreeChannel` does not yet expose proxy nodes.)
2. `Typed` becomes `ProxyNode` (but is the same idea: it extracts TypeScript types from Schema definitions.)
3. Use `builder.list` (`builder.sequence` is becoming internal -- `""` is still temporarily required.)
4. Don't use `boxedQuantity` -- boxed vs. unboxed is becoming an internal concept.
5. Schematizing changes a bit - `schematizeView()` instead of `schematize()` gives an untyped view, then `root2()` to apply typing to that view, and then we can get the list.
6. `parentField` is unavailable on the list, so unfortunately this makes it harder to encapsulate item deletion to the individual item.  But we can stick with passing in the callback.
7. Use `node.on` for event registration.  This is a bit awkward, so also filed a feedback bug on it.

[AB#6052](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6052)