### PR TITLE
fix(tree2): fix generation of deltas for optional field

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
@@ -546,7 +546,7 @@ export function optionalFieldIntoDelta(
 			const setUpdate = update as { set: JsonableTree; buildId: ChangeAtomId };
 			const content = [singleTextCursor(setUpdate.set)];
 			const buildId = makeDetachedNodeId(
-				setUpdate.buildId.revision,
+				setUpdate.buildId.revision ?? change.fieldChange.revision ?? revision,
 				setUpdate.buildId.localId,
 			);
 			mark.attach = buildId;

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalField.spec.ts
@@ -382,25 +382,27 @@ describe("optionalField", () => {
 
 	describe("optionalFieldIntoDelta", () => {
 		it("can be converted to a delta when field was empty", () => {
+			const outerNodeId = makeDetachedNodeId(tag, 41);
+			const innerNodeId = makeDetachedNodeId(tag, 1);
 			const expected: Delta.FieldChanges = {
-				build: [{ id: { minor: 41 }, trees: [testTreeCursor("tree1")] }],
+				build: [{ id: outerNodeId, trees: [testTreeCursor("tree1")] }],
 				global: [
 					{
-						id: { minor: 41 },
+						id: outerNodeId,
 						fields: new Map<FieldKey, Delta.FieldChanges>([
 							[
 								fooKey,
 								{
 									build: [
 										{
-											id: makeDetachedNodeId(tag, 1),
+											id: innerNodeId,
 											trees: [testTreeCursor("nodeChange1")],
 										},
 									],
 									local: [
 										{
 											count: 1,
-											attach: makeDetachedNodeId(tag, 1),
+											attach: innerNodeId,
 											detach: { major: tag, minor: 0 },
 										},
 									],
@@ -409,7 +411,7 @@ describe("optionalField", () => {
 						]),
 					},
 				],
-				local: [{ count: 1, attach: { minor: 41 } }],
+				local: [{ count: 1, attach: outerNodeId }],
 			};
 
 			const actual = optionalFieldIntoDelta(change1, (change) =>

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1742,7 +1742,7 @@ describe("Editing", () => {
 			expectJsonTree([tree1, tree2], [{ foo: "43" }]);
 		});
 
-		it.skip("can rebase a node edit over an unrelated edit", () => {
+		it("can rebase a node edit over an unrelated edit", () => {
 			const tree1 = makeTreeFromJson([{ foo: "40", bar: "123" }]);
 			const tree2 = tree1.fork();
 
@@ -1807,6 +1807,28 @@ describe("Editing", () => {
 
 			expectJsonTree(tree1, ["42"]);
 			unsubscribe();
+		});
+
+		it("can rebase populating a new node over an unrelated change", () => {
+			const tree1 = makeTreeFromJson({});
+			const tree2 = tree1.fork();
+
+			tree1.editor
+				.optionalField({ parent: rootNode, field: brand("foo") })
+				.set(singleJsonCursor("A"), true);
+
+			tree2.editor
+				.optionalField({ parent: rootNode, field: brand("bar") })
+				.set(singleJsonCursor("B"), true);
+
+			expectJsonTree(tree1, [{ foo: "A" }]);
+			expectJsonTree(tree2, [{ bar: "B" }]);
+
+			tree1.merge(tree2, false);
+			tree2.rebaseOnto(tree1);
+
+			expectJsonTree(tree1, [{ foo: "A", bar: "B" }]);
+			expectJsonTree(tree2, [{ foo: "A", bar: "B" }]);
 		});
 
 		it.skip("undo restores a removed node even when that node was not the one originally removed by the undone change", () => {


### PR DESCRIPTION
Fixes the generation of deltas for optional field.
Enables tests that now succeed.