### PR TITLE
fix(tree2): cancelling out changes in optional composition

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -206,7 +206,7 @@ export type RevisionIndexer = (tag: RevisionTag) => number;
  */
 export interface RevisionMetadataSource {
 	readonly getIndex: RevisionIndexer;
-	readonly getInfo: (tag: RevisionTag) => RevisionInfo;
+	readonly tryGetInfo: (tag: RevisionTag | undefined) => RevisionInfo | undefined;
 }
 
 /**
@@ -216,5 +216,5 @@ export function getIntention(
 	rev: RevisionTag | undefined,
 	revisionMetadata: RevisionMetadataSource,
 ): RevisionTag | undefined {
-	return rev === undefined ? undefined : revisionMetadata.getInfo(rev).rollbackOf ?? rev;
+	return revisionMetadata.tryGetInfo(rev)?.rollbackOf ?? rev;
 }

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -762,10 +762,10 @@ export function revisionMetadataSourceFromInfo(
 		assert(index !== -1, 0x5a0 /* Unable to index unknown revision */);
 		return index;
 	};
-	const getInfo = (revision: RevisionTag): RevisionInfo => {
-		return revInfos[getIndex(revision)];
+	const tryGetInfo = (revision: RevisionTag | undefined): RevisionInfo | undefined => {
+		return revision === undefined ? undefined : revInfos[getIndex(revision)];
 	};
-	return { getIndex, getInfo };
+	return { getIndex, tryGetInfo };
 }
 
 function isEmptyNodeChangeset(change: NodeChangeset): boolean {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -80,8 +80,7 @@ export function rebase<TNodeChange>(
 	nodeExistenceState: NodeExistenceState = NodeExistenceState.Alive,
 ): Changeset<TNodeChange> {
 	assert(base.revision !== undefined, 0x69b /* Cannot rebase over changeset with no revision */);
-	const baseInfo =
-		base.revision === undefined ? undefined : revisionMetadata.getInfo(base.revision);
+	const baseInfo = revisionMetadata.tryGetInfo(base.revision);
 	const baseIntention = baseInfo?.rollbackOf ?? base.revision;
 	return rebaseMarkList(
 		change,

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalChangeRebaser.spec.ts
@@ -153,7 +153,7 @@ function rebaseComposed(
 	baseChanges.forEach((base) => deepFreeze(base));
 	deepFreeze(change);
 
-	const composed = compose(baseChanges);
+	const composed = compose(baseChanges, metadata);
 	const moveEffects = failCrossFieldManager;
 	const idAllocator = idAllocatorFromMaxId(getMaxId(composed));
 	return optionalChangeRebaser.rebase(
@@ -167,7 +167,10 @@ function rebaseComposed(
 	);
 }
 
-function compose(changes: TaggedChange<OptionalChangeset>[]): OptionalChangeset {
+function compose(
+	changes: TaggedChange<OptionalChangeset>[],
+	metadata?: RevisionMetadataSource,
+): OptionalChangeset {
 	const moveEffects = failCrossFieldManager;
 	const idAllocator = idAllocatorFromMaxId(getMaxId(...changes.map((c) => c.change)));
 	return optionalChangeRebaser.compose(
@@ -175,7 +178,7 @@ function compose(changes: TaggedChange<OptionalChangeset>[]): OptionalChangeset 
 		TestChange.compose as any,
 		idAllocator,
 		moveEffects,
-		defaultRevisionMetadataFromChanges(changes),
+		metadata ?? defaultRevisionMetadataFromChanges(changes),
 	);
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/exhaustiveRebaserUtils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/exhaustiveRebaserUtils.ts
@@ -47,7 +47,7 @@ export interface BoundFieldChangeRebaser<TChangeset> {
 		change: TChangeset,
 		...baseChanges: TaggedChange<TChangeset>[]
 	): TChangeset;
-	compose(changes: TaggedChange<TChangeset>[]): TChangeset;
+	compose(changes: TaggedChange<TChangeset>[], metadata?: RevisionMetadataSource): TChangeset;
 }
 
 export interface NamedChangeset<TChangeset> {

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -65,7 +65,7 @@ const unexpectedDelegate = () => assert.fail("Unexpected call");
 
 const revisionMetadata: RevisionMetadataSource = {
 	getIndex: () => assert.fail("Unexpected revision index query"),
-	getInfo: () => assert.fail("Unexpected revision info query"),
+	tryGetInfo: () => assert.fail("Unexpected revision info query"),
 };
 
 const childComposer = (nodeChanges: TaggedChange<NodeChangeset>[]): NodeChangeset => {

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -668,11 +668,13 @@ describe("ModularChangeFamily", () => {
 			composeChild,
 			genId,
 			crossFieldManager,
-			{ getIndex, getInfo },
+			{ getIndex, tryGetInfo },
 		): RevisionTag[] => {
 			const relevantRevisions = [rev1, rev2, rev3, rev4];
 			const revsIndices: number[] = relevantRevisions.map((c) => getIndex(c));
-			const revsInfos: RevisionInfo[] = relevantRevisions.map((c) => getInfo(c));
+			const revsInfos: RevisionInfo[] = relevantRevisions.map(
+				(c) => tryGetInfo(c) ?? assert.fail(),
+			);
 			assert.deepEqual(revsIndices, [0, 1, 2, 3]);
 			const expected: RevisionInfo[] = [
 				{ revision: rev1 },
@@ -692,11 +694,13 @@ describe("ModularChangeFamily", () => {
 			rebaseChild,
 			genId,
 			crossFieldManager,
-			{ getIndex, getInfo },
+			{ getIndex, tryGetInfo },
 		): RevisionTag[] => {
 			const relevantRevisions = [rev1, rev2, rev4];
 			const revsIndices: number[] = relevantRevisions.map((c) => getIndex(c));
-			const revsInfos: RevisionInfo[] = relevantRevisions.map((c) => getInfo(c));
+			const revsInfos: RevisionInfo[] = relevantRevisions.map(
+				(c) => tryGetInfo(c) ?? assert.fail(),
+			);
 			assert.deepEqual(revsIndices, [0, 1, 2]);
 			const expected: RevisionInfo[] = [
 				{ revision: rev1 },

--- a/experimental/dds/tree2/src/test/feature-libraries/rebaserAxiomaticTests.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/rebaserAxiomaticTests.ts
@@ -143,21 +143,25 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 							// This needs to be used to pass an updated RevisionMetadataSource to rebase.
 							const allTaggedEdits = [...inverses, editToRebaseOver];
 							for (let i = 0; i < sourceEdits.length; i++) {
-								const metadata = defaultRevisionMetadataFromChanges(allTaggedEdits);
+								let metadata = defaultRevisionMetadataFromChanges(allTaggedEdits);
 								const edit = sourceEdits[i];
 								const rebasedEdit = tagChange(
 									rebaseComposed(metadata, edit.change, currentComposedEdit),
 									edit.revision,
 								);
 								rebasedEditsWithCompose.push(rebasedEdit);
-								currentComposedEdit = makeAnonChange(
-									compose([
-										inverses[sourceEdits.length - i - 1],
-										currentComposedEdit,
-										rebasedEdit,
-									]),
-								);
 								allTaggedEdits.push(rebasedEdit);
+								metadata = defaultRevisionMetadataFromChanges(allTaggedEdits);
+								currentComposedEdit = makeAnonChange(
+									compose(
+										[
+											inverses[sourceEdits.length - i - 1],
+											currentComposedEdit,
+											rebasedEdit,
+										],
+										metadata,
+									),
+								);
 							}
 
 							for (let i = 0; i < rebasedEditsWithoutCompose.length; i++) {


### PR DESCRIPTION
When attempting to detect cases where changes should cancel-out, the current code uses `revision` and `rollbackOf` that may not be set.