### PR TITLE
fix: Support r11s endpoint name in e2e tests that use versioned test object provider

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -102,12 +102,21 @@ describeInstallVersions(
 )("Op Compression self-healing with old loader", (getProvider) =>
 	compressionSuite(async () => {
 		const provider = getProvider();
+		// Ensure support for endpoint names for r11s driver. ODSP might need similar help at some point if we have
+		// scenarios that run into issues otherwise.
+		const driverConfig =
+			provider.driver.endpointName !== undefined
+				? {
+						r11s: { r11sEndpointName: provider.driver.endpointName },
+				  }
+				: undefined;
 		return getVersionedTestObjectProvider(
 			pkgVersion, // base version
 			loaderWithoutCompressionField, // loader version
 			{
 				type: provider.driver.type,
 				version: pkgVersion,
+				config: driverConfig,
 			}, // driver version
 			pkgVersion, // runtime version
 			pkgVersion, // datastore runtime version


### PR DESCRIPTION
## Description

Adds support for r11s' endpointName to some tests that use a custom test object provider with particular loader versions. Without this they would always time out when running against a local dockerized instance of r11s, because the test driver created for them was not made aware of the custom endpoint, and ended up using endpoint URLs for our internal r11s cluster, not localhost pointing to the docker instance.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#5522](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5522)