### PR TITLE
fix(build-tools): coerce relative paths to use /

### DIFF
--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -361,7 +361,8 @@ export class FluidRepo {
 	 * @returns the relative path.
 	 */
 	public relativeToRepo(p: string): string {
-		return path.relative(this.resolvedRoot, p);
+		// Replace \ in result with / in case OS is Windows.
+		return path.relative(this.resolvedRoot, p).replace(/\\/g, "/");
 	}
 }
 


### PR DESCRIPTION
path.relative with return path with native separator which will be `\` on Windows. But handler `match`_s have been written with only `/` in mind.
build-cli tests now pass under Windows.