### PR TITLE
tidy(tree): prepare twitter.ts for schema

### DIFF
--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -37,7 +37,7 @@ import {
 import { jsonRoot, SchemaBuilder } from "../../../domains";
 import { Canada, generateCanada } from "./canada";
 import { averageTwoValues, sum, sumMap } from "./benchmarks";
-import { generateTwitterJsonByByteSize, Twitter } from "./twitter";
+import { generateTwitterJsonByByteSize, TwitterKey } from "./twitter";
 import { CitmCatalog, generateCitmJson } from "./citm";
 import { clone } from "./jsObjectUtil";
 
@@ -224,18 +224,18 @@ function extractAvgValsFromTwitter(
 	cursor: ITreeCursor,
 	calculate: (x: number, y: number) => void,
 ): void {
-	cursor.enterField(Twitter.SharedTreeFieldKey.statuses); // move from root to field
+	cursor.enterField(TwitterKey.statuses); // move from root to field
 	cursor.enterNode(0); // move from field to node at 0 (which is an object of type array)
 	cursor.enterField(EmptyKey); // enter the array field at the node,
 
 	for (let result = cursor.firstNode(); result; result = cursor.nextNode()) {
-		cursor.enterField(Twitter.SharedTreeFieldKey.retweetCount);
+		cursor.enterField(TwitterKey.retweetCount);
 		cursor.enterNode(0);
 		const retweetCount = cursor.value as number;
 		cursor.exitNode();
 		cursor.exitField();
 
-		cursor.enterField(Twitter.SharedTreeFieldKey.favoriteCount);
+		cursor.enterField(TwitterKey.favoriteCount);
 		cursor.enterNode(0);
 		const favoriteCount = cursor.value;
 		cursor.exitNode();

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -13,6 +13,7 @@ import {
 	cursorToJsonObject,
 	jsonSchema,
 	JsonCompatible,
+	brand,
 } from "../../..";
 import {
 	buildForest,
@@ -23,6 +24,7 @@ import {
 	buildChunkedForest,
 } from "../../../feature-libraries";
 import {
+	FieldKey,
 	initializeForest,
 	InMemoryStoredSchemaRepository,
 	JsonableTree,
@@ -37,9 +39,16 @@ import {
 import { jsonRoot, SchemaBuilder } from "../../../domains";
 import { Canada, generateCanada } from "./canada";
 import { averageTwoValues, sum, sumMap } from "./benchmarks";
-import { generateTwitterJsonByByteSize, TwitterKey } from "./twitter";
+import { generateTwitterJsonByByteSize } from "./twitter";
 import { CitmCatalog, generateCitmJson } from "./citm";
 import { clone } from "./jsObjectUtil";
+
+// Shared tree keys that map to the type used by the Twitter type/dataset
+export const TwitterKey = {
+	statuses: brand<FieldKey>("statuses"),
+	retweetCount: brand<FieldKey>("retweet_count"),
+	favoriteCount: brand<FieldKey>("favorite_count"),
+};
 
 /**
  * Performance test suite that measures a variety of access patterns using ITreeCursor.

--- a/experimental/dds/tree2/src/test/domains/json/twitter.ts
+++ b/experimental/dds/tree2/src/test/domains/json/twitter.ts
@@ -130,10 +130,10 @@ export interface TwitterStatus {
 	in_reply_to_user_id_str: string | null;
 	in_reply_to_screen_name: string | null;
 	user: TwitterUser;
-	geo: null; // could not find an example of non null value
-	coordinates: null; // could not find an example of non null value
-	place: null; // could not find an example of non null value
-	contributors: null; // could not find an example of non null value
+	geo: null; // always null in source json
+	coordinates: null; // always null in source json
+	place: null; // always null in source json
+	contributors: null; // always null in source json
 	retweet_count: number;
 	favorite_count: number;
 	entities: {
@@ -141,7 +141,7 @@ export interface TwitterStatus {
 			text: string;
 			indices: number[];
 		}[];
-		symbols: unknown[]; // could not find a populated value from source json
+		symbols: never[]; // always empty in source json
 		urls: {
 			url: string;
 			expanded_url: string;
@@ -340,11 +340,10 @@ function generateTwitterStatus(
          ${random.string(random.integer(2, 30), alphabet)}</a>`,
 		truncated: true, // no examples found where truncated was false
 		user,
-		// could not find an example of non null value for these 4 values (geo, coordinaes, place, contributors)
-		geo: null,
-		coordinates: null,
-		place: null,
-		contributors: null,
+		geo: null, // always null in source json
+		coordinates: null, // always null in source json
+		place: null, // always null in source json
+		contributors: null, // always null in source json
 		possibly_sensitive: random.bool(),
 		retweet_count: retweetCount,
 		favorite_count: favoriteCount,

--- a/experimental/dds/tree2/src/test/domains/json/twitter.ts
+++ b/experimental/dds/tree2/src/test/domains/json/twitter.ts
@@ -459,6 +459,7 @@ function generateTwitterStatus(
 		status.entities.media = [mediaEntity];
 	}
 
+	// Now that 'status' is fully constructed, cast from Partial<TwitterStatus> to a full TwitterStatus.
 	return status as TwitterStatus;
 }
 

--- a/experimental/dds/tree2/src/test/domains/json/twitter.ts
+++ b/experimental/dds/tree2/src/test/domains/json/twitter.ts
@@ -8,8 +8,6 @@ import {
 	makeRandom,
 	SpaceEfficientWordMarkovChain,
 } from "@fluid-internal/stochastic-test-utils";
-import { FieldKey } from "../../../core";
-import { brand } from "../../../util";
 import {
 	createAlphabetFromUnicodeRange,
 	getRandomEnglishString,
@@ -17,16 +15,8 @@ import {
 	getSizeInBytes,
 } from "./jsonGeneratorUtils";
 
-/**
- * This file contains logic to generate a JSON file that is statistically similar to the well-known
- * json benchmarks twitter.json - https://raw.githubusercontent.com/serde-rs/json-benchmark/master/data/twitter.json
- */
-// Shared tree keys that map to the type used by the Twitter type/dataset
-export const TwitterKey = {
-	statuses: brand<FieldKey>("statuses"),
-	retweetCount: brand<FieldKey>("retweet_count"),
-	favoriteCount: brand<FieldKey>("favorite_count"),
-};
+// This file contains logic to generate a JSON file that is statistically similar to the well-known
+// json benchmarks twitter.json - https://raw.githubusercontent.com/serde-rs/json-benchmark/master/data/twitter.json
 
 /* eslint-disable @rushstack/no-new-null */
 export interface TwitterUser {

--- a/experimental/dds/tree2/src/test/domains/json/twitter.ts
+++ b/experimental/dds/tree2/src/test/domains/json/twitter.ts
@@ -311,7 +311,7 @@ function generateTwitterStatus(
 	const statusIdString = getRandomNumberString(random, 18, 18);
 	const retweetCount = Math.floor(random.integer(0, 99999));
 	const favoriteCount = Math.floor(random.integer(0, 99999));
-	const twitterUser = generateTwitterUser(random, userDescFieldMarkovChain, alphabet);
+	const user = generateTwitterUser(random, userDescFieldMarkovChain, alphabet);
 	// The following boolean values mirror the statistical probability of the original json
 	const shouldAddHashtagEntity = type === "standard" ? random.bool(0.07) : random.bool(0.027397);
 	const shouldAddUrlEntity = type === "standard" ? random.bool(0.12) : random.bool(0.068493);
@@ -344,10 +344,10 @@ function generateTwitterStatus(
 		id_str: `${statusIdString}`,
 		text: textFieldMarkovChain.generateData(144), // average length the original json text field is 123
 		// source can have unicode nested in it
-		source: `<a href=\"https://twitter.com/${twitterUser.screen_name}\" rel=\"nofollow\">
+		source: `<a href=\"https://twitter.com/${user.screen_name}\" rel=\"nofollow\">
          ${random.string(random.integer(2, 30), alphabet)}</a>`,
 		truncated: true, // no examples found where truncated was false
-		user: twitterUser,
+		user,
 		// could not find an example of non null value for these 4 values (geo, coordinaes, place, contributors)
 		geo: null,
 		coordinates: null,

--- a/experimental/dds/tree2/src/test/domains/json/twitter.ts
+++ b/experimental/dds/tree2/src/test/domains/json/twitter.ts
@@ -79,6 +79,42 @@ export interface TwitterUser {
 	notifications: boolean;
 }
 
+export interface TwitterMediaEntity {
+	id: number;
+	id_str: string;
+	indices: number[];
+	media_url: string;
+	media_url_https: string;
+	url: string;
+	display_url: string;
+	expanded_url: string;
+	type: string;
+	sizes: {
+		large: {
+			w: number;
+			h: number;
+			resize: "fit" | "crop";
+		};
+		medium: {
+			w: number;
+			h: number;
+			resize: "fit" | "crop";
+		};
+		thumb: {
+			w: number;
+			h: number;
+			resize: "fit" | "crop";
+		};
+		small: {
+			w: number;
+			h: number;
+			resize: "fit" | "crop";
+		};
+	};
+	source_status_id?: number;
+	source_status_id_str?: string;
+}
+
 export interface TwitterStatus {
 	metadata: {
 		result_type: string;
@@ -119,41 +155,7 @@ export interface TwitterStatus {
 			id_str: string;
 			indices: number[];
 		}[];
-		media?: {
-			id: number;
-			id_str: string;
-			indices: number[];
-			media_url: string;
-			media_url_https: string;
-			url: string;
-			display_url: string;
-			expanded_url: string;
-			type: string;
-			sizes: {
-				large: {
-					w: number;
-					h: number;
-					resize: "fit" | "crop";
-				};
-				medium: {
-					w: number;
-					h: number;
-					resize: "fit" | "crop";
-				};
-				thumb: {
-					w: number;
-					h: number;
-					resize: "fit" | "crop";
-				};
-				small: {
-					w: number;
-					h: number;
-					resize: "fit" | "crop";
-				};
-			};
-			source_status_id?: number;
-			source_status_id_str?: string;
-		}[];
+		media?: TwitterMediaEntity[];
 	};
 	favorited: boolean;
 	retweeted: boolean;
@@ -408,7 +410,7 @@ function generateTwitterStatus(
 	if (shouldAddMediaEntity) {
 		const mediaStatusIdString = getRandomNumberString(random, 18, 18);
 		const shouldAddSourceIdData = random.bool();
-		const mediaEntity: any = {
+		const mediaEntity: TwitterMediaEntity = {
 			id: Number(mediaStatusIdString),
 			id_str: "statusIdString",
 			indices: [Math.floor(random.integer(0, 199)), Math.floor(random.integer(0, 199))],


### PR DESCRIPTION
This rearranges interfaces so they are declared before being referenced (this is necessary when using SchemaBuilder because the type references turn into variable references.)

It also includes a couple of minor renames to avoid collisions with schema variables.