### PR TITLE
[DRAFT] GC: Op-based References (collecting outbound routes on submit not process)

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -59,7 +59,7 @@ interface IDirectoryMessageHandler {
 	): void;
 
 	/**
-	 * Communicate the operation to remote clients.
+	 * Submit a message to remote clients based on a previous submit (aka reSubmit)
 	 * @param op - The directory operation to submit
 	 * @param localOpMetadata - The metadata to be submitted with the message.
 	 */
@@ -1259,6 +1259,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			this.serializer,
 			this.directory.handle,
 		);
+		//* Also get handles from makeSerializable
 
 		// Set the value locally.
 		const previousValue = this.setCore(key, localValue, true);
@@ -1274,7 +1275,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			type: "set",
 			value: serializableValue,
 		};
-		this.submitKeyMessage(op, previousValue);
+		this.submitKeyMessage(op, previousValue); //* Also pass handles
 		return this;
 	}
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -421,8 +421,8 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 		//* TODO: We can't generically "roundtrip" content through makeHandlesSerializable,
 		//* so we'll have to plumb rootMetadata down to provide whatever is needed here.
 		//* Or make this abstract, but it may be difficult to recompute the rootMetadata, and better to just pass it.
-		// this.submitLocalMessage(content, localOpMetadata, ???);
 
+		// this.submitLocalMessage2({ content, localOpMetadata, rootMetadata: ???});
 		throw new Error(
 			"reSubmitCore must be overridden in order to correctly compute rootMetadata",
 		);

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -24,6 +24,7 @@ export function serializeHandles(
 ): string | undefined {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return value !== undefined ? serializer.stringify(value, bind) : value;
+	//* Also return handles
 }
 
 /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2063,6 +2063,7 @@ export class ContainerRuntime
 		const opContents = this.parseLocalOpContent(serializedOpContent);
 		switch (opContents.type) {
 			case ContainerMessageType.FluidDataStoreOp:
+				//* rootMetadata is encapsulated within contents
 				return this.dataStores.applyStashedOp(opContents.contents);
 			case ContainerMessageType.Attach:
 				return this.dataStores.applyStashedAttachOp(opContents.contents);
@@ -3718,6 +3719,8 @@ export class ContainerRuntime
 			case ContainerMessageType.FluidDataStoreOp:
 				// For Operations, call resubmitDataStoreOp which will find the right store
 				// and trigger resubmission on it.
+
+				//* rootMetadata is encapsulated in contents here
 				this.dataStores.resubmitDataStoreOp(message.contents, localOpMetadata);
 				break;
 			case ContainerMessageType.Attach:
@@ -3772,6 +3775,7 @@ export class ContainerRuntime
 			case ContainerMessageType.FluidDataStoreOp:
 				// For operations, call rollbackDataStoreOp which will find the right store
 				// and trigger rollback on it.
+				//* rootMetadata is encapsulated in the contents here.  Irrelevant anyway.
 				this.dataStores.rollbackDataStoreOp(contents, localOpMetadata);
 				break;
 			default:

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -90,6 +90,7 @@ export interface RecentlyAddedContainerRuntimeMessageDetails {
 
 export type ContainerRuntimeDataStoreOpMessage = TypedContainerRuntimeMessage<
 	ContainerMessageType.FluidDataStoreOp,
+	//* Update to a new type that includes rootMetadata
 	IEnvelope
 >;
 export type InboundContainerRuntimeAttachMessage = TypedContainerRuntimeMessage<

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -161,7 +161,7 @@ export interface IDeltaHandler {
 }
 
 /**
- * Interface to represent a connection to a delta notification stream.
+ * Interface to represent a channel's connection to a delta notification stream.
  */
 export interface IDeltaConnection {
 	connected: boolean;
@@ -183,7 +183,7 @@ export interface IDeltaConnection {
 	 */
 	submit2?(data: {
 		/** The channel-specific content of the message to be sent */
-		messageContent: unknown;
+		messageContent: unknown; //* Rename to channelData or something?
 		/**
 		 * The local metadata associated with the message. This is kept locally by the runtime
 		 * and not sent to the server. It will be provided back when this message is acknowledged by the server.

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -13,6 +13,7 @@ import {
 	IChannel,
 	IChannelAttributes,
 	IChannelFactory,
+	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
@@ -68,7 +69,7 @@ export interface IChannelContext {
 	updateUsedRoutes(usedRoutes: string[]): void;
 }
 
-export interface ChannelServiceEndpoints {
+export interface ChannelServiceEndpoints extends IChannelServices {
 	deltaConnection: ChannelDeltaConnection;
 	objectStorage: ChannelStorageService;
 }


### PR DESCRIPTION
## Description

Fixes [AB#5761](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5761)

### WORK IN PROGRESS

See PR description for #17571 - This is the follow-on PR containing the actual implementation. Until that PR is merged, this PR targets that branch to separate the new logic (this PR) from the plumbing (that PR).

To Do:

- [ ] Update FluidSerializer to return handles along with serialized payload
- [ ] As an example, update Shared Directory to include those handles when calling submit, via `rootMetadata` (see base PR)
- [ ] Update ContainerRuntime to pull the handles out of rootMetadata and put them on the `IEnvelope` (updating that type) during submit
- [ ] Update ContainerRuntime to check for the handles during process, and notify GC so it can track the new outbound routes

Open questions:

- [ ] How do we migrate from current scheme where DDS calls `addedGCOutboundReference` when parsing the op to the new scheme where ContainerRuntime notifies GC?  There likely will be a period of time where some DDSes will support the new thing but others won't.  And multiple versions collaborating together will last months+.

## Reviewer Guidance

Note that this PR currently targets another WIP branch (See PR #17571).  I'm splitting the 2 PRs apart so all the plumbing in the other PR doesn't distract from the actual logic added in this PR.
