### PR TITLE
build(devtools): Bundle devtools-core symbols in devtools API via api-extractor

### DIFF
--- a/packages/tools/devtools/devtools/api-extractor.json
+++ b/packages/tools/devtools/devtools/api-extractor.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json"
+	"extends": "@fluidframework/build-common/api-extractor-base.json",
+	"bundledPackages": ["@fluid-experimental/devtools-core"]
 }

--- a/packages/tools/devtools/devtools/api-report/devtools.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.api.md
@@ -4,20 +4,24 @@
 
 ```ts
 
-import { ContainerKey } from '@fluid-experimental/devtools-core';
-import { DevtoolsLogger } from '@fluid-experimental/devtools-core';
-import { HasContainerKey } from '@fluid-experimental/devtools-core';
 import { IDisposable } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
+import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 
 // @public
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
 }
 
-export { ContainerKey }
+// @public
+export type ContainerKey = string;
 
-export { DevtoolsLogger }
+// @public @sealed
+export class DevtoolsLogger implements ITelemetryBaseLogger {
+    constructor(baseLogger?: ITelemetryBaseLogger);
+    send(event: ITelemetryBaseEvent): void;
+}
 
 // @public
 export interface DevtoolsProps {
@@ -25,7 +29,10 @@ export interface DevtoolsProps {
     logger?: DevtoolsLogger;
 }
 
-export { HasContainerKey }
+// @public
+export interface HasContainerKey {
+    containerKey: ContainerKey;
+}
 
 // @public
 export interface IDevtools extends IDisposable {


### PR DESCRIPTION
Bundling the exports via API-Extractor accomplished a couple of things:
1. It ensures that our exports from `devtools` are _complete_ in terms of re-exports from `devtools-core`. E.g. if we re-export `Foo` from the other package, and `Foo` references `Bar` (also in the other package), then API-Extractor will enforce that we also re-export `Bar`.
2. It bubbles up generated API documentation such that API members appear as though they are native to the re-exporting package. This makes the API docs easier to navigate.

For more info, see here: https://api-extractor.com/pages/configs/api-extractor_json/#bundledpackages