### PR TITLE
tree2: Cleanup anchor fuzz test setup

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1035,10 +1035,16 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 			if (!shouldMinimize) {
 				throw error;
 			}
-
-			const operations = JSON.parse(
-				readFileSync(saveInfo.filepath).toString(),
-			) as TOperation[];
+			let file: Buffer;
+			try {
+				file = readFileSync(saveInfo.filepath);
+			} catch {
+				// File could not be read and likely does not exist.
+				// Test may have failed outside of the fuzz test portion (on setup or teardown).
+				// Throw original error that made test fail.
+				throw error;
+			}
+			const operations = JSON.parse(file.toString()) as TOperation[];
 			const minimizer = new FuzzTestMinimizer(model, options, operations, seed, saveInfo, 3);
 
 			const minimized = await minimizer.minimize();


### PR DESCRIPTION
## Description

Simply anchor fuzz tests to avoid mutating module level state during the test and to instead just eagerly initialize the expected tree.

Make the fuzz test minimization logic not crash if there is not json file: this can happen if the test fails in some places, and was suppressing the real error.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

