### PR TITLE
docs(ink): Add explicit release tags to exported API members

### DIFF
--- a/packages/dds/ink/api-extractor.json
+++ b/packages/dds/ink/api-extractor.json
@@ -1,15 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-	"messages": {
-		// TODO: Fix violations and remove this rule override
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				"logLevel": "none"
-			},
-			"ae-forgotten-export": {
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -99,6 +99,7 @@ const snapshotFileName = "header";
  * ink.on("clear", this.renderClear.bind(this));
  * ```
  * @sealed
+ * @public
  */
 export class Ink extends SharedObject<IInkEvents> implements IInk {
 	/**

--- a/packages/dds/ink/src/inkCanvas.ts
+++ b/packages/dds/ink/src/inkCanvas.ts
@@ -108,6 +108,9 @@ function drawShapes(
 	drawCircle(context, { x: endPoint.x, y: endPoint.y }, widthAtEnd);
 }
 
+/**
+ * @public
+ */
 export class InkCanvas {
 	private readonly context: CanvasRenderingContext2D;
 	private readonly localActiveStrokeMap: Map<number, string> = new Map();

--- a/packages/dds/ink/src/inkFactory.ts
+++ b/packages/dds/ink/src/inkFactory.ts
@@ -16,6 +16,7 @@ import { pkgVersion } from "./packageVersion";
 /**
  * Factory for Ink.
  * @sealed
+ * @public
  */
 export class InkFactory implements IChannelFactory {
 	/**

--- a/packages/dds/ink/src/interfaces.ts
+++ b/packages/dds/ink/src/interfaces.ts
@@ -7,6 +7,7 @@ import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-objec
 
 /**
  * Data about a single point in an ink stroke
+ * @public
  */
 export interface IInkPoint {
 	/**
@@ -32,6 +33,7 @@ export interface IInkPoint {
 
 /**
  * RGBA color.
+ * @public
  */
 export interface IColor {
 	/**
@@ -55,6 +57,9 @@ export interface IColor {
 	a: number;
 }
 
+/**
+ * @public
+ */
 export interface IInkEvents extends ISharedObjectEvents {
 	(event: "stylus", listener: (operation: IStylusOperation) => void);
 	(event: "clear", listener: () => void);
@@ -62,12 +67,14 @@ export interface IInkEvents extends ISharedObjectEvents {
 
 /**
  * Shared data structure for representing ink.
+ * @public
  */
 export interface IInk extends ISharedObject<IInkEvents> {
 	/**
 	 * Create a stroke with the given pen information.
 	 * @param pen - The pen information for this stroke
 	 * @returns The stroke that was created
+	 * @public
 	 */
 	createStroke(pen: IPen): IInkStroke;
 
@@ -100,6 +107,7 @@ export interface IInk extends ISharedObject<IInkEvents> {
 
 /**
  * Pen data for the current stroke
+ * @public
  */
 export interface IPen {
 	/**
@@ -115,6 +123,7 @@ export interface IPen {
 
 /**
  * Signals a clear operation.
+ * @public
  */
 export interface IClearOperation {
 	/**
@@ -131,6 +140,7 @@ export interface IClearOperation {
 /**
  * Create stroke operations notify clients that a new stroke has been created, along with basic information about
  * the stroke.
+ * @public
  */
 export interface ICreateStrokeOperation {
 	/**
@@ -156,6 +166,7 @@ export interface ICreateStrokeOperation {
 
 /**
  * Base interface for stylus operations.
+ * @public
  */
 export interface IStylusOperation {
 	/**
@@ -176,11 +187,13 @@ export interface IStylusOperation {
 
 /**
  * Ink operations are one of several types.
+ * @public
  */
 export type IInkOperation = IClearOperation | ICreateStrokeOperation | IStylusOperation;
 
 /**
  * Represents a single ink stroke.
+ * @public
  */
 export interface IInkStroke {
 	/**


### PR DESCRIPTION
[AB#5831](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5831)

## Description
This PR adds the @public explicit release tag for all exported interfaces in the dds/ink package.