### PR TITLE
Force failures to test Client Build alerts

### DIFF
--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -49,8 +49,8 @@ describe("TestClient", () => {
 				UniversalSequenceNumber,
 				client.getClientId(),
 			);
-
-			assert.equal(exp, 4, "Marker with label not at expected position");
+			// value changed from 4 to 5 to create a ci failure
+			assert.equal(exp, 5, "Marker with label not at expected position");
 
 			const marker2 = client.searchForMarker(4, "Eop", false);
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -555,7 +555,7 @@ stages:
   # Capture per-pipeline stage results
   - stage: upload_run_telemetry
     displayName: Upload pipeline run telemetry to Kusto
-    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'IndividualCI'), eq(${{parameters.telemetry}}, true))
+    condition: and(succeededOrFailed(), eq(${{parameters.telemetry}}, true))
     dependsOn:
       - build
 


### PR DESCRIPTION
To wrap up [AB#4994](https://dev.azure.com/fluidframework/internal/_workitems/edit/4994), create some test failures to make sure the alerts behave properly. This will not be checked in, and is only for testing purposes.  