### PR TITLE
Few fixes in doc corruption scenarios

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -127,20 +127,19 @@ export class ScribeLambdaFactory
 				(error) => true /* shouldRetry */,
 			)) as IDocument;
 
-			if (JSON.parse(document.scribe)?.isCorrupt) {
-				Lumberjack.info(
-					`Received attempt to connect to a corrupted document.`,
-					lumberProperties,
-				);
-				return new NoOpLambda(context);
-			}
-
 			if (!isDocumentValid(document)) {
 				// Document sessions can be joined (via Alfred) after a document is functionally deleted.
 				// If the document doesn't exist or is marked for deletion then we trivially accept every message.
 				const errorMessage = `Received attempt to connect to a missing/deleted document.`;
 				context.log?.error(errorMessage, { messageMetaData });
 				Lumberjack.error(errorMessage, lumberProperties);
+				return new NoOpLambda(context);
+			}
+			if (JSON.parse(document.scribe)?.isCorrupt) {
+				Lumberjack.info(
+					`Received attempt to connect to a corrupted document.`,
+					lumberProperties,
+				);
 				return new NoOpLambda(context);
 			}
 			if (!isDocumentSessionValid(document, this.serviceConfiguration)) {

--- a/server/routerlicious/packages/services-client/src/auth.ts
+++ b/server/routerlicious/packages/services-client/src/auth.ts
@@ -32,7 +32,7 @@ export function validateTokenClaims(
 		);
 	}
 
-	if (claims.scopes === undefined || claims.scopes.length === 0) {
+	if (claims.scopes === undefined || claims.scopes === null || claims.scopes.length === 0) {
 		throw new NetworkError(403, "Missing scopes in token claims");
 	}
 

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -336,7 +336,7 @@ export function validateTokenScopeClaims(expectedScopes: string): RequestHandler
 			);
 		}
 
-		if (claims.scopes === undefined || claims.scopes.length === 0) {
+		if (claims.scopes === undefined || claims.scopes === null || claims.scopes.length === 0) {
 			return respondWithNetworkError(
 				response,
 				new NetworkError(403, "Missing scopes in token claims."),

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -57,7 +57,7 @@ export function validateTokenClaims(
 		throw new NetworkError(403, "DocumentId in token claims does not match request.");
 	}
 
-	if (claims.scopes === undefined || claims.scopes.length === 0) {
+	if (claims.scopes === undefined || claims.scopes === null || claims.scopes.length === 0) {
 		throw new NetworkError(403, "Missing scopes in token claims.");
 	}
 


### PR DESCRIPTION
## Description

1. In deli, almost all the doc corruption exceptions are "MongoServerSelectionError". Since this error is recoverable, updated the code to restart service in case of such error instead of marking the doc as corrupted.

![image](https://github.com/microsoft/FluidFramework/assets/22322514/a8825aad-de11-4953-ae15-8254e3b8005b)


2. In scribe, there are a few exceptions causing doc corruption because of TypeError, i.e. "document" undefined error when checking for isCorrupt flag in the lambda factory. Fixed that by moving this check below the isDocumentValid check.

![image](https://github.com/microsoft/FluidFramework/assets/22322514/8d4be9bd-b1b5-40e4-a74c-9ff7064e1b1e)

3. A few exceptions in scribe's doc corruption logs are due to "Internal Server Error" which is a default error message returned by historian in case of unexpected errors. I noticed a lot of these were due to "TypeError: Cannot read properties of null (reading 'length')\n    at validateTokenClaims" - Fixed this by adding the check for null value. This will help give a better error message instead of the default "Internal Server Error".

![image](https://github.com/microsoft/FluidFramework/assets/22322514/8468097a-62d7-4b12-b60d-049faf832c29)
