### PR TITLE
Add verbose telemetry event in case connectToDeltaStream throws

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -602,9 +602,6 @@ export class ConnectionManager implements IConnectionManager {
 					undefined,
 					LogLevel.verbose,
 				);
-				if (connection !== undefined) {
-					connection.dispose();
-				}
 				if (isDeltaStreamConnectionForbiddenError(origError)) {
 					connection = new NoDeltaStream(origError.storageOnlyReason, {
 						text: origError.message,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -594,6 +594,16 @@ export class ConnectionManager implements IConnectionManager {
 					LogLevel.verbose,
 				);
 			} catch (origError: any) {
+				this.logger.sendTelemetryEvent(
+					{
+						eventName: "ConnectToDeltaStreamException",
+					},
+					undefined,
+					LogLevel.verbose,
+				);
+				if (connection !== undefined) {
+					connection.dispose();
+				}
 				if (isDeltaStreamConnectionForbiddenError(origError)) {
 					connection = new NoDeltaStream(origError.storageOnlyReason, {
 						text: origError.message,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -597,6 +597,7 @@ export class ConnectionManager implements IConnectionManager {
 				this.logger.sendTelemetryEvent(
 					{
 						eventName: "ConnectToDeltaStreamException",
+						connected: connection !== undefined && connection.disposed === false,
 					},
 					undefined,
 					LogLevel.verbose,


### PR DESCRIPTION
## Description

During the investigation of the NoJoinOps for tinylicious, we found out the connection returned from connectToDeltaStream  is never disposed of and the new verbose event ConnectionReceived is not triggered as well. To confirm our theory, we are adding a new verbose logging in case the exception is caught. 