### PR TITLE
Add tests for SharedTreeLists with overlapping types

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1990,11 +1990,11 @@ export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaSc
     insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes>>): void;
     insertAtStart(value: Iterable<ProxyNodeUnion<TTypes>>): void;
     moveToEnd(sourceStart: number, sourceEnd: number): void;
-    moveToEnd<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>): void;
+    moveToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveToIndex<TTypesSource extends AllowedTypes>(index: number, sourceStart: number, sourceEnd: number, source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>): void;
+    moveToIndex(index: number, sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     moveToStart(sourceStart: number, sourceEnd: number): void;
-    moveToStart<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>): void;
+    moveToStart(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     removeAt(index: number): void;
     removeRange(start?: number, end?: number): void;
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -19,7 +19,7 @@ import {
 	TreeNodeSchema,
 	TreeSchema,
 } from "../../typed-schema";
-import { CheckTypesOverlap, AssignableFieldKinds, TreeNode } from "../editableTreeTypes";
+import { AssignableFieldKinds, TreeNode } from "../editableTreeTypes";
 
 /**
  * An object-like SharedTree node. Includes objects, lists, and maps.
@@ -95,11 +95,7 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToStart<TTypesSource extends AllowedTypes>(
-		sourceStart: number,
-		sourceEnd: number,
-		source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>,
-	): void;
+	moveToStart(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
 
 	/**
 	 * Moves the specified items to the end of the sequence.
@@ -120,11 +116,7 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToEnd<TTypesSource extends AllowedTypes>(
-		sourceStart: number,
-		sourceEnd: number,
-		source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>,
-	): void;
+	moveToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
 
 	/**
 	 * Moves the specified items to the desired location within the sequence.
@@ -147,11 +139,11 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToIndex<TTypesSource extends AllowedTypes>(
+	moveToIndex(
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source: SharedTreeList<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: SharedTreeList<AllowedTypes>,
 	): void;
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SchemaBuilder } from "../../../domains";
-import { node, typeNameSymbol } from "../../../feature-libraries";
+import { ProxyNode, ProxyRoot, node, typeNameSymbol } from "../../../feature-libraries";
 import { itWithRoot, pretty } from "./utils";
 
 describe("SharedTree proxies", () => {
@@ -275,6 +275,80 @@ describe("SharedTreeList", () => {
 				listB.moveToIndex(/* index: */ 1, /* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
 				assert.deepEqual(listA, ["a1"]);
 				assert.deepEqual(listB, ["b0", "a0", "b1"]);
+			});
+		});
+
+		describe("between lists with overlapping types", () => {
+			const _ = new SchemaBuilder({
+				scope: "test",
+			});
+
+			const listA = _.list([_.string, _.number]);
+			const listB = _.list([_.number, _.boolean]);
+
+			const objectSchema = _.object("parent", {
+				listA,
+				listB,
+			});
+
+			const schema = _.intoSchema(objectSchema);
+
+			const initialTree = {
+				listA: ["a", 1],
+				listB: [2, true],
+			};
+
+			function getEitherList(
+				root: ProxyRoot<typeof schema>,
+				list: "a" | "b",
+			): ProxyNode<typeof listA> | ProxyNode<typeof listB> {
+				return list === "a" ? root.listA : root.listB;
+			}
+
+			itWithRoot("moveToStart()", schema, initialTree, (root) => {
+				const list1 = getEitherList(root, "a");
+				const list2 = getEitherList(root, "b");
+				list2.moveToStart(/* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
+				assert.deepEqual(list1, ["a"]);
+				assert.deepEqual(list2, [1, 2, true]);
+				list1.moveToStart(/* sourceStart: */ 0, /* sourceEnd: */ 2, list2);
+				assert.deepEqual(list1, [1, 2, "a"]);
+				assert.deepEqual(list2, [true]);
+			});
+
+			itWithRoot("moveToEnd()", schema, initialTree, (root) => {
+				const list1 = getEitherList(root, "a");
+				const list2 = getEitherList(root, "b");
+				list2.moveToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
+				assert.deepEqual(list1, ["a"]);
+				assert.deepEqual(list2, [2, true, 1]);
+				list1.moveToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, list2);
+				assert.deepEqual(list1, ["a", 2]);
+				assert.deepEqual(list2, [true, 1]);
+			});
+
+			itWithRoot("moveToIndex()", schema, initialTree, (root) => {
+				const list1 = getEitherList(root, "a");
+				const list2 = getEitherList(root, "b");
+				list2.moveToIndex(/* index: */ 1, /* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
+				assert.deepEqual(list1, ["a"]);
+				assert.deepEqual(list2, [2, 1, true]);
+				list1.moveToIndex(/* index: */ 0, /* sourceStart: */ 0, /* sourceEnd: */ 2, list2);
+				assert.deepEqual(list1, [2, 1, "a"]);
+				assert.deepEqual(list2, [true]);
+			});
+
+			itWithRoot("fails if incompatible type", schema, initialTree, (root) => {
+				const list1 = getEitherList(root, "a");
+				const list2 = getEitherList(root, "b");
+				assert.throws(() =>
+					list2.moveToIndex(
+						/* index: */ 0,
+						/* sourceStart: */ 0,
+						/* sourceEnd: */ 1,
+						list1,
+					),
+				);
 			});
 		});
 	});


### PR DESCRIPTION
## Description

This adds some test coverage for moving items between lists that have overlapping item schema. It also removes the overlapping type restriction on list types, since it doesn't work.