### PR TITLE
docs(fluid-static): Add explicit release tags to exported API members

### DIFF
--- a/packages/framework/fluid-static/api-extractor.json
+++ b/packages/framework/fluid-static/api-extractor.json
@@ -1,12 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-	"messages": {
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				// TODO: Fix violations and remove this rule override
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -14,6 +14,8 @@ import type { IRootDataObject, LoadableObjectClass, LoadableObjectRecord } from 
 
 /**
  * Events emitted from {@link IFluidContainer}.
+ *
+ * @public
  */
 export interface IFluidContainerEvents extends IEvent {
 	/**
@@ -76,6 +78,8 @@ export interface IFluidContainerEvents extends IEvent {
  * Provides access to the data as well as status on the collaboration session.
  *
  * @remarks Note: external implementations of this interface are not supported.
+ *
+ * @public
  */
 export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
 	/**
@@ -196,6 +200,8 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
  *
  * Note: this implementation is not complete. Consumers who rely on {@link IFluidContainer.attach}
  * will need to utilize or provide a service-specific implementation of this type that implements that method.
+ *
+ * @public
  */
 export class FluidContainer
 	extends TypedEventEmitter<IFluidContainerEvents>

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -146,6 +146,8 @@ const rootDataStoreId = "rootDOId";
  *
  * This data object is dynamically customized (registry and initial objects) based on the schema provided.
  * to the container runtime factory.
+ *
+ * @public
  */
 export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 	private readonly rootDataObjectFactory: DataObjectFactory<

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -17,6 +17,8 @@ import { IServiceAudience, IServiceAudienceEvents, IMember, Myself } from "./typ
  * the user and client details returned in {@link IMember}.
  *
  * @typeParam M - A service-specific {@link IMember} implementation.
+ *
+ * @public
  */
 export abstract class ServiceAudience<M extends IMember = IMember>
 	extends TypedEventEmitter<IServiceAudienceEvents<M>>

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -245,8 +245,13 @@ export interface IMember {
 }
 
 /**
- * An extended member object that includes currentConnection.
+ * An extended {@link IMember}, which includes {@link Myself.currentConnection}.
  *
  * @public
  */
-export type Myself<M extends IMember = IMember> = M & { currentConnection: string };
+export type Myself<M extends IMember = IMember> = M & {
+	/**
+	 * TODO
+	 */
+	currentConnection: string;
+};

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -9,12 +9,16 @@ import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 
 /**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.
+ *
+ * @public
  */
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 /**
  * A mapping of string identifiers to classes that will later be used to instantiate a corresponding `DataObject`
  * or `SharedObject` in a {@link LoadableObjectRecord}.
+ *
+ * @public
  */
 export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>;
 
@@ -22,6 +26,8 @@ export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>
  * A class object of `DataObject` or `SharedObject`.
  *
  * @typeParam T - The class of the `DataObject` or `SharedObject`.
+ *
+ * @public
  */
 export type LoadableObjectClass<T extends IFluidLoadable> =
 	| DataObjectClass<T>
@@ -32,6 +38,8 @@ export type LoadableObjectClass<T extends IFluidLoadable> =
  * constructor that will return the type of the `DataObject`.
  *
  * @typeParam T - The class of the `DataObject`.
+ *
+ * @public
  */
 export type DataObjectClass<T extends IFluidLoadable> = {
 	readonly factory: IFluidDataStoreFactory;
@@ -42,6 +50,8 @@ export type DataObjectClass<T extends IFluidLoadable> = {
  * constructor that will return the type of the `DataObject`.
  *
  * @typeParam T - The class of the `SharedObject`.
+ *
+ * @public
  */
 export type SharedObjectClass<T extends IFluidLoadable> = {
 	readonly getFactory: () => IChannelFactory;
@@ -51,6 +61,8 @@ export type SharedObjectClass<T extends IFluidLoadable> = {
  * An object with a constructor that will return an {@link @fluidframework/core-interfaces#IFluidLoadable}.
  *
  * @typeParam T - The class of the loadable object.
+ *
+ * @public
  */
 export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) => T;
 
@@ -61,6 +73,8 @@ export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) 
  *
  * It includes both the instances of objects that are initially available upon `Container` creation, as well
  * as the types of objects that may be dynamically created throughout the lifetime of the `Container`.
+ *
+ * @public
  */
 export interface ContainerSchema {
 	/**
@@ -99,6 +113,8 @@ export interface ContainerSchema {
 /**
  * Holds the collection of objects that the container was initially created with, as well as provides the ability
  * to dynamically create further objects during usage.
+ *
+ * @public
  */
 export interface IRootDataObject {
 	/**
@@ -123,6 +139,8 @@ export interface IRootDataObject {
  * @param member - The service-specific member object for the client.
  *
  * @see See {@link IServiceAudienceEvents} for usage details.
+ *
+ * @public
  */
 export type MemberChangedListener<M extends IMember> = (clientId: string, member: M) => void;
 
@@ -135,6 +153,8 @@ export type MemberChangedListener<M extends IMember> = (clientId: string, member
  * {@link IServiceAudience.getMembers} method will emit events.
  *
  * @typeParam M - A service-specific {@link IMember} implementation.
+ *
+ * @public
  */
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 	/**
@@ -168,6 +188,8 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
  * details about the connecting client, such as device information, environment, or a username.
  *
  * @typeParam M - A service-specific {@link IMember} type.
+ *
+ * @public
  */
 export interface IServiceAudience<M extends IMember>
 	extends IEventProvider<IServiceAudienceEvents<M>> {
@@ -188,6 +210,8 @@ export interface IServiceAudience<M extends IMember>
  * Base interface for information for each connection made to the Fluid session.
  *
  * @remarks This interface can be extended to provide additional information specific to each service.
+ *
+ * @public
  */
 export interface IConnection {
 	/**
@@ -205,6 +229,8 @@ export interface IConnection {
  * Base interface to be implemented to fetch each service's member.
  *
  * @remarks This interface can be extended by each service to provide additional service-specific user metadata.
+ *
+ * @public
  */
 export interface IMember {
 	/**
@@ -219,6 +245,8 @@ export interface IMember {
 }
 
 /**
- * An extended member object that includes currentConnection
+ * An extended member object that includes currentConnection.
+ *
+ * @public
  */
 export type Myself<M extends IMember = IMember> = M & { currentConnection: string };


### PR DESCRIPTION
Removes temporary workaround in package api-extractor config

[AB#5896](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5896)