### PR TITLE
Rename SharedTreeList.move* to moveRange*

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1944,12 +1944,12 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
     readonly length: number;
     map<U>(callbackfn: (value: UnboxNodeUnion<TTypes>, index: number) => U): U[];
     mapBoxed<U>(callbackfn: (value: TypedNodeUnion<TTypes>, index: number) => U): U[];
-    moveToEnd(sourceStart: number, sourceEnd: number): void;
-    moveToEnd<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>): void;
-    moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveToIndex<TTypesSource extends AllowedTypes>(index: number, sourceStart: number, sourceEnd: number, source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>): void;
-    moveToStart(sourceStart: number, sourceEnd: number): void;
-    moveToStart<TTypesSource extends AllowedTypes>(sourceStart: number, sourceEnd: number, source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>): void;
+    moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
+    moveRangeToEnd(sourceStart: number, sourceEnd: number, source: Sequence<AllowedTypes>): void;
+    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: Sequence<AllowedTypes>): void;
+    moveRangeToStart(sourceStart: number, sourceEnd: number): void;
+    moveRangeToStart(sourceStart: number, sourceEnd: number, source: Sequence<AllowedTypes>): void;
     removeAt(index: number): void;
     removeRange(start?: number, end?: number): void;
 }
@@ -1989,12 +1989,12 @@ export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaSc
     insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes>>): void;
     insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes>>): void;
     insertAtStart(value: Iterable<ProxyNodeUnion<TTypes>>): void;
-    moveToEnd(sourceStart: number, sourceEnd: number): void;
-    moveToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
-    moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveToIndex(index: number, sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
-    moveToStart(sourceStart: number, sourceEnd: number): void;
-    moveToStart(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
+    moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
+    moveRangeToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
+    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
+    moveRangeToStart(sourceStart: number, sourceEnd: number): void;
+    moveRangeToStart(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     removeAt(index: number): void;
     removeRange(start?: number, end?: number): void;
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -608,7 +608,7 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToStart(sourceStart: number, sourceEnd: number): void;
+	moveRangeToStart(sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the start of the sequence.
@@ -619,11 +619,7 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToStart<TTypesSource extends AllowedTypes>(
-		sourceStart: number,
-		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
-	): void;
+	moveRangeToStart(sourceStart: number, sourceEnd: number, source: Sequence<AllowedTypes>): void;
 
 	/**
 	 * Moves the specified items to the end of the sequence.
@@ -633,7 +629,7 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToEnd(sourceStart: number, sourceEnd: number): void;
+	moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the end of the sequence.
@@ -644,11 +640,7 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToEnd<TTypesSource extends AllowedTypes>(
-		sourceStart: number,
-		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
-	): void;
+	moveRangeToEnd(sourceStart: number, sourceEnd: number, source: Sequence<AllowedTypes>): void;
 
 	/**
 	 * Moves the specified items to the desired location within the sequence.
@@ -659,7 +651,7 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+	moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the desired location within the sequence.
@@ -671,11 +663,11 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToIndex<TTypesSource extends AllowedTypes>(
+	moveRangeToIndex(
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: Sequence<AllowedTypes>,
 	): void;
 
 	[boxedIterator](): IterableIterator<TypedNodeUnion<TTypes>>;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -40,7 +40,6 @@ import {
 	TreeNode,
 	RequiredField,
 	boxedIterator,
-	CheckTypesOverlap,
 	TreeStatus,
 	NodeKeyField,
 } from "./editableTreeTypes";
@@ -224,12 +223,6 @@ export abstract class LazyField<TKind extends FieldKind, TTypes extends AllowedT
 	}
 }
 
-function assertIsLazySequence<TTypesSource extends AllowedTypes>(
-	sourceField: unknown,
-): asserts sourceField is LazySequence<TTypesSource> {
-	assert(sourceField instanceof LazySequence, 0x7b1 /* Unsupported sequence implementation. */);
-}
-
 export class LazySequence<TTypes extends AllowedTypes>
 	extends LazyField<typeof FieldKinds.sequence, TTypes>
 	implements Sequence<TTypes>
@@ -284,59 +277,63 @@ export class LazySequence<TTypes extends AllowedTypes>
 		fieldEditor.delete(removeStart, removeEnd - removeStart);
 	}
 
-	public moveToStart(sourceStart: number, sourceEnd: number): void;
-	public moveToStart<TTypesSource extends AllowedTypes>(
+	public moveRangeToStart(sourceStart: number, sourceEnd: number): void;
+	public moveRangeToStart(
 		sourceStart: number,
 		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: Sequence<AllowedTypes>,
 	): void;
-	public moveToStart<TTypesSource extends AllowedTypes>(
+	public moveRangeToStart(
 		sourceStart: number,
 		sourceEnd: number,
-		source?: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source?: Sequence<AllowedTypes>,
 	): void {
-		this._moveToIndex(0, sourceStart, sourceEnd, source);
+		this._moveRangeToIndex(0, sourceStart, sourceEnd, source);
 	}
 
-	public moveToEnd(sourceStart: number, sourceEnd: number): void;
-	public moveToEnd<TTypesSource extends AllowedTypes>(
+	public moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
+	public moveRangeToEnd(
 		sourceStart: number,
 		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: Sequence<AllowedTypes>,
 	): void;
-	public moveToEnd<TTypesSource extends AllowedTypes>(
+	public moveRangeToEnd(
 		sourceStart: number,
 		sourceEnd: number,
-		source?: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source?: Sequence<AllowedTypes>,
 	): void {
-		this._moveToIndex(this.length, sourceStart, sourceEnd, source);
+		this._moveRangeToIndex(this.length, sourceStart, sourceEnd, source);
 	}
 
-	public moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-	public moveToIndex<TTypesSource extends AllowedTypes>(
+	public moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+	public moveRangeToIndex(
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source: Sequence<AllowedTypes>,
 	): void;
-	public moveToIndex<TTypesSource extends AllowedTypes>(
+	public moveRangeToIndex(
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source?: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source?: Sequence<AllowedTypes>,
 	): void {
-		this._moveToIndex(index, sourceStart, sourceEnd, source);
+		this._moveRangeToIndex(index, sourceStart, sourceEnd, source);
 	}
 
-	private _moveToIndex<TTypesSource extends AllowedTypes>(
+	private _moveRangeToIndex(
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source?: Sequence<CheckTypesOverlap<TTypesSource, TTypes>>,
+		source?: Sequence<AllowedTypes>,
 	): void {
 		const sourceField = source !== undefined ? (this.isSameAs(source) ? this : source) : this;
+
 		// TODO: determine support for move across different sequence types
-		assertIsLazySequence(sourceField);
+		assert(
+			sourceField instanceof LazySequence,
+			0x7b1 /* Unsupported sequence implementation. */,
+		);
 		assertValidRangeIndices(sourceStart, sourceEnd, sourceField);
 		if (this.schema.types !== undefined && sourceField !== this) {
 			for (let i = sourceStart; i < sourceEnd; i++) {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -298,7 +298,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			getSequenceField(this).removeRange(start, end);
 		},
 	},
-	moveToStart: {
+	moveRangeToStart: {
 		value(
 			this: SharedTreeList<AllowedTypes, "javaScript">,
 			sourceStart: number,
@@ -306,17 +306,17 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			source?: SharedTreeList<AllowedTypes>,
 		): void {
 			if (source !== undefined) {
-				getSequenceField(this).moveToStart(
+				getSequenceField(this).moveRangeToStart(
 					sourceStart,
 					sourceEnd,
 					getSequenceField(source),
 				);
 			} else {
-				getSequenceField(this).moveToStart(sourceStart, sourceEnd);
+				getSequenceField(this).moveRangeToStart(sourceStart, sourceEnd);
 			}
 		},
 	},
-	moveToEnd: {
+	moveRangeToEnd: {
 		value(
 			this: SharedTreeList<AllowedTypes, "javaScript">,
 			sourceStart: number,
@@ -324,13 +324,17 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			source?: SharedTreeList<AllowedTypes>,
 		): void {
 			if (source !== undefined) {
-				getSequenceField(this).moveToEnd(sourceStart, sourceEnd, getSequenceField(source));
+				getSequenceField(this).moveRangeToEnd(
+					sourceStart,
+					sourceEnd,
+					getSequenceField(source),
+				);
 			} else {
-				getSequenceField(this).moveToEnd(sourceStart, sourceEnd);
+				getSequenceField(this).moveRangeToEnd(sourceStart, sourceEnd);
 			}
 		},
 	},
-	moveToIndex: {
+	moveRangeToIndex: {
 		value(
 			this: SharedTreeList<AllowedTypes, "javaScript">,
 			index: number,
@@ -339,14 +343,14 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			source?: SharedTreeList<AllowedTypes>,
 		): void {
 			if (source !== undefined) {
-				getSequenceField(this).moveToIndex(
+				getSequenceField(this).moveRangeToIndex(
 					index,
 					sourceStart,
 					sourceEnd,
 					getSequenceField(source),
 				);
 			} else {
-				getSequenceField(this).moveToIndex(index, sourceStart, sourceEnd);
+				getSequenceField(this).moveRangeToIndex(index, sourceStart, sourceEnd);
 			}
 		},
 	},

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -84,7 +84,7 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToStart(sourceStart: number, sourceEnd: number): void;
+	moveRangeToStart(sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the start of the sequence.
@@ -95,7 +95,11 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToStart(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
+	moveRangeToStart(
+		sourceStart: number,
+		sourceEnd: number,
+		source: SharedTreeList<AllowedTypes>,
+	): void;
 
 	/**
 	 * Moves the specified items to the end of the sequence.
@@ -105,7 +109,7 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToEnd(sourceStart: number, sourceEnd: number): void;
+	moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the end of the sequence.
@@ -116,7 +120,11 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
+	moveRangeToEnd(
+		sourceStart: number,
+		sourceEnd: number,
+		source: SharedTreeList<AllowedTypes>,
+	): void;
 
 	/**
 	 * Moves the specified items to the desired location within the sequence.
@@ -127,7 +135,7 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+	moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the desired location within the sequence.
@@ -139,7 +147,7 @@ export interface SharedTreeList<
 	 * @remarks
 	 * All indices are relative to the sequence excluding the nodes being moved.
 	 */
-	moveToIndex(
+	moveRangeToIndex(
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.events.spec.ts
@@ -134,7 +134,7 @@ describe("beforeChange/afterChange events", () => {
 		// Move nodes in a sequence field - myNumberSequence; should fire events on the root node
 		// NOTE: events will fire for each node individually. Also this is a special case where the events are fired twice:
 		// once when detaching the nodes from the source location, and again when attaching them at the target location.
-		root.myNumberSequence.moveToEnd(0, 2);
+		root.myNumberSequence.moveRangeToEnd(0, 2);
 
 		assert.strictEqual(rootBeforeChangeCount, 17);
 		assert.strictEqual(rootAfterChangeCount, 17);
@@ -182,7 +182,7 @@ describe("beforeChange/afterChange events", () => {
 		// NOTE: events will fire for each moved node (so 2 time)
 		// NOTE: this is a special case where the beforeChange/afterChange events are fired twice for each node: once when
 		// detaching it from the source location, and again when attaching it at the target location.
-		root.myNumberSequence.moveToEnd(0, 2);
+		root.myNumberSequence.moveRangeToEnd(0, 2);
 		// Other miscellaneous updates
 		root.child.myInnerString = "new string in child";
 		// TODO: update to `root.child = <something>;` once assignment to struct nodes is implemented in EditableTree2
@@ -250,7 +250,7 @@ describe("beforeChange/afterChange events", () => {
 		// NOTE: events will fire for each moved node (so 2 time)
 		// NOTE: this is a special case where the beforeChange/afterChange events are fired twice for each node: once when
 		// detaching it from the source location, and again when attaching it at the target location.
-		root.myNumberSequence.moveToEnd(0, 2);
+		root.myNumberSequence.moveRangeToEnd(0, 2);
 
 		// Make sure the listeners fired (otherwise assertions might not have executed)
 		assert.strictEqual(rootBeforeCounter, 14);
@@ -574,7 +574,7 @@ describe("beforeChange/afterChange events", () => {
 			}
 		});
 
-		root.myNumberSequence.moveToEnd(0, 2);
+		root.myNumberSequence.moveRangeToEnd(0, 2);
 		assert.strictEqual(totalListenerCalls, 8); // 2 moved nodes * 2 events each * 2 times fired (detach + attach)
 	});
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -201,19 +201,19 @@ describe("SharedTreeList", () => {
 			const schema = _.intoSchema(_.list(_.number));
 			const initialTree = [0, 1, 2, 3];
 
-			itWithRoot("moveToStart()", schema, initialTree, (list) => {
+			itWithRoot("moveRangeToStart()", schema, initialTree, (list) => {
 				assert.deepEqual(list, [0, 1, 2, 3]);
-				list.moveToStart(/* sourceStart: */ 1, /* sourceEnd: */ 3);
+				list.moveRangeToStart(/* sourceStart: */ 1, /* sourceEnd: */ 3);
 				assert.deepEqual(list, [1, 2, 0, 3]);
 			});
 
-			itWithRoot("moveToEnd()", schema, initialTree, (list) => {
+			itWithRoot("moveRangeToEnd()", schema, initialTree, (list) => {
 				assert.deepEqual(list, [0, 1, 2, 3]);
-				list.moveToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 3);
+				list.moveRangeToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 3);
 				assert.deepEqual(list, [0, 3, 1, 2]);
 			});
 
-			describe("moveToIndex()", () => {
+			describe("moveRangeToIndex()", () => {
 				function check(index: number, start: number, end: number) {
 					const expected = initialTree.slice(0);
 					// Remove the moved items from [start..end).
@@ -239,7 +239,7 @@ describe("SharedTreeList", () => {
 						initialTree,
 						(list) => {
 							assert.deepEqual(list, initialTree);
-							list.moveToIndex(index, start, end);
+							list.moveRangeToIndex(index, start, end);
 							assert.deepEqual(list, expected);
 						},
 					);
@@ -273,26 +273,31 @@ describe("SharedTreeList", () => {
 				listB: ["b0", "b1"],
 			};
 
-			itWithRoot("moveToStart()", schema, initialTree, ({ listA, listB }) => {
+			itWithRoot("moveRangeToStart()", schema, initialTree, ({ listA, listB }) => {
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
-				listB.moveToStart(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
+				listB.moveRangeToStart(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
 				assert.deepEqual(listA, ["a1"]);
 				assert.deepEqual(listB, ["a0", "b0", "b1"]);
 			});
 
-			itWithRoot("moveToEnd()", schema, initialTree, ({ listA, listB }) => {
+			itWithRoot("moveRangeToEnd()", schema, initialTree, ({ listA, listB }) => {
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
-				listB.moveToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
+				listB.moveRangeToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
 				assert.deepEqual(listA, ["a1"]);
 				assert.deepEqual(listB, ["b0", "b1", "a0"]);
 			});
 
-			itWithRoot("moveToIndex()", schema, initialTree, ({ listA, listB }) => {
+			itWithRoot("moveRangeToIndex()", schema, initialTree, ({ listA, listB }) => {
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
-				listB.moveToIndex(/* index: */ 1, /* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
+				listB.moveRangeToIndex(
+					/* index: */ 1,
+					/* sourceStart: */ 0,
+					/* sourceEnd: */ 1,
+					listA,
+				);
 				assert.deepEqual(listA, ["a1"]);
 				assert.deepEqual(listB, ["b0", "a0", "b1"]);
 			});
@@ -318,6 +323,7 @@ describe("SharedTreeList", () => {
 				listB: [2, true],
 			};
 
+			/** This function returns a union of both listA and listB, which exercises more interesting compile type-checking cases */
 			function getEitherList(
 				root: ProxyRoot<typeof schema>,
 				list: "a" | "b",
@@ -325,35 +331,45 @@ describe("SharedTreeList", () => {
 				return list === "a" ? root.listA : root.listB;
 			}
 
-			itWithRoot("moveToStart()", schema, initialTree, (root) => {
+			itWithRoot("moveRangeToStart()", schema, initialTree, (root) => {
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
-				list2.moveToStart(/* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
+				list2.moveRangeToStart(/* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
 				assert.deepEqual(list1, ["a"]);
 				assert.deepEqual(list2, [1, 2, true]);
-				list1.moveToStart(/* sourceStart: */ 0, /* sourceEnd: */ 2, list2);
+				list1.moveRangeToStart(/* sourceStart: */ 0, /* sourceEnd: */ 2, list2);
 				assert.deepEqual(list1, [1, 2, "a"]);
 				assert.deepEqual(list2, [true]);
 			});
 
-			itWithRoot("moveToEnd()", schema, initialTree, (root) => {
+			itWithRoot("moveRangeToEnd()", schema, initialTree, (root) => {
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
-				list2.moveToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
+				list2.moveRangeToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
 				assert.deepEqual(list1, ["a"]);
 				assert.deepEqual(list2, [2, true, 1]);
-				list1.moveToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, list2);
+				list1.moveRangeToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, list2);
 				assert.deepEqual(list1, ["a", 2]);
 				assert.deepEqual(list2, [true, 1]);
 			});
 
-			itWithRoot("moveToIndex()", schema, initialTree, (root) => {
+			itWithRoot("moveRangeToIndex()", schema, initialTree, (root) => {
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
-				list2.moveToIndex(/* index: */ 1, /* sourceStart: */ 1, /* sourceEnd: */ 2, list1);
+				list2.moveRangeToIndex(
+					/* index: */ 1,
+					/* sourceStart: */ 1,
+					/* sourceEnd: */ 2,
+					list1,
+				);
 				assert.deepEqual(list1, ["a"]);
 				assert.deepEqual(list2, [2, 1, true]);
-				list1.moveToIndex(/* index: */ 0, /* sourceStart: */ 0, /* sourceEnd: */ 2, list2);
+				list1.moveRangeToIndex(
+					/* index: */ 0,
+					/* sourceStart: */ 0,
+					/* sourceEnd: */ 2,
+					list2,
+				);
 				assert.deepEqual(list1, [2, 1, "a"]);
 				assert.deepEqual(list2, [true]);
 			});
@@ -362,7 +378,7 @@ describe("SharedTreeList", () => {
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
 				assert.throws(() =>
-					list2.moveToIndex(
+					list2.moveRangeToIndex(
 						/* index: */ 0,
 						/* sourceStart: */ 0,
 						/* sourceEnd: */ 1,


### PR DESCRIPTION
## Description

At the request of the spec, this renames some of the methods on lists. It also loosens the type overlap restrictions on the EditableTree2 API, as they are currently incorrect.

## Breaking Changes

The three move functions on SharedTreeList and Sequence have been renamed, but the signatures remain compatible.