### PR TITLE
Update build-tools to 0.26.2 across repo

### DIFF
--- a/common/lib/common-definitions/pnpm-lock.yaml
+++ b/common/lib/common-definitions/pnpm-lock.yaml
@@ -19,9 +19,9 @@ importers:
       rimraf: ^2.6.2
       typescript: ~4.5.5
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_k7sla5vheyw5nos66xltzmmhke
+      '@fluid-tools/build-cli': 0.26.2_k7sla5vheyw5nos66xltzmmhke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.38
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.38
       '@fluidframework/common-definitions-previous': /@fluidframework/common-definitions/0.20.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.36.0_@types+node@16.18.38
@@ -159,22 +159,22 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_k7sla5vheyw5nos66xltzmmhke:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_k7sla5vheyw5nos66xltzmmhke:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_vy4ah4eawmaxtqslmps6irc47e
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.38
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_vy4ah4eawmaxtqslmps6irc47e
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.38
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.38
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_vy4ah4eawmaxtqslmps6irc47e
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_vy4ah4eawmaxtqslmps6irc47e
-      '@oclif/test': 2.3.30_vy4ah4eawmaxtqslmps6irc47e
+      '@oclif/plugin-plugins': 3.9.4_vy4ah4eawmaxtqslmps6irc47e
+      '@oclif/test': 2.3.33_vy4ah4eawmaxtqslmps6irc47e
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.38
       async: 3.2.4
@@ -225,17 +225,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_undwa5qxrriq4xnbtioa2ez7wy:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_undwa5qxrriq4xnbtioa2ez7wy:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_undwa5qxrriq4xnbtioa2ez7wy
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_undwa5qxrriq4xnbtioa2ez7wy
+      '@oclif/plugin-plugins': 3.9.4_undwa5qxrriq4xnbtioa2ez7wy
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -247,17 +247,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_vy4ah4eawmaxtqslmps6irc47e:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_vy4ah4eawmaxtqslmps6irc47e:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_vy4ah4eawmaxtqslmps6irc47e
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_vy4ah4eawmaxtqslmps6irc47e
+      '@oclif/plugin-plugins': 3.9.4_vy4ah4eawmaxtqslmps6irc47e
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -274,13 +274,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@16.18.38:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@16.18.38:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_undwa5qxrriq4xnbtioa2ez7wy
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_undwa5qxrriq4xnbtioa2ez7wy
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.38
@@ -318,8 +318,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -891,8 +891,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -952,11 +952,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
@@ -975,11 +975,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/2.4.3_vy4ah4eawmaxtqslmps6irc47e:
@@ -1000,13 +1000,13 @@ packages:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_undwa5qxrriq4xnbtioa2ez7wy:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_undwa5qxrriq4xnbtioa2ez7wy:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_undwa5qxrriq4xnbtioa2ez7wy
@@ -1029,8 +1029,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_vy4ah4eawmaxtqslmps6irc47e:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_vy4ah4eawmaxtqslmps6irc47e:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_vy4ah4eawmaxtqslmps6irc47e
@@ -1057,7 +1057,7 @@ packages:
     resolution: {integrity: sha512-dUXfRNFtnezS4uqQ+Ap4qb6UP0DWExTvoqghNvvGTIN4PEgfYHogvBORn+rFnDXXE8kgZFuqP4ZQJRP9NyLhOA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       debug: 4.3.4
       http-call: 5.3.0
@@ -1066,12 +1066,12 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/2.3.30_vy4ah4eawmaxtqslmps6irc47e:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_vy4ah4eawmaxtqslmps6irc47e:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_vy4ah4eawmaxtqslmps6irc47e
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4216,8 +4216,8 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fancy-test/2.0.30:
-    resolution: {integrity: sha512-bDQnAXYYODKwjb/6VEwAovEN0uJ1iRMTahEqOpQCRxIX7rIqoFHCy0LEqWYAU3kVw4ERgK4HQSn6GISEA1ipxg==}
+  /fancy-test/2.0.42:
+    resolution: {integrity: sha512-TX8YTALYAmExny+f+G24MFxWry3Pk09+9uykwRjfwjibRxJ9ZjJzrnHYVBZK46XQdyli7d+rQc5U/KK7V6uLsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.4
@@ -4226,7 +4226,7 @@ packages:
       '@types/sinon': 10.0.14
       lodash: 4.17.21
       mock-stdin: 1.0.0
-      nock: 13.3.2
+      nock: 13.3.6
       stdout-stderr: 0.1.13
     transitivePeerDependencies:
       - supports-color
@@ -6427,13 +6427,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /nock/13.3.2:
-    resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
+  /nock/13.3.6:
+    resolution: {integrity: sha512-lT6YuktKroUFM+27mubf2uqQZVy2Jf+pfGzuh9N6VwdHlFoZqvi4zyxFTVR1w/ChPqGY6yxGehHp6C3wqCASCw==}
     engines: {node: '>= 10.13'}
     dependencies:
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6926,7 +6925,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_vy4ah4eawmaxtqslmps6irc47e
       '@oclif/plugin-not-found': 2.4.3_vy4ah4eawmaxtqslmps6irc47e
       '@oclif/plugin-warn-if-update-available': 3.0.2

--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -56,9 +56,9 @@ importers:
       lodash: 4.17.21
       sha.js: 2.4.11
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_k7sla5vheyw5nos66xltzmmhke
+      '@fluid-tools/build-cli': 0.26.2_k7sla5vheyw5nos66xltzmmhke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.38
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.38
       '@fluidframework/common-utils-previous': /@fluidframework/common-utils/1.0.0
       '@fluidframework/eslint-config-fluid': 2.1.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.36.0_@types+node@16.18.38
@@ -528,22 +528,22 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_k7sla5vheyw5nos66xltzmmhke:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_k7sla5vheyw5nos66xltzmmhke:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_vy4ah4eawmaxtqslmps6irc47e
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.38
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_vy4ah4eawmaxtqslmps6irc47e
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.38
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.38
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_vy4ah4eawmaxtqslmps6irc47e
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_vy4ah4eawmaxtqslmps6irc47e
-      '@oclif/test': 2.3.30_vy4ah4eawmaxtqslmps6irc47e
+      '@oclif/plugin-plugins': 3.9.4_vy4ah4eawmaxtqslmps6irc47e
+      '@oclif/test': 2.3.33_vy4ah4eawmaxtqslmps6irc47e
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.38
       async: 3.2.4
@@ -594,17 +594,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_undwa5qxrriq4xnbtioa2ez7wy:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_undwa5qxrriq4xnbtioa2ez7wy:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_undwa5qxrriq4xnbtioa2ez7wy
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_undwa5qxrriq4xnbtioa2ez7wy
+      '@oclif/plugin-plugins': 3.9.4_undwa5qxrriq4xnbtioa2ez7wy
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -616,17 +616,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_vy4ah4eawmaxtqslmps6irc47e:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_vy4ah4eawmaxtqslmps6irc47e:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_vy4ah4eawmaxtqslmps6irc47e
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_vy4ah4eawmaxtqslmps6irc47e
+      '@oclif/plugin-plugins': 3.9.4_vy4ah4eawmaxtqslmps6irc47e
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -643,13 +643,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@16.18.38:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@16.18.38:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_undwa5qxrriq4xnbtioa2ez7wy
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_undwa5qxrriq4xnbtioa2ez7wy
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.38
@@ -687,8 +687,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -1520,8 +1520,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -1581,11 +1581,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
@@ -1604,11 +1604,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/2.4.3_vy4ah4eawmaxtqslmps6irc47e:
@@ -1629,13 +1629,13 @@ packages:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_undwa5qxrriq4xnbtioa2ez7wy:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_undwa5qxrriq4xnbtioa2ez7wy:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_undwa5qxrriq4xnbtioa2ez7wy
@@ -1658,8 +1658,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_vy4ah4eawmaxtqslmps6irc47e:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_vy4ah4eawmaxtqslmps6irc47e:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_vy4ah4eawmaxtqslmps6irc47e
@@ -1686,7 +1686,7 @@ packages:
     resolution: {integrity: sha512-dUXfRNFtnezS4uqQ+Ap4qb6UP0DWExTvoqghNvvGTIN4PEgfYHogvBORn+rFnDXXE8kgZFuqP4ZQJRP9NyLhOA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       debug: 4.3.4
       http-call: 5.3.0
@@ -1695,12 +1695,12 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/2.3.30_vy4ah4eawmaxtqslmps6irc47e:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_vy4ah4eawmaxtqslmps6irc47e:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_vy4ah4eawmaxtqslmps6irc47e
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -5399,7 +5399,7 @@ packages:
     dependencies:
       acorn: 8.8.2
       acorn-jsx: 5.3.2_acorn@8.8.2
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /esprima/4.0.1:
@@ -5635,8 +5635,8 @@ packages:
     engines: {'0': node >=0.6.0}
     dev: true
 
-  /fancy-test/2.0.30:
-    resolution: {integrity: sha512-bDQnAXYYODKwjb/6VEwAovEN0uJ1iRMTahEqOpQCRxIX7rIqoFHCy0LEqWYAU3kVw4ERgK4HQSn6GISEA1ipxg==}
+  /fancy-test/2.0.42:
+    resolution: {integrity: sha512-TX8YTALYAmExny+f+G24MFxWry3Pk09+9uykwRjfwjibRxJ9ZjJzrnHYVBZK46XQdyli7d+rQc5U/KK7V6uLsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.4
@@ -5645,7 +5645,7 @@ packages:
       '@types/sinon': 7.5.2
       lodash: 4.17.21
       mock-stdin: 1.0.0
-      nock: 13.3.2
+      nock: 13.3.6
       stdout-stderr: 0.1.13
     transitivePeerDependencies:
       - supports-color
@@ -9140,13 +9140,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /nock/13.3.2:
-    resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
+  /nock/13.3.6:
+    resolution: {integrity: sha512-lT6YuktKroUFM+27mubf2uqQZVy2Jf+pfGzuh9N6VwdHlFoZqvi4zyxFTVR1w/ChPqGY6yxGehHp6C3wqCASCw==}
     engines: {node: '>= 10.13'}
     dependencies:
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -9694,7 +9693,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_vy4ah4eawmaxtqslmps6irc47e
       '@oclif/plugin-not-found': 2.4.3_vy4ah4eawmaxtqslmps6irc47e
       '@oclif/plugin-warn-if-update-available': 3.0.2

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -22,9 +22,9 @@ importers:
     dependencies:
       '@fluidframework/common-definitions': 1.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluid-tools/build-cli': 0.26.2_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/2.0.0
       '@microsoft/api-extractor': 7.34.8
@@ -162,22 +162,22 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@4.5.5
-      '@fluidframework/build-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@4.5.5
+      '@fluidframework/build-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
-      '@oclif/test': 2.3.30_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
+      '@oclif/test': 2.3.33_typescript@4.5.5
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
       async: 3.2.4
@@ -228,17 +228,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_typescript@4.5.5:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_typescript@4.5.5:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -250,17 +250,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_typescript@5.1.6:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_typescript@5.1.6:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@5.1.6
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@5.1.6
+      '@oclif/plugin-plugins': 3.9.4_typescript@5.1.6
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -277,13 +277,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@5.1.6
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@5.1.6
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
@@ -321,8 +321,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -904,8 +904,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -965,11 +965,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
@@ -988,11 +988,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/2.4.3_typescript@4.5.5:
@@ -1013,13 +1013,13 @@ packages:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_typescript@4.5.5:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_typescript@4.5.5:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@4.5.5
@@ -1042,8 +1042,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_typescript@5.1.6:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_typescript@5.1.6:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@5.1.6
@@ -1070,7 +1070,7 @@ packages:
     resolution: {integrity: sha512-dUXfRNFtnezS4uqQ+Ap4qb6UP0DWExTvoqghNvvGTIN4PEgfYHogvBORn+rFnDXXE8kgZFuqP4ZQJRP9NyLhOA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       debug: 4.3.4
       http-call: 5.3.0
@@ -1079,12 +1079,12 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/2.3.30_typescript@4.5.5:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_typescript@4.5.5:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@4.5.5
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -4214,8 +4214,8 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fancy-test/2.0.30:
-    resolution: {integrity: sha512-bDQnAXYYODKwjb/6VEwAovEN0uJ1iRMTahEqOpQCRxIX7rIqoFHCy0LEqWYAU3kVw4ERgK4HQSn6GISEA1ipxg==}
+  /fancy-test/2.0.42:
+    resolution: {integrity: sha512-TX8YTALYAmExny+f+G24MFxWry3Pk09+9uykwRjfwjibRxJ9ZjJzrnHYVBZK46XQdyli7d+rQc5U/KK7V6uLsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.5
@@ -4224,7 +4224,7 @@ packages:
       '@types/sinon': 10.0.14
       lodash: 4.17.21
       mock-stdin: 1.0.0
-      nock: 13.3.2
+      nock: 13.3.6
       stdout-stderr: 0.1.13
     transitivePeerDependencies:
       - supports-color
@@ -6424,13 +6424,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /nock/13.3.2:
-    resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
+  /nock/13.3.6:
+    resolution: {integrity: sha512-lT6YuktKroUFM+27mubf2uqQZVy2Jf+pfGzuh9N6VwdHlFoZqvi4zyxFTVR1w/ChPqGY6yxGehHp6C3wqCASCw==}
     engines: {node: '>= 10.13'}
     dependencies:
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6922,7 +6921,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_typescript@4.5.5
       '@oclif/plugin-not-found': 2.4.3_typescript@4.5.5
       '@oclif/plugin-warn-if-update-available': 3.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,9 @@ importers:
     devDependencies:
       '@changesets/cli': 2.26.2
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@microsoft/api-documenter': 7.23.9
@@ -121,12 +121,12 @@ importers:
       '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
       axios: 0.26.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.1.0
       '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/counter': link:../../../packages/dds/counter
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
@@ -163,7 +163,7 @@ importers:
       tinylicious: 2.0.1
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
       eslint: 8.50.0
@@ -196,10 +196,10 @@ importers:
       jsrsasign: 10.8.6
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.1.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
       '@types/jsrsasign': 8.0.13
@@ -269,7 +269,7 @@ importers:
     devDependencies:
       '@fluid-experimental/devtools': link:../../../packages/tools/devtools/devtools
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -371,7 +371,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -450,9 +450,9 @@ importers:
       tinylicious: 2.0.1
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/js-yaml': 4.0.7
       '@types/mocha': 9.1.1
@@ -517,9 +517,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -605,9 +605,9 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
@@ -690,9 +690,9 @@ importers:
       style-loader: 1.3.0_webpack@5.88.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -808,9 +808,9 @@ importers:
       scheduler: 0.20.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -898,9 +898,9 @@ importers:
       fluid-framework: link:../../../packages/framework/fluid-framework
       process: 0.11.10
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -981,9 +981,9 @@ importers:
       css-loader: 1.0.1_webpack@5.88.2
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1094,9 +1094,9 @@ importers:
       tiny-typed-emitter: 2.1.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1176,7 +1176,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1248,9 +1248,9 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       use-resize-observer: 7.1.0_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@fluidframework/test-tools': 1.0.195075
@@ -1323,7 +1323,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1403,7 +1403,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1480,7 +1480,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1553,9 +1553,9 @@ importers:
       nconf: 0.12.0
       webpack-dev-server: 4.6.0_zgvvfjf2tx73ossdpc3n4rrlyy
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/express': 4.17.19
       '@types/fs-extra': 9.0.13
@@ -1640,7 +1640,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluidframework/build-tools': 0.26.2_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
       '@testing-library/dom': 8.20.1
@@ -1721,7 +1721,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -1799,7 +1799,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
@@ -1887,7 +1887,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/codemirror': 5.60.7
       '@types/node': 16.18.58
@@ -1948,7 +1948,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2019,7 +2019,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2092,7 +2092,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluidframework/build-tools': 0.26.2_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/react': 17.0.68
       css-loader: 1.0.1_webpack@5.88.2
@@ -2155,7 +2155,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2221,7 +2221,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2314,7 +2314,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2380,7 +2380,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2426,9 +2426,9 @@ importers:
       webpack-dev-server: ~4.6.0
       webpack-merge: ^5.8.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/expect-puppeteer': 2.2.1
       '@types/node': 16.18.58
@@ -2486,7 +2486,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2555,7 +2555,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2624,7 +2624,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -2737,7 +2737,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
       '@types/orderedmap': 1.0.0
@@ -2843,7 +2843,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
@@ -2935,7 +2935,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluidframework/build-tools': 0.26.2_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/events': 3.0.1
       '@types/react': 17.0.68
@@ -3003,9 +3003,9 @@ importers:
       debug: 4.3.4
     devDependencies:
       '@fluid-internal/test-version-utils': link:../../../packages/test/test-version-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
@@ -3075,7 +3075,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
       '@types/react': 17.0.68
@@ -3152,7 +3152,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
@@ -3260,7 +3260,7 @@ importers:
       '@fluid-internal/test-version-utils': link:../../../packages/test/test-version-utils
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
@@ -3408,7 +3408,7 @@ importers:
       valid-url: 1.0.9
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/cors': 2.8.14
@@ -3493,10 +3493,10 @@ importers:
       source-map-loader: 2.0.2_webpack@5.88.2
     devDependencies:
       '@cerner/duplicate-package-checker-webpack-plugin': 2.3.0_webpack@5.88.2
-      '@fluid-tools/version-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/bundle-size-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/bundle-size-tools': 0.26.2_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@mixer/webpack-bundle-compare': 0.1.1
       '@types/node': 16.18.58
@@ -3573,9 +3573,9 @@ importers:
       '@fluidframework/view-adapters': link:../../../packages/framework/view-adapters
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -3643,9 +3643,9 @@ importers:
       css-loader: 1.0.1_webpack@5.88.2
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -3758,9 +3758,9 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -3879,9 +3879,9 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -3971,9 +3971,9 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -4047,9 +4047,9 @@ importers:
       css-loader: 1.0.1_webpack@5.88.2
       style-loader: 1.3.0_webpack@5.88.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -4130,9 +4130,9 @@ importers:
       style-loader: 1.3.0_webpack@5.88.2
       vue: 2.6.14
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
@@ -4267,7 +4267,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluidframework/build-tools': 0.26.2_webpack-cli@4.10.0
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -4405,7 +4405,7 @@ importers:
       react-virtualized-auto-sizer: 1.0.7_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluidframework/build-tools': 0.26.2_webpack-cli@4.10.0
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -4443,7 +4443,7 @@ importers:
       typescript: ~5.1.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       eslint: 8.50.0
       prettier: 3.0.3
       rimraf: 4.4.1
@@ -4507,7 +4507,7 @@ importers:
       '@babel/plugin-transform-runtime': 7.23.2_@babel+core@7.23.2
       '@babel/preset-env': 7.23.2_@babel+core@7.23.2
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../../packages/test/test-utils
       '@types/jest': 29.5.3
@@ -4578,7 +4578,7 @@ importers:
       traverse: 0.6.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/lodash': 4.14.199
       '@types/mocha': 9.1.1
@@ -4644,7 +4644,7 @@ importers:
       traverse: 0.6.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -4743,7 +4743,7 @@ importers:
       '@fluid-experimental/property-common': link:../property-common
       '@fluid-internal/test-drivers': link:../../../../packages/test/test-drivers
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/container-loader': link:../../../../packages/loader/container-loader
       '@fluidframework/driver-definitions': link:../../../../packages/common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -4865,7 +4865,7 @@ importers:
       '@fluid-experimental/property-proxy': link:../property-proxy
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@storybook/addon-actions': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-essentials': 6.5.16_iihciws2wayuowiypdwx4ihdlm
       '@storybook/addon-links': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
@@ -4952,7 +4952,7 @@ importers:
       underscore: 1.13.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -5001,7 +5001,7 @@ importers:
       '@babel/plugin-transform-runtime': 7.23.2_@babel+core@7.23.2
       '@babel/preset-env': 7.23.2_@babel+core@7.23.2
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/jest': 29.5.3
       '@types/node': 16.18.58
@@ -5096,7 +5096,7 @@ importers:
       '@fluidframework/core-utils': link:../../../../packages/common/core-utils
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@types/jest': 29.5.3
       '@types/node': 16.18.58
@@ -5292,9 +5292,9 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
@@ -5354,7 +5354,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../../packages/dds/test-dds-utils
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
@@ -5413,7 +5413,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../../../packages/dds/test-dds-utils
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../../../packages/runtime/test-runtime-utils
@@ -5472,9 +5472,9 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
@@ -5563,7 +5563,7 @@ importers:
       '@fluid-internal/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/container-runtime': link:../../../packages/runtime/container-runtime
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -5663,9 +5663,9 @@ importers:
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-internal/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -5727,9 +5727,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
       events: 3.3.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -5768,9 +5768,9 @@ importers:
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
       '@fluidframework/shared-summary-block': link:../../../packages/dds/shared-summary-block
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -5807,9 +5807,9 @@ importers:
       '@fluidframework/sequence': link:../../../packages/dds/sequence
       react: 17.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -5851,9 +5851,9 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
@@ -5927,9 +5927,9 @@ importers:
       lodash: 4.17.21
       sha.js: 2.4.11
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -5987,9 +5987,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
@@ -6014,9 +6014,9 @@ importers:
       rimraf: ^4.4.0
       typescript: ~5.1.6
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -6052,9 +6052,9 @@ importers:
       typescript: ~5.1.6
     devDependencies:
       '@fluid-tools/benchmark': 0.47.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -6092,9 +6092,9 @@ importers:
       '@fluidframework/core-interfaces': link:../core-interfaces
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
@@ -6143,9 +6143,9 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6202,9 +6202,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6260,9 +6260,9 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6333,9 +6333,9 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6416,9 +6416,9 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6494,9 +6494,9 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6569,10 +6569,10 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@fluid-internal/test-version-utils': link:../../test/test-version-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/aqueduct': link:../../framework/aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -6636,9 +6636,9 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.7.1.0
@@ -6700,7 +6700,7 @@ importers:
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6762,9 +6762,9 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.7.1.0
@@ -6839,9 +6839,9 @@ importers:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.7.1.0
@@ -6915,9 +6915,9 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.7.1.0
@@ -6977,9 +6977,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.7.1.0
@@ -7049,9 +7049,9 @@ importers:
     devDependencies:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.7.1.0
@@ -7107,9 +7107,9 @@ importers:
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       mocha: 10.2.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
@@ -7153,9 +7153,9 @@ importers:
       '@fluidframework/replay-driver': link:../replay-driver
       jsonschema: 1.4.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -7203,9 +7203,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7252,9 +7252,9 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       idb: 6.1.5
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -7296,9 +7296,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/replay-driver': link:../replay-driver
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -7341,10 +7341,10 @@ importers:
       '@fluidframework/odsp-driver': link:../odsp-driver
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.1.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
@@ -7421,9 +7421,9 @@ importers:
       url: 0.11.3
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -7499,9 +7499,9 @@ importers:
       socket.io-client: 4.7.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.7.1.0
@@ -7541,9 +7541,9 @@ importers:
     dependencies:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.1.0
       '@fluidframework/protocol-definitions': 3.0.0
@@ -7583,9 +7583,9 @@ importers:
       '@fluidframework/odsp-driver': link:../odsp-driver
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.7.1.0
@@ -7632,9 +7632,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -7708,9 +7708,9 @@ importers:
       url-parse: 1.5.10
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.7.1.0
@@ -7770,9 +7770,9 @@ importers:
       nconf: 0.12.0
       url: 0.11.3
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.1.0
@@ -7826,9 +7826,9 @@ importers:
       jsrsasign: 10.8.6
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 1.0.195075
@@ -7884,10 +7884,10 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.1.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -7950,10 +7950,10 @@ importers:
       '@fluidframework/view-interfaces': link:../view-interfaces
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.1.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -8023,9 +8023,9 @@ importers:
       lz4js: 0.2.0
     devDependencies:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/merge-tree': link:../../dds/merge-tree
@@ -8076,7 +8076,7 @@ importers:
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
@@ -8134,9 +8134,9 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
       '@fluidframework/shared-object-base': link:../../dds/shared-object-base
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -8182,9 +8182,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8231,9 +8231,9 @@ importers:
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -8289,9 +8289,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.1.0
       '@fluidframework/map': link:../../dds/map
@@ -8339,9 +8339,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-internal/test-dds-utils': link:../../dds/test-dds-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -8388,9 +8388,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.7.1.0
@@ -8438,9 +8438,9 @@ importers:
     dependencies:
       '@fluidframework/core-utils': link:../../common/core-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8509,10 +8509,10 @@ importers:
       '@fluidframework/tinylicious-driver': link:../../drivers/tinylicious-driver
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/aqueduct': link:../aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8566,9 +8566,9 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
       events: 3.3.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8614,9 +8614,9 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0
@@ -8645,9 +8645,9 @@ importers:
     dependencies:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0
@@ -8718,9 +8718,9 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-internal/test-loader-utils': link:../test-loader-utils
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8792,9 +8792,9 @@ importers:
       url: 0.11.3
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8846,9 +8846,9 @@ importers:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -8889,9 +8889,9 @@ importers:
       '@fluidframework/driver-utils': link:../driver-utils
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
       prettier: 3.0.3
@@ -8964,9 +8964,9 @@ importers:
     devDependencies:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -9013,9 +9013,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/runtime-definitions': link:../runtime-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
@@ -9075,9 +9075,9 @@ importers:
       lodash: 4.17.21
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -9119,9 +9119,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/runtime-definitions': link:../runtime-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.1.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
@@ -9153,9 +9153,9 @@ importers:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0
@@ -9210,9 +9210,9 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.7.1.0
@@ -9289,9 +9289,9 @@ importers:
       jsrsasign: 10.8.6
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.7.1.0
@@ -9346,9 +9346,9 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-internal/test-loader-utils': link:../../loader/test-loader-utils
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/container-loader': link:../../loader/container-loader
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
@@ -9441,7 +9441,7 @@ importers:
       '@fluid-internal/test-pairwise-generator': link:../test-pairwise-generator
       '@fluidframework/aqueduct': link:../../framework/aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/cell': link:../../dds/cell
       '@fluidframework/container-definitions': link:../../common/container-definitions
       '@fluidframework/container-loader': link:../../loader/container-loader
@@ -9520,9 +9520,9 @@ importers:
       mocha: 10.2.0
       source-map-support: 0.5.21
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -9599,9 +9599,9 @@ importers:
       '@fluidframework/test-utils': link:../test-utils
       mocha: 10.2.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
@@ -9645,7 +9645,7 @@ importers:
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
@@ -9682,9 +9682,9 @@ importers:
       '@fluidframework/test-driver-definitions': link:../test-driver-definitions
       applicationinsights: 2.9.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
       eslint: 8.50.0
@@ -9714,9 +9714,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.1.0
       '@microsoft/api-extractor': 7.38.0
@@ -9782,9 +9782,9 @@ importers:
       semver: 7.5.4
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -9915,9 +9915,9 @@ importers:
       url: 0.11.3
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -9956,9 +9956,9 @@ importers:
     dependencies:
       random-js: 1.0.8
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
@@ -10044,9 +10044,9 @@ importers:
       start-server-and-test: 1.15.5
       tinylicious: 2.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
@@ -10134,9 +10134,9 @@ importers:
       debug: 4.3.4
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.7.1.0
@@ -10220,7 +10220,7 @@ importers:
       '@fluid-experimental/attributor': link:../../framework/attributor
       '@fluid-experimental/sequence-deprecated': link:../../../experimental/dds/sequence-deprecated
       '@fluid-internal/test-drivers': link:../test-drivers
-      '@fluid-tools/version-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2
       '@fluidframework/aqueduct': link:../../framework/aqueduct
       '@fluidframework/cell': link:../../dds/cell
       '@fluidframework/container-definitions': link:../../common/container-definitions
@@ -10247,9 +10247,9 @@ importers:
       proper-lockfile: 4.1.2
       semver: 7.5.4
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_pxfla23bjixg2qfx5ekihsuzhy
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
@@ -10309,9 +10309,9 @@ importers:
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
       '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.1.0
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../runtime/test-runtime-utils
@@ -10422,7 +10422,7 @@ importers:
       '@fluid-experimental/react-inputs': link:../../../../experimental/framework/react-inputs
       '@fluidframework/aqueduct': link:../../../framework/aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/container-definitions': link:../../../common/container-definitions
       '@fluidframework/container-loader': link:../../../loader/container-loader
       '@fluidframework/container-runtime-definitions': link:../../../runtime/container-runtime-definitions
@@ -10538,9 +10538,9 @@ importers:
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
     devDependencies:
       '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.1.0
-      '@fluid-tools/build-cli': 0.26.1_loebgezstcsvd2poh2d55fifke
+      '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/driver-definitions': link:../../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
@@ -10665,7 +10665,7 @@ importers:
       scheduler: 0.20.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../../test/test-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -10789,7 +10789,7 @@ importers:
       scheduler: 0.20.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
@@ -10882,10 +10882,10 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.1.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@types/node': 16.18.58
       eslint: 8.50.0
@@ -10936,9 +10936,9 @@ importers:
       json2csv: 5.0.7
       yargs: 13.2.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.1.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
@@ -11027,9 +11027,9 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
       json-stable-stringify: 1.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/json-stable-stringify': 1.0.34
@@ -11121,10 +11121,10 @@ importers:
       uuid: 9.0.1
       webpack-dev-server: 4.6.0_zgvvfjf2tx73ossdpc3n4rrlyy
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y
+      '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
       '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.1.0_zgvvfjf2tx73ossdpc3n4rrlyy
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/express': 4.17.19
@@ -11188,9 +11188,9 @@ importers:
       '@fluidframework/telemetry-utils': link:../telemetry-utils
       node-fetch: 2.7.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.1.0
@@ -11250,9 +11250,9 @@ importers:
       events: 3.3.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.7.1.0
@@ -11315,9 +11315,9 @@ importers:
       jwt-decode: 2.2.0
       proper-lockfile: 4.1.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bnjxas577mbdnhldblqqi36nsq
+      '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.7.1.0
@@ -15051,21 +15051,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/build-cli/0.26.1_bnjxas577mbdnhldblqqi36nsq:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_bnjxas577mbdnhldblqqi36nsq:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/build-tools': 0.26.1_@types+node@16.18.58
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@oclif/core': 2.4.0
-      '@oclif/plugin-autocomplete': 2.3.9
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-autocomplete': 2.3.10
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.1
+      '@oclif/plugin-plugins': 3.9.4
       '@oclif/test': 2.3.33
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.58
@@ -15116,21 +15116,21 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_loebgezstcsvd2poh2d55fifke:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_loebgezstcsvd2poh2d55fifke:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/build-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/build-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0
       '@oclif/core': 2.4.0
-      '@oclif/plugin-autocomplete': 2.3.9
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-autocomplete': 2.3.10
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.1
+      '@oclif/plugin-plugins': 3.9.4
       '@oclif/test': 2.3.33
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
@@ -15181,21 +15181,21 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_ue7fu4ddzgjm4mmyagkmdfjn7y:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/build-tools': 0.26.1_7zrvdqqpe6raskx6zfqiiakk2y
-      '@fluidframework/bundle-size-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
+      '@fluidframework/bundle-size-tools': 0.26.2_webpack-cli@4.10.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@oclif/core': 2.4.0
-      '@oclif/plugin-autocomplete': 2.3.9
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-autocomplete': 2.3.10
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.1
+      '@oclif/plugin-plugins': 3.9.4
       '@oclif/test': 2.3.33
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.58
@@ -15291,17 +15291,17 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
       '@oclif/core': 2.4.0
-      '@oclif/plugin-autocomplete': 2.3.9
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-autocomplete': 2.3.10
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.1
+      '@oclif/plugin-plugins': 3.9.4
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -15452,13 +15452,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
@@ -15495,13 +15495,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_7zrvdqqpe6raskx6zfqiiakk2y:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_7zrvdqqpe6raskx6zfqiiakk2y:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2_webpack-cli@4.10.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.58
@@ -15538,13 +15538,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@16.18.58:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@16.18.58:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@16.18.58
@@ -15581,13 +15581,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_webpack-cli@4.10.0:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_webpack-cli@4.10.0:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluid-tools/version-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2_webpack-cli@4.10.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
@@ -15624,8 +15624,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -15640,8 +15640,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1_webpack-cli@4.10.0:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2_webpack-cli@4.10.0:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -18490,8 +18490,8 @@ packages:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  /@oclif/plugin-autocomplete/2.3.9:
-    resolution: {integrity: sha512-MLmJtyp2iVnihDaogMDy+U323wI5vlV2raHOHKfe6mwzq6ObowimiOXnT9l2a0HELGHI0Fmd1tKeCgPrJE152A==}
+  /@oclif/plugin-autocomplete/2.3.10:
+    resolution: {integrity: sha512-Ow1AR8WtjzlyCtiWWPgzMyT8SbcDJFr47009riLioHa+MHX2BCDtVn2DVnN/E6b9JlPV5ptQpjefoRSNWBesmg==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.4.0
@@ -18500,8 +18500,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@oclif/core': 2.4.0
@@ -18517,8 +18517,8 @@ packages:
       '@oclif/core': 2.4.0
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@oclif/core': 2.4.0
@@ -18540,8 +18540,8 @@ packages:
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
 
-  /@oclif/plugin-plugins/3.9.1:
-    resolution: {integrity: sha512-86155GW6fQ8ZsmscffIOuvjjCCnXfuUJ/3dA+s6vqVgyGu8VshsHxnA9LCVja/Gz53j9TeaEog08IMcMDsmS7g==}
+  /@oclif/plugin-plugins/3.9.4:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.4.0
@@ -22232,7 +22232,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.88.2_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_webpack@5.88.2
+      webpack-cli: 4.10.0_ai6cu5vnuisb2akyozxbiaqwvu
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -22240,7 +22240,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.10.0
-      webpack-cli: 4.10.0_webpack@5.88.2
+      webpack-cli: 4.10.0_ai6cu5vnuisb2akyozxbiaqwvu
 
   /@webpack-cli/serve/1.7.0_hxwqhfj3xkkgp5omnyg2m7pnsm:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -22263,7 +22263,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_webpack@5.88.2
+      webpack-cli: 4.10.0_xrcblan7buurh2bchxgxle5xda
+    dev: true
 
   /@wojtekmaj/enzyme-adapter-react-17/0.6.7_7ltvq4e2railvf5uya4ffxpe2a:
     resolution: {integrity: sha512-B+byiwi/T1bx5hcj9wc0fUL5Hlb5giSXJzcnEfJVl2j6dGV2NJfcxDBYX0WWwIxlzNiFz8kAvlkFWI2y/nscZQ==}
@@ -27763,7 +27764,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.62.0_loebgezstcsvd2poh2d55fifke
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.58
+      jest: 29.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -43103,6 +43104,7 @@ packages:
       rechoir: 0.7.1
       webpack: 5.88.2_webpack-cli@4.10.0
       webpack-merge: 5.9.0
+    dev: true
 
   /webpack-cli/4.10.0_xrcblan7buurh2bchxgxle5xda:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
@@ -43487,7 +43489,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9_webpack@5.88.2
       watchpack: 2.4.0
-      webpack-cli: 4.10.0_webpack@5.88.2
+      webpack-cli: 4.10.0_ai6cu5vnuisb2akyozxbiaqwvu
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -37,9 +37,9 @@ importers:
       supertest: ^3.4.2
       typescript: ~4.5.5
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_bkxvyo6swyyjbzntcteneey2uq
+      '@fluid-tools/build-cli': 0.26.2_bkxvyo6swyyjbzntcteneey2uq
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.7
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.7
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/async': 3.2.16
       '@types/cors': 2.8.13
@@ -342,22 +342,22 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_bkxvyo6swyyjbzntcteneey2uq:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_bkxvyo6swyyjbzntcteneey2uq:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_ymnhzceeoeqwo36456pbfebzye
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.7
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_ymnhzceeoeqwo36456pbfebzye
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.7
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0_@types+node@18.17.7
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_ymnhzceeoeqwo36456pbfebzye
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_ymnhzceeoeqwo36456pbfebzye
-      '@oclif/test': 2.3.30_ymnhzceeoeqwo36456pbfebzye
+      '@oclif/plugin-plugins': 3.9.4_ymnhzceeoeqwo36456pbfebzye
+      '@oclif/test': 2.3.33_ymnhzceeoeqwo36456pbfebzye
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.17.7
       async: 3.2.4
@@ -408,17 +408,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_kkxksr3d2nijjwpjhklum2mdfm:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_kkxksr3d2nijjwpjhklum2mdfm:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_kkxksr3d2nijjwpjhklum2mdfm
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_kkxksr3d2nijjwpjhklum2mdfm
+      '@oclif/plugin-plugins': 3.9.4_kkxksr3d2nijjwpjhklum2mdfm
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -430,17 +430,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_ymnhzceeoeqwo36456pbfebzye:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_ymnhzceeoeqwo36456pbfebzye:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_ymnhzceeoeqwo36456pbfebzye
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_ymnhzceeoeqwo36456pbfebzye
+      '@oclif/plugin-plugins': 3.9.4_ymnhzceeoeqwo36456pbfebzye
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -457,13 +457,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@18.17.7:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@18.17.7:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_kkxksr3d2nijjwpjhklum2mdfm
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_kkxksr3d2nijjwpjhklum2mdfm
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.17.7
@@ -501,8 +501,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -2134,8 +2134,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -2195,11 +2195,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
@@ -2218,11 +2218,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/2.4.3_ymnhzceeoeqwo36456pbfebzye:
@@ -2243,13 +2243,13 @@ packages:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_kkxksr3d2nijjwpjhklum2mdfm:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_kkxksr3d2nijjwpjhklum2mdfm:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_kkxksr3d2nijjwpjhklum2mdfm
@@ -2272,8 +2272,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_ymnhzceeoeqwo36456pbfebzye:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_ymnhzceeoeqwo36456pbfebzye:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_ymnhzceeoeqwo36456pbfebzye
@@ -2300,7 +2300,7 @@ packages:
     resolution: {integrity: sha512-dUXfRNFtnezS4uqQ+Ap4qb6UP0DWExTvoqghNvvGTIN4PEgfYHogvBORn+rFnDXXE8kgZFuqP4ZQJRP9NyLhOA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       debug: 4.3.4
       http-call: 5.3.0
@@ -2309,12 +2309,12 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/2.3.30_ymnhzceeoeqwo36456pbfebzye:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_ymnhzceeoeqwo36456pbfebzye:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_ymnhzceeoeqwo36456pbfebzye
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -6153,8 +6153,8 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fancy-test/2.0.30:
-    resolution: {integrity: sha512-bDQnAXYYODKwjb/6VEwAovEN0uJ1iRMTahEqOpQCRxIX7rIqoFHCy0LEqWYAU3kVw4ERgK4HQSn6GISEA1ipxg==}
+  /fancy-test/2.0.42:
+    resolution: {integrity: sha512-TX8YTALYAmExny+f+G24MFxWry3Pk09+9uykwRjfwjibRxJ9ZjJzrnHYVBZK46XQdyli7d+rQc5U/KK7V6uLsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.4
@@ -6163,7 +6163,7 @@ packages:
       '@types/sinon': 10.0.13
       lodash: 4.17.21
       mock-stdin: 1.0.0
-      nock: 13.3.2
+      nock: 13.3.6
       stdout-stderr: 0.1.13
     transitivePeerDependencies:
       - supports-color
@@ -9021,13 +9021,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /nock/13.3.2:
-    resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
+  /nock/13.3.6:
+    resolution: {integrity: sha512-lT6YuktKroUFM+27mubf2uqQZVy2Jf+pfGzuh9N6VwdHlFoZqvi4zyxFTVR1w/ChPqGY6yxGehHp6C3wqCASCw==}
     engines: {node: '>= 10.13'}
     dependencies:
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -9676,7 +9675,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_ymnhzceeoeqwo36456pbfebzye
       '@oclif/plugin-not-found': 2.4.3_ymnhzceeoeqwo36456pbfebzye
       '@oclif/plugin-warn-if-update-available': 3.0.2

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -32,9 +32,9 @@ importers:
       tslint: ^5.12.0
       typescript: ~4.5.5
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_4rqwsplhh2ekz63wktwk7d7ht4
+      '@fluid-tools/build-cli': 0.26.2_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@types/compression': 0.0.36
       '@types/cors': 2.8.13
@@ -853,22 +853,22 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_4rqwsplhh2ekz63wktwk7d7ht4:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_4rqwsplhh2ekz63wktwk7d7ht4:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@4.5.5
-      '@fluidframework/build-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@4.5.5
+      '@fluidframework/build-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
-      '@oclif/test': 2.3.30_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
+      '@oclif/test': 2.3.33_typescript@4.5.5
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
       async: 3.2.4
@@ -919,17 +919,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_typescript@4.5.5:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_typescript@4.5.5:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -941,17 +941,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_typescript@5.1.6:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_typescript@5.1.6:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@5.1.6
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@5.1.6
+      '@oclif/plugin-plugins': 3.9.4_typescript@5.1.6
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -968,13 +968,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@5.1.6
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@5.1.6
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
@@ -1012,8 +1012,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -2744,8 +2744,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -2805,11 +2805,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
@@ -2828,11 +2828,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/2.4.3_typescript@4.5.5:
@@ -2853,13 +2853,13 @@ packages:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_typescript@4.5.5:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_typescript@4.5.5:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@4.5.5
@@ -2882,8 +2882,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_typescript@5.1.6:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_typescript@5.1.6:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@5.1.6
@@ -2910,7 +2910,7 @@ packages:
     resolution: {integrity: sha512-dUXfRNFtnezS4uqQ+Ap4qb6UP0DWExTvoqghNvvGTIN4PEgfYHogvBORn+rFnDXXE8kgZFuqP4ZQJRP9NyLhOA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       debug: 4.3.4
       http-call: 5.3.0
@@ -2919,12 +2919,12 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/2.3.30_typescript@4.5.5:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_typescript@4.5.5:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@4.5.5
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -7381,8 +7381,8 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fancy-test/2.0.30:
-    resolution: {integrity: sha512-bDQnAXYYODKwjb/6VEwAovEN0uJ1iRMTahEqOpQCRxIX7rIqoFHCy0LEqWYAU3kVw4ERgK4HQSn6GISEA1ipxg==}
+  /fancy-test/2.0.42:
+    resolution: {integrity: sha512-TX8YTALYAmExny+f+G24MFxWry3Pk09+9uykwRjfwjibRxJ9ZjJzrnHYVBZK46XQdyli7d+rQc5U/KK7V6uLsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.5
@@ -7391,7 +7391,7 @@ packages:
       '@types/sinon': 10.0.14
       lodash: 4.17.21
       mock-stdin: 1.0.0
-      nock: 13.3.2
+      nock: 13.3.6
       stdout-stderr: 0.1.13
     transitivePeerDependencies:
       - supports-color
@@ -10374,13 +10374,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /nock/13.3.2:
-    resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
+  /nock/13.3.6:
+    resolution: {integrity: sha512-lT6YuktKroUFM+27mubf2uqQZVy2Jf+pfGzuh9N6VwdHlFoZqvi4zyxFTVR1w/ChPqGY6yxGehHp6C3wqCASCw==}
     engines: {node: '>= 10.13'}
     dependencies:
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -11070,7 +11069,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_typescript@4.5.5
       '@oclif/plugin-not-found': 2.4.3_typescript@4.5.5
       '@oclif/plugin-warn-if-update-available': 3.0.2

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -30,9 +30,9 @@ importers:
     devDependencies:
       '@changesets/cli': 2.26.2
       '@fluid-private/changelog-generator-wrapper': file:../../tools/changelog-generator-wrapper
-      '@fluid-tools/build-cli': 0.26.1_typescript@4.5.5
+      '@fluid-tools/build-cli': 0.26.2_typescript@4.5.5
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@microsoft/api-documenter': 7.22.21
       '@microsoft/api-extractor': 7.36.0
       c8: 7.14.0
@@ -61,9 +61,9 @@ importers:
       rimraf: ^4.4.0
       typescript: ~4.5.5
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_4rqwsplhh2ekz63wktwk7d7ht4
+      '@fluid-tools/build-cli': 0.26.2_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1
+      '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/gitresources-previous': /@fluidframework/gitresources/2.0.0
       '@microsoft/api-extractor': 7.36.0
@@ -93,9 +93,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-core': link:../services-core
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-kafka-orderer-previous': /@fluidframework/server-kafka-orderer/2.0.0
       '@types/node': 18.17.6
@@ -178,9 +178,9 @@ importers:
       sha.js: 2.4.11
       uuid: 9.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-lambdas-previous': /@fluidframework/server-lambdas/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -245,9 +245,9 @@ importers:
       nconf: 0.12.0
       serialize-error: 8.1.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-lambdas-driver-previous': /@fluidframework/server-lambdas-driver/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -315,9 +315,9 @@ importers:
       jsrsasign: 10.8.6
       uuid: 9.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_u7qdhkoo3ay2mtnmijn73feu3u
+      '@fluid-tools/build-cli': 0.26.2_u7qdhkoo3ay2mtnmijn73feu3u
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_qiwzlxsc7nv6vcdymu2njnpbxe
+      '@fluidframework/build-tools': 0.26.2_qiwzlxsc7nv6vcdymu2njnpbxe
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server-previous': /@fluidframework/server-local-server/2.0.0
       '@microsoft/api-extractor': 7.36.0_@types+node@18.17.6
@@ -399,9 +399,9 @@ importers:
       uuid: 9.0.0
       ws: 7.5.9
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-memory-orderer-previous': /@fluidframework/server-memory-orderer/2.0.0
       '@types/mocha': 10.0.1
@@ -444,9 +444,9 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/protocol-base-previous': /@fluidframework/protocol-base/2.0.0
       '@microsoft/api-extractor': 7.36.0_@types+node@18.17.6
@@ -518,9 +518,9 @@ importers:
       nconf: 0.12.0
       winston: 3.9.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server': link:../local-server
       '@fluidframework/server-routerlicious-previous': /@fluidframework/server-routerlicious/2.0.0
@@ -635,9 +635,9 @@ importers:
       winston: 3.9.0
       ws: 7.5.9
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-local-server': link:../local-server
       '@fluidframework/server-routerlicious-base-previous': /@fluidframework/server-routerlicious-base/2.0.0
@@ -746,9 +746,9 @@ importers:
       uuid: 9.0.0
       winston: 3.9.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-previous': /@fluidframework/server-services/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -821,9 +821,9 @@ importers:
       sillyname: 0.1.0
       uuid: 9.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-client-previous': /@fluidframework/server-services-client/2.0.0
       '@microsoft/api-extractor': 7.36.0_@types+node@18.17.6
@@ -876,9 +876,9 @@ importers:
       events: 3.3.0
       nconf: 0.12.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-core-previous': /@fluidframework/server-services-core/2.0.0
       concurrently: 8.2.1
@@ -923,9 +923,9 @@ importers:
       nconf: 0.12.0
       sillyname: 0.1.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-kafkanode-previous': /@fluidframework/server-services-ordering-kafkanode/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -977,9 +977,9 @@ importers:
       node-rdkafka: 2.16.1
       sillyname: 0.1.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-rdkafka-previous': /@fluidframework/server-services-ordering-rdkafka/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -1019,9 +1019,9 @@ importers:
       '@fluidframework/server-services-core': link:../services-core
       zookeeper: 5.6.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-ordering-zookeeper-previous': /@fluidframework/server-services-ordering-zookeeper/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -1108,9 +1108,9 @@ importers:
       uuid: 9.0.0
       winston: 3.9.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-shared-previous': /@fluidframework/server-services-shared/2.0.0
       '@types/body-parser': 1.19.2
@@ -1162,9 +1162,9 @@ importers:
       serialize-error: 8.1.0
       uuid: 9.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-telemetry-previous': /@fluidframework/server-services-telemetry/2.0.0
       '@types/mocha': 10.0.1
@@ -1243,9 +1243,9 @@ importers:
       winston: 3.9.0
       winston-transport: 4.5.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-services-utils-previous': /@fluidframework/server-services-utils/2.0.0
       '@fluidframework/server-test-utils': link:../test-utils
@@ -1317,9 +1317,9 @@ importers:
       string-hash: 1.1.3
       uuid: 9.0.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.26.1_arb67uuw3qsmr24y5xn6pymdwm
+      '@fluid-tools/build-cli': 0.26.2_arb67uuw3qsmr24y5xn6pymdwm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 2.0.0_4rqwsplhh2ekz63wktwk7d7ht4
       '@fluidframework/server-test-utils-previous': /@fluidframework/server-test-utils/2.0.0
       '@types/lodash': 4.14.195
@@ -2128,22 +2128,22 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_4rqwsplhh2ekz63wktwk7d7ht4:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_4rqwsplhh2ekz63wktwk7d7ht4:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@4.5.5
-      '@fluidframework/build-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@4.5.5
+      '@fluidframework/build-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
-      '@oclif/test': 2.3.30_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
+      '@oclif/test': 2.3.33_typescript@4.5.5
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
       async: 3.2.4
@@ -2194,22 +2194,22 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_arb67uuw3qsmr24y5xn6pymdwm:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_arb67uuw3qsmr24y5xn6pymdwm:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.17.6
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_mmpl2z7rynse2pmynonhikz2qy
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.17.6
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0_@types+node@18.17.6
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_mmpl2z7rynse2pmynonhikz2qy
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_mmpl2z7rynse2pmynonhikz2qy
-      '@oclif/test': 2.3.30_mmpl2z7rynse2pmynonhikz2qy
+      '@oclif/plugin-plugins': 3.9.4_mmpl2z7rynse2pmynonhikz2qy
+      '@oclif/test': 2.3.33_mmpl2z7rynse2pmynonhikz2qy
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.17.6
       async: 3.2.4
@@ -2260,22 +2260,22 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_typescript@4.5.5:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_typescript@4.5.5:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@4.5.5
-      '@fluidframework/build-tools': 0.26.1
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@4.5.5
+      '@fluidframework/build-tools': 0.26.2
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@microsoft/api-extractor': 7.38.0
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
-      '@oclif/test': 2.3.30_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
+      '@oclif/test': 2.3.33_typescript@4.5.5
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
       async: 3.2.4
@@ -2326,22 +2326,22 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/build-cli/0.26.1_u7qdhkoo3ay2mtnmijn73feu3u:
-    resolution: {integrity: sha512-eqvUMIcJVgXdWN1tQrdVhx0FnLhstfcx4VywmmlT+nNt197sq2Lar5M+7C7enN3zlysctt3mJ9WIgcvZfc1Dew==}
+  /@fluid-tools/build-cli/0.26.2_u7qdhkoo3ay2mtnmijn73feu3u:
+    resolution: {integrity: sha512-0L0vuo8l/ksYaEgmX9G/R7PO9XQHC1WTFNw4cp7ipDwbrSOA1MbSAnIRYjIqrzeD+CEyKFUsWZrTR7669g9YUg==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_mmpl2z7rynse2pmynonhikz2qy
-      '@fluidframework/build-tools': 0.26.1_qiwzlxsc7nv6vcdymu2njnpbxe
-      '@fluidframework/bundle-size-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluid-tools/version-tools': 0.26.2_mmpl2z7rynse2pmynonhikz2qy
+      '@fluidframework/build-tools': 0.26.2_qiwzlxsc7nv6vcdymu2njnpbxe
+      '@fluidframework/bundle-size-tools': 0.26.2_webpack-cli@4.10.0
       '@microsoft/api-extractor': 7.38.0_@types+node@18.17.6
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_mmpl2z7rynse2pmynonhikz2qy
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_mmpl2z7rynse2pmynonhikz2qy
-      '@oclif/test': 2.3.30_mmpl2z7rynse2pmynonhikz2qy
+      '@oclif/plugin-plugins': 3.9.4_mmpl2z7rynse2pmynonhikz2qy
+      '@oclif/test': 2.3.33_mmpl2z7rynse2pmynonhikz2qy
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.17.6
       async: 3.2.4
@@ -2392,17 +2392,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_i66k3arednklksy2ivodm65s6a:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_i66k3arednklksy2ivodm65s6a:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_i66k3arednklksy2ivodm65s6a
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_i66k3arednklksy2ivodm65s6a
+      '@oclif/plugin-plugins': 3.9.4_i66k3arednklksy2ivodm65s6a
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -2414,17 +2414,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_mmpl2z7rynse2pmynonhikz2qy:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_mmpl2z7rynse2pmynonhikz2qy:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_mmpl2z7rynse2pmynonhikz2qy
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_mmpl2z7rynse2pmynonhikz2qy
+      '@oclif/plugin-plugins': 3.9.4_mmpl2z7rynse2pmynonhikz2qy
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -2436,17 +2436,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_typescript@4.5.5:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_typescript@4.5.5:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@4.5.5
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@4.5.5
+      '@oclif/plugin-plugins': 3.9.4_typescript@4.5.5
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -2458,17 +2458,17 @@ packages:
       - typescript
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_typescript@5.1.6:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_typescript@5.1.6:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_typescript@5.1.6
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_typescript@5.1.6
+      '@oclif/plugin-plugins': 3.9.4_typescript@5.1.6
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -2485,13 +2485,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_typescript@5.1.6
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_typescript@5.1.6
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0
@@ -2529,13 +2529,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@18.17.6:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@18.17.6:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_i66k3arednklksy2ivodm65s6a
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_i66k3arednklksy2ivodm65s6a
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.17.6
@@ -2573,13 +2573,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_qiwzlxsc7nv6vcdymu2njnpbxe:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_qiwzlxsc7nv6vcdymu2njnpbxe:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_i66k3arednklksy2ivodm65s6a
-      '@fluidframework/bundle-size-tools': 0.26.1_webpack-cli@4.10.0
+      '@fluid-tools/version-tools': 0.26.2_i66k3arednklksy2ivodm65s6a
+      '@fluidframework/bundle-size-tools': 0.26.2_webpack-cli@4.10.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.17.6
@@ -2617,8 +2617,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -2633,8 +2633,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1_webpack-cli@4.10.0:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2_webpack-cli@4.10.0:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -5090,8 +5090,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -5181,11 +5181,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
@@ -5216,11 +5216,11 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/2.4.3_mmpl2z7rynse2pmynonhikz2qy:
@@ -5255,13 +5255,13 @@ packages:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_i66k3arednklksy2ivodm65s6a:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_i66k3arednklksy2ivodm65s6a:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_i66k3arednklksy2ivodm65s6a
@@ -5284,8 +5284,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_mmpl2z7rynse2pmynonhikz2qy:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_mmpl2z7rynse2pmynonhikz2qy:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_mmpl2z7rynse2pmynonhikz2qy
@@ -5308,8 +5308,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_typescript@4.5.5:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_typescript@4.5.5:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@4.5.5
@@ -5332,8 +5332,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_typescript@5.1.6:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_typescript@5.1.6:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@5.1.6
@@ -5360,7 +5360,7 @@ packages:
     resolution: {integrity: sha512-dUXfRNFtnezS4uqQ+Ap4qb6UP0DWExTvoqghNvvGTIN4PEgfYHogvBORn+rFnDXXE8kgZFuqP4ZQJRP9NyLhOA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       debug: 4.3.4
       http-call: 5.3.0
@@ -5369,12 +5369,12 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/2.3.30_mmpl2z7rynse2pmynonhikz2qy:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_mmpl2z7rynse2pmynonhikz2qy:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_mmpl2z7rynse2pmynonhikz2qy
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -5383,12 +5383,12 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/test/2.3.30_typescript@4.5.5:
-    resolution: {integrity: sha512-zuOv23wiF+H7cRGMjcKx/91qhdcNMcZnr+1TCpbyDeQBIvRs/nGWyuwfrmoF2fXs+HtNZsNFvwbjg7Ue5JfAug==}
+  /@oclif/test/2.3.33_typescript@4.5.5:
+    resolution: {integrity: sha512-AmhsxZRDDqJHTk1mDQ+Rl3mNUvb7GIXNcNdP7G7r5l3fRYBUsbzflSy3M760WZfAW4r85rnB+SNG5OBvmajWow==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/core': 2.15.0_typescript@4.5.5
-      fancy-test: 2.0.30
+      fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -10083,8 +10083,8 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fancy-test/2.0.30:
-    resolution: {integrity: sha512-bDQnAXYYODKwjb/6VEwAovEN0uJ1iRMTahEqOpQCRxIX7rIqoFHCy0LEqWYAU3kVw4ERgK4HQSn6GISEA1ipxg==}
+  /fancy-test/2.0.42:
+    resolution: {integrity: sha512-TX8YTALYAmExny+f+G24MFxWry3Pk09+9uykwRjfwjibRxJ9ZjJzrnHYVBZK46XQdyli7d+rQc5U/KK7V6uLsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@types/chai': 4.3.5
@@ -13894,7 +13894,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_typescript@4.5.5
       '@oclif/plugin-not-found': 2.4.3_typescript@4.5.5
       '@oclif/plugin-warn-if-update-available': 3.0.2
@@ -13933,7 +13933,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_mmpl2z7rynse2pmynonhikz2qy
       '@oclif/plugin-not-found': 2.4.3_mmpl2z7rynse2pmynonhikz2qy
       '@oclif/plugin-warn-if-update-available': 3.0.2
@@ -13972,7 +13972,7 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-help': 5.2.20_typescript@4.5.5
       '@oclif/plugin-not-found': 2.4.3_typescript@4.5.5
       '@oclif/plugin-warn-if-update-available': 3.0.2

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
       chalk: 4.1.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@18.15.11
+      '@fluidframework/build-tools': 0.26.2_@types+node@18.15.11
       '@fluidframework/eslint-config-fluid': 2.0.0_flcvfono3v34oogyclggnmpgme
       '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.34.4_@types+node@18.15.11
@@ -162,17 +162,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_vkotigkp5s62xv6rdodgvy6lfm:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_vkotigkp5s62xv6rdodgvy6lfm:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_vkotigkp5s62xv6rdodgvy6lfm
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_vkotigkp5s62xv6rdodgvy6lfm
+      '@oclif/plugin-plugins': 3.9.4_vkotigkp5s62xv6rdodgvy6lfm
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -189,13 +189,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@18.15.11:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@18.15.11:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_vkotigkp5s62xv6rdodgvy6lfm
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_vkotigkp5s62xv6rdodgvy6lfm
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.61.0_@types+node@18.15.11
@@ -233,8 +233,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -539,8 +539,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -585,35 +585,35 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
       lodash.uniqby: 4.7.0
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/3.0.2:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_vkotigkp5s62xv6rdodgvy6lfm:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_vkotigkp5s62xv6rdodgvy6lfm:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_vkotigkp5s62xv6rdodgvy6lfm

--- a/tools/test-tools/pnpm-lock.yaml
+++ b/tools/test-tools/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       typescript: ~4.5.5
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.26.1_@types+node@14.18.0
+      '@fluidframework/build-tools': 0.26.2_@types+node@14.18.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 10.0.1
       '@types/node': 14.18.0
@@ -120,17 +120,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/version-tools/0.26.1_kpo3n76hqs2au4ihpelszmtrcy:
-    resolution: {integrity: sha512-pktW83q4E4PteL+pnCg3CdcXVQqzMO8Vrmp5zWLX5rKbPwKN1puvue5413R7MvkCRnqtmzQuwXepHHmitpMD/Q==}
+  /@fluid-tools/version-tools/0.26.2_kpo3n76hqs2au4ihpelszmtrcy:
+    resolution: {integrity: sha512-eP83WLzUQUA3FKfUcc800DNA7II+sPl0erKaMTqkzrjwLnqVfFcAI+uyXCq1x4KWh8Zp6nPptOj/X1D9IwlvQA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       '@oclif/plugin-autocomplete': 2.3.10_kpo3n76hqs2au4ihpelszmtrcy
-      '@oclif/plugin-commands': 3.0.3
-      '@oclif/plugin-help': 6.0.3
+      '@oclif/plugin-commands': 3.0.4
+      '@oclif/plugin-help': 6.0.4
       '@oclif/plugin-not-found': 3.0.2
-      '@oclif/plugin-plugins': 3.9.3_kpo3n76hqs2au4ihpelszmtrcy
+      '@oclif/plugin-plugins': 3.9.4_kpo3n76hqs2au4ihpelszmtrcy
       chalk: 2.4.2
       semver: 7.5.4
       table: 6.8.1
@@ -147,13 +147,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools/0.26.1_@types+node@14.18.0:
-    resolution: {integrity: sha512-+wbQv/TPj8ek0/6/yyUIrteDw8OiJi09ueHoYVkGrypMwL2TsMkHvUxcD1Pk5BVsMnflu3osT/9Jd8cP8DzlzA==}
+  /@fluidframework/build-tools/0.26.2_@types+node@14.18.0:
+    resolution: {integrity: sha512-rHw00d5XZj4InkQWrVWFhclr6lYAZmBbzSw0jBwWUHJ4S+ZDQbanPVufBscxI+NhTHJeErQ+LmvKbQRSY0COYA==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.26.1_kpo3n76hqs2au4ihpelszmtrcy
-      '@fluidframework/bundle-size-tools': 0.26.1
+      '@fluid-tools/version-tools': 0.26.2_kpo3n76hqs2au4ihpelszmtrcy
+      '@fluidframework/bundle-size-tools': 0.26.2
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.59.5_@types+node@14.18.0
@@ -191,8 +191,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools/0.26.1:
-    resolution: {integrity: sha512-eAlRGrVg70+Yj7oytEA1Mv+7HIw2RwF2iW5kf7xTZObGuGEfUygSB8w8FDMZTbv8UWRGXfP4Q6IZJqq6MxO0AQ==}
+  /@fluidframework/bundle-size-tools/0.26.2:
+    resolution: {integrity: sha512-nkZf70j2N5CJKVeukhpXesNn5qZZdjGqvE774uqT4InIkQKAZ132SLY3wFOorAZEI00OW3y+Ut99weLStze8TQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -402,8 +402,8 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/core/3.5.0:
-    resolution: {integrity: sha512-u1X8KguaIoLClbTWgnvXeVb6bu+GUCbmrY/1e1E6Xl3P8zw1cj8nm57RkvBnAHLVixnZ+4maVJrJ2vRVro/S+g==}
+  /@oclif/core/3.9.1:
+    resolution: {integrity: sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -448,35 +448,35 @@ packages:
       - typescript
     dev: true
 
-  /@oclif/plugin-commands/3.0.3:
-    resolution: {integrity: sha512-xIs+6Ka7qm7XZOkezpTmAU0h90GZOlctLCnbK80Kh/Qr3wQJJR/w9jEQ0PLaMzc9u1zQRqBLIhl24DuFFESw+g==}
+  /@oclif/plugin-commands/3.0.4:
+    resolution: {integrity: sha512-xeuoh/VaAxd7Xtext190yzdbfLvxYNMfHJZlnGK+9a1MTNPLZiKte/0gD/kBDBChrqfPegl1rpzYhAx2Iej4rA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       lodash.pickby: 4.6.0
       lodash.sortby: 4.7.0
       lodash.template: 4.5.0
       lodash.uniqby: 4.7.0
     dev: true
 
-  /@oclif/plugin-help/6.0.3:
-    resolution: {integrity: sha512-4oJ/rqf9kIzNyNZ4R5dmOXSC5S8kKxn2NHMW2kRIBHzQBg2R0RCrY7aHPHqFWCArPUk4K+YlRyhsiSgdslkV4A==}
+  /@oclif/plugin-help/6.0.4:
+    resolution: {integrity: sha512-IxiH1petVjLKdITMPbGWKGQtrIn+FSaUt2NKMs6RW5qjVhlkHXLNiN0MJ7/uvn6X/DmG+CDCHxigFgr1eDSmRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
     dev: true
 
   /@oclif/plugin-not-found/3.0.2:
     resolution: {integrity: sha512-tmm/Q/hxZRRAjb2tbx0hg9LUEnuIhIafEAhZBQW7kWg+dYYAb8ut3UfYrIVGNz3K42r+SSMQCdu8QsheZhQi5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 3.5.0
+      '@oclif/core': 3.9.1
       chalk: 5.3.0
       fast-levenshtein: 3.0.0
     dev: true
 
-  /@oclif/plugin-plugins/3.9.3_kpo3n76hqs2au4ihpelszmtrcy:
-    resolution: {integrity: sha512-hsm2mTL6uCP79WpltC+G1gkOrn2ckWXUnSi4UmF0eKbddOxJ9vakekuQpj/zlRJkXBNWaXlAskzJmnRoCGT+AQ==}
+  /@oclif/plugin-plugins/3.9.4_kpo3n76hqs2au4ihpelszmtrcy:
+    resolution: {integrity: sha512-JtumjspRdzJgHk1S10wu68tdlqSnyYRmSgCsmsc6AEvU+Orb0DQfrAgJEO77rPKPNo5MfnVAj0WyCDTi0JT/vw==}
     engines: {node: '>=16'}
     dependencies:
       '@oclif/core': 2.15.0_kpo3n76hqs2au4ihpelszmtrcy


### PR DESCRIPTION
Updates to the latest build-tools release across the repo. I only updated the lockfiles since the latest release was a patch. This way there's less churn in package.json.