### PR TITLE
docs(runtime-definitions): Add explicit release tags to exported API members

### DIFF
--- a/packages/runtime/runtime-definitions/api-extractor.json
+++ b/packages/runtime/runtime-definitions/api-extractor.json
@@ -1,12 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "@fluidframework/build-common/api-extractor-base.json",
-	"messages": {
-		"extractorMessageReporting": {
-			"ae-missing-release-tag": {
-				// TODO: Fix violations and remove this rule override
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "@fluidframework/build-common/api-extractor-base.json"
 }

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -91,7 +91,7 @@ export enum FlushMode {
     TurnBased = 1
 }
 
-// @public (undocumented)
+// @alpha (undocumented)
 export enum FlushModeExperimental {
     Async = 2
 }
@@ -138,7 +138,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
-// @public (undocumented)
+// @public
 export interface IContainerRuntimeBaseEvents extends IEvent {
     // (undocumented)
     (event: "batchBegin", listener: (op: ISequencedDocumentMessage) => void): any;
@@ -276,7 +276,7 @@ export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {
     attachRuntime(factory: IProvideFluidDataStoreFactory, dataStoreRuntime: IFluidDataStoreChannel): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export interface IFluidDataStoreContextEvents extends IEvent {
     // (undocumented)
     (event: "attaching" | "attached", listener: () => void): any;
@@ -339,7 +339,7 @@ export interface IInboundSignalMessage extends ISignalMessage {
     type: string;
 }
 
-// @public
+// @public (undocumented)
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
     snapshot: IAttachMessage["snapshot"] | null;
 };

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -46,6 +46,8 @@ import { IIdCompressor } from "./id-compressor";
 
 /**
  * Runtime flush mode handling
+ *
+ * @public
  */
 export enum FlushMode {
 	/**
@@ -60,6 +62,11 @@ export enum FlushMode {
 	TurnBased,
 }
 
+/**
+ * @remarks Note: this API is experimental and not ready for production use.
+ *
+ * @alpha
+ */
 export enum FlushModeExperimental {
 	/**
 	 * When in Async flush mode, the runtime will accumulate all operations across JS turns and send them as a single
@@ -67,8 +74,6 @@ export enum FlushModeExperimental {
 	 *
 	 * This feature requires a version of the loader which supports reference sequence numbers. If an older version of
 	 * the loader is used, the runtime will fall back on FlushMode.TurnBased.
-	 *
-	 * @experimental - Not ready for use
 	 */
 	Async = 2,
 }
@@ -76,6 +81,8 @@ export enum FlushModeExperimental {
 /**
  * This tells the visibility state of a Fluid object. It basically tracks whether the object is not visible, visible
  * locally within the container only or visible globally to all clients.
+ *
+ * @public
  */
 export const VisibilityState = {
 	/**
@@ -101,8 +108,14 @@ export const VisibilityState = {
 	 */
 	GloballyVisible: "GloballyVisible",
 };
+/** @public */
 export type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 
+/**
+ * Events emitted by {@link IContainerRuntimeBase}.
+ *
+ * @public
+ */
 export interface IContainerRuntimeBaseEvents extends IEvent {
 	(event: "batchBegin", listener: (op: ISequencedDocumentMessage) => void);
 	/**
@@ -118,18 +131,27 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
  * Encapsulates the return codes of the aliasing API.
  *
  * 'Success' - the datastore has been successfully aliased. It can now be used.
+ *
  * 'Conflict' - there is already a datastore bound to the provided alias. To acquire it's entry point, use
  * the `IContainerRuntime.getAliasedDataStoreEntryPoint` function. The current datastore should be discarded
  * and will be garbage collected. The current datastore cannot be aliased to a different value.
+ *
  * 'AlreadyAliased' - the datastore has already been previously bound to another alias name.
+ *
+ * @public
  */
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
 /**
  * Exposes some functionality/features of a data store:
+ *
  * - Handle to the data store's entryPoint
+ *
  * - Fluid router for the data store
+ *
  * - Can be assigned an alias
+ *
+ * @public
  */
 export interface IDataStore {
 	/**
@@ -183,7 +205,10 @@ export interface IDataStore {
 
 /**
  * A reduced set of functionality of IContainerRuntime that a data store context/data store runtime will need
- * TODO: this should be merged into IFluidDataStoreContext
+ *
+ * @privateRemarks TODO: this should be merged into {@link IFluidDataStoreContext}.
+ *
+ * @public
  */
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents> {
 	readonly logger: ITelemetryBaseLogger;
@@ -263,7 +288,9 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
  * Minimal interface a data store runtime needs to provide for IFluidDataStoreContext to bind to control.
  *
  * Functionality include attach, snapshot, op/signal processing, request routes, expose an entryPoint,
- * and connection state notifications
+ * and connection state notifications.
+ *
+ * @public
  */
 export interface IFluidDataStoreChannel extends IDisposable {
 	readonly id: string;
@@ -369,6 +396,9 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	readonly IFluidRouter: IFluidRouter;
 }
 
+/**
+ * @public
+ */
 export type CreateChildSummarizerNodeFn = (
 	summarizeInternal: SummarizeInternalFn,
 	getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
@@ -378,13 +408,21 @@ export type CreateChildSummarizerNodeFn = (
 	getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 ) => ISummarizerNodeWithGC;
 
+/**
+ * Events emitted by {@link IFluidDataStoreContext}.
+ *
+ * @public
+ */
 export interface IFluidDataStoreContextEvents extends IEvent {
 	(event: "attaching" | "attached", listener: () => void);
 }
 
 /**
- * Represents the context for the data store. It is used by the data store runtime to
- * get information and call functionality to the container.
+ * Represents the context for the data store.
+ *
+ * @remarks It is used by the data store runtime to get information and call functionality to the container.
+ *
+ * @public
  */
 export interface IFluidDataStoreContext
 	extends IEventProvider<IFluidDataStoreContextEvents>,
@@ -520,6 +558,9 @@ export interface IFluidDataStoreContext
 	addedGCOutboundReference?(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
 }
 
+/**
+ * @public
+ */
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {
 	/**
 	 * Binds a runtime to the context.

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -5,15 +5,26 @@
 
 import { IFluidDataStoreContext, IFluidDataStoreChannel } from "./dataStoreContext";
 
+/**
+ * @public
+ */
 export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory = "IFluidDataStoreFactory";
 
+/**
+ * @public
+ */
 export interface IProvideFluidDataStoreFactory {
 	readonly IFluidDataStoreFactory: IFluidDataStoreFactory;
 }
 
 /**
- * IFluidDataStoreFactory create data stores.  It is associated with an identifier (its `type` member)
- * and usually provided to consumers using this mapping through a data store registry.
+ * Create data stores.
+ *
+ * @remarks
+ * It is associated with an identifier (its `type` member) and usually provided to consumers using this mapping
+ * through a data store registry.
+ *
+ * @public
  */
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
 	/**

--- a/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
@@ -6,25 +6,41 @@
 import { IProvideFluidDataStoreFactory } from "./dataStoreFactory";
 
 /**
- * A single registry entry that may be used to create data stores
- * It has to have either factory or registry, or both.
+ * A single registry entry that may be used to create data stores.
+ *
+ * @remarks It must have either factory or registry, or both.
+ *
+ * @public
  */
 export type FluidDataStoreRegistryEntry = Readonly<
 	Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>
 >;
+
 /**
- * An associated pair of an identifier and registry entry.  Registry entries
- * may be dynamically loaded.
+ * An associated pair of an identifier and registry entry.
+ *
+ * @remarks Registry entries may be dynamically loaded.
+ *
+ * @public
  */
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
+
 /**
- * An iterable identifier/registry entry pair list
+ * An iterable identifier/registry entry pair list.
+ *
+ * @public
  */
 export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreRegistryEntry>;
 
+/**
+ * @public
+ */
 export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry =
 	"IFluidDataStoreRegistry";
 
+/**
+ * @public
+ */
 export interface IProvideFluidDataStoreRegistry {
 	readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
 }
@@ -32,6 +48,8 @@ export interface IProvideFluidDataStoreRegistry {
 /**
  * An association of identifiers to data store registry entries, where the
  * entries can be used to create data stores.
+ *
+ * @public
  */
 export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry {
 	get(name: string): Promise<FluidDataStoreRegistryEntry | undefined>;

--- a/packages/runtime/runtime-definitions/src/garbageCollection.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollection.ts
@@ -3,18 +3,40 @@
  * Licensed under the MIT License.
  */
 
-/** The key for the GC tree in summary. */
+/**
+ * The key for the GC tree in summary.
+ *
+ * @public
+ */
 export const gcTreeKey = "gc";
-/** They prefix for GC blobs in the GC tree in summary. */
+
+/**
+ * They prefix for GC blobs in the GC tree in summary.
+ *
+ * @public
+ */
 export const gcBlobPrefix = "__gc";
-/** The key for tombstone blob in the GC tree in summary. */
+
+/**
+ * The key for tombstone blob in the GC tree in summary.
+ *
+ * @public
+ */
 export const gcTombstoneBlobKey = "__tombstones";
-/** The key for deleted nodes blob in the GC tree in summary. */
+
+/**
+ * The key for deleted nodes blob in the GC tree in summary.
+ *
+ * @public
+ */
 export const gcDeletedBlobKey = "__deletedNodes";
 
 /**
  * Garbage collection data returned by nodes in a Container.
- * Used for running GC in the Container.
+ *
+ * @remarks Used for running GC in the Container.
+ *
+ * @public
  */
 export interface IGarbageCollectionData {
 	/**
@@ -25,6 +47,8 @@ export interface IGarbageCollectionData {
 
 /**
  * GC details provided to each node during creation.
+ *
+ * @public
  */
 export interface IGarbageCollectionDetailsBase {
 	/**

--- a/packages/runtime/runtime-definitions/src/id-compressor/idCompressor.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/idCompressor.ts
@@ -10,6 +10,9 @@ import {
 	SerializedIdCompressorWithOngoingSession,
 } from "./persisted-types";
 
+/**
+ * @public
+ */
 export interface IIdCompressorCore {
 	/**
 	 * Returns a range of IDs created by this session in a format for sending to the server for finalizing.
@@ -41,6 +44,7 @@ export interface IIdCompressorCore {
 /**
  * A distributed UUID generator and compressor.
  *
+ * @remarks
  * Generates arbitrary non-colliding v4 UUIDs, called stable IDs, for multiple "sessions" (which can be distributed across the network),
  * providing each session with the ability to map these UUIDs to `numbers`.
  *
@@ -99,6 +103,7 @@ export interface IIdCompressorCore {
  * These two spaces naturally define a rule: consumers of compressed IDs should use session-space IDs, but serialized forms such as ops
  * should use op-space IDs.
  *
+ * @public
  */
 export interface IIdCompressor {
 	localSessionId: SessionId;

--- a/packages/runtime/runtime-definitions/src/id-compressor/identifiers.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/identifiers.ts
@@ -5,8 +5,12 @@
 
 /**
  * A compressed ID that has been normalized into "session space" (see `IdCompressor` for more).
+ *
+ * @remarks
  * Consumer-facing APIs and data structures should use session-space IDs as their lifetime and equality is stable and tied to
  * the scope of the session (i.e. compressor) that produced them.
+ *
+ * @public
  */
 export type SessionSpaceCompressedId = number & {
 	readonly SessionUnique: "cea55054-6b82-4cbf-ad19-1fa645ea3b3e";
@@ -14,8 +18,12 @@ export type SessionSpaceCompressedId = number & {
 
 /**
  * A compressed ID that has been normalized into "op space".
+ *
+ * @remarks
  * Serialized/persisted structures (e.g. ops) should use op-space IDs as a performance optimization, as they require less normalizing when
  * received by a remote client due to the fact that op space for a given compressor is session space for all other compressors.
+ *
+ * @public
  */
 export type OpSpaceCompressedId = number & {
 	readonly OpNormalized: "9209432d-a959-4df7-b2ad-767ead4dbcae";
@@ -26,10 +34,14 @@ export type OpSpaceCompressedId = number & {
  * A 128-bit Universally Unique IDentifier. Represented here
  * with a string of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
  * where x is a lowercase hex digit.
+ *
+ * @public
  */
 export type StableId = string & { readonly StableId: "53172b0d-a3d5-41ea-bd75-b43839c97f5a" };
 
 /**
- * A StableId which is suitable for use as a session identifier
+ * A {@link StableId} which is suitable for use as a session identifier.
+ *
+ * @public
  */
 export type SessionId = StableId & { readonly SessionId: "4498f850-e14e-4be9-8db0-89ec00997e58" };

--- a/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
@@ -6,21 +6,30 @@
 import type { SessionId } from "../identifiers";
 
 /**
- * The serialized contents of an IdCompressor, suitable for persistence in a summary.
+ * The serialized contents of an {@link @fluidframework/container-runtime#IdCompressor}, suitable for persistence
+ * in a summary.
+ *
+ * @public
  */
 export type SerializedIdCompressor = string & {
 	readonly _serializedIdCompressor: "8c73c57c-1cf4-4278-8915-6444cb4f6af5";
 };
 
 /**
- * The serialized contents of an IdCompressor, suitable for persistence in a summary.
+ * The serialized contents of an {@link @fluidframework/container-runtime#IdCompressor}, suitable for persistence
+ * in a summary.
+ *
+ * @public
  */
 export type SerializedIdCompressorWithNoSession = SerializedIdCompressor & {
 	readonly _noLocalState: "3aa2e1e8-cc28-4ea7-bc1a-a11dc3f26dfb";
 };
 
 /**
- * The serialized contents of an IdCompressor, suitable for persistence in a summary.
+ * The serialized contents of an {@link @fluidframework/container-runtime#IdCompressor}, suitable for persistence
+ * in a summary.
+ *
+ * @public
  */
 export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & {
 	readonly _hasLocalState: "1281acae-6d14-47e7-bc92-71c8ee0819cb";
@@ -30,6 +39,8 @@ export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & 
  * Data describing a range of session-local IDs (from a remote or local session).
  *
  * A range is composed of local IDs that were generated.
+ *
+ * @public
  */
 export interface IdCreationRange {
 	readonly sessionId: SessionId;
@@ -41,10 +52,16 @@ export interface IdCreationRange {
 
 /**
  * Roughly equates to a minimum of 1M sessions before we start allocating 64 bit IDs.
- * This value must *NOT* change without careful consideration to compatibility.
+ *
+ * @remarks This value must *NOT* change without careful consideration to compatibility.
+ *
+ * @public
  */
 export const initialClusterCapacity = 512;
 
+/**
+ * @public
+ */
 export type IdCreationRangeWithStashedState = IdCreationRange & {
 	stashedState: SerializedIdCompressorWithOngoingSession;
 };

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -6,7 +6,9 @@
 import { ISignalMessage, ITree } from "@fluidframework/protocol-definitions";
 
 /**
- * An envelope wraps the contents with the intended target
+ * An envelope wraps the contents with the intended target.
+ *
+ * @public
  */
 export interface IEnvelope {
 	/**
@@ -20,6 +22,9 @@ export interface IEnvelope {
 	contents: any;
 }
 
+/**
+ * @public
+ */
 export interface ISignalEnvelope {
 	/**
 	 * The target for the envelope, undefined for the container
@@ -41,15 +46,20 @@ export interface ISignalEnvelope {
 }
 
 /**
- * Represents ISignalMessage with its type.
+ * An {@link @fluidframework/protocol-definitions#ISignalMessage} with its type.
+ *
+ * @public
  */
 export interface IInboundSignalMessage extends ISignalMessage {
 	type: string;
 }
 
 /**
- * Message send by client attaching local data structure.
- * Contains snapshot of data structure which is the current state of this data structure.
+ * Message sent by a client attaching a local data structure.
+ *
+ * @remarks Contains snapshot of data structure which is the current state of this data structure.
+ *
+ * @public
  */
 export interface IAttachMessage {
 	/**
@@ -69,10 +79,13 @@ export interface IAttachMessage {
 }
 
 /**
+ * @remarks
  * This type should be used when reading an incoming attach op,
  * but it should not be used when creating a new attach op.
  * Older versions of attach messages could have null snapshots,
  * so this gives correct typings for writing backward compatible code.
+ *
+ * @public
  */
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
 	snapshot: IAttachMessage["snapshot"] | null;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -15,6 +15,8 @@ import { IGarbageCollectionData, IGarbageCollectionDetailsBase } from "./garbage
 
 /**
  * Contains the aggregation data from a Tree/Subtree.
+ *
+ * @public
  */
 export interface ISummaryStats {
 	treeNodeCount: number;
@@ -26,10 +28,16 @@ export interface ISummaryStats {
 
 /**
  * Represents the summary tree for a node along with the statistics for that tree.
+ *
+ * @remarks
  * For example, for a given data store, it contains the data for data store along with a subtree for
  * each of its DDS.
- * Any component that implements IChannelContext, IFluidDataStoreChannel or extends SharedObject
+ *
+ * Any component that implements {@link @fluidframework/datastore#IChannelContext}, {@link IFluidDataStoreChannel}
+ * or extends {@link @fluidframework/shared-object-base#SharedObject}
  * will be taking part of the summarization process.
+ *
+ * @public
  */
 export interface ISummaryTreeWithStats {
 	/**
@@ -45,6 +53,8 @@ export interface ISummaryTreeWithStats {
 
 /**
  * Represents a summary at a current sequence number.
+ *
+ * @public
  */
 export interface ISummarizeResult {
 	stats: ISummaryStats;
@@ -53,7 +63,8 @@ export interface ISummarizeResult {
 
 /**
  * Contains the same data as ISummaryResult but in order to avoid naming collisions,
- * the data store summaries are wrapped around an array of labels identified by pathPartsForChildren.
+ * the data store summaries are wrapped around an array of labels identified by
+ * {@link ISummarizeInternalResult.pathPartsForChildren}.
  *
  * @example
  *
@@ -65,6 +76,8 @@ export interface ISummarizeResult {
  *   ...
  *     "path1":
  * ```
+ *
+ * @public
  */
 export interface ISummarizeInternalResult extends ISummarizeResult {
 	id: string;
@@ -75,8 +88,11 @@ export interface ISummarizeInternalResult extends ISummarizeResult {
 }
 
 /**
- * @experimental - Can be deleted/changed at any time
- * Contains the necessary information to allow DDSes to do incremental summaries
+ * Contains the necessary information to allow DDSes to do incremental summaries.
+ *
+ * @remarks Note: this API is experimental and not ready for production use.
+ *
+ * @public
  */
 export interface IExperimentalIncrementalSummaryContext {
 	/**
@@ -101,6 +117,11 @@ export interface IExperimentalIncrementalSummaryContext {
 	summaryPath: string;
 }
 
+/**
+ * @remarks Note: this API is experimental and not ready for production use.
+ *
+ * @public
+ */
 export type SummarizeInternalFn = (
 	fullTree: boolean,
 	trackState: boolean,
@@ -108,6 +129,9 @@ export type SummarizeInternalFn = (
 	incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 ) => Promise<ISummarizeInternalResult>;
 
+/**
+ * @public
+ */
 export interface ISummarizerNodeConfig {
 	/**
 	 * True to reuse previous handle when unchanged since last acked summary.
@@ -126,6 +150,9 @@ export interface ISummarizerNodeConfig {
 	readonly throwOnFailure?: true;
 }
 
+/**
+ * @public
+ */
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 	/**
 	 * True if GC is disabled. If so, don't track GC related state for a summary.
@@ -134,11 +161,18 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 	readonly gcDisabled?: boolean;
 }
 
+/**
+ * @public
+ */
 export enum CreateSummarizerNodeSource {
 	FromSummary,
 	FromAttach,
 	Local,
 }
+
+/**
+ * @public
+ */
 export type CreateChildSummarizerNodeParam =
 	| {
 			type: CreateSummarizerNodeSource.FromSummary;
@@ -152,6 +186,9 @@ export type CreateChildSummarizerNodeParam =
 			type: CreateSummarizerNodeSource.Local;
 	  };
 
+/**
+ * @public
+ */
 export interface ISummarizerNode {
 	/**
 	 * Latest successfully acked summary reference sequence number
@@ -220,7 +257,10 @@ export interface ISummarizerNode {
 }
 
 /**
- * Extends the functionality of ISummarizerNode to support garbage collection. It adds / updates the following APIs:
+ * Extends the functionality of ISummarizerNode to support garbage collection.
+ *
+ * @remarks
+ * It adds / updates the following APIs:
  *
  * `usedRoutes`: The routes in this node that are currently in use.
  *
@@ -240,6 +280,8 @@ export interface ISummarizerNode {
  * `isReferenced`: This tells whether this node is referenced in the document or not.
  *
  * `updateUsedRoutes`: Used to notify this node of routes that are currently in use in it.
+ *
+ * @public
  */
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
 	createChild(
@@ -289,8 +331,13 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
 	isReferenced(): boolean;
 
 	/**
-	 * After GC has run, called to notify this node of routes that are used in it. These are used for the following:
+	 * After GC has run, called to notify this node of routes that are used in it.
+	 *
+	 * @remarks
+	 * These are used for the following:
+	 *
 	 * 1. To identify if this node is being referenced in the document or not.
+	 *
 	 * 2. To identify if this node or any of its children's used routes changed since last summary.
 	 *
 	 * @param usedRoutes - The routes that are used in this node.
@@ -298,11 +345,17 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
 	updateUsedRoutes(usedRoutes: string[]): void;
 }
 
+/**
+ * @public
+ */
 export const channelsTreeName = ".channels";
 
 /**
  * Contains telemetry data relevant to summarization workflows.
- * This object is expected to be modified directly by various summarize methods.
+ *
+ * @remarks This object is expected to be modified directly by various summarize methods.
+ *
+ * @public
  */
 export interface ITelemetryContext {
 	/**
@@ -340,6 +393,12 @@ export interface ITelemetryContext {
 	serialize(): string;
 }
 
+/**
+ * @public
+ */
 export const blobCountPropertyName = "BlobCount";
 
+/**
+ * @public
+ */
 export const totalBlobSizePropertyName = "TotalBlobSize";

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -93,6 +93,7 @@ export interface ISummarizeInternalResult extends ISummarizeResult {
  * @remarks Note: this API is experimental and not ready for production use.
  *
  * @public
+ * @experimental
  */
 export interface IExperimentalIncrementalSummaryContext {
 	/**
@@ -118,8 +119,6 @@ export interface IExperimentalIncrementalSummaryContext {
 }
 
 /**
- * @remarks Note: this API is experimental and not ready for production use.
- *
  * @public
  */
 export type SummarizeInternalFn = (


### PR DESCRIPTION
Removes rules override in the package's api-extractor config, and adds missing release tags.

Also makes some misc. comment improvements following our [TSDoc guidelines](https://github.com/microsoft/FluidFramework/wiki/TSDoc-Guidelines).

[AB#5902](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5902)