### PR TITLE
Stress: Move ConnectToDeltaStream After Offline Wait

### DIFF
--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -23,7 +23,7 @@ import {
 	INack,
 	NackErrorType,
 } from "@fluidframework/protocol-definitions";
-import { LoggingError } from "@fluidframework/telemetry-utils";
+import { LoggingError, wrapError } from "@fluidframework/telemetry-utils";
 
 export class FaultInjectionDocumentServiceFactory implements IDocumentServiceFactory {
 	private readonly _documentServices = new Map<IResolvedUrl, FaultInjectionDocumentService>();
@@ -115,6 +115,9 @@ export class FaultInjectionDocumentService implements IDocumentService {
 	}
 
 	public dispose(error?: any) {
+		this.onlineP.reject(
+			wrapError(error, (message) => new FaultInjectionError(`disposed: ${message}`, false)),
+		);
 		this.internal.dispose(error);
 	}
 

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -123,11 +123,12 @@ export class FaultInjectionDocumentService implements IDocumentService {
 			this._currentDeltaStream?.disposed !== false,
 			"Document service factory should only have one open connection",
 		);
-		const internal = await this.internal.connectToDeltaStream(client);
-
 		// this method is not expected to resolve until connected
 		await this.onlineP.promise;
-		this._currentDeltaStream = new FaultInjectionDocumentDeltaConnection(internal, this.online);
+		this._currentDeltaStream = new FaultInjectionDocumentDeltaConnection(
+			await this.internal.connectToDeltaStream(client),
+			this.online,
+		);
 		return this._currentDeltaStream;
 	}
 


### PR DESCRIPTION
Move ConnectToDeltaStream  after we wait for the offline promise. Calling ConnectToDeltaStream  has side effects, like actually connecting to the service, which is then visible to other clients. This in turn looks more like a stalled client to other clients. A truly offline client wouldn't have those side effects. This change re-orders the time we connect at to ensure we don't have side effects until the offline client comes back online and really connects.

[AB#5936](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5936)