### PR TITLE
mapCursorToPath bug fix

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -845,8 +845,10 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
     allocateCursor(): ITreeSubscriptionCursor;
     clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
+    // (undocumented)
+    getRootCursor(): ITreeCursorSynchronous;
     readonly isEmpty: boolean;
-    moveCursorToPath(destination: UpPath | undefined, cursorToMove: ITreeSubscriptionCursor): void;
+    moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor): void;
     tryMoveCursorToField(destination: FieldAnchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
     tryMoveCursorToNode(destination: Anchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
 }

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -845,7 +845,6 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
     allocateCursor(): ITreeSubscriptionCursor;
     clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
-    // (undocumented)
     getRootCursor(): ITreeCursorSynchronous;
     readonly isEmpty: boolean;
     moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor): void;

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -845,7 +845,7 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
     allocateCursor(): ITreeSubscriptionCursor;
     clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
-    getRootCursor(): ITreeCursorSynchronous;
+    getCursorAboveDetachedFields(): ITreeCursorSynchronous;
     readonly isEmpty: boolean;
     moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor): void;
     tryMoveCursorToField(destination: FieldAnchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;

--- a/experimental/dds/tree2/src/core/forest/forest.ts
+++ b/experimental/dds/tree2/src/core/forest/forest.ts
@@ -13,6 +13,7 @@ import {
 	DetachedField,
 	detachedFieldAsKey,
 	ITreeCursor,
+	ITreeCursorSynchronous,
 	rootField,
 	UpPath,
 } from "../tree";
@@ -99,7 +100,16 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 	 * This dummy node can be used to read the detached fields,
 	 * but other operations (such as inspecting the dummy node's type or path) should not be relied upon.
 	 */
-	moveCursorToPath(destination: UpPath | undefined, cursorToMove: ITreeSubscriptionCursor): void;
+	moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor): void;
+
+	/**
+	 * The cursor is moved to a special dummy node above the detached fields.
+	 * This dummy node can be used to read the detached fields,
+	 * but other operations (such as inspecting the dummy node's type or path) should not be relied upon.
+	 * As this method does not return a forest cursor and cannot be freed, the caller of this method must
+	 * use with caution and ensure that it is not used incorrectly.
+	 */
+	getRootCursor(): ITreeCursorSynchronous;
 
 	/**
 	 * True if there are no nodes in the forest at all.

--- a/experimental/dds/tree2/src/core/forest/forest.ts
+++ b/experimental/dds/tree2/src/core/forest/forest.ts
@@ -95,10 +95,7 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 	/**
 	 * Set `cursorToMove` to location described by path.
 	 * This is NOT a relative move: current position is discarded.
-	 * Path must point to existing node. If a destination is not provided, the cursor
-	 * is moved to a special dummy node above the detached fields.
-	 * This dummy node can be used to read the detached fields,
-	 * but other operations (such as inspecting the dummy node's type or path) should not be relied upon.
+	 * Path must point to existing node.
 	 */
 	moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor): void;
 
@@ -106,10 +103,10 @@ export interface IForestSubscription extends Dependee, ISubscribable<ForestEvent
 	 * The cursor is moved to a special dummy node above the detached fields.
 	 * This dummy node can be used to read the detached fields,
 	 * but other operations (such as inspecting the dummy node's type or path) should not be relied upon.
-	 * As this method does not return a forest cursor and cannot be freed, the caller of this method must
-	 * use with caution and ensure that it is not used incorrectly.
+	 * While this method does not return an {@link ITreeSubscriptionCursor}, similar restrictions apply to its use:
+	 * the returned cursor must not used after any edits are made to the forest.
 	 */
-	getRootCursor(): ITreeCursorSynchronous;
+	getCursorAboveDetachedFields(): ITreeCursorSynchronous;
 
 	/**
 	 * True if there are no nodes in the forest at all.

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -26,6 +26,7 @@ import {
 	DeltaVisitor,
 	PlaceIndex,
 	Range,
+	ITreeCursorSynchronous,
 } from "../../core";
 import { assertValidRange, brand, fail, getOrAddEmptyToMap } from "../../util";
 import { createEmitter } from "../../events";
@@ -321,10 +322,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		return TreeNavigationResult.Ok;
 	}
 
-	public moveCursorToPath(
-		destination: UpPath | undefined,
-		cursorToMove: ITreeSubscriptionCursor,
-	): void {
+	public moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor): void {
 		assert(
 			cursorToMove instanceof Cursor,
 			0x53c /* ChunkedForest must only be given its own Cursor type */,
@@ -357,6 +355,12 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			cursorToMove.enterNode(indexStack.pop()!);
 		}
+	}
+
+	public getRootCursor(): ITreeCursorSynchronous {
+		const rootCursor = this.roots.cursor();
+		rootCursor.enterNode(0);
+		return rootCursor;
 	}
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -357,7 +357,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		}
 	}
 
-	public getRootCursor(): ITreeCursorSynchronous {
+	public getCursorAboveDetachedFields(): ITreeCursorSynchronous {
 		const rootCursor = this.roots.cursor();
 		rootCursor.enterNode(0);
 		return rootCursor;
@@ -449,6 +449,6 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
  */
-export function buildChunkedForest(chunker: IChunker, anchors?: AnchorSet): IEditableForest {
+export function buildChunkedForest(chunker: IChunker, anchors?: AnchorSet): ChunkedForest {
 	return new ChunkedForest(makeRoot(), chunker.schema, chunker, anchors);
 }

--- a/experimental/dds/tree2/src/feature-libraries/forestSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/forestSummarizer.ts
@@ -17,7 +17,6 @@ import {
 	Delta,
 	FieldKey,
 	IEditableForest,
-	ITreeSubscriptionCursor,
 	JsonableTree,
 	makeDetachedFieldIndex,
 	mapCursorField,
@@ -36,12 +35,7 @@ const treeBlobKey = "ForestTree";
  */
 export class ForestSummarizer implements Summarizable {
 	public readonly key = "Forest";
-
-	private readonly cursor: ITreeSubscriptionCursor;
-
-	public constructor(private readonly forest: IEditableForest) {
-		this.cursor = this.forest.allocateCursor();
-	}
+	public constructor(private readonly forest: IEditableForest) {}
 
 	/**
 	 * Synchronous monolithic summarization of tree content.
@@ -51,12 +45,11 @@ export class ForestSummarizer implements Summarizable {
 	 * @returns a snapshot of the forest's tree as a string.
 	 */
 	private getTreeString(stringify: SummaryElementStringifier): string {
-		this.forest.moveCursorToPath(undefined, this.cursor);
-		const fields = mapCursorFields(this.cursor, (cursor) => [
-			this.cursor.getFieldKey(),
+		const rootCursor = this.forest.getRootCursor();
+		const fields = mapCursorFields(rootCursor, (cursor) => [
+			rootCursor.getFieldKey(),
 			mapCursorField(cursor, jsonableTreeFromCursor),
 		]);
-		this.cursor.clear();
 		return stringify(fields);
 	}
 

--- a/experimental/dds/tree2/src/feature-libraries/forestSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/forestSummarizer.ts
@@ -45,7 +45,7 @@ export class ForestSummarizer implements Summarizable {
 	 * @returns a snapshot of the forest's tree as a string.
 	 */
 	private getTreeString(stringify: SummaryElementStringifier): string {
-		const rootCursor = this.forest.getRootCursor();
+		const rootCursor = this.forest.getCursorAboveDetachedFields();
 		const fields = mapCursorFields(rootCursor, (cursor) => [
 			rootCursor.getFieldKey(),
 			mapCursorField(cursor, jsonableTreeFromCursor),

--- a/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
@@ -322,7 +322,7 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		return;
 	}
 
-	public getRootCursor(): ITreeCursorSynchronous {
+	public getCursorAboveDetachedFields(): ITreeCursorSynchronous {
 		return singleMapTreeCursor(this.roots);
 	}
 }
@@ -510,6 +510,6 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
  */
-export function buildForest(anchors?: AnchorSet): IEditableForest {
+export function buildForest(anchors?: AnchorSet): ObjectForest {
 	return new ObjectForest(anchors);
 }

--- a/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
+++ b/experimental/dds/tree2/src/feature-libraries/object-forest/objectForest.ts
@@ -31,6 +31,7 @@ import {
 	Range,
 	PlaceIndex,
 	Value,
+	ITreeCursorSynchronous,
 } from "../../core";
 import {
 	brand,
@@ -319,6 +320,10 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		}
 
 		return;
+	}
+
+	public getRootCursor(): ITreeCursorSynchronous {
+		return singleMapTreeCursor(this.roots);
 	}
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -17,17 +17,9 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
 
-import {
-	initializeForest,
-	InMemoryStoredSchemaRepository,
-	rootFieldKey,
-	StoredSchemaRepository,
-	UpPath,
-} from "../../../core";
+import { StoredSchemaRepository } from "../../../core";
 import { defaultSchemaPolicy } from "../../../feature-libraries";
 import { testForest } from "../../forestTestSuite";
-import { jsonRoot, jsonSchema, SchemaBuilder, singleJsonCursor } from "../../../domains";
-import { expectEqualPaths } from "../../utils";
 
 const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
 	[
@@ -86,11 +78,6 @@ const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
 	],
 ];
 
-const jsonDocumentSchema = new SchemaBuilder({
-	scope: "jsonDocumentSchema",
-	libraries: [jsonSchema],
-}).intoSchema(SchemaBuilder.sequence(jsonRoot));
-
 describe("ChunkedForest", () => {
 	for (const [name, chunker] of chunkers) {
 		describe(name, () => {
@@ -98,20 +85,6 @@ describe("ChunkedForest", () => {
 				suiteName: "ChunkedForest forest suite",
 				factory: (schema) => buildChunkedForest(chunker(schema)),
 				skipCursorErrorCheck: true,
-			});
-
-			it("getCursorAboveDetachedFields", () => {
-				const forest = buildChunkedForest(
-					chunker(new InMemoryStoredSchemaRepository(jsonDocumentSchema)),
-				);
-				initializeForest(forest, [singleJsonCursor([1, 2])]);
-				const cursor = forest.getCursorAboveDetachedFields();
-				const expectedPath: UpPath = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
-				expectEqualPaths(cursor.getPath(), expectedPath);
 			});
 		});
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -4,8 +4,6 @@
  */
 
 // Allow importing from this specific file which is being tested:
-/* eslint-disable-next-line import/no-internal-modules */
-import { strict as assert } from "assert";
 // eslint-disable-next-line import/no-internal-modules
 import { buildChunkedForest } from "../../../feature-libraries/chunked-forest/chunkedForest";
 import {
@@ -29,6 +27,7 @@ import {
 import { defaultSchemaPolicy } from "../../../feature-libraries";
 import { testForest } from "../../forestTestSuite";
 import { jsonRoot, jsonSchema, SchemaBuilder, singleJsonCursor } from "../../../domains";
+import { expectEqualPaths } from "../../utils";
 
 const chunkers: [string, (schema: StoredSchemaRepository) => IChunker][] = [
 	[
@@ -100,24 +99,6 @@ describe("ChunkedForest", () => {
 				factory: (schema) => buildChunkedForest(chunker(schema)),
 				skipCursorErrorCheck: true,
 			});
-			describe("moveCursorToPath", () => {
-				it("moves cursor to specified path.", () => {
-					const forest = buildChunkedForest(
-						chunker(new InMemoryStoredSchemaRepository(jsonDocumentSchema)),
-					);
-					initializeForest(forest, [singleJsonCursor([1, 2])]);
-
-					const cursor = forest.allocateCursor();
-					const path: UpPath = {
-						parent: undefined,
-						parentField: rootFieldKey,
-						parentIndex: 0,
-					};
-
-					forest.moveCursorToPath(path, cursor);
-					assert.deepEqual(path, cursor.getPath());
-				});
-			});
 
 			it("getCursorAboveDetachedFields", () => {
 				const forest = buildChunkedForest(
@@ -130,7 +111,7 @@ describe("ChunkedForest", () => {
 					parentField: rootFieldKey,
 					parentIndex: 0,
 				};
-				assert.deepEqual(cursor.getPath(), expectedPath);
+				expectEqualPaths(cursor.getPath(), expectedPath);
 			});
 		});
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
@@ -14,7 +14,7 @@ import { JsonCompatible, brand } from "../../util";
 
 import { testForest } from "../forestTestSuite";
 import { singleJsonCursor } from "../../domains";
-import { jsonableTreeFromCursor, singleMapTreeCursor } from "../../feature-libraries";
+import { singleMapTreeCursor } from "../../feature-libraries";
 
 describe("object-forest", () => {
 	testForest({
@@ -86,13 +86,5 @@ describe("object-forest", () => {
 		const cursor = forest.allocateCursor();
 		forest.moveCursorToPath(undefined, cursor);
 		assert.deepEqual(cursor.getFieldKey(), singleMapTreeCursor(forest.roots).getFieldKey());
-	});
-
-	it("getCursorAboveDetachedFields", () => {
-		const forest = buildForest();
-		initializeForest(forest, [singleJsonCursor([1, 2])]);
-		const cursor = forest.getCursorAboveDetachedFields();
-		const expected = jsonableTreeFromCursor(singleMapTreeCursor(forest.roots));
-		assert.deepEqual(jsonableTreeFromCursor(cursor), expected);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
@@ -9,7 +9,7 @@ import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { buildForest } from "../../feature-libraries/object-forest";
-import { FieldKey, UpPath, initializeForest, rootFieldKey } from "../../core";
+import { FieldKey, initializeForest, rootFieldKey } from "../../core";
 import { JsonCompatible, brand } from "../../util";
 
 import { testForest } from "../forestTestSuite";
@@ -80,34 +80,18 @@ describe("object-forest", () => {
 		});
 	});
 
-	describe("moveCursorToPath", () => {
-		it("moves cursor to specified path.", () => {
-			const forest = buildForest();
-			initializeForest(forest, [singleJsonCursor([1, 2])]);
-
-			const cursor = forest.allocateCursor();
-			const path: UpPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			forest.moveCursorToPath(path, cursor);
-			assert.deepEqual(path, cursor.getPath());
-		});
-		it("undefined path points to dummy node above detachedFields.", () => {
-			const forest = buildForest();
-			initializeForest(forest, [singleJsonCursor([1, 2])]);
-			const cursor = forest.allocateCursor();
-			forest.moveCursorToPath(undefined, cursor);
-			assert.deepEqual(cursor.getFieldKey(), singleMapTreeCursor(forest.roots).getFieldKey());
-		});
+	it("moveCursorToPath with an undefined path points to dummy node above detachedFields.", () => {
+		const forest = buildForest();
+		initializeForest(forest, [singleJsonCursor([1, 2])]);
+		const cursor = forest.allocateCursor();
+		forest.moveCursorToPath(undefined, cursor);
+		assert.deepEqual(cursor.getFieldKey(), singleMapTreeCursor(forest.roots).getFieldKey());
 	});
 
 	it("getCursorAboveDetachedFields", () => {
 		const forest = buildForest();
 		initializeForest(forest, [singleJsonCursor([1, 2])]);
 		const cursor = forest.getCursorAboveDetachedFields();
-		assert.deepEqual(cursor.getFieldKey(), singleMapTreeCursor(forest.roots).getFieldKey());
+		assert.deepEqual(cursor, singleMapTreeCursor(forest.roots));
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
@@ -15,7 +15,6 @@ import { JsonCompatible, brand } from "../../util";
 import { testForest } from "../forestTestSuite";
 import { singleJsonCursor } from "../../domains";
 import { jsonableTreeFromCursor, singleMapTreeCursor } from "../../feature-libraries";
-import { toJsonableTree } from "../utils";
 
 describe("object-forest", () => {
 	testForest({

--- a/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
@@ -14,7 +14,8 @@ import { JsonCompatible, brand } from "../../util";
 
 import { testForest } from "../forestTestSuite";
 import { singleJsonCursor } from "../../domains";
-import { singleMapTreeCursor } from "../../feature-libraries";
+import { jsonableTreeFromCursor, singleMapTreeCursor } from "../../feature-libraries";
+import { toJsonableTree } from "../utils";
 
 describe("object-forest", () => {
 	testForest({
@@ -92,6 +93,7 @@ describe("object-forest", () => {
 		const forest = buildForest();
 		initializeForest(forest, [singleJsonCursor([1, 2])]);
 		const cursor = forest.getCursorAboveDetachedFields();
-		assert.deepEqual(cursor, singleMapTreeCursor(forest.roots));
+		const expected = jsonableTreeFromCursor(singleMapTreeCursor(forest.roots));
+		assert.deepEqual(jsonableTreeFromCursor(cursor), expected);
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/objectForest.spec.ts
@@ -9,11 +9,12 @@ import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { buildForest } from "../../feature-libraries/object-forest";
-import { FieldKey, initializeForest, rootFieldKey } from "../../core";
+import { FieldKey, UpPath, initializeForest, rootFieldKey } from "../../core";
 import { JsonCompatible, brand } from "../../util";
 
 import { testForest } from "../forestTestSuite";
 import { singleJsonCursor } from "../../domains";
+import { singleMapTreeCursor } from "../../feature-libraries";
 
 describe("object-forest", () => {
 	testForest({
@@ -77,5 +78,36 @@ describe("object-forest", () => {
 			visitor.exitField(rootFieldKey);
 			visitor.free();
 		});
+	});
+
+	describe("moveCursorToPath", () => {
+		it("moves cursor to specified path.", () => {
+			const forest = buildForest();
+			initializeForest(forest, [singleJsonCursor([1, 2])]);
+
+			const cursor = forest.allocateCursor();
+			const path: UpPath = {
+				parent: undefined,
+				parentField: rootFieldKey,
+				parentIndex: 0,
+			};
+
+			forest.moveCursorToPath(path, cursor);
+			assert.deepEqual(path, cursor.getPath());
+		});
+		it("undefined path points to dummy node above detachedFields.", () => {
+			const forest = buildForest();
+			initializeForest(forest, [singleJsonCursor([1, 2])]);
+			const cursor = forest.allocateCursor();
+			forest.moveCursorToPath(undefined, cursor);
+			assert.deepEqual(cursor.getFieldKey(), singleMapTreeCursor(forest.roots).getFieldKey());
+		});
+	});
+
+	it("getCursorAboveDetachedFields", () => {
+		const forest = buildForest();
+		initializeForest(forest, [singleJsonCursor([1, 2])]);
+		const cursor = forest.getCursorAboveDetachedFields();
+		assert.deepEqual(cursor.getFieldKey(), singleMapTreeCursor(forest.roots).getFieldKey());
 	});
 });

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -273,6 +273,20 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 		});
 
+		it("getCursorAboveDetachedFields", () => {
+			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
+			initializeForest(forest, [singleJsonCursor([1, 2])]);
+
+			const forestCursor = forest.allocateCursor();
+			moveToDetachedField(forest, forestCursor);
+			const expected = mapCursorField(forestCursor, jsonableTreeFromCursor);
+
+			const cursor = forest.getCursorAboveDetachedFields();
+			cursor.enterField(rootFieldKey);
+			const actual = mapCursorField(cursor, jsonableTreeFromCursor);
+			assert.deepEqual(actual, expected);
+		});
+
 		it("anchors creation and use", () => {
 			const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
 			initializeForest(forest, [singleJsonCursor([1, 2])]);

--- a/experimental/dds/tree2/src/test/forestTestSuite.ts
+++ b/experimental/dds/tree2/src/test/forestTestSuite.ts
@@ -46,6 +46,7 @@ import {
 	MockDependent,
 	applyTestDelta,
 	expectEqualFieldPaths,
+	expectEqualPaths,
 	jsonSequenceRootSchema,
 } from "./utils";
 import { testGeneralPurposeTreeCursor, testTreeSchema } from "./cursorTestSuite";
@@ -253,6 +254,23 @@ export function testForest(config: ForestTestConfiguration): void {
 				TreeNavigationResult.Ok,
 			);
 			expectEqualFieldPaths(cursor.getFieldPath(), childPath);
+		});
+
+		describe("moveCursorToPath", () => {
+			it("moves cursor to specified path.", () => {
+				const forest = factory(new InMemoryStoredSchemaRepository(jsonDocumentSchema));
+				initializeForest(forest, [singleJsonCursor([1, 2])]);
+
+				const cursor = forest.allocateCursor();
+				const path: UpPath = {
+					parent: undefined,
+					parentField: rootFieldKey,
+					parentIndex: 0,
+				};
+
+				forest.moveCursorToPath(path, cursor);
+				expectEqualPaths(path, cursor.getPath());
+			});
 		});
 
 		it("anchors creation and use", () => {

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -6,7 +6,6 @@
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { brand } from "../../util";
 import {
-	ForestType,
 	ISharedTree,
 	ISharedTreeView,
 	InitializeAndSchematizeConfiguration,
@@ -27,10 +26,7 @@ import {
 import { AllowedUpdateType, FieldKey, JsonableTree, UpPath, rootFieldKey } from "../../core";
 import { leaf, SchemaBuilder } from "../../domains";
 
-const factory = new SharedTreeFactory({
-	jsonValidator: typeboxValidator,
-	forest: ForestType.Optimized,
-});
+const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
 
 const builder = new SchemaBuilder({ scope: "test trees" });
 const rootNodeSchema = builder.map("TestInner", SchemaBuilder.sequence(Any));

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -6,6 +6,7 @@
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { brand } from "../../util";
 import {
+	ForestType,
 	ISharedTree,
 	ISharedTreeView,
 	InitializeAndSchematizeConfiguration,
@@ -26,7 +27,10 @@ import {
 import { AllowedUpdateType, FieldKey, JsonableTree, UpPath, rootFieldKey } from "../../core";
 import { leaf, SchemaBuilder } from "../../domains";
 
-const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
+const factory = new SharedTreeFactory({
+	jsonValidator: typeboxValidator,
+	forest: ForestType.Optimized,
+});
 
 const builder = new SchemaBuilder({ scope: "test trees" });
 const rootNodeSchema = builder.map("TestInner", SchemaBuilder.sequence(Any));


### PR DESCRIPTION
## Description

This PR fixes a bug with an edge case with the use of `moveCursorToPath` in `forestSummarizer.ts`, where when passing the path as `undefined` through this method in chunked forest, the cursor is just cleared (whereas in object forest, it is set to the roots' cursor).

This PR introduces a new method `getCursorAboveDetachedFields`, which returns the cursor at the first node of the chunked forest's roots.