### PR TITLE
PropertyDDS: Summary generation Bug Fix

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
+++ b/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
@@ -223,7 +223,7 @@ export class SharedPropertyTree extends SharedObject {
     // (undocumented)
     propertyTreeConfig: IPropertyTreeConfig;
     // (undocumented)
-    static prune(minimumSequenceNumber: number, remoteChanges: IPropertyTreeMessage[], unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>): {
+    static prune(minimumSequenceNumber: number, remoteChanges: IPropertyTreeMessage[], unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>, remoteHeadGuid: string): {
         remoteChanges: IPropertyTreeMessage[];
         unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>;
         prunedCount: number;

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -127,15 +127,6 @@ describe("PropertyDDS summarizer", () => {
 		} = await getClient(true);
 		await objProvider.ensureSynchronized();
 
-		// Test debugging code
-		// container.deltaManager.inbound.on("op", (task: any) => {
-		//     console.info(task);
-		// });
-
-		// container.deltaManager.outbound.on("op", (task: any) => {
-		//     console.info(task);
-		// });
-
 		// 2- Insert array with u1 as user
 		u1.root.insert(USERS, PropertyFactory.create("NodeProperty", "array"));
 		u1.commit();
@@ -160,25 +151,11 @@ describe("PropertyDDS summarizer", () => {
 		// updates are triggered that do not affect the propertyDDS
 		dataObject1.root.set("c2", "aaa");
 		dataObject2.root.set("c2", "aaa");
+		await objProvider.ensureSynchronized();
 
 		// Now we wait until the msn has sufficiently advanced that the pruning below
 		// will remove all remoteChanges
-		const expectedSequenceNumber = container2.deltaManager.lastSequenceNumber;
-		await new Promise((resolve) => {
-			const waitForMSN = () => {
-				if (
-					container1.deltaManager.minimumSequenceNumber >= expectedSequenceNumber &&
-					container2.deltaManager.minimumSequenceNumber >= expectedSequenceNumber
-				) {
-					resolve(undefined);
-				}
-
-				void objProvider.ensureSynchronized().then((x) => {
-					setTimeout(waitForMSN, 5);
-				});
-			};
-			waitForMSN();
-		});
+		await synchronizeMSN(container2, container1);
 
 		// Summarize
 		await summarizeNow(summarizer.summarizer);
@@ -196,6 +173,102 @@ describe("PropertyDDS summarizer", () => {
 
 		expect(u1.root.get<ArrayProperty>(USERS)?.getValues().length).to.equal(1);
 	});
+
+	it("Scenario 2 (repeated summarization)", async function () {
+		/**
+		 * This test produces a scenario where we have an empty remoteChanges array in the summarizer client
+		 * and then get more changes that cannot yet be pruned away, because the MSN continues to point to the
+		 * previous head commit.
+		 *
+		 * We used to have a bug that was caused by this, where the prune code would prune the remote changes
+		 * but not the unrebased remote changes, causing rebase errors.
+		 */
+		this.timeout(30000);
+
+		// 1- U1 joins together with summarizer
+		const {
+			client: u1,
+			summarizer,
+			dataObject: dataObject1,
+			container: container1,
+		} = await getClient(true);
+		await objProvider.ensureSynchronized();
+
+		// 2- Make some modifications
+		u1.root.insert("c1", PropertyFactory.create("NodeProperty"));
+		u1.commit();
+		await objProvider.ensureSynchronized();
+
+		u1.root.insert("c2", PropertyFactory.create("NodeProperty"));
+		u1.commit();
+
+		await objProvider.ensureSynchronized();
+
+		const {
+			client: u2,
+			dataObject: dataObject2,
+			container: container2,
+		} = await getClient(false, true);
+		await objProvider.ensureSynchronized();
+
+		// We do two changes to a different DDS (the root map), to make sure, that
+		// updates are triggered that do not affect the propertyDDS
+		dataObject1.root.set("c2", "aaa");
+		dataObject2.root.set("c2", "aaa");
+		await objProvider.ensureSynchronized();
+
+		// Now we wait until the msn has sufficiently advanced that the pruning below
+		// will remove all remoteChanges
+		await synchronizeMSN(container2, container1);
+
+		// Summarize
+		await summarizeNow(summarizer.summarizer);
+
+		const summarizerDataObject = await requestFluidObject<ITestFluidObject>(
+			summarizer.container,
+			"/",
+		);
+		const summarizerClient =
+			await summarizerDataObject.getSharedObject<SharedPropertyTree>(propertyDdsId);
+
+		// Make changes only on u1, u2 must not advance to make sure
+		// the msn is not advanced
+		u1.root.insert("a", PropertyFactory.create("NodeProperty"));
+		u1.commit();
+
+		u1.root.insert("b", PropertyFactory.create("NodeProperty"));
+		u1.commit();
+
+		await objProvider.opProcessingController.processOutgoing(container1);
+		await objProvider.opProcessingController.processIncoming(container1);
+
+		// Summarize again
+		await summarizeNow(summarizer.summarizer);
+
+		// Make sure the summarizer did not delete any of the unrebased changes
+		expect(summarizerClient.remoteChanges.length).to.equal(2);
+		expect(Object.keys(summarizerClient.unrebasedRemoteChanges).length).to.equal(2);
+	});
+
+	async function synchronizeMSN(container2: IContainer, container1: IContainer) {
+		const expectedSequenceNumber = container2.deltaManager.lastSequenceNumber;
+		await new Promise((resolve) => {
+			const waitForMSN = () => {
+				if (
+					container1.deltaManager.minimumSequenceNumber >= expectedSequenceNumber &&
+					container2.deltaManager.minimumSequenceNumber >= expectedSequenceNumber
+				) {
+					resolve(undefined);
+					return;
+				}
+
+				void objProvider.ensureSynchronized().then((x) => {
+					setTimeout(waitForMSN, 5);
+				});
+			};
+			waitForMSN();
+		});
+	}
 });
 
 describe("PropertyTree", () => {

--- a/experimental/PropertyDDS/packages/property-dds/src/test/prune.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/prune.spec.ts
@@ -55,6 +55,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 
 			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
@@ -102,6 +103,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 			expect(prundedData.prunedCount).to.equal(0);
 			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
@@ -162,6 +164,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 			expect(prundedData.prunedCount).to.equal(0);
 			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
@@ -209,6 +212,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(1);
@@ -269,6 +273,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(1);
@@ -339,6 +344,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(3);
@@ -409,6 +415,7 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(0);
@@ -448,11 +455,70 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
+				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(0);
 			expect(prundedData.remoteChanges.length).to.be.equal(1);
 			expect(Object.keys(prundedData.unrebasedRemoteChanges).length).to.equal(1);
+		});
+		it("Prune does nothing if unrebased changes point to remote head that is not in the remote changes", () => {
+			/**
+			 * REMOTE CHANGES:      (remoteHead X) - (A,0) - (B,1)
+			 * UNREBASED CHANGES:                 \- (A,0) - (B,1)
+			 * minimum sequence number: 0
+			 */
+			const msn = 0;
+			const remoteChanges: IPropertyTreeMessage[] = [
+				{
+					op: OpKind.ChangeSet,
+					metadata: {},
+					changeSet: {},
+					guid: "A",
+					referenceGuid: "X",
+					remoteHeadGuid: "X",
+					localBranchStart: undefined,
+				},
+				{
+					op: OpKind.ChangeSet,
+					metadata: {},
+					changeSet: {},
+					guid: "B",
+					referenceGuid: "A",
+					remoteHeadGuid: "X",
+					localBranchStart: undefined,
+				},
+			];
+			const unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage> = {};
+			unrebasedRemoteChanges.A = {
+				op: OpKind.ChangeSet,
+				metadata: {},
+				changeSet: {},
+				guid: "A",
+				referenceGuid: "X",
+				remoteHeadGuid: "X",
+				localBranchStart: undefined,
+				sequenceNumber: 2,
+			};
+			unrebasedRemoteChanges.B = {
+				op: OpKind.ChangeSet,
+				metadata: {},
+				changeSet: {},
+				guid: "B",
+				referenceGuid: "A",
+				remoteHeadGuid: "X",
+				localBranchStart: undefined,
+				sequenceNumber: 2,
+			};
+			const prundedData = SharedPropertyTree.prune(
+				msn,
+				remoteChanges,
+				unrebasedRemoteChanges,
+				"X",
+			);
+
+			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
+			expect(unrebasedRemoteChanges).to.deep.equal(prundedData.unrebasedRemoteChanges);
 		});
 	});
 });


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description
This PR fixes a bug that resulted in the prune algorithm in PropertyDDS to prune remoteChanges but keep the associated unrebasedChanges when generating a summary. This could later result in rebase errors for clients that would join using this summary as a starting point.

The problem would occur, when a summarizer has several remote changes in its history, but the MSN points to a state before the first of these changes. In that case, none of those can yet be removed, but the old implementation would incorrectly handle this case and remove the remote change, but keep the unrebasedChanges.

## Breaking Changes

This change only affects the summarizer and thus will not cause any incompatibility between clients with different versions.
