### PR TITLE
Increase tree2 merge benchmark test timeout

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
@@ -385,7 +385,7 @@ describe("SharedTree benchmarks", () => {
 				},
 				// Force batch size of 1
 				minBatchDurationSeconds: 0,
-			});
+			}).timeout(5000);
 		}
 	});
 });


### PR DESCRIPTION
## Description

This test is close to the 2s timeout on the highest setting as evidenced by the test stability pipeline.
