### PR TITLE
Add try-catch block for resources.dispose call

### DIFF
--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -75,8 +75,12 @@ export async function run<T extends IResources>(
 		// Wait for the runner to complete
 		await runningP;
 	} finally {
-		// And then dispose of any resources
-		await resources.dispose();
+		try {
+			// And then dispose of any resources
+			await resources.dispose();
+		} catch (err) {
+			Lumberjack.error(`Could not dispose the resources due to error`, undefined, err);
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

An exception during resources.dispose() call is caught by runService method and shows up in the RunService restart logs, making it look like the exception that caused the restart. Whereas, the exception happened during the restart process (and not the reason for causing the restart).

Hence adding a try-catch block to swallow and log such errors, to avoid bubbling up to the RunService metric.