### PR TITLE
tidy(tree2): avoid creating ST/View outside of test execution

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { LeafSchema, TreeSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
 import { TreeValue } from "../../../core";
-import { createTreeView, itWithRoot, makeSchema, pretty } from "./utils";
+import { itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
 	initialTree: object;
@@ -38,14 +38,14 @@ function testObjectLike(testCases: TestCase[]) {
 	describe("Object-like", () => {
 		describe("satisfies 'deepEquals'", () => {
 			for (const { schema, initialTree } of testCases) {
-				const view = createTreeView(schema, initialTree);
-				const real = initialTree;
-				const proxy = view.root2(schema);
-
-				// We do not use 'itWithRoot()' so we can pretty-print the 'proxy' in the test title.
-				it(`deepEquals(${pretty(proxy)}, ${pretty(real)})`, () => {
-					assert.deepEqual(proxy, real, "Proxy must satisfy 'deepEquals'.");
-				});
+				itWithRoot(
+					`deepEquals(${pretty(initialTree)}, ${pretty(initialTree)})`,
+					schema,
+					initialTree,
+					(proxy) => {
+						assert.deepEqual(proxy, initialTree, "Proxy must satisfy 'deepEquals'.");
+					},
+				);
 			}
 		});
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { createTreeView, pretty } from "./utils";
+import { itWithRoot, pretty } from "./utils";
 
 const _ = new SchemaBuilder({ scope: "test", libraries: [leaf.library] });
 const schema = _.intoSchema(_.optional(leaf.all));
@@ -43,14 +43,15 @@ const testCases = [
 // a tree with an 'undefined' root.
 describe("Primitives", () => {
 	describe("satisfy 'deepEquals'", () => {
-		for (const testCase of testCases) {
-			const view = createTreeView(schema, testCase);
-			const real = testCase;
-			const proxy = view.root2(schema);
-
-			it(`deepEquals(${pretty(proxy)}, ${pretty(real)})`, () => {
-				assert.deepEqual(proxy, real, "Proxy must satisfy 'deepEquals'.");
-			});
+		for (const initialTree of testCases) {
+			itWithRoot(
+				`deepEquals(${pretty(initialTree)}, ${pretty(initialTree)})`,
+				schema,
+				initialTree,
+				(proxy) => {
+					assert.deepEqual(proxy, initialTree, "Proxy must satisfy 'deepEquals'.");
+				},
+			);
 		}
 	});
 });


### PR DESCRIPTION
Consistently uses the 'itWithRoot(..)' which avoids constructing the SharedTree/SharedTreeView outside of the it(..) callback function.  This will also make it easier to replace full ST/STV construction with lighter-weight mocks in the future (if desired.)