### PR TITLE
Update dev tool to use newer APIs for tree2

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -224,6 +224,9 @@ export interface BindTree<T = BindTreeDefault> extends PathStep {
 export type BindTreeDefault = BindTree;
 
 // @alpha
+export const boxedIterator: unique symbol;
+
+// @alpha
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -25,7 +25,8 @@ import { FieldKind } from "../modular-schema";
 import { TreeContext } from "./context";
 
 /**
- * Allows boxed iteration of a tree/field
+ * Allows boxed iteration of a trees.
+ * @alpha
  */
 export const boxedIterator = Symbol();
 

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -290,6 +290,7 @@ export {
 	FactoryTreeSchema,
 	treeSchemaFromStoredSchema,
 	encodeTreeSchema,
+	boxedIterator,
 } from "./feature-libraries";
 
 export {


### PR DESCRIPTION
## Description

Fixes that tree2 forgot to export boxedIterator.

Updates dev tool to not use deprecated SharedTree.view.

Update dev tool to use editable tree 2 instead of editable tree 1.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Its unclear exactly how the dev tool needs to be updated for the change to the new editable tree, since the code that handles it isn't strongly typed.