### PR TITLE
Simplify tree visualizer

### DIFF
--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -13,12 +13,7 @@ import { SharedCounter } from "@fluidframework/counter";
 import { type IDirectory, SharedDirectory, SharedMap } from "@fluidframework/map";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { SharedString } from "@fluidframework/sequence";
-import {
-	SharedTreeFactory,
-	type ISharedTree,
-	type UntypedTree,
-	type UntypedField,
-} from "@fluid-experimental/tree2";
+import { SharedTreeFactory, type ISharedTree } from "@fluid-experimental/tree2";
 import { type ISharedObject } from "@fluidframework/shared-object-base";
 import { EditType } from "../CommonInterfaces";
 import { type VisualizeChildData, type VisualizeSharedObject } from "./DataVisualization";
@@ -247,29 +242,14 @@ export const visualizeSharedTree: VisualizeSharedObject = async (
 	visualizeChildData: VisualizeChildData,
 ): Promise<FluidObjectTreeNode> => {
 	const sharedTree = sharedObject as ISharedTree;
-
-	const contextRoot = sharedTree.view.context.root;
-	const children: Record<string, VisualChildNode> = {};
-
-	const iterateNodes = async (field: UntypedField): Promise<void> => {
-		for (const child of field) {
-			await iterateFields(child as unknown as UntypedTree);
-		}
-	};
-
-	const iterateFields = async (node: UntypedTree): Promise<void> => {
-		for (const field of node) {
-			const renderedChild = await visualizeChildData(field);
-
-			children[field.fieldKey as string] = renderedChild;
-		}
-	};
-
-	await iterateNodes(contextRoot);
+	const content = sharedTree.contentSnapshot();
 
 	return {
 		fluidObjectId: sharedTree.id,
-		children,
+		children: {
+			tree: await visualizeChildData(content.tree),
+			schema: await visualizeChildData(content.schema),
+		},
 		typeMetadata: "SharedTree",
 		nodeKind: VisualNodeKind.FluidTreeNode,
 	};

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -13,7 +13,7 @@ import { SharedCounter } from "@fluidframework/counter";
 import { type IDirectory, SharedDirectory, SharedMap } from "@fluidframework/map";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { SharedString } from "@fluidframework/sequence";
-import { SharedTreeFactory, type ISharedTree } from "@fluid-experimental/tree2";
+import { SharedTreeFactory, type ISharedTree, encodeTreeSchema } from "@fluid-experimental/tree2";
 import { type ISharedObject } from "@fluidframework/shared-object-base";
 import { EditType } from "../CommonInterfaces";
 import { type VisualizeChildData, type VisualizeSharedObject } from "./DataVisualization";
@@ -248,7 +248,7 @@ export const visualizeSharedTree: VisualizeSharedObject = async (
 		fluidObjectId: sharedTree.id,
 		children: {
 			tree: await visualizeChildData(content.tree),
-			schema: await visualizeChildData(content.schema),
+			schema: await visualizeChildData(encodeTreeSchema(content.schema)),
 		},
 		typeMetadata: "SharedTree",
 		nodeKind: VisualNodeKind.FluidTreeNode,

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -457,75 +457,688 @@ describe("DefaultVisualizers unit tests", () => {
 			visualizeChildData,
 		);
 
+		// TODO: this should probably:
+		// 1. Use a more maintainable approach (like comparing json snapshot files on disk with an automated way to update them).
+		// 2. Use a more concise format.
+		// 3. Use a smaller test tree with a simpler schema.
 		const expected: FluidObjectTreeNode = {
-			typeMetadata: "SharedTree",
-			nodeKind: VisualNodeKind.FluidTreeNode,
 			fluidObjectId: "test",
 			children: {
-				childrenOne: {
-					nodeKind: VisualNodeKind.TreeNode,
-					typeMetadata: "object",
+				tree: {
 					children: {
 						"0": {
-							nodeKind: VisualNodeKind.TreeNode,
-							typeMetadata: "object",
 							children: {
-								childField: {
-									nodeKind: VisualNodeKind.ValueNode,
+								type: {
+									value: "DefaultVisualizer_SharedTree_Test.root-item",
 									typeMetadata: "string",
-									value: "Hello world!",
+									nodeKind: VisualNodeKind.ValueNode,
 								},
-								childData: {
-									nodeKind: VisualNodeKind.TreeNode,
-									typeMetadata: "object",
+								fields: {
 									children: {
-										leafField: {
-											nodeKind: VisualNodeKind.ValueNode,
-											typeMetadata: "string",
-											value: "Hello world again!",
+										childrenTwo: {
+											children: {
+												"0": {
+													children: {
+														type: {
+															value: "com.fluidframework.leaf.number",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														value: {
+															value: 32,
+															typeMetadata: "number",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+											},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+										childrenOne: {
+											children: {
+												"0": {
+													children: {
+														type: {
+															value: "DefaultVisualizer_SharedTree_Test.child-item",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														fields: {
+															children: {
+																childField: {
+																	children: {
+																		"0": {
+																			children: {
+																				type: {
+																					value: "com.fluidframework.leaf.string",
+																					typeMetadata:
+																						"string",
+																					nodeKind:
+																						VisualNodeKind.ValueNode,
+																				},
+																				value: {
+																					value: "Hello world!",
+																					typeMetadata:
+																						"string",
+																					nodeKind:
+																						VisualNodeKind.ValueNode,
+																				},
+																			},
+																			nodeKind:
+																				VisualNodeKind.TreeNode,
+																			typeMetadata: "object",
+																		},
+																	},
+																	nodeKind:
+																		VisualNodeKind.TreeNode,
+																	typeMetadata: "object",
+																},
+																childData: {
+																	children: {
+																		"0": {
+																			children: {
+																				type: {
+																					value: "DefaultVisualizer_SharedTree_Test.leaf-item",
+																					typeMetadata:
+																						"string",
+																					nodeKind:
+																						VisualNodeKind.ValueNode,
+																				},
+																				fields: {
+																					children: {
+																						leafField: {
+																							children:
+																								{
+																									"0": {
+																										children:
+																											{
+																												type: {
+																													value: "com.fluidframework.leaf.string",
+																													typeMetadata:
+																														"string",
+																													nodeKind:
+																														VisualNodeKind.ValueNode,
+																												},
+																												value: {
+																													value: "Hello world again!",
+																													typeMetadata:
+																														"string",
+																													nodeKind:
+																														VisualNodeKind.ValueNode,
+																												},
+																											},
+																										nodeKind:
+																											VisualNodeKind.TreeNode,
+																										typeMetadata:
+																											"object",
+																									},
+																								},
+																							nodeKind:
+																								VisualNodeKind.TreeNode,
+																							typeMetadata:
+																								"object",
+																						},
+																					},
+																					nodeKind:
+																						VisualNodeKind.TreeNode,
+																					typeMetadata:
+																						"object",
+																				},
+																			},
+																			nodeKind:
+																				VisualNodeKind.TreeNode,
+																			typeMetadata: "object",
+																		},
+																	},
+																	nodeKind:
+																		VisualNodeKind.TreeNode,
+																	typeMetadata: "object",
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+												"1": {
+													children: {
+														type: {
+															value: "DefaultVisualizer_SharedTree_Test.child-item",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														fields: {
+															children: {
+																childField: {
+																	children: {
+																		"0": {
+																			children: {
+																				type: {
+																					value: "com.fluidframework.leaf.boolean",
+																					typeMetadata:
+																						"string",
+																					nodeKind:
+																						VisualNodeKind.ValueNode,
+																				},
+																				value: {
+																					value: true,
+																					typeMetadata:
+																						"boolean",
+																					nodeKind:
+																						VisualNodeKind.ValueNode,
+																				},
+																			},
+																			nodeKind:
+																				VisualNodeKind.TreeNode,
+																			typeMetadata: "object",
+																		},
+																	},
+																	nodeKind:
+																		VisualNodeKind.TreeNode,
+																	typeMetadata: "object",
+																},
+																childData: {
+																	children: {
+																		"0": {
+																			children: {
+																				type: {
+																					value: "DefaultVisualizer_SharedTree_Test.leaf-item",
+																					typeMetadata:
+																						"string",
+																					nodeKind:
+																						VisualNodeKind.ValueNode,
+																				},
+																				fields: {
+																					children: {
+																						leafField: {
+																							children:
+																								{
+																									"0": {
+																										children:
+																											{
+																												type: {
+																													value: "com.fluidframework.leaf.boolean",
+																													typeMetadata:
+																														"string",
+																													nodeKind:
+																														VisualNodeKind.ValueNode,
+																												},
+																												value: {
+																													value: false,
+																													typeMetadata:
+																														"boolean",
+																													nodeKind:
+																														VisualNodeKind.ValueNode,
+																												},
+																											},
+																										nodeKind:
+																											VisualNodeKind.TreeNode,
+																										typeMetadata:
+																											"object",
+																									},
+																								},
+																							nodeKind:
+																								VisualNodeKind.TreeNode,
+																							typeMetadata:
+																								"object",
+																						},
+																					},
+																					nodeKind:
+																						VisualNodeKind.TreeNode,
+																					typeMetadata:
+																						"object",
+																				},
+																			},
+																			nodeKind:
+																				VisualNodeKind.TreeNode,
+																			typeMetadata: "object",
+																		},
+																	},
+																	nodeKind:
+																		VisualNodeKind.TreeNode,
+																	typeMetadata: "object",
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+											},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
 										},
 									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
 								},
 							},
-						},
-						"1": {
 							nodeKind: VisualNodeKind.TreeNode,
 							typeMetadata: "object",
-							children: {
-								childField: {
-									nodeKind: VisualNodeKind.ValueNode,
-									typeMetadata: "boolean",
-									value: true,
-								},
-								childData: {
-									nodeKind: VisualNodeKind.TreeNode,
-									typeMetadata: "object",
-									children: {
-										leafField: {
-											nodeKind: VisualNodeKind.ValueNode,
-											typeMetadata: "boolean",
-											value: false,
-										},
-									},
-								},
-							},
 						},
 					},
-				},
-				childrenTwo: {
 					nodeKind: VisualNodeKind.TreeNode,
 					typeMetadata: "object",
+				},
+				schema: {
 					children: {
-						"0": {
+						version: {
+							value: "1.0.0",
+							typeMetadata: "string",
 							nodeKind: VisualNodeKind.ValueNode,
-							typeMetadata: "number",
-							value: 32,
+						},
+						rootFieldSchema: {
+							children: {
+								kind: {
+									value: "Value",
+									typeMetadata: "string",
+									nodeKind: VisualNodeKind.ValueNode,
+								},
+								types: {
+									children: {
+										"0": {
+											value: "DefaultVisualizer_SharedTree_Test.root-item",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+							},
+							nodeKind: VisualNodeKind.TreeNode,
+							typeMetadata: "object",
+						},
+						nodeSchema: {
+							children: {
+								"0": {
+									children: {
+										name: {
+											value: "DefaultVisualizer_SharedTree_Test.child-item",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										objectNodeFields: {
+											children: {
+												"0": {
+													children: {
+														kind: {
+															value: "Optional",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														name: {
+															value: "childData",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														types: {
+															children: {
+																"0": {
+																	value: "DefaultVisualizer_SharedTree_Test.leaf-item",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+												"1": {
+													children: {
+														kind: {
+															value: "Value",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														name: {
+															value: "childField",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														types: {
+															children: {
+																"0": {
+																	value: "com.fluidframework.leaf.string",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+																"1": {
+																	value: "com.fluidframework.leaf.boolean",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+											},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"1": {
+									children: {
+										name: {
+											value: "DefaultVisualizer_SharedTree_Test.leaf-item",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										objectNodeFields: {
+											children: {
+												"0": {
+													children: {
+														kind: {
+															value: "Value",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														name: {
+															value: "leafField",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														types: {
+															children: {
+																"0": {
+																	value: "com.fluidframework.leaf.boolean",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+																"1": {
+																	value: "com.fluidframework.leaf.handle",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+																"2": {
+																	value: "com.fluidframework.leaf.string",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+											},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"2": {
+									children: {
+										name: {
+											value: "DefaultVisualizer_SharedTree_Test.root-item",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										objectNodeFields: {
+											children: {
+												"0": {
+													children: {
+														kind: {
+															value: "Sequence",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														name: {
+															value: "childrenOne",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														types: {
+															children: {
+																"0": {
+																	value: "DefaultVisualizer_SharedTree_Test.child-item",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+												"1": {
+													children: {
+														kind: {
+															value: "Value",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														name: {
+															value: "childrenTwo",
+															typeMetadata: "string",
+															nodeKind: VisualNodeKind.ValueNode,
+														},
+														types: {
+															children: {
+																"0": {
+																	value: "com.fluidframework.leaf.number",
+																	typeMetadata: "string",
+																	nodeKind:
+																		VisualNodeKind.ValueNode,
+																},
+															},
+															nodeKind: VisualNodeKind.TreeNode,
+															typeMetadata: "object",
+														},
+													},
+													nodeKind: VisualNodeKind.TreeNode,
+													typeMetadata: "object",
+												},
+											},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"3": {
+									children: {
+										name: {
+											value: "com.fluidframework.leaf.boolean",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											value: 2,
+											typeMetadata: "number",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										objectNodeFields: {
+											children: {},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"4": {
+									children: {
+										name: {
+											value: "com.fluidframework.leaf.handle",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											value: 3,
+											typeMetadata: "number",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										objectNodeFields: {
+											children: {},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"5": {
+									children: {
+										name: {
+											value: "com.fluidframework.leaf.null",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											value: 4,
+											typeMetadata: "number",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										objectNodeFields: {
+											children: {},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"6": {
+									children: {
+										name: {
+											value: "com.fluidframework.leaf.number",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											value: 0,
+											typeMetadata: "number",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										objectNodeFields: {
+											children: {},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+								"7": {
+									children: {
+										name: {
+											value: "com.fluidframework.leaf.string",
+											typeMetadata: "string",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										mapFields: {
+											typeMetadata: "undefined",
+											nodeKind: VisualNodeKind.ValueNode,
+											value: undefined,
+										},
+										leafValue: {
+											value: 1,
+											typeMetadata: "number",
+											nodeKind: VisualNodeKind.ValueNode,
+										},
+										objectNodeFields: {
+											children: {},
+											nodeKind: VisualNodeKind.TreeNode,
+											typeMetadata: "object",
+										},
+									},
+									nodeKind: VisualNodeKind.TreeNode,
+									typeMetadata: "object",
+								},
+							},
+							nodeKind: VisualNodeKind.TreeNode,
+							typeMetadata: "object",
 						},
 					},
+					nodeKind: VisualNodeKind.TreeNode,
+					typeMetadata: "object",
 				},
 			},
+			typeMetadata: "SharedTree",
+			nodeKind: VisualNodeKind.FluidTreeNode,
 		};
-
 		expect(result).to.deep.equal(expected);
 	});
 


### PR DESCRIPTION
## Description

Remove use of deprecated APIs and dependence on view schema from tree visualizer in dev tools, and just use content snapshot.
Now includes schema which was missing before.

## Breaking Changes

Encoding of tree data for visualizer is different.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
