### PR TITLE
Update release notes with searchForMarker function name

### DIFF
--- a/RELEASE_NOTES/2.0.0-internal.7.2.0.md
+++ b/RELEASE_NOTES/2.0.0-internal.7.2.0.md
@@ -4,28 +4,28 @@
 
 ## sequence: SharedString.findTile is now deprecated
 
-findTile was previously deprecated on client and mergeTree, but was not on SharedString. Usage is mostly the same, with the exception that the parameter 'startPos' must be a number and cannot be undefined.
+findTile was previously deprecated on client and mergeTree, but was not on SharedString. For the replacement method searchForMarker, usage is mostly the same, with the exception that the parameter 'startPos' must be a number and cannot be undefined.
 
 ## tree2: Rename DocumentSchema and toDocumentSchema
 
 The following APIs have been renamed:
 
-- `DocumentSchema` is now `TreeSchema`
-- `toDocumentSchema` is now `intoSchema`
+-   `DocumentSchema` is now `TreeSchema`
+-   `toDocumentSchema` is now `intoSchema`
 
 ## tree2: Rename SchemaData, FieldSchema, and FieldStoredSchema
 
 The following APIs have been renamed:
 
-- `SchemaData` is now `TreeStoredSchema`
-- `FieldSchema` is now `TreeFieldSchema`
-- `FieldStoredSchema` is now `TreeFieldStoredSchema`
+-   `SchemaData` is now `TreeStoredSchema`
+-   `FieldSchema` is now `TreeFieldSchema`
+-   `FieldStoredSchema` is now `TreeFieldStoredSchema`
 
 ## tree2: Rename TreeSchema
 
 The following APIs have been renamed:
 
-- `TreeSchema` is now `TreeNodeSchema`
+-   `TreeSchema` is now `TreeNodeSchema`
 
 ## tree2: Add `null` to allowed leaf types
 
@@ -35,4 +35,4 @@ Replaced the jsonNull schema with a new null leaf schema, and added support for 
 
 The following APIs have been renamed:
 
-- `Struct` is now `ObjectNode`
+-   `Struct` is now `ObjectNode`


### PR DESCRIPTION
When I created the changeset deprecating findTile on SharedString, I forgot to note the name of the replacement function. This PR fixes that in the RELEASE_NOTES/ file. 