### PR TITLE
Update type compat tests for 7.2

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -71,7 +71,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.1.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.2.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.2.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -73,7 +73,7 @@
 		"path-browserify": "^1.0.1"
 	},
 	"devDependencies": {
-		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.0.0-internal.7.1.0",
+		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.0.0-internal.7.2.0",
 		"@fluid-internal/stochastic-test-utils": "workspace:~",
 		"@fluid-internal/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/events": "^3.0.0",

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -936,6 +936,30 @@ use_old_InterfaceDeclaration_IGenericError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGetPendingLocalStateProps": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IGetPendingLocalStateProps():
+    TypeOnly<old.IGetPendingLocalStateProps>;
+declare function use_current_InterfaceDeclaration_IGetPendingLocalStateProps(
+    use: TypeOnly<current.IGetPendingLocalStateProps>);
+use_current_InterfaceDeclaration_IGetPendingLocalStateProps(
+    get_old_InterfaceDeclaration_IGetPendingLocalStateProps());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGetPendingLocalStateProps": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IGetPendingLocalStateProps():
+    TypeOnly<current.IGetPendingLocalStateProps>;
+declare function use_old_InterfaceDeclaration_IGetPendingLocalStateProps(
+    use: TypeOnly<old.IGetPendingLocalStateProps>);
+use_old_InterfaceDeclaration_IGetPendingLocalStateProps(
+    get_current_InterfaceDeclaration_IGetPendingLocalStateProps());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IHostLoader": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IHostLoader():

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.1.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/node": "^16.18.38",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"eslint": "~8.50.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.1.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -72,7 +72,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.1.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.1.0",
+		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.1.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.1.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.1.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.7.1.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.7.1.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.7.1.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/diff": "^3.5.1",
@@ -119,10 +119,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_SharedString": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -991,7 +991,6 @@ declare function get_old_ClassDeclaration_SharedString():
 declare function use_current_ClassDeclaration_SharedString(
     use: TypeOnly<current.SharedString>);
 use_current_ClassDeclaration_SharedString(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SharedString());
 
 /*

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.7.1.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.7.1.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.7.1.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.1.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/node": "^16.18.38",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -72,7 +72,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.1.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.1.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -44,7 +44,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.1.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/node": "^16.18.38",
 		"eslint": "~8.50.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.1.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.2.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.1.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.2.0",
 		"@fluidframework/protocol-definitions": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"cross-env": "^7.0.3",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.7.1.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
@@ -48,6 +48,102 @@ use_old_EnumDeclaration_ClpCompliantAppHeader(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_EpochTracker": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_EpochTracker():
+    TypeOnly<old.EpochTracker>;
+declare function use_current_ClassDeclaration_EpochTracker(
+    use: TypeOnly<current.EpochTracker>);
+use_current_ClassDeclaration_EpochTracker(
+    get_old_ClassDeclaration_EpochTracker());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_EpochTracker": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_EpochTracker():
+    TypeOnly<current.EpochTracker>;
+declare function use_old_ClassDeclaration_EpochTracker(
+    use: TypeOnly<old.EpochTracker>);
+use_old_ClassDeclaration_EpochTracker(
+    get_current_ClassDeclaration_EpochTracker());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_FetchType": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_FetchType():
+    TypeOnly<old.FetchType>;
+declare function use_current_TypeAliasDeclaration_FetchType(
+    use: TypeOnly<current.FetchType>);
+use_current_TypeAliasDeclaration_FetchType(
+    get_old_TypeAliasDeclaration_FetchType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_FetchType": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_FetchType():
+    TypeOnly<current.FetchType>;
+declare function use_old_TypeAliasDeclaration_FetchType(
+    use: TypeOnly<old.FetchType>);
+use_old_TypeAliasDeclaration_FetchType(
+    get_current_TypeAliasDeclaration_FetchType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_FetchTypeInternal": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_FetchTypeInternal():
+    TypeOnly<old.FetchTypeInternal>;
+declare function use_current_TypeAliasDeclaration_FetchTypeInternal(
+    use: TypeOnly<current.FetchTypeInternal>);
+use_current_TypeAliasDeclaration_FetchTypeInternal(
+    get_old_TypeAliasDeclaration_FetchTypeInternal());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_FetchTypeInternal": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_FetchTypeInternal():
+    TypeOnly<current.FetchTypeInternal>;
+declare function use_old_TypeAliasDeclaration_FetchTypeInternal(
+    use: TypeOnly<old.FetchTypeInternal>);
+use_old_TypeAliasDeclaration_FetchTypeInternal(
+    get_current_TypeAliasDeclaration_FetchTypeInternal());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICacheAndTracker": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ICacheAndTracker():
+    TypeOnly<old.ICacheAndTracker>;
+declare function use_current_InterfaceDeclaration_ICacheAndTracker(
+    use: TypeOnly<current.ICacheAndTracker>);
+use_current_InterfaceDeclaration_ICacheAndTracker(
+    get_old_InterfaceDeclaration_ICacheAndTracker());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICacheAndTracker": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ICacheAndTracker():
+    TypeOnly<current.ICacheAndTracker>;
+declare function use_old_InterfaceDeclaration_ICacheAndTracker(
+    use: TypeOnly<old.ICacheAndTracker>);
+use_old_InterfaceDeclaration_ICacheAndTracker(
+    get_current_InterfaceDeclaration_ICacheAndTracker());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IClpCompliantAppHeader": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IClpCompliantAppHeader():
@@ -68,6 +164,126 @@ declare function use_old_InterfaceDeclaration_IClpCompliantAppHeader(
     use: TypeOnly<old.IClpCompliantAppHeader>);
 use_old_InterfaceDeclaration_IClpCompliantAppHeader(
     get_current_InterfaceDeclaration_IClpCompliantAppHeader());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INonPersistentCache": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_INonPersistentCache():
+    TypeOnly<old.INonPersistentCache>;
+declare function use_current_InterfaceDeclaration_INonPersistentCache(
+    use: TypeOnly<current.INonPersistentCache>);
+use_current_InterfaceDeclaration_INonPersistentCache(
+    get_old_InterfaceDeclaration_INonPersistentCache());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INonPersistentCache": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_INonPersistentCache():
+    TypeOnly<current.INonPersistentCache>;
+declare function use_old_InterfaceDeclaration_INonPersistentCache(
+    use: TypeOnly<old.INonPersistentCache>);
+use_old_InterfaceDeclaration_INonPersistentCache(
+    get_current_InterfaceDeclaration_INonPersistentCache());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOdspCache": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IOdspCache():
+    TypeOnly<old.IOdspCache>;
+declare function use_current_InterfaceDeclaration_IOdspCache(
+    use: TypeOnly<current.IOdspCache>);
+use_current_InterfaceDeclaration_IOdspCache(
+    get_old_InterfaceDeclaration_IOdspCache());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOdspCache": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IOdspCache():
+    TypeOnly<current.IOdspCache>;
+declare function use_old_InterfaceDeclaration_IOdspCache(
+    use: TypeOnly<old.IOdspCache>);
+use_old_InterfaceDeclaration_IOdspCache(
+    get_current_InterfaceDeclaration_IOdspCache());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOdspResponse": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IOdspResponse():
+    TypeOnly<old.IOdspResponse<any>>;
+declare function use_current_InterfaceDeclaration_IOdspResponse(
+    use: TypeOnly<current.IOdspResponse<any>>);
+use_current_InterfaceDeclaration_IOdspResponse(
+    get_old_InterfaceDeclaration_IOdspResponse());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOdspResponse": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IOdspResponse():
+    TypeOnly<current.IOdspResponse<any>>;
+declare function use_old_InterfaceDeclaration_IOdspResponse(
+    use: TypeOnly<old.IOdspResponse<any>>);
+use_old_InterfaceDeclaration_IOdspResponse(
+    get_current_InterfaceDeclaration_IOdspResponse());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IPersistedFileCache": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IPersistedFileCache():
+    TypeOnly<old.IPersistedFileCache>;
+declare function use_current_InterfaceDeclaration_IPersistedFileCache(
+    use: TypeOnly<current.IPersistedFileCache>);
+use_current_InterfaceDeclaration_IPersistedFileCache(
+    get_old_InterfaceDeclaration_IPersistedFileCache());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IPersistedFileCache": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IPersistedFileCache():
+    TypeOnly<current.IPersistedFileCache>;
+declare function use_old_InterfaceDeclaration_IPersistedFileCache(
+    use: TypeOnly<old.IPersistedFileCache>);
+use_old_InterfaceDeclaration_IPersistedFileCache(
+    get_current_InterfaceDeclaration_IPersistedFileCache());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IPrefetchSnapshotContents": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IPrefetchSnapshotContents():
+    TypeOnly<old.IPrefetchSnapshotContents>;
+declare function use_current_InterfaceDeclaration_IPrefetchSnapshotContents(
+    use: TypeOnly<current.IPrefetchSnapshotContents>);
+use_current_InterfaceDeclaration_IPrefetchSnapshotContents(
+    get_old_InterfaceDeclaration_IPrefetchSnapshotContents());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IPrefetchSnapshotContents": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IPrefetchSnapshotContents():
+    TypeOnly<current.IPrefetchSnapshotContents>;
+declare function use_old_InterfaceDeclaration_IPrefetchSnapshotContents(
+    use: TypeOnly<old.IPrefetchSnapshotContents>);
+use_old_InterfaceDeclaration_IPrefetchSnapshotContents(
+    get_current_InterfaceDeclaration_IPrefetchSnapshotContents());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -116,6 +332,30 @@ declare function use_old_InterfaceDeclaration_ISnapshotContents(
     use: TypeOnly<old.ISnapshotContents>);
 use_old_InterfaceDeclaration_ISnapshotContents(
     get_current_InterfaceDeclaration_ISnapshotContents());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISnapshotContentsWithProps": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISnapshotContentsWithProps():
+    TypeOnly<old.ISnapshotContentsWithProps>;
+declare function use_current_InterfaceDeclaration_ISnapshotContentsWithProps(
+    use: TypeOnly<current.ISnapshotContentsWithProps>);
+use_current_InterfaceDeclaration_ISnapshotContentsWithProps(
+    get_old_InterfaceDeclaration_ISnapshotContentsWithProps());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISnapshotContentsWithProps": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISnapshotContentsWithProps():
+    TypeOnly<current.ISnapshotContentsWithProps>;
+declare function use_old_InterfaceDeclaration_ISnapshotContentsWithProps(
+    use: TypeOnly<old.ISnapshotContentsWithProps>);
+use_old_InterfaceDeclaration_ISnapshotContentsWithProps(
+    get_current_InterfaceDeclaration_ISnapshotContentsWithProps());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -356,6 +596,30 @@ declare function use_old_EnumDeclaration_SharingLinkHeader(
     use: TypeOnly<old.SharingLinkHeader>);
 use_old_EnumDeclaration_SharingLinkHeader(
     get_current_EnumDeclaration_SharingLinkHeader());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_SnapshotFormatSupportType": {"forwardCompat": false}
+*/
+declare function get_old_EnumDeclaration_SnapshotFormatSupportType():
+    TypeOnly<old.SnapshotFormatSupportType>;
+declare function use_current_EnumDeclaration_SnapshotFormatSupportType(
+    use: TypeOnly<current.SnapshotFormatSupportType>);
+use_current_EnumDeclaration_SnapshotFormatSupportType(
+    get_old_EnumDeclaration_SnapshotFormatSupportType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_SnapshotFormatSupportType": {"backCompat": false}
+*/
+declare function get_current_EnumDeclaration_SnapshotFormatSupportType():
+    TypeOnly<current.SnapshotFormatSupportType>;
+declare function use_old_EnumDeclaration_SnapshotFormatSupportType(
+    use: TypeOnly<old.SnapshotFormatSupportType>);
+use_old_EnumDeclaration_SnapshotFormatSupportType(
+    get_current_EnumDeclaration_SnapshotFormatSupportType());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.1.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",
 		"cross-env": "^7.0.3",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.1.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^16.18.38",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.1.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.1.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",
 		"@types/node": "^16.18.38",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-tools": "^1.0.195075",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.1.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -50,7 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.1.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.2.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.1.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.2.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -57,7 +57,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.1.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/node": "^16.18.38",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -70,7 +70,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.1.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.1.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.2.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -71,7 +71,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.7.1.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.7.2.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.7.1.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.7.1.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.7.1.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.1.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.1.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -82,7 +82,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.1.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -216,6 +216,30 @@ use_old_InterfaceDeclaration_ILoaderServices(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IParsedUrl": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IParsedUrl():
+    TypeOnly<old.IParsedUrl>;
+declare function use_current_InterfaceDeclaration_IParsedUrl(
+    use: TypeOnly<current.IParsedUrl>);
+use_current_InterfaceDeclaration_IParsedUrl(
+    get_old_InterfaceDeclaration_IParsedUrl());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IParsedUrl": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IParsedUrl():
+    TypeOnly<current.IParsedUrl>;
+declare function use_old_InterfaceDeclaration_IParsedUrl(
+    use: TypeOnly<old.IParsedUrl>);
+use_old_InterfaceDeclaration_IParsedUrl(
+    get_current_InterfaceDeclaration_IParsedUrl());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProtocolHandler": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProtocolHandler():
@@ -356,6 +380,30 @@ declare function use_old_FunctionDeclaration_resolveWithLocationRedirectionHandl
     use: TypeOnly<typeof old.resolveWithLocationRedirectionHandling>);
 use_old_FunctionDeclaration_resolveWithLocationRedirectionHandling(
     get_current_FunctionDeclaration_resolveWithLocationRedirectionHandling());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_tryParseCompatibleResolvedUrl": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_tryParseCompatibleResolvedUrl():
+    TypeOnly<typeof old.tryParseCompatibleResolvedUrl>;
+declare function use_current_FunctionDeclaration_tryParseCompatibleResolvedUrl(
+    use: TypeOnly<typeof current.tryParseCompatibleResolvedUrl>);
+use_current_FunctionDeclaration_tryParseCompatibleResolvedUrl(
+    get_old_FunctionDeclaration_tryParseCompatibleResolvedUrl());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_tryParseCompatibleResolvedUrl": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_tryParseCompatibleResolvedUrl():
+    TypeOnly<typeof current.tryParseCompatibleResolvedUrl>;
+declare function use_old_FunctionDeclaration_tryParseCompatibleResolvedUrl(
+    use: TypeOnly<typeof old.tryParseCompatibleResolvedUrl>);
+use_old_FunctionDeclaration_tryParseCompatibleResolvedUrl(
+    get_current_FunctionDeclaration_tryParseCompatibleResolvedUrl());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -77,7 +77,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -552,6 +552,30 @@ use_old_ClassDeclaration_RetryableError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_SummaryCompressionAlgorithm": {"forwardCompat": false}
+*/
+declare function get_old_EnumDeclaration_SummaryCompressionAlgorithm():
+    TypeOnly<old.SummaryCompressionAlgorithm>;
+declare function use_current_EnumDeclaration_SummaryCompressionAlgorithm(
+    use: TypeOnly<current.SummaryCompressionAlgorithm>);
+use_current_EnumDeclaration_SummaryCompressionAlgorithm(
+    get_old_EnumDeclaration_SummaryCompressionAlgorithm());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_SummaryCompressionAlgorithm": {"backCompat": false}
+*/
+declare function get_current_EnumDeclaration_SummaryCompressionAlgorithm():
+    TypeOnly<current.SummaryCompressionAlgorithm>;
+declare function use_old_EnumDeclaration_SummaryCompressionAlgorithm(
+    use: TypeOnly<old.SummaryCompressionAlgorithm>);
+use_old_EnumDeclaration_SummaryCompressionAlgorithm(
+    get_current_EnumDeclaration_SummaryCompressionAlgorithm());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_ThrottlingError": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_ThrottlingError():

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.37.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"eslint": "~8.50.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -109,6 +109,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_ContainerRuntime": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -86,7 +86,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.1.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
@@ -109,10 +109,6 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_ContainerRuntime": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -163,6 +163,7 @@ declare function get_current_ClassDeclaration_ContainerRuntime():
 declare function use_old_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<old.ContainerRuntime>);
 use_old_ClassDeclaration_ContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -151,7 +151,6 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -265,6 +264,102 @@ use_old_ClassDeclaration_FluidDataStoreRegistry(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_GCFeatureMatrix": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_GCFeatureMatrix():
+    TypeOnly<old.GCFeatureMatrix>;
+declare function use_current_InterfaceDeclaration_GCFeatureMatrix(
+    use: TypeOnly<current.GCFeatureMatrix>);
+use_current_InterfaceDeclaration_GCFeatureMatrix(
+    get_old_InterfaceDeclaration_GCFeatureMatrix());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_GCFeatureMatrix": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_GCFeatureMatrix():
+    TypeOnly<current.GCFeatureMatrix>;
+declare function use_old_InterfaceDeclaration_GCFeatureMatrix(
+    use: TypeOnly<old.GCFeatureMatrix>);
+use_old_InterfaceDeclaration_GCFeatureMatrix(
+    get_current_InterfaceDeclaration_GCFeatureMatrix());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_GCNodeType": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_GCNodeType():
+    TypeOnly<typeof old.GCNodeType>;
+declare function use_current_VariableDeclaration_GCNodeType(
+    use: TypeOnly<typeof current.GCNodeType>);
+use_current_VariableDeclaration_GCNodeType(
+    get_old_VariableDeclaration_GCNodeType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_GCNodeType": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_GCNodeType():
+    TypeOnly<typeof current.GCNodeType>;
+declare function use_old_VariableDeclaration_GCNodeType(
+    use: TypeOnly<typeof old.GCNodeType>);
+use_old_VariableDeclaration_GCNodeType(
+    get_current_VariableDeclaration_GCNodeType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_GCNodeType": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_GCNodeType():
+    TypeOnly<old.GCNodeType>;
+declare function use_current_TypeAliasDeclaration_GCNodeType(
+    use: TypeOnly<current.GCNodeType>);
+use_current_TypeAliasDeclaration_GCNodeType(
+    get_old_TypeAliasDeclaration_GCNodeType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_GCNodeType": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_GCNodeType():
+    TypeOnly<current.GCNodeType>;
+declare function use_old_TypeAliasDeclaration_GCNodeType(
+    use: TypeOnly<old.GCNodeType>);
+use_old_TypeAliasDeclaration_GCNodeType(
+    get_current_TypeAliasDeclaration_GCNodeType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_GCVersion": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_GCVersion():
+    TypeOnly<old.GCVersion>;
+declare function use_current_TypeAliasDeclaration_GCVersion(
+    use: TypeOnly<current.GCVersion>);
+use_current_TypeAliasDeclaration_GCVersion(
+    get_old_TypeAliasDeclaration_GCVersion());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_GCVersion": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_GCVersion():
+    TypeOnly<current.GCVersion>;
+declare function use_old_TypeAliasDeclaration_GCVersion(
+    use: TypeOnly<old.GCVersion>);
+use_old_TypeAliasDeclaration_GCVersion(
+    get_current_TypeAliasDeclaration_GCVersion());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IAckSummaryResult": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IAckSummaryResult():
@@ -333,6 +428,30 @@ declare function use_old_InterfaceDeclaration_IBaseSummarizeResult(
     use: TypeOnly<old.IBaseSummarizeResult>);
 use_old_InterfaceDeclaration_IBaseSummarizeResult(
     get_current_InterfaceDeclaration_IBaseSummarizeResult());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IBlobManagerLoadInfo": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IBlobManagerLoadInfo():
+    TypeOnly<old.IBlobManagerLoadInfo>;
+declare function use_current_InterfaceDeclaration_IBlobManagerLoadInfo(
+    use: TypeOnly<current.IBlobManagerLoadInfo>);
+use_current_InterfaceDeclaration_IBlobManagerLoadInfo(
+    get_old_InterfaceDeclaration_IBlobManagerLoadInfo());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IBlobManagerLoadInfo": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IBlobManagerLoadInfo():
+    TypeOnly<current.IBlobManagerLoadInfo>;
+declare function use_old_InterfaceDeclaration_IBlobManagerLoadInfo(
+    use: TypeOnly<old.IBlobManagerLoadInfo>);
+use_old_InterfaceDeclaration_IBlobManagerLoadInfo(
+    get_current_InterfaceDeclaration_IBlobManagerLoadInfo());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -529,6 +648,30 @@ use_old_InterfaceDeclaration_IContainerRuntimeMessageCompatDetails(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IContainerRuntimeMetadata": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IContainerRuntimeMetadata():
+    TypeOnly<old.IContainerRuntimeMetadata>;
+declare function use_current_InterfaceDeclaration_IContainerRuntimeMetadata(
+    use: TypeOnly<current.IContainerRuntimeMetadata>);
+use_current_InterfaceDeclaration_IContainerRuntimeMetadata(
+    get_old_InterfaceDeclaration_IContainerRuntimeMetadata());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IContainerRuntimeMetadata": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IContainerRuntimeMetadata():
+    TypeOnly<current.IContainerRuntimeMetadata>;
+declare function use_old_InterfaceDeclaration_IContainerRuntimeMetadata(
+    use: TypeOnly<old.IContainerRuntimeMetadata>);
+use_old_InterfaceDeclaration_IContainerRuntimeMetadata(
+    get_current_InterfaceDeclaration_IContainerRuntimeMetadata());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IContainerRuntimeOptions": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IContainerRuntimeOptions():
@@ -553,6 +696,30 @@ use_old_InterfaceDeclaration_IContainerRuntimeOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICreateContainerMetadata": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ICreateContainerMetadata():
+    TypeOnly<old.ICreateContainerMetadata>;
+declare function use_current_InterfaceDeclaration_ICreateContainerMetadata(
+    use: TypeOnly<current.ICreateContainerMetadata>);
+use_current_InterfaceDeclaration_ICreateContainerMetadata(
+    get_old_InterfaceDeclaration_ICreateContainerMetadata());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICreateContainerMetadata": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ICreateContainerMetadata():
+    TypeOnly<current.ICreateContainerMetadata>;
+declare function use_old_InterfaceDeclaration_ICreateContainerMetadata(
+    use: TypeOnly<old.ICreateContainerMetadata>);
+use_old_InterfaceDeclaration_ICreateContainerMetadata(
+    get_current_InterfaceDeclaration_ICreateContainerMetadata());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IEnqueueSummarizeOptions": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IEnqueueSummarizeOptions():
@@ -573,6 +740,30 @@ declare function use_old_InterfaceDeclaration_IEnqueueSummarizeOptions(
     use: TypeOnly<old.IEnqueueSummarizeOptions>);
 use_old_InterfaceDeclaration_IEnqueueSummarizeOptions(
     get_current_InterfaceDeclaration_IEnqueueSummarizeOptions());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGCMetadata": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IGCMetadata():
+    TypeOnly<old.IGCMetadata>;
+declare function use_current_InterfaceDeclaration_IGCMetadata(
+    use: TypeOnly<current.IGCMetadata>);
+use_current_InterfaceDeclaration_IGCMetadata(
+    get_old_InterfaceDeclaration_IGCMetadata());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGCMetadata": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IGCMetadata():
+    TypeOnly<current.IGCMetadata>;
+declare function use_old_InterfaceDeclaration_IGCMetadata(
+    use: TypeOnly<old.IGCMetadata>);
+use_old_InterfaceDeclaration_IGCMetadata(
+    get_current_InterfaceDeclaration_IGCMetadata());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -765,6 +956,30 @@ declare function use_old_InterfaceDeclaration_IRetriableFailureResult(
     use: TypeOnly<old.IRetriableFailureResult>);
 use_old_InterfaceDeclaration_IRetriableFailureResult(
     get_current_InterfaceDeclaration_IRetriableFailureResult());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISerializedElection": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISerializedElection():
+    TypeOnly<old.ISerializedElection>;
+declare function use_current_InterfaceDeclaration_ISerializedElection(
+    use: TypeOnly<current.ISerializedElection>);
+use_current_InterfaceDeclaration_ISerializedElection(
+    get_old_InterfaceDeclaration_ISerializedElection());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISerializedElection": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISerializedElection():
+    TypeOnly<current.ISerializedElection>;
+declare function use_old_InterfaceDeclaration_ISerializedElection(
+    use: TypeOnly<old.ISerializedElection>);
+use_old_InterfaceDeclaration_ISerializedElection(
+    get_current_InterfaceDeclaration_ISerializedElection());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1221,6 +1436,30 @@ declare function use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
     use: TypeOnly<old.ISummaryConfigurationHeuristics>);
 use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
     get_current_InterfaceDeclaration_ISummaryConfigurationHeuristics());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ISummaryMetadataMessage": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ISummaryMetadataMessage():
+    TypeOnly<old.ISummaryMetadataMessage>;
+declare function use_current_TypeAliasDeclaration_ISummaryMetadataMessage(
+    use: TypeOnly<current.ISummaryMetadataMessage>);
+use_current_TypeAliasDeclaration_ISummaryMetadataMessage(
+    get_old_TypeAliasDeclaration_ISummaryMetadataMessage());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ISummaryMetadataMessage": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ISummaryMetadataMessage():
+    TypeOnly<current.ISummaryMetadataMessage>;
+declare function use_old_TypeAliasDeclaration_ISummaryMetadataMessage(
+    use: TypeOnly<old.ISummaryMetadataMessage>);
+use_old_TypeAliasDeclaration_ISummaryMetadataMessage(
+    get_current_TypeAliasDeclaration_ISummaryMetadataMessage());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -41,7 +41,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"eslint": "~8.50.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.1.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"eslint": "~8.50.0",
 		"eslint-plugin-deprecation": "~2.0.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.1.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.1.0",
+		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.1.0",
+		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.2.0",
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/fluid-static": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.1.0",
+		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.2.0",
 		"@fluid-tools/build-cli": "^0.26.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.1.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.2.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.1.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -91,7 +91,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.26.1",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.1.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.2.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.18.38",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^3.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.7.1.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.37.0",
 		"@types/debug": "^4.1.5",
 		"@types/jwt-decode": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
     specifiers:
       '@fluid-tools/build-cli': ^0.26.1
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.1.0
+      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.2.0
       '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
@@ -123,7 +123,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
-      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.1.0
+      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.2.0
       '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
@@ -177,7 +177,7 @@ importers:
   azure/packages/azure-service-utils:
     specifiers:
       '@fluid-tools/build-cli': ^0.26.1
-      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.1.0
+      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.2.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -197,7 +197,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.1.0
+      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -5351,7 +5351,7 @@ importers:
 
   experimental/dds/attributable-map:
     specifiers:
-      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.7.1.0
+      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.7.2.0
       '@fluid-internal/client-utils': workspace:~
       '@fluid-internal/stochastic-test-utils': workspace:~
       '@fluid-internal/test-dds-utils': workspace:~
@@ -5397,7 +5397,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
       path-browserify: 1.0.1
     devDependencies:
-      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.7.1.0
+      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.7.2.0
       '@fluid-internal/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-internal/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
@@ -6077,7 +6077,7 @@ importers:
       '@fluid-tools/build-cli': ^0.26.1
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.2.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -6099,7 +6099,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
       '@types/events': 3.0.1
@@ -6114,7 +6114,7 @@ importers:
       '@fluid-tools/build-cli': ^0.26.1
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/node': ^16.18.38
@@ -6126,7 +6126,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -6189,7 +6189,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@microsoft/api-extractor': ^7.37.0
@@ -6204,7 +6204,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
       eslint: 8.50.0
@@ -6218,7 +6218,7 @@ importers:
       '@fluid-tools/build-cli': ^0.26.1
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.1.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.2.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6255,7 +6255,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.1.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6280,7 +6280,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.7.1.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.7.2.0
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -6314,7 +6314,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.1.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6341,7 +6341,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.7.1.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6373,7 +6373,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.1.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0
@@ -6403,7 +6403,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.7.1.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6446,7 +6446,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.1.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -6477,7 +6477,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.7.1.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.7.2.0
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -6529,7 +6529,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.1.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -6565,7 +6565,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.7.1.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6607,7 +6607,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.1.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -6713,7 +6713,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.7.1.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
@@ -6750,7 +6750,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.7.1.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
@@ -6843,7 +6843,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.7.1.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.7.2.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -6876,7 +6876,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.7.1.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
@@ -6910,7 +6910,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.7.1.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.7.2.0
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -6953,7 +6953,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.7.1.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/diff': 3.5.6
@@ -6990,7 +6990,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.7.1.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.7.2.0
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
@@ -7029,7 +7029,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.7.1.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/benchmark': 2.1.3
@@ -7061,7 +7061,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.7.1.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/benchmark': ^2.1.0
@@ -7091,7 +7091,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.7.1.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/benchmark': 2.1.3
@@ -7127,7 +7127,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.7.1.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/mocha': ^9.1.1
@@ -7163,7 +7163,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.7.1.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
@@ -7241,7 +7241,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.1.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.2.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -7265,7 +7265,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.1.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -7282,7 +7282,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.7.1.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.7.2.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -7315,7 +7315,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.1.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -7340,7 +7340,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.7.1.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -7364,7 +7364,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.1.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/jest': 29.5.3
@@ -7387,7 +7387,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.7.1.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.37.0
@@ -7409,7 +7409,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.1.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
       eslint: 8.50.0
@@ -7421,7 +7421,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.26.1
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.1.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.2.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
@@ -7451,7 +7451,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.1.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -7480,7 +7480,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.7.1.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^2.0.1
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -7534,7 +7534,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.1.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/jsrsasign': 8.0.13
@@ -7568,7 +7568,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.7.1.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.7.2.0
       '@fluidframework/protocol-base': ^2.0.1
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/telemetry-utils': workspace:~
@@ -7613,7 +7613,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.7.1.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -7639,7 +7639,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@microsoft/api-extractor': ^7.37.0
       cross-env: ^7.0.3
@@ -7654,7 +7654,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
       '@microsoft/api-extractor': 7.38.0
       cross-env: 7.0.3
@@ -7674,7 +7674,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.1.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.2.0
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
       cross-env: ^7.0.3
@@ -7697,7 +7697,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.7.1.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.7.2.0
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
       cross-env: 7.0.3
@@ -7722,7 +7722,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.7.1.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.7.2.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/nock': ^9.3.0
@@ -7745,7 +7745,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.1.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/nock': 9.3.1
       '@types/node': 16.18.58
@@ -7771,7 +7771,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^2.0.1
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.2.0
       '@fluidframework/server-services-client': ^2.0.1
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
@@ -7822,7 +7822,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -7855,7 +7855,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.2.0
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
       '@types/node': ^16.18.38
@@ -7884,7 +7884,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.2.0
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.4
       '@types/node': 16.18.58
@@ -7912,7 +7912,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/test-tools': ^1.0.195075
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.1.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -7941,7 +7941,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 1.0.195075
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.7.1.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -7958,7 +7958,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.26.1
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.1.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.2.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
@@ -7994,7 +7994,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.1.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8009,7 +8009,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.26.1
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.1.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.2.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
@@ -8060,7 +8060,7 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.1.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -8215,7 +8215,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.7.1.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.7.2.0
       '@fluidframework/datastore': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -8246,7 +8246,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.1.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/node': 16.18.58
@@ -8261,7 +8261,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.1.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/map': workspace:~
       '@fluidframework/merge-tree': workspace:~
@@ -8294,7 +8294,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.1.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8364,7 +8364,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.7.1.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.7.2.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -8402,7 +8402,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.1.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.2.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -8471,7 +8471,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.7.1.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.7.2.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -8502,7 +8502,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.7.1.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/diff': 3.5.6
@@ -8530,7 +8530,7 @@ importers:
       '@fluidframework/datastore': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.7.1.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/mocha': ^9.1.1
       '@types/node': ^16.18.38
@@ -8554,7 +8554,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.7.1.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -8590,7 +8590,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.7.1.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.7.2.0
       '@fluidframework/tinylicious-driver': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/mocha': ^9.1.1
@@ -8626,7 +8626,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.7.1.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -8650,7 +8650,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.7.1.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -8681,7 +8681,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.7.1.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/diff': 3.5.6
       '@types/events': 3.0.1
@@ -8706,7 +8706,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.7.1.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.7.2.0
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/react': ^17.0.44
@@ -8727,7 +8727,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.1.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0
       '@types/react': 17.0.68
       '@types/react-dom': 17.0.21
@@ -8743,7 +8743,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.7.1.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -8758,7 +8758,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.1.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0
       '@types/react': 17.0.68
       '@types/react-dom': 17.0.21
@@ -8775,7 +8775,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.1.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.2.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -8830,7 +8830,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.1.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -8861,7 +8861,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-definitions': workspace:~
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.7.1.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/gitresources': ^2.0.1
       '@fluidframework/mocha-test-setup': workspace:~
@@ -8904,7 +8904,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.1.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -8932,7 +8932,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.1.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -8959,7 +8959,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.1.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
@@ -9017,7 +9017,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.7.1.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.7.2.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore': workspace:~
@@ -9076,7 +9076,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.1.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9104,7 +9104,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.2.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9125,7 +9125,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
       eslint: 8.50.0
@@ -9143,7 +9143,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.7.1.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.7.2.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
@@ -9187,7 +9187,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.1.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9213,7 +9213,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -9231,7 +9231,7 @@ importers:
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.0
       eslint: 8.50.0
@@ -9249,7 +9249,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       eslint: ~8.50.0
       eslint-plugin-deprecation: ~2.0.0
@@ -9266,7 +9266,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0
       eslint: 8.50.0
       eslint-plugin-deprecation: 2.0.0_loebgezstcsvd2poh2d55fifke
@@ -9290,7 +9290,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.7.1.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.7.2.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/mocha': ^9.1.1
@@ -9324,7 +9324,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.7.1.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -9360,7 +9360,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.1.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -9403,7 +9403,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.7.1.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -9612,7 +9612,7 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.1.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.2.0
       '@fluidframework/test-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.37.0
       '@types/mocha': ^9.1.1
@@ -9633,7 +9633,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.1.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -9810,7 +9810,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.1.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -9827,7 +9827,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.1.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0
       eslint: 8.50.0
       prettier: 3.0.3
@@ -10196,7 +10196,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-driver-definitions': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.7.1.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -10248,7 +10248,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.7.1.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/debug': 4.1.9
       '@types/diff': 3.5.6
@@ -10387,7 +10387,7 @@ importers:
   packages/tools/devtools/devtools:
     specifiers:
       '@fluid-experimental/devtools-core': workspace:~
-      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.1.0
+      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.2.0
       '@fluid-tools/build-cli': ^0.26.1
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
@@ -10417,7 +10417,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
-      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.1.0
+      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.2.0
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
@@ -10590,7 +10590,7 @@ importers:
 
   packages/tools/devtools/devtools-core:
     specifiers:
-      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.7.1.0
+      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.7.2.0
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.26.1
@@ -10646,7 +10646,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
     devDependencies:
-      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.1.0
+      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.2.0
       '@fluid-tools/build-cli': 0.26.2_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2
@@ -10949,7 +10949,7 @@ importers:
     specifiers:
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.26.1
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.1.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.2.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
@@ -10992,7 +10992,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_bnjxas577mbdnhldblqqi36nsq
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.1.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -11013,7 +11013,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.7.1.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
@@ -11049,7 +11049,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.1.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -11151,7 +11151,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.26.1
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.1.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.2.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-definitions': workspace:~
@@ -11231,7 +11231,7 @@ importers:
       webpack-dev-server: 4.6.0_zgvvfjf2tx73ossdpc3n4rrlyy
     devDependencies:
       '@fluid-tools/build-cli': 0.26.2_ue7fu4ddzgjm4mmyagkmdfjn7y
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.1.0_zgvvfjf2tx73ossdpc3n4rrlyy
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.2.0_zgvvfjf2tx73ossdpc3n4rrlyy
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.2_7zrvdqqpe6raskx6zfqiiakk2y
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
@@ -11269,7 +11269,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.1.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.2.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.37.0
@@ -11302,7 +11302,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.1.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/mocha': 9.1.1
       '@types/node': 16.18.58
@@ -11329,7 +11329,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.0.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -11364,7 +11364,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/debug': 4.1.9
       '@types/events': 3.0.1
@@ -11394,7 +11394,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.7.1.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.37.0
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
@@ -11429,7 +11429,7 @@ importers:
       '@fluidframework/build-tools': 0.26.2_@types+node@16.18.58
       '@fluidframework/eslint-config-fluid': 3.0.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.7.1.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.7.2.0
       '@microsoft/api-extractor': 7.38.0_@types+node@16.18.58
       '@types/debug': 4.1.9
       '@types/jwt-decode': 2.2.1
@@ -15048,69 +15048,69 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@fluid-experimental/attributable-map/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-2PCOTcMOYf7Ttl1zE6mbQaeDkk8xCpECLdXwgfsNZ7p3pDXhrDEfqO6c6lc+DyjOeekIrFPwdx8M6wA2dhAOKQ==}
+  /@fluid-experimental/attributable-map/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-L3Imq2wNJN90qhK4FDXyaVEa53Vxe8YLtFFHPiTMa0orartRz+yRJKLDw31VxolhH4cGIhXrMX6DkTLtwcepNg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-z/jjBlG86L5Pwj2efFnSOiBsXO1snnfxVQE2KhKlUOI148XICY6aZv3/Qnco/LgSiGmlZJwoeuyAbr0b4+48vg==}
+  /@fluid-experimental/devtools-core/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-0wz1gieoidisI+AsEzMDlpVXKvwOR7SUBhilwu+QvCNybUy7tVKv/BBzStXSgq2Qu3IA2FEh5Y4NPLW/AU1JeQ==}
     dependencies:
-      '@fluid-experimental/tree2': 2.0.0-internal.7.1.0
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/cell': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/counter': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0
-      '@fluidframework/matrix': 2.0.0-internal.7.1.0
+      '@fluid-experimental/tree2': 2.0.0-internal.7.2.1
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/cell': 2.0.0-internal.7.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/counter': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/map': 2.0.0-internal.7.2.0
+      '@fluidframework/matrix': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/sequence': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/sequence': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-2R8HBpPltllORXXMI8RgcYRJbGMeuWO9LbJA+CRvBe0jpBCfJtj+8z1z5gBIcimuvNl59zmfuEwhuXfFZ5wlQg==}
+  /@fluid-experimental/devtools/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-GTp/PXo7MS3oj8AQUWIZkN9xV2JKZos4tTokpd3u4TzZeA1j80g+zqCOstG/J2cDlihCgcvqXVCF3n1MRbUFwg==}
     dependencies:
-      '@fluid-experimental/devtools-core': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/fluid-static': 2.0.0-internal.7.1.0
+      '@fluid-experimental/devtools-core': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/fluid-static': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/tree2/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-4sPhsThHJ2U2I56AIrZdjgLooraX9zs+6Y40t0eyYktd4W0UVjNAurJrQtcmqtduOcQ151jkseyMZorYZmMKag==}
+  /@fluid-experimental/tree2/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-jFlcA704ZkLDff6ulJEzwdrzorHRjOZUof82hiVxpdWwdakuSudFdBHjcTFBfuXqVSiZF9eGePMmPT8xppDFmA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.1
       '@sinclair/typebox': 0.29.6
       '@ungap/structured-clone': 1.2.0
       sorted-btree: 1.8.1
@@ -15120,11 +15120,11 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-internal/client-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==}
+  /@fluid-internal/client-utils/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-iDhs0W0we+ZQb4RiRedYrqtAznicNpc7JUdWe9EsustXm8umVBr5bswadXyodLiW6numVHcYPfskQII0dKFgJA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
       '@types/events': 3.0.1
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -15355,26 +15355,26 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-lLJEcUi8hi037oFTnqpVs8k3rdZlmZsqLh3Ui72vgb366j838xlvTeWwhdRBs4ZkaFELE4oXxk23GuBQCwzVJw==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-OFcaC7v7rGg5v39pZiKm7jJV9EDt2HBImuuZ7ordw6Cf2kKMEcht7sZkRcXbLTSBYRV7iAOeIBV6wO7MTpnrHA==}
     hasBin: true
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/tool-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15383,15 +15383,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-KDYzTdyG7PKJq3UEkGDLJ8PQGNPVm3KtRVcpzOYTatntjGFeVAdW43qv2NJWnexkSVHlhf2j94nH0/9381MjKw==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-PD33VTs7enMElsYc2uPdl8lwhQV55AHxa9a1ANQbXpDHCClkVv98jJhwkl0j1aEo5RWwyggmO4qzVGQkwfPAnw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15417,27 +15417,27 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.1.0_zgvvfjf2tx73ossdpc3n4rrlyy:
-    resolution: {integrity: sha512-EgUQgQnUIah0mBF/5ZDGVzKEdAw2rTRzflWFWeOfjC6rEUjh92AcOxjSnEXpVo2M1lACIvTp3bj+1a7i0Eu3eg==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.2.0_zgvvfjf2tx73ossdpc3n4rrlyy:
+    resolution: {integrity: sha512-FkgEQrI8OECrk/ZhALn8dLAzZ5EL8v7Qt85bu/ReDpmsn93RazvpVy0ok1wkv6+SUIAS9c5yl3y0ovTmaBRswA==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/local-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/local-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
       '@fluidframework/server-local-server': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/tool-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -15457,88 +15457,111 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-PzKNFQSJGqjFtB2WMbVOHBlzCbk/KbhIhtpJpot8A8PNzAqe+BruzwN/e3RDpRWY8rFaD334+rwPpTev/Vezkg==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-mKd8LMJCZqyHxvo9zIQrZ/TJ5v91hsuxqzZ4SOjdUOCr87CTrLMylRQFueRTn28ETGZgEWzNRsYedNR0hL7FSw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/map': 2.0.0-internal.7.2.0
+      '@fluidframework/register-collection': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==}
+  /@fluidframework/aqueduct/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-eG+8E1/eH3cHi8ne8ltvkMR1ycChGZMC+cmBk4eRGbFu1z7KxzwUcXFxeEnE+K6n9j74VK9E5E1u4gwwjP1K3A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/synthesize': 2.0.0-internal.7.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/map': 2.0.0-internal.7.2.0
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/synthesize': 2.0.0-internal.7.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==}
+  /@fluidframework/aqueduct/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-eG+8E1/eH3cHi8ne8ltvkMR1ycChGZMC+cmBk4eRGbFu1z7KxzwUcXFxeEnE+K6n9j74VK9E5E1u4gwwjP1K3A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/synthesize': 2.0.0-internal.7.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/map': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/synthesize': 2.0.0-internal.7.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/azure-client/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-PwiARzeJo5hiSpLWOb9Ctjn6x7kIuVFtk4wXBEZt8sl1v+tIm8blly6InOODrlnekRImovhC+aVV8s9aHj3wtA==}
+  /@fluidframework/aqueduct/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-g+6xKnPkgDps/91SNS27yHlFQ+UaZjdoKkKTtrwMH//Hs6pbLd9qRUsLNk1LHXbFKKPd3d3bvgVBVeZD1bx/tg==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/fluid-static': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/map': 2.0.0-internal.7.2.1
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/synthesize': 2.0.0-internal.7.2.1
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/azure-client/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Tn4wDpm0mJ9HiG0MVIHEP/9FV+QshJqcCI5pNkrL26aZVrBppofPpfVoy8VYQ2AnGXTp0zwMuPxFASjAZLGBTA==}
+    dependencies:
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/fluid-static': 2.0.0-internal.7.2.1
+      '@fluidframework/map': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
       '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
       axios: 0.26.1
     transitivePeerDependencies:
       - bufferutil
@@ -15548,8 +15571,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/azure-service-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-sRCe0W0B8K5FwZKOsGcmlBTILmiVU84NXFk+d9y/kS0prfvKIeYKZCicebTn16nrFJ0L2OOOUilzGOZtxASgqQ==}
+  /@fluidframework/azure-service-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-e7SFa2tMEmPD0AfEPeWfHY5ZP5KzCyk4vEEeXGic5r02gohrOEX5jjaef9RmNhrdIo/1HE2HJu7EQwEBvssEBQ==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.0.0
       jsrsasign: 10.8.6
@@ -15765,16 +15788,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-FE6Amw/ThRCbbIMQ96drx93o/b9hUkSB7tAE+LvVnm8ligt7z9VNiDbJZbwmgCSxY0WST6uwIMdBydbqb2OtCA==}
+  /@fluidframework/cell/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-uO8eApSsjdTalvniwJnqLIJ4wb3Yc8INFWhg5GvOdPh1o/28wcO48qqEsyyx/fVlf/ZN1nmMRTRRTkYAm/4R0A==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -15794,27 +15817,36 @@ packages:
       lodash: 4.17.21
       sha.js: 2.4.11
 
-  /@fluidframework/container-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==}
+  /@fluidframework/container-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-xjL/lX8+hsXdZ0SW1TX94ONDfhKlOveYvo6GB6IV+28gvRy+05Cnb5rMbwYuuHY7sN0jOnnZDY7wbIC02L9sLw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==}
+  /@fluidframework/container-definitions/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-q7xkUX8H7PsF/aF8Gj56XRbA+FUrBkNeybnqjL+luQ01vqnUnZs+C2mQUgQQbyvlZB1delOCupZYGv8MyySLrw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      events: 3.3.0
+    dev: true
+
+  /@fluidframework/container-loader/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Idx1RImCeD2tv2C+R2l6HmRG1HEBu0fQjFNuzxbN3XJokYdns2PMZ5w98vmzDSWDMRpBk1dTDoorMRun8jgFyA==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -15825,31 +15857,63 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==}
+  /@fluidframework/container-loader/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-7u/gXw/umdD1QAWWQmYKVCGOMdX9JszWrOPsgKteqEvyNpI4lUUbVkRRPUetg28z56+MzwPBTZa/B0dNYKWWPA==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1_debug@4.3.4
+      '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      debug: 4.3.4
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lodash: 4.17.21
+      url: 0.11.3
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-/vTDa4te1gCCiYr3NvXhxno6NQKD83N238ocdd5EygjFNX4ksilz+JsgH6tIwA/7PnArKtECDUR+LU2xQeXTIw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+    dev: true
+
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-dW1iiz5bwumwaSz/ZOfKxzHHCsBdeu2A1ETGvT0NPCsShEFZaMANzmXd/AIZAf1qSNTEkLpP8gC3dVP3+28Ihg==}
+    dependencies:
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+    dev: true
+
+  /@fluidframework/container-runtime/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-sKbsOzV4dhQulwlWq856acjQskdLQmmSxGpbhD1Q66tDu1mXLEbm7LgI0nDb1BpC6kVCLtCi8viKmNVXDSaNMQ==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -15860,21 +15924,21 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==}
+  /@fluidframework/container-runtime/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-sKbsOzV4dhQulwlWq856acjQskdLQmmSxGpbhD1Q66tDu1mXLEbm7LgI0nDb1BpC6kVCLtCi8viKmNVXDSaNMQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -15885,72 +15949,110 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ==}
-    dev: true
-
-  /@fluidframework/core-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA==}
-    dev: true
-
-  /@fluidframework/counter/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-fkaE0mtreXr0WdC4rVK5twzyR19ME/9JqqP0LMbKUHKiE1PValcnQvE/o6YkIpizat29do1rC13ZsMFWJ1OlrA==}
+  /@fluidframework/container-runtime/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-vaLLyW0BkctO4qadfcEXJb1roV2voNIIXcj9fudrCgYHKIattOdngx0Z4JcSoY/YeLdLsymiyOTGY1XX5iW+eg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      sorted-btree: 1.8.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-DQ/yaLR+5mXGZcPz4AiOh9kSHLET//NBr8PDD5Gj4e8sXZnXUY6vvBjMshtKY9k6qHWVM980/HkrFw1XU/gjYg==}
+  /@fluidframework/core-interfaces/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-eTGvlJZNN+xWAFHzgkmrOStaLeN3zX8MguWdlSDWS5Jo+QHmuZ5Pxwhz367QitRYjWfAWuyF4BuK4Vz66P4NkQ==}
+    dev: true
+
+  /@fluidframework/core-interfaces/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-TQ8LyirB8mWkWN62vGCmiS732JDC2e5zcVt5CD+T5cwBRlJ0SgHlMaevNyWMJQlYycT4fABtSNk0mNaRguRA9Q==}
+    dev: true
+
+  /@fluidframework/core-utils/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-EXjkJNKlKNZSGHtX651QARRaKovnjU/iVgrTjwmpxgYKCgzOi28HJuHpdS4GuBnP8PAW/oR3AlEPCY8ox3lB5Q==}
+    dev: true
+
+  /@fluidframework/counter/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-QFjtHBAdwPR2eHRVoo7X8nncHdq4y6ZIX0LlEnvtA8WCoGDOALoK5KF40+B3fZ84q8NyDWtcXoU6SJSh/Q/ztA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==}
+  /@fluidframework/data-object-base/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-LHIwp3MoF1Kg144mkN9lIohQN5MrEaY/tLxpd3W8SCr+PqIf5+6hOSLR5WsEXvI4n4NP9w7Qbu3WZuKw/eKyhQ==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-d1oAFxpxt7vJY+N5R1h7JmWalc8i7hZL6tSCBGQcYMtDGvG5LBv7mHEPJVQOx3/b3AIZuPNfLuzBYjbMy5IioA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+    dev: true
+
+  /@fluidframework/datastore-definitions/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-Bkwzfe1Kj4bgnkCxpqEK/iLzGegPwEGlW4u5Kw1FhoxY5rLK2MAgpNu4UL6eUS58J6q94aLjo6z17ivE5jWmZw==}
+    dependencies:
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+    dev: true
+
+  /@fluidframework/datastore/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-abRSJT67NeX918jHWIzHKElMrY5nUxenWSK73ZQMKBhNoCiZ/ThGpy46BgvajutMAuIDa2uOUNUTj7tH2754pA==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       lodash: 4.17.21
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -15958,20 +16060,20 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==}
+  /@fluidframework/datastore/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-abRSJT67NeX918jHWIzHKElMrY5nUxenWSK73ZQMKBhNoCiZ/ThGpy46BgvajutMAuIDa2uOUNUTj7tH2754pA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       lodash: 4.17.21
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -15979,81 +16081,124 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-HfKWkCnU2ayIIQ9Wp2ybRukXwn2JkVW/dABj4b4KMmTKI1GWa5/4LYE8/yXnC36UChACRuwpj2sGzSG4+a+UhA==}
+  /@fluidframework/datastore/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-KPTPFIT7OkM8vpTwWX5iqQ2LE6hJeDR8c7BZkBSfApKUx3jpgQwJ1M1iL57ISL+x8UHtCMUkADe7E/mcJ58ryg==}
     dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/sequence': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      lodash: 4.17.21
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-9WOVIaaB7xwRcoY4e9AVP0gL1SRIqvJWGHo0A9V/hd52JKtUPvs67kENKgz/FnE6pGgAyl9UFo++togNOjwOuQ==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-VdQ/5BONJwza8XFz0MVGUwUTe0vtHjIS/F/U4LwUU/cm2ByfZ3xeE3RAMqAD11fJFuxozdhYO6AihAoJosYOOw==}
     dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/map': 2.0.0-internal.7.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/sequence': 2.0.0-internal.7.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/debugger/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-UzgecmeRFlwS8/XVsn+jltZT1gjw5MN9e8MxeU94Vg5nybAL8SQzGJCbG1ZquBiylefCPEIiB5GcQMrvAWR9Pw==}
+    dependencies:
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/replay-driver': 2.0.0-internal.7.1.0
+      '@fluidframework/replay-driver': 2.0.0-internal.7.2.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==}
+  /@fluidframework/driver-base/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-wsI6boRw+A1DfChAh4T/prRm66+Upb59xz2yUWQoxMwClLon2DbAr6iVpsODbnJgQN3ZMwQevQg2ltmgZ1tkIQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==}
+  /@fluidframework/driver-base/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-wsI6boRw+A1DfChAh4T/prRm66+Upb59xz2yUWQoxMwClLon2DbAr6iVpsODbnJgQN3ZMwQevQg2ltmgZ1tkIQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==}
+  /@fluidframework/driver-base/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-9b/r6fgWv133NJDeKb0oONdlCwnhhBqKZebpeMHemxcbF9YS39tYVgwTI0Cwp9QaN8O3J483lYhlhrxMGvEqBg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Rr4v/pj0sCRSg7/SzL+t6z5y0auw2HoiZlhZaPd3J94CXun0V+Qe2UztXWNOCOpRvDZH+EHLKY09LDjItb3onQ==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==}
+  /@fluidframework/driver-definitions/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-2/edprtc6uFDpA0pwBZNDq4ZBXTTDY3HAX34ymykxd0vlL8E9TNEVzO3q3eVZSbwKawumK/Jk0jgLhsym6kXMQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+    dev: true
+
+  /@fluidframework/driver-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-7f9MFkCP41z+J8iXtwspvH3Hz6FbU8fjVYT3CEu1FeQZszHb7CMasHFjFmxsiNv6v6vcas/VJuClM5nLpsbxQg==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       axios: 0.26.1
       lz4js: 0.2.0
       url: 0.11.3
@@ -16063,17 +16208,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==}
+  /@fluidframework/driver-utils/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-7f9MFkCP41z+J8iXtwspvH3Hz6FbU8fjVYT3CEu1FeQZszHb7CMasHFjFmxsiNv6v6vcas/VJuClM5nLpsbxQg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
       url: 0.11.3
@@ -16083,13 +16228,53 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-vWkJm+aTjtxEnclmK/kagFJqkw7WtAquGW1+98qdJfw2v2LBaNcayw1vvCAyqO2aXY+KNGwyxQFGVow7NNKGYw==}
+  /@fluidframework/driver-utils/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-phWq473Npapx6//R3e7Jb/OTRHRSFZ23k83HNmLAdoTg+ex1ieypEzCvB6603xZ3FXm5wE/IwkP3qSI0VuvW1g==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/gitresources': 2.0.2
+      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      axios: 0.26.1
+      lz4js: 0.2.0
+      url: 0.11.3
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-utils/2.0.0-internal.7.2.1_debug@4.3.4:
+    resolution: {integrity: sha512-phWq473Npapx6//R3e7Jb/OTRHRSFZ23k83HNmLAdoTg+ex1ieypEzCvB6603xZ3FXm5wE/IwkP3qSI0VuvW1g==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/gitresources': 2.0.2
+      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      axios: 0.26.1_debug@4.3.4
+      lz4js: 0.2.0
+      url: 0.11.3
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-web-cache/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-SSpHINRBok9Apj+vz5u1/ySAU/d7gfTXN8rFQ8JBARL3IC+qJE7N93mCNneXfTc2zm5kEswyUOZ5YEgSOUaJRg==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -16147,33 +16332,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-eYAF9BNChi7UxaUneESzqhKBfpCUcpWo9A+kHo5EHgFCRUG51YJkKzw/N5nGKN55592XRjDCsR7tfWDDS+ErZQ==}
+  /@fluidframework/file-driver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Bg9uyNHZBfvJIq0KyAg6C57nuoDL3FZA1FzDKUGH+Y3CjfypLo/U40WHPWuBai3s2iEdLvTTc9oHtXCkUpuKlw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/replay-driver': 2.0.0-internal.7.1.0
+      '@fluidframework/replay-driver': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-YxnHWZHr2fhAn9tRzlei4Vv3Q+IxucZWWzg+4qbtNZ5nzYbuuhlKQtC7jM4oBbJidmSsGO8IWByesqOGU6To4Q==}
+  /@fluidframework/fluid-runner/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-G9UvSrt1WFpmXr/LfnbobeHLu68D7XECHSWggB+iziPOWdEYiU7aYN06QTTRbVTj1gxz5MW6G6id3dKoyUpBMg==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/aqueduct': 2.0.0-internal.7.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -16184,20 +16369,39 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==}
+  /@fluidframework/fluid-static/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Q48ycnQ/2THbND5zHGj12/hh8etnNlGSGCeYaj9q0aB6tJl3h3bwEluJypXwUvXkPzAQNGtGyRABKulcOvHHkg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/aqueduct': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/aqueduct': 2.0.0-internal.7.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/fluid-static/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-fLfsYONc6Cx+9HdoGD3/ysuBhWSmM1YH8+mqSNBhgs4DQnwmgZDp1xhWPGCo15sm9Vq3NNOJbz2IC5K+SVHA2A==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/aqueduct': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16206,38 +16410,38 @@ packages:
   /@fluidframework/gitresources/2.0.2:
     resolution: {integrity: sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw==}
 
-  /@fluidframework/ink/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-UC4KJTspSv6/I/kz4pLh+G2Va0c15EAOsDDidpcfBIVcYjPjFuqpVEU3r+124teCai/O+xI7uSN+Ml6gEFATcQ==}
+  /@fluidframework/ink/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-5HQ9DSt5qe43UWqgsI1dd1Yy6mt65KAv0hgUirnfoOFYb4a48HL0cA4eXTG5a1z3d9B8L6AtCyufAGiZ0seYEg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-pNzlRBDirOwVRiPQl9hf3Ux2KZ6WNmtqu68ibtnDW9HoPDClC1ipI+BBIrkoSDnj7V6XZOE1XYYh/rfdJcjUBw==}
+  /@fluidframework/local-driver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-iS/fdq4DALV12rlZqyd1JF/6zh+cR86+WoQjNp3SSnuW0YfhAcVTLAsqBR+DMz15GbAKJCg3W/5ENAoYhyYndA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-base': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0
       '@fluidframework/server-local-server': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-test-utils': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.3
@@ -16250,23 +16454,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-pNzlRBDirOwVRiPQl9hf3Ux2KZ6WNmtqu68ibtnDW9HoPDClC1ipI+BBIrkoSDnj7V6XZOE1XYYh/rfdJcjUBw==}
+  /@fluidframework/local-driver/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-iS/fdq4DALV12rlZqyd1JF/6zh+cR86+WoQjNp3SSnuW0YfhAcVTLAsqBR+DMz15GbAKJCg3W/5ENAoYhyYndA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-base': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/server-local-server': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-test-utils': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       events: 3.3.0
       jsrsasign: 10.8.6
       url: 0.11.3
@@ -16279,69 +16483,88 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/location-redirection-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-Ovbg4v+DxTD/VVvZIDq1k/crdg2tWl9H7TLS4Dqii8DHV5BVo1gnQZ+L+DguKXWn8B96ZeeQQFP7QTBR9An2mg==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-dL2/nuBNzh/RfcwQ/dgUYlFnK5r5okLw/mAl0UBFI0kwbcBU3Wv7W2QYrx1YsrlRLsOzyZlSW4BgFCzEgYU0AQ==}
     dependencies:
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==}
+  /@fluidframework/map/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-wEIB8VM5SRqORjROU7gZF5K2YlE/fnv0KIgatVL9YeuHWWbjBp3D66q3Jvae2KdXKLsLYBHiMYUnl7iH5hTY4A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==}
+  /@fluidframework/map/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-wEIB8VM5SRqORjROU7gZF5K2YlE/fnv0KIgatVL9YeuHWWbjBp3D66q3Jvae2KdXKLsLYBHiMYUnl7iH5hTY4A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-GqBM1kMfbZ8yNN17WIey09YDRgRSlvSjBLJRvtCkuOTGWIsX63igeesnMqqth2dulqMITzvMUDHoVi7CYwqufw==}
+  /@fluidframework/map/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-HRR/F9/ssAX/NT+QQaE/kHoMa9awvA5D4wWbIeo9U44J0e5loM6zdp8cbz0ZIFTQ9TdnZkn3i0f9P7wZRDjFzA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/matrix/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-AOUk3Np38A7jVpzT3JXdbgbudX2foSM79MVgc4ox8GYo3SXUbP3p9/zsNL0m9YdEpzjOtAkEMZNXz8gOWUVosg==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -16350,43 +16573,43 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==}
+  /@fluidframework/merge-tree/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-mY4GjFaKJi1lho+TTMYuWKx9BOKWIPSZVLOaa5nlih/YpNka8XA7+39i4xL+EqJoGa+s+Rm9lukdHH/97RMpMg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-who6jfj6DpNg56YfCouqL+ovLsQwf29yorCwlccigK/Q9cbESGYv8m3jGtAAYiSzPRVmPbJRfpFneHgpSuzI7g==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-+yaftIRkk9iQPGPRlOLZLDFDMTpW8Cf32XSfL1iV4QqDO4yIN9mLH9lHGIx6JaqwhvBPGcXlvALvZIbl/m96Ig==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.2.0
       mocha: 10.2.0
       source-map-support: 0.5.21
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-BKLXorlfx/qKJmdfgJ6fTpaF+hsvq3vfjWQeUYp7iG4Zz/E0ZW47DXnZfnMfcQKBvyaJ0C5pbUqZ2+2wogT6+g==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-7A9TrXRWegVTkEoWGGiq6OaSYrQ3Tza6QixQRb2+woCLchKZNaVPYGB350Ooa9vZCo8SAX64KyufBjPwgYXm7w==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
@@ -16394,16 +16617,16 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-BKLXorlfx/qKJmdfgJ6fTpaF+hsvq3vfjWQeUYp7iG4Zz/E0ZW47DXnZfnMfcQKBvyaJ0C5pbUqZ2+2wogT6+g==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-7A9TrXRWegVTkEoWGGiq6OaSYrQ3Tza6QixQRb2+woCLchKZNaVPYGB350Ooa9vZCo8SAX64KyufBjPwgYXm7w==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
@@ -16411,26 +16634,26 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-dh70BYxsWg/uaO9cFDOxXO1RtJfM7lTONBzhJTkyU7Ou5UxXf2JwY3sJFawOr03jDRZS9oihJHRxVVELHUT0RQ==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-WfSRN2pQxDEmEv9eDJIYpaznFbRC2Rlp2/BJ3H1OjMnPnUKNRQjAaPJTDYC+kR90zViLIaWm/4eArEIL2caHeA==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-uDXMVDg2YW3VumNZyHCLwt+9oAc+l8+AkgbddkS3VIWHjFmo1LIrPvnzdC3qy45qm7mTb8G7YGH0Xib7uk7p2g==}
+  /@fluidframework/odsp-driver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-XdBx40fY3EDF+5/PR7BiMdb1fougcz+o0qh9fIEUXnUhQIKkN97fPr8j2Fi6MYiAIT5GjPhoCwsysEibnG5qTQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-base': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       node-fetch: 2.7.0
       socket.io-client: 4.7.2
       uuid: 9.0.1
@@ -16442,13 +16665,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-ZLymXWOAAYSzJ/1b7CocKUjk4uDmENqVMterJxRc8B7DI9C/8Ppco2HpV9ijxkeddr5M8fJRRVXCaS0VHFrCOA==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-wz1Ojx37Bkr/fzRR0oq6R14pVhaK8sIO3TV0knj8n/+LtAoJ5rp6GJ823BFYhlyapuxUAy9oUdQjcxoTC70HYQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16457,17 +16680,17 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-Rf/25qfmorsn/x8Rn5zrrBIzsK1REcokOa9jzAmZB1lmiBymhhSzZ7fYuavvq9XD9WKMrke5tMETFGpMu8N4pQ==}
+  /@fluidframework/ordered-collection/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-VI0RFAv2rrARPhPVaNn9pubxbx77kwy7psNLpAMMehHIkBerLKcemTiAcUd1H5Q/MtMI9LiNSdhn+rdmn9V6ow==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -16487,77 +16710,90 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 1.0.0
 
-  /@fluidframework/register-collection/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-y12D3tT8uA1kmbUUqatlWOlDivkLMK07gpiftWL9E1kjM3EVbFbxT1ugqB2kmLYbiVMw4iuoRP6P3wYIollfNQ==}
+  /@fluidframework/register-collection/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-vJ8fIsQSQlVY1b5lZxKKPap3SkU/VhfbFzZS0TUkuiCuBNqv76aiN3/m85C7I9ssDaZHhO79kZVEun2imSNhIA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-NBg4tqL2z65xvfkWJwpsh4AGNdpx2enBwEQjb2AJLaiQYn2eyUi+WFqdAU5S2M4HeI7T3EqrDzc30QQYQr+7Gg==}
+  /@fluidframework/replay-driver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-9rGc/7jK61ZjzanIsXnuj3YA9H9/9gbiCA1ZaDbRSaaZwpa87eJl6BcDIVIxOJFXtk6pLs6SF1kTzqh3pN/MCw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==}
+  /@fluidframework/request-handler/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-zY2Gn6AOytcsRRROBkxrtQacFhfojf7mFx5C9MDNpK6hPWEIorTgLyrNqmjR3axgkBMClVxDVRnlWWxeYsGQJw==}
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==}
+  /@fluidframework/request-handler/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-zY2Gn6AOytcsRRROBkxrtQacFhfojf7mFx5C9MDNpK6hPWEIorTgLyrNqmjR3axgkBMClVxDVRnlWWxeYsGQJw==}
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==}
+  /@fluidframework/request-handler/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-RLYK+Gs9CcLtQgMT0+ZSolRH/CeC//BxQ5UYUXFxJILAqNpmVdFwxp9V6s3sGjMImS/YKA5GU1Z1l8dex+icLA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-8PbOAQjH20olgJp6vtrZX9gU6Z6utHfEyVLF4g8zOsVft1bjUk/XRhoFYROfImTELssIEk63V/e4nwbDpfrAEg==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-base': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       cross-fetch: 3.1.8
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.2
@@ -16571,20 +16807,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-8PbOAQjH20olgJp6vtrZX9gU6Z6utHfEyVLF4g8zOsVft1bjUk/XRhoFYROfImTELssIEk63V/e4nwbDpfrAEg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-base': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       cross-fetch: 3.1.8
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.2
@@ -16598,75 +16834,129 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-xYbW6Ix3P8UbV9GO60n1Ou4vvc/KYZo1wfZ7ZoO4EiWoDSKFY4a6JyNUtubMf0Z8/v5r8LYKN7MmTE8frD0/xA==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-ZcOjpuL/gvqISiKG5Q0pNgz4F3fOVOUguSledvF6TECM4s16V0uDu2sjeXnCVVJfzkYZdXYlifeDcgoitmYeCw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-base': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/gitresources': 2.0.2
+      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/server-services-client': 2.0.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      cross-fetch: 3.1.8
+      json-stringify-safe: 5.0.1
+      socket.io-client: 4.7.2
+      url-parse: 1.5.10
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-3Fo4J/F+G7pwrV8j4ZSGvV7ZlLCUcivrLDaL6wu1LLHJp92vUN0l4mZoO+v3Gga3Z5daOEpJmlnZv+Bv43pGvQ==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
       nconf: 0.12.0
       url: 0.11.3
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-fuU3+ZZlTyRemNkQp8eFvjVllMnWdx+WKn7apRQiHrmlAmTMRYBBolgS2pyBC1wLhzoBQf0lJzpE42usB4V0vg==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-jjnFw8zDTkRLTswNpDWv0GqOaGB/ey9W4BTvJBkBnnXg0puWTS+XaA0e7Fxo8DHj7q3HwUDzeWLcb6gi0mBdxQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+    dev: true
+
+  /@fluidframework/runtime-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Ccq133fn8Tnh7avT+VAm6jcgvBHCjqT29Y2V2g0crgCaqnN7xwkDYDAM+QUcux2osAtTLyy0Xq4apyZMK6CJjQ==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==}
+  /@fluidframework/runtime-utils/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-Ccq133fn8Tnh7avT+VAm6jcgvBHCjqT29Y2V2g0crgCaqnN7xwkDYDAM+QUcux2osAtTLyy0Xq4apyZMK6CJjQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==}
+  /@fluidframework/runtime-utils/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-U/F6dWfbYtO0zPBIILEI8tH+3ONDnb1x3+VHVgVp//mCLOdnLx8kmJ8XPE/1W3uNeg+QIYytc1+9X+XiTeozNw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/sequence/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-VBR3eZm22hh6oS8IeBZbrH1nOrYbpJM8iX58ftIjy/I/JfJSmYao3k6Go07VsE4tg/KdqyhtYcQwZGpJb5b+NA==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -16911,90 +17201,116 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/shared-object-base/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-5wHmGPgd31acYaVMBjamGqzbLvEs8eYWXvfc2cPpvY3NRYa1lbo2xiRIFAFAsBR4I7V/0h1J9N9R4WJ8gNC7rQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-5wHmGPgd31acYaVMBjamGqzbLvEs8eYWXvfc2cPpvY3NRYa1lbo2xiRIFAFAsBR4I7V/0h1J9N9R4WJ8gNC7rQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-0Po/P4IR/woMgRq0WrSdH/ZmWp7+KJNmm3wSzOKCPUZw5I/coofnLZN6Y3uEOgXFXYqYRbxkbclgxgyVtvkuKQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-O0f9JhigRYG0/zFCtW4wgctheW61tbz+DaWoG7zu0f13gWAvc+qRTxU0kUH7eWxug+XLRNnDMIwnaTKBetZ8IA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.1
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-fJxPPRlXMWYFgnZ+biLSjcipgSGcMB66uQ7/vU7bkRPNgg0Q5pBw8KBtQZR2vaxJ/86lCCDUombp0VucwZFDEw==}
     dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-BbrlU1Pz6rLLk8B8B7Qep/ndS5HM0+j6jgRHcmte/j/jOxdL2rJTFgZ5rGF+wYjsXYrhFffT6ePQ5C38CV+OEA==}
+  /@fluidframework/synthesize/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-VENhFUwNZJIz9n1EIRFvZYgGtdqr9CITKIES6S29QiH82cx8AbSginSKYZgooW30JgLHpvXkk35AMixpmhuKcg==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+    dev: true
+
+  /@fluidframework/synthesize/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-4ByK3gOeXG3NHKObyZva+HJ+v0t/DJuUjAbUZA3MiLEIaOfoAJk4bfxb+gh/sUNdupwISw7YaCw/k7Zc6T09EQ==}
+    dependencies:
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+    dev: true
+
+  /@fluidframework/task-manager/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-dSy2SjWy2K52tYcnH8jwLpNKlx8HLPuov0WOhvX/Lg3uynY8F4b9NkK8R1bv8AgBkHIgY45PnbkEleXBjWdm+g==}
+    dependencies:
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-4ydYNfLv8SPiKTdAbTNPH/u2P817/7UF/SK8RCRpmTVGHVIB+l+GR85QUsFw7yLkAslA7Og7Cg9j3017v+KQiw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
       '@fluidframework/protocol-definitions': 3.0.0
       debug: 4.3.4
       events: 3.3.0
@@ -17003,30 +17319,44 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-BqoQtIX2ExZRbfRDCQD7tGPcKFCyeUizDhKMnbJ+OD7lXixUdwQRDUQ6fPMCeZnnFQXe9VkxpNOa4FaeFIgIng==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-pyIes1HMsY36QWf2q1oQCqAn+A/QVC6faD+bi7bx3JcwhkrlmmqklRVHwwsea8K1qIJDHSR6MP+Ro6zC2uOvOA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/protocol-definitions': 3.0.0
+      debug: 4.3.4
+      events: 3.3.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/test-driver-definitions/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-KfPWHI31U2YuG0yNdeQ8gKULjilbdKgvWgAPEzAGEbbg41ZDFG0eAumbvlkUpBl1AM/cQprMKkYloAIQeGZiBQ==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
       uuid: 9.0.1
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-9xpfAbPBy2DT9k5Pja7SIbr+UGdZhX45gcBHVXX6kZXDgJmWbbLYBYZVtiFKfu9VZPLn7C5g9njym3xFlhpCXw==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-Nj5gENe68wNDJgdKpIWy88rWwUNwlFT3Yq0098MfRcKQTK2Bki7cJXcN4mm6dQ9elUMr0+9X5yNpBMGzSAieAg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17039,21 +17369,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.7.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-9xpfAbPBy2DT9k5Pja7SIbr+UGdZhX45gcBHVXX6kZXDgJmWbbLYBYZVtiFKfu9VZPLn7C5g9njym3xFlhpCXw==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-Nj5gENe68wNDJgdKpIWy88rWwUNwlFT3Yq0098MfRcKQTK2Bki7cJXcN4mm6dQ9elUMr0+9X5yNpBMGzSAieAg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.8.6
@@ -17071,30 +17401,30 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-6K8HXdelwVLvz4fhapaiR1ASGbWRMp8N1LTmINIMi9ozpnMEAX6vJ6LnDD1/SdI1iwxcrXWSHE+rhSh+to5qCA==}
+  /@fluidframework/test-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-gxoh4+4BI2Tztmaq2M7O+u1sUXUnOQA9fCwi+lCn7wqrfjfpUMk3TRd6G8jhQb2dXcp8Y8JInfJOG0wfzkKoFw==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/datastore': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/datastore': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 9.0.1
@@ -17105,21 +17435,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-bArH0Vrg6FZO+TcyNQLdV9CikoQZaFXgZh1Lhwnd76WCxB7sC7A/huCqYAml9dpcVIU5drz+ZNdxpUIxE1jh1Q==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.7.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/fluid-static': 2.0.0-internal.7.1.0
-      '@fluidframework/map': 2.0.0-internal.7.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/fluid-static': 2.0.0-internal.7.2.0
+      '@fluidframework/map': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.7.2.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -17129,14 +17459,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-fMmmD1i5wxM+bXqaGKHDKaFmqS2Y/lSRVwcM3vgDxHcEPppanJPTiu1jPaMEHHFEmhpptv/wI+rA5ItutKZxjA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.0
       jsrsasign: 10.8.6
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -17147,12 +17477,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-F7/V+djKVD81PnHedJiAlkm2z+Jbco6u3TbTcZRpX88HnGkvmsprA6eqLbHjXDiJY3Kx7T+blfibAzS12sUpwg==}
+  /@fluidframework/tool-utils/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-fAmRk+ivfC4nxmbWcey9ATUP4Fnp76ffZVoAUHG+4sD+UKWCT/65Mq1EFx65EPW7Yb/+Mhs68onBfGwIwwgpjQ==}
     dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.7.1.0_debug@4.3.4
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.1.0_debug@4.3.4
+      '@fluidframework/core-utils': 2.0.0-internal.7.2.1
+      '@fluidframework/driver-utils': 2.0.0-internal.7.2.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
       async-mutex: 0.3.2
       debug: 4.3.4
@@ -17163,32 +17493,38 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-u/l9QLySIFw63ArULse27ZZWRkYpezHeBRrCgBEWpuljJg5q16Ii+5lKPRMlfC7ztbxqSdjw76LlGF7b785Y/Q==}
+  /@fluidframework/undo-redo/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-DLx52lSBNEa2Ck6RHEGRTX7qlRARuF5hVw9gQKaqVMivm84mDYfjUrmv2wwwi82mIzN0uTaeNJU34pZzs8t56w==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.7.1.0
-      '@fluidframework/matrix': 2.0.0-internal.7.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.7.1.0
-      '@fluidframework/sequence': 2.0.0-internal.7.1.0
+      '@fluidframework/map': 2.0.0-internal.7.2.0
+      '@fluidframework/matrix': 2.0.0-internal.7.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.2.0
+      '@fluidframework/sequence': 2.0.0-internal.7.2.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-qzO2YzTxpnW52D+kRQ2q4MeG3AjCN9yD0NIarZyA630D9+gTR8SPHi79gYX9354OSgH9HRNivlajHOVMXt4upQ==}
+  /@fluidframework/view-adapters/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-oBbiezJ5JwVHxNY7JP2tnoqaV7ytPAXGZawF03nF3Jjlug7hUxPJzduAVFRXMLHrr5bhuWlU1JKOWkOC2kUSHg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.7.1.0:
-    resolution: {integrity: sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==}
+  /@fluidframework/view-interfaces/2.0.0-internal.7.2.0:
+    resolution: {integrity: sha512-WKVpbwX8l4Qa/qL73qHdVCuNJMM4OA6xwuJx9WWWAWwH8gRfKV4vvKN/RWcvSnrM/tt7bfBcSAbT8niJcE/Uug==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.0
+    dev: true
+
+  /@fluidframework/view-interfaces/2.0.0-internal.7.2.1:
+    resolution: {integrity: sha512-5BSvozlkZvQmvK/wg6W+4sgpWrbGdkGCwZIK8TxGmvbv8/LqG5baew04Z4E4Kx6T3SXG3VIPtsU/GSpkj2o7Aw==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.1
     dev: true
 
   /@fwouts/vite-tsconfig-paths/4.2.1_r4r6c3cdao6xxaatmhvdmzzgsi:
@@ -19278,7 +19614,7 @@ packages:
       '@previewjs/type-analyzer': 9.0.1
       assert-never: 1.2.1
       prettier: 2.8.8
-      typescript: 5.2.2
+      typescript: 5.1.6
     dev: true
 
   /@previewjs/storybook-helpers/3.0.0_@types+node@16.18.58:
@@ -19288,7 +19624,7 @@ packages:
       '@previewjs/core': 23.0.1_@types+node@16.18.58
       '@previewjs/serializable-values': 7.0.3
       '@previewjs/type-analyzer': 8.0.2
-      typescript: 5.2.2
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -19309,7 +19645,7 @@ packages:
       '@previewjs/vfs': 2.0.17
       assert-never: 1.2.1
       prettier: 2.8.8
-      typescript: 5.2.2
+      typescript: 5.1.6
     dev: true
 
   /@previewjs/type-analyzer/9.0.1:
@@ -23329,7 +23665,7 @@ packages:
   /axios/0.21.4_debug@4.3.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.3
+      follow-redirects: 1.15.3_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: true
@@ -23367,7 +23703,7 @@ packages:
   /axios/0.27.2_debug@4.3.4:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.3
+      follow-redirects: 1.15.3_debug@4.3.4
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
Following https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/on-call/release/release-minor instructtions to update type compatibility tests