### PR TITLE
fix(check:policy): Include the handler name in failure message

### DIFF
--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -256,7 +256,7 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy> {
 					handler.handler(relPath, gitRoot),
 				);
 				if (result !== undefined && result !== "") {
-					let output = `${newline}file failed policy check: ${relPath}${newline}${result}`;
+					let output = `${newline}file failed the "${handler.name}" policy: ${relPath}${newline}${result}`;
 					const { resolver } = handler;
 					if (this.flags.fix && resolver) {
 						output += `${newline}attempting to resolve: ${relPath}`;


### PR DESCRIPTION
When a policy fails, it's helpful to know what the name of the failing policy is, so you can easily add an exclusion if needed. The error message will now contain the policy name.