### PR TITLE
fix(check:policy): Exclude tsc --watch tasks from policy

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -482,7 +482,12 @@ export const handlers: Handler[] = [
 				for (const script in json.scripts) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					const command = json.scripts[script]!;
-					if (command.startsWith("tsc") && !ignore.has(script)) {
+					if (
+						command.startsWith("tsc") &&
+						// tsc --watch tasks are long-running processes and don't need the standard task deps
+						!command.includes("--watch") &&
+						!ignore.has(script)
+					) {
 						try {
 							const checkDeps = getTscCommandDependencies(
 								packageDir,


### PR DESCRIPTION
Scripts that call `tsc` with the `--watch` flag should be excluded from the fluid-build task policy since fluid-build doesn't need to run them.