### PR TITLE
fix(build-cli): Fix broken test

### DIFF
--- a/build-tools/packages/build-cli/test/filter.test.ts
+++ b/build-tools/packages/build-cli/test/filter.test.ts
@@ -178,7 +178,6 @@ describe("selectAndFilterPackages", async () => {
 			"@fluid-private/changelog-generator-wrapper",
 			"@fluid-internal/getkeys",
 			"@fluidframework/test-tools",
-			"tinylicious",
 		]);
 	});
 


### PR DESCRIPTION
Tinylicious was recently moved to the server release group which broke a build-tools test. Build-tools wasn't triggered in the PR CI run so the failure wasn't caught in PR.