### PR TITLE
Don't allow strings to be passed directly as inserted content into SharedTreeLists

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1988,9 +1988,9 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha
 export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> extends ReadonlyArray<ProxyNodeUnion<TTypes, API>> {
-    insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes>>): void;
-    insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes>>): void;
-    insertAtStart(value: Iterable<ProxyNodeUnion<TTypes>>): void;
+    insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(index: number, value: T extends string ? never : T): void;
+    insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
+    insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -43,20 +43,36 @@ export interface SharedTreeList<
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
+	 * @privateRemarks
+	 * We explicitly prevent the user from passing "strings" in.
+	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
-	insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes>>): void;
+	insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(
+		index: number,
+		value: T extends string ? never : T,
+	): void;
 
 	/**
 	 * Inserts new item(s) at the start of the list.
 	 * @param value - The content to insert.
+	 * @privateRemarks
+	 * We explicitly prevent the user from passing "strings" in.
+	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
-	insertAtStart(value: Iterable<ProxyNodeUnion<TTypes>>): void;
+	insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(
+		value: T extends string ? never : T,
+	): void;
 
 	/**
 	 * Inserts new item(s) at the end of the list.
 	 * @param value - The content to insert.
+	 * @privateRemarks
+	 * We explicitly prevent the user from passing "strings" in.
+	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
-	insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes>>): void;
+	insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(
+		value: T extends string ? never : T,
+	): void;
 
 	/**
 	 * Removes the item at the specified location.

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -178,6 +178,63 @@ describe("SharedTreeList", () => {
 		});
 	});
 
+	describe("inserting primitive", () => {
+		const _ = new SchemaBuilder({ scope: "test" });
+		const obj = _.object("Obj", {
+			numbers: _.list(_.number),
+			strings: _.list(_.string),
+			booleans: _.list(_.boolean),
+		});
+		const schema = _.intoSchema(obj);
+		const initialTree = { numbers: [], strings: [], booleans: [] };
+		itWithRoot("numbers", schema, initialTree, (root) => {
+			root.numbers.insertAtStart([0]);
+			root.numbers.insertAt(1, [1]);
+			root.numbers.insertAtEnd([2]);
+			assert.throws(() => {
+				// @ts-expect-error Inserted content needs to be iterable
+				root.numbers.insertAtStart(3);
+				// @ts-expect-error Inserted content needs to be iterable
+				root.numbers.insertAt(1, 4);
+				// @ts-expect-error Inserted content needs to be iterable
+				root.numbers.insertAtEnd(5);
+			});
+			assert.deepEqual(root.numbers, [0, 1, 2]);
+		});
+
+		itWithRoot("strings", schema, initialTree, (root) => {
+			// This test catches a usability regression in which strings can be passed directly as content to insert,
+			// because strings are also iterables of strings. Passing a string directly as an iterable is very likely not what the user intends.
+			root.strings.insertAtStart(["a"]);
+			root.strings.insertAt(1, ["b"]);
+			root.strings.insertAtEnd(["c"]);
+			assert.throws(() => {
+				// @ts-expect-error Inserted content needs to be non-string iterable
+				root.strings.insertAtStart("d");
+				// @ts-expect-error Inserted content needs to be non-string iterable
+				root.strings.insertAt(1, "e");
+				// @ts-expect-error Inserted content needs to be non-string iterable
+				root.strings.insertAtEnd("f");
+			});
+			assert.deepEqual(root.strings, ["a", "b", "c"]);
+		});
+
+		itWithRoot("booleans", schema, initialTree, (root) => {
+			root.booleans.insertAtStart([true]);
+			root.booleans.insertAt(1, [false]);
+			root.booleans.insertAtEnd([true]);
+			assert.throws(() => {
+				// @ts-expect-error Inserted content needs to be iterable
+				root.booleans.insertAtStart(false);
+				// @ts-expect-error Inserted content needs to be iterable
+				root.booleans.insertAt(1, true);
+				// @ts-expect-error Inserted content needs to be iterable
+				root.booleans.insertAtEnd(false);
+			});
+			assert.deepEqual(root.booleans, [true, false, true]);
+		});
+	});
+
 	describe("removing items", () => {
 		const _ = new SchemaBuilder({ scope: "test" });
 		const schema = _.intoSchema(_.list(_.number));

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -191,14 +191,6 @@ describe("SharedTreeList", () => {
 			root.numbers.insertAtStart([0]);
 			root.numbers.insertAt(1, [1]);
 			root.numbers.insertAtEnd([2]);
-			assert.throws(() => {
-				// @ts-expect-error Inserted content needs to be iterable
-				root.numbers.insertAtStart(3);
-				// @ts-expect-error Inserted content needs to be iterable
-				root.numbers.insertAt(1, 4);
-				// @ts-expect-error Inserted content needs to be iterable
-				root.numbers.insertAtEnd(5);
-			});
 			assert.deepEqual(root.numbers, [0, 1, 2]);
 		});
 
@@ -208,29 +200,27 @@ describe("SharedTreeList", () => {
 			root.strings.insertAtStart(["a"]);
 			root.strings.insertAt(1, ["b"]);
 			root.strings.insertAtEnd(["c"]);
-			assert.throws(() => {
+			const _errors = () => {
 				// @ts-expect-error Inserted content needs to be non-string iterable
 				root.strings.insertAtStart("d");
 				// @ts-expect-error Inserted content needs to be non-string iterable
 				root.strings.insertAt(1, "e");
 				// @ts-expect-error Inserted content needs to be non-string iterable
 				root.strings.insertAtEnd("f");
-			});
-			assert.deepEqual(root.strings, ["a", "b", "c"]);
+			};
+			const gh: Iterable<string> = "gh";
+			root.strings.insertAtStart(gh);
+			const ij: Iterable<string> = "ij";
+			root.strings.insertAt(3, ij);
+			const kl: Iterable<string> = "kl";
+			root.strings.insertAtEnd(kl);
+			assert.deepEqual(root.strings, ["g", "h", "a", "i", "j", "b", "c", "k", "l"]);
 		});
 
 		itWithRoot("booleans", schema, initialTree, (root) => {
 			root.booleans.insertAtStart([true]);
 			root.booleans.insertAt(1, [false]);
 			root.booleans.insertAtEnd([true]);
-			assert.throws(() => {
-				// @ts-expect-error Inserted content needs to be iterable
-				root.booleans.insertAtStart(false);
-				// @ts-expect-error Inserted content needs to be iterable
-				root.booleans.insertAt(1, true);
-				// @ts-expect-error Inserted content needs to be iterable
-				root.booleans.insertAtEnd(false);
-			});
 			assert.deepEqual(root.booleans, [true, false, true]);
 		});
 	});


### PR DESCRIPTION
## Description

When inserting content into a SharedTreeList, the content must be an iterable. For example, `list.insertAtEnd([5])` is allowed, but `list.insertAtEnd(5)` is not. This works for most cases, but is odd for strings, because strings are iterables of strings. Therefore, a user can do `list.insertAtEnd("hello")`, which inserts "h", "e", "l", "l", "o" - almost certainly not what they intended (which was `list.insertAtEnd(["hello"])`. This PR adds a compile time check that strings are not passed in directly to the insert functions, though a user can always bypass this by casting their string to `Iterable<string>` if they really need to.

## Breaking Changes
`strings` can no longer be passed to the SharedTreeList insertion functions without first being cast/narrowed to `Iterable<string>`.
