### PR TITLE
Add additional validation to prevent inserting a string directly into a list

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1988,9 +1988,9 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha
 export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> extends ReadonlyArray<ProxyNodeUnion<TTypes, API>> {
-    insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(index: number, value: T extends string ? never : T): void;
-    insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
-    insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
+    insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(index: number, value: T extends string ? never : string extends T ? never : T): void;
+    insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : string extends T ? never : T): void;
+    insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : string extends T ? never : T): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -202,7 +202,7 @@ function contextualizeInsertedListContent(
 ): Iterable<ContextuallyTypedNodeData> {
 	if (typeof iterable === "string") {
 		throw new TypeError(
-			"Attempted to directly insert a string as iterable list content. Wrap the input string 's' in an array ('[s]') or, if this was intentional, supply the iterator of the string directly via 's[Symbol.iterator]()'",
+			"Attempted to directly insert a string as iterable list content. Wrap the input string 's' in an array ('[s]') to insert it as a single item or, supply the iterator of the string directly via 's[Symbol.iterator]()' if intending to insert each Unicode code point as a separate item.",
 		);
 	}
 	// If the iterable is not already an array, copy it into an array to use '.map()' below.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -197,9 +197,14 @@ const getSequenceField = <TTypes extends AllowedTypes>(
 
 // Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
 // typed data prior to forwarding to 'LazySequence.insert*()'.
-function itemsAsContextuallyTyped(
+function contextualizeInsertedListContent(
 	iterable: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
 ): Iterable<ContextuallyTypedNodeData> {
+	if (typeof iterable === "string") {
+		throw new TypeError(
+			"Attempted to directly insert a string as iterable list content. Wrap the input string 's' in an array ('[s]') or, if this was intentional, supply the iterator of the string directly via 's[Symbol.iterator]()'",
+		);
+	}
 	// If the iterable is not already an array, copy it into an array to use '.map()' below.
 	return Array.isArray(iterable)
 		? iterable.map((item) => extractFactoryContent(item) as ContextuallyTypedNodeData)
@@ -226,7 +231,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			index: number,
 			value: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
-			getSequenceField(this).insertAt(index, itemsAsContextuallyTyped(value));
+			getSequenceField(this).insertAt(index, contextualizeInsertedListContent(value));
 		},
 	},
 	insertAtStart: {
@@ -234,7 +239,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			this: SharedTreeList<AllowedTypes, "javaScript">,
 			value: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
-			getSequenceField(this).insertAtStart(itemsAsContextuallyTyped(value));
+			getSequenceField(this).insertAtStart(contextualizeInsertedListContent(value));
 		},
 	},
 	insertAtEnd: {
@@ -242,7 +247,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			this: SharedTreeList<AllowedTypes, "javaScript">,
 			value: Iterable<ProxyNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
-			getSequenceField(this).insertAtEnd(itemsAsContextuallyTyped(value));
+			getSequenceField(this).insertAtEnd(contextualizeInsertedListContent(value));
 		},
 	},
 	removeAt: {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -49,7 +49,7 @@ export interface SharedTreeList<
 	 */
 	insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(
 		index: number,
-		value: T extends string ? never : T,
+		value: T extends string ? never : string extends T ? never : T,
 	): void;
 
 	/**
@@ -60,7 +60,7 @@ export interface SharedTreeList<
 	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
 	insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		value: T extends string ? never : T,
+		value: T extends string ? never : string extends T ? never : T,
 	): void;
 
 	/**
@@ -71,7 +71,7 @@ export interface SharedTreeList<
 	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
 	insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		value: T extends string ? never : T,
+		value: T extends string ? never : string extends T ? never : T,
 	): void;
 
 	/**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -200,21 +200,67 @@ describe("SharedTreeList", () => {
 			root.strings.insertAtStart(["a"]);
 			root.strings.insertAt(1, ["b"]);
 			root.strings.insertAtEnd(["c"]);
-			const _errors = () => {
-				// @ts-expect-error Inserted content needs to be non-string iterable
-				root.strings.insertAtStart("d");
-				// @ts-expect-error Inserted content needs to be non-string iterable
-				root.strings.insertAt(1, "e");
-				// @ts-expect-error Inserted content needs to be non-string iterable
-				root.strings.insertAtEnd("f");
-			};
-			const gh: Iterable<string> = "gh";
-			root.strings.insertAtStart(gh);
-			const ij: Iterable<string> = "ij";
-			root.strings.insertAt(3, ij);
-			const kl: Iterable<string> = "kl";
-			root.strings.insertAtEnd(kl);
-			assert.deepEqual(root.strings, ["g", "h", "a", "i", "j", "b", "c", "k", "l"]);
+
+			const string: string = "hello";
+			const stringLiteral: "hello" = "hello" as const;
+			const iterableOrString: Iterable<string> | string = "hello";
+			const iterableOrLiteral: Iterable<string> | "hello" = "hello";
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtStart(string);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtStart(stringLiteral);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtStart(iterableOrString);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtStart(iterableOrLiteral);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAt(0, string);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAt(0, stringLiteral);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAt(0, iterableOrString);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAt(0, iterableOrLiteral);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtEnd(string);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtEnd(stringLiteral);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtEnd(iterableOrString);
+			});
+			assert.throws(() => {
+				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtEnd(iterableOrLiteral);
+			});
+
+			const de = "de"[Symbol.iterator]();
+			root.strings.insertAtStart(de);
+			const fg = "fg"[Symbol.iterator]();
+			root.strings.insertAt(3, fg);
+			const hi = "hi"[Symbol.iterator]();
+			root.strings.insertAtEnd(hi);
+			assert.deepEqual(root.strings, ["d", "e", "a", "f", "g", "b", "c", "h", "i"]);
 		});
 
 		itWithRoot("booleans", schema, initialTree, (root) => {


### PR DESCRIPTION
## Breaking Changes
If a string manages to be inserted directly as list content (without wrapping it in an array), there is now a runtime failure with a helpful error message.