### PR TITLE
tree2: Split typed and untyped views

### DIFF
--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -154,29 +154,27 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 		// 3. On all loads, gets an (untyped) view of the data (the contents can't be accessed directly from the sharedTree).
 		// Then the root2() call applies a typing to the untyped view based on our schema.  After that we can actually
 		// reach in and grab the inventoryItems list.
-		this._inventoryItemList = this.sharedTree
-			.schematizeView({
-				initialTree: {
-					inventoryItemList: {
-						// TODO: The list type unfortunately needs this "" key for now, but it's supposed to go away soon.
-						"": [
-							{
-								id: uuid(),
-								name: "nut",
-								quantity: 0,
-							},
-							{
-								id: uuid(),
-								name: "bolt",
-								quantity: 0,
-							},
-						],
-					},
+		this._inventoryItemList = this.sharedTree.schematize({
+			initialTree: {
+				inventoryItemList: {
+					// TODO: The list type unfortunately needs this "" key for now, but it's supposed to go away soon.
+					"": [
+						{
+							id: uuid(),
+							name: "nut",
+							quantity: 0,
+						},
+						{
+							id: uuid(),
+							name: "bolt",
+							quantity: 0,
+						},
+					],
 				},
-				allowedSchemaModifications: AllowedUpdateType.None,
-				schema,
-			})
-			.root2(schema).inventoryItemList;
+			},
+			allowedSchemaModifications: AllowedUpdateType.None,
+			schema,
+		}).root.inventoryItemList;
 		// afterChange will fire for any change of any type anywhere in the subtree.  In this application we expect
 		// three types of tree changes that will trigger this handler - add items, delete items, change item quantities.
 		// Since "afterChange" doesn't provide event args, we need to scan the tree and compare it to our InventoryItems

--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -73,11 +73,11 @@ export class Bubblebench extends DataObject {
 	 * @param tree - ISharedTree
 	 */
 	initializeTree(tree: ISharedTree) {
-		this.view = tree.schematizeView({
+		this.view = tree.schematize({
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [],
 			schema: appSchemaData,
-		});
+		}).branch;
 	}
 
 	/**

--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -7,7 +7,7 @@ import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import {
 	ForestType,
 	ISharedTree,
-	ISharedTreeView,
+	ISharedTreeView2,
 	SharedTreeFactory,
 	typeboxValidator,
 } from "@fluid-experimental/tree2";
@@ -23,12 +23,12 @@ const factory = new SharedTreeFactory({
 
 export class InventoryList extends DataObject {
 	#tree?: ISharedTree;
-	#view?: ISharedTreeView;
+	#view?: ISharedTreeView2<typeof treeConfiguration.schema.rootFieldSchema>;
 
 	public get inventory(): Inventory {
 		if (this.#view === undefined)
 			throw new Error("view should be initialized by hasInitialized");
-		return this.#view.root2(treeConfiguration.schema);
+		return this.#view.root;
 	}
 
 	protected async initializingFirstTime() {
@@ -46,7 +46,7 @@ export class InventoryList extends DataObject {
 	protected async hasInitialized() {
 		if (this.#tree === undefined)
 			throw new Error("tree should be initialized by initializing* methods");
-		this.#view = this.#tree.schematizeView(treeConfiguration);
+		this.#view = this.#tree.schematize(treeConfiguration);
 	}
 }
 

--- a/examples/version-migration/tree-shim/src/model/newTreeInventoryList.ts
+++ b/examples/version-migration/tree-shim/src/model/newTreeInventoryList.ts
@@ -157,29 +157,27 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 		// 3. On all loads, gets an (untyped) view of the data (the contents can't be accessed directly from the sharedTree).
 		// Then the root2() call applies a typing to the untyped view based on our schema.  After that we can actually
 		// reach in and grab the inventoryItems list.
-		this._inventoryItemList = this.sharedTree
-			.schematizeView({
-				initialTree: {
-					inventoryItemList: {
-						// TODO: The list type unfortunately needs this "" key for now, but it's supposed to go away soon.
-						"": [
-							{
-								id: uuid(),
-								name: "nut",
-								quantity: 0,
-							},
-							{
-								id: uuid(),
-								name: "bolt",
-								quantity: 0,
-							},
-						],
-					},
+		this._inventoryItemList = this.sharedTree.schematize({
+			initialTree: {
+				inventoryItemList: {
+					// TODO: The list type unfortunately needs this "" key for now, but it's supposed to go away soon.
+					"": [
+						{
+							id: uuid(),
+							name: "nut",
+							quantity: 0,
+						},
+						{
+							id: uuid(),
+							name: "bolt",
+							quantity: 0,
+						},
+					],
 				},
-				allowedSchemaModifications: AllowedUpdateType.None,
-				schema,
-			})
-			.root2(schema).inventoryItemList;
+			},
+			allowedSchemaModifications: AllowedUpdateType.None,
+			schema,
+		}).root.inventoryItemList;
 		// afterChange will fire for any change of any type anywhere in the subtree.  In this application we expect
 		// three types of tree changes that will trigger this handler - add items, delete items, change item quantities.
 		// Since "afterChange" doesn't provide event args, we need to scan the tree and compare it to our InventoryItems

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -516,6 +516,9 @@ export enum DiscardResult {
 }
 
 // @alpha
+export const disposeSymbol: unique symbol;
+
+// @alpha
 function downCast<TSchema extends TreeNodeSchema>(schema: TSchema, tree: UntypedTreeCore): tree is TypedNode_2<TSchema>;
 
 // @alpha
@@ -849,9 +852,13 @@ export interface IDefaultEditBuilder {
 }
 
 // @alpha
+export interface IDisposable {
+    [disposeSymbol](): void;
+}
+
+// @alpha
 export interface IEditableForest extends IForestSubscription {
     acquireVisitor(): DeltaVisitor;
-    readonly anchors: AnchorSet;
 }
 
 // @alpha
@@ -863,6 +870,7 @@ export interface IEmitter<E extends Events<E>> {
 // @alpha
 export interface IForestSubscription extends Dependee, ISubscribable<ForestEvents> {
     allocateCursor(): ITreeSubscriptionCursor;
+    readonly anchors: AnchorSet;
     clone(schema: StoredSchemaRepository, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
     readonly isEmpty: boolean;
@@ -1050,8 +1058,9 @@ export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : fals
 // @alpha
 export interface ISharedTree extends ISharedObject, TypedTreeChannel {
     contentSnapshot(): SharedTreeContentSnapshot;
-    requireSchema<TRoot extends TreeFieldSchema>(schema: TreeSchema<TRoot>, onSchemaIncompatible: () => void): ISharedTreeView | undefined;
-    schematizeView<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView;
+    requireSchema<TRoot extends TreeFieldSchema>(schema: TreeSchema<TRoot>, onSchemaIncompatible: () => void): ISharedTreeView2<TRoot> | undefined;
+    // (undocumented)
+    schematize<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ISharedTreeView2<TRoot>;
 }
 
 // @alpha
@@ -1061,7 +1070,9 @@ export interface ISharedTreeBranchView extends ISharedTreeView {
 
 // @alpha
 export interface ISharedTreeView extends AnchorLocator {
+    // @deprecated
     readonly context: EditableTreeContext;
+    // @deprecated
     editableTree2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): TypedField<TRoot>;
     readonly editor: IDefaultEditBuilder;
     readonly events: ISubscribable<ViewEvents>;
@@ -1070,13 +1081,22 @@ export interface ISharedTreeView extends AnchorLocator {
     merge(view: ISharedTreeBranchView): void;
     merge(view: ISharedTreeBranchView, disposeView: boolean): void;
     rebase(view: ISharedTreeBranchView): void;
+    // @deprecated
     get root(): UnwrappedEditableField;
-    // (undocumented)
+    // @deprecated (undocumented)
     root2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): ProxyField<TRoot>;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
+    // @deprecated
     setContent(data: NewFieldContent): void;
     readonly storedSchema: StoredSchemaRepository;
     readonly transaction: ITransaction;
+}
+
+// @alpha
+export interface ISharedTreeView2<in out TRoot extends TreeFieldSchema> extends IDisposable, TypedTreeView<TRoot> {
+    readonly branch: ISharedTreeView;
+    readonly context: TreeContext;
+    readonly editableTree: TypedField<TRoot>;
 }
 
 // @alpha (undocumented)
@@ -2314,7 +2334,7 @@ type TypedNodeUnionHelper<TTypes extends InternalTypedSchemaTypes.FlexList<TreeN
 
 // @alpha
 export interface TypedTreeChannel extends IChannel {
-    schematize<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): TypedField<TRoot>;
+    schematize<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): TypedTreeView<TRoot>;
 }
 
 // @alpha
@@ -2333,6 +2353,11 @@ export class TypedTreeFactory implements IChannelFactory {
 // @alpha
 export interface TypedTreeOptions extends SharedTreeOptions {
     readonly subtype: string;
+}
+
+// @alpha
+export interface TypedTreeView<in out TRoot extends TreeFieldSchema> {
+    readonly root: ProxyField<TRoot>;
 }
 
 // @alpha

--- a/experimental/dds/tree2/src/core/forest/editableForest.ts
+++ b/experimental/dds/tree2/src/core/forest/editableForest.ts
@@ -6,7 +6,6 @@
 import { assert } from "@fluidframework/core-utils";
 import { FieldKey } from "../schema-stored";
 import {
-	AnchorSet,
 	DetachedField,
 	Delta,
 	Anchor,
@@ -23,16 +22,6 @@ import { IForestSubscription, ITreeSubscriptionCursor } from "./forest";
  * @alpha
  */
 export interface IEditableForest extends IForestSubscription {
-	/**
-	 * Set of anchors this forest is tracking.
-	 *
-	 * To keep these anchors usable, this AnchorSet must be updated / rebased for any changes made to the forest.
-	 * It is the responsibility of the caller of the forest-editing methods to do this, not the forest itself.
-	 * The caller performs these updates because it has more semantic knowledge about the edits, which can be needed to
-	 * update the anchors in a semantically optimal way.
-	 */
-	readonly anchors: AnchorSet;
-
 	/**
 	 * Provides a visitor that can be used to mutate the forest.
 	 *

--- a/experimental/dds/tree2/src/core/forest/forest.ts
+++ b/experimental/dds/tree2/src/core/forest/forest.ts
@@ -57,6 +57,16 @@ export interface ForestEvents {
  */
 export interface IForestSubscription extends Dependee, ISubscribable<ForestEvents> {
 	/**
+	 * Set of anchors this forest is tracking.
+	 *
+	 * To keep these anchors usable, this AnchorSet must be updated / rebased for any changes made to the forest.
+	 * It is the responsibility of the caller of the forest-editing methods to do this, not the forest itself.
+	 * The caller performs these updates because it has more semantic knowledge about the edits, which can be needed to
+	 * update the anchors in a semantically optimal way.
+	 */
+	readonly anchors: AnchorSet;
+
+	/**
 	 * Create an independent copy of this forest, that uses the provided schema and anchors.
 	 *
 	 * The new copy will not invalidate observers (dependents) of the old one.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/context.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/context.ts
@@ -5,14 +5,14 @@
 
 import { assert } from "@fluidframework/core-utils";
 import {
-	IEditableForest,
 	moveToDetachedField,
 	ForestEvents,
 	TreeFieldStoredSchema,
 	FieldKey,
+	IForestSubscription,
 } from "../../core";
 import { ISubscribable } from "../../events";
-import { DefaultEditBuilder } from "../default-field-kinds";
+import { IDefaultEditBuilder } from "../default-field-kinds";
 import { NodeKeyIndex, NodeKeyManager } from "../node-key";
 import { FieldGenerator } from "../contextuallyTyped";
 import { TreeSchema } from "../typed-schema";
@@ -66,8 +66,8 @@ export class Context implements TreeContext, IDisposable {
 	 */
 	public constructor(
 		public readonly schema: TreeSchema,
-		public readonly forest: IEditableForest,
-		public readonly editor: DefaultEditBuilder,
+		public readonly forest: IForestSubscription,
+		public readonly editor: IDefaultEditBuilder,
 		public readonly nodeKeys: NodeKeys,
 		public readonly nodeKeyFieldKey: FieldKey,
 	) {
@@ -142,8 +142,8 @@ export class Context implements TreeContext, IDisposable {
  */
 export function getTreeContext(
 	schema: TreeSchema,
-	forest: IEditableForest,
-	editor: DefaultEditBuilder,
+	forest: IForestSubscription,
+	editor: IDefaultEditBuilder,
 	nodeKeyManager: NodeKeyManager,
 	nodeKeyFieldKey: FieldKey,
 ): Context {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/index.ts
@@ -55,7 +55,7 @@ export {
 	visitIterableTreeWithState,
 } from "./navigation";
 
-export { getTreeContext, TreeContext } from "./context";
+export { getTreeContext, TreeContext, Context } from "./context";
 
 // Below here are things that are used by the above, but not part of the desired API surface.
 import * as InternalEditableTreeTypes from "./internal";

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -281,6 +281,7 @@ export {
 	SharedTreeObjectFactory,
 	FactoryTreeSchema,
 	addFactory,
+	Context,
 } from "./editable-tree-2";
 
 export { treeSchemaFromStoredSchema } from "./storedToViewSchema";

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -106,6 +106,8 @@ export {
 	RangeQueryResult,
 	Named,
 	oneFromSet,
+	disposeSymbol,
+	IDisposable,
 } from "./util";
 
 export {
@@ -310,6 +312,8 @@ export {
 	TypedTreeOptions,
 	TypedTreeChannel,
 	SharedTreeContentSnapshot,
+	ISharedTreeView2,
+	TypedTreeView,
 } from "./shared-tree";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec";

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -28,4 +28,6 @@ export {
 	SchemaConfiguration,
 } from "./schematizedTree";
 
-export { TypedTreeFactory, TypedTreeOptions, TypedTreeChannel } from "./typedTree";
+export { TypedTreeFactory, TypedTreeOptions, TypedTreeChannel, TypedTreeView } from "./typedTree";
+
+export { ISharedTreeView2 } from "./sharedTreeView2";

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -15,6 +15,7 @@ import { ISharedObject } from "@fluidframework/shared-object-base";
 import { ICodecOptions, noopValidator } from "../codec";
 import {
 	Compatibility,
+	FieldKey,
 	InMemoryStoredSchemaRepository,
 	JsonableTree,
 	TreeStoredSchema,
@@ -37,14 +38,14 @@ import {
 	makeTreeChunker,
 	DetachedFieldIndexSummarizer,
 	createNodeKeyManager,
-	nodeKeyFieldKey,
-	TypedField,
+	nodeKeyFieldKey as defailtNodeKeyFieldKey,
 	jsonableTreeFromFieldCursor,
 	TreeSchema,
 	ViewSchema,
+	NodeKeyManager,
 } from "../feature-libraries";
 import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events";
-import { JsonCompatibleReadOnly, brand } from "../util";
+import { JsonCompatibleReadOnly, brand, fail } from "../util";
 import { type TypedTreeChannel } from "./typedTree";
 import {
 	InitializeAndSchematizeConfiguration,
@@ -52,12 +53,8 @@ import {
 	initializeContent,
 	schematize,
 } from "./schematizedTree";
-import {
-	ISharedTreeView,
-	SharedTreeView,
-	ViewEvents,
-	createSharedTreeView,
-} from "./sharedTreeView";
+import { SharedTreeView, ViewEvents, createSharedTreeView } from "./sharedTreeView";
+import { ISharedTreeView2, SharedTreeView2 } from "./sharedTreeView2";
 
 /**
  * Copy of data from an {@link ISharedTree} at some point in time.
@@ -97,38 +94,13 @@ export interface ISharedTree extends ISharedObject, TypedTreeChannel {
 	 */
 	contentSnapshot(): SharedTreeContentSnapshot;
 
-	/**
-	 * Takes in a tree and returns a view of it that conforms to the view schema.
-	 * The returned view referees to and can edit the provided one: it is not a fork of it.
-	 * Updates the stored schema in the tree to match the provided one if requested by config and compatible.
-	 *
-	 * If the tree is uninitialized (has no nodes or schema at all),
-	 * it is initialized to the config's initial tree and the provided schema are stored.
-	 * This is done even if `AllowedUpdateType.None`.
-	 *
-	 * @remarks
-	 * Doing initialization here, regardless of `AllowedUpdateType`, allows a small API that is hard to use incorrectly.
-	 * Other approach tend to have leave easy to make mistakes.
-	 * For example, having a separate initialization function means apps can forget to call it, making an app that can only open existing document,
-	 * or call it unconditionally leaving an app that can only create new documents.
-	 * It also would require the schema to be passed into to separate places and could cause issues if they didn't match.
-	 * Since the initialization function couldn't return a typed tree, the type checking wouldn't help catch that.
-	 * Also, if an app manages to create a document, but the initialization fails to get persisted, an app that only calls the initialization function
-	 * on the create code-path (for example how a schematized factory might do it),
-	 * would leave the document in an unusable state which could not be repaired when it is reopened (by the same or other clients).
-	 * Additionally, once out of schema content adapters are properly supported (with lazy document updates),
-	 * this initialization could become just another out of schema content adapter: at tha point it clearly belong here in schematize.
-	 *
-	 * TODO:
-	 * - Implement schema-aware API for return type.
-	 * - Support adapters for handling out of schema data.
-	 */
-	schematizeView<TRoot extends TreeFieldSchema>(
+	// Overrides less specific schematize from base
+	schematize<TRoot extends TreeFieldSchema>(
 		config: InitializeAndSchematizeConfiguration<TRoot>,
-	): ISharedTreeView;
+	): ISharedTreeView2<TRoot>;
 
 	/**
-	 * Like {@link ISharedTree.schematizeView}, but will never modify the document.
+	 * Like {@link ISharedTree.schematize}, but will never modify the document.
 	 *
 	 * @param schema - The view schema to use.
 	 * @param onSchemaIncompatible - A callback.
@@ -145,7 +117,7 @@ export interface ISharedTree extends ISharedObject, TypedTreeChannel {
 	requireSchema<TRoot extends TreeFieldSchema>(
 		schema: TreeSchema<TRoot>,
 		onSchemaIncompatible: () => void,
-	): ISharedTreeView | undefined;
+	): ISharedTreeView2<TRoot> | undefined;
 }
 
 /**
@@ -207,7 +179,9 @@ export class SharedTree
 	public requireSchema<TRoot extends TreeFieldSchema>(
 		schema: TreeSchema<TRoot>,
 		onSchemaIncompatible: () => void,
-	): ISharedTreeView | undefined {
+		nodeKeyManager?: NodeKeyManager,
+		nodeKeyFieldKey?: FieldKey,
+	): SharedTreeView2<TRoot> | undefined {
 		const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schema);
 		const compatibility = viewSchema.checkCompatibility(this.storedSchema);
 		if (
@@ -232,7 +206,12 @@ export class SharedTree
 
 		afterSchemaChanges(this._events, this.storedSchema, onSchemaChange);
 
-		return this.view;
+		return new SharedTreeView2(
+			this.view,
+			schema,
+			nodeKeyManager ?? createNodeKeyManager(this.runtime.idCompressor),
+			nodeKeyFieldKey ?? brand(defailtNodeKeyFieldKey),
+		);
 	}
 
 	public contentSnapshot(): SharedTreeContentSnapshot {
@@ -248,9 +227,11 @@ export class SharedTree
 		}
 	}
 
-	public schematizeView<TRoot extends TreeFieldSchema>(
+	public schematize<TRoot extends TreeFieldSchema>(
 		config: InitializeAndSchematizeConfiguration<TRoot>,
-	): SharedTreeView {
+		nodeKeyManager?: NodeKeyManager,
+		nodeKeyFieldKey?: FieldKey,
+	): SharedTreeView2<TRoot> {
 		// TODO:
 		// When this becomes a more proper out of schema adapter, editing should be made lazy.
 		// This will improve support for readonly documents, cross version collaboration and attribution.
@@ -266,15 +247,14 @@ export class SharedTree
 
 		schematize(this.view.events, this.storedSchema, config);
 
-		return this.view;
-	}
-
-	public schematize<TRoot extends TreeFieldSchema>(
-		config: InitializeAndSchematizeConfiguration<TRoot>,
-	): TypedField<TRoot> {
-		const nodeKeyManager = createNodeKeyManager(this.runtime.idCompressor);
-		const view = this.schematizeView(config);
-		return view.editableTree2(config.schema, nodeKeyManager, brand(nodeKeyFieldKey));
+		return (
+			this.requireSchema(
+				config.schema,
+				() => fail("schema incompatible"),
+				nodeKeyManager,
+				nodeKeyFieldKey,
+			) ?? fail("Schematize failed")
+		);
 	}
 
 	/**

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -75,7 +75,11 @@ export interface ViewEvents {
  * Provides a means for interacting with a SharedTree.
  * This includes reading data from the tree and running transactions to mutate the tree.
  * @remarks This interface should not have any implementations other than those provided by the SharedTree package libraries.
- * @privateRemarks Implementations of this interface must implement the {@link branchKey} property.
+ * @privateRemarks
+ * Implementations of this interface must implement the {@link branchKey} property.
+ * TODO:
+ * This interface is the one without a View schema.
+ * For clarity it should be renamed to something like "BranchCheckout"
  * @alpha
  */
 export interface ISharedTreeView extends AnchorLocator {
@@ -90,6 +94,8 @@ export interface ISharedTreeView extends AnchorLocator {
 	 *
 	 * Currently any access to this view of the tree may allocate cursors and thus require
 	 * `context.prepareForEdit()` before editing can occur.
+	 *
+	 * @deprecated Use {@link ISharedTreeView2} and editable tree 2.
 	 */
 	// TODO: either rename this or `EditableTreeContext.unwrappedRoot` to avoid name confusion.
 	get root(): UnwrappedEditableField;
@@ -98,6 +104,7 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * Sets the content of the root field of the tree.
 	 *
 	 * See {@link EditableTreeContext.unwrappedRoot} on how this works.
+	 * @deprecated Use {@link ISharedTreeView2} and editable tree 2.
 	 */
 	setContent(data: NewFieldContent): void;
 
@@ -105,6 +112,7 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * Context for controlling the EditableTree nodes produced from {@link ISharedTreeView.root}.
 	 *
 	 * TODO: Exposing access to this should be unneeded once editing APIs are finished.
+	 * @deprecated Use {@link ISharedTreeView2} and editable tree 2.
 	 */
 	readonly context: EditableTreeContext;
 
@@ -193,9 +201,14 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * As long as it is passed in here as a workaround, the caller must ensure that the stored schema is compatible.
 	 * If the stored schema is edited and becomes incompatible (or was not originally compatible),
 	 * using the returned tree is invalid and is likely to error or corrupt the document.
+	 *
+	 * @deprecated Use {@link ISharedTreeView2}.
 	 */
 	editableTree2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): TypedField<TRoot>;
 
+	/**
+	 * @deprecated Use {@link TypedTreeView}.
+	 */
 	root2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): ProxyField<TRoot>;
 }
 

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView2.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView2.ts
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FieldKey } from "../core";
+import {
+	TreeFieldSchema,
+	TreeSchema,
+	TypedField,
+	ProxyField,
+	TreeContext,
+	NodeKeyManager,
+	getTreeContext,
+	getProxyForField,
+	Context,
+} from "../feature-libraries";
+import { IDisposable, disposeSymbol } from "../util";
+import { ISharedTreeView } from "./sharedTreeView";
+import { TypedTreeView } from "./typedTree";
+
+/**
+ * An editable view of a (version control style) branch of a shared tree.
+ * @privateRemarks
+ * TODO:
+ * 1. Once ISharedTreeView is renamed this can become ISharedTreeView.
+ * 2. This object should be combined with or accessible from the TreeContext to allow easy access to thinks like branching.
+ * @alpha
+ */
+export interface ISharedTreeView2<in out TRoot extends TreeFieldSchema>
+	extends IDisposable,
+		TypedTreeView<TRoot> {
+	/**
+	 * Context for controlling the EditableTree nodes produced from {@link ISharedTreeView.root}.
+	 *
+	 * @remarks
+	 * This is an owning reference: disposing of this view disposes its context.
+	 */
+	readonly context: TreeContext;
+
+	/**
+	 * Access non-view schema specific aspects of of this branch.
+	 *
+	 * @remarks
+	 * This is a non-owning reference: disposing of this view does not impact the branch.
+	 */
+	readonly branch: ISharedTreeView;
+
+	/**
+	 * Get a typed view of the tree content using the editable-tree-2 API.
+	 */
+	readonly editableTree: TypedField<TRoot>;
+}
+
+/**
+ * Implementation of ISharedTreeView2.
+ */
+export class SharedTreeView2<in out TRoot extends TreeFieldSchema>
+	implements ISharedTreeView2<TRoot>
+{
+	public readonly context: Context;
+	public readonly editableTree: TypedField<TRoot>;
+	public constructor(
+		public readonly branch: ISharedTreeView,
+		public readonly schema: TreeSchema<TRoot>,
+		public readonly nodeKeyManager: NodeKeyManager,
+		public readonly nodeKeyFieldKey: FieldKey,
+	) {
+		this.context = getTreeContext(
+			schema,
+			this.branch.forest,
+			this.branch.editor,
+			nodeKeyManager,
+			nodeKeyFieldKey,
+		);
+		this.editableTree = this.context.root as TypedField<TRoot>;
+	}
+
+	public [disposeSymbol](): void {
+		this.context[disposeSymbol]();
+	}
+
+	public get root(): ProxyField<TRoot> {
+		return getProxyForField(this.editableTree);
+	}
+}

--- a/experimental/dds/tree2/src/shared-tree/typedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/typedTree.ts
@@ -10,7 +10,7 @@ import {
 	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { TreeFieldSchema, TypedField } from "../feature-libraries";
+import { ProxyField, TreeFieldSchema } from "../feature-libraries";
 import { SharedTree, SharedTreeOptions } from "./sharedTree";
 import { InitializeAndSchematizeConfiguration } from "./schematizedTree";
 
@@ -68,7 +68,24 @@ export interface TypedTreeChannel extends IChannel {
 	 */
 	schematize<TRoot extends TreeFieldSchema>(
 		config: InitializeAndSchematizeConfiguration<TRoot>,
-	): TypedField<TRoot>;
+	): TypedTreeView<TRoot>;
+}
+
+/**
+ * An editable view of a (version control style) branch of a shared tree.
+ * @privateRemarks
+ * TODO:
+ * 1. Once ISharedTreeView is renamed this can become ISharedTreeView.
+ * 2. This object should be combined with or accessible from the TreeContext to allow easy access to thinks like branching.
+ * @alpha
+ */
+export interface TypedTreeView<in out TRoot extends TreeFieldSchema> {
+	/**
+	 * The current root of the tree.
+	 */
+	readonly root: ProxyField<TRoot>;
+
+	// TODO: root setter.
 }
 
 /**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.events.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 
 import { FieldKinds } from "../../../feature-libraries";
-import { ForestType, TypedTreeFactory } from "../../../shared-tree";
+import { ForestType, SharedTreeFactory } from "../../../shared-tree";
 import { typeboxValidator } from "../../../external-utilities";
 import { AllowedUpdateType, SchemaBuilder, leaf } from "../../..";
 
@@ -26,10 +26,9 @@ describe("beforeChange/afterChange events", () => {
 		myNumberSequence: SchemaBuilder.sequence(leaf.number),
 	});
 	const schema = builder.intoSchema(SchemaBuilder.field(FieldKinds.required, myNodeSchema));
-	const factory = new TypedTreeFactory({
+	const factory = new SharedTreeFactory({
 		jsonValidator: typeboxValidator,
 		forest: ForestType.Reference,
-		subtype: "test",
 	});
 
 	it("fire the expected number of times", () => {
@@ -43,7 +42,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let rootBeforeChangeCount = 0;
 		let rootAfterChangeCount = 0;
@@ -151,7 +150,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let beforeCounter = 0;
 		let afterCounter = 0;
@@ -207,7 +206,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let rootBeforeCounter = 0;
 		let rootAfterCounter = 0;
@@ -280,7 +279,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let beforeHasFired = false;
 		let afterHasFired = false;
@@ -329,7 +328,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let totalListenerCalls = 0;
 
@@ -357,7 +356,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		const newNumber = 20;
 
@@ -387,7 +386,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 		let totalListenerCalls = 0;
 		const newString = "John";
 
@@ -415,7 +414,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let totalListenerCalls = 0;
 
@@ -477,7 +476,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let totalListenerCalls = 0;
 
@@ -517,7 +516,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let totalListenerCalls = 0;
 
@@ -589,7 +588,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let beforeCounter = 0;
 		let afterCounter = 0;
@@ -619,7 +618,7 @@ describe("beforeChange/afterChange events", () => {
 			},
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		}).content;
+		}).editableTree.content;
 
 		let rootBeforeCounter = 0;
 		let rootAfterCounter = 0;

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -13,11 +13,12 @@ import {
 	TreeSchema,
 	createMockNodeKeyManager,
 	nodeKeyFieldKey,
+	SchemaAware,
 } from "../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { Context, getTreeContext } from "../../../feature-libraries/editable-tree-2/context";
-import { AllowedUpdateType, IEditableForest } from "../../../core";
-import { ISharedTree, ISharedTreeView, TreeContent } from "../../../shared-tree";
+import { AllowedUpdateType, IEditableForest, ITreeCursorSynchronous } from "../../../core";
+import { ISharedTree, ISharedTreeView, ISharedTreeView2, TreeContent } from "../../../shared-tree";
 import { TestTreeProviderLite, forestWithContent } from "../../utils";
 import { brand } from "../../../util";
 import { SchemaBuilder } from "../../../domains";
@@ -50,11 +51,28 @@ export function createTree(): ISharedTree {
 	return tree;
 }
 
+/**
+ * @deprecated less general and less type safe than createTreeView2.
+ */
 export function createTreeView<TRoot extends TreeFieldSchema>(
 	schema: TreeSchema<TRoot>,
 	initialTree: any,
 ): ISharedTreeView {
-	return createTree().schematizeView({
+	return createTree().schematize({
+		allowedSchemaModifications: AllowedUpdateType.None,
+		initialTree,
+		schema,
+	}).branch;
+}
+
+export function createTreeView2<TRoot extends TreeFieldSchema>(
+	schema: TreeSchema<TRoot>,
+	initialTree:
+		| ITreeCursorSynchronous
+		| readonly ITreeCursorSynchronous[]
+		| SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Flexible>,
+): ISharedTreeView2<TRoot> {
+	return createTree().schematize({
 		allowedSchemaModifications: AllowedUpdateType.None,
 		initialTree,
 		schema,

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -145,31 +145,35 @@ describe("Node Key Index", () => {
 
 		const manager1 = createMockNodeKeyManager();
 		const key = manager1.generateLocalNodeKey();
-		tree.schematizeView({
-			initialTree: {
-				[nodeKeyFieldKey]: manager1.stabilizeNodeKey(key),
-				child: undefined,
+		tree.schematize(
+			{
+				initialTree: {
+					[nodeKeyFieldKey]: manager1.stabilizeNodeKey(key),
+					child: undefined,
+				},
+				schema: nodeSchemaData,
+				allowedSchemaModifications: AllowedUpdateType.None,
 			},
-			schema: nodeSchemaData,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		});
+			createMockNodeKeyManager(),
+		);
 
 		await provider.ensureSynchronized();
 
 		await provider.summarize();
 		const tree2 = await provider.createTree();
 		await provider.ensureSynchronized();
-		const view2 = tree2
-			.schematizeView({
+		const view2 = tree2.schematize(
+			{
 				initialTree: {
 					[nodeKeyFieldKey]: "not used",
 					child: undefined,
 				},
 				schema: nodeSchemaData,
 				allowedSchemaModifications: AllowedUpdateType.None,
-			})
+			},
 			// Since the key was produced with a MockNodeKeyManager, we must use one to process it.
-			.editableTree2(nodeSchemaData, createMockNodeKeyManager());
+			createMockNodeKeyManager(),
+		);
 		assertIds(view2.context.nodeKeys, [
 			view2.context.nodeKeys.localize(manager1.stabilizeNodeKey(key)),
 		]);

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -345,16 +345,16 @@ describe("SharedTreeCore", () => {
 			factory.attributes,
 		);
 
-		const config: InitializeAndSchematizeConfiguration = {
+		const config = {
 			schema,
 			initialTree: undefined,
 			allowedSchemaModifications: AllowedUpdateType.None,
-		};
+		} satisfies InitializeAndSchematizeConfiguration;
 
-		const view1 = tree1.schematizeView(config);
-		const view2 = tree2.schematizeView(config);
-		const editable1 = view1.editableTree2(schema);
-		const editable2 = view2.editableTree2(schema);
+		const view1 = tree1.schematize(config);
+		const view2 = tree2.schematize(config);
+		const editable1 = view1.editableTree;
+		const editable2 = view2.editableTree;
 
 		editable2.content = { [typeNameSymbol]: node.name, child: undefined };
 		editable1.content = { [typeNameSymbol]: node.name, child: undefined };

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
@@ -103,7 +103,7 @@ describe("Fuzz - anchor stability", () => {
 
 		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: AnchorFuzzTestState) => {
-			const tree = initialState.clients[0].channel.schematizeView(config);
+			const tree = initialState.clients[0].channel.schematize(config).branch;
 			tree.transaction.start();
 			// These tests are hard coded to a single client, so this is fine.
 			initialState.views = [tree];
@@ -171,7 +171,7 @@ describe("Fuzz - anchor stability", () => {
 			initialState.anchors = [];
 			initialState.views = [];
 			for (const client of initialState.clients) {
-				const view = client.channel.schematizeView(config) as RevertibleSharedTreeView;
+				const view = client.channel.schematize(config).branch as RevertibleSharedTreeView;
 				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view);
 				view.undoStack = undoStack;
 				view.redoStack = redoStack;

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -106,11 +106,11 @@ describe("Fuzz - composed vs individual changes", () => {
 		};
 		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: BranchedTreeFuzzTestState) => {
-			initialState.main = initialState.clients[0].channel.schematizeView({
+			initialState.main = initialState.clients[0].channel.schematize({
 				initialTree: undefined,
 				schema: fuzzSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
-			});
+			}).branch;
 			initialState.branch = initialState.main.fork();
 			initialState.branch.transaction.start();
 		});

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -48,11 +48,11 @@ export type FuzzNode = ObjectNodeTyped<FuzzNodeSchema>;
 export const fuzzSchema = builder.intoSchema(fuzzNode.objectNodeFieldsObject.optionalChild);
 
 export function fuzzViewFromTree(tree: ISharedTree): ISharedTreeView {
-	return tree.schematizeView({
+	return tree.schematize({
 		initialTree: undefined,
 		schema: fuzzSchema,
 		allowedSchemaModifications: AllowedUpdateType.None,
-	});
+	}).branch;
 }
 
 export const onCreate = (tree: SharedTree) => {

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -57,11 +57,11 @@ function initializeTestTree(
 	state: JsonableTree = initialTestJsonTree,
 ): ISharedTreeView {
 	const writeCursor = singleTextCursor(state);
-	return tree.schematizeView({
+	return tree.schematize({
 		allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 		initialTree: [writeCursor],
 		schema: fullSchemaData,
-	});
+	}).branch;
 }
 
 function utf8Length(data: JsonCompatibleReadOnly): number {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -99,8 +99,8 @@ describe("SharedTree", () => {
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: [1],
 			};
-			const tree1 = provider.trees[0].schematizeView(content);
-			provider.trees[1].schematizeView(content);
+			const tree1 = provider.trees[0].schematize(content).branch;
+			provider.trees[1].schematize(content);
 			provider.processMessages();
 
 			validateRootField(tree1, [1]);
@@ -112,10 +112,10 @@ describe("SharedTree", () => {
 
 			const view = tree.schematize({
 				allowedSchemaModifications: AllowedUpdateType.None,
-				initialTree: 10 as any,
+				initialTree: 10,
 				schema,
 			});
-			assert.equal(view.content, 10);
+			assert.equal(view.root, 10);
 		});
 
 		it("noop upgrade", () => {
@@ -123,7 +123,7 @@ describe("SharedTree", () => {
 			tree.storedSchema.update(schema);
 
 			// No op upgrade with AllowedUpdateType.None does not error
-			const schematized = tree.schematizeView({
+			const schematized = tree.schematize({
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: 10,
 				schema,
@@ -147,7 +147,7 @@ describe("SharedTree", () => {
 		it("upgrade schema", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
 			tree.storedSchema.update(schema);
-			const schematized = tree.schematizeView({
+			const schematized = tree.schematize({
 				allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 				initialTree: 5,
 				schema: schemaGeneralized,
@@ -176,7 +176,7 @@ describe("SharedTree", () => {
 		it("empty", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
 			const view = tree.requireSchema(schemaEmpty, () => assert.fail()) ?? assert.fail();
-			assert.deepEqual([...view.editableTree2(schemaEmpty)[boxedIterator]()], []);
+			assert.deepEqual([...view.editableTree[boxedIterator]()], []);
 		});
 
 		it("differing schema errors and schema change callback", () => {
@@ -219,12 +219,12 @@ describe("SharedTree", () => {
 			forest: ForestType.Reference,
 		});
 		const sharedTree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const view = sharedTree.schematizeView({
+		const view = sharedTree.schematize({
 			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 			initialTree: 1,
 			schema,
 		});
-		const root = view.editableTree2(schema);
+		const root = view.editableTree;
 		const leafNode = root.boxedContent;
 		assert.equal(leafNode.value, 1);
 		root.content = 2;
@@ -264,11 +264,11 @@ describe("SharedTree", () => {
 		const expectedSchema = schemaCodec.encode(jsonSequenceRootSchema);
 
 		// Apply an edit to the first tree which inserts a node with a value
-		const view1 = provider.trees[0].schematizeView({
+		const view1 = provider.trees[0].schematize({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [value],
-		});
+		}).branch;
 
 		// Ensure that the first tree has the state we expect
 		assert.equal(getTestValue(view1), value);
@@ -284,7 +284,7 @@ describe("SharedTree", () => {
 	it("can summarize and load", async () => {
 		const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
 		const value = 42;
-		const summarizingTree = provider.trees[0].schematizeView({
+		const summarizingTree = provider.trees[0].schematize({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [value],
@@ -304,11 +304,11 @@ describe("SharedTree", () => {
 		const tree3 = (await provider.createTree()).view;
 		const [container1, container2, container3] = provider.containers;
 
-		const tree1 = provider.trees[0].schematizeView({
+		const tree1 = provider.trees[0].schematize({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: ["Z", "A", "C"],
-		});
+		}).branch;
 
 		await provider.ensureSynchronized();
 
@@ -570,7 +570,7 @@ describe("SharedTree", () => {
 
 	it("has bounded memory growth in EditManager", () => {
 		const provider = new TestTreeProviderLite(2);
-		provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+		provider.trees[0].schematize(emptyJsonSequenceConfig);
 
 		const [tree1, tree2] = provider.trees.map((t) => t.view);
 
@@ -603,7 +603,7 @@ describe("SharedTree", () => {
 
 	it("can process changes while detached", async () => {
 		const onCreate = (t: ISharedTree) => {
-			const view = t.schematizeView(emptyJsonSequenceConfig);
+			const view = t.schematize(emptyJsonSequenceConfig).branch;
 			insertFirstNode(view, "B");
 			insertFirstNode(view, "A");
 			validateRootField(view, ["A", "B"]);
@@ -626,9 +626,9 @@ describe("SharedTree", () => {
 		it("can insert and delete a node in a sequence field", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 
 			// Insert node
@@ -655,11 +655,11 @@ describe("SharedTree", () => {
 					initialTree: [0, 1, 2, 3],
 					allowedSchemaModifications: AllowedUpdateType.None,
 				};
-				const tree1 = provider.trees[0].schematizeView(config);
+				const tree1 = provider.trees[0].schematize(config).branch;
 				provider.processMessages();
-				const tree2 = provider.trees[1].schematizeView(config);
-				const tree3 = provider.trees[2].schematizeView(config);
-				const tree4 = provider.trees[3].schematizeView(config);
+				const tree2 = provider.trees[1].schematize(config).branch;
+				const tree3 = provider.trees[2].schematize(config).branch;
+				const tree4 = provider.trees[3].schematize(config).branch;
 				provider.processMessages();
 
 				remove(tree1, index, 1);
@@ -689,9 +689,9 @@ describe("SharedTree", () => {
 				initialTree: value,
 				allowedSchemaModifications: AllowedUpdateType.None,
 			};
-			const tree1 = provider.trees[0].schematizeView(config);
+			const tree1 = provider.trees[0].schematize(config).branch;
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematizeView(config);
+			const tree2 = provider.trees[1].schematize(config).branch;
 
 			// Delete node
 			tree1.setContent(undefined);
@@ -918,10 +918,10 @@ describe("SharedTree", () => {
 		it("the insert of a node in a sequence field", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree1);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 
 			// Insert node
@@ -954,7 +954,7 @@ describe("SharedTree", () => {
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: ["A", "B", "C", "D"],
 			};
-			const tree1 = provider.trees[0].schematizeView(content);
+			const tree1 = provider.trees[0].schematize(content).branch;
 			const tree2 = provider.trees[1].view;
 			const {
 				undoStack: undoStack1,
@@ -1023,7 +1023,7 @@ describe("SharedTree", () => {
 		it("triggers revertible events for local changes", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			const tree2 = provider.trees[1].view;
 			provider.processMessages();
 
@@ -1074,11 +1074,11 @@ describe("SharedTree", () => {
 		it("doesn't trigger a revertible event for rebases", () => {
 			const provider = new TestTreeProviderLite(2);
 			// Initialize the tree
-			const tree1 = provider.trees[0].schematizeView({
+			const tree1 = provider.trees[0].schematize({
 				initialTree: ["A", "B", "C", "D"],
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
-			});
+			}).branch;
 			const tree2 = provider.trees[1].view;
 
 			provider.processMessages();
@@ -1125,7 +1125,7 @@ describe("SharedTree", () => {
 				schema: jsonSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
 			};
-			const view1 = provider.trees[0].schematizeView(config);
+			const view1 = provider.trees[0].schematize(config).branch;
 			await provider.ensureSynchronized();
 
 			const pausedContainer: IContainerExperimental = provider.containers[0];
@@ -1147,7 +1147,7 @@ describe("SharedTree", () => {
 			const tree = await dataStore.getSharedObject<ISharedTree>("TestSharedTree");
 			await waitForContainerConnection(loadedContainer, true);
 			await provider.ensureSynchronized();
-			validateRootField(tree.schematizeView(config), ["d", "a", "b", "c"]);
+			validateRootField(tree.schematize(config).branch, ["d", "a", "b", "c"]);
 			validateRootField(otherLoadedTree, ["d", "a", "b", "c"]);
 		});
 	});
@@ -1424,9 +1424,9 @@ describe("SharedTree", () => {
 
 		it("submit edits to Fluid when merging into the root view", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
+			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 			const baseView = tree1.fork();
 			const view = baseView.fork();
@@ -1444,7 +1444,7 @@ describe("SharedTree", () => {
 
 		it("do not squash commits", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1612,7 +1612,7 @@ describe("SharedTree", () => {
 
 		it("don't send ops before committing", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1629,7 +1629,7 @@ describe("SharedTree", () => {
 
 		it("send only one op after committing", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1645,7 +1645,7 @@ describe("SharedTree", () => {
 
 		it("do not send an op after committing if nested", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -1666,11 +1666,11 @@ describe("SharedTree", () => {
 
 		it("process changes while detached", async () => {
 			const onCreate = (parentTree: SharedTree) => {
-				const parent = parentTree.schematizeView({
+				const parent = parentTree.schematize({
 					initialTree: ["A"],
 					schema: jsonSequenceRootSchema,
 					allowedSchemaModifications: AllowedUpdateType.None,
-				});
+				}).branch;
 				parent.transaction.start();
 				insertFirstNode(parent, "B");
 				parent.transaction.commit();
@@ -1971,7 +1971,7 @@ function itView(title: string, fn: (view: ISharedTreeView) => void): void {
 	it(`${title} (root view)`, () => {
 		const provider = new TestTreeProviderLite();
 		// Test an actual SharedTree.
-		fn(provider.trees[0].schematizeView(config));
+		fn(provider.trees[0].schematize(config).branch);
 	});
 
 	it(`${title} (reference view)`, () => {
@@ -1980,7 +1980,7 @@ function itView(title: string, fn: (view: ISharedTreeView) => void): void {
 
 	it(`${title} (forked view)`, () => {
 		const provider = new TestTreeProviderLite();
-		fn(provider.trees[0].schematizeView(config).fork());
+		fn(provider.trees[0].schematize(config).branch.fork());
 	});
 
 	it(`${title} (reference forked view)`, () => {

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -41,11 +41,11 @@ function generateCompleteTree(
 		new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 		"test",
 	);
-	const view = tree.schematizeView({
+	const view = tree.schematize({
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema: testSchema,
 		initialTree: [],
-	});
+	}).branch;
 	generateTreeRecursively(view, undefined, fields, height, nodesPerField, { value: 1 });
 	return tree;
 }
@@ -169,9 +169,9 @@ export function generateTestTrees() {
 			runScenario: async (takeSnapshot) => {
 				const value = "42";
 				const provider = new TestTreeProviderLite(2);
-				const tree1 = provider.trees[0].schematizeView(emptyJsonSequenceConfig);
+				const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).branch;
 				provider.processMessages();
-				const tree2 = provider.trees[1].schematizeView(emptyJsonSequenceConfig);
+				const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig).branch;
 				provider.processMessages();
 
 				// Insert node
@@ -199,11 +199,11 @@ export function generateTestTrees() {
 						initialTree: [0, 1, 2, 3],
 						allowedSchemaModifications: AllowedUpdateType.None,
 					};
-					const tree1 = provider.trees[0].schematizeView(config);
+					const tree1 = provider.trees[0].schematize(config).branch;
 					provider.processMessages();
-					const tree2 = provider.trees[1].schematizeView(config);
-					const tree3 = provider.trees[2].schematizeView(config);
-					const tree4 = provider.trees[3].schematizeView(config);
+					const tree2 = provider.trees[1].schematize(config).branch;
+					const tree3 = provider.trees[2].schematize(config).branch;
+					const tree4 = provider.trees[3].schematize(config).branch;
 					provider.processMessages();
 					remove(tree1, index, 1);
 					remove(tree2, index, 1);
@@ -221,11 +221,11 @@ export function generateTestTrees() {
 					"test",
 				);
 
-				const tree1 = baseTree.schematizeView({
+				const tree1 = baseTree.schematize({
 					allowedSchemaModifications: AllowedUpdateType.None,
 					schema: jsonSequenceRootSchema,
 					initialTree: [],
-				});
+				}).branch;
 
 				const tree2 = tree1.fork();
 				insert(tree1, 0, "y");
@@ -282,7 +282,7 @@ export function generateTestTrees() {
 					new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 					"test",
 				);
-				const view = tree.schematizeView(config);
+				const view = tree.schematize(config).branch;
 
 				const field = view.editor.optionalField({
 					parent: undefined,
@@ -314,7 +314,7 @@ export function generateTestTrees() {
 					new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 					"test",
 				);
-				const view = tree.schematizeView(config);
+				const view = tree.schematize(config).branch;
 				view.transaction.start();
 				// We must make this shallow change to the sequence field as part of the same transaction as the
 				// nested change. Otherwise, the nested change will be represented using the generic field kind.

--- a/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/typed-tree/typedTree.spec.ts
@@ -7,23 +7,24 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { ForestType, TypedTreeFactory } from "../../shared-tree";
 import { AllowedUpdateType } from "../../core";
 import { typeboxValidator } from "../../external-utilities";
-import { leaf, SchemaBuilder } from "../../domains";
+import { SchemaBuilder } from "../../domains";
 
 describe("TypedTree", () => {
-	it("editable-tree-2-end-to-end", () => {
+	it("typed-tree end to end", () => {
 		const builder = new SchemaBuilder({ scope: "e2e" });
-		const schema = builder.intoSchema(leaf.number);
+		const Node = builder.object("Node", { item: builder.number });
+		const schema = builder.intoSchema(Node);
 		const factory = new TypedTreeFactory({
 			jsonValidator: typeboxValidator,
 			forest: ForestType.Reference,
 			subtype: "test",
 		});
-		const root = factory.create(new MockFluidDataStoreRuntime(), "the tree").schematize({
+		const view = factory.create(new MockFluidDataStoreRuntime(), "the tree").schematize({
 			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
-			initialTree: 1,
+			initialTree: { item: 1 },
 			schema,
 		});
-		root.content += 1;
-		assert.equal(root.content, 2);
+		view.root.item += 1;
+		assert.equal(view.root.item, 2);
 	});
 });

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -455,11 +455,15 @@ export interface Named<TName> {
  * Placeholder for `Symbol.dispose`.
  *
  * Replace this with `Symbol.dispose` when it is available.
+ * @alpha
  */
-export const disposeSymbol: unique symbol = Symbol("Symbol.dispose");
+export const disposeSymbol: unique symbol = Symbol("Symbol.dispose placeholder");
 
 /**
  * An object with an explicit lifetime that can be ended.
+ * @privateRemarks
+ * TODO: align this with core-utils/IDisposable.
+ * @alpha
  */
 export interface IDisposable {
 	/**

--- a/experimental/framework/tree-react-api/src/test/schema.ts
+++ b/experimental/framework/tree-react-api/src/test/schema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SchemaBuilder, TypedField, leaf } from "@fluid-experimental/tree2";
+import { ProxyField, SchemaBuilder, leaf } from "@fluid-experimental/tree2";
 
 const builder = new SchemaBuilder({ scope: "tree-react-api" });
 
@@ -14,4 +14,4 @@ export const inventory = builder.object("Contoso:Inventory-1.0.0", {
 
 export const schema = builder.intoSchema(inventory);
 
-export type Inventory = TypedField<typeof schema.rootFieldSchema>;
+export type Inventory = ProxyField<typeof schema.rootFieldSchema>;

--- a/experimental/framework/tree-react-api/src/test/useTree.spec.ts
+++ b/experimental/framework/tree-react-api/src/test/useTree.spec.ts
@@ -13,7 +13,6 @@ import {
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import React from "react";
 import { SinonSandbox, createSandbox } from "sinon";
-import { useTreeContext } from "..";
 import { Inventory, schema } from "./schema";
 
 // TODO: why do failing tests in this suite not cause CI to fail?
@@ -33,7 +32,7 @@ describe("useTree()", () => {
 			},
 			allowedSchemaModifications: AllowedUpdateType.None,
 			schema,
-		});
+		}).root;
 	}
 
 	// Mock 'React.setState()'
@@ -72,11 +71,10 @@ describe("useTree()", () => {
 
 	it("works", () => {
 		const tree = createLocalTree("tree");
-		useTreeContext(tree.context);
-		assert.deepEqual(JSON.parse(JSON.stringify(tree.content)), {
+		// TODO test use functions
+		assert.deepEqual(JSON.parse(JSON.stringify(tree)), {
 			nuts: 0,
 			bolts: 0,
-			type: "tree-react-api.Contoso:Inventory-1.0.0",
 		});
 	});
 });

--- a/packages/dds/migration-shim/src/test/dataMigration.spec.ts
+++ b/packages/dds/migration-shim/src/test/dataMigration.spec.ts
@@ -109,13 +109,13 @@ const inventoryFieldSchema = SchemaBuilder.required(inventorySchema);
 const schema = builder.intoSchema(inventoryFieldSchema);
 
 function getNewTreeView(tree: ISharedTree): ISharedTreeView {
-	return tree.schematizeView({
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	});
+	}).branch;
 }
 
 describeNoCompat("HotSwap", (getTestObjectProvider) => {
@@ -160,7 +160,7 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 			const legacyNode = legacyTree.currentView.getViewNode(nodeId);
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const quantity = legacyNode.payload.quantity as number;
-			newTree.schematizeView({
+			newTree.schematize({
 				initialTree: {
 					quantity,
 				},

--- a/packages/dds/migration-shim/src/test/migrationShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/migrationShim.spec.ts
@@ -65,17 +65,17 @@ const rootType = builder.object("abc", {
 });
 const schema = builder.intoSchema(rootType);
 function getNewTreeView(tree: ISharedTree): ISharedTreeView {
-	return tree.schematizeView({
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	});
+	}).branch;
 }
 const migrate = (legacyTree: LegacySharedTree, newTree: ISharedTree): void => {
 	const quantity = getQuantity(legacyTree);
-	newTree.schematizeView({
+	newTree.schematize({
 		initialTree: {
 			quantity,
 		},

--- a/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
@@ -56,13 +56,13 @@ const rootType = builder.object("abc", {
 const schema = builder.intoSchema(rootType);
 
 function getNewTreeView(tree: ISharedTree): ISharedTreeView {
-	return tree.schematizeView({
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	});
+	}).branch;
 }
 
 const testValue = 5;

--- a/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
+++ b/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
@@ -122,13 +122,13 @@ const quantityType = builder.object("quantityObj", {
 const schema = builder.intoSchema(quantityType);
 
 function getNewTreeView(tree: ISharedTree): ISharedTreeView {
-	return tree.schematizeView({
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	});
+	}).branch;
 }
 
 describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
@@ -175,7 +175,7 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 			}
 			// migrate data
 			const quantity = getQuantity(legacyTree);
-			newTree.schematizeView({
+			newTree.schematize({
 				initialTree: {
 					quantity,
 				},

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -425,7 +425,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 		const schema = builder.intoSchema(rootNodeSchema);
 
-		sharedTree.schematizeView({
+		sharedTree.schematize({
 			schema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: {


### PR DESCRIPTION
## Description

Introduce new ISharedTreeView2 which provides a schema aware wrapper around ISharedTreeView.

This does not rename the existing types, and instead picks temporary non colliding names. This helps keep this PR smaller and easier to review: renames as well as migrations off the newly deprecated APIs will follow in separate changes.

Using the TypedTree entry point it is now possible to access the ProxyNode based API instead of the editable-tree-2 one, and re-accessing the root no longer leaks contexts putting it in a bad state.

APIs which should depend on the view schema and are present on ISharedTreeView have been deprecated: users should migrate to using ISharedTreeView2 which already has the view schema.

## Breaking Changes

Several schematize related API have been changed or deprecated.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

