### PR TITLE
Tree: Fix bug with splitting moved marks

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -135,6 +135,8 @@ function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: Move
 
 	const adjusted = { ...effect, basis: newBasis };
 	const basisShift = newBasis - effect.basis;
+	assert(basisShift > 0, "Expected basis shift to be positive");
+
 	if (effect.endpoint !== undefined) {
 		adjusted.endpoint = {
 			...effect.endpoint,
@@ -142,8 +144,11 @@ function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: Move
 		};
 	}
 
-	// TODO: Handle splitting `movedMark`, as it may cover multiple cells
-	// and may have its own identifiers which need to be adjusted to the new basis.
+	if (effect.movedMark !== undefined) {
+		const [_mark1, mark2] = splitMark(effect.movedMark, basisShift);
+		adjusted.movedMark = mark2;
+	}
+
 	return adjusted;
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -32,6 +32,7 @@ import {
 	getOutputCellId,
 	getEndpoint,
 	isReattach,
+	splitMark,
 } from "./utils";
 import {
 	Changeset,
@@ -696,7 +697,12 @@ function getMovedMark<T>(
 			newEffect,
 			false,
 		);
-		return effect.value.movedMark;
+
+		if (effect.value.movedMark.count === count) {
+			return effect.value.movedMark;
+		}
+		const [mark1, _mark2] = splitMark(effect.value.movedMark, count);
+		return mark1;
 	}
 
 	return undefined;

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -755,6 +755,26 @@ describe("SequenceField - Rebase", () => {
 		assert.deepEqual(rebased, expected);
 	});
 
+	it("delete ↷ move with multiple destinations", () => {
+		const del = [Mark.delete(2, brand(0))];
+		const move = [
+			Mark.moveOut(2, brand(0)),
+			{ count: 1 },
+			Mark.moveIn(1, brand(0)),
+			{ count: 1 },
+			Mark.moveIn(1, brand(1)),
+		];
+
+		const rebased = rebase(del, move);
+		const expected = [
+			{ count: 1 },
+			Mark.delete(1, brand(0)),
+			{ count: 1 },
+			Mark.delete(1, brand(1)),
+		];
+		assert.deepEqual(rebased, expected);
+	});
+
 	describe("Over composition", () => {
 		it("insert ↷ [delete, delete]", () => {
 			const deletes: TestChangeset = shallowCompose([


### PR DESCRIPTION
## Description
Fixed a bug where the `movedMark` in a `MoveEffect` was not being split when reading a portion of the range the `MoveEffect` originally covered. This would cause incorrect rebase result if we didn't atomically process the destination of a move.