### PR TITLE
fix(tree2): adopt override ID in removal delta

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -8,7 +8,7 @@ import { fail, Mutable } from "../../util";
 import { Delta, TaggedChange, areEqualChangeAtomIds, makeDetachedNodeId } from "../../core";
 import { nodeIdFromChangeAtom } from "../deltaUtils";
 import { singleTextCursor } from "../treeTextCursor";
-import { MarkList, NoopMarkType, ReturnFrom } from "./format";
+import { MarkList, NoopMarkType } from "./format";
 import {
 	areInputCellsEmpty,
 	areOutputCellsEmpty,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -8,7 +8,7 @@ import { fail, Mutable } from "../../util";
 import { Delta, TaggedChange, areEqualChangeAtomIds, makeDetachedNodeId } from "../../core";
 import { nodeIdFromChangeAtom } from "../deltaUtils";
 import { singleTextCursor } from "../treeTextCursor";
-import { MarkList, NoopMarkType } from "./format";
+import { MarkList, NoopMarkType, ReturnFrom } from "./format";
 import {
 	areInputCellsEmpty,
 	areOutputCellsEmpty,
@@ -93,7 +93,12 @@ export function sequenceFieldToDelta<TNodeChange>(
 				}
 				case "Delete": {
 					if (mark.cellId === undefined) {
-						deltaMark.detach = makeDetachedNodeId(mark.revision ?? revision, mark.id);
+						deltaMark.detach = nodeIdFromChangeAtom(
+							mark.detachIdOverride ?? {
+								revision: mark.revision ?? revision,
+								localId: mark.id,
+							},
+						);
 						local.push(deltaMark);
 					} else {
 						// Removal of already removed content is a no-op.

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -133,12 +133,28 @@ describe("SequenceField - toDelta", () => {
 	});
 
 	it("delete", () => {
-		const changeset = Change.delete(0, 10, brand(42));
+		const changeset = [Mark.delete(10, brand(42))];
 		const expected: Delta.FieldChanges = {
 			local: [
 				{
 					count: 10,
 					detach: detachId,
+				},
+			],
+		};
+		const actual = toDelta(changeset, tag);
+		assert.deepStrictEqual(actual, expected);
+	});
+
+	it("delete with override", () => {
+		const changeset = [
+			Mark.delete(10, brand(42), { detachIdOverride: { revision: tag2, localId: brand(1) } }),
+		];
+		const expected: Delta.FieldChanges = {
+			local: [
+				{
+					count: 10,
+					detach: { major: tag2, minor: 1 },
 				},
 			],
 		};

--- a/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
@@ -323,7 +323,7 @@ describe("Undo and redo", () => {
 		unsubscribe();
 	});
 
-	it.skip("cab revert a reattach", () => {
+	it("can undo and redo an insert multiple times", () => {
 		const tree = makeTreeFromJson(["A", "B"]);
 
 		const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree);
@@ -338,6 +338,24 @@ describe("Undo and redo", () => {
 		expectJsonTree(tree, ["A", "B"]);
 		redoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B", "C"]);
+		unsubscribe();
+	});
+
+	it("can undo and redo a move multiple times", () => {
+		const tree = makeTreeFromJson(["A", "B"]);
+
+		const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree);
+		tree.editor.sequenceField(rootField).move(1, 1, 0);
+
+		expectJsonTree(tree, ["B", "A"]);
+		undoStack.pop()?.revert();
+		expectJsonTree(tree, ["A", "B"]);
+		redoStack.pop()?.revert();
+		expectJsonTree(tree, ["B", "A"]);
+		undoStack.pop()?.revert();
+		expectJsonTree(tree, ["A", "B"]);
+		redoStack.pop()?.revert();
+		expectJsonTree(tree, ["B", "A"]);
 		unsubscribe();
 	});
 });


### PR DESCRIPTION
Fix a bug where the delta produced for a removal did not use the ID override. This lead to a discrepancy with subsequent generated revive/restore since they abide by the override and therefore generate a delta that attempts to restore the tree from the detached field associated with the override ID.