### PR TITLE
Allow Iterable<string> in SharedTreeList insert methods

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1985,9 +1985,9 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha
 export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> extends ReadonlyArray<ProxyNodeUnion<TTypes, API>> {
-    insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(index: number, value: T extends string ? never : string extends T ? never : T): void;
-    insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : string extends T ? never : T): void;
-    insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : string extends T ? never : T): void;
+    insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(index: number, value: T extends string ? never : T): void;
+    insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
+    insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -49,7 +49,7 @@ export interface SharedTreeList<
 	 */
 	insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(
 		index: number,
-		value: T extends string ? never : string extends T ? never : T,
+		value: T extends string ? never : T,
 	): void;
 
 	/**
@@ -60,7 +60,7 @@ export interface SharedTreeList<
 	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
 	insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		value: T extends string ? never : string extends T ? never : T,
+		value: T extends string ? never : T,
 	): void;
 
 	/**
@@ -71,7 +71,7 @@ export interface SharedTreeList<
 	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
 	insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		value: T extends string ? never : string extends T ? never : T,
+		value: T extends string ? never : T,
 	): void;
 
 	/**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -203,8 +203,6 @@ describe("SharedTreeList", () => {
 
 			const string: string = "hello";
 			const stringLiteral: "hello" = "hello" as const;
-			const iterableOrString: Iterable<string> | string = "hello";
-			const iterableOrLiteral: Iterable<string> | "hello" = "hello";
 			assert.throws(() => {
 				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtStart(string);
@@ -212,14 +210,6 @@ describe("SharedTreeList", () => {
 			assert.throws(() => {
 				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtStart(stringLiteral);
-			});
-			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
-				root.strings.insertAtStart(iterableOrString);
-			});
-			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
-				root.strings.insertAtStart(iterableOrLiteral);
 			});
 			assert.throws(() => {
 				// @ts-expect-error Inserted content should not be a string
@@ -231,34 +221,41 @@ describe("SharedTreeList", () => {
 			});
 			assert.throws(() => {
 				// @ts-expect-error Inserted content should not be a string
-				root.strings.insertAt(0, iterableOrString);
-			});
-			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
-				root.strings.insertAt(0, iterableOrLiteral);
-			});
-			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtEnd(string);
 			});
 			assert.throws(() => {
 				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtEnd(stringLiteral);
 			});
+
+			// TODO: It would be nice if there were a way to prevent these unions at compile time as well.
+			// However, it might take some complicated type magic.
+			const iterableOrString: Iterable<string> | string = "hello";
+			const iterableOrLiteral: Iterable<string> | "hello" = "hello";
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
+				root.strings.insertAtStart(iterableOrString);
+			});
+			assert.throws(() => {
+				root.strings.insertAtStart(iterableOrLiteral);
+			});
+			assert.throws(() => {
+				root.strings.insertAt(0, iterableOrString);
+			});
+			assert.throws(() => {
+				root.strings.insertAt(0, iterableOrLiteral);
+			});
+			assert.throws(() => {
 				root.strings.insertAtEnd(iterableOrString);
 			});
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtEnd(iterableOrLiteral);
 			});
 
-			const de = "de"[Symbol.iterator]();
+			const de: Iterable<string> = "de"[Symbol.iterator]();
 			root.strings.insertAtStart(de);
-			const fg = "fg"[Symbol.iterator]();
+			const fg: Iterable<string> = "fg"[Symbol.iterator]();
 			root.strings.insertAt(3, fg);
-			const hi = "hi"[Symbol.iterator]();
+			const hi: Iterable<string> = "hi"[Symbol.iterator]();
 			root.strings.insertAtEnd(hi);
 			assert.deepEqual(root.strings, ["d", "e", "a", "f", "g", "b", "c", "h", "i"]);
 		});


### PR DESCRIPTION
## Description

This loosens the type restrictions on the input to SharedTreeList insert methods since it was accidentally preventing `Iterable<string>` from being allowed.

`string extends T ? never` was intended to prevent type unions like `string | Iterable<string>`, however, it also prevents just `Iterable<string>`. There is a runtime check for the cases where the compile check is not sufficient to block a string; we'll attempt to make the compile check stronger in the future.