### PR TITLE
Remove compile time restrictions for strings in SharedTreeList

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1985,9 +1985,9 @@ export class SharedTreeFactory implements IChannelFactory {
 
 // @alpha
 export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> extends ReadonlyArray<ProxyNodeUnion<TTypes, API>> {
-    insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(index: number, value: T extends string ? never : T): void;
-    insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
-    insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(value: T extends string ? never : T): void;
+    insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void;
+    insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void;
+    insertAtStart(value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: SharedTreeList<AllowedTypes>): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -43,36 +43,20 @@ export interface SharedTreeList<
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
-	 * @privateRemarks
-	 * We explicitly prevent the user from passing "strings" in.
-	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
-	insertAt<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		index: number,
-		value: T extends string ? never : T,
-	): void;
+	insertAt(index: number, value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void;
 
 	/**
 	 * Inserts new item(s) at the start of the list.
 	 * @param value - The content to insert.
-	 * @privateRemarks
-	 * We explicitly prevent the user from passing "strings" in.
-	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
-	insertAtStart<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		value: T extends string ? never : T,
-	): void;
+	insertAtStart(value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void;
 
 	/**
 	 * Inserts new item(s) at the end of the list.
 	 * @param value - The content to insert.
-	 * @privateRemarks
-	 * We explicitly prevent the user from passing "strings" in.
-	 * It's technically permitted since strings are iterables of strings, but it's too easy for a user to mistakenly pass `myString` instead of `[myString]`.
 	 */
-	insertAtEnd<T extends Iterable<ProxyNodeUnion<TTypes>>>(
-		value: T extends string ? never : T,
-	): void;
+	insertAtEnd(value: Iterable<ProxyNodeUnion<TTypes, "javaScript">>): void;
 
 	/**
 	 * Removes the item at the specified location.

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/proxies.spec.ts
@@ -184,9 +184,10 @@ describe("SharedTreeList", () => {
 			numbers: _.list(_.number),
 			strings: _.list(_.string),
 			booleans: _.list(_.boolean),
+			poly: _.list([_.number, _.string, _.boolean]),
 		});
 		const schema = _.intoSchema(obj);
-		const initialTree = { numbers: [], strings: [], booleans: [] };
+		const initialTree = { numbers: [], strings: [], booleans: [], poly: [] };
 		itWithRoot("numbers", schema, initialTree, (root) => {
 			root.numbers.insertAtStart([0]);
 			root.numbers.insertAt(1, [1]);
@@ -204,32 +205,24 @@ describe("SharedTreeList", () => {
 			const string: string = "hello";
 			const stringLiteral: "hello" = "hello" as const;
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtStart(string);
 			});
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtStart(stringLiteral);
 			});
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAt(0, string);
 			});
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAt(0, stringLiteral);
 			});
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtEnd(string);
 			});
 			assert.throws(() => {
-				// @ts-expect-error Inserted content should not be a string
 				root.strings.insertAtEnd(stringLiteral);
 			});
 
-			// TODO: It would be nice if there were a way to prevent these unions at compile time as well.
-			// However, it might take some complicated type magic.
 			const iterableOrString: Iterable<string> | string = "hello";
 			const iterableOrLiteral: Iterable<string> | "hello" = "hello";
 			assert.throws(() => {
@@ -265,6 +258,16 @@ describe("SharedTreeList", () => {
 			root.booleans.insertAt(1, [false]);
 			root.booleans.insertAtEnd([true]);
 			assert.deepEqual(root.booleans, [true, false, true]);
+		});
+
+		itWithRoot("of multiple possible types", schema, initialTree, (root) => {
+			const allowsStrings: typeof root.numbers | typeof root.poly = root.poly;
+			allowsStrings.insertAtStart([42]);
+			const allowsStsrings: typeof root.strings | typeof root.poly = root.poly;
+			allowsStsrings.insertAt(1, ["s"]);
+			const allowsBooleans: typeof root.booleans | typeof root.poly = root.poly;
+			allowsBooleans.insertAtEnd([true]);
+			assert.deepEqual(root.poly, [42, "s", true]);
 		});
 	});
 


### PR DESCRIPTION
The compile time type restrictions for SharedTreeLists that prevent strings from being inserted have been removed. They make it impossible to insert content into a list that is typed as a union of compatible types. 

`(list as List<X> | List<X | Y>).insert(x: X)` fails with an error along the lines of "TS can't figure out that the insert of both the list types are compatible".

The runtime check remains, to guide the user if they accidentally insert a string. All tests of previous behavior remain so that we can attempt to re-introduce better compile time checks in the future and check the compatibility with all currently known scenarios.