### PR TITLE
fix(tree2): Correct the typing of `SharedTreeMap` to ensure `delete` signature is correct

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2005,7 +2005,10 @@ export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaSc
 }
 
 // @alpha
-export type SharedTreeMap<TSchema extends MapSchema> = Omit<Map<string, ProxyField<TSchema["mapFields"]>>, "clear">;
+export interface SharedTreeMap<TSchema extends MapSchema> extends ReadonlyMap<string, ProxyField<TSchema["mapFields"]>> {
+    delete(key: string): void;
+    set(key: string, value: ProxyNodeUnion<AllowedTypes, "javaScript">): void;
+}
 
 // @alpha
 export type SharedTreeNode = SharedTreeList<AllowedTypes> | SharedTreeObject<ObjectNodeSchema> | SharedTreeMap<MapSchema>;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -268,10 +268,32 @@ export type ObjectFields<
  *
  * @alpha
  */
-export type SharedTreeMap<TSchema extends MapSchema> = Omit<
-	Map<string, ProxyField<TSchema["mapFields"]>>,
-	"clear"
->;
+export interface SharedTreeMap<TSchema extends MapSchema>
+	extends ReadonlyMap<string, ProxyField<TSchema["mapFields"]>> {
+	/**
+	 * Adds or updates an entry in the map with a specified `key` and a `value`.
+	 *
+	 * @param key - The key of the element to add to the map.
+	 * @param value - The value of the element to add to the map.
+	 */
+	set(key: string, value: ProxyNodeUnion<AllowedTypes, "javaScript">): void;
+
+	/**
+	 * Removes the specified element from this map by its `key`.
+	 *
+	 * @remarks
+	 * Note: unlike JavaScript's Map API, this method does not return a flag indicating whether or not the value was
+	 * deleted.
+	 *
+	 * @privateRemarks
+	 * Regarding the choice to not return a boolean: Since this data structure is distributed in nature, it isn't
+	 * possible to tell whether or not the item was deleted as a result of this method call. Returning a "best guess"
+	 * is more likely to create issues / promote bad usage patterns than offer useful information.
+	 *
+	 * @param key - The key of the element to remove from the map.
+	 */
+	delete(key: string): void;
+}
 
 /**
  * Given a field's schema, return the corresponding object in the proxy-based API.


### PR DESCRIPTION
Our version of `delete` differs from JavaScript's Map API, but the typing introduced in #18093 used JavaScript's Map's `delete` signature, rather than ours.

[AB#5834](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5834)
[AB#6081](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6081)