### PR TITLE
GC: Add GC configs to inactive / tombstone telemetry

### DIFF
--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -24,6 +24,8 @@ import {
 	disableSweepLogKey,
 	UnreferencedStateTracker,
 	cloneGCData,
+	IGarbageCollectorConfigs,
+	stableGCVersion,
 } from "../../gc";
 import { pkgVersion } from "../../packageVersion";
 import { BlobManager } from "../../blobManager";
@@ -69,15 +71,28 @@ describe("GC Telemetry Tracker", () => {
 			}
 			return GCNodeType.Other;
 		};
+		const configs: IGarbageCollectorConfigs = {
+			gcEnabled: true,
+			sweepEnabled: false,
+			shouldRunGC: true,
+			shouldRunSweep: false,
+			runFullGC: false,
+			testMode: false,
+			tombstoneMode: false,
+			inactiveTimeoutMs,
+			sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+			sweepTimeoutMs: enableSweep ? sweepTimeoutMs : undefined,
+			tombstoneEnforcementAllowed: false,
+			throwOnTombstoneLoad: false,
+			throwOnTombstoneUsage: false,
+			throwOnInactiveLoad: false,
+			persistedGcFeatureMatrix: undefined,
+			gcVersionInBaseSnapshot: stableGCVersion,
+			gcVersionInEffect: stableGCVersion,
+		};
 		const tracker = new GCTelemetryTracker(
 			mc,
-			{
-				inactiveTimeoutMs,
-				sweepTimeoutMs: enableSweep ? sweepTimeoutMs : undefined,
-				tombstoneEnforcementAllowed: false,
-				throwOnTombstoneLoad: false,
-				throwOnTombstoneUsage: false,
-			},
+			configs,
 			isSummarizerClient,
 			{ createContainerRuntimeVersion: pkgVersion },
 			getNodeType,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -28,7 +28,13 @@ import {
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { delay } from "@fluidframework/core-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
-import { IErrorBase, IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
+import {
+	IErrorBase,
+	IFluidHandle,
+	IRequest,
+	IResponse,
+	ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
@@ -81,11 +87,19 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 	async function loadContainer(
 		summaryVersion: string,
 		disableTombstoneFailureViaOption: boolean = false,
+		logger?: ITelemetryBaseLogger,
 	) {
 		const config = disableTombstoneFailureViaOption
 			? testContainerConfigWithFutureMinGcOption
 			: testContainerConfig;
-		return provider.loadTestContainer(config, {
+		const config2: ITestContainerConfig = {
+			...config,
+			loaderProps: {
+				...config.loaderProps,
+				logger,
+			},
+		};
+		return provider.loadTestContainer(config2, {
 			[LoaderHeader.version]: summaryVersion,
 		});
 	}
@@ -525,7 +539,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					gcTombstoneEnforcementAllowed: false,
 					clientType: "interactive",
 				},
 			],
@@ -537,9 +550,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
 				// The datastore should be tombstoned now
 				const { summaryVersion } = await summarize(summarizer);
+				const logger = new MockLogger();
 				const container = await loadContainer(
 					summaryVersion,
 					true /* disableTombstoneFailureViaOption */,
+					logger,
 				);
 
 				// This request succeeds even though the datastore is tombstoned, on account of the later gcTombstoneGeneration passed in
@@ -566,7 +581,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					gcTombstoneEnforcementAllowed: false,
 					clientType: "interactive",
 				},
 			],


### PR DESCRIPTION
There are certain GC configs and flags that are used to analyze and filter telemetry such as GC version, tombstone configs / flags, inactive, sweep and session expiry timeouts. These are not logged along with inactive object / tombstone telemetry which makes it a little complex to get these values from other logs.
This PR adds all GC configs to the inactive / tombstone logs so that analyzing and filtering this data becomes simpler. It also adds tombstone and sweep flags to the tombstone logs.

[AB#6136](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6136)