### PR TITLE
tree2: Move use of root2 to TypedTreeView

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1084,8 +1084,6 @@ export interface ISharedTreeView extends AnchorLocator {
     rebase(view: ISharedTreeBranchView): void;
     // @deprecated
     get root(): UnwrappedEditableField;
-    // @deprecated (undocumented)
-    root2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): ProxyField<TRoot>;
     readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
     // @deprecated
     setContent(data: NewFieldContent): void;

--- a/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTreeView.ts
@@ -40,7 +40,6 @@ import {
 	createNodeKeyManager,
 	nodeKeyFieldKey as nodeKeyFieldKeyDefault,
 	getProxyForField,
-	ProxyField,
 } from "../feature-libraries";
 import { SharedTreeBranch, getChangeReplaceType } from "../shared-tree-core";
 import { TransactionResult, brand } from "../util";
@@ -205,11 +204,6 @@ export interface ISharedTreeView extends AnchorLocator {
 	 * @deprecated Use {@link ISharedTreeView2}.
 	 */
 	editableTree2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): TypedField<TRoot>;
-
-	/**
-	 * @deprecated Use {@link TypedTreeView}.
-	 */
-	root2<TRoot extends TreeFieldSchema>(viewSchema: TreeSchema<TRoot>): ProxyField<TRoot>;
 }
 
 /**

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { createTreeView, pretty } from "./utils";
+import { createTreeView2, pretty } from "./utils";
 
 const builder = new SchemaBuilder({ scope: "test" });
 
@@ -58,8 +58,8 @@ describe("List", () => {
 	/** Helper that creates a new SharedTree with the test schema and returns the root proxy. */
 	function createTree() {
 		// Consider 'initializeTreeWithContent' for readonly tests?
-		const view = createTreeView(schema, { numbers: [], strings: [] });
-		return view.root2(schema);
+		const view = createTreeView2(schema, { numbers: { "": [] }, strings: { "": [] } });
+		return view.root;
 	}
 
 	// TODO: Combine createList helpers once we unbox unions.

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -4,10 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-import { LeafSchema, TreeSchema } from "../../../feature-libraries";
+import { LeafSchema, NewFieldContent, TreeSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
 import { TreeValue } from "../../../core";
-import { createTreeView, itWithRoot, makeSchema, pretty } from "./utils";
+import { createTreeView2, itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
 	initialTree: object;
@@ -38,9 +38,9 @@ function testObjectLike(testCases: TestCase[]) {
 	describe("Object-like", () => {
 		describe("satisfies 'deepEquals'", () => {
 			for (const { schema, initialTree } of testCases) {
-				const view = createTreeView(schema, initialTree);
+				const view = createTreeView2(schema, initialTree as NewFieldContent);
 				const real = initialTree;
-				const proxy = view.root2(schema);
+				const proxy = view.root;
 
 				// We do not use 'itWithRoot()' so we can pretty-print the 'proxy' in the test title.
 				it(`deepEquals(${pretty(proxy)}, ${pretty(real)})`, () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { createTreeView, pretty } from "./utils";
+import { createTreeView2, pretty } from "./utils";
 
 const _ = new SchemaBuilder({ scope: "test", libraries: [leaf.library] });
 const schema = _.intoSchema(_.optional(leaf.all));
@@ -44,9 +44,9 @@ const testCases = [
 describe("Primitives", () => {
 	describe("satisfy 'deepEquals'", () => {
 		for (const testCase of testCases) {
-			const view = createTreeView(schema, testCase);
+			const view = createTreeView2(schema, testCase);
 			const real = testCase;
-			const proxy = view.root2(schema);
+			const proxy = view.root;
 
 			it(`deepEquals(${pretty(proxy)}, ${pretty(real)})`, () => {
 				assert.deepEqual(proxy, real, "Proxy must satisfy 'deepEquals'.");

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -18,7 +18,7 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { Context, getTreeContext } from "../../../feature-libraries/editable-tree-2/context";
 import { AllowedUpdateType, IEditableForest, ITreeCursorSynchronous } from "../../../core";
-import { ISharedTree, ISharedTreeView, ISharedTreeView2, TreeContent } from "../../../shared-tree";
+import { ISharedTree, ISharedTreeView2, TreeContent } from "../../../shared-tree";
 import { TestTreeProviderLite, forestWithContent } from "../../utils";
 import { brand } from "../../../util";
 import { SchemaBuilder } from "../../../domains";
@@ -49,20 +49,6 @@ export function createTree(): ISharedTree {
 	const tree = new TestTreeProviderLite(1).trees[0];
 	assert(tree.isAttached());
 	return tree;
-}
-
-/**
- * @deprecated less general and less type safe than createTreeView2.
- */
-export function createTreeView<TRoot extends TreeFieldSchema>(
-	schema: TreeSchema<TRoot>,
-	initialTree: any,
-): ISharedTreeView {
-	return createTree().schematize({
-		allowedSchemaModifications: AllowedUpdateType.None,
-		initialTree,
-		schema,
-	}).branch;
 }
 
 export function createTreeView2<TRoot extends TreeFieldSchema>(
@@ -97,8 +83,11 @@ export function itWithRoot<TRoot extends TreeFieldSchema>(
 	fn: (root: ProxyField<(typeof schema)["rootFieldSchema"]>) => void,
 ): void {
 	it(title, () => {
-		const view = createTreeView(schema, initialTree);
-		const root = view.root2(schema);
+		const view = createTreeView2(
+			schema,
+			initialTree as SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Flexible>,
+		);
+		const root = view.root;
 		fn(root);
 	});
 }

--- a/packages/dds/migration-shim/src/test/migrationShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/migrationShim.spec.ts
@@ -28,7 +28,7 @@ import {
 import {
 	AllowedUpdateType,
 	type ISharedTree,
-	type ISharedTreeView,
+	type ISharedTreeView2,
 	SchemaBuilder,
 	SharedTreeFactory,
 	type ProxyNode,
@@ -64,14 +64,14 @@ const rootType = builder.object("abc", {
 	quantity: builder.number,
 });
 const schema = builder.intoSchema(rootType);
-function getNewTreeView(tree: ISharedTree): ISharedTreeView {
+function getNewTreeView(tree: ISharedTree): ISharedTreeView2<typeof schema.rootFieldSchema> {
 	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	}).branch;
+	});
 }
 const migrate = (legacyTree: LegacySharedTree, newTree: ISharedTree): void => {
 	const quantity = getQuantity(legacyTree);
@@ -266,7 +266,7 @@ describeNoCompat("MigrationShim", (getTestObjectProvider) => {
 
 		const newTree1 = shim1.currentTree as ISharedTree;
 		const view1 = getNewTreeView(newTree1);
-		const rootNode1: ProxyNode<typeof rootType> = view1.root2(schema);
+		const rootNode1: ProxyNode<typeof rootType> = view1.root;
 
 		// Summarize
 		const { summarizer } = await createSummarizerFromFactory(
@@ -286,7 +286,7 @@ describeNoCompat("MigrationShim", (getTestObjectProvider) => {
 		const shim3 = await testObj3.getShim();
 		const tree3 = shim3.currentTree as ISharedTree;
 		const view3 = getNewTreeView(tree3);
-		const rootNode3: ProxyNode<typeof rootType> = view3.root2(schema);
+		const rootNode3: ProxyNode<typeof rootType> = view3.root;
 
 		// Verify that the value loaded from the summary matches the one loaded from a different summary
 		await provider.ensureSynchronized();

--- a/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
@@ -22,7 +22,7 @@ import {
 	type ISharedTree,
 	SchemaBuilder,
 	SharedTreeFactory,
-	type ISharedTreeView,
+	type ISharedTreeView2,
 	type ProxyNode,
 } from "@fluid-experimental/tree2";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
@@ -55,14 +55,14 @@ const rootType = builder.object("abc", {
 });
 const schema = builder.intoSchema(rootType);
 
-function getNewTreeView(tree: ISharedTree): ISharedTreeView {
+function getNewTreeView(tree: ISharedTree): ISharedTreeView2<typeof schema.rootFieldSchema> {
 	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	}).branch;
+	});
 }
 
 const testValue = 5;
@@ -127,8 +127,8 @@ describeNoCompat("SharedTreeShim", (getTestObjectProvider) => {
 		await provider.ensureSynchronized();
 
 		// This does some typing and gives us the root node.
-		const rootNode1: ProxyNode<typeof rootType> = view1.root2(schema);
-		const rootNode2: ProxyNode<typeof rootType> = view2.root2(schema);
+		const rootNode1: ProxyNode<typeof rootType> = view1.root;
+		const rootNode2: ProxyNode<typeof rootType> = view2.root;
 
 		// Test that we can modify/send ops with the new Shared Tree
 		rootNode1.quantity = testValue;
@@ -154,7 +154,7 @@ describeNoCompat("SharedTreeShim", (getTestObjectProvider) => {
 		const shim3 = await testObj3.getTree();
 		const tree3 = shim3.currentTree;
 		const view3 = getNewTreeView(tree3);
-		const rootNode3: ProxyNode<typeof rootType> = view3.root2(schema);
+		const rootNode3: ProxyNode<typeof rootType> = view3.root;
 
 		// Verify that it matches the previous node
 		await provider.ensureSynchronized();

--- a/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
+++ b/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
@@ -31,7 +31,7 @@ import {
 	type ISharedTree,
 	SchemaBuilder,
 	SharedTreeFactory,
-	type ISharedTreeView,
+	type ISharedTreeView2,
 } from "@fluid-experimental/tree2";
 // eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/dist/EditLog.js";
@@ -121,14 +121,14 @@ const quantityType = builder.object("quantityObj", {
 });
 const schema = builder.intoSchema(quantityType);
 
-function getNewTreeView(tree: ISharedTree): ISharedTreeView {
+function getNewTreeView(tree: ISharedTree): ISharedTreeView2<typeof schema.rootFieldSchema> {
 	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
-	}).branch;
+	});
 }
 
 describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
@@ -256,8 +256,8 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 		const newTree2 = shim2.currentTree as ISharedTree;
 		const view1 = getNewTreeView(newTree1);
 		const view2 = getNewTreeView(newTree2);
-		const node1 = view1.root2(schema);
-		const node2 = view2.root2(schema);
+		const node1 = view1.root;
+		const node2 = view2.root;
 		assert.equal(node1.quantity, node2.quantity, "expected to migrate to the same value");
 		assert.equal(node1.quantity, originalValue, "expected no values to be updated");
 
@@ -321,8 +321,8 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 		const newTree2 = shim2.currentTree;
 		const view1 = getNewTreeView(newTree1);
 		const view2 = getNewTreeView(newTree2);
-		const node1 = view1.root2(schema);
-		const node2 = view2.root2(schema);
+		const node1 = view1.root;
+		const node2 = view2.root;
 		assert.equal(node1.quantity, originalValue, "Node1 should be the original value");
 		assert.equal(node2.quantity, originalValue, "Node2 should have loaded the original value");
 


### PR DESCRIPTION
## Description

Migrate use of proxy API from old to new API (added in #18118), and remove old one.

## Breaking Changes

ISharedTreeView.root2 is removed. Use TypedTreeView.root instead.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

