### PR TITLE
test(tee2): enable exhaustive remove-restore test for sequence field

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1531,7 +1531,7 @@ describe("Editing", () => {
 			// Should be committed with the constant set to false.
 			const individualTests = false;
 			const nbNodes = 3;
-			const nbPeers = 3;
+			const nbPeers = 2;
 			const testRemoveRevive = true;
 			const testMoveReturn = false;
 			assert(testRemoveRevive || testMoveReturn, "No scenarios to run");

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1523,7 +1523,7 @@ describe("Editing", () => {
 			unsubscribePathVisitor();
 		});
 
-		describe.skip("Exhaustive removal tests", () => {
+		describe("Exhaustive removal tests", () => {
 			// Toggle the constant below to run each scenario as a separate test.
 			// This is useful to debug a specific scenario but makes CI and the test browser slower.
 			// Note that if the numbers of nodes and peers are too high (more than 3 nodes and 3 peers),
@@ -1533,7 +1533,7 @@ describe("Editing", () => {
 			const nbNodes = 3;
 			const nbPeers = 3;
 			const testRemoveRevive = true;
-			const testMoveReturn = true;
+			const testMoveReturn = false;
 			assert(testRemoveRevive || testMoveReturn, "No scenarios to run");
 
 			const [outerFixture, innerFixture] = individualTests
@@ -1702,7 +1702,7 @@ describe("Editing", () => {
 							default:
 								unreachableCase(step);
 						}
-						tree.merge(peer);
+						tree.merge(peer, false);
 						// We only let peers with a higher index learn of this edit.
 						// This breaks the symmetry between scenarios where the permutation of actions is the same
 						// except for which peer does which set of actions.


### PR DESCRIPTION
This only enables the remove-restore flavor of edits, it leaves the move-return flavor disabled as those scenarios still fail with either assert 0x6a1 ("Lineage should determine order of marks unless one is a new attach") or an unexpected merge outcome.