### PR TITLE
disable checkpoints collection TTL

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -57,7 +57,7 @@ storage:
 
 checkpoints:
   localCheckpointEnabled: false
-  checkpointsTTLInSeconds: 864000
+  checkpointsTTLInSeconds: -1
   kafkaCheckpointOnReprocessingOp: false
 
 session:

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -60,7 +60,7 @@
 	},
 	"checkpoints": {
 		"localCheckpointEnabled": true,
-		"checkpointsTTLInSeconds": 864000,
+		"checkpointsTTLInSeconds": -1,
 		"kafkaCheckpointOnReprocessingOp": false,
 		"ignoreCheckpointFlushException": false
 	},


### PR DESCRIPTION
With recent checkpoint localization changes, we will temporarily disable the checkpoints TTL so we can always use local checkpoints when global checkpoints fail.

Setting the TTL value to -1 disables TTL.