### PR TITLE
Fix an issue where Redis client instances are excessively created

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
@@ -39,17 +39,20 @@ export class RedisFsManager implements IFileSystemManager {
 	// is `fs`, it would do `fs.promises.readfile()`. Therefore, we wrap `RedisFs`
 	// in `RedisFsManager`, with a `promises` property
 	public readonly promises: IFileSystemPromises;
+
 	constructor(
 		redisParam: RedisParams,
 		redisOptions: IoRedis.RedisOptions,
 		redisFsConfig: RedisFsConfig,
 	) {
-		this.promises = new RedisFs(redisParam, redisOptions, redisFsConfig);
+		this.promises = RedisFs.getInstance(redisParam, redisOptions, redisFsConfig);
 	}
 }
 
 export class RedisFs implements IFileSystemPromises {
+	private static instance: RedisFs;
 	public readonly redisFsClient: Redis;
+
 	constructor(
 		redisParams: RedisParams,
 		redisOptions: IoRedis.RedisOptions,
@@ -57,6 +60,17 @@ export class RedisFs implements IFileSystemPromises {
 	) {
 		const redisClient = new IoRedis.default(redisOptions);
 		this.redisFsClient = new Redis(redisClient, redisParams);
+	}
+
+	public static getInstance(
+		redisParams: RedisParams,
+		redisOptions: IoRedis.RedisOptions,
+		redisFsConfig: RedisFsConfig,
+	): RedisFs {
+		if (!RedisFs.instance) {
+			RedisFs.instance = new RedisFs(redisParams, redisOptions, redisFsConfig);
+		}
+		return RedisFs.instance;
 	}
 
 	/**


### PR DESCRIPTION
## Description
> Implemented RedisFs singleton, so that new RedisFsManagers don't create new Redis instances