### PR TITLE
Update the shouldIgnoreError check for duplicate key error + Update runner log properties

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -250,7 +250,10 @@ export class DeliLambdaFactory
 							3 /* maxRetries */,
 							1000 /* retryAfterMs */,
 							getLumberBaseProperties(documentId, tenantId),
-							(error) => error.code === 11000 /* shouldIgnoreError */,
+							(error) =>
+								error.code === 11000 ||
+								error.message?.toString()?.indexOf("E11000 duplicate key") >=
+									0 /* shouldIgnoreError */,
 							(error) => true /* shouldRetry */,
 						);
 

--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -134,7 +134,10 @@ export class CheckpointManager implements ICheckpointManager {
 					3 /* maxRetries */,
 					1000 /* retryAfterMs */,
 					getLumberBaseProperties(this.documentId, this.tenantId),
-					(error) => error.code === 11000 /* shouldIgnoreError */,
+					(error) =>
+						error.code === 11000 ||
+						error.message?.toString()?.indexOf("E11000 duplicate key") >=
+							0 /* shouldIgnoreError */,
 					(error) => !this.clientFacadeRetryEnabled /* shouldRetry */,
 				);
 			}

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -259,7 +259,9 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				...getLumberBaseProperties(documentId, tenantId),
 				...{ sequenceNumberRanges, insertBatchSize, scriptoriumMetricId },
 			},
-			(error) => error.code === 11000,
+			(error) =>
+				error.code === 11000 ||
+				error.message?.toString()?.indexOf("E11000 duplicate key") >= 0,
 			(error) => !this.clientFacadeRetryEnabled /* shouldRetry */,
 			undefined /* calculateIntervalMs */,
 			undefined /* onErrorFn */,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -161,12 +161,12 @@ export class AlfredRunner implements IRunner {
 
 	public async stop(caller?: string, uncaughtException?: any): Promise<void> {
 		if (this.stopped) {
-			Lumberjack.info("AlfredRunner.stop already called, returning early.");
+			Lumberjack.info("AlfredRunner.stop already called, returning early.", { caller });
 			return;
 		}
 
 		this.stopped = true;
-		Lumberjack.info("AlfredRunner.stop starting.");
+		Lumberjack.info("AlfredRunner.stop starting.", { caller });
 
 		const runnerServerCloseTimeoutMs =
 			this.config.get("shared:runnerServerCloseTimeoutMs") ?? 30000;

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -73,12 +73,12 @@ export class RiddlerRunner implements IRunner {
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
 	public async stop(caller?: string, uncaughtException?: any): Promise<void> {
 		if (this.stopped) {
-			Lumberjack.info("RiddlerRunner.stop already called, returning early.");
+			Lumberjack.info("RiddlerRunner.stop already called, returning early.", { caller });
 			return;
 		}
 
 		this.stopped = true;
-		Lumberjack.info("RiddlerRunner.stop starting.");
+		Lumberjack.info("RiddlerRunner.stop starting.", { caller });
 
 		const runnerServerCloseTimeoutMs =
 			this.config?.get("shared:runnerServerCloseTimeoutMs") ?? 30000;

--- a/server/routerlicious/packages/services-shared/src/runnerUtils.ts
+++ b/server/routerlicious/packages/services-shared/src/runnerUtils.ts
@@ -17,11 +17,12 @@ export async function runnerHttpServerStop(
 	caller: string | undefined,
 	uncaughtException: any | undefined,
 ): Promise<void> {
+	const runnerMetricProperties = {
+		caller,
+		runnerServerCloseTimeoutMs,
+	};
 	try {
-		runnerMetric.setProperties({
-			caller,
-			runnerServerCloseTimeoutMs,
-		});
+		runnerMetric.setProperties(runnerMetricProperties);
 		// Close the underlying server and then resolve the runner once closed
 		await promiseTimeout(runnerServerCloseTimeoutMs, server.close());
 		if (caller === "uncaughtException") {
@@ -34,7 +35,7 @@ export async function runnerHttpServerStop(
 		if (!runnerMetric.isCompleted()) {
 			runnerMetric.success(`${runnerMetric.eventName} stopped`);
 		} else {
-			Lumberjack.info(`${runnerMetric.eventName} stopped`);
+			Lumberjack.info(`${runnerMetric.eventName} stopped`, runnerMetricProperties);
 		}
 	} catch (error) {
 		if (!runnerMetric.isCompleted()) {
@@ -42,7 +43,7 @@ export async function runnerHttpServerStop(
 		} else {
 			Lumberjack.error(
 				`${runnerMetric.eventName} encountered an error during stop`,
-				undefined,
+				runnerMetricProperties,
 				error,
 			);
 		}

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -392,7 +392,8 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 				MaxRetryAttempts, // maxRetries
 				InitialRetryIntervalInMs, // retryAfterMs
 				telemetryProperties,
-				(e) => e.code === 11000, // shouldIgnoreError
+				(e) =>
+					e.code === 11000 || e.message?.toString()?.indexOf("E11000 duplicate key") >= 0, // shouldIgnoreError
 				(e) => this.retryEnabled && this.mongoErrorRetryAnalyzer.shouldRetry(e), // ShouldRetry
 				(error: any, numRetries: number, retryAfterInterval: number) =>
 					numRetries * retryAfterInterval, // calculateIntervalMs


### PR DESCRIPTION
## Description

This PR includes 2 changes:
1. Fix for "11000 duplicate key error" causing scriptorium restarts and exceptions in checkpointing too. Earlier we used to ignore this error by comparing error.code. But the error object returned by cosmos/mongodb seems to have changed and it doesnt contain the "code" property anymore. Hence, updated the shouldIgnoreError logic to check the error message.

Sample error:
> {"name":"Error","message":"E11000 duplicate key error collection: admin.deltas. Failed _id or unique index constraint.","stack":"MongoBulkWriteError: E11000 duplicate key error collection: admin.deltas. Failed _id or unique index constraint.\n    at UnorderedBulkOperation.handleWriteError (\/usr\/src\/server\/bundle\/kafka-service\/index.js:85836:20)\n    at UnorderedBulkOperation.handleWriteError (\/usr\/src\/server\/bundle\/kafka-service\/index.js:85955:22)\n    at resultHandler (\/usr\/src\/server\/bundle\/kafka-service\/index.js:85474:27)\n    at \/usr\/src\/server\/bundle\/kafka-service\/index.js:83281:33\n    at process.processTicksAndRejections (node:internal\/process\/task_queues:95:5)"}

2. Updated a few runner logs to include the metric properties.