### PR TITLE
Fix the indention typo in include-test-task.yml

### DIFF
--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -35,7 +35,7 @@ steps:
       command: 'custom'
       workingDir: ${{ parameters.buildDirectory }}
       customCommand: 'run ${{ parameters.taskTestStep }}'
-      condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+    condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:


### PR DESCRIPTION
As title, to correct the step of logging failed test: https://dev.azure.com/fluidframework/public/_build/results?buildId=207336&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=5b08483c-14eb-5fbf-7473-4f46aab75bd9&s=6884a131-87da-5381-61f3-d7acc3b91d76