### PR TITLE
Temporary workaround: make tinylicious private

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -245,7 +245,6 @@ module.exports = {
 				npm: [
 					"@fluidframework",
 					"fluid-framework",
-					"tinylicious",
 					"@fluid-internal/client-utils",
 				],
 				// A list of packages published to our internal-build feed. Note that packages published

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -242,11 +242,7 @@ module.exports = {
 
 			mustPublish: {
 				// These packages will always be published to npm. This is called the "public" feed.
-				npm: [
-					"@fluidframework",
-					"fluid-framework",
-					"@fluid-internal/client-utils",
-				],
+				npm: ["@fluidframework", "fluid-framework", "@fluid-internal/client-utils"],
 				// A list of packages published to our internal-build feed. Note that packages published
 				// to npm will also be published to this feed. This should be a minimal set required for legacy compat of
 				// internal partners or internal CI requirements.

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "tinylicious",
 	"version": "3.0.0",
+	"private": true,
 	"description": "Tiny, test implementation of the routerlicious reference service",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
#### Description

https://dev.azure.com/fluidframework/internal/_workitems/edit/6150

Since the move of `t9s` to the `r9s` release-group, Pipeline's `Publish to internal build feed` stage has been failing consistently in the main branch due to an authentication error to publish `t9s` to npmjs.org (despite the target should be internal feed). 

This PR servers as a temporary measure to fix the pipeline failure by setting `"private": true` in `tinylicious/package.json`.