### PR TITLE
tree2: Optimize unboxed code-path

### DIFF
--- a/examples/benchmarks/bubblebench/editable-shared-tree/tests/demo.test.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/tests/demo.test.ts
@@ -21,7 +21,7 @@ describe("Bubblebench", () => {
 
 		beforeEach(async () => {
 			await page.goto(globals.PATH, { waitUntil: "load" });
-			await page.waitForFunction(() => window["fluidStarted"]);
+			await page.waitForFunction(() => (window as any).fluidStarted as unknown);
 		});
 
 		it("The page loads and displays current FPS", async () => {

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2164,6 +2164,7 @@ export class TreeFieldSchema<out TKind extends FieldKind = FieldKind, const out 
     equals(other: TreeFieldSchema): boolean;
     // (undocumented)
     readonly kind: TKind;
+    get monomorphicChildType(): TreeNodeSchema | undefined;
     // (undocumented)
     protected _typeCheck?: MakeNominal;
     get types(): TreeTypeSet;

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/unboxed.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/unboxed.ts
@@ -6,7 +6,7 @@
 import { ITreeSubscriptionCursor, inCursorNode, EmptyKey } from "../../core";
 import { FieldKind } from "../modular-schema";
 import { FieldKinds } from "../default-field-kinds";
-import { fail, oneFromSet } from "../../util";
+import { fail } from "../../util";
 import {
 	AllowedTypes,
 	TreeFieldSchema,
@@ -52,13 +52,9 @@ export function unboxedUnion<TTypes extends AllowedTypes>(
 	schema: TreeFieldSchema<FieldKind, TTypes>,
 	cursor: ITreeSubscriptionCursor,
 ): UnboxNodeUnion<TTypes> {
-	const type = oneFromSet(schema.types);
+	const type = schema.monomorphicChildType;
 	if (type !== undefined) {
-		return unboxedTree(
-			context,
-			context.schema.nodeSchema.get(type) ?? fail("missing schema"),
-			cursor,
-		) as UnboxNodeUnion<TTypes>;
+		return unboxedTree(context, type, cursor) as UnboxNodeUnion<TTypes>;
 	}
 	return makeTree(context, cursor) as UnboxNodeUnion<TTypes>;
 }

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -424,6 +424,9 @@ export class TreeFieldSchema<
 
 	/**
 	 * If exactly one type of child is allowed in this field, it is provided here.
+	 * @remarks
+	 * Some code paths (like unboxing and compressed tree encoding) special case schema with exactly one allowed type.
+	 * This field allows for simple and optimized handling of this case.
 	 */
 	public get monomorphicChildType(): TreeNodeSchema | undefined {
 		return this.lazyTypes.value.monomorphicChildType;


### PR DESCRIPTION
## Description

Optimize unboxed leaf access in editable-tree-2

Bubblebench is currently broken, but with #18150 this change improves performance ~10% since unboxed leaf access is a hot path in the collision logic.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

