### PR TITLE
fix(tree2): Correct value-typing for map proxies

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2025,7 +2025,7 @@ export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaSc
 // @alpha
 export interface SharedTreeMap<TSchema extends MapSchema> extends ReadonlyMap<string, ProxyField<TSchema["mapFields"], "sharedTree", "notEmpty">> {
     delete(key: string): void;
-    set(key: string, value: ProxyNodeUnion<AllowedTypes, "javaScript">): void;
+    set(key: string, value: ProxyField<TSchema["mapFields"], "sharedTree", "notEmpty"> | undefined): void;
 }
 
 // @alpha

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2023,7 +2023,7 @@ export interface SharedTreeList<TTypes extends AllowedTypes, API extends "javaSc
 }
 
 // @alpha
-export interface SharedTreeMap<TSchema extends MapSchema> extends ReadonlyMap<string, ProxyField<TSchema["mapFields"]>> {
+export interface SharedTreeMap<TSchema extends MapSchema> extends ReadonlyMap<string, ProxyField<TSchema["mapFields"], "sharedTree", "notEmpty">> {
     delete(key: string): void;
     set(key: string, value: ProxyNodeUnion<AllowedTypes, "javaScript">): void;
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -606,7 +606,7 @@ function createMapProxy<TSchema extends MapSchema>(): SharedTreeMap<TSchema> {
 	// TODO: Although the target is an object literal, it's still worthwhile to try experimenting with
 	// a dispatch object to see if it improves performance.
 	const proxy = new Proxy<SharedTreeMap<TSchema>>(
-		new Map<string, ProxyField<TSchema["mapFields"]>>(),
+		new Map<string, ProxyField<TSchema["mapFields"], "sharedTree", "notEmpty">>(),
 		{
 			get: (target, key, receiver): unknown => {
 				// Pass the proxy as the receiver here, so that any methods on the prototype receive `proxy` as `this`.

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/proxies.ts
@@ -16,10 +16,12 @@ import {
 	schemaIsObjectNode,
 	MapSchema,
 	FieldNodeSchema,
+	MapFieldSchema,
 } from "../../typed-schema";
 import { FieldKinds } from "../../default-field-kinds";
 import {
 	FieldNode,
+	FlexibleFieldContent,
 	MapNode,
 	ObjectNode,
 	OptionalField,
@@ -575,7 +577,7 @@ const mapStaticDispatchMap: PropertyDescriptorMap = {
 			value: ProxyNodeUnion<AllowedTypes, "javaScript">,
 		): SharedTreeMap<MapSchema> {
 			const node = getEditNode(this);
-			node.set(key, extractFactoryContent(value as any));
+			node.set(key, extractFactoryContent(value as FlexibleFieldContent<MapFieldSchema>));
 			return this;
 		},
 	},

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -253,7 +253,7 @@ export type ObjectFields<
  * @alpha
  */
 export interface SharedTreeMap<TSchema extends MapSchema>
-	extends ReadonlyMap<string, ProxyField<TSchema["mapFields"]>> {
+	extends ReadonlyMap<string, ProxyField<TSchema["mapFields"], "sharedTree", "notEmpty">> {
 	/**
 	 * Adds or updates an entry in the map with a specified `key` and a `value`.
 	 *

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/proxies/types.ts
@@ -259,8 +259,14 @@ export interface SharedTreeMap<TSchema extends MapSchema>
 	 *
 	 * @param key - The key of the element to add to the map.
 	 * @param value - The value of the element to add to the map.
+	 *
+	 * @remarks
+	 * Setting the value at a key to `undefined` is equivalent to calling {@link SharedTreeMap.delete} with that key.
 	 */
-	set(key: string, value: ProxyNodeUnion<AllowedTypes, "javaScript">): void;
+	set(
+		key: string,
+		value: ProxyField<TSchema["mapFields"], "sharedTree", "notEmpty"> | undefined,
+	): void;
 
 	/**
 	 * Removes the specified element from this map by its `key`.


### PR DESCRIPTION
The previous typing allowed map values to be `undefined`, which is not desired. It resulted in consumption of entries/values to check for potentially undefined values, which is contractually not supported. This change makes the underlying model and the API typing agree that values in the map are defined.