### PR TITLE
Allow more jest config file names

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -1156,7 +1156,11 @@ export const handlers: Handler[] = [
 			}
 
 			const packageDir = path.dirname(file);
-			const jestFileName = ["jest.config.js", "jest.config.cjs"].find((name) =>
+			// From https://jestjs.io/docs/configuration
+			const jestConfigFileNames = ["js", "ts", "mjs", "cjs", "json"].map(
+				(extension) => `jest.config.${extension}`,
+			);
+			const jestFileName = jestConfigFileNames.find((name) =>
 				fs.existsSync(path.join(packageDir, name)),
 			);
 			if (jestFileName === undefined) {


### PR DESCRIPTION
## Description

Currently it's impossible (or at least non-trivial) to use Jest with noImplicitAny if you want to import the config in the test.

#18150 hit this limitation.

This change adjusts our policy to allow TypeScript config files (as well as other options Jest supports) to fix this issue.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
