### PR TITLE
Only bump tree2 merge perf test timeout in correctness mode

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { benchmark, BenchmarkTimer, BenchmarkType } from "@fluid-tools/benchmark";
+import {
+	benchmark,
+	BenchmarkTimer,
+	BenchmarkType,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import {
 	jsonableTreeFromCursor,
 	cursorForTypedData,
@@ -357,7 +362,7 @@ describe("SharedTree benchmarks", () => {
 		const commitCounts = [1, 10, 20];
 		const nbPeers = 5;
 		for (const nbCommits of commitCounts) {
-			benchmark({
+			const test = benchmark({
 				type: BenchmarkType.Measurement,
 				title: `for ${nbCommits} commits per peer for ${nbPeers} peers`,
 				benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
@@ -385,7 +390,11 @@ describe("SharedTree benchmarks", () => {
 				},
 				// Force batch size of 1
 				minBatchDurationSeconds: 0,
-			}).timeout(5000);
+			});
+
+			if (!isInPerformanceTestingMode) {
+				test.timeout(5000);
+			}
 		}
 	});
 });


### PR DESCRIPTION
## Description

Setting the timeout fails in perf mode, likely as test-specific timeouts override the `--timeout` CLI flag.