### PR TITLE
Tree: Remove revision tag from TransientEffect

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -51,6 +51,7 @@ import {
 	extractMarkEffect,
 	getEndpoint,
 	areEqualCellIds,
+	addRevision,
 } from "./utils";
 import { EmptyInputCellMark } from "./helperTypes";
 
@@ -164,7 +165,7 @@ function composeMarks<TNodeChange>(
 	const nodeChange = composeChildChanges(baseMark.changes, newMark.changes, newRev, composeChild);
 
 	if (isTransientEffect(newMark)) {
-		const newDetachRevision = newMark.detach.revision ?? newMark.revision ?? newRev;
+		const newDetachRevision = newMark.detach.revision ?? newRev;
 		if (markEmptiesCells(baseMark)) {
 			if (isMoveDestination(newMark.attach) && isMoveSource(newMark.detach)) {
 				assert(isMoveSource(baseMark), "Unexpected mark type");
@@ -208,12 +209,8 @@ function composeMarks<TNodeChange>(
 
 			// `newMark`'s attach portion cancels with `baseMark`'s detach portion.
 			const originalAttach = { ...baseMark.attach };
-			if (originalAttach.revision === undefined && baseMark.revision !== undefined) {
-				originalAttach.revision = baseMark.revision;
-			}
-
 			const finalDetach = { ...newMark.detach };
-			const detachRevision = finalDetach.revision ?? newMark.revision ?? newRev;
+			const detachRevision = finalDetach.revision ?? newRev;
 			if (detachRevision !== undefined) {
 				finalDetach.revision = detachRevision;
 			}
@@ -234,7 +231,6 @@ function composeMarks<TNodeChange>(
 	}
 	if (isTransientEffect(baseMark)) {
 		if (markFillsCells(newMark)) {
-			const baseAttachRevision = baseMark.attach.revision ?? baseMark.revision;
 			if (isMoveDestination(baseMark.attach) && isMoveSource(baseMark.detach)) {
 				assert(isMoveDestination(newMark), "Unexpected mark type");
 				setEndpoint(
@@ -242,7 +238,7 @@ function composeMarks<TNodeChange>(
 					CrossFieldTarget.Source,
 					getEndpoint(newMark, newRev),
 					baseMark.count,
-					{ revision: baseAttachRevision, localId: baseMark.attach.id },
+					{ revision: baseMark.attach.revision, localId: baseMark.attach.id },
 				);
 			}
 
@@ -251,7 +247,7 @@ function composeMarks<TNodeChange>(
 					{ ...baseMark.attach, cellId: baseMark.cellId, count: baseMark.count },
 					nodeChange,
 				),
-				baseAttachRevision,
+				baseMark.attach.revision,
 			);
 
 			// TODO: This assumes that the original attach was successful.
@@ -441,11 +437,7 @@ function composeMark<TNodeChange, TMark extends Mark<TNodeChange>>(
 		asMutable(cloned.cellId).revision = revision;
 	}
 
-	assert(!isNoopMark(cloned), 0x4de /* Cloned should be same type as input mark */);
-	if (revision !== undefined && cloned.revision === undefined) {
-		cloned.revision = revision;
-	}
-
+	addRevision(cloned, revision);
 	if (cloned.type !== "MoveIn" && cloned.changes !== undefined) {
 		cloned.changes = composeChild([tagChange(cloned.changes, revision)]);
 		return cloned;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -309,7 +309,7 @@ export interface MovePlaceholder extends HasRevisionTag, HasMoveId {
 	type: "Placeholder";
 }
 
-export interface TransientEffect extends HasRevisionTag {
+export interface TransientEffect {
 	type: "Transient";
 	attach: Attach;
 	detach: Detach;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -316,7 +316,6 @@ export interface TransientEffect {
 }
 
 export const TransientEffect = Type.Composite([
-	HasRevisionTag,
 	Type.Object({
 		type: Type.Literal("Transient"),
 		attach: Attach,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -315,13 +315,11 @@ export interface TransientEffect {
 	detach: Detach;
 }
 
-export const TransientEffect = Type.Composite([
-	Type.Object({
-		type: Type.Literal("Transient"),
-		attach: Attach,
-		detach: Detach,
-	}),
-]);
+export const TransientEffect = Type.Object({
+	type: Type.Literal("Transient"),
+	attach: Attach,
+	detach: Detach,
+});
 
 export type MarkEffect = NoopMark | MovePlaceholder | Attach | Detach | TransientEffect;
 export const MarkEffect = Type.Union([NoopMark, Attach, Detach, TransientEffect]);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -253,14 +253,14 @@ function invertMark<TNodeChange>(
 			const attachInverses = invertMark(
 				attach,
 				inputIndex,
-				mark.revision ?? revision,
+				revision,
 				invertChild,
 				crossFieldManager,
 			);
 			const detachInverses = invertMark(
 				detach,
 				inputIndex,
-				mark.revision ?? revision,
+				revision,
 				invertChild,
 				crossFieldManager,
 			);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -310,7 +310,7 @@ export function applyMoveEffectsToMark<T>(
 				// Move effects should not be applied to intermediate move locations.
 				return [mark];
 			}
-			const attachRevision = mark.attach.revision ?? mark.revision ?? revision;
+			const attachRevision = mark.attach.revision ?? revision;
 			const effect = getMoveEffect(
 				effects,
 				CrossFieldTarget.Destination,
@@ -361,7 +361,7 @@ export function applyMoveEffectsToMark<T>(
 		}
 
 		if (isMoveSource(mark.detach)) {
-			const detachRevision = mark.detach.revision ?? mark.revision ?? revision;
+			const detachRevision = mark.detach.revision ?? revision;
 			const effect = getMoveEffect(
 				effects,
 				CrossFieldTarget.Source,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -459,7 +459,7 @@ function rebaseMarkIgnoreChild<TNodeChange>(
 		rebasedMark = rebaseMarkIgnoreChild(
 			rebasedMark,
 			{ ...baseMark.attach, cellId: cloneCellId(baseMark.cellId), count: baseMark.count },
-			baseMark.revision ?? baseRevision,
+			baseRevision,
 			metadata,
 			moveEffects,
 			nodeExistenceState,
@@ -467,7 +467,7 @@ function rebaseMarkIgnoreChild<TNodeChange>(
 		rebasedMark = rebaseMarkIgnoreChild(
 			rebasedMark,
 			{ ...baseMark.detach, count: baseMark.count },
-			baseMark.revision ?? baseRevision,
+			baseRevision,
 			metadata,
 			moveEffects,
 			nodeExistenceState,
@@ -663,7 +663,7 @@ function getMovedMarkFromBaseMark<T>(
 	} else if (isTransientEffect(baseMark) && isMoveDestination(baseMark.attach)) {
 		return getMovedMark(
 			moveEffects,
-			baseMark.attach.revision ?? baseMark.revision ?? baseRevision,
+			baseMark.attach.revision ?? baseRevision,
 			baseMark.attach.id,
 			baseMark.count,
 		);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -57,7 +57,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 				assert(outputId !== undefined, "Transient mark should have defined output cell ID");
 				const oldId = nodeIdFromChangeAtom(
 					isMoveDestination(mark.attach)
-						? getEndpoint(mark.attach, mark.revision ?? revision)
+						? getEndpoint(mark.attach, revision)
 						: mark.cellId,
 				);
 				if (!areEqualChangeAtomIds(mark.cellId, outputId)) {


### PR DESCRIPTION
## Description

Simplified `TransientEffect` by removing its `RevisionTag` field.