### PR TITLE
Allow for partially enabling grouped batching.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1356,7 +1356,17 @@ export class ContainerRuntime
 			"Fluid.ContainerRuntime.CompressionChunkingDisabled",
 		);
 
-		const opGroupingManager = new OpGroupingManager(this.groupedBatchingEnabled);
+		const opGroupingManager = new OpGroupingManager(
+			{
+				groupedBatchingEnabled: this.groupedBatchingEnabled,
+				opCountThreshold:
+					this.mc.config.getNumber("Fluid.ContainerRuntime.GroupedBatchingOpCount") ?? 2,
+				reentrantBatchGroupingEnabled:
+					this.mc.config.getBoolean("Fluid.ContainerRuntime.GroupedBatchingReentrancy") ??
+					true,
+			},
+			this.mc.logger,
+		);
 
 		const opSplitter = new OpSplitter(
 			chunks,
@@ -1566,7 +1576,6 @@ export class ContainerRuntime
 				compressionOptions,
 				maxBatchSizeInBytes: runtimeOptions.maxBatchSizeInBytes,
 				disablePartialFlush: disablePartialFlush === true,
-				enableGroupedBatching: this.groupedBatchingEnabled,
 			},
 			logger: this.mc.logger,
 			groupingManager: opGroupingManager,

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -50,11 +50,7 @@ export class OpGroupingManager {
 			return batch;
 		}
 
-		assert(
-			batch.content.length >= this.config.opCountThreshold,
-			"Expecting to always group batches with op counts larger than the threshold",
-		);
-		if (this.config.opCountThreshold >= 1000) {
+		if (batch.content.length >= 1000) {
 			this.logger.sendTelemetryEvent({
 				eventName: "GroupLargeBatch",
 				length: batch.content.length,

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -5,6 +5,8 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
+import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { ContainerMessageType } from "../messageTypes";
 import { IBatch } from "./definitions";
 
@@ -26,14 +28,40 @@ function isGroupContents(opContents: any): opContents is IGroupedBatchMessageCon
 	return opContents?.type === OpGroupingManager.groupedBatchOp;
 }
 
+export interface OpGroupingManagerConfig {
+	readonly groupedBatchingEnabled: boolean;
+	readonly opCountThreshold: number;
+	readonly reentrantBatchGroupingEnabled: boolean;
+}
+
 export class OpGroupingManager {
 	static readonly groupedBatchOp = "groupedBatch";
+	private readonly logger;
 
-	constructor(private readonly groupedBatchingEnabled: boolean) {}
+	constructor(
+		private readonly config: OpGroupingManagerConfig,
+		logger: ITelemetryBaseLogger,
+	) {
+		this.logger = createChildLogger({ logger, namespace: "OpGroupingManager" });
+	}
 
 	public groupBatch(batch: IBatch): IBatch {
-		if (batch.content.length < 2 || !this.groupedBatchingEnabled) {
+		if (!this.shouldGroup(batch)) {
 			return batch;
+		}
+
+		assert(
+			batch.content.length >= this.config.opCountThreshold,
+			"Expecting to always group batches with op counts larger than the threshold",
+		);
+		if (this.config.opCountThreshold >= 1000) {
+			this.logger.sendTelemetryEvent({
+				eventName: "GroupLargeBatch",
+				length: batch.content.length,
+				threshold: this.config.opCountThreshold,
+				reentrant: batch.hasReentrantOps,
+				referenceSequenceNumber: batch.content[0].referenceSequenceNumber,
+			});
 		}
 
 		for (const message of batch.content) {
@@ -85,5 +113,16 @@ export class OpGroupingManager {
 			metadata: subMessage.metadata,
 			compression: subMessage.compression,
 		}));
+	}
+
+	public shouldGroup(batch: IBatch): boolean {
+		return (
+			// Grouped batching must be enabled
+			this.config.groupedBatchingEnabled &&
+			// The number of ops in the batch must surpass the configured threshold
+			batch.content.length >= this.config.opCountThreshold &&
+			// Support for reentrant batches must be explicitly enabled
+			(this.config.reentrantBatchGroupingEnabled || batch.hasReentrantOps !== true)
+		);
 	}
 }

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -30,7 +30,6 @@ export interface IOutboxConfig {
 	// The maximum size of a batch that we can send over the wire.
 	readonly maxBatchSizeInBytes: number;
 	readonly disablePartialFlush: boolean;
-	readonly enableGroupedBatching: boolean;
 }
 
 export interface IOutboxParameters {
@@ -304,7 +303,10 @@ export class Outbox {
 		}
 
 		const rawBatch = batchManager.popBatch();
-		if (rawBatch.hasReentrantOps === true && this.params.config.enableGroupedBatching) {
+		if (
+			rawBatch.hasReentrantOps === true &&
+			this.params.groupingManager.shouldGroup(rawBatch)
+		) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
 			// it needs to be rebased so that we can ensure consistent reference sequence numbers

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -10,14 +10,8 @@ import { BatchMessage, IBatch, OpGroupingManager } from "../../opLifecycle";
 
 describe("OpGroupingManager", () => {
 	const mockLogger = new MockLogger();
-	const createBatch = (
-		length: number,
-		messageSize: number,
-		hasReentrantOps?: boolean,
-	): IBatch => ({
-		...messagesToBatch(
-			new Array(length).fill(createMessage(generateStringOfSize(messageSize))),
-		),
+	const createBatch = (length: number, hasReentrantOps?: boolean): IBatch => ({
+		...messagesToBatch(new Array(length).fill(createMessage(generateStringOfSize(1)))),
 		hasReentrantOps,
 	});
 	const messagesToBatch = (messages: BatchMessage[]): IBatch => ({
@@ -47,7 +41,7 @@ describe("OpGroupingManager", () => {
 						reentrantBatchGroupingEnabled: true,
 					},
 					mockLogger,
-				).shouldGroup(createBatch(100, 1)),
+				).shouldGroup(createBatch(100)),
 				false,
 			);
 		});
@@ -61,7 +55,7 @@ describe("OpGroupingManager", () => {
 						reentrantBatchGroupingEnabled: true,
 					},
 					mockLogger,
-				).shouldGroup(createBatch(5, 1)),
+				).shouldGroup(createBatch(5)),
 				false,
 			);
 		});
@@ -75,7 +69,7 @@ describe("OpGroupingManager", () => {
 						reentrantBatchGroupingEnabled: false,
 					},
 					mockLogger,
-				).shouldGroup(createBatch(5, 1, true)),
+				).shouldGroup(createBatch(5, true)),
 				false,
 			);
 		});
@@ -89,7 +83,7 @@ describe("OpGroupingManager", () => {
 						reentrantBatchGroupingEnabled: true,
 					},
 					mockLogger,
-				).shouldGroup(createBatch(5, 1, true)),
+				).shouldGroup(createBatch(5, true)),
 				true,
 			);
 		});
@@ -103,7 +97,7 @@ describe("OpGroupingManager", () => {
 						reentrantBatchGroupingEnabled: false,
 					},
 					mockLogger,
-				).shouldGroup(createBatch(5, 1)),
+				).shouldGroup(createBatch(5)),
 				true,
 			);
 		});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { MockLogger } from "@fluidframework/telemetry-utils";
+import { ContainerMessageType } from "../..";
+import { BatchMessage, IBatch, OpGroupingManager } from "../../opLifecycle";
+
+describe("OpGroupingManager", () => {
+	const mockLogger = new MockLogger();
+	const createBatch = (
+		length: number,
+		messageSize: number,
+		hasReentrantOps?: boolean,
+	): IBatch => ({
+		...messagesToBatch(
+			new Array(length).fill(createMessage(generateStringOfSize(messageSize))),
+		),
+		hasReentrantOps,
+	});
+	const messagesToBatch = (messages: BatchMessage[]): IBatch => ({
+		content: messages,
+		contentSizeInBytes: messages
+			.map((message) => JSON.stringify(message).length)
+			.reduce((a, b) => a + b),
+		referenceSequenceNumber: messages[0].referenceSequenceNumber,
+	});
+	const createMessage = (contents: string) => ({
+		metadata: { flag: true },
+		localOpMetadata: undefined,
+		type: ContainerMessageType.FluidDataStoreOp,
+		contents,
+		referenceSequenceNumber: 0,
+	});
+	const generateStringOfSize = (sizeInBytes: number): string =>
+		new Array(sizeInBytes + 1).join("0");
+
+	describe("Configs", () => {
+		it("Grouped batching is disabled", () => {
+			assert.strictEqual(
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: false,
+						opCountThreshold: 0,
+						reentrantBatchGroupingEnabled: true,
+					},
+					mockLogger,
+				).shouldGroup(createBatch(100, 1)),
+				false,
+			);
+		});
+
+		it("Grouped batching is enabled but the batch is too small", () => {
+			assert.strictEqual(
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: true,
+						opCountThreshold: 10,
+						reentrantBatchGroupingEnabled: true,
+					},
+					mockLogger,
+				).shouldGroup(createBatch(5, 1)),
+				false,
+			);
+		});
+
+		it("Grouped batching is enabled, the batch is large enough, but it is reentrant", () => {
+			assert.strictEqual(
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: true,
+						opCountThreshold: 2,
+						reentrantBatchGroupingEnabled: false,
+					},
+					mockLogger,
+				).shouldGroup(createBatch(5, 1, true)),
+				false,
+			);
+		});
+
+		it("Grouped batching is enabled, the batch is large enough, and it is reentrant", () => {
+			assert.strictEqual(
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: true,
+						opCountThreshold: 2,
+						reentrantBatchGroupingEnabled: true,
+					},
+					mockLogger,
+				).shouldGroup(createBatch(5, 1, true)),
+				true,
+			);
+		});
+
+		it("Grouped batching is enabled and the batch is large enough", () => {
+			assert.strictEqual(
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: true,
+						opCountThreshold: 2,
+						reentrantBatchGroupingEnabled: false,
+					},
+					mockLogger,
+				).shouldGroup(createBatch(5, 1)),
+				true,
+			);
+		});
+	});
+});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -185,7 +185,6 @@ describe("Outbox", () => {
 		enableChunking?: boolean;
 		disablePartialFlush?: boolean;
 		chunkSizeInBytes?: number;
-		enableGroupedBatching?: boolean;
 	}) => {
 		const { submitFn, submitBatchFn, deltaManager } = params.context;
 
@@ -205,10 +204,16 @@ describe("Outbox", () => {
 				maxBatchSizeInBytes: params.maxBatchSize ?? maxBatchSizeInBytes,
 				compressionOptions: params.compressionOptions ?? DefaultCompressionOptions,
 				disablePartialFlush: params.disablePartialFlush ?? false,
-				enableGroupedBatching: params.enableGroupedBatching ?? false,
 			},
 			logger: mockLogger,
-			groupingManager: new OpGroupingManager(false),
+			groupingManager: new OpGroupingManager(
+				{
+					groupedBatchingEnabled: false,
+					opCountThreshold: Infinity,
+					reentrantBatchGroupingEnabled: false,
+				},
+				mockLogger,
+			),
 			getCurrentSequenceNumbers: () => currentSeqNumbers,
 			reSubmit: (message: IPendingBatchMessage) => {},
 			opReentrancy: () => false,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import {
 	IMessageProcessingResult,
 	OpDecompressor,
@@ -51,7 +52,14 @@ describe("RemoteMessageProcessor", () => {
 		new RemoteMessageProcessor(
 			mockSpliter as OpSplitter,
 			mockDecompressor as OpDecompressor,
-			new OpGroupingManager(false),
+			new OpGroupingManager(
+				{
+					groupedBatchingEnabled: false,
+					opCountThreshold: Infinity,
+					reentrantBatchGroupingEnabled: false,
+				},
+				new MockLogger(),
+			),
 		);
 
 	it("Invokes internal processors in order", () => {


### PR DESCRIPTION
## Description

ADO:6102

Using feature gates, allow for enabling grouped batching only for:

- batches over a certain limit
- batches which are not reentrant

All other batches will not be grouped. The goal here is to maybe fix some large payload scenarios and at the same time minimize the risk added by the grouped batching feature.

### As rebasing is required for grouped batching, this change will make it so that rebasing does not happen unless the batch will actually get grouped.