### PR TITLE
Avoid copying fuzz test state object

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -834,10 +834,9 @@ export function mixinClientSelection<
 			// 2. Make it available to the subsequent reducer logic we're going to inject
 			// (so that we can recover the channel from serialized data)
 			const client = state.random.pick(state.clients);
-			const baseOp = await baseGenerator({
-				...state,
-				client,
-			});
+			const baseOp = await runInStateWithClient(state, client, async () =>
+				baseGenerator(state),
+			);
 			return baseOp === done
 				? done
 				: {
@@ -851,13 +850,37 @@ export function mixinClientSelection<
 		assert(isClientSpec(operation), "operation should have been given a client");
 		const client = state.clients.find((c) => c.channel.id === operation.clientId);
 		assert(client !== undefined);
-		return model.reducer({ ...state, client }, operation as TOperation);
+		await runInStateWithClient(state, client, async () =>
+			model.reducer(state, operation as TOperation),
+		);
 	};
 	return {
 		...model,
 		generatorFactory,
 		reducer,
 	};
+}
+
+/**
+ * This modifies the value of "client" while callback is running, then restores it.
+ * This is does instead of copying the state since the state object is mutable, and running callback might make changes to state (like add new members) which are lost if state is just copied.
+ *
+ * Since the callback is async, this modification to the state could be an issue if multiple runs of this function are done concurrently.
+ */
+async function runInStateWithClient<TState extends DDSFuzzTestState<IChannelFactory>, Result>(
+	state: TState,
+	client: TState["client"],
+	callback: (state: TState) => Promise<Result>,
+): Promise<Result> {
+	const oldClient = state.client;
+	state.client = client;
+	try {
+		return await callback(state);
+	} finally {
+		// This code is explicitly trying to "update" to the old value.
+		// eslint-disable-next-line require-atomic-updates
+		state.client = oldClient;
+	}
 }
 
 function makeUnreachableCodePathProxy<T extends object>(name: string): T {


### PR DESCRIPTION
## Description

mixinClientSelection used to copy the state object. This breaks tests which lazily allocate members of their state object, and since the construction of state objects forces all extra members to be optional, lazily allocating them seems like a good idea until you hit this issue.

This PR changes this approach to instead mutate then restore the "client" member.

## Breaking Changes

Fuzz tests which rely on having separate state objects created, for example cunning multiple calls to mixinClientSelection concurrently, may be impacted. I do not think our tests do this, but if they did, it could cause issues.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

