### PR TITLE
GC: Add a GC option to control throwing on loading a tombstoned object

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -24,8 +24,9 @@ import {
 	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
-	throwOnTombstoneLoadKey,
+	throwOnTombstoneLoadOverrideKey,
 	throwOnTombstoneUsageKey,
+	gcThrowOnTombstoneLoadOptionName,
 } from "./gcDefinitions";
 import { getGCVersion, shouldAllowGcSweep, shouldAllowGcTombstoneEnforcement } from "./gcHelpers";
 
@@ -168,8 +169,13 @@ export function generateGCConfigs(
 		createParams.metadata?.gcFeatureMatrix?.tombstoneGeneration /* persisted */,
 		createParams.gcOptions[gcTombstoneGenerationOptionName] /* current */,
 	);
+
+	const throwOnTombstoneLoadConfig =
+		mc.config.getBoolean(throwOnTombstoneLoadOverrideKey) ??
+		createParams.gcOptions[gcThrowOnTombstoneLoadOptionName] ??
+		false;
 	const throwOnTombstoneLoad =
-		mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
+		throwOnTombstoneLoadConfig &&
 		tombstoneEnforcementAllowed &&
 		!createParams.isSummarizerClient;
 	const throwOnTombstoneUsage =

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -38,6 +38,13 @@ export const nextGCVersion: GCVersion = 4;
  * Otherwise, only enforce GC Tombstone if the passed in value matches the persisted value
  */
 export const gcTombstoneGenerationOptionName = "gcTombstoneGeneration";
+
+/**
+ * This undocumented GC Option (on ContainerRuntime Options) allows an app to enable throwing an error when tombstone
+ * object is loaded (requested).
+ */
+export const gcThrowOnTombstoneLoadOptionName = "gcThrowOnTombstoneLoad";
+
 /**
  * This GC Option (on ContainerRuntime Options) allows an app to disable GC Sweep on old documents by incrementing this value.
  *
@@ -59,8 +66,9 @@ export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
 export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 /** Config key to disable the tombstone feature, i.e., tombstone information is not read / written into summary. */
 export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
-/** Config key to enable throwing an error when tombstone object is loaded (requested). */
-export const throwOnTombstoneLoadKey = "Fluid.GarbageCollection.ThrowOnTombstoneLoad";
+/** Config key to override throwing an error when tombstone object is loaded (requested). */
+export const throwOnTombstoneLoadOverrideKey =
+	"Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride";
 /** Config key to enable throwing an error when tombstone object is used (e.g. outgoing or incoming ops). */
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 /** Config key to enable GC version upgrade. */

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -20,7 +20,7 @@ import {
 	IGarbageCollectorConfigs,
 	disableTombstoneKey,
 	throwOnTombstoneUsageKey,
-	throwOnTombstoneLoadKey,
+	throwOnTombstoneLoadOverrideKey,
 	runSweepKey,
 } from "./gcDefinitions";
 import { UnreferencedStateTracker } from "./gcUnreferencedStateTracker";
@@ -452,7 +452,7 @@ export function sendGCUnexpectedUsageEvent(
 	event.tombstoneFlags = JSON.stringify({
 		DisableTombstone: mc.config.getBoolean(disableTombstoneKey),
 		ThrowOnTombstoneUsage: mc.config.getBoolean(throwOnTombstoneUsageKey),
-		ThrowOnTombstoneLoad: mc.config.getBoolean(throwOnTombstoneLoadKey),
+		ThrowOnTombstoneLoad: mc.config.getBoolean(throwOnTombstoneLoadOverrideKey),
 	});
 	event.sweepFlags = JSON.stringify({
 		EnableSweepFlag: mc.config.getBoolean(runSweepKey),

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -12,6 +12,7 @@ export {
 	GCNodeType,
 	gcTestModeKey,
 	gcTombstoneGenerationOptionName,
+	gcThrowOnTombstoneLoadOptionName,
 	gcSweepGenerationOptionName,
 	GCFeatureMatrix,
 	GCVersion,
@@ -32,6 +33,7 @@ export {
 	disableAttachmentBlobSweepKey,
 	disableDatastoreSweepKey,
 	UnreferencedState,
+	throwOnTombstoneLoadOverrideKey,
 } from "./gcDefinitions";
 export {
 	cloneGCData,

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -41,6 +41,8 @@ import {
 	gcVersionUpgradeToV4Key,
 	gcTombstoneGenerationOptionName,
 	gcSweepGenerationOptionName,
+	throwOnTombstoneLoadOverrideKey,
+	gcThrowOnTombstoneLoadOptionName,
 	GCVersion,
 	runSessionExpiryKey,
 } from "../../gc";
@@ -76,13 +78,19 @@ describe("Garbage Collection configurations", () => {
 	const createGcWithPrivateMembers = (
 		gcMetadata?: IGCMetadata,
 		gcOptions?: IGCRuntimeOptions,
+		isSummarizerClient?: boolean,
 	): GcWithPrivates => {
 		const metadata: IContainerRuntimeMetadata | undefined = gcMetadata && {
 			summaryFormatVersion: 1,
 			message: undefined,
 			...gcMetadata,
 		};
-		return createGarbageCollector({ metadata, gcOptions }) as GcWithPrivates;
+		return createGarbageCollector(
+			{ metadata, gcOptions },
+			undefined /* gcBlobsMap */,
+			undefined /* closeFn */,
+			isSummarizerClient,
+		) as GcWithPrivates;
 	};
 
 	function createGarbageCollector(
@@ -842,6 +850,51 @@ describe("Garbage Collection configurations", () => {
 					);
 				});
 			});
+		});
+	});
+
+	describe("throwOnTombstoneLoad", () => {
+		it("throwOnTombstoneLoad enabled", () => {
+			gc = createGcWithPrivateMembers(
+				{ gcFeature: 0 },
+				{ [gcThrowOnTombstoneLoadOptionName]: true },
+				false /* isSummarizerClient */,
+			);
+			assert.equal(gc.configs.throwOnTombstoneLoad, true, "throwOnTombstoneLoad incorrect");
+		});
+		it("throwOnTombstoneLoad disabled", () => {
+			gc = createGcWithPrivateMembers(
+				{ gcFeature: 0 },
+				{ [gcThrowOnTombstoneLoadOptionName]: false },
+				false /* isSummarizerClient */,
+			);
+			assert.equal(gc.configs.throwOnTombstoneLoad, false, "throwOnTombstoneLoad incorrect");
+		});
+		it("throwOnTombstoneLoad undefined", () => {
+			gc = createGcWithPrivateMembers(
+				{ gcFeature: 0 },
+				undefined /* gcOptions */,
+				false /* isSummarizerClient */,
+			);
+			assert.equal(gc.configs.throwOnTombstoneLoad, false, "throwOnTombstoneLoad incorrect");
+		});
+		it("throwOnTombstoneLoad enabled via override", () => {
+			injectedSettings[throwOnTombstoneLoadOverrideKey] = true;
+			gc = createGcWithPrivateMembers(
+				{ gcFeature: 0 },
+				{ [gcThrowOnTombstoneLoadOptionName]: false },
+				false /* isSummarizerClient */,
+			);
+			assert.equal(gc.configs.throwOnTombstoneLoad, true, "throwOnTombstoneLoad incorrect");
+		});
+		it("throwOnTombstoneLoad disabled via override", () => {
+			injectedSettings[throwOnTombstoneLoadOverrideKey] = false;
+			gc = createGcWithPrivateMembers(
+				{ gcFeature: 0 },
+				{ [gcThrowOnTombstoneLoadOptionName]: true },
+				false /* isSummarizerClient */,
+			);
+			assert.equal(gc.configs.throwOnTombstoneLoad, false, "throwOnTombstoneLoad incorrect");
 		});
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -32,8 +32,11 @@ import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils.j
  */
 describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) => {
 	const sweepTimeoutMs = 200;
-	const settings = {};
-	const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0 };
+	let settings = {};
+	const gcOptions: IGCRuntimeOptions = {
+		inactiveTimeoutMs: 0,
+		gcThrowOnTombstoneLoad: true,
+	};
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {
 			summaryOptions: {
@@ -43,20 +46,36 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 			},
 			gcOptions,
 		},
-		loaderProps: { configProvider: mockConfigProvider(settings) },
 	};
 
 	let provider: ITestObjectProvider;
 
 	async function loadContainer(summaryVersion: string) {
-		return provider.loadTestContainer(testContainerConfig, {
+		const testConfigWithProvider: ITestContainerConfig = {
+			...testContainerConfig,
+			loaderProps: { configProvider: mockConfigProvider(settings) },
+		};
+		return provider.loadTestContainer(testConfigWithProvider, {
 			[LoaderHeader.version]: summaryVersion,
 		});
 	}
 
+	beforeEach(async function () {
+		provider = getTestObjectProvider({ syncSummarizer: true });
+		settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+	});
+
+	afterEach(() => {
+		settings = {};
+	});
+
 	describe("Attachment blobs in attached container", () => {
 		async function createDataStoreAndSummarizer() {
-			const container = await provider.makeTestContainer(testContainerConfig);
+			const testConfigWithProvider: ITestContainerConfig = {
+				...testContainerConfig,
+				loaderProps: { configProvider: mockConfigProvider(settings) },
+			};
+			const container = await provider.makeTestContainer(testConfigWithProvider);
 			const dataStore = await requestFluidObject<ITestDataObject>(container, "default");
 
 			// Send an op to transition the container to write mode.
@@ -72,13 +91,9 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 		}
 
 		beforeEach(async function () {
-			provider = getTestObjectProvider({ syncSummarizer: true });
 			if (provider.driver.type !== "local") {
 				this.skip();
 			}
-
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-			settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
 		});
 
 		itExpects(
@@ -314,8 +329,8 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 				},
 			],
 			async () => {
-				// Turn ThrowOnTombstoneUsage setting off.
-				settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+				// Override ThrowOnTombstoneLoad setting to off.
+				settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = false;
 
 				const { dataStore: mainDataStore, summarizer } =
 					await createDataStoreAndSummarizer();
@@ -428,14 +443,18 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 	});
 
 	describe("Attachment blobs in detached container", () => {
+		const testConfigWithProvider: ITestContainerConfig = {
+			...testContainerConfig,
+			loaderProps: { configProvider: mockConfigProvider(settings) },
+		};
 		/**
 		 * Creates a detached container and returns it along with the default data store.
 		 */
 		async function createDetachedContainerAndDataStore() {
 			const detachedBlobStorage = new MockDetachedBlobStorage();
 			const loader = provider.makeTestLoader({
-				...testContainerConfig,
-				loaderProps: { ...testContainerConfig.loaderProps, detachedBlobStorage },
+				...testConfigWithProvider,
+				loaderProps: { ...testConfigWithProvider.loaderProps, detachedBlobStorage },
 			});
 			const mainContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
 			const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "/");
@@ -443,13 +462,9 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 		}
 
 		beforeEach(async function () {
-			provider = getTestObjectProvider({ syncSummarizer: true });
 			if (!driverSupportsBlobs(provider.driver)) {
 				this.skip();
 			}
-
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-			settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
 		});
 
 		itExpects(
@@ -505,7 +520,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 
 				// Load a new container from the above summary which should have the blob tombstoned.
 				const url = await getUrlFromDetachedBlobStorage(mainContainer, provider);
-				const container2 = await provider.makeTestLoader(testContainerConfig).resolve({
+				const container2 = await provider.makeTestLoader(testConfigWithProvider).resolve({
 					url,
 					headers: { [LoaderHeader.version]: summary2.summaryVersion },
 				});
@@ -594,7 +609,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 
 				// Load a new container from the above summary which should have the blob tombstoned.
 				const url = await getUrlFromDetachedBlobStorage(mainContainer, provider);
-				const container2 = await provider.makeTestLoader(testContainerConfig).resolve({
+				const container2 = await provider.makeTestLoader(testConfigWithProvider).resolve({
 					url,
 					headers: { [LoaderHeader.version]: summary2.summaryVersion },
 				});
@@ -709,7 +724,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 
 				// Load a new container from the above summary which should have the blobs tombstoned.
 				const url = await getUrlFromDetachedBlobStorage(mainContainer, provider);
-				const container2 = await provider.makeTestLoader(testContainerConfig).resolve({
+				const container2 = await provider.makeTestLoader(testConfigWithProvider).resolve({
 					url,
 					headers: { [LoaderHeader.version]: summary2.summaryVersion },
 				});
@@ -757,7 +772,11 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 		 * Creates a container and returns it along with the default data store.
 		 */
 		async function createContainerAndDataStore() {
-			const mainContainer = await provider.makeTestContainer(testContainerConfig);
+			const testConfigWithProvider: ITestContainerConfig = {
+				...testContainerConfig,
+				loaderProps: { configProvider: mockConfigProvider(settings) },
+			};
+			const mainContainer = await provider.makeTestContainer(testConfigWithProvider);
 			const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "/");
 			await waitForContainerConnection(mainContainer);
 			return { mainContainer, mainDataStore };
@@ -779,13 +798,9 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 		}
 
 		beforeEach(async function () {
-			provider = getTestObjectProvider({ syncSummarizer: true });
 			if (provider.driver.type !== "local") {
 				this.skip();
 			}
-
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-			settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
 		});
 
 		itExpects(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -222,7 +222,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 	describe("Using tombstone data stores not allowed (per config)", () => {
 		beforeEach(() => {
 			// Allow Loading but not Usage
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = false;
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
 		});
 
@@ -412,7 +412,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
 		beforeEach(() => {
 			// Allow Usage but not Loading
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = true;
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
 		});
 
@@ -830,7 +830,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 		],
 		async () => {
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = false;
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
 			const { unreferencedId, summarizingContainer, summarizer } =
 				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
@@ -839,7 +839,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			// The datastore should be tombstoned now
 			const { summaryVersion } = await summarize(summarizer);
 			const container = await loadContainer(summaryVersion);
-			// Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoad is not enabled.
+			// Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoadOverride is not enabled.
 			// Logs a tombstone and sweep ready error
 			let dataObject: ITestDataObject;
 			await assert.doesNotReject(async () => {
@@ -889,7 +889,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
 		beforeEach(() => {
 			// This is not the typical configuration we expect (usage may be allowed), but keeping it more strict for the tests
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = true;
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
 		});
 
@@ -1245,7 +1245,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 	 */
 	describe("No unexpected tombstone behavior", () => {
 		beforeEach(() => {
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = false;
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
 		});
 		/**
@@ -1367,7 +1367,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				},
 			],
 			async () => {
-				settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+				settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = true;
 				const container = await makeContainer();
 				const defaultDataObject = await requestFluidObject<ITestDataObject>(
 					container,
@@ -1501,7 +1501,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				},
 			],
 			async () => {
-				settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+				settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = true;
 				const container = await makeContainer();
 				const defaultDataObject = await requestFluidObject<ITestDataObject>(
 					container,


### PR DESCRIPTION
Currently, throwing on loading a tombstoned object is disabled by default. It can only be enabled via config flags. Since config provider is passed to the loader, it means this behavior can be controlled at the loader layer not at the container layer.
This is not always desirable for all customers and some of them may want to control this behavior at the container level. This will also let them progagate changes to this behavior quickly since container changes are propagated faster.