### PR TITLE
fix(tree2): fix missing call to composeChild in sequence composition

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -424,10 +424,6 @@ function composeMark<TNodeChange, TMark extends Mark<TNodeChange>>(
 	revision: RevisionTag | undefined,
 	composeChild: NodeChangeComposer<TNodeChange>,
 ): TMark {
-	if (isNoopMark(mark)) {
-		return mark;
-	}
-
 	const cloned = cloneMark(mark);
 	if (
 		cloned.cellId !== undefined &&
@@ -438,7 +434,7 @@ function composeMark<TNodeChange, TMark extends Mark<TNodeChange>>(
 	}
 
 	addRevision(cloned, revision);
-	if (cloned.type !== "MoveIn" && cloned.changes !== undefined) {
+	if (cloned.changes !== undefined) {
 		cloned.changes = composeChild([tagChange(cloned.changes, revision)]);
 		return cloned;
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
@@ -41,8 +41,9 @@ export function composeNoVerify(
 export function compose(
 	changes: TaggedChange<TestChangeset>[],
 	revInfos?: RevisionInfo[],
+	childComposer?: (childChanges: TaggedChange<TestChange>[]) => TestChange,
 ): TestChangeset {
-	return composeI(changes, TestChange.compose, revInfos);
+	return composeI(changes, childComposer ?? TestChange.compose, revInfos);
 }
 
 export function composeAnonChangesShallow<T>(changes: SF.Changeset<T>[]): SF.Changeset<T> {


### PR DESCRIPTION
Fixes a bug in sequence field's implementation of compose: the childCompose delegate was not invoked on marks that make no shallow changes in the field. This prevents proper revision tracking for these child changes.