### PR TITLE
refactor(tree2) remove index tracking logic from changeset inverting

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/optionalField.ts
@@ -262,12 +262,12 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 		if (change.childChanges !== undefined) {
 			for (const [id, childChange] of change.childChanges) {
 				if (id === "self" && change.fieldChange !== undefined) {
-					originalChildChanges = invertChild(childChange, 0);
+					originalChildChanges = invertChild(childChange);
 				} else {
 					inverseChildChanges.set(
 						// This makes assumptions about how sandwich rebasing works
 						id,
-						invertChild(childChange, 0),
+						invertChild(childChange),
 					);
 				}
 			}
@@ -275,7 +275,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 
 		const selfChanges = change.fieldChange?.newContent?.changes;
 		if (selfChanges !== undefined) {
-			inverseChildChanges.set("self", invertChild(selfChanges, 0));
+			inverseChildChanges.set("self", invertChild(selfChanges));
 		}
 
 		const inverse: OptionalChangeset = {

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -171,10 +171,7 @@ export type ToDelta = (child: NodeChangeset) => Delta.FieldMap;
 /**
  * @alpha
  */
-export type NodeChangeInverter = (
-	change: NodeChangeset,
-	index: number | undefined,
-) => NodeChangeset;
+export type NodeChangeInverter = (change: NodeChangeset) => NodeChangeset;
 
 /**
  * @alpha

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -72,7 +72,7 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
 			return change.map(
 				({ index, nodeChange }: GenericChange): GenericChange => ({
 					index,
-					nodeChange: invertChild(nodeChange, index),
+					nodeChange: invertChild(nodeChange),
 				}),
 			);
 		},

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -302,7 +302,6 @@ export class ModularChangeFamily
 		const invertedFields = this.invertFieldMap(
 			tagChange(change.change.fieldChanges, change.revision),
 			genId,
-			undefined,
 			crossFieldTable,
 		);
 
@@ -345,7 +344,6 @@ export class ModularChangeFamily
 	private invertFieldMap(
 		changes: TaggedChange<FieldChangeMap>,
 		genId: IdAllocator,
-		path: UpPath | undefined,
 		crossFieldTable: CrossFieldTable<InvertData>,
 	): FieldChangeMap {
 		const invertedFields: FieldChangeMap = new Map();
@@ -359,18 +357,11 @@ export class ModularChangeFamily
 				fieldChange.fieldKind,
 			).rebaser.invert(
 				{ revision, change: fieldChange.change },
-				(childChanges, index) =>
+				(childChanges) =>
 					this.invertNodeChange(
 						{ revision, change: childChanges },
 						genId,
 						crossFieldTable,
-						index === undefined
-							? undefined
-							: {
-									parent: path,
-									parentField: field,
-									parentIndex: index,
-							  },
 					),
 				genId,
 				manager,
@@ -385,7 +376,6 @@ export class ModularChangeFamily
 			const invertData: InvertData = {
 				fieldKey: field,
 				fieldChange: invertedFieldChange,
-				path,
 				originalRevision: changes.revision,
 			};
 
@@ -399,7 +389,6 @@ export class ModularChangeFamily
 		change: TaggedChange<NodeChangeset>,
 		genId: IdAllocator,
 		crossFieldTable: CrossFieldTable<InvertData>,
-		path?: UpPath,
 	): NodeChangeset {
 		const inverse: NodeChangeset = {};
 
@@ -407,7 +396,6 @@ export class ModularChangeFamily
 			inverse.fieldChanges = this.invertFieldMap(
 				{ ...change, change: change.change.fieldChanges },
 				genId,
-				path,
 				crossFieldTable,
 			);
 		}
@@ -847,7 +835,6 @@ interface InvertData {
 	originalRevision: RevisionTag | undefined;
 	fieldKey: FieldKey;
 	fieldChange: FieldChange;
-	path: UpPath | undefined;
 }
 
 type ComposeData = FieldChange;

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -50,7 +50,7 @@ import { ValueChangeset, valueField } from "./basicRebasers";
 
 const singleNodeRebaser: FieldChangeRebaser<NodeChangeset> = {
 	compose: (changes, composeChild) => composeChild(changes),
-	invert: (change, invertChild) => invertChild(change.change, 0),
+	invert: (change, invertChild) => invertChild(change.change),
 	rebase: (change, base, rebaseChild) => rebaseChild(change, base.change) ?? {},
 	amendCompose: () => fail("Not supported"),
 	amendInvert: () => fail("Not supported"),


### PR DESCRIPTION
This logic was left over from when the inversion required access to a repair data store. This is no longer the case.