### PR TITLE
fix: Run prettier on previously ignored files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,7 +19,7 @@ build-tools/packages/*/docs/*.md
 build-tools/packages/build-cli/README.md
 build-tools/packages/readme-command/README.md
 build-tools/packages/version-tools/README.md
-**/src/**/test/types/*
+**/src/**/test/types/*.generated.ts
 **/src/packageVersion.ts
 **/build-tools/CHANGELOG.md
 **/*.done.build.log

--- a/packages/common/client-utils/src/test/types/tsconfig.json
+++ b/packages/common/client-utils/src/test/types/tsconfig.json
@@ -1,19 +1,14 @@
 {
-    "extends": "@fluidframework/build-common/ts-common-config.json",
-    "exclude": [
-        "dist",
-        "node_modules"
-    ],
-    "compilerOptions": {
-        "rootDir": "./",
-        "outDir": "../../../dist/test/types",
-    },
-    "include": [
-        "./**/*"
-    ],
-    "references": [
-        {
-            "path": "../../.."
-        }
-    ]
+	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"exclude": ["dist", "node_modules"],
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../../dist/test/types",
+	},
+	"include": ["./**/*"],
+	"references": [
+		{
+			"path": "../../..",
+		},
+	],
 }

--- a/packages/common/client-utils/src/test/types/tsconfig.json
+++ b/packages/common/client-utils/src/test/types/tsconfig.json
@@ -4,10 +4,7 @@
 		"../../../../../../common/build/build-common/tsconfig.test.json",
 	],
 	"include": ["./**/*"],
-    "exclude": [
-        "dist",
-        "node_modules"
-    ],
+	"exclude": ["dist", "node_modules"],
 	"references": [
 		{
 			"path": "../../..",
@@ -15,7 +12,7 @@
 	],
 	"compilerOptions": {
 		"rootDir": "./",
-    "outDir": "../../../dist/test/types",
+		"outDir": "../../../dist/test/types",
 		"types": [],
 	},
 }

--- a/packages/common/container-definitions/src/test/types/tsconfig.json
+++ b/packages/common/container-definitions/src/test/types/tsconfig.json
@@ -1,19 +1,17 @@
 {
-    "extends": "@fluidframework/build-common/ts-common-config.json",
-    "compilerOptions": {
-        "rootDir": "./",
-        "outDir": "../../../dist/test/types",
-        "declaration": false,
-        "declarationMap": false,
-        "skipLibCheck": true,
-        "noEmit": true,
-    },
-    "include": [
-        "./**/*"
-    ],
-    "references": [
-        {
-            "path": "../../.."
-        }
-    ]
+	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../../dist/test/types",
+		"declaration": false,
+		"declarationMap": false,
+		"skipLibCheck": true,
+		"noEmit": true,
+	},
+	"include": ["./**/*"],
+	"references": [
+		{
+			"path": "../../..",
+		},
+	],
 }

--- a/packages/common/core-interfaces/src/test/types/fluidObjectTypes.ts
+++ b/packages/common/core-interfaces/src/test/types/fluidObjectTypes.ts
@@ -15,7 +15,9 @@ declare function useFluidObject(params: FluidObject | undefined): void;
 
 declare function useProvider<T extends FluidObject>(params: FluidObject<T> | undefined): void;
 
-declare function useProviderKey<T, TKey extends FluidObjectKeys<T> = FluidObjectKeys<T>>(key: TKey): void;
+declare function useProviderKey<T, TKey extends FluidObjectKeys<T> = FluidObjectKeys<T>>(
+	key: TKey,
+): void;
 
 declare function useLoadable(params: FluidObject<IFluidLoadable> | undefined): void;
 declare function getLoadable(): IFluidLoadable;
@@ -23,125 +25,125 @@ declare function getLoadable(): IFluidLoadable;
 declare function use(obj: unknown);
 // test implicit conversions between FluidObject and a FluidObject with a provides interface
 {
-    const provider: FluidObject<IProvideFluidLoadable> = getFluidObject();
-    useFluidObject(provider);
-    useFluidObject(provider.IFluidLoadable);
-    useProvider(provider);
-    useProvider(provider.IFluidLoadable);
-    useLoadable(provider);
-    useLoadable(provider.IFluidLoadable);
-    // @ts-expect-error provider shouldn't have any non-provider properties
-    use(provider.handle);
-    use(provider.IFluidLoadable?.handle);
-    const unknown: FluidObject | undefined = provider.IFluidLoadable;
-    useFluidObject(unknown);
-    useProvider(unknown);
-    useProvider<IFluidLoadable>(unknown);
-    useLoadable(unknown);
+	const provider: FluidObject<IProvideFluidLoadable> = getFluidObject();
+	useFluidObject(provider);
+	useFluidObject(provider.IFluidLoadable);
+	useProvider(provider);
+	useProvider(provider.IFluidLoadable);
+	useLoadable(provider);
+	useLoadable(provider.IFluidLoadable);
+	// @ts-expect-error provider shouldn't have any non-provider properties
+	use(provider.handle);
+	use(provider.IFluidLoadable?.handle);
+	const unknown: FluidObject | undefined = provider.IFluidLoadable;
+	useFluidObject(unknown);
+	useProvider(unknown);
+	useProvider<IFluidLoadable>(unknown);
+	useLoadable(unknown);
 }
 
 // test implicit conversions between FluidObject and a FluidObject with a implementation interface
 {
-    const foo: FluidObject<IFluidLoadable> = getFluidObject();
-    useFluidObject(foo);
-    useFluidObject(foo.IFluidLoadable);
-    useProvider(foo);
-    useProvider(foo.IFluidLoadable);
-    useLoadable(foo);
-    useLoadable(foo.IFluidLoadable);
-    // @ts-expect-error provider shouldn't have any non-provider properties
-    use(foo.handle);
-    use(foo.IFluidLoadable?.handle);
-    const unknown: FluidObject | undefined = foo.IFluidLoadable;
-    useFluidObject(unknown);
-    useProvider(unknown);
-    useProvider<IFluidLoadable>(unknown);
-    useLoadable(unknown);
+	const foo: FluidObject<IFluidLoadable> = getFluidObject();
+	useFluidObject(foo);
+	useFluidObject(foo.IFluidLoadable);
+	useProvider(foo);
+	useProvider(foo.IFluidLoadable);
+	useLoadable(foo);
+	useLoadable(foo.IFluidLoadable);
+	// @ts-expect-error provider shouldn't have any non-provider properties
+	use(foo.handle);
+	use(foo.IFluidLoadable?.handle);
+	const unknown: FluidObject | undefined = foo.IFluidLoadable;
+	useFluidObject(unknown);
+	useProvider(unknown);
+	useProvider<IFluidLoadable>(unknown);
+	useLoadable(unknown);
 }
 
 // test getting keys
 {
-    useProviderKey<IProvideFluidLoadable>(IFluidLoadable);
-    useProviderKey<IFluidLoadable>(IFluidLoadable);
-    const loadableKey: keyof IFluidLoadable = "handle";
-    // @ts-expect-error provider shouldn't have any non-provider properties
-    useProviderKey<IFluidLoadable>(loadableKey);
+	useProviderKey<IProvideFluidLoadable>(IFluidLoadable);
+	useProviderKey<IFluidLoadable>(IFluidLoadable);
+	const loadableKey: keyof IFluidLoadable = "handle";
+	// @ts-expect-error provider shouldn't have any non-provider properties
+	useProviderKey<IFluidLoadable>(loadableKey);
 }
 
 // test implicit conversions between FluidObject and a FluidObject with a partial provider interface
 {
-    interface IProvideFoo{
-        IFoo: IFoo;
-    }
-    interface IFoo extends Partial<IProvideFoo>{
-        doFoo();
-    }
+	interface IProvideFoo {
+		IFoo: IFoo;
+	}
+	interface IFoo extends Partial<IProvideFoo> {
+		doFoo();
+	}
 
-    const foo: FluidObject<IFoo> = getFluidObject();
-    useFluidObject(foo);
-    useFluidObject(foo.IFoo);
-    useProvider(foo);
-    useProvider(foo.IFoo);
-    foo.IFoo?.doFoo();
-    const fooKey: keyof IFoo = "doFoo";
-    // @ts-expect-error provider shouldn't have any non-provider properties
-    useProviderKey<IFoo>(fooKey);
-    const unknown: FluidObject | undefined = foo.IFoo;
-    useFluidObject(unknown);
-    useProvider(unknown);
-    useProvider<IFoo>(unknown);
-    useLoadable(unknown);
+	const foo: FluidObject<IFoo> = getFluidObject();
+	useFluidObject(foo);
+	useFluidObject(foo.IFoo);
+	useProvider(foo);
+	useProvider(foo.IFoo);
+	foo.IFoo?.doFoo();
+	const fooKey: keyof IFoo = "doFoo";
+	// @ts-expect-error provider shouldn't have any non-provider properties
+	useProviderKey<IFoo>(fooKey);
+	const unknown: FluidObject | undefined = foo.IFoo;
+	useFluidObject(unknown);
+	useProvider(unknown);
+	useProvider<IFoo>(unknown);
+	useLoadable(unknown);
 }
 
 // validate nested property is FluidObject too
 {
-    interface IFoo {
-        z: { z: { z: boolean; }; };
-      }
+	interface IFoo {
+		z: { z: { z: boolean } };
+	}
 
-    const foo: FluidObject<IFoo> = getFluidObject();
-    // @ts-expect-error "Property 'z' does not exist on type 'FluidObject<IFoo>'."
-    useProvider(foo.z);
+	const foo: FluidObject<IFoo> = getFluidObject();
+	// @ts-expect-error "Property 'z' does not exist on type 'FluidObject<IFoo>'."
+	useProvider(foo.z);
 }
 
 // validate provider inheritance
 {
-    interface IProvideFooParent{
-        IFooParent: IFooParent;
-    }
+	interface IProvideFooParent {
+		IFooParent: IFooParent;
+	}
 
-    interface IFooParent extends Partial<IProvideFooParent>{
-        parent();
-    }
+	interface IFooParent extends Partial<IProvideFooParent> {
+		parent();
+	}
 
-    interface IFooProvideChild {
-        IFooChild: IFooChild;
-    }
+	interface IFooProvideChild {
+		IFooChild: IFooChild;
+	}
 
-    interface IFooChild extends IFooParent, Partial<IFooProvideChild>{
-        child();
-    }
+	interface IFooChild extends IFooParent, Partial<IFooProvideChild> {
+		child();
+	}
 
-    const p: FluidObject<IProvideFooParent> = getFluidObject();
-    useProvider(p.IFooParent?.parent());
+	const p: FluidObject<IProvideFooParent> = getFluidObject();
+	useProvider(p.IFooParent?.parent());
 
-    const c: FluidObject<IFooProvideChild> = getFluidObject();
-    // @ts-expect-error Property 'IFooParent' does not exist on type 'FluidObject<IFooProvideChild>'.
-    useProvider(c.IFooParent?.parent());
-    useProvider(c.IFooChild?.child());
-    useProvider(c.IFooChild?.parent());
-    useProvider(c.IFooChild?.IFooParent?.parent());
+	const c: FluidObject<IFooProvideChild> = getFluidObject();
+	// @ts-expect-error Property 'IFooParent' does not exist on type 'FluidObject<IFooProvideChild>'.
+	useProvider(c.IFooParent?.parent());
+	useProvider(c.IFooChild?.child());
+	useProvider(c.IFooChild?.parent());
+	useProvider(c.IFooChild?.IFooParent?.parent());
 }
 
 // validate usage as builder
 {
-    const builder: FluidObject<IFluidLoadable> = {};
-    builder.IFluidLoadable = getLoadable();
+	const builder: FluidObject<IFluidLoadable> = {};
+	builder.IFluidLoadable = getLoadable();
 }
 
 // validate readonly prevents modification
 {
-    const builder: Readonly<FluidObject<IFluidLoadable>> = {};
-    // @ts-expect-error Cannot assign to 'IFluidLoadable' because it is a read-only property.
-    builder.IFluidLoadable = getLoadable();
+	const builder: Readonly<FluidObject<IFluidLoadable>> = {};
+	// @ts-expect-error Cannot assign to 'IFluidLoadable' because it is a read-only property.
+	builder.IFluidLoadable = getLoadable();
 }

--- a/packages/common/driver-definitions/src/test/types/maximumCacheDurationPolicy.spec.ts
+++ b/packages/common/driver-definitions/src/test/types/maximumCacheDurationPolicy.spec.ts
@@ -25,12 +25,12 @@ import { IDocumentStorageServicePolicies } from "../../storage";
 declare function assertNever(x: never): void;
 declare const maximumCacheDurationMs: IDocumentStorageServicePolicies["maximumCacheDurationMs"];
 switch (maximumCacheDurationMs) {
-    // These are the only two valid values
-    case undefined:
-    case 432_000_000: {
-        break;
-    }
-    default: {
-        assertNever(maximumCacheDurationMs);
-    }
+	// These are the only two valid values
+	case undefined:
+	case 432_000_000: {
+		break;
+	}
+	default: {
+		assertNever(maximumCacheDurationMs);
+	}
 }

--- a/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
@@ -11,18 +11,18 @@ declare function foo<T>(jsonable: Jsonable<T>): void;
 
 // test simple class.
 class Z {
-    public a = "a";
+	public a = "a";
 }
 
 foo<Z>(new Z());
 
 // test class with getter
 class getter {
-    // The point here is to test a getter
-    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
-    public get baz(): number {
-        return 0;
-    }
+	// The point here is to test a getter
+	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
+	public get baz(): number {
+		return 0;
+	}
 }
 
 foo(new getter());
@@ -43,40 +43,40 @@ foo({ a: "a" });
 
 // test simple interface
 interface IA {
-    a: "a";
+	a: "a";
 }
 declare const a: IA;
 foo(a);
 
 // test simple indexed interface
 interface IA2 {
-    ["a"]: "a";
+	["a"]: "a";
 }
 declare const a2: IA2;
 foo(a2);
 
 // text complex indexed interface
-declare const a3: { [key: string]: Jsonable<string>; };
+declare const a3: { [key: string]: Jsonable<string> };
 foo(a3);
 
 // test interface with multiple properties
 interface A5 {
-    a: "a";
-    b: "b";
+	a: "a";
+	b: "b";
 }
 declare const a5: A5;
 foo(a5);
 
 // test interface with optional property
 interface A6 {
-    a?: "a";
+	a?: "a";
 }
 declare const a6: A6;
 foo(a6);
 
 // test simple type
 interface A7 {
-    a: "a";
+	a: "a";
 }
 
 declare const a7: A7;
@@ -84,19 +84,19 @@ foo(a7);
 
 // test nested interface
 interface IBN {
-    b2: string;
+	b2: string;
 }
 
 interface INested {
-    a: string;
-    b: IBN;
+	a: string;
+	b: IBN;
 }
 
 const nested: INested = {
-    a: "a",
-    b: {
-        b2: "foo",
-    },
+	a: "a",
+	b: {
+		b2: "foo",
+	},
 };
 foo(nested);
 
@@ -104,8 +104,8 @@ foo(nested);
 
 // test interface with method, and member
 interface IA11 {
-    ["a"]: "a";
-    foo: () => void;
+	["a"]: "a";
+	foo: () => void;
 }
 declare const a11: IA11;
 // @ts-expect-error should not be jsonable
@@ -113,7 +113,7 @@ foo(a11);
 
 // test interface with optional method
 interface A12 {
-    foo?: () => void;
+	foo?: () => void;
 }
 declare const a12: A12;
 // @ts-expect-error should not be jsonable
@@ -121,7 +121,7 @@ foo(a12);
 
 // test type with method
 interface A13 {
-    foo: () => void;
+	foo: () => void;
 }
 declare const a13: A13;
 // @ts-expect-error should not be jsonable
@@ -129,7 +129,7 @@ foo(a13);
 
 // test type with primative and object with classes union
 interface IA14 {
-    a: number | Date;
+	a: number | Date;
 }
 declare const a14: IA14;
 // @ts-expect-error should not be jsonable
@@ -137,39 +137,38 @@ foo(a14);
 
 // test class with function
 class bar {
-    public baz() {
-    }
+	public baz() {}
 }
 // @ts-expect-error should not be jsonable
 foo(new bar());
 
 // test class with complex property
-interface MapProp{
-    m: Map<string, string>;
+interface MapProp {
+	m: Map<string, string>;
 }
 const mt: MapProp = {
-    m: new Map(),
+	m: new Map(),
 };
 // @ts-expect-error should not be jsonable
 foo(mt);
 
 // test nested interface with complex property
-interface NestedMapProp{
-    n: MapProp;
+interface NestedMapProp {
+	n: MapProp;
 }
 const nmt: NestedMapProp = {
-    n: mt,
+	n: mt,
 };
 // @ts-expect-error should not be jsonable
 foo(nmt);
 
 // test class with symbol indexer for property
 const sym = Symbol.for("test");
-interface ISymbol{
-    [sym]: string;
+interface ISymbol {
+	[sym]: string;
 }
 const isym: ISymbol = {
-    [sym]: "foo",
+	[sym]: "foo",
 };
 // @ts-expect-error should not be jsonable
 foo(isym);

--- a/packages/runtime/runtime-definitions/src/test/types/requestSignatureDeprecation.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/requestSignatureDeprecation.ts
@@ -8,7 +8,6 @@
 
 import { IDataStore } from "../../dataStoreContext";
 
-
 declare const dataStore: IDataStore;
 
 // These are deprecated


### PR DESCRIPTION
Prettier was ignoring files it shouldn't. I tightened up the ignore pattern so it should only ignore generated files now.