### PR TITLE
Attempt to repro SharedDirectory fuzz test failure - seed 8

### DIFF
--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -369,11 +369,10 @@ describe("SharedDirectory fuzz Create/Delete concentrated", () => {
 			defaultTestCount: 200,
 			// The seeds below fail only when rebaseProbability is non-zero ADO:6044
 			skip: [
-				4, 6, 8, 19, 48, 82, 83, 87, 94, 95, 110, 118, 123, 138, 154, 159, 180, 181, 190,
-				195,
+				4, 6, 19, 48, 82, 83, 87, 94, 95, 110, 118, 123, 138, 154, 159, 180, 181, 190, 195,
 			],
 			// Uncomment this line to replay a specific seed from its failure file:
-			// replay: 21,
+			replay: 8,
 			saveFailures: {
 				directory: dirPath.join(__dirname, "../../../src/test/mocha/results/1"),
 			},

--- a/packages/dds/map/src/test/mocha/results/1/default-directory-1-with-rebasing/8.json
+++ b/packages/dds/map/src/test/mocha/results/1/default-directory-1-with-rebasing/8.json
@@ -1,0 +1,472 @@
+[
+	{
+		"type": "attach"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "rebase",
+		"clientId": "A"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "A"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "B"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "A"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/dir2",
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "C"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "B"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/dir1",
+		"clientId": "A"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir1",
+		"path": "/dir1",
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/dir2",
+		"clientId": "C"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "C"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "B"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "B"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/dir1",
+		"clientId": "B"
+	},
+	{
+		"type": "rebase",
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "C"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/dir1",
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "C"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "B"
+	},
+	{
+		"type": "rebase",
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "A"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir1",
+		"path": "/",
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "createSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "deleteSubDirectory",
+		"name": "dir2",
+		"path": "/",
+		"clientId": "A"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "A"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "B"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": false,
+		"clientId": "B"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "synchronize"
+	},
+	{
+		"type": "changeConnectionState",
+		"connected": true,
+		"clientId": "C"
+	},
+	{
+		"type": "synchronize"
+	}
+]


### PR DESCRIPTION
[AB#6044](https://dev.azure.com/fluidframework/internal/_workitems/edit/6044)

It is an EXPERIMENTAL repro attempt, will not be merged to the main branch.

I disabled the fuzz test minimization and manually generated the failed test based on the complete JSON file in seed 8. However, despite my efforts, the test still passes. Upon further examination, it appears that something went weird after the third rebase in the seed 8 fuzz test. Specifically, it seems that the container of client C is missing in the process of handling a `deleteSubdirectory("dir1")` message. I am still in the process of investigating this issue.


