### PR TITLE
refactor(ci): Use stage identifier instead of display name for stage telemetry

### DIFF
--- a/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
+++ b/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
@@ -38,7 +38,9 @@ module.exports = function handler(fileData, logger) {
 				finishTime && startTime ? Math.abs(finishTime - startTime) / 1000 : undefined; // diff in seconds
 			console.log(`Name=${job.name}`);
 			return {
-				stageName: job.name,
+				// Using the 'identifier' property because that's the one available in the API response for test results,
+				// and we want the values to be consistent so we can correlate them later.
+				stageName: job.identifier,
 				startTime,
 				finishTime,
 				totalTime: dateDiff,


### PR DESCRIPTION
## Description

Changes the value we use to identify the pipeline stage in a telemetry record for pipeline timing/results from the display name (in ADO) of the stage, to its id.

### Context

When we [submit pipeline telemetry for e2e test pass rate](https://github.com/microsoft/FluidFramework/blob/7221f421eb23712b21a45cbedc66b65c7bff3c5f/tools/telemetry-generator/src/handlers/testPassRate.ts#L35), the only identifier for the stage that is readily available is its id (confusingly named `stageName`), not its display name (see the file changed in this PR):

![image](https://github.com/microsoft/FluidFramework/assets/716334/66294a0b-c75a-4456-aaef-0447e54ca92b)

In the ADO API response for stage timing results, we have access to both the id (`identifier`) and the display name (`name`), and are currently using the display name:

![image](https://github.com/microsoft/FluidFramework/assets/716334/b3c7488d-d291-4416-b01e-ebf53626aae5)

This makes it hard to correlate all telemetry for a given stage in our Geneva health model.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
