### PR TITLE
tree2: Allow inserting content into editable tree with cursors

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -552,10 +552,13 @@ type FlattenKeys<T> = [{
 }][_InlineTrick];
 
 // @alpha
-export type FlexibleFieldContent<TSchema extends TreeFieldSchema> = SchemaAware.TypedField<TSchema, SchemaAware.ApiMode.Flexible>;
+export type FlexibleFieldContent<TSchema extends TreeFieldSchema> = SchemaAware.TypedField<TSchema, SchemaAware.ApiMode.Flexible> | ITreeCursorSynchronous;
 
 // @alpha
-export type FlexibleNodeContent<TTypes extends AllowedTypes> = SchemaAware.AllowedTypesToTypedTrees<SchemaAware.ApiMode.Flexible, TTypes>;
+export type FlexibleNodeContent<TTypes extends AllowedTypes> = SchemaAware.AllowedTypesToTypedTrees<SchemaAware.ApiMode.Flexible, TTypes> | ITreeCursorSynchronous;
+
+// @alpha
+type FlexibleNodeSubSequence<TTypes extends AllowedTypes> = Iterable<SchemaAware.AllowedTypesToTypedTrees<SchemaAware.ApiMode.Flexible, TTypes>> | ITreeCursorSynchronous;
 
 // @alpha
 type FlexibleObject<TValueSchema extends ValueSchema | undefined, TName> = [
@@ -699,6 +702,7 @@ declare namespace InternalEditableTreeTypes {
         UnknownUnboxed,
         FixedSizeTypeArrayToTypedTree,
         TypedNodeUnionHelper,
+        FlexibleNodeSubSequence,
         NodeKeys
     }
 }
@@ -1288,7 +1292,7 @@ interface Optional extends FieldKind<"Optional", Multiplicity.Optional> {
 }
 
 // @alpha
-export interface OptionalField<TTypes extends AllowedTypes> extends TreeField {
+export interface OptionalField<in out TTypes extends AllowedTypes> extends TreeField {
     // (undocumented)
     readonly boxedContent?: TypedNodeUnion<TTypes>;
     // (undocumented)
@@ -1412,7 +1416,7 @@ interface Required_2 extends FieldKind<"Value", Multiplicity.Single> {
 }
 
 // @alpha
-export interface RequiredField<TTypes extends AllowedTypes> extends TreeField {
+export interface RequiredField<in out TTypes extends AllowedTypes> extends TreeField {
     // (undocumented)
     readonly boxedContent: TypedNodeUnion<TTypes>;
     // (undocumented)
@@ -1646,9 +1650,9 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
     readonly asArray: readonly UnboxNodeUnion<TTypes>[];
     at(index: number): UnboxNodeUnion<TTypes> | undefined;
     boxedAt(index: number): TypedNodeUnion<TTypes>;
-    insertAt(index: number, value: Iterable<FlexibleNodeContent<TTypes>>): void;
-    insertAtEnd(value: Iterable<FlexibleNodeContent<TTypes>>): void;
-    insertAtStart(value: Iterable<FlexibleNodeContent<TTypes>>): void;
+    insertAt(index: number, value: FlexibleNodeSubSequence<TTypes>): void;
+    insertAtEnd(value: FlexibleNodeSubSequence<TTypes>): void;
+    insertAtStart(value: FlexibleNodeSubSequence<TTypes>): void;
     // (undocumented)
     readonly length: number;
     map<U>(callbackfn: (value: UnboxNodeUnion<TTypes>, index: number) => U): U[];

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -476,6 +476,7 @@ function shallowCompatibilityTest(
  * Construct a tree from ContextuallyTypedNodeData.
  *
  * TODO: this should probably be refactored into a `try` function which either returns a Cursor or a SchemaError with a path to the error.
+ * @returns a cursor in Nodes mode for a single node containing the provided data.
  * @alpha
  */
 export function cursorFromContextualData(
@@ -488,7 +489,8 @@ export function cursorFromContextualData(
 }
 
 /**
- * Strongly typed {@link cursorFromContextualData} for a TreeNodeSchema
+ * Strongly typed {@link cursorFromContextualData} for a TreeNodeSchema.
+ * @returns a cursor in Nodes mode for a single node containing the provided data.
  * @alpha
  */
 export function cursorForTypedTreeData<T extends TreeNodeSchema>(
@@ -505,6 +507,7 @@ export function cursorForTypedTreeData<T extends TreeNodeSchema>(
 
 /**
  * Strongly typed {@link cursorFromContextualData} for AllowedTypes.
+ * @returns a cursor in Nodes mode for a single node containing the provided data.
  * @alpha
  */
 export function cursorForTypedData<T extends AllowedTypes>(

--- a/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-field-kinds/defaultChangeFamily.ts
@@ -245,11 +245,11 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		return {
 			insert: (index: number, newContent: ITreeCursor | readonly ITreeCursor[]): void => {
 				const content = isReadonlyArray(newContent) ? newContent : [newContent];
-				if (content.length === 0) {
+				const length = content.length;
+				if (length === 0) {
 					return;
 				}
 
-				const length = Array.isArray(newContent) ? newContent.length : 1;
 				const firstId = this.modularBuilder.generateId(length);
 				const change: FieldChangeset = brand(
 					sequence.changeHandler.editor.insert(index, content, firstId),
@@ -291,7 +291,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 export interface ValueFieldEditBuilder {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`.
-	 * @param newContent - the new content for the field
+	 * @param newContent - the new content for the field. Must be in Nodes mode.
 	 */
 	set(newContent: ITreeCursor): void;
 }
@@ -302,7 +302,7 @@ export interface ValueFieldEditBuilder {
 export interface OptionalFieldEditBuilder {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`
-	 * @param newContent - the new content for the field
+	 * @param newContent - the new content for the field. Must be in Nodes mode.
 	 * @param wasEmpty - whether the field is empty when creating this change
 	 */
 	set(newContent: ITreeCursor | undefined, wasEmpty: boolean): void;
@@ -315,7 +315,7 @@ export interface SequenceFieldEditBuilder {
 	/**
 	 * Issues a change which inserts the `newContent` at the given `index`.
 	 * @param index - the index at which to insert the `newContent`.
-	 * @param newContent - the new content to be inserted in the field
+	 * @param newContent - the new content to be inserted in the field. Cursors must be in Nodes mode.
 	 */
 	insert(index: number, newContent: ITreeCursor | readonly ITreeCursor[]): void;
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -534,6 +534,8 @@ export type FlexibleNodeContent<TTypes extends AllowedTypes> =
 /**
  * Strongly typed tree literals for inserting a subsequence of nodes.
  *
+ * Used to insert a batch of 0 or more nodes into some location in a {@link Sequence}.
+ *
  * If a cursor is provided, it must be in Fields mode.
  * @alpha
  */

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -4,7 +4,7 @@
  */
 
 import * as SchemaAware from "../schema-aware";
-import { FieldKey, TreeNodeSchemaIdentifier, TreeValue } from "../../core";
+import { FieldKey, ITreeCursorSynchronous, TreeNodeSchemaIdentifier, TreeValue } from "../../core";
 import { Assume, FlattenKeys, RestrictiveReadonlyRecord, _InlineTrick } from "../../util";
 import { LocalNodeKey, StableNodeKey } from "../node-key";
 import {
@@ -513,21 +513,33 @@ export type AssignableFieldKinds = typeof FieldKinds.optional | typeof FieldKind
 
 /**
  * Strongly typed tree literals for inserting as the content of a field.
+ *
+ * If a cursor is provided, it must be in Fields mode.
  * @alpha
  */
-export type FlexibleFieldContent<TSchema extends TreeFieldSchema> = SchemaAware.TypedField<
-	TSchema,
-	SchemaAware.ApiMode.Flexible
->;
+export type FlexibleFieldContent<TSchema extends TreeFieldSchema> =
+	| SchemaAware.TypedField<TSchema, SchemaAware.ApiMode.Flexible>
+	| ITreeCursorSynchronous;
 
 /**
  * Strongly typed tree literals for inserting as a node.
+ *
+ * If a cursor is provided, it must be in Nodes mode.
  * @alpha
  */
-export type FlexibleNodeContent<TTypes extends AllowedTypes> = SchemaAware.AllowedTypesToTypedTrees<
-	SchemaAware.ApiMode.Flexible,
-	TTypes
->;
+export type FlexibleNodeContent<TTypes extends AllowedTypes> =
+	| SchemaAware.AllowedTypesToTypedTrees<SchemaAware.ApiMode.Flexible, TTypes>
+	| ITreeCursorSynchronous;
+
+/**
+ * Strongly typed tree literals for inserting a subsequence of nodes.
+ *
+ * If a cursor is provided, it must be in Fields mode.
+ * @alpha
+ */
+export type FlexibleNodeSubSequence<TTypes extends AllowedTypes> =
+	| Iterable<SchemaAware.AllowedTypesToTypedTrees<SchemaAware.ApiMode.Flexible, TTypes>>
+	| ITreeCursorSynchronous;
 
 /**
  * Type to ensures two types overlap in at least one way.
@@ -595,19 +607,19 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
 	 */
-	insertAt(index: number, value: Iterable<FlexibleNodeContent<TTypes>>): void;
+	insertAt(index: number, value: FlexibleNodeSubSequence<TTypes>): void;
 
 	/**
 	 * Inserts new item(s) at the start of the sequence.
 	 * @param value - The content to insert.
 	 */
-	insertAtStart(value: Iterable<FlexibleNodeContent<TTypes>>): void;
+	insertAtStart(value: FlexibleNodeSubSequence<TTypes>): void;
 
 	/**
 	 * Inserts new item(s) at the end of the sequence.
 	 * @param value - The content to insert.
 	 */
-	insertAtEnd(value: Iterable<FlexibleNodeContent<TTypes>>): void;
+	insertAtEnd(value: FlexibleNodeSubSequence<TTypes>): void;
 
 	/**
 	 * Removes the item at the specified location.
@@ -755,11 +767,9 @@ export interface Sequence<in out TTypes extends AllowedTypes> extends TreeField 
  *
  * @remarks
  * Unboxes its content, so in schema aware APIs which do unboxing, the RequiredField itself will be skipped over and its content will be returned directly.
- * @privateRemarks
- * TODO: Finish renaming from ValueField to RequiredField
  * @alpha
  */
-export interface RequiredField<TTypes extends AllowedTypes> extends TreeField {
+export interface RequiredField<in out TTypes extends AllowedTypes> extends TreeField {
 	get content(): UnboxNodeUnion<TTypes>;
 	set content(content: FlexibleNodeContent<TTypes>);
 
@@ -780,7 +790,7 @@ export interface RequiredField<TTypes extends AllowedTypes> extends TreeField {
  * Maybe link editor?
  * @alpha
  */
-export interface OptionalField<TTypes extends AllowedTypes> extends TreeField {
+export interface OptionalField<in out TTypes extends AllowedTypes> extends TreeField {
 	get content(): UnboxNodeUnion<TTypes> | undefined;
 	set content(newContent: FlexibleNodeContent<TTypes> | undefined);
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/internal.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/internal.ts
@@ -18,6 +18,7 @@ export {
 	UnknownUnboxed,
 	FixedSizeTypeArrayToTypedTree,
 	TypedNodeUnionHelper,
+	FlexibleNodeSubSequence,
 } from "./editableTreeTypes";
 
 export { NodeKeys } from "./nodeKeys";

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/lazyField.ts
@@ -13,12 +13,14 @@ import {
 	FieldAnchor,
 	inCursorNode,
 	FieldUpPath,
-	ITreeCursor,
 	keyAsDetachedField,
 	iterateCursorField,
+	isCursor,
+	ITreeCursorSynchronous,
+	mapCursorField,
 } from "../../core";
 import { FieldKind } from "../modular-schema";
-import { NewFieldContent, normalizeNewFieldContent } from "../contextuallyTyped";
+import { cursorFromContextualData } from "../contextuallyTyped";
 import {
 	FieldKinds,
 	OptionalFieldEditBuilder,
@@ -28,6 +30,7 @@ import {
 import { assertValidIndex, assertValidRangeIndices, brand, disposeSymbol, fail } from "../../util";
 import { AllowedTypes, TreeFieldSchema } from "../typed-schema";
 import { LocalNodeKey, StableNodeKey, nodeKeyTreeIdentifier } from "../node-key";
+import { mapTreeFromCursor, singleMapTreeCursor } from "../mapTreeCursor";
 import { Context } from "./context";
 import {
 	FlexibleNodeContent,
@@ -42,6 +45,7 @@ import {
 	boxedIterator,
 	TreeStatus,
 	NodeKeyField,
+	FlexibleNodeSubSequence,
 } from "./editableTreeTypes";
 import { makeTree } from "./lazyTree";
 import {
@@ -122,10 +126,6 @@ export abstract class LazyField<TKind extends FieldKind, TTypes extends AllowedT
 			0x77d /* Content from different editable trees should not be used together */,
 		);
 		return this.key === other.key && this.parent === other.parent;
-	}
-
-	public normalizeNewContent(content: NewFieldContent): readonly ITreeCursor[] {
-		return normalizeNewFieldContent(this.context, this.schema, content);
 	}
 
 	public get parent(): TreeNode | undefined {
@@ -265,18 +265,22 @@ export class LazySequence<TTypes extends AllowedTypes>
 		return fieldEditor;
 	}
 
-	public insertAt(index: number, value: Iterable<FlexibleNodeContent<TTypes>>): void {
-		const fieldEditor = this.sequenceEditor();
-		const content = this.normalizeNewContent(Array.isArray(value) ? value : Array.from(value));
+	public insertAt(index: number, value: FlexibleNodeSubSequence<TTypes>): void {
 		assertValidIndex(index, this, true);
+		const content: ITreeCursorSynchronous[] = isCursor(value)
+			? prepareFieldCursorForInsert(value)
+			: Array.from(value, (item) =>
+					cursorFromContextualData(this.context, this.schema.types, item),
+			  );
+		const fieldEditor = this.sequenceEditor();
 		fieldEditor.insert(index, content);
 	}
 
-	public insertAtStart(value: Iterable<FlexibleNodeContent<TTypes>>): void {
+	public insertAtStart(value: FlexibleNodeSubSequence<TTypes>): void {
 		this.insertAt(0, value);
 	}
 
-	public insertAtEnd(value: Iterable<FlexibleNodeContent<TTypes>>): void {
+	public insertAtEnd(value: FlexibleNodeSubSequence<TTypes>): void {
 		this.insertAt(this.length, value);
 	}
 
@@ -416,7 +420,9 @@ export class LazyValueField<TTypes extends AllowedTypes>
 	}
 
 	public set content(newContent: FlexibleNodeContent<TTypes>) {
-		const content = this.normalizeNewContent(newContent);
+		const content: ITreeCursorSynchronous[] = isCursor(newContent)
+			? prepareNodeCursorForInsert(newContent)
+			: [cursorFromContextualData(this.context, this.schema.types, newContent)];
 		const fieldEditor = this.valueFieldEditor();
 		assert(content.length === 1, 0x780 /* value field content should normalize to one item */);
 		fieldEditor.set(content[0]);
@@ -453,7 +459,12 @@ export class LazyOptionalField<TTypes extends AllowedTypes>
 	}
 
 	public set content(newContent: FlexibleNodeContent<TTypes> | undefined) {
-		const content = this.normalizeNewContent(newContent);
+		const content: ITreeCursorSynchronous[] =
+			newContent === undefined
+				? []
+				: isCursor(newContent)
+				? prepareNodeCursorForInsert(newContent)
+				: [cursorFromContextualData(this.context, this.schema.types, newContent)];
 		const fieldEditor = this.optionalEditor();
 		assert(
 			content.length <= 1,
@@ -520,3 +531,25 @@ const builderList: [FieldKind, Builder][] = [
 ];
 
 const kindToClass: ReadonlyMap<FieldKind, Builder> = new Map(builderList);
+
+/**
+ * Prepare a fields cursor (holding a sequence of nodes) for inserting.
+ */
+function prepareFieldCursorForInsert(cursor: ITreeCursorSynchronous): ITreeCursorSynchronous[] {
+	// TODO: optionally validate content against schema.
+
+	// Convert from the desired API (single field cursor) to the currently required API (array of node cursors).
+	// This is inefficient, and particularly bad if the data was efficiently chunked using uniform chunks.
+	// TODO: update editing APIs to take in field cursors not arrays of node cursors, then remove this copying conversion.
+	return mapCursorField(cursor, () => singleMapTreeCursor(mapTreeFromCursor(cursor)));
+}
+
+/**
+ * Prepare a node cursor (holding a single node) for inserting.
+ */
+function prepareNodeCursorForInsert(cursor: ITreeCursorSynchronous): ITreeCursorSynchronous[] {
+	// TODO: optionally validate content against schema.
+
+	assert(cursor.mode === CursorLocationType.Nodes, "should be in nodes mode");
+	return [cursor];
+}

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -26,6 +26,11 @@ import { splitMark } from "./utils";
 import { MoveDestination } from "./helperTypes";
 
 export interface SequenceFieldEditor extends FieldEditor<Changeset> {
+	/**
+	 * @param cursor - cursors in Nodes mode.
+	 * @privateRemarks
+	 * TODO: this should take a single cursor in fields mode.
+	 */
 	insert(index: number, cursor: readonly ITreeCursor[], id: ChangesetLocalId): Changeset<never>;
 	delete(index: number, count: number, id: ChangesetLocalId): Changeset<never>;
 	revive(index: number, count: number, detachEvent: CellId, isIntention?: true): Changeset<never>;
@@ -146,7 +151,7 @@ export const sequenceFieldEditor = {
 
 		return moveMarksToMarkList(sourceIndex, count, destIndex, returnFrom, returnTo);
 	},
-};
+} satisfies SequenceFieldEditor;
 
 function moveMarksToMarkList(
 	sourceIndex: number,

--- a/experimental/dds/tree2/src/feature-libraries/treeCursorUtils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/treeCursorUtils.ts
@@ -45,6 +45,9 @@ export interface CursorWithNode<TNode> extends ITreeCursorSynchronous {
  *
  * @returns an {@link ITreeCursorSynchronous} for a single root.
  * @alpha
+ *
+ * @privateRemarks
+ * A version of this API which produces field cursors should be provided.
  */
 export function singleStackTreeCursor<TNode>(
 	root: TNode,
@@ -95,8 +98,13 @@ export abstract class SynchronousCursor {
  *
  * As this is a generic implementation, it's ability to optimize is limited.
  *
+ * @privateRemarks
  * Note that TNode can be `null` (and we should support `undefined` as well),
  * so be careful using types like `TNode | undefined` and expressions like `TNode ??`.
+ *
+ * TODO:
+ * 1. Unit tests for this.
+ * 2. Support for cursors which are field cursors at the root.
  */
 class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNode> {
 	public readonly [CursorMarker] = true;

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/fieldCursorTestUtilities.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/fieldCursorTestUtilities.ts
@@ -19,6 +19,9 @@ import { checkFieldTraversal } from "../../cursorTestSuite";
 /**
  * Note that returned cursor is not at the root of its tree, so its path may be unexpected.
  * It is placed under index 0 of the EmptyKey field.
+ *
+ * TODO:
+ * treeCursorUtils should support creating field cursors not just "singleTextCursor", and that logic should replace this function.
  */
 export function fieldCursorFromJsonableTrees(trees: JsonableTree[]): ITreeCursorSynchronous {
 	const fullTree: JsonableTree = { type: jsonArray.name, fields: { [EmptyKey]: trees } };

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyField.spec.ts
@@ -9,61 +9,27 @@ import { strict as assert } from "assert";
 
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 
-import { TreeContent } from "../../../shared-tree";
-import { type AllowedTypes, Any, type FieldKind, FieldKinds } from "../../../feature-libraries";
-import {
-	FieldAnchor,
-	FieldKey,
-	type ITreeSubscriptionCursor,
-	rootFieldKey,
-	TreeNavigationResult,
-	UpPath,
-} from "../../../core";
-import { forestWithContent } from "../../utils";
-import { leaf as leafDomain, SchemaBuilder } from "../../../domains";
+import { type AllowedTypes, Any, FieldKinds, singleTextCursor } from "../../../feature-libraries";
+import { FieldAnchor, FieldKey, rootFieldKey, UpPath } from "../../../core";
+import { forestWithContent, viewWithContent } from "../../utils";
+import { leaf, leaf as leafDomain, SchemaBuilder } from "../../../domains";
 import { brand } from "../../../util";
-import { type Context } from "../../../feature-libraries/editable-tree-2/context";
 import {
 	LazyField,
 	LazyOptionalField,
 	LazySequence,
 	LazyValueField,
 } from "../../../feature-libraries/editable-tree-2/lazyField";
-import { contextWithContentReadonly, getReadonlyContext } from "./utils";
+import { fieldCursorFromJsonableTrees } from "../chunked-forest/fieldCursorTestUtilities";
+import {
+	getReadonlyContext,
+	initializeCursor,
+	readonlyTreeWithContent,
+	rootFieldAnchor,
+} from "./utils";
 
 const detachedField: FieldKey = brand("detached");
 const detachedFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: detachedField };
-const rootFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: rootFieldKey };
-
-/**
- * Creates a cursor from the provided `context` and moves it to the provided `anchor`.
- */
-function initializeCursor(context: Context, anchor: FieldAnchor): ITreeSubscriptionCursor {
-	const cursor = context.forest.allocateCursor();
-
-	assert.equal(context.forest.tryMoveCursorToField(anchor, cursor), TreeNavigationResult.Ok);
-	return cursor;
-}
-
-/**
- * Initializes a test tree, context, and cursor, and moves the cursor to the tree's root.
- *
- * @returns The initialized context and cursor.
- */
-function initializeTreeWithContent<Kind extends FieldKind, Types extends AllowedTypes>(
-	treeContent: TreeContent,
-): {
-	context: Context;
-	cursor: ITreeSubscriptionCursor;
-} {
-	const context = contextWithContentReadonly(treeContent);
-	const cursor = initializeCursor(context, rootFieldAnchor);
-
-	return {
-		context,
-		cursor,
-	};
-}
 
 /**
  * Test {@link LazyField} implementation.
@@ -136,7 +102,7 @@ describe("LazyField", () => {
 
 		// Note: this tree initialization is strictly to enable construction of the lazy field.
 		// The test cases below are strictly in terms of the schema of the created fields.
-		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: {} });
+		const { context, cursor } = readonlyTreeWithContent({ schema, initialTree: {} });
 
 		// #endregion
 
@@ -196,7 +162,7 @@ describe("LazyField", () => {
 		const rootSchema = SchemaBuilder.optional(struct);
 		const schema = builder.intoSchema(rootSchema);
 
-		const { context, cursor } = initializeTreeWithContent({
+		const { context, cursor } = readonlyTreeWithContent({
 			schema,
 			initialTree: {
 				foo: "Hello world",
@@ -236,7 +202,7 @@ describe("LazyOptionalField", () => {
 	const schema = builder.intoSchema(rootSchema);
 
 	describe("Field with value", () => {
-		const { context, cursor } = initializeTreeWithContent({ schema, initialTree: 42 });
+		const { context, cursor } = readonlyTreeWithContent({ schema, initialTree: 42 });
 		const field = new LazyOptionalField(context, rootSchema, cursor, rootFieldAnchor);
 
 		it("atIndex", () => {
@@ -268,7 +234,7 @@ describe("LazyOptionalField", () => {
 	});
 
 	describe("Field without value", () => {
-		const { context, cursor } = initializeTreeWithContent({
+		const { context, cursor } = readonlyTreeWithContent({
 			schema,
 			initialTree: undefined,
 		});
@@ -302,6 +268,20 @@ describe("LazyOptionalField", () => {
 			);
 		});
 	});
+
+	it("content", () => {
+		const view = viewWithContent({
+			schema,
+			initialTree: 5,
+		});
+		assert.equal(view.editableTree.content, 5);
+		view.editableTree.content = 6;
+		assert.equal(view.editableTree.content, 6);
+		view.editableTree.content = undefined;
+		assert.equal(view.editableTree.content, undefined);
+		view.editableTree.content = singleTextCursor({ type: leaf.string.name, value: 7 });
+		assert.equal(view.editableTree.content, 7);
+	});
 });
 
 describe("LazyValueField", () => {
@@ -311,7 +291,7 @@ describe("LazyValueField", () => {
 
 	const initialTree = "Hello world";
 
-	const { context, cursor } = initializeTreeWithContent({ schema, initialTree });
+	const { context, cursor } = readonlyTreeWithContent({ schema, initialTree });
 
 	const field = new LazyValueField(context, rootSchema, cursor, rootFieldAnchor);
 
@@ -341,6 +321,19 @@ describe("LazyValueField", () => {
 		assert.equal(mapResult.length, 1);
 		assert.equal(mapResult[0].value, initialTree);
 	});
+
+	it("content", () => {
+		const view = viewWithContent({
+			schema,
+			initialTree: "X",
+		});
+		assert.equal(view.editableTree.content, "X");
+		view.editableTree.content = "Y";
+		assert.equal(view.editableTree.content, "Y");
+		const zCursor = singleTextCursor({ type: leaf.string.name, value: "Z" });
+		view.editableTree.content = zCursor;
+		assert.equal(view.editableTree.content, "Z");
+	});
 });
 
 describe("LazySequence", () => {
@@ -348,14 +341,27 @@ describe("LazySequence", () => {
 	const rootSchema = SchemaBuilder.sequence(leafDomain.number);
 	const schema = builder.intoSchema(rootSchema);
 
-	const { context, cursor } = initializeTreeWithContent({
-		schema,
-		initialTree: [37, 42],
-	});
+	/**
+	 * Creates a tree with a sequence of numbers at the root, and returns the sequence
+	 */
+	function testSequence(data: number[]) {
+		const { context, cursor } = readonlyTreeWithContent({
+			schema,
+			initialTree: data,
+		});
+		return new LazySequence(context, rootSchema, cursor, rootFieldAnchor);
+	}
 
-	const sequence = new LazySequence(context, rootSchema, cursor, rootFieldAnchor);
+	function testMutableSequence(data: number[]) {
+		const view = viewWithContent({
+			schema,
+			initialTree: data,
+		});
+		return view.editableTree;
+	}
 
 	it("atIndex", () => {
+		const sequence = testSequence([37, 42]);
 		assert.equal(sequence.length, 2);
 		assert.equal(sequence.atIndex(0), 37);
 		assert.equal(sequence.atIndex(1), 42);
@@ -363,6 +369,7 @@ describe("LazySequence", () => {
 	});
 
 	it("at", () => {
+		const sequence = testSequence([37, 42]);
 		assert.equal(sequence.length, 2);
 		assert.equal(sequence.at(0), 37);
 		assert.equal(sequence.at(1), 42);
@@ -373,6 +380,7 @@ describe("LazySequence", () => {
 	});
 
 	it("boxedAt", () => {
+		const sequence = testSequence([37, 42]);
 		const boxedResult0 = sequence.boxedAt(0);
 		assert.equal(boxedResult0.type, leafDomain.number.name);
 		assert.equal(boxedResult0.value, 37);
@@ -385,17 +393,18 @@ describe("LazySequence", () => {
 	});
 
 	it("length", () => {
-		assert.equal(sequence.length, 2);
+		assert.equal(testSequence([]).length, 0);
+		assert.equal(testSequence([37, 42]).length, 2);
 	});
 
 	it("map", () => {
-		const mapResult = sequence.map((value) => value);
-		assert.equal(mapResult.length, 2);
-		assert.equal(mapResult[0], 37);
-		assert.equal(mapResult[1], 42);
+		const sequence = testSequence([1, 2]);
+		const mapResult = sequence.map((value) => value * 2);
+		assert.deepEqual(mapResult, [2, 4]);
 	});
 
 	it("mapBoxed", () => {
+		const sequence = testSequence([37, 42]);
 		const mapResult = sequence.mapBoxed((value) => value);
 		assert.equal(mapResult.length, 2);
 		assert.equal(mapResult[0].type, leafDomain.number.name);
@@ -405,9 +414,67 @@ describe("LazySequence", () => {
 	});
 
 	it("asArray", () => {
+		const sequence = testSequence([37, 42]);
 		const array = sequence.asArray;
-		assert.equal(array.length, 2);
-		assert.equal(array[0], 37);
-		assert.equal(array[1], 42);
+		assert.deepEqual(array, [37, 42]);
+	});
+
+	describe("insertAt", () => {
+		it("basic use", () => {
+			const sequence = testMutableSequence([]);
+			assert.deepEqual(sequence.asArray, []);
+			sequence.insertAt(0, []);
+			assert.deepEqual(sequence.asArray, []);
+			sequence.insertAt(0, [10]);
+			assert.deepEqual(sequence.asArray, [10]);
+			sequence.insertAt(0, [11]);
+			assert.deepEqual(sequence.asArray, [11, 10]);
+			sequence.insertAt(1, [12]);
+			assert.deepEqual(sequence.asArray, [11, 12, 10]);
+			sequence.insertAt(3, [13]);
+			assert.deepEqual(sequence.asArray, [11, 12, 10, 13]);
+			sequence.insertAt(1, [1, 2, 3]);
+			assert.deepEqual(sequence.asArray, [11, 1, 2, 3, 12, 10, 13]);
+			assert.throws(
+				() => sequence.insertAt(-1, []),
+				(e: Error) => validateAssertionError(e, /index/),
+			);
+			assert.throws(
+				() => sequence.insertAt(0.5, []),
+				(e: Error) => validateAssertionError(e, /index/),
+			);
+			assert.throws(
+				() => sequence.insertAt(NaN, []),
+				(e: Error) => validateAssertionError(e, /index/),
+			);
+			assert.throws(
+				() => sequence.insertAt(Number.POSITIVE_INFINITY, []),
+				(e: Error) => validateAssertionError(e, /index/),
+			);
+			assert.throws(
+				() => sequence.insertAt(8, []),
+				(e: Error) => validateAssertionError(e, /index/),
+			);
+		});
+
+		it("with cursors", () => {
+			const sequence = testMutableSequence([]);
+			assert.deepEqual(sequence.asArray, []);
+			sequence.insertAt(0, fieldCursorFromJsonableTrees([]));
+			assert.deepEqual(sequence.asArray, []);
+			sequence.insertAt(
+				0,
+				fieldCursorFromJsonableTrees([{ type: leaf.number.name, value: 10 }]),
+			);
+			assert.deepEqual(sequence.asArray, [10]);
+			sequence.insertAt(
+				0,
+				fieldCursorFromJsonableTrees([
+					{ type: leaf.number.name, value: 11 },
+					{ type: leaf.number.name, value: 12 },
+				]),
+			);
+			assert.deepEqual(sequence.asArray, [11, 12, 10]);
+		});
 	});
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/list.spec.ts
@@ -5,7 +5,8 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { createTreeView2, pretty } from "./utils";
+import { viewWithContent } from "../../utils";
+import { pretty } from "./utils";
 
 const builder = new SchemaBuilder({ scope: "test" });
 
@@ -57,8 +58,11 @@ describe("List", () => {
 
 	/** Helper that creates a new SharedTree with the test schema and returns the root proxy. */
 	function createTree() {
-		// Consider 'initializeTreeWithContent' for readonly tests?
-		const view = createTreeView2(schema, { numbers: { "": [] }, strings: { "": [] } });
+		// Consider 'readonlyTreeWithContent' for readonly tests?
+		const view = viewWithContent({
+			schema,
+			initialTree: { numbers: { "": [] }, strings: { "": [] } },
+		});
 		return view.root;
 	}
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/object.spec.ts
@@ -7,7 +7,8 @@ import { strict as assert } from "assert";
 import { LeafSchema, NewFieldContent, TreeSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
 import { TreeValue } from "../../../core";
-import { createTreeView2, itWithRoot, makeSchema, pretty } from "./utils";
+import { viewWithContent } from "../../utils";
+import { itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
 	initialTree: object;
@@ -38,7 +39,10 @@ function testObjectLike(testCases: TestCase[]) {
 	describe("Object-like", () => {
 		describe("satisfies 'deepEquals'", () => {
 			for (const { schema, initialTree } of testCases) {
-				const view = createTreeView2(schema, initialTree as NewFieldContent);
+				const view = viewWithContent({
+					schema,
+					initialTree: initialTree as NewFieldContent,
+				});
 				const real = initialTree;
 				const proxy = view.root;
 

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/objectFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/objectFactory.spec.ts
@@ -8,7 +8,8 @@ import { SchemaBuilder } from "../../../domains";
 import { ProxyNode, typeNameSymbol } from "../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { extractFactoryContent } from "../../../feature-libraries/editable-tree-2/proxies/proxies";
-import { createTreeView2, itWithRoot } from "./utils";
+import { viewWithContent } from "../../utils";
+import { itWithRoot } from "./utils";
 
 describe("SharedTreeObject factories", () => {
 	const sb = new SchemaBuilder({
@@ -338,7 +339,7 @@ describe("SharedTreeObject factories", () => {
 			return { tree: createComboRoot(), objects };
 		}
 
-		const view = createTreeView2(comboSchema, { root: undefined });
+		const view = viewWithContent({ schema: comboSchema, initialTree: { root: undefined } });
 
 		const objectTypes = ["object", "list", "map"] as const;
 		for (const root of objectTypes) {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/primitives.spec.ts
@@ -5,7 +5,8 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { createTreeView2, pretty } from "./utils";
+import { viewWithContent } from "../../utils";
+import { pretty } from "./utils";
 
 const _ = new SchemaBuilder({ scope: "test", libraries: [leaf.library] });
 const schema = _.intoSchema(_.optional(leaf.all));
@@ -43,9 +44,9 @@ const testCases = [
 // a tree with an 'undefined' root.
 describe("Primitives", () => {
 	describe("satisfy 'deepEquals'", () => {
-		for (const testCase of testCases) {
-			const view = createTreeView2(schema, testCase);
-			const real = testCase;
+		for (const initialTree of testCases) {
+			const view = viewWithContent({ schema, initialTree });
+			const real = initialTree;
 			const proxy = view.root;
 
 			it(`deepEquals(${pretty(proxy)}, ${pretty(real)})`, () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -46,7 +46,7 @@ export function getReadonlyContext(forest: IEditableForest, schema: TreeSchema):
 /**
  * Creates a context and its backing forest from the provided `content`.
  *
- * For creating mutable views use {@link viewWithContent}, but prefer this when possible as its has fewer dependencies and simpler setup.
+ * For creating mutable views use {@link viewWithContent}, but prefer this when possible as it has fewer dependencies and simpler setup.
  *
  * @returns The created context.
  */
@@ -98,7 +98,7 @@ export function makeSchema<const TSchema extends ImplicitFieldSchema>(
 }
 
 /**
- * @deprecated Writing a normal `it` test. Doing so allows:
+ * @deprecated Write a normal `it` test. Doing so allows:
  * 1. Selecting between viewWithContent and {@link readonlyTreeWithContent} or some other setup.
  * 2. Navigate to test source and similar tools and IDE integration to work.
  * 3. Use of `it.only` and `it.skip`.

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import {
 	DefaultEditBuilder,
 	TreeFieldSchema,
@@ -14,12 +14,20 @@ import {
 	createMockNodeKeyManager,
 	nodeKeyFieldKey,
 	SchemaAware,
+	AllowedTypes,
+	FieldKind,
 } from "../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { Context, getTreeContext } from "../../../feature-libraries/editable-tree-2/context";
-import { AllowedUpdateType, IEditableForest, ITreeCursorSynchronous } from "../../../core";
-import { ISharedTree, ITreeView, TreeContent } from "../../../shared-tree";
-import { TestTreeProviderLite, forestWithContent } from "../../utils";
+import {
+	FieldAnchor,
+	IEditableForest,
+	ITreeSubscriptionCursor,
+	TreeNavigationResult,
+	rootFieldKey,
+} from "../../../core";
+import { TreeContent } from "../../../shared-tree";
+import { forestWithContent, viewWithContent } from "../../utils";
 import { brand } from "../../../util";
 import { SchemaBuilder } from "../../../domains";
 
@@ -38,6 +46,8 @@ export function getReadonlyContext(forest: IEditableForest, schema: TreeSchema):
 /**
  * Creates a context and its backing forest from the provided `content`.
  *
+ * For creating mutable views use {@link viewWithContent}, but prefer this when possible as its has fewer dependencies and simpler setup.
+ *
  * @returns The created context.
  */
 export function contextWithContentReadonly(content: TreeContent): Context {
@@ -45,24 +55,35 @@ export function contextWithContentReadonly(content: TreeContent): Context {
 	return getReadonlyContext(forest, content.schema);
 }
 
-export function createTree(): ISharedTree {
-	const tree = new TestTreeProviderLite(1).trees[0];
-	assert(tree.isAttached());
-	return tree;
+/**
+ * Creates a cursor from the provided `context` and moves it to the provided `anchor`.
+ */
+export function initializeCursor(context: Context, anchor: FieldAnchor): ITreeSubscriptionCursor {
+	const cursor = context.forest.allocateCursor();
+	assert.equal(context.forest.tryMoveCursorToField(anchor, cursor), TreeNavigationResult.Ok);
+	return cursor;
 }
 
-export function createTreeView2<TRoot extends TreeFieldSchema>(
-	schema: TreeSchema<TRoot>,
-	initialTree:
-		| ITreeCursorSynchronous
-		| readonly ITreeCursorSynchronous[]
-		| SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Flexible>,
-): ITreeView<TRoot> {
-	return createTree().schematize({
-		allowedSchemaModifications: AllowedUpdateType.None,
-		initialTree,
-		schema,
-	});
+export const rootFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: rootFieldKey };
+
+/**
+ * Initializes a readonly test tree, context, and cursor, and moves the cursor to the tree's root.
+ *
+ * @returns The initialized context and cursor.
+ */
+export function readonlyTreeWithContent<Kind extends FieldKind, Types extends AllowedTypes>(
+	treeContent: TreeContent,
+): {
+	context: Context;
+	cursor: ITreeSubscriptionCursor;
+} {
+	const context = contextWithContentReadonly(treeContent);
+	const cursor = initializeCursor(context, rootFieldAnchor);
+
+	return {
+		context,
+		cursor,
+	};
 }
 
 /** Helper for making small test schemas. */
@@ -76,6 +97,15 @@ export function makeSchema<const TSchema extends ImplicitFieldSchema>(
 	return builder.intoSchema(root);
 }
 
+/**
+ * @deprecated Writing a normal `it` test. Doing so allows:
+ * 1. Selecting between viewWithContent and {@link readonlyTreeWithContent} or some other setup.
+ * 2. Navigate to test source and similar tools and IDE integration to work.
+ * 3. Use of `it.only` and `it.skip`.
+ * 4. Easier understanding of what is a test for new people looking at the test files.
+ * 5. Consistent test patterns for users of APIs other than context.root.
+ * 6. Ability to write async tests.
+ */
 export function itWithRoot<TRoot extends TreeFieldSchema>(
 	title: string,
 	schema: TreeSchema<TRoot>,
@@ -83,10 +113,10 @@ export function itWithRoot<TRoot extends TreeFieldSchema>(
 	fn: (root: ProxyField<(typeof schema)["rootFieldSchema"]>) => void,
 ): void {
 	it(title, () => {
-		const view = createTreeView2(
+		const view = viewWithContent({
 			schema,
-			initialTree as SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Flexible>,
-		);
+			initialTree: initialTree as SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Flexible>,
+		});
 		const root = view.root;
 		fn(root);
 	});

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -11,6 +11,8 @@ import { fail } from "../../../util";
 import { validateTreeConsistency } from "../../utils";
 import { ISharedTree, ITreeCheckout, ITreeView, SharedTreeFactory } from "../../../shared-tree";
 import { Revertible } from "../../../core";
+// eslint-disable-next-line import/no-internal-modules
+import { fieldCursorFromJsonableTrees } from "../../feature-libraries/chunked-forest/fieldCursorTestUtilities";
 import {
 	FieldEdit,
 	FuzzDelete,
@@ -103,7 +105,7 @@ function applySequenceFieldEdit(
 			const parent = navigateToNode(tree, change.parent);
 			assert(parent?.is(fuzzNode), "Defined down-path should point to a valid parent");
 			const field = parent.boxedSequenceChildren;
-			field.insertAt(change.index, [singleTextCursor(change.value) as any]);
+			field.insertAt(change.index, fieldCursorFromJsonableTrees([change.value]));
 			break;
 		}
 		case "delete": {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
@@ -19,8 +19,8 @@ import {
 	insert,
 	TestTreeProviderLite,
 	toJsonableTree,
-	view2WithContent,
 	viewWithContent,
+	checkoutWithContent,
 } from "../utils";
 import { ITreeView } from "../../shared-tree";
 import { rootFieldKey } from "../../core";
@@ -146,7 +146,7 @@ describe("SharedTree benchmarks", () => {
 				type: benchmarkType,
 				title: `Deep Tree with cursor: reads with ${numberOfNodes} nodes`,
 				before: () => {
-					tree = view2WithContent(makeDeepContent(numberOfNodes));
+					tree = viewWithContent(makeDeepContent(numberOfNodes));
 				},
 				benchmarkFn: () => {
 					const { depth, value } = readDeepCursorTree(tree);
@@ -167,7 +167,7 @@ describe("SharedTree benchmarks", () => {
 						numbers.push(index);
 						expected += index;
 					}
-					tree = view2WithContent(
+					tree = viewWithContent(
 						makeWideContentWithEndValue(numberOfNodes, numberOfNodes - 1),
 					);
 				},
@@ -186,7 +186,7 @@ describe("SharedTree benchmarks", () => {
 				type: benchmarkType,
 				title: `Deep Tree with Editable Tree: reads with ${numberOfNodes} nodes`,
 				before: () => {
-					tree = view2WithContent(makeDeepContent(numberOfNodes));
+					tree = viewWithContent(makeDeepContent(numberOfNodes));
 				},
 				benchmarkFn: () => {
 					const { depth, value } = readDeepEditableTree(tree);
@@ -207,7 +207,7 @@ describe("SharedTree benchmarks", () => {
 						numbers.push(index);
 						expected += index;
 					}
-					tree = view2WithContent({
+					tree = viewWithContent({
 						initialTree: { foo: numbers },
 						schema: wideSchema,
 					});
@@ -234,7 +234,7 @@ describe("SharedTree benchmarks", () => {
 						assert.equal(state.iterationsPerBatch, 1);
 
 						// Setup
-						const tree = viewWithContent(makeDeepContent(numberOfNodes));
+						const tree = checkoutWithContent(makeDeepContent(numberOfNodes));
 						const path = deepPath(numberOfNodes);
 
 						// Measure
@@ -280,7 +280,7 @@ describe("SharedTree benchmarks", () => {
 						for (let index = 0; index < numberOfNodes; index++) {
 							numbers.push(index);
 						}
-						const tree = viewWithContent({
+						const tree = checkoutWithContent({
 							initialTree: { foo: numbers },
 							schema: wideSchema,
 						});

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -33,7 +33,7 @@ import {
 	validateTreeConsistency,
 	validateTreeContent,
 	validateViewConsistency,
-	viewWithContent,
+	checkoutWithContent,
 } from "../utils";
 import {
 	ForestType,
@@ -1231,7 +1231,7 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 	});
 
 	it(`${title} (reference view)`, () => {
-		fn(viewWithContent(content));
+		fn(checkoutWithContent(content));
 	});
 
 	it(`${title} (forked view)`, () => {
@@ -1240,6 +1240,6 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 	});
 
 	it(`${title} (reference forked view)`, () => {
-		fn(viewWithContent(content).fork());
+		fn(checkoutWithContent(content).fork());
 	});
 }

--- a/experimental/dds/tree2/src/test/shared-tree/treeCheckout.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/treeCheckout.spec.ts
@@ -12,8 +12,8 @@ import {
 	emptyJsonSequenceConfig,
 	insert,
 	jsonSequenceRootSchema,
-	view2WithContent,
 	viewWithContent,
+	checkoutWithContent,
 } from "../utils";
 import {
 	AllowedUpdateType,
@@ -34,7 +34,7 @@ describe("sharedTreeView", () => {
 		const schema = builder.intoSchema(builder.optional(rootTreeNodeSchema));
 
 		it("triggers events for local and subtree changes", () => {
-			const view = view2WithContent({
+			const view = viewWithContent({
 				schema,
 				initialTree: {
 					x: 24,
@@ -75,7 +75,7 @@ describe("sharedTreeView", () => {
 		});
 
 		it("propagates path args for local and subtree changes", () => {
-			const view = view2WithContent({
+			const view = viewWithContent({
 				schema,
 				initialTree: {
 					x: 24,
@@ -119,7 +119,7 @@ describe("sharedTreeView", () => {
 
 		// TODO: unskip once forking revertibles is supported
 		it.skip("triggers a revertible event for a changes merged into the local branch", () => {
-			const tree1 = viewWithContent({
+			const tree1 = checkoutWithContent({
 				schema: jsonSequenceRootSchema,
 				initialTree: [],
 			});
@@ -630,7 +630,7 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 	});
 
 	it(`${title} (reference view)`, () => {
-		fn(viewWithContent(content));
+		fn(checkoutWithContent(content));
 	});
 
 	it(`${title} (forked view)`, () => {
@@ -639,6 +639,6 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 	});
 
 	it(`${title} (reference forked view)`, () => {
-		fn(viewWithContent(content).fork());
+		fn(checkoutWithContent(content).fork());
 	});
 }

--- a/experimental/dds/tree2/src/test/shared-tree/treeView.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/treeView.spec.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { emptyStringSequenceConfig, view2WithContent } from "../utils";
+import { emptyStringSequenceConfig, viewWithContent } from "../utils";
 
 describe("sharedTreeView", () => {
 	it("reads only one node", () => {
 		// This is a regression test for a scenario in which a transaction would apply its delta twice,
 		// inserting two nodes instead of just one
-		const view = view2WithContent(emptyStringSequenceConfig);
+		const view = viewWithContent(emptyStringSequenceConfig);
 		view.editableTree.insertAtStart("x");
 		assert.deepEqual(view.editableTree.asArray, ["x"]);
 	});

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -65,7 +65,7 @@ import {
 	singleTextCursor,
 	TypedField,
 	jsonableTreeFromForest,
-	nodeKeyFieldKey as defailtNodeKeyFieldKey,
+	nodeKeyFieldKey as defaultNodeKeyFieldKey,
 	ContextuallyTypedNodeData,
 } from "../feature-libraries";
 import {
@@ -589,7 +589,7 @@ export function validateSnapshotConsistency(
 	expectSchemaEqual(treeA.schema, treeB.schema, idDifferentiator);
 }
 
-export function viewWithContent(
+export function checkoutWithContent(
 	content: TreeContent,
 	args?: {
 		events?: ISubscribable<CheckoutEvents> &
@@ -597,10 +597,10 @@ export function viewWithContent(
 			HasListeners<CheckoutEvents>;
 	},
 ): ITreeCheckout {
-	return view2WithContent(content, args).checkout;
+	return viewWithContent(content, args).checkout;
 }
 
-export function view2WithContent<TRoot extends TreeFieldSchema>(
+export function viewWithContent<TRoot extends TreeFieldSchema>(
 	content: TreeContent<TRoot>,
 	args?: {
 		events?: ISubscribable<CheckoutEvents> &
@@ -620,7 +620,7 @@ export function view2WithContent<TRoot extends TreeFieldSchema>(
 		view,
 		content.schema,
 		args?.nodeKeyManager ?? createMockNodeKeyManager(),
-		args?.nodeKeyFieldKey ?? brand(defailtNodeKeyFieldKey),
+		args?.nodeKeyFieldKey ?? brand(defaultNodeKeyFieldKey),
 	);
 }
 
@@ -695,7 +695,7 @@ export const emptyStringSequenceConfig = {
  */
 export function makeTreeFromJson(json: JsonCompatible[] | JsonCompatible): ITreeCheckout {
 	const cursors = (Array.isArray(json) ? json : [json]).map(singleJsonCursor);
-	const tree = viewWithContent({
+	const tree = checkoutWithContent({
 		schema: jsonSequenceRootSchema,
 		initialTree: cursors,
 	});


### PR DESCRIPTION
## Description

Editable tree now excepts new content in the form of cursors.

Alos included are some testing cleanups to avoid depending on SharedTree for testing editable tree, and some improved coverage on the editing methods of fields which were previously entirely untested.

## Breaking Changes

Code that was violating the type system and providing cursors already for list insertion methods happened to work, but now requires a single field cursor instead of an array of node cursors (and no longer violates the typing).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

