### PR TITLE
server: Add Nexus to server/docker-compose

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -6,10 +6,12 @@ services:
     depends_on:
       - "alfred"
       - "historian"
+      - "nexus"
     volumes:
       - ./routerlicious/nginx.conf:/etc/nginx/nginx.conf
     ports:
       - "3003:3003"
+      - "3002:3002"
       - "3001:3001"
   alfred:
     platform: linux/amd64
@@ -21,6 +23,24 @@ services:
     expose:
       - "3000"
     command: node packages/routerlicious/dist/alfred/www.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+      - IS_FLUID_SERVER=true
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules
+    restart: on-failure
+  nexus:
+    platform: linux/amd64
+    build:
+      context: ./routerlicious
+      target: runner
+      additional_contexts:
+        root: ..
+    expose:
+      - "3000"
+    command: node packages/routerlicious/dist/nexus/www.js
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,6 +10,16 @@ services:
       - NODE_ENV=development
       - IS_FLUID_SERVER=true
     restart: always
+  nexus:
+    image: ${REGISTRY_URL:-mcr.microsoft.com}/fluidframework/routerlicious/server:${ALFRED_IMAGE_TAG:-latest}
+    ports:
+      - "3002:3000"
+    command: node packages/routerlicious/dist/nexus/www.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+      - IS_FLUID_SERVER=true
+    restart: always
   deli:
     image: ${REGISTRY_URL:-mcr.microsoft.com}/fluidframework/routerlicious/server:${ALFRED_IMAGE_TAG:-latest}
     command: node packages/routerlicious/dist/kafka-service/index.js deli /usr/src/server/packages/routerlicious/dist/deli/index.js


### PR DESCRIPTION
## Description

The new Nexus service was not added to the server/docker-compose*.yml files, so running R11s that way does not work with AzureClient because it can't find Nexus. This isn't terrible, since I think I'm one of very few people who use docker-compose.dev.yml, but would be nice to have it fixed.