### PR TITLE
feat(build-tools): Add support for tsc-multi

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,15 @@
 			"type": "node",
 		},
 		{
+			"name": "fluid-build",
+			"program": "${workspaceFolder}/build-tools/packages/build-tools/bin/fluid-build",
+			"cwd": "${workspaceFolder}/packages/common/container-definitions",
+			"request": "launch",
+			"skipFiles": ["<node_internals>/**"],
+			"type": "node",
+			"args": [".", "--task", "build"],
+		},
+		{
 			"name": "flub",
 			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",
 			"cwd": "${workspaceFolder}",
@@ -41,14 +50,14 @@
     {
 			"name": "flub check policy",
 			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",
-			"cwd": "${workspaceFolder}/build-tools",
+			"cwd": "${workspaceFolder}",
 			"request": "launch",
 			"skipFiles": ["<node_internals>/**"],
 			"type": "node",
 			"args": ["check", "policy",],
 		},
 		{
-			"name": "flub check policy",
+			"name": "flub check policy --fix",
 			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",
 			"cwd": "${workspaceFolder}",
 			"request": "launch",

--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -127,7 +127,13 @@ function printExecError(
 				? `${errorPrefix}: ${ret.stdout}\n${ret.stderr}`
 				: `${errorPrefix}: ${ret.stderr}`,
 		);
-	} else if (warning && ret.stderr) {
+	} else if (
+		warning &&
+		ret.stderr &&
+		// tsc-multi writes to stderr even when there are no errors, so this condition excludes that case as a workaround.
+		// Otherwise fluid-build spams warnings for all tsc-multi tasks.
+		!ret.stderr.includes("Found 0 errors")
+	) {
 		// no error code but still error messages, treat them is non fatal warnings
 		console.warn(`${errorPrefix}: warning during command ${command}`);
 		console.warn(`${errorPrefix}: ${ret.stderr}`);

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -178,7 +178,12 @@ export abstract class LeafTask extends Task {
 			console.error(this.getExecErrors(ret));
 			return this.execDone(startTime, BuildResult.Failed);
 		}
-		if (ret.stderr) {
+		if (
+			ret.stderr &&
+			// tsc-multi writes to stderr even when there are no errors, so this condition excludes that case as a workaround.
+			// Otherwise fluid-build spams warnings for all tsc-multi tasks.
+			!ret.stderr.includes("Found 0 errors")
+		) {
 			// no error code but still error messages, treat them is non fatal warnings
 			console.warn(`${this.node.pkg.nameColored}: warning during command '${this.command}'`);
 			console.warn(this.getExecErrors(ret));

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -413,11 +413,15 @@ export class TscTask extends LeafTask {
 	}
 }
 
+/**
+ * A fluid-build task definition for tsc-multi.
+ *
+ * This implementation is a hack. It just uses the contents of the tsbuildinfo files created by the tsc-multi processes,
+ * and duplicates the content into the doneFile. It's duplicative but seems to be the simplest way to get basic
+ * incremental support in fluid-build.
+ */
 export class TscMultiTask extends LeafWithDoneFileTask {
 	protected async getDoneFileContent(): Promise<string | undefined> {
-		// This implementation is a hack. It just uses the contents of the tsbuildinfo files created by the tsc-multi
-		// processes, and duplicates the content into the doneFile. It's duplicative but seems to be the simplest way to
-		// get basic incremental support in fluid-build.
 		const command = this.command;
 		const doneFile = this.getPackageFileFullPath(
 			command.includes("esnext") ? "tsconfig.mjs.tsbuildinfo" : "tsconfig.cjs.tsbuildinfo",

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -5,7 +5,7 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import path from "path";
-import type * as tsTypes from "typescript";
+import * as tsTypes from "typescript";
 import isEqual from "lodash.isequal";
 
 import { existsSync, readFileAsync } from "../../../common/utils";
@@ -287,7 +287,7 @@ export class TscTask extends LeafTask {
 		}
 
 		const outFile = options.options.out ? options.options.out : options.options.outFile;
-		if (outFile) {
+				if (outFile) {
 			return `${outFile}.tsbuildinfo`;
 		}
 
@@ -410,6 +410,25 @@ export class TscTask extends LeafTask {
 			(parsed.fileNames.length === 0 || parsed.options.project === undefined) &&
 			!parsed.watchOptions
 		);
+	}
+}
+
+export class TscMultiTask extends LeafWithDoneFileTask {
+	protected async getDoneFileContent(): Promise<string | undefined> {
+		// This implementation is a hack. It just uses the contents of the tsbuildinfo files created by the tsc-multi
+		// processes, and duplicates the content into the doneFile. It's duplicative, but seems to be the simplest way to
+		// get basic incremental support in fluid-build.
+		const command = this.command;
+		const doneFile = this.getPackageFileFullPath(
+			command.includes("esnext") ? "tsconfig.mjs.tsbuildinfo" : "tsconfig.cjs.tsbuildinfo",
+		);
+
+		if (existsSync(doneFile)) {
+			const content = await readFileAsync(doneFile);
+			return content.toString();
+		}
+
+		return undefined;
 	}
 }
 

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -287,7 +287,7 @@ export class TscTask extends LeafTask {
 		}
 
 		const outFile = options.options.out ? options.options.out : options.options.outFile;
-				if (outFile) {
+		if (outFile) {
 			return `${outFile}.tsbuildinfo`;
 		}
 

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -416,7 +416,7 @@ export class TscTask extends LeafTask {
 export class TscMultiTask extends LeafWithDoneFileTask {
 	protected async getDoneFileContent(): Promise<string | undefined> {
 		// This implementation is a hack. It just uses the contents of the tsbuildinfo files created by the tsc-multi
-		// processes, and duplicates the content into the doneFile. It's duplicative, but seems to be the simplest way to
+		// processes, and duplicates the content into the doneFile. It's duplicative but seems to be the simplest way to
 		// get basic incremental support in fluid-build.
 		const command = this.command;
 		const doneFile = this.getPackageFileFullPath(

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -17,7 +17,7 @@ import {
 	DepCruiseTask,
 } from "./leaf/miscTasks";
 import { PrettierTask } from "./leaf/prettierTask";
-import { TscTask } from "./leaf/tscTask";
+import { TscMultiTask, TscTask } from "./leaf/tscTask";
 import { WebpackTask } from "./leaf/webpackTask";
 import { GroupTask } from "./groupTask";
 import { Task } from "./task";
@@ -28,6 +28,7 @@ const executableToLeafTask: {
 	[key: string]: new (node: BuildPackage, command: string, taskName?: string) => LeafTask;
 } = {
 	"tsc": TscTask,
+	"tsc-multi": TscMultiTask,
 	"tslint": TsLintTask,
 	"eslint": EsLintTask,
 	"webpack": WebpackTask,

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -451,7 +451,7 @@ export const handlers: Handler[] = [
 			for (const script in json.scripts) {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const command = json.scripts[script]!;
-				if (command.startsWith("tsc ") && !ignore.has(script)) {
+				if ((command.startsWith("tsc ") || command === "tsc") && !ignore.has(script)) {
 					try {
 						const checkDeps = getTscCommandDependencies(
 							packageDir,

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -146,9 +146,12 @@ function getDefaultTscTaskDependencies(root: string, json: PackageJson) {
 
 function findTscScript(json: PackageJson, project: string) {
 	if (project === "./tsconfig.json") {
-		return findScript(json, "tsc");
+		return findScript(json, "tsc") || findScript(json, "tsc-multi --config tsc-multi.cjs.json");
 	}
-	return findScript(json, `tsc --project ${project}`);
+	return (
+		findScript(json, `tsc --project ${project}`) ||
+		findScript(json, `tsc-multi --config ${project}`)
+	);
 }
 /**
  * Get a list of build script names that the eslint depends on, based on .eslintrc file.
@@ -448,7 +451,7 @@ export const handlers: Handler[] = [
 			for (const script in json.scripts) {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const command = json.scripts[script]!;
-				if (command.startsWith("tsc") && !ignore.has(script)) {
+				if (command.startsWith("tsc ") && !ignore.has(script)) {
 					try {
 						const checkDeps = getTscCommandDependencies(
 							packageDir,

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -92,6 +92,26 @@ function findScript(json: PackageJson, command: string) {
 }
 
 /**
+ * Find the script name for the tsc-multi command in a npm package.json
+ *
+ * @param json - the package.json content to search script in
+ * @param config - the tsc-multi config to check for
+ * @returns  first script name found to match the command
+ *
+ * @remarks
+ */
+function findTscMultiScript(json: PackageJson, config: string) {
+	for (const script in json.scripts) {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const scriptCommand = json.scripts[script]!;
+
+		if (scriptCommand.startsWith("tsc-multi") && scriptCommand.includes(config)) {
+			return script;
+		}
+	}
+}
+
+/**
  * By default, all `tsc*` script task will depend on "build:genver", and "^tsc",
  * So all the files that it depends on are in place.
  *
@@ -146,12 +166,9 @@ function getDefaultTscTaskDependencies(root: string, json: PackageJson) {
 
 function findTscScript(json: PackageJson, project: string) {
 	if (project === "./tsconfig.json") {
-		return findScript(json, "tsc") || findScript(json, "tsc-multi --config tsc-multi.cjs.json");
+		return findScript(json, "tsc") || findTscMultiScript(json, "tsc-multi.cjs.json");
 	}
-	return (
-		findScript(json, `tsc --project ${project}`) ||
-		findScript(json, `tsc-multi --config ${project}`)
-	);
+	return findScript(json, `tsc --project ${project}`) || findTscMultiScript(json, project);
 }
 /**
  * Get a list of build script names that the eslint depends on, based on .eslintrc file.

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -451,7 +451,12 @@ export const handlers: Handler[] = [
 			for (const script in json.scripts) {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const command = json.scripts[script]!;
-				if ((command.startsWith("tsc ") || command === "tsc") && !ignore.has(script)) {
+				if (
+					// This clause ensures we don't match commands that are prefixed with "tsc", like "tsc-multi". The exception
+					// is when the whole command is "tsc".
+					(command.startsWith("tsc ") || command === "tsc") &&
+					!ignore.has(script)
+				) {
 					try {
 						const checkDeps = getTscCommandDependencies(
 							packageDir,


### PR DESCRIPTION
Adds basic support for tsc-multi tasks in fluid-build. Also updates some fluid-build-related policy handlers to treat tsc-multi as equivalent to tsc.

My goal with these changes is to unblock further work, so I'm only aiming for basic support. Any bells and whistles can wait.