### PR TITLE
Add santizeError function to remove sensitive information from Redis errors

### DIFF
--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -156,6 +156,15 @@ function getTokenFromRequest(request: Request): string {
 
 const defaultMaxTokenLifetimeSec = 60 * 60; // 1 hour
 
+// Used to sanitize Redis error object and remove sensitive information
+function sanitizeError(error: any) {
+	if (error?.command?.args) {
+		error.command.args = ["REDACTED"];
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	return error;
+}
+
 export async function verifyToken(
 	tenantId: string,
 	documentId: string,
@@ -198,7 +207,11 @@ export async function verifyToken(
 		// Check token cache first
 		if ((options.enableTokenCache || options.ensureSingleUseToken) && options.tokenCache) {
 			const cachedToken = await options.tokenCache.get(token).catch((error) => {
-				Lumberjack.error("Unable to retrieve cached JWT", logProperties, error);
+				Lumberjack.error(
+					"Unable to retrieve cached JWT",
+					logProperties,
+					sanitizeError(error),
+				);
 				return false;
 			});
 
@@ -224,7 +237,7 @@ export async function verifyToken(
 					tokenLifetimeMs !== undefined ? Math.floor(tokenLifetimeMs / 1000) : undefined,
 				)
 				.catch((error) => {
-					Lumberjack.error("Unable to cache JWT", logProperties, error);
+					Lumberjack.error("Unable to cache JWT", logProperties, sanitizeError(error));
 				});
 		}
 	} catch (error) {


### PR DESCRIPTION
Remove args from Redis errors since args may contain sensitive information such as tokens