### PR TITLE
Updates app insights example app dependency  from `@fluid-internal/app-insights-logger` to `@fluidframework/app-insights-logger`

### DIFF
--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -40,7 +40,7 @@
 	},
 	"dependencies": {
 		"@fluid-experimental/react-inputs": "workspace:~",
-		"@fluidframework/app-insights-logger": "workspace:2.0.0-internal.7.3.0",
+		"@fluidframework/app-insights-logger": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/counter": "workspace:~",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -40,7 +40,7 @@
 	},
 	"dependencies": {
 		"@fluid-experimental/react-inputs": "workspace:~",
-		"@fluid-internal/app-insights-logger": "workspace:~",
+		"@fluidframework/app-insights-logger": "workspace:2.0.0-internal.7.3.0",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/counter": "workspace:~",

--- a/examples/client-logger/app-insights-logger/src/components/ClientUtilities.ts
+++ b/examples/client-logger/app-insights-logger/src/components/ClientUtilities.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { FluidAppInsightsLogger } from "@fluid-internal/app-insights-logger";
+import { FluidAppInsightsLogger } from "@fluidframework/app-insights-logger";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,7 +1590,7 @@ importers:
   examples/client-logger/app-insights-logger:
     specifiers:
       '@fluid-experimental/react-inputs': workspace:~
-      '@fluid-internal/app-insights-logger': workspace:~
+      '@fluidframework/app-insights-logger': workspace:2.0.0-internal.7.3.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-loader': workspace:~
@@ -1637,7 +1637,7 @@ importers:
       webpack-merge: ^5.8.0
     dependencies:
       '@fluid-experimental/react-inputs': link:../../../experimental/framework/react-inputs
-      '@fluid-internal/app-insights-logger': link:../../../packages/framework/client-logger/app-insights-logger
+      '@fluidframework/app-insights-logger': link:../../../packages/framework/client-logger/app-insights-logger
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/core-interfaces': link:../../../packages/common/core-interfaces
       '@fluidframework/counter': link:../../../packages/dds/counter
@@ -42629,7 +42629,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0_@types+node@16.18.58
+      jest: 29.7.0
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -45423,12 +45423,14 @@ packages:
     dependencies:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/eslint-config-fluid': 2.1.0_loebgezstcsvd2poh2d55fifke
+      '@rushstack/node-core-library': 3.61.0
       '@tylerbu/markdown-magic': 2.4.0-tylerbu-1
       chalk: 2.4.2
       markdown-magic-package-scripts: 1.2.2
       markdown-magic-template: 1.0.1
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@types/node'
       - eslint
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,7 +1590,7 @@ importers:
   examples/client-logger/app-insights-logger:
     specifiers:
       '@fluid-experimental/react-inputs': workspace:~
-      '@fluidframework/app-insights-logger': workspace:2.0.0-internal.7.3.0
+      '@fluidframework/app-insights-logger': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/container-loader': workspace:~
@@ -42629,7 +42629,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0
+      jest: 29.7.0_@types+node@16.18.58
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
Updates app insights example app dependency  from `@fluid-internal/app-insights-logger` to `@fluidframework/app-insights-logger`. This was missed and didn't get caught in the build checks when the packages scope changed in a previous pr: https://github.com/microsoft/FluidFramework/pull/18239/files
