### PR TITLE
fix(release:fromTag): Return correct release dates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,16 @@
 			"args": ["release", "report", "-g", "build-tools", "-v"],
 		},
 		{
+			// Runs the `flub release fromTag build-tools_v0.26.1` command with a debugger attached.
+			"name": "flub release fromTag build-tools_v0.26.1",
+			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",
+			"cwd": "${workspaceFolder}",
+			"request": "launch",
+			"skipFiles": ["<node_internals>/**"],
+			"type": "node",
+			"args": ["release", "fromTag", "build-tools_v0.26.1", "--json"],
+		},
+		{
 			// Runs the `flub list --private` command with a debugger attached.
 			"name": "flub list",
 			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",

--- a/build-tools/packages/build-cli/src/commands/release/fromTag.ts
+++ b/build-tools/packages/build-cli/src/commands/release/fromTag.ts
@@ -79,6 +79,8 @@ export default class FromTagCommand extends ReleaseReportBaseCommand<typeof From
 			this.error(`Release matching version '${version.version}' not found`);
 		}
 
+		const taggedVersion = versions[taggedReleaseIndex];
+
 		const prevVersionDetails = versions[taggedReleaseIndex + 1];
 		if (prevVersionDetails === undefined) {
 			this.error(`No previous release found`);
@@ -99,7 +101,7 @@ export default class FromTagCommand extends ReleaseReportBaseCommand<typeof From
 			packageOrReleaseGroup: this.releaseGroupName,
 			title: getReleaseTitle(this.releaseGroupName, version, releaseType),
 			tag,
-			date: release.latestReleasedVersion.date,
+			date: taggedVersion.date,
 			releaseType,
 			version: version.version,
 			previousVersion,

--- a/build-tools/packages/build-cli/test/commands/release/fromTag.test.ts
+++ b/build-tools/packages/build-cli/test/commands/release/fromTag.test.ts
@@ -24,7 +24,7 @@ interface jsonOutput {
 describe("flub release fromTag", () => {
 	const expected = {
 		version: "0.26.1",
-		date: "2023-10-27T20:16:48.000Z",
+		date: "2023-10-26T19:35:13.000Z",
 		packageOrReleaseGroup: "build-tools",
 		previousTag: "build-tools_v0.26.0",
 		previousVersion: "0.26.0",


### PR DESCRIPTION
The fromTag command was returning the date of the most recent release instead of the date of the release that was being looked up.

