### PR TITLE
tree2: Cleanup typed/simple tree entry point

### DIFF
--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -72,7 +72,7 @@ export class Bubblebench extends DataObject {
 	 * @param tree - ISharedTree
 	 */
 	initializeTree(tree: ISharedTree) {
-		this.view = tree.schematize({
+		this.view = tree.schematizeInternal({
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [],
 			schema: appSchemaData,

--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -7,8 +7,8 @@ import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import {
 	ForestType,
 	ISharedTree,
-	ITreeView,
 	SharedTreeFactory,
+	TreeView,
 	typeboxValidator,
 } from "@fluid-experimental/tree2";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -23,7 +23,7 @@ const factory = new SharedTreeFactory({
 
 export class InventoryList extends DataObject {
 	#tree?: ISharedTree;
-	#view?: ITreeView<typeof treeConfiguration.schema.rootFieldSchema>;
+	#view?: TreeView<Inventory>;
 
 	public get inventory(): Inventory {
 		if (this.#view === undefined)

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -5,7 +5,7 @@
 
 import {
 	AllowedUpdateType,
-	InitializeAndSchematizeConfiguration,
+	buildTreeConfiguration,
 	ProxyNode,
 	SchemaBuilder,
 } from "@fluid-experimental/tree2";
@@ -23,7 +23,7 @@ export const Inventory = builder.object("Inventory", {
 	parts: builder.list(Part),
 });
 
-export const treeConfiguration = {
+export const treeConfiguration = buildTreeConfiguration({
 	schema: builder.intoSchema(Inventory),
 	allowedSchemaModifications: AllowedUpdateType.None,
 	initialTree: {
@@ -41,4 +41,4 @@ export const treeConfiguration = {
 			],
 		},
 	},
-} satisfies InitializeAndSchematizeConfiguration;
+});

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -190,6 +190,9 @@ abstract class BrandedType<out ValueType, Name extends string> {
 export function brandOpaque<T extends BrandedType<any, string>>(value: isAny<ValueFromBranded<T>> extends true ? never : ValueFromBranded<T>): BrandedType<ValueFromBranded<T>, NameFromBranded<T>>;
 
 // @alpha
+export function buildTreeConfiguration<T extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<T>): InitializeAndSchematizeConfiguration<T>;
+
+// @alpha
 export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
 
 // @alpha
@@ -815,11 +818,10 @@ export function isContextuallyTypedNodeDataObject(data: ContextuallyTypedNodeDat
 export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : false;
 
 // @alpha
-export interface ISharedTree extends ISharedObject, TypedTreeChannel {
+export interface ISharedTree extends ISharedObject, ITree {
     contentSnapshot(): SharedTreeContentSnapshot;
     requireSchema<TRoot extends TreeFieldSchema>(schema: TreeSchema<TRoot>, onSchemaIncompatible: () => void): ITreeView<TRoot> | undefined;
-    // (undocumented)
-    schematize<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ITreeView<TRoot>;
+    schematizeInternal<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ITreeView<TRoot>;
 }
 
 // @alpha (undocumented)
@@ -836,6 +838,11 @@ export interface ITransaction {
     commit(): TransactionResult.Commit;
     inProgress(): boolean;
     start(): void;
+}
+
+// @alpha
+export interface ITree extends IChannel {
+    schematize<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): TreeView<ProxyField<TRoot>>;
 }
 
 // @alpha
@@ -910,11 +917,12 @@ export enum ITreeSubscriptionCursorState {
 }
 
 // @alpha
-export interface ITreeView<in out TRoot extends TreeFieldSchema> extends IDisposable, TypedTreeView<TRoot> {
+export interface ITreeView<in out TRoot extends TreeFieldSchema> extends IDisposable {
     readonly checkout: ITreeCheckout;
     readonly context: TreeContext;
     readonly editableTree: TypedField<TRoot>;
     fork(): ITreeViewFork<TRoot>;
+    readonly root: ProxyField<TRoot>;
 }
 
 // @alpha
@@ -1999,6 +2007,12 @@ export type TreeValue<TSchema extends ValueSchema = ValueSchema> = [
 ][_InlineTrick];
 
 // @alpha
+export interface TreeView<in out TRoot> extends IDisposable {
+    readonly events: ISubscribable<CheckoutEvents>;
+    readonly root: TRoot;
+}
+
+// @alpha
 type TypeArrayToTypedTreeArray<Mode extends ApiMode, T extends readonly TreeNodeSchema[]> = [
 T extends readonly [infer Head, ...infer Tail] ? [
 TypedNode_2<Assume<Head, TreeNodeSchema>, Mode>,
@@ -2052,19 +2066,14 @@ export type TypedNodeUnion<TTypes extends AllowedTypes> = TTypes extends Interna
 type TypedNodeUnionHelper<TTypes extends InternalTypedSchemaTypes.FlexList<TreeNodeSchema>> = InternalTypedSchemaTypes.ArrayToUnion<TypeArrayToTypedTreeArray_2<Assume<InternalTypedSchemaTypes.FlexListToNonLazyArray<TTypes>, readonly TreeNodeSchema[]>>>;
 
 // @alpha
-export interface TypedTreeChannel extends IChannel {
-    schematize<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): TypedTreeView<TRoot>;
-}
-
-// @alpha
 export class TypedTreeFactory implements IChannelFactory {
     constructor(options: TypedTreeOptions);
     // (undocumented)
     readonly attributes: IChannelAttributes;
     // (undocumented)
-    create(runtime: IFluidDataStoreRuntime, id: string): TypedTreeChannel;
+    create(runtime: IFluidDataStoreRuntime, id: string): ITree;
     // (undocumented)
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<TypedTreeChannel>;
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<ITree>;
     // (undocumented)
     readonly type: string;
 }
@@ -2072,11 +2081,6 @@ export class TypedTreeFactory implements IChannelFactory {
 // @alpha
 export interface TypedTreeOptions extends SharedTreeOptions {
     readonly subtype: string;
-}
-
-// @alpha
-export interface TypedTreeView<in out TRoot extends TreeFieldSchema> {
-    readonly root: ProxyField<TRoot>;
 }
 
 // @alpha

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -75,7 +75,7 @@ export interface TreeEntity<out TSchema = unknown> {
 }
 
 /**
- * Status of the tree that a particular node in {@link Tree} belongs to.
+ * Status of the tree that a particular node belongs to.
  * @alpha
  */
 export enum TreeStatus {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/rawObjectNode.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/rawObjectNode.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { SessionSpaceCompressedId } from "@fluidframework/runtime-definitions";
 import { FieldKey, TreeNodeSchemaIdentifier } from "../../core";
-import { BrandedType, capitalize } from "../../util";
+import { capitalize } from "../../util";
 import { ObjectNodeSchema, TreeNodeSchema } from "../typed-schema";
 import { EditableTreeEvents } from "../untypedTree";
+import { LocalNodeKey } from "../node-key";
 import { TreeContext } from "./context";
 import {
 	ObjectNode,
@@ -119,7 +119,7 @@ class RawObjectNode<TSchema extends ObjectNodeSchema, TContent> implements Objec
 		return rawObjectNodeError();
 	}
 
-	public get localNodeKey(): BrandedType<SessionSpaceCompressedId, "Local Node Key"> | undefined {
+	public get localNodeKey(): LocalNodeKey | undefined {
 		return rawObjectNodeError();
 	}
 }

--- a/experimental/dds/tree2/src/feature-libraries/untypedTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/untypedTree.ts
@@ -31,7 +31,7 @@ export interface TreeEvent {
 }
 
 /**
- * A collection of events that can be raised by a {@link Tree}.
+ * A collection of events that can be raised by a {@link TreeNode}.
  * These events are triggered while the internal data structures are being updated.
  * Thus these events must not trigger reading of the anchorSet or forest.
  *

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -252,11 +252,12 @@ export {
 	ForestType,
 	TypedTreeFactory,
 	TypedTreeOptions,
-	TypedTreeChannel,
+	ITree,
 	SharedTreeContentSnapshot,
 	ITreeView,
-	TypedTreeView,
+	TreeView,
 	ITreeViewFork,
+	buildTreeConfiguration,
 } from "./shared-tree";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec";

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -26,8 +26,9 @@ export {
 	TreeContent,
 	InitializeAndSchematizeConfiguration,
 	SchemaConfiguration,
+	buildTreeConfiguration,
 } from "./schematizedTree";
 
-export { TypedTreeFactory, TypedTreeOptions, TypedTreeChannel, TypedTreeView } from "./typedTree";
+export { TypedTreeFactory, TypedTreeOptions, ITree, TreeView } from "./simpleTree";
 
-export { ITreeView, TreeView, ITreeViewFork } from "./treeView";
+export { ITreeView, CheckoutView, ITreeViewFork } from "./treeView";

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -248,3 +248,15 @@ export interface InitializeAndSchematizeConfiguration<
 	TRoot extends TreeFieldSchema = TreeFieldSchema,
 > extends TreeContent<TRoot>,
 		SchematizeConfiguration<TRoot> {}
+
+/**
+ * Options used to initialize (if needed) and schematize a `SharedTree`.
+ * @remarks
+ * Using this builder improves type safety and error quality over just constructing the configuration as a object.
+ * @alpha
+ */
+export function buildTreeConfiguration<T extends TreeFieldSchema>(
+	config: InitializeAndSchematizeConfiguration<T>,
+): InitializeAndSchematizeConfiguration<T> {
+	return config;
+}

--- a/experimental/dds/tree2/src/shared-tree/treeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/treeView.ts
@@ -17,7 +17,6 @@ import {
 } from "../feature-libraries";
 import { IDisposable, disposeSymbol } from "../util";
 import { ITreeCheckoutFork, ITreeCheckout } from "./treeCheckout";
-import { TypedTreeView } from "./typedTree";
 
 /**
  * An editable view of a (version control style) branch of a shared tree.
@@ -27,9 +26,12 @@ import { TypedTreeView } from "./typedTree";
  * 2. This object should be combined with or accessible from the TreeContext to allow easy access to thinks like branching.
  * @alpha
  */
-export interface ITreeView<in out TRoot extends TreeFieldSchema>
-	extends IDisposable,
-		TypedTreeView<TRoot> {
+export interface ITreeView<in out TRoot extends TreeFieldSchema> extends IDisposable {
+	/**
+	 * The current root of the tree.
+	 */
+	readonly root: ProxyField<TRoot>;
+
 	/**
 	 * Context for controlling the EditableTree nodes produced from {@link ITreeView.editableTree}.
 	 *
@@ -69,17 +71,17 @@ export interface ITreeViewFork<in out TRoot extends TreeFieldSchema> extends ITr
 }
 
 /**
- * Implementation of ITreeView.
+ * Implementation of ITreeView wrapping a ITreeCheckout.
  */
-export class TreeView<
+export class CheckoutView<
 	in out TRoot extends TreeFieldSchema,
-	out TBranch extends ITreeCheckout = ITreeCheckout,
+	out TCheckout extends ITreeCheckout = ITreeCheckout,
 > implements ITreeView<TRoot>
 {
 	public readonly context: Context;
 	public readonly editableTree: TypedField<TRoot>;
 	public constructor(
-		public readonly checkout: TBranch,
+		public readonly checkout: TCheckout,
 		public readonly schema: TreeSchema<TRoot>,
 		public readonly nodeKeyManager: NodeKeyManager,
 		public readonly nodeKeyFieldKey: FieldKey,
@@ -104,8 +106,8 @@ export class TreeView<
 		return getProxyForField(this.editableTree);
 	}
 
-	public fork(): TreeView<TRoot, ITreeCheckoutFork> {
+	public fork(): CheckoutView<TRoot, ITreeCheckoutFork> {
 		const branch = this.checkout.fork();
-		return new TreeView(branch, this.schema, this.nodeKeyManager, this.nodeKeyFieldKey);
+		return new CheckoutView(branch, this.schema, this.nodeKeyManager, this.nodeKeyFieldKey);
 	}
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTree.events.spec.ts
@@ -33,7 +33,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("fire the expected number of times", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -141,7 +141,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("fire in the expected order and always together", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -197,7 +197,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("event argument contains the expected node", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -270,7 +270,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("listeners can be removed successfully", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -319,7 +319,7 @@ describe("beforeChange/afterChange events", () => {
 	it("tree is in correct state when events fire - primitive node deletions", () => {
 		const initialNumber = 20;
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: initialNumber,
@@ -347,7 +347,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("tree is in correct state when events fire - primitive node additions", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -377,7 +377,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("tree is in correct state when events fire - primitive node replacements", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -405,7 +405,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("tree is in correct state when events fire - node inserts to sequence fields", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -467,7 +467,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("tree is in correct state when events fire - node removals from sequence fields", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -507,7 +507,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("tree is in correct state when events fire - node moves in sequence fields", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -579,7 +579,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("not emitted by nodes when they are replaced", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -609,7 +609,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("bubble up from the affected node to the root", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const root = tree.schematize({
+		const root = tree.schematizeInternal({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,

--- a/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/node-key/nodeKeyIndex.spec.ts
@@ -145,7 +145,7 @@ describe("Node Key Index", () => {
 
 		const manager1 = createMockNodeKeyManager();
 		const key = manager1.generateLocalNodeKey();
-		tree.schematize(
+		tree.schematizeInternal(
 			{
 				initialTree: {
 					[nodeKeyFieldKey]: manager1.stabilizeNodeKey(key),
@@ -162,7 +162,7 @@ describe("Node Key Index", () => {
 		await provider.summarize();
 		const tree2 = await provider.createTree();
 		await provider.ensureSynchronized();
-		const view2 = tree2.schematize(
+		const view2 = tree2.schematizeInternal(
 			{
 				initialTree: {
 					[nodeKeyFieldKey]: "not used",

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -351,8 +351,8 @@ describe("SharedTreeCore", () => {
 			allowedSchemaModifications: AllowedUpdateType.None,
 		} satisfies InitializeAndSchematizeConfiguration;
 
-		const view1 = tree1.schematize(config);
-		const view2 = tree2.schematize(config);
+		const view1 = tree1.schematizeInternal(config);
+		const view2 = tree2.schematizeInternal(config);
 		const editable1 = view1.editableTree;
 		const editable2 = view2.editableTree;
 

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -53,7 +53,7 @@ export function viewFromState(
 ): ITreeView<typeof fuzzSchema.rootFieldSchema> {
 	state.view2 ??= new Map();
 	return getOrCreate(state.view2, client.channel, (tree) =>
-		tree.schematize({
+		tree.schematizeInternal({
 			initialTree,
 			schema: fuzzSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -57,7 +57,7 @@ function initializeTestTree(
 	state: JsonableTree = initialTestJsonTree,
 ): ITreeCheckout {
 	const writeCursor = cursorForJsonableTreeNode(state);
-	return tree.schematize({
+	return tree.schematizeInternal({
 		allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 		initialTree: [writeCursor],
 		schema: fullSchemaData,

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -95,8 +95,8 @@ describe("SharedTree", () => {
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: ["x"],
 			} satisfies InitializeAndSchematizeConfiguration;
-			const tree1 = provider.trees[0].schematize(content);
-			provider.trees[1].schematize(content);
+			const tree1 = provider.trees[0].schematizeInternal(content);
+			provider.trees[1].schematizeInternal(content);
 			provider.processMessages();
 
 			assert.deepEqual(tree1.editableTree.asArray, ["x"]);
@@ -106,7 +106,7 @@ describe("SharedTree", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
 			assert.equal(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 
-			const view = tree.schematize({
+			const view = tree.schematizeInternal({
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: 10,
 				schema,
@@ -119,7 +119,7 @@ describe("SharedTree", () => {
 			tree.storedSchema.update(schema);
 
 			// No op upgrade with AllowedUpdateType.None does not error
-			const schematized = tree.schematize({
+			const schematized = tree.schematizeInternal({
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: 10,
 				schema,
@@ -132,7 +132,7 @@ describe("SharedTree", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
 			tree.storedSchema.update(schemaGeneralized);
 			assert.throws(() => {
-				tree.schematize({
+				tree.schematizeInternal({
 					allowedSchemaModifications: AllowedUpdateType.None,
 					initialTree: 5,
 					schema,
@@ -143,7 +143,7 @@ describe("SharedTree", () => {
 		it("upgrade schema", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
 			tree.storedSchema.update(schema);
-			const schematized = tree.schematize({
+			const schematized = tree.schematizeInternal({
 				allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 				initialTree: 5,
 				schema: schemaGeneralized,
@@ -230,7 +230,7 @@ describe("SharedTree", () => {
 			forest: ForestType.Reference,
 		});
 		const sharedTree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-		const view = sharedTree.schematize({
+		const view = sharedTree.schematizeInternal({
 			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 			initialTree: 1,
 			schema,
@@ -254,7 +254,7 @@ describe("SharedTree", () => {
 				nodeSchema: new Map(),
 			});
 		}
-		sharedTree.schematize({
+		sharedTree.schematizeInternal({
 			allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 			initialTree: ["x"],
 			schema: stringSequenceRootSchema,
@@ -275,7 +275,7 @@ describe("SharedTree", () => {
 		const expectedSchema = schemaCodec.encode(stringSequenceRootSchema);
 
 		// Apply an edit to the first tree which inserts a node with a value
-		const view1 = provider.trees[0].schematize({
+		const view1 = provider.trees[0].schematizeInternal({
 			schema: stringSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [value],
@@ -295,7 +295,7 @@ describe("SharedTree", () => {
 	it("can summarize and load", async () => {
 		const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
 		const value = 42;
-		const summarizingTree = provider.trees[0].schematize({
+		const summarizingTree = provider.trees[0].schematizeInternal({
 			schema: jsonSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: [value],
@@ -316,7 +316,7 @@ describe("SharedTree", () => {
 
 		const [container1, container2, container3] = provider.containers;
 
-		const tree1 = provider.trees[0].schematize({
+		const tree1 = provider.trees[0].schematizeInternal({
 			schema: stringSequenceRootSchema,
 			allowedSchemaModifications: AllowedUpdateType.None,
 			initialTree: ["Z", "A", "C"],
@@ -502,7 +502,7 @@ describe("SharedTree", () => {
 
 	it("can summarize local edits in the attach summary", async () => {
 		const onCreate = (tree: SharedTree) => {
-			const view = tree.schematize(emptyStringSequenceConfig);
+			const view = tree.schematizeInternal(emptyStringSequenceConfig);
 			view.editableTree.insertAtStart(["A"]);
 			view.editableTree.insertAtEnd(["C"]);
 			assert.deepEqual(view.editableTree.asArray, ["A", "C"]);
@@ -529,7 +529,7 @@ describe("SharedTree", () => {
 	it("can tolerate local edits submitted as part of a transaction in the attach summary", async () => {
 		const onCreate = (tree: SharedTree) => {
 			// Schematize uses a transaction as well
-			const view = tree.schematize(emptyStringSequenceConfig);
+			const view = tree.schematizeInternal(emptyStringSequenceConfig);
 			view.checkout.transaction.start();
 			view.editableTree.insertAtStart(["A"]);
 			view.editableTree.insertAt(1, ["C"]);
@@ -590,7 +590,7 @@ describe("SharedTree", () => {
 
 	it("has bounded memory growth in EditManager", () => {
 		const provider = new TestTreeProviderLite(2);
-		provider.trees[0].schematize(emptyStringSequenceConfig)[disposeSymbol]();
+		provider.trees[0].schematizeInternal(emptyStringSequenceConfig)[disposeSymbol]();
 		provider.processMessages();
 
 		const [tree1, tree2] = provider.trees.map(
@@ -626,7 +626,7 @@ describe("SharedTree", () => {
 
 	it("can process changes while detached", async () => {
 		const onCreate = (t: ISharedTree) => {
-			const view = t.schematize(emptyStringSequenceConfig);
+			const view = t.schematizeInternal(emptyStringSequenceConfig);
 			view.editableTree.insertAtStart(["B"]);
 			view.editableTree.insertAtStart(["A"]);
 			assert.deepEqual(view.editableTree.asArray, ["A", "B"]);
@@ -645,10 +645,10 @@ describe("SharedTree", () => {
 		it("the insert of a node in a sequence field", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyStringSequenceConfig);
+			const tree1 = provider.trees[0].schematizeInternal(emptyStringSequenceConfig);
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree1.checkout);
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(emptyStringSequenceConfig);
+			const tree2 = provider.trees[1].schematizeInternal(emptyStringSequenceConfig);
 			provider.processMessages();
 
 			// Insert node
@@ -681,7 +681,7 @@ describe("SharedTree", () => {
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: ["A", "B", "C", "D"],
 			} satisfies InitializeAndSchematizeConfiguration;
-			const tree1 = provider.trees[0].schematize(content);
+			const tree1 = provider.trees[0].schematizeInternal(content);
 
 			const {
 				undoStack: undoStack1,
@@ -756,7 +756,7 @@ describe("SharedTree", () => {
 		it("triggers revertible events for local changes", () => {
 			const value = "42";
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyStringSequenceConfig);
+			const tree1 = provider.trees[0].schematizeInternal(emptyStringSequenceConfig);
 			provider.processMessages();
 			const tree2 = assertSchema(provider.trees[1], stringSequenceRootSchema);
 
@@ -807,7 +807,7 @@ describe("SharedTree", () => {
 		it("doesn't trigger a revertible event for rebases", () => {
 			const provider = new TestTreeProviderLite(2);
 			// Initialize the tree
-			const tree1 = provider.trees[0].schematize({
+			const tree1 = provider.trees[0].schematizeInternal({
 				initialTree: ["A", "B", "C", "D"],
 				schema: stringSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
@@ -864,7 +864,7 @@ describe("SharedTree", () => {
 				schema: stringSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
 			};
-			const view1 = provider.trees[0].schematize(config);
+			const view1 = provider.trees[0].schematizeInternal(config);
 			await provider.ensureSynchronized();
 
 			const pausedContainer: IContainerExperimental = provider.containers[0];
@@ -938,7 +938,7 @@ describe("SharedTree", () => {
 
 	it("don't send ops before committing", () => {
 		const provider = new TestTreeProviderLite(2);
-		const tree1 = provider.trees[0].schematize(emptyStringSequenceConfig);
+		const tree1 = provider.trees[0].schematizeInternal(emptyStringSequenceConfig);
 		provider.processMessages();
 		const tree2 = provider.trees[1];
 		let opsReceived = 0;
@@ -955,7 +955,7 @@ describe("SharedTree", () => {
 
 	it("send only one op after committing", () => {
 		const provider = new TestTreeProviderLite(2);
-		const tree1 = provider.trees[0].schematize(emptyStringSequenceConfig);
+		const tree1 = provider.trees[0].schematizeInternal(emptyStringSequenceConfig);
 		provider.processMessages();
 		const tree2 = provider.trees[1];
 		let opsReceived = 0;
@@ -974,7 +974,7 @@ describe("SharedTree", () => {
 
 	it("do not send an op after committing if nested", () => {
 		const provider = new TestTreeProviderLite(2);
-		const tree1 = provider.trees[0].schematize(emptyStringSequenceConfig);
+		const tree1 = provider.trees[0].schematizeInternal(emptyStringSequenceConfig);
 		provider.processMessages();
 		const tree2 = provider.trees[1];
 		let opsReceived = 0;
@@ -996,7 +996,7 @@ describe("SharedTree", () => {
 
 	it("process changes while detached", async () => {
 		const onCreate = (parentTree: SharedTree) => {
-			const parent = parentTree.schematize({
+			const parent = parentTree.schematizeInternal({
 				initialTree: ["A"],
 				schema: stringSequenceRootSchema,
 				allowedSchemaModifications: AllowedUpdateType.None,
@@ -1227,7 +1227,7 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 	it(`${title} (root view)`, () => {
 		const provider = new TestTreeProviderLite();
 		// Test an actual SharedTree.
-		fn(provider.trees[0].schematize(config).checkout);
+		fn(provider.trees[0].schematizeInternal(config).checkout);
 	});
 
 	it(`${title} (reference view)`, () => {
@@ -1236,7 +1236,7 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 
 	it(`${title} (forked view)`, () => {
 		const provider = new TestTreeProviderLite();
-		fn(provider.trees[0].schematize(config).checkout.fork());
+		fn(provider.trees[0].schematizeInternal(config).checkout.fork());
 	});
 
 	it(`${title} (reference forked view)`, () => {

--- a/experimental/dds/tree2/src/test/shared-tree/summary.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/summary.bench.ts
@@ -123,7 +123,7 @@ describe("Summary benchmarks", () => {
 function getSummaryTree(content: TreeContent): ISummaryTree {
 	const provider = new TestTreeProviderLite();
 	const tree = provider.trees[0];
-	tree.schematize({ ...content, allowedSchemaModifications: AllowedUpdateType.None });
+	tree.schematizeInternal({ ...content, allowedSchemaModifications: AllowedUpdateType.None });
 	provider.processMessages();
 	const { summary } = tree.getAttachSummary(true);
 	return summary;

--- a/experimental/dds/tree2/src/test/shared-tree/treeCheckout.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/treeCheckout.spec.ts
@@ -378,9 +378,9 @@ describe("sharedTreeView", () => {
 
 		it("submit edits to Fluid when merging into the root view", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).checkout;
+			const tree1 = provider.trees[0].schematizeInternal(emptyJsonSequenceConfig).checkout;
 			provider.processMessages();
-			const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig).checkout;
+			const tree2 = provider.trees[1].schematizeInternal(emptyJsonSequenceConfig).checkout;
 			provider.processMessages();
 			const baseView = tree1.fork();
 			const view = baseView.fork();
@@ -398,7 +398,7 @@ describe("sharedTreeView", () => {
 
 		it("do not squash commits", () => {
 			const provider = new TestTreeProviderLite(2);
-			const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig).checkout;
+			const tree1 = provider.trees[0].schematizeInternal(emptyJsonSequenceConfig).checkout;
 			provider.processMessages();
 			const tree2 = provider.trees[1];
 			let opsReceived = 0;
@@ -626,7 +626,7 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 	it(`${title} (root view)`, () => {
 		const provider = new TestTreeProviderLite();
 		// Test an actual SharedTree.
-		fn(provider.trees[0].schematize(config).checkout);
+		fn(provider.trees[0].schematizeInternal(config).checkout);
 	});
 
 	it(`${title} (reference view)`, () => {
@@ -635,7 +635,7 @@ function itView(title: string, fn: (view: ITreeCheckout) => void): void {
 
 	it(`${title} (forked view)`, () => {
 		const provider = new TestTreeProviderLite();
-		fn(provider.trees[0].schematize(config).checkout.fork());
+		fn(provider.trees[0].schematizeInternal(config).checkout.fork());
 	});
 
 	it(`${title} (reference forked view)`, () => {

--- a/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
+++ b/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
@@ -29,7 +29,7 @@ const someType = builder.object("foo", {
 const schema = builder.intoSchema(SchemaBuilder.required(someType));
 
 function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematize({
+	return tree.schematizeInternal({
 		initialTree: {
 			handles: [],
 			nested: undefined,

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -50,7 +50,7 @@ function generateCompleteTree(
 		new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 		"test",
 	);
-	const view = tree.schematize({
+	const view = tree.schematizeInternal({
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema: testSchema,
 		initialTree: [],
@@ -178,9 +178,10 @@ export function generateTestTrees() {
 			runScenario: async (takeSnapshot) => {
 				const value = "42";
 				const provider = new TestTreeProviderLite(2);
-				const tree1 = provider.trees[0].schematize(emptyJsonSequenceConfig);
+				const tree1 = provider.trees[0].schematizeInternal(emptyJsonSequenceConfig);
 				provider.processMessages();
-				const tree2 = provider.trees[1].schematize(emptyJsonSequenceConfig).checkout;
+				const tree2 =
+					provider.trees[1].schematizeInternal(emptyJsonSequenceConfig).checkout;
 				provider.processMessages();
 
 				// Insert node
@@ -208,11 +209,11 @@ export function generateTestTrees() {
 						initialTree: [0, 1, 2, 3],
 						allowedSchemaModifications: AllowedUpdateType.None,
 					};
-					const tree1 = provider.trees[0].schematize(config).checkout;
+					const tree1 = provider.trees[0].schematizeInternal(config).checkout;
 					provider.processMessages();
-					const tree2 = provider.trees[1].schematize(config).checkout;
-					const tree3 = provider.trees[2].schematize(config).checkout;
-					const tree4 = provider.trees[3].schematize(config).checkout;
+					const tree2 = provider.trees[1].schematizeInternal(config).checkout;
+					const tree3 = provider.trees[2].schematizeInternal(config).checkout;
+					const tree4 = provider.trees[3].schematizeInternal(config).checkout;
 					provider.processMessages();
 					remove(tree1, index, 1);
 					remove(tree2, index, 1);
@@ -230,7 +231,7 @@ export function generateTestTrees() {
 					"test",
 				);
 
-				const tree1 = baseTree.schematize({
+				const tree1 = baseTree.schematizeInternal({
 					allowedSchemaModifications: AllowedUpdateType.None,
 					schema: jsonSequenceRootSchema,
 					initialTree: [],
@@ -291,7 +292,7 @@ export function generateTestTrees() {
 					new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 					"test",
 				);
-				const view = tree.schematize(config).checkout;
+				const view = tree.schematizeInternal(config).checkout;
 
 				const field = view.editor.optionalField({
 					parent: undefined,
@@ -326,7 +327,7 @@ export function generateTestTrees() {
 					new MockFluidDataStoreRuntime({ clientId: "test-client", id: "test" }),
 					"test",
 				);
-				const view = tree.schematize(config).checkout;
+				const view = tree.schematizeInternal(config).checkout;
 				view.transaction.start();
 				// We must make this shallow change to the sequence field as part of the same transaction as the
 				// nested change. Otherwise, the nested change will be represented using the generic field kind.

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -43,7 +43,7 @@ import {
 	runSynchronous,
 	SharedTreeContentSnapshot,
 	ITreeView,
-	TreeView,
+	CheckoutView,
 } from "../shared-tree";
 import {
 	Any,
@@ -616,7 +616,7 @@ export function viewWithContent<TRoot extends TreeFieldSchema>(
 		forest,
 		schema: new InMemoryStoredSchemaRepository(content.schema),
 	});
-	return new TreeView(
+	return new CheckoutView(
 		view,
 		content.schema,
 		args?.nodeKeyManager ?? createMockNodeKeyManager(),
@@ -654,7 +654,7 @@ export function treeWithContent<TRoot extends TreeFieldSchema>(
 		schema: new InMemoryStoredSchemaRepository(content.schema),
 	});
 	const manager = args?.nodeKeyManager ?? createMockNodeKeyManager();
-	const view = new TreeView(
+	const view = new CheckoutView(
 		branch,
 		content.schema,
 		manager,

--- a/packages/dds/migration-shim/src/test/dataMigration.spec.ts
+++ b/packages/dds/migration-shim/src/test/dataMigration.spec.ts
@@ -110,7 +110,7 @@ const inventoryFieldSchema = SchemaBuilder.required(inventorySchema);
 const schema = builder.intoSchema(inventoryFieldSchema);
 
 function getNewTreeView(tree: ISharedTree): ITreeView<typeof inventoryFieldSchema> {
-	return tree.schematize({
+	return tree.schematizeInternal({
 		initialTree: {
 			quantity: 0,
 		},
@@ -162,7 +162,7 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const quantity = legacyNode.payload.quantity as number;
 			newTree
-				.schematize({
+				.schematizeInternal({
 					initialTree: {
 						quantity,
 					},

--- a/packages/dds/migration-shim/src/test/migrationShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/migrationShim.spec.ts
@@ -66,7 +66,7 @@ const rootType = builder.object("abc", {
 });
 const schema = builder.intoSchema(rootType);
 function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematize({
+	return tree.schematizeInternal({
 		initialTree: {
 			quantity: 0,
 		},

--- a/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
@@ -56,7 +56,7 @@ const rootType = builder.object("abc", {
 const schema = builder.intoSchema(rootType);
 
 function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematize({
+	return tree.schematizeInternal({
 		initialTree: {
 			quantity: 0,
 		},

--- a/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
+++ b/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
@@ -123,7 +123,7 @@ const quantityType = builder.object("quantityObj", {
 const schema = builder.intoSchema(quantityType);
 
 function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematize({
+	return tree.schematizeInternal({
 		initialTree: {
 			quantity: 0,
 		},


### PR DESCRIPTION
## Description

Cleanup typed/simple tree entry point to actually use a wrapper object for the view and expose what's needed for undo+redo and disposal.

This should allow apps to use this simpler entry point.

It also makes it possible to refer to TreeView types without needing access to the schema types, since its now parametric over the Proxy type instead.

This is work toward having the "simple" public layer be more of a wrapper and less of an API subset, which better aligns with the differing data model and concepts between the public API and the implementation logic.

The changes to the inventoryList sample show the main intended impact of these changes.

## Breaking Changes

Code explicitly providing type parameters to TypedTree view will need to provide the proxy API instead. Users of the internal types and "schematize" need to call schemtizeInternal now. The typed tree types have been renamed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

