### PR TITLE
Revert "describeNoCompat partial clean up (#18242)"

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -20,9 +20,10 @@ import { SharedObject } from "@fluidframework/shared-object-base";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 
-describeFullCompat(`Attach/Reference Api Tests For Attached Container`, (getTestObjectProvider) => {
+// REVIEW: enable compat testing?
+describeNoCompat(`Attach/Reference Api Tests For Attached Container`, (getTestObjectProvider) => {
 	const codeDetails: IFluidCodeDetails = {
 		package: "detachedContainerTestPackage1",
 		config: {},

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -20,7 +20,7 @@ import {
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
 import {
-	describeFullCompat,
+	describeNoCompat,
 	itSkipsFailureOnSpecificDrivers,
 } from "@fluid-private/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
@@ -93,7 +93,7 @@ function assertAttributionMatches(
 
 // TODO: Expand the e2e tests in this suite to cover interesting combinations of configuration and versioning that aren't covered by mixinAttributor
 // unit tests.
-describeFullCompat("Attributor", (getTestObjectProvider) => {
+describeNoCompat("Attributor", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -23,7 +23,7 @@ import {
 	ITestContainerConfig,
 	DataObjectFactoryType,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
@@ -106,7 +106,7 @@ async function waitForCleanContainers(...dataStores: ITestFluidObject[]) {
 	);
 }
 
-describeFullCompat("Flushing ops", (getTestObjectProvider) => {
+describeNoCompat("Flushing ops", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import {
 	MockFluidDataStoreRuntime,
 	MockContainerRuntimeFactory,
@@ -20,7 +20,7 @@ function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
 	return new SharedString(dataStoreRuntime, id, SharedStringFactory.Attributes);
 }
 
-describeFullCompat("PAS Test", () => {
+describeNoCompat("PAS Test", () => {
 	let matrix: SharedMatrix;
 	let containerRuntimeFactory: MockContainerRuntimeFactory;
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/SimpleTest.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/SimpleTest.all.spec.ts
@@ -5,10 +5,10 @@
 import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { benchmarkAll, IBenchmarkParameters } from "./DocumentCreator.js";
 
-describeFullCompat("Simple Scenario Title", (getTestObjectProvider) => {
+describeNoCompat("Simple Scenario Title", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 
 	before(async () => {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -15,12 +15,12 @@ import {
 	ITestObjectProvider,
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeFullCompat("Container - memory usage benchmarks", (getTestObjectProvider) => {
+describeNoCompat("Container - memory usage benchmarks", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let loader: Loader;
 	let fileName: string;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
@@ -14,12 +14,12 @@ import {
 	ITestObjectProvider,
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeFullCompat("Container - runtime benchmarks", (getTestObjectProvider) => {
+describeNoCompat("Container - runtime benchmarks", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let loader: Loader;
 	let fileName: string;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -9,7 +9,7 @@ import { ContainerRuntime, DefaultSummaryConfiguration } from "@fluidframework/c
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeFullCompat, ITestDataObject } from "@fluid-private/test-version-utils";
+import { describeNoCompat, ITestDataObject } from "@fluid-private/test-version-utils";
 import { benchmarkMemory, IMemoryTestObject } from "@fluid-tools/benchmark";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
 import { bufferToString } from "@fluid-internal/client-utils";
@@ -32,7 +32,7 @@ function readBlobContent(content: ISummaryBlob["content"]): unknown {
 	return JSON.parse(json);
 }
 
-describeFullCompat("Summarization - runtime benchmarks", (getTestObjectProvider) => {
+describeNoCompat("Summarization - runtime benchmarks", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	before(async () => {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -9,7 +9,7 @@ import { ContainerRuntime, DefaultSummaryConfiguration } from "@fluidframework/c
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeFullCompat, ITestDataObject } from "@fluid-private/test-version-utils";
+import { describeNoCompat, ITestDataObject } from "@fluid-private/test-version-utils";
 import { benchmark } from "@fluid-tools/benchmark";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
 import { bufferToString } from "@fluid-internal/client-utils";
@@ -32,7 +32,7 @@ function readBlobContent(content: ISummaryBlob["content"]): unknown {
 	return JSON.parse(json);
 }
 
-describeFullCompat("Summarization - runtime benchmarks", (getTestObjectProvider) => {
+describeNoCompat("Summarization - runtime benchmarks", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -20,7 +20,7 @@ import {
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
 import {
-	describeFullCompat,
+	describeNoCompat,
 	itSkipsFailureOnSpecificDrivers,
 } from "@fluid-private/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
@@ -80,7 +80,7 @@ function assertAttributionMatches(
 	}
 }
 
-describeFullCompat("Attributor for SharedCell", (getTestObjectProvider) => {
+describeNoCompat("Attributor for SharedCell", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -21,7 +21,7 @@ import {
 } from "@fluidframework/test-utils";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { describeFullCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 
 interface ICodeProposalTestPackage extends IFluidPackage {
 	version: number;
@@ -37,7 +37,8 @@ function isCodeProposalTestPackage(pkg: unknown): pkg is ICodeProposalTestPackag
 	);
 }
 
-describeFullCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
+// REVIEW: enable compat testing?
+describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
 	const packageV1: ICodeProposalTestPackage = {
 		name: "test",
 		version: 1,

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -13,7 +13,7 @@ import {
 	ChannelFactoryRegistry,
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeFullCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeFullCompat, describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 import { ContainerErrorType, IContainer } from "@fluidframework/container-definitions";
 
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
@@ -163,7 +163,7 @@ describeFullCompat("SharedCounter", (getTestObjectProvider) => {
 	});
 });
 
-describeFullCompat("SharedCounter orderSequentially", (getTestObjectProvider) => {
+describeNoCompat("SharedCounter orderSequentially", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -21,9 +21,9 @@ import {
 	ITestObjectProvider,
 	createContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 
-describeFullCompat("Generate Summary Stats", (getTestObjectProvider, apis) => {
+describeNoCompat("Generate Summary Stats", (getTestObjectProvider, apis) => {
 	const {
 		dataRuntime: { DataObject, DataObjectFactory },
 		containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -37,7 +37,7 @@ import {
 	waitForContainerConnection,
 	timeoutPromise,
 } from "@fluidframework/test-utils";
-import { describeFullCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeFullCompat, describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -902,7 +902,8 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 	});
 });
 
-describeFullCompat("Detached Container", (getTestObjectProvider) => {
+// Review: Run with Full Compat?
+describeNoCompat("Detached Container", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let request: IRequest;
 	let loader: Loader;

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -15,10 +15,11 @@ import {
 	ITestObjectProvider,
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
-import { describeFullCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 import { ContainerErrorType } from "@fluidframework/container-definitions";
 
-describeFullCompat("Errors Types", (getTestObjectProvider) => {
+// REVIEW: enable compat testing?
+describeNoCompat("Errors Types", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -16,14 +16,14 @@ import {
 	DataObjectFactoryType,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 
 /**
  * This test validates that changing the FlushMode does not hit any validation errors in PendingStateManager.
  * It also validates the scenario in this bug - https://github.com/microsoft/FluidFramework/issues/9398.
  */
-describeFullCompat("Flush mode validation", (getTestObjectProvider) => {
+describeNoCompat("Flush mode validation", (getTestObjectProvider) => {
 	const map1Id = "map1Key";
 	const registry: ChannelFactoryRegistry = [[map1Id, SharedMap.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -27,7 +27,7 @@ import {
 	ITestObjectProvider,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 const counterKey = "count";
@@ -95,7 +95,8 @@ const testDataObjectFactory = new DataObjectFactory(
 	{},
 );
 
-describeFullCompat("LocalLoader", (getTestObjectProvider) => {
+// REVIEW: enable compat testing?
+describeNoCompat("LocalLoader", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	before(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -17,7 +17,7 @@ import {
 	ChannelFactoryRegistry,
 	ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluid-private/test-version-utils";
+import { describeFullCompat, describeNoCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 
 const mapId = "mapKey";
@@ -376,7 +376,7 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
 	});
 });
 
-describeFullCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
+describeNoCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -15,13 +15,13 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import { describeFullCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 import { SharedString } from "@fluidframework/sequence";
 import { IContainer } from "@fluidframework/container-definitions";
 import { IMergeTreeInsertMsg } from "@fluidframework/merge-tree";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 
-describeFullCompat("Concurrent op processing via DDS event handlers", (getTestObjectProvider) => {
+describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObjectProvider) => {
 	const mapId = "mapKey";
 	const sharedStringId = "sharedStringKey";
 	const sharedDirectoryId = "sharedDirectoryKey";

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -24,10 +24,11 @@ import {
 import { NonRetryableError, readAndParse } from "@fluidframework/driver-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ReferenceType, TextSegment } from "@fluidframework/merge-tree";
-import { describeFullCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 import { pkgVersion } from "../packageVersion.js";
 
-describeFullCompat("SharedString", (getTestObjectProvider) => {
+// REVIEW: enable compat testing?
+describeNoCompat("SharedString", (getTestObjectProvider) => {
 	itExpects(
 		"Failure to Load in Shared String",
 		[

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -31,7 +31,6 @@ import {
 } from "@fluidframework/test-utils";
 import {
 	describeNoCompat,
-	describeFullCompat,
 	ITestDataObject,
 	itExpects,
 	TestDataObjectType,
@@ -440,7 +439,7 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 	});
 });
 
-describeFullCompat("Summaries", (getTestObjectProvider) => {
+describeNoCompat("Summaries", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();
@@ -501,7 +500,7 @@ describeFullCompat("Summaries", (getTestObjectProvider) => {
 	it("TelemetryContext is populated with data even if summarize fails", getTestFn(true));
 });
 
-describeFullCompat("SingleCommit Summaries Tests", (getTestObjectProvider) => {
+describeNoCompat("SingleCommit Summaries Tests", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let configForSingleCommitSummary: ITestContainerConfig;
 	beforeEach(() => {


### PR DESCRIPTION
This reverts commit 3bdedb94b08d254a47fdcf90282ca8be703fb41e.

The full compat is enabled for some tests that were not running in full compat, it broke the ci starting from: https://dev.azure.com/fluidframework/internal/_build/results?buildId=209931&view=results
