### PR TITLE
tree2: Remove FieldNode unboxing

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2096,7 +2096,7 @@ type UnboxField<TSchema extends TreeFieldSchema, Emptiness extends "maybeEmpty" 
 type UnboxFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? Sequence<TTypes> : Kind extends typeof FieldKinds.required ? UnboxNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? UnboxNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined) : Kind extends typeof FieldKinds.nodeKey ? NodeKeyField : unknown;
 
 // @alpha
-type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema ? TreeValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? UnboxField<TSchema["objectNodeFieldsObject"][""]> : TSchema extends ObjectNodeSchema ? ObjectNodeTyped<TSchema> : UnknownUnboxed;
+type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSchema ? TreeValue<TSchema["leafValue"]> : TSchema extends MapSchema ? MapNode<TSchema> : TSchema extends FieldNodeSchema ? FieldNode<TSchema> : TSchema extends ObjectNodeSchema ? ObjectNodeTyped<TSchema> : UnknownUnboxed;
 
 // @alpha
 type UnboxNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [
@@ -2118,7 +2118,7 @@ type UnbrandList<T extends unknown[], B> = T extends [infer Head, ...infer Tail]
 export type Unenforced<_DesiredExtendsConstraint> = unknown;
 
 // @alpha
-type UnknownUnboxed = TreeValue | TreeNode | TreeField;
+type UnknownUnboxed = TreeValue | TreeNode;
 
 // @alpha
 type UntypedApi<Mode extends ApiMode> = {

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/editableTreeTypes.ts
@@ -348,9 +348,7 @@ export interface MapNode<in out TSchema extends MapSchema> extends TreeNode {
  * A {@link TreeNode} that wraps a single {@link TreeField} (which is placed under the {@link EmptyKey}).
  *
  * @remarks
- * FieldNodes unbox to their content, so in schema aware APIs which do unboxing, the FieldNode itself will be skipped over.
- * This layer of field nodes is then omitted when using schema-aware APIs which do unboxing.
- * Other than this unboxing, a FieldNode is identical to a struct node with a single field using the {@link EmptyKey}.
+ * A FieldNode is mostly identical to a struct node with a single field using the {@link EmptyKey}, but provides access to it via a field named "content".
  *
  * There are several use-cases where it makes sense to use a field node.
  * Here are a few:
@@ -377,10 +375,8 @@ export interface MapNode<in out TSchema extends MapSchema> extends TreeNode {
  * `FieldNode<Sequence<Foo>> | FieldNode<Sequence<Bar>>` or `OptionalField<FieldNode<Sequence<Foo>>>`.
  *
  * @privateRemarks
- * TODO: The rule walking over the tree via enumerable own properties is lossless (see [ReadMe](./README.md) for details)
- * fails to be true for recursive field nodes with field kind optional, since the length of the chain of field nodes is lost.
- * THis could be fixed by tweaking the unboxing rules, or simply ban view schema that would have this problem (check for recursive optional field nodes).
- * Replacing the field node pattern with one where the FieldNode node exposes APIs from its field instead of unboxing could have the same issue, and same solutions.
+ * FieldNodes do not unbox to their content, so in schema aware APIs which do unboxing, the FieldNode will NOT be skipped over.
+ * This is a change from the old behavior to simplify unboxing and prevent cases where arbitrary deep chains of field nodes could unbox omitting information about the tree depth.
  * @alpha
  */
 export interface FieldNode<in out TSchema extends FieldNodeSchema> extends TreeNode {
@@ -991,7 +987,7 @@ export type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSche
 	: TSchema extends MapSchema
 	? MapNode<TSchema>
 	: TSchema extends FieldNodeSchema
-	? UnboxField<TSchema["objectNodeFieldsObject"][""]>
+	? FieldNode<TSchema>
 	: TSchema extends ObjectNodeSchema
 	? ObjectNodeTyped<TSchema>
 	: UnknownUnboxed;
@@ -1000,6 +996,6 @@ export type UnboxNode<TSchema extends TreeNodeSchema> = TSchema extends LeafSche
  * Unboxed tree type for unknown schema cases.
  * @alpha
  */
-export type UnknownUnboxed = TreeValue | TreeNode | TreeField;
+export type UnknownUnboxed = TreeValue | TreeNode;
 
 // #endregion

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree-2/unboxed.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree-2/unboxed.ts
@@ -3,19 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { ITreeSubscriptionCursor, inCursorNode, EmptyKey } from "../../core";
+import { ITreeSubscriptionCursor, inCursorNode } from "../../core";
 import { FieldKind } from "../modular-schema";
 import { FieldKinds } from "../default-field-kinds";
-import { fail } from "../../util";
-import {
-	AllowedTypes,
-	TreeFieldSchema,
-	TreeNodeSchema,
-	schemaIsFieldNode,
-	schemaIsLeaf,
-} from "../typed-schema";
+import { AllowedTypes, TreeFieldSchema, TreeNodeSchema, schemaIsLeaf } from "../typed-schema";
 import { Context } from "./context";
-import { UnboxField, UnboxNode, UnboxNodeUnion } from "./editableTreeTypes";
+import { TreeNode, UnboxField, UnboxNode, UnboxNodeUnion } from "./editableTreeTypes";
 import { makeTree } from "./lazyTree";
 import { makeField } from "./lazyField";
 
@@ -30,18 +23,8 @@ export function unboxedTree<TSchema extends TreeNodeSchema>(
 	if (schemaIsLeaf(schema)) {
 		return cursor.value as UnboxNode<TSchema>;
 	}
-	if (schemaIsFieldNode(schema)) {
-		cursor.enterField(EmptyKey);
-		const primaryField = makeField(
-			context,
-			schema.objectNodeFields.get(EmptyKey) ?? fail("invalid schema"),
-			cursor,
-		);
-		cursor.exitField();
-		return primaryField as UnboxNode<TSchema>;
-	}
 
-	return makeTree(context, cursor) as UnboxNode<TSchema>;
+	return makeTree(context, cursor) as TreeNode as UnboxNode<TSchema>;
 }
 
 /**

--- a/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
+++ b/experimental/dds/tree2/src/test/domains/schemaBuilder.spec.ts
@@ -18,7 +18,7 @@ import {
 	SharedTreeObject,
 } from "../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
-import { TypedNode, UnboxNode } from "../../feature-libraries/editable-tree-2/editableTreeTypes";
+import { TypedNode } from "../../feature-libraries/editable-tree-2/editableTreeTypes";
 import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../../util";
 // eslint-disable-next-line import/no-internal-modules
 import { structuralName } from "../../domains/schemaBuilder";
@@ -39,7 +39,7 @@ describe("domains - SchemaBuilder", () => {
 						.get("")
 						.equals(TreeFieldSchema.create(FieldKinds.sequence, [Any])),
 				);
-				type ListAny = UnboxNode<typeof listAny>;
+				type ListAny = TypedNode<typeof listAny>["content"];
 				type _check = requireTrue<areSafelyAssignable<ListAny, Sequence<readonly [Any]>>>;
 
 				assert.equal(builder.list(Any), listAny);
@@ -56,9 +56,9 @@ describe("domains - SchemaBuilder", () => {
 						.get("")
 						.equals(TreeFieldSchema.create(FieldKinds.sequence, [builder.number])),
 				);
-				type ListAny = UnboxNode<typeof listImplicit>;
+				type ListImplicit = TypedNode<typeof listImplicit>["content"];
 				type _check = requireTrue<
-					areSafelyAssignable<ListAny, Sequence<readonly [typeof builder.number]>>
+					areSafelyAssignable<ListImplicit, Sequence<readonly [typeof builder.number]>>
 				>;
 
 				assert.equal(builder.list(builder.number), listImplicit);
@@ -94,10 +94,10 @@ describe("domains - SchemaBuilder", () => {
 							]),
 						),
 				);
-				type ListAny = UnboxNode<typeof listUnion>;
+				type ListUnion = TypedNode<typeof listUnion>["content"];
 				type _check = requireTrue<
 					areSafelyAssignable<
-						ListAny,
+						ListUnion,
 						Sequence<readonly [typeof builder.number, typeof builder.boolean]>
 					>
 				>;
@@ -105,7 +105,7 @@ describe("domains - SchemaBuilder", () => {
 				type _check2 = requireTrue<
 					// @ts-expect-error Currently not order independent: ideally this would compile
 					areSafelyAssignable<
-						ListAny,
+						ListUnion,
 						Sequence<readonly [typeof builder.boolean, typeof builder.number]>
 					>
 				>;
@@ -127,9 +127,9 @@ describe("domains - SchemaBuilder", () => {
 						.get("")
 						.equals(TreeFieldSchema.create(FieldKinds.sequence, [builder.number])),
 				);
-				type ListAny = UnboxNode<typeof list>;
+				type List = TypedNode<typeof list>["content"];
 				type _check = requireTrue<
-					areSafelyAssignable<ListAny, Sequence<readonly [typeof builder.number]>>
+					areSafelyAssignable<List, Sequence<readonly [typeof builder.number]>>
 				>;
 
 				// Not cached for structural use

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/editableTreeTypes.spec.ts
@@ -381,8 +381,9 @@ describe("editableTreeTypes", () => {
 		// Unboxed FieldNode
 		{
 			type UnboxedFieldNode = UnboxNodeUnion<[typeof basicFieldNode]>;
-			type _1 = requireTrue<areSafelyAssignable<TreeNode | undefined, UnboxedFieldNode>>;
-			// @ts-expect-error union can unbox to undefined
+			type _1 = requireTrue<
+				areSafelyAssignable<TypedNode<typeof basicFieldNode>, UnboxedFieldNode>
+			>;
 			type _2 = requireAssignableTo<UnboxedFieldNode, TreeNode>;
 		}
 		// Recursive

--- a/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/editable-tree-2/lazyTree.spec.ts
@@ -633,7 +633,6 @@ function checkPropertyInvariants(root: TreeEntity): void {
 
 	const unboxable = new Set([
 		LazyLeaf.prototype,
-		LazyFieldNode.prototype,
 		LazyValueField.prototype,
 		LazyOptionalField.prototype,
 	]);


### PR DESCRIPTION
## Description

FieldNodes in editable-tree will no longer implicitly unbox.

This means unboxing now removes at most 2 tree levels (leaf in an unboxing field) instead of potentially infinite.
This simplifies typing a bit, fixes an issue where recursive field nodes were lossy when traversing enumerable own properties, and better aligns with how the Proxy API handles Lists.

## Breaking Changes

Use `.content` to access the content of field nodes in cases where they no longer implicitly unbox to that.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
