### PR TITLE
Cluster capacity request

### DIFF
--- a/packages/runtime/container-runtime/src/id-compressor/idCompressor.ts
+++ b/packages/runtime/container-runtime/src/id-compressor/idCompressor.ts
@@ -16,7 +16,6 @@ import {
 	SessionId,
 	SessionSpaceCompressedId,
 	StableId,
-	initialClusterCapacity,
 } from "@fluidframework/runtime-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
@@ -80,15 +79,21 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	// The gen count to be annotated on the range returned by the next call to `takeNextCreationRange`.
 	// This is updated to be equal to `generatedIdCount` + 1 each time it is called.
 	private nextRangeBaseGenCount = 1;
-	// The capacity of the next cluster to be created
-	private newClusterCapacity = initialClusterCapacity;
 	private readonly sessions = new Sessions();
 	private readonly finalSpace = new FinalSpace();
 
 	// -----------------------
 
-	// ----- Telemetry state -----
+	// ----- Ephemeral state -----
 
+	/**
+	 * Roughly equates to a minimum of 1M sessions before we start allocating 64 bit IDs.
+	 * This value must *NOT* change without careful consideration to compatibility.
+	 * Eventually, this can be adjusted dynamically to have cluster reservation policies that
+	 * optimize the number of eager finals.
+	 * Exposed only for tests to override during clear-box testing.
+	 */
+	public nextRequestedClusterSizeOverride: number = 512;
 	// The number of local IDs generated since the last telemetry was sent.
 	private telemetryLocalIdCount = 0;
 	// The number of eager final IDs generated since the last telemetry was sent.
@@ -143,27 +148,6 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		return compressor;
 	}
 
-	/**
-	 * The size of each newly created ID cluster.
-	 */
-	public get clusterCapacity(): number {
-		return this.newClusterCapacity;
-	}
-
-	/**
-	 * Must only be set with a value upon which consensus has been reached. Value must be greater than zero and less than
-	 * `IdCompressor.maxClusterSize`.
-	 */
-	public set clusterCapacity(value: number) {
-		if (value <= 0) {
-			throw new Error("Clusters must have a positive capacity.");
-		}
-		if (value > IdCompressor.maxClusterSize) {
-			throw new Error("Clusters must not exceed max cluster size.");
-		}
-		this.newClusterCapacity = value;
-	}
-
 	public generateCompressedId(): SessionSpaceCompressedId {
 		this.localGenCount++;
 		const lastCluster = this.localSession.getLastCluster();
@@ -207,10 +191,25 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			ids: {
 				firstGenCount: this.nextRangeBaseGenCount,
 				count,
+				requestedClusterSize: this.nextRequestedClusterSizeOverride,
 			},
 		};
 		this.nextRangeBaseGenCount = this.localGenCount + 1;
+		IdCompressor.assertValidRange(range);
 		return range;
+	}
+
+	private static assertValidRange(range: IdCreationRange): void {
+		if (range.ids === undefined) {
+			return;
+		}
+		const { count, requestedClusterSize } = range.ids;
+		assert(count > 0, 0x755 /* Malformed ID Range. */);
+		assert(requestedClusterSize > 0, "Clusters must have a positive capacity.");
+		assert(
+			requestedClusterSize <= IdCompressor.maxClusterSize,
+			"Clusters must not exceed max cluster size.",
+		);
 	}
 
 	public finalizeCreationRange(range: IdCreationRange): void {
@@ -219,9 +218,9 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			return;
 		}
 
-		assert(range.ids.count > 0, 0x755 /* Malformed ID Range. */);
+		IdCompressor.assertValidRange(range);
 		const { sessionId, ids } = range;
-		const { count, firstGenCount } = ids;
+		const { count, firstGenCount, requestedClusterSize } = ids;
 		const session = this.sessions.getOrCreate(sessionId);
 		const isLocal = session === this.localSession;
 		const rangeBaseLocal = localIdFromGenCount(firstGenCount);
@@ -231,7 +230,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			if (rangeBaseLocal !== -1) {
 				throw new Error("Ranges finalized out of order.");
 			}
-			lastCluster = this.addEmptyCluster(session, this.clusterCapacity + count);
+			lastCluster = this.addEmptyCluster(session, requestedClusterSize + count);
 			if (isLocal) {
 				this.logger?.sendTelemetryEvent({
 					eventName: "RuntimeIdCompressor:FirstCluster",
@@ -250,7 +249,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			lastCluster.count += count;
 		} else {
 			const overflow = count - remainingCapacity;
-			const newClaimedFinalCount = overflow + this.clusterCapacity;
+			const newClaimedFinalCount = overflow + requestedClusterSize;
 			if (lastCluster === this.finalSpace.getLastCluster()) {
 				// The last cluster in the sessions chain is the last cluster globally, so it can be expanded.
 				lastCluster.capacity += newClaimedFinalCount;
@@ -480,7 +479,6 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		const totalSize =
 			1 + // version
 			1 + // hasLocalState
-			1 + // cluster capacity
 			1 + // session count
 			1 + // cluster count
 			sessionIndexMap.size * 2 + // session IDs
@@ -492,7 +490,6 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		let index = 0;
 		index = writeNumber(serializedFloat, index, currentWrittenVersion);
 		index = writeBoolean(serializedFloat, index, hasLocalState);
-		index = writeNumber(serializedFloat, index, this.clusterCapacity);
 		index = writeNumber(serializedFloat, index, sessionIndexMap.size);
 		index = writeNumber(serializedFloat, index, finalSpace.clusters.length);
 
@@ -549,7 +546,6 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		const version = readNumber(index);
 		assert(version === currentWrittenVersion, 0x75c /* Unknown serialized version. */);
 		const hasLocalState = readBoolean(index);
-		const clusterCapacity = readNumber(index);
 		const sessionCount = readNumber(index);
 		const clusterCount = readNumber(index);
 
@@ -575,7 +571,6 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		}
 
 		const compressor = new IdCompressor(new Sessions(sessions));
-		compressor.clusterCapacity = clusterCapacity;
 
 		// Clusters
 		let baseFinalId = 0;
@@ -622,7 +617,6 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			return false;
 		}
 		return (
-			this.newClusterCapacity === other.newClusterCapacity &&
 			this.sessions.equals(other.sessions, includeLocalState) &&
 			this.finalSpace.equals(other.finalSpace)
 		);

--- a/packages/runtime/container-runtime/src/id-compressor/idCompressor.ts
+++ b/packages/runtime/container-runtime/src/id-compressor/idCompressor.ts
@@ -88,12 +88,12 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 	/**
 	 * Roughly equates to a minimum of 1M sessions before we start allocating 64 bit IDs.
-	 * This value must *NOT* change without careful consideration to compatibility.
 	 * Eventually, this can be adjusted dynamically to have cluster reservation policies that
 	 * optimize the number of eager finals.
-	 * Exposed only for tests to override during clear-box testing.
+	 * It is not readonly as it is accessed by tests for clear-box testing.
 	 */
-	public nextRequestedClusterSizeOverride: number = 512;
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly
+	private nextRequestedClusterSize: number = 512;
 	// The number of local IDs generated since the last telemetry was sent.
 	private telemetryLocalIdCount = 0;
 	// The number of eager final IDs generated since the last telemetry was sent.
@@ -191,7 +191,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			ids: {
 				firstGenCount: this.nextRangeBaseGenCount,
 				count,
-				requestedClusterSize: this.nextRequestedClusterSizeOverride,
+				requestedClusterSize: this.nextRequestedClusterSize,
 			},
 		};
 		this.nextRangeBaseGenCount = this.localGenCount + 1;

--- a/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.perf.spec.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.perf.spec.ts
@@ -225,11 +225,13 @@ describe("IdCompressor Perf", () => {
 				for (let clusterCount = 0; clusterCount < 5; clusterCount++) {
 					network.allocateAndSendIds(
 						localClient,
-						perfCompressor.nextRequestedClusterSizeOverride,
+						// eslint-disable-next-line @typescript-eslint/dot-notation
+						perfCompressor["nextRequestedClusterSize"],
 					);
 					network.allocateAndSendIds(
 						remoteClient,
-						perfCompressor.nextRequestedClusterSizeOverride * 2,
+						// eslint-disable-next-line @typescript-eslint/dot-notation
+						perfCompressor["nextRequestedClusterSize"] * 2,
 					);
 					network.deliverOperations(DestinationClient.All);
 				}
@@ -252,7 +254,8 @@ describe("IdCompressor Perf", () => {
 			// Ensure no eager finals
 			network.allocateAndSendIds(
 				localClient,
-				network.getCompressor(localClient).nextRequestedClusterSizeOverride * 2 + 1,
+				// eslint-disable-next-line @typescript-eslint/dot-notation
+				network.getCompressor(localClient)["nextRequestedClusterSize"] * 2 + 1,
 			);
 			unackedLocalId = getIdMadeBy(localClient, false, network);
 			assert(

--- a/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.perf.spec.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.perf.spec.ts
@@ -42,7 +42,7 @@ describe("IdCompressor Perf", () => {
 		synchronizeAtEnd: boolean,
 	): IdCompressorTestNetwork {
 		const perfNetwork = new IdCompressorTestNetwork(clusterSize);
-		const maxClusterSize = 25;
+		const maxClusterSize = clusterSize * 2;
 		const generator = take(
 			1000,
 			makeOpGenerator({
@@ -51,9 +51,6 @@ describe("IdCompressor Perf", () => {
 				outsideAllocationFraction: 0.9,
 			}),
 		);
-		if (perfNetwork.initialClusterSize > maxClusterSize) {
-			perfNetwork.enqueueCapacityChange(maxClusterSize);
-		}
 		performFuzzActions(
 			generator,
 			perfNetwork,
@@ -251,7 +248,7 @@ describe("IdCompressor Perf", () => {
 		type,
 		title: `normalize an unacked local ID from the local session to op space`,
 		before: () => {
-			const network = setupCompressors(15, true, false);
+			const network = setupCompressors(initialClusterCapacity, true, false);
 			// Ensure no eager finals
 			network.allocateAndSendIds(
 				localClient,

--- a/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.spec.ts
@@ -29,22 +29,6 @@ import {
 import { LocalCompressedId, incrementStableId, isFinalId, isLocalId, fail } from "./testCommon";
 
 describe("IdCompressor", () => {
-	it("detects invalid cluster sizes", () => {
-		const compressor = CompressorFactory.createCompressor(Client.Client1, 1);
-		assert.throws(
-			() => (compressor.clusterCapacity = -1),
-			(e: Error) => validateAssertionError(e, "Clusters must have a positive capacity."),
-		);
-		assert.throws(
-			() => (compressor.clusterCapacity = 0),
-			(e: Error) => validateAssertionError(e, "Clusters must have a positive capacity."),
-		);
-		assert.throws(
-			() => (compressor.clusterCapacity = 2 ** 20 + 1),
-			(e: Error) => validateAssertionError(e, "Clusters must not exceed max cluster size."),
-		);
-	});
-
 	it("reports the proper session ID", () => {
 		const sessionId = createSessionId();
 		const compressor = CompressorFactory.createCompressorWithSession(sessionId);
@@ -712,7 +696,7 @@ describe("IdCompressor", () => {
 			mockLogger.assertMatchAny([
 				{
 					eventName: "RuntimeIdCompressor:SerializedIdCompressorSize",
-					size: 80,
+					size: 72,
 					clusterCount: 1,
 					sessionCount: 1,
 				},
@@ -979,23 +963,6 @@ describe("IdCompressor", () => {
 			network.deliverOperations(DestinationClient.All);
 		});
 
-		itNetwork("can set the cluster size via API", 2, (network) => {
-			const compressor = network.getCompressor(Client.Client1);
-			const compressor2 = network.getCompressor(Client.Client2);
-			const initialClusterCapacity = compressor.clusterCapacity;
-			network.allocateAndSendIds(Client.Client1, 1);
-			network.allocateAndSendIds(Client.Client2, 1);
-			network.enqueueCapacityChange(5);
-			network.allocateAndSendIds(Client.Client1, 3);
-			const opSpaceIds = network.allocateAndSendIds(Client.Client2, 3);
-			network.deliverOperations(DestinationClient.All);
-			// Glass box test, as it knows the order of final IDs
-			assert.equal(
-				compressor.normalizeToSessionSpace(opSpaceIds[2], compressor2.localSessionId),
-				(initialClusterCapacity + 1) * 2 + compressor.clusterCapacity + 1,
-			);
-		});
-
 		itNetwork("does not decompress ids for empty parts of clusters", 2, (network) => {
 			// This is a glass box test in that it creates a final ID outside of the ID compressor
 			network.allocateAndSendIds(Client.Client1, 1);
@@ -1015,14 +982,17 @@ describe("IdCompressor", () => {
 				network.allocateAndSendIds(Client.Client1, 3);
 				network.allocateAndSendIds(
 					Client.Client2,
-					network.getCompressor(Client.Client2).clusterCapacity * 2,
+
+					network.getCompressor(Client.Client2).nextRequestedClusterSizeOverride * 2,
 				);
 				network.allocateAndSendIds(Client.Client3, 5);
 				expectSequencedLogsAlign(network, Client.Client1, Client.Client2);
 			});
 
 			itNetwork("can finalize a range when the current cluster is full", 5, (network) => {
-				const clusterCapacity = network.getCompressor(Client.Client1).clusterCapacity;
+				const clusterCapacity = network.getCompressor(
+					Client.Client1,
+				).nextRequestedClusterSizeOverride;
 				network.allocateAndSendIds(Client.Client1, clusterCapacity);
 				network.allocateAndSendIds(Client.Client2, clusterCapacity);
 				network.allocateAndSendIds(Client.Client1, clusterCapacity);
@@ -1030,7 +1000,9 @@ describe("IdCompressor", () => {
 			});
 
 			itNetwork("can finalize a range that spans multiple clusters", 5, (network) => {
-				const clusterCapacity = network.getCompressor(Client.Client1).clusterCapacity;
+				const clusterCapacity = network.getCompressor(
+					Client.Client1,
+				).nextRequestedClusterSizeOverride;
 				network.allocateAndSendIds(Client.Client1, 1);
 				network.allocateAndSendIds(Client.Client2, 1);
 				network.allocateAndSendIds(Client.Client1, clusterCapacity * 3);
@@ -1104,31 +1076,13 @@ describe("IdCompressor", () => {
 				expectSerializes(network.getCompressor(Client.Client3));
 			});
 
-			// TODO: test in Rust
-			// itNetwork(
-			// 	"packs IDs into a single cluster when a single client generates non-overridden ids",
-			// 	3,
-			// 	(network) => {
-			// 		network.allocateAndSendIds(Client.Client1, 20);
-			// 		network.deliverOperations(DestinationClient.All);
-			// 		const [serialized1WithNoSession, serialized1WithSession] = expectSerializes(
-			// 			network.getCompressor(Client.Client1),
-			// 		);
-			// 		assert.equal(serialized1WithNoSession.clusters.length, 1);
-			// 		assert.equal(serialized1WithSession.clusters.length, 1);
-			// 		const [serialized3WithNoSession, serialized3WithSession] = expectSerializes(
-			// 			network.getCompressor(Client.Client3),
-			// 		);
-			// 		assert.equal(serialized3WithNoSession.clusters.length, 1);
-			// 		assert.equal(serialized3WithSession.clusters.length, 1);
-			// 	},
-			// );
-
 			itNetwork(
 				"can resume a session and interact with multiple other clients",
 				3,
 				(network) => {
-					const clusterSize = network.getCompressor(Client.Client1).clusterCapacity;
+					const clusterSize = network.getCompressor(
+						Client.Client1,
+					).nextRequestedClusterSizeOverride;
 					network.allocateAndSendIds(Client.Client1, clusterSize);
 					network.allocateAndSendIds(Client.Client2, clusterSize);
 					network.allocateAndSendIds(Client.Client3, clusterSize);

--- a/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/idCompressor.spec.ts
@@ -983,7 +983,8 @@ describe("IdCompressor", () => {
 				network.allocateAndSendIds(
 					Client.Client2,
 
-					network.getCompressor(Client.Client2).nextRequestedClusterSizeOverride * 2,
+					// eslint-disable-next-line @typescript-eslint/dot-notation
+					network.getCompressor(Client.Client2)["nextRequestedClusterSize"] * 2,
 				);
 				network.allocateAndSendIds(Client.Client3, 5);
 				expectSequencedLogsAlign(network, Client.Client1, Client.Client2);
@@ -992,7 +993,8 @@ describe("IdCompressor", () => {
 			itNetwork("can finalize a range when the current cluster is full", 5, (network) => {
 				const clusterCapacity = network.getCompressor(
 					Client.Client1,
-				).nextRequestedClusterSizeOverride;
+					// eslint-disable-next-line @typescript-eslint/dot-notation
+				)["nextRequestedClusterSize"];
 				network.allocateAndSendIds(Client.Client1, clusterCapacity);
 				network.allocateAndSendIds(Client.Client2, clusterCapacity);
 				network.allocateAndSendIds(Client.Client1, clusterCapacity);
@@ -1002,7 +1004,8 @@ describe("IdCompressor", () => {
 			itNetwork("can finalize a range that spans multiple clusters", 5, (network) => {
 				const clusterCapacity = network.getCompressor(
 					Client.Client1,
-				).nextRequestedClusterSizeOverride;
+					// eslint-disable-next-line @typescript-eslint/dot-notation
+				)["nextRequestedClusterSize"];
 				network.allocateAndSendIds(Client.Client1, 1);
 				network.allocateAndSendIds(Client.Client2, 1);
 				network.allocateAndSendIds(Client.Client1, clusterCapacity * 3);
@@ -1082,7 +1085,8 @@ describe("IdCompressor", () => {
 				(network) => {
 					const clusterSize = network.getCompressor(
 						Client.Client1,
-					).nextRequestedClusterSizeOverride;
+						// eslint-disable-next-line @typescript-eslint/dot-notation
+					)["nextRequestedClusterSize"];
 					network.allocateAndSendIds(Client.Client1, clusterSize);
 					network.allocateAndSendIds(Client.Client2, clusterSize);
 					network.allocateAndSendIds(Client.Client3, clusterSize);

--- a/packages/runtime/container-runtime/src/test/id-compressor/idCompressorTestUtilities.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/idCompressorTestUtilities.ts
@@ -97,7 +97,8 @@ export class CompressorFactory {
 		logger?: ITelemetryBaseLogger,
 	): IdCompressor {
 		const compressor = IdCompressor.create(sessionId, logger);
-		compressor.nextRequestedClusterSizeOverride = clusterCapacity;
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		compressor["nextRequestedClusterSize"] = clusterCapacity;
 		return compressor;
 	}
 }
@@ -277,7 +278,8 @@ export class IdCompressorTestNetwork {
 	 * Changes the capacity request amount for a client. It will take effect immediately.
 	 */
 	public changeCapacity(client: Client, newClusterCapacity: number): void {
-		this.compressors.get(client).nextRequestedClusterSizeOverride = newClusterCapacity;
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		this.compressors.get(client)["nextRequestedClusterSize"] = newClusterCapacity;
 	}
 
 	private addNewId(
@@ -328,8 +330,10 @@ export class IdCompressorTestNetwork {
 				ids: {
 					firstGenCount: 1,
 					count: numIds,
-					requestedClusterSize: this.getCompressor(Client.Client1)
-						.nextRequestedClusterSizeOverride,
+					requestedClusterSize: this.getCompressor(Client.Client1)[
+						// eslint-disable-next-line @typescript-eslint/dot-notation
+						"nextRequestedClusterSize"
+					],
 				},
 			};
 			const opSpaceIds: OpSpaceCompressedId[] = [];

--- a/packages/runtime/container-runtime/src/test/id-compressor/idCompressorTestUtilities.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/idCompressorTestUtilities.ts
@@ -97,7 +97,7 @@ export class CompressorFactory {
 		logger?: ITelemetryBaseLogger,
 	): IdCompressor {
 		const compressor = IdCompressor.create(sessionId, logger);
-		compressor.clusterCapacity = clusterCapacity;
+		compressor.nextRequestedClusterSizeOverride = clusterCapacity;
 		return compressor;
 	}
 }
@@ -129,6 +129,7 @@ export function buildHugeCompressor(
 			ids: {
 				firstGenCount: Math.floor(i / numSessions) * capacity + 1,
 				count: capacity,
+				requestedClusterSize: capacity,
 			},
 		});
 	}
@@ -330,6 +331,8 @@ export class IdCompressorTestNetwork {
 				ids: {
 					firstGenCount: 1,
 					count: numIds,
+					requestedClusterSize: this.getCompressor(Client.Client1)
+						.nextRequestedClusterSizeOverride,
 				},
 			};
 			const opSpaceIds: OpSpaceCompressedId[] = [];
@@ -380,7 +383,7 @@ export class IdCompressorTestNetwork {
 			for (let i = this.clientProgress.get(clientTo); i < opIndexBound; i++) {
 				const operation = this.serverOperations[i];
 				if (typeof operation === "number") {
-					compressorTo.clusterCapacity = operation;
+					compressorTo.nextRequestedClusterSizeOverride = operation;
 				} else {
 					const [range, opSpaceIds, clientFrom, sessionIdFrom] = operation;
 					compressorTo.finalizeCreationRange(range);

--- a/packages/runtime/container-runtime/src/test/id-compressor/testCommon.ts
+++ b/packages/runtime/container-runtime/src/test/id-compressor/testCommon.ts
@@ -98,16 +98,13 @@ export function incrementStableId(stableId: StableId, offset: number): StableId 
 }
 
 /** An immutable view of an `IdCompressor` */
-export interface ReadonlyIdCompressor
-	extends Omit<
-		IdCompressor,
-		| "generateCompressedId"
-		| "generateCompressedIdRange"
-		| "takeNextCreationRange"
-		| "finalizeCreationRange"
-	> {
-	readonly clusterCapacity: number;
-}
+export type ReadonlyIdCompressor = Omit<
+	IdCompressor,
+	| "generateCompressedId"
+	| "generateCompressedIdRange"
+	| "takeNextCreationRange"
+	| "finalizeCreationRange"
+>;
 
 /**
  * Asserts a value is not undefined, and returns the value.

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -171,6 +171,7 @@ export interface IdCreationRange {
     readonly ids?: {
         readonly firstGenCount: number;
         readonly count: number;
+        readonly requestedClusterSize: number;
     };
     // (undocumented)
     readonly sessionId: SessionId;
@@ -338,9 +339,6 @@ export interface IInboundSignalMessage extends ISignalMessage {
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
     snapshot: IAttachMessage["snapshot"] | null;
 };
-
-// @public
-export const initialClusterCapacity = 512;
 
 // @public (undocumented)
 export interface IProvideFluidDataStoreFactory {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -59,6 +59,17 @@
 			"RemovedTypeAliasDeclaration_IdCreationRangeWithStashedState": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IdCreationRange": {
+				"forwardCompat": false
+			},
+			"VariableDeclaration_initialClusterCapacity": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedVariableDeclaration_initialClusterCapacity": {
+				"forwardCompat": false,
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-definitions/src/id-compressor/index.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/index.ts
@@ -8,7 +8,6 @@ export {
 	SerializedIdCompressor,
 	SerializedIdCompressorWithNoSession,
 	SerializedIdCompressorWithOngoingSession,
-	initialClusterCapacity,
 } from "./persisted-types";
 
 export { IIdCompressorCore, IIdCompressor } from "./idCompressor";

--- a/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
@@ -34,8 +34,21 @@ export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & 
 export interface IdCreationRange {
 	readonly sessionId: SessionId;
 	readonly ids?: {
+		/**
+		 * The gen count of the first ID in the range created by `sessionId.`
+		 */
 		readonly firstGenCount: number;
+
+		/**
+		 * The number of IDs created in the range created by `sessionId.`
+		 */
 		readonly count: number;
+
+		/**
+		 * The size of the ID cluster to create if `count` overflows the existing cluster for
+		 * `sessionId`, if one exists. This request will be respected, and the size of the cluster
+		 * will be equal to overflow + `requestedClusterSize`.
+		 */
 		readonly requestedClusterSize: number;
 	};
 }

--- a/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
@@ -36,11 +36,6 @@ export interface IdCreationRange {
 	readonly ids?: {
 		readonly firstGenCount: number;
 		readonly count: number;
+		readonly requestedClusterSize: number;
 	};
 }
-
-/**
- * Roughly equates to a minimum of 1M sessions before we start allocating 64 bit IDs.
- * This value must *NOT* change without careful consideration to compatibility.
- */
-export const initialClusterCapacity = 512;

--- a/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/index.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/index.ts
@@ -8,5 +8,4 @@ export {
 	SerializedIdCompressor,
 	SerializedIdCompressorWithNoSession,
 	SerializedIdCompressorWithOngoingSession,
-	initialClusterCapacity,
 } from "./0.0.1";

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -76,5 +76,4 @@ export {
 	SessionId,
 	StableId,
 	IdCreationRange,
-	initialClusterCapacity,
 } from "./id-compressor";

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -1015,6 +1015,7 @@ declare function get_old_InterfaceDeclaration_IdCreationRange():
 declare function use_current_InterfaceDeclaration_IdCreationRange(
     use: TypeOnly<current.IdCreationRange>);
 use_current_InterfaceDeclaration_IdCreationRange(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IdCreationRange());
 
 /*
@@ -1548,26 +1549,14 @@ use_old_VariableDeclaration_gcTreeKey(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "VariableDeclaration_initialClusterCapacity": {"forwardCompat": false}
+* "RemovedVariableDeclaration_initialClusterCapacity": {"forwardCompat": false}
 */
-declare function get_old_VariableDeclaration_initialClusterCapacity():
-    TypeOnly<typeof old.initialClusterCapacity>;
-declare function use_current_VariableDeclaration_initialClusterCapacity(
-    use: TypeOnly<typeof current.initialClusterCapacity>);
-use_current_VariableDeclaration_initialClusterCapacity(
-    get_old_VariableDeclaration_initialClusterCapacity());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "VariableDeclaration_initialClusterCapacity": {"backCompat": false}
+* "RemovedVariableDeclaration_initialClusterCapacity": {"backCompat": false}
 */
-declare function get_current_VariableDeclaration_initialClusterCapacity():
-    TypeOnly<typeof current.initialClusterCapacity>;
-declare function use_old_VariableDeclaration_initialClusterCapacity(
-    use: TypeOnly<typeof old.initialClusterCapacity>);
-use_old_VariableDeclaration_initialClusterCapacity(
-    get_current_VariableDeclaration_initialClusterCapacity());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -720,8 +720,8 @@ describeNoCompat("IdCompressor Summaries", (getTestObjectProvider) => {
 		const base64Content = (compressorSummary as any).content as string;
 		const floatView = new Float64Array(stringToBuffer(base64Content, "base64"));
 		return {
-			sessionCount: floatView[3],
-			clusterCount: floatView[4],
+			sessionCount: floatView[2],
+			clusterCount: floatView[3],
 		};
 	}
 


### PR DESCRIPTION
## Description

This change annotates the compressor creation ranges with the desired cluster size. This allows for future "smart" request policies without needed to make a format change, as the policy can be run by one client without sequencing.

## Breaking Changes

This breaks the IdCompressor persisted format, but no code yet uses it so this is acceptable.