### PR TITLE
Remove requestResolvedObjectFromContainer

### DIFF
--- a/.changeset/tangy-geckos-swim.md
+++ b/.changeset/tangy-geckos-swim.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-loader": major
+---
+
+Removed `requestResolvedObjectFromContainer`
+
+The helper function `requestResolvedObjectFromContainer` has been removed. Please remove all calls to it and instead use the new `entryPoint` pattern. See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

--- a/packages/common/core-interfaces/Removing-IFluidRouter.md
+++ b/packages/common/core-interfaces/Removing-IFluidRouter.md
@@ -114,6 +114,6 @@ const entryPoint = await container.getEntryPoint();
 | `request` and `IFluidRouter` on `IDataStore`                                                 | 2.0.0-internal.7.0.0 |                      |
 | `IFluidRouter` and `IProvideFluidRouter`                                                     | 2.0.0-internal.7.0.0 |                      |
 | `requestFluidObject`                                                                         | 2.0.0-internal.7.0.0 |                      |
-| `requestResolvedObjectFromContainer`                                                         | 2.0.0-internal.7.0.0 |                      |
+| `requestResolvedObjectFromContainer`                                                         | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
 | `getDefaultObjectFromContainer`, `getObjectWithIdFromContainer` and `getObjectFromContainer` | 2.0.0-internal.7.0.0 |                      |
 <!-- prettier-ignore-end -->

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -22,7 +22,6 @@ import { IProtocolHandler as IProtocolHandler_2 } from '@fluidframework/protocol
 import { IProvideFluidCodeDetailsComparer } from '@fluidframework/container-definitions';
 import { IQuorumSnapshot } from '@fluidframework/protocol-base';
 import { IRequest } from '@fluidframework/core-interfaces';
-import { IRequestHeader } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
@@ -135,9 +134,6 @@ export class Loader implements IHostLoader {
 
 // @public
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
-
-// @public @deprecated
-export function requestResolvedObjectFromContainer(container: IContainer, headers?: IRequestHeader): Promise<IResponse>;
 
 // @public
 export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger): Promise<T>;

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -105,6 +105,11 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedFunctionDeclaration_requestResolvedObjectFromContainer": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -13,7 +13,6 @@ export {
 	ILoaderProps,
 	ILoaderServices,
 	Loader,
-	requestResolvedObjectFromContainer,
 } from "./loader";
 export {
 	isLocationRedirectionError,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -20,7 +20,6 @@ import {
 	// eslint-disable-next-line import/no-deprecated
 	IFluidRouter,
 	IRequest,
-	IRequestHeader,
 	IResponse,
 } from "@fluidframework/core-interfaces";
 import {
@@ -268,33 +267,6 @@ export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | 
 	 */
 	getBlobIds(): string[];
 };
-
-/**
- * With an already-resolved container, we can request a component directly, without loading the container again
- * @param container - a resolved container
- * @returns component on the container
- * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
- */
-export async function requestResolvedObjectFromContainer(
-	container: IContainer,
-	headers?: IRequestHeader,
-): Promise<IResponse> {
-	ensureResolvedUrlDefined(container.resolvedUrl);
-	const parsedUrl = tryParseCompatibleResolvedUrl(container.resolvedUrl.url);
-
-	if (parsedUrl === undefined) {
-		throw new Error(`Invalid URL ${container.resolvedUrl.url}`);
-	}
-
-	// eslint-disable-next-line import/no-deprecated
-	const entryPoint: FluidObject<IFluidRouter> | undefined = await container.getEntryPoint?.();
-	const router = entryPoint?.IFluidRouter ?? container.IFluidRouter;
-
-	return router.request({
-		url: `${parsedUrl.path}${parsedUrl.query}`,
-		headers,
-	});
-}
 
 /**
  * Manages Fluid resource loading

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -336,26 +336,14 @@ use_old_FunctionDeclaration_isLocationRedirectionError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_requestResolvedObjectFromContainer": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_requestResolvedObjectFromContainer": {"forwardCompat": false}
 */
-declare function get_old_FunctionDeclaration_requestResolvedObjectFromContainer():
-    TypeOnly<typeof old.requestResolvedObjectFromContainer>;
-declare function use_current_FunctionDeclaration_requestResolvedObjectFromContainer(
-    use: TypeOnly<typeof current.requestResolvedObjectFromContainer>);
-use_current_FunctionDeclaration_requestResolvedObjectFromContainer(
-    get_old_FunctionDeclaration_requestResolvedObjectFromContainer());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_requestResolvedObjectFromContainer": {"backCompat": false}
+* "RemovedFunctionDeclaration_requestResolvedObjectFromContainer": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_requestResolvedObjectFromContainer():
-    TypeOnly<typeof current.requestResolvedObjectFromContainer>;
-declare function use_old_FunctionDeclaration_requestResolvedObjectFromContainer(
-    use: TypeOnly<typeof old.requestResolvedObjectFromContainer>);
-use_old_FunctionDeclaration_requestResolvedObjectFromContainer(
-    get_current_FunctionDeclaration_requestResolvedObjectFromContainer());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -16,11 +16,6 @@ import {
 } from "@fluid-internal/test-version-utils";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { RuntimeHeaders } from "@fluidframework/container-runtime";
-import {
-	requestResolvedObjectFromContainer,
-	waitContainerToCatchUp,
-} from "@fluidframework/container-loader";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
 // REVIEW: enable compat testing?
 describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
@@ -135,8 +130,6 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 			[testFactoryWithRequestHeaders.type, Promise.resolve(testFactoryWithRequestHeaders)],
 		],
 		requestHandlers: [innerRequestHandler],
-		// The requestResolvedObjectFromContainer expects the entryPoint to act as containerRuntime request router
-		provideEntryPoint: async (containerRuntime: IContainerRuntime) => containerRuntime,
 	});
 
 	beforeEach(async () => {
@@ -147,7 +140,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 			loader,
 			provider.driver.createCreateNewRequest(provider.documentId),
 		);
-		dataStore1 = await requestFluidObject(container, "default");
+		dataStore1 = (await container.getEntryPoint()) as TestSharedDataObject1;
 
 		dataStore2 = await testSharedDataObjectFactory2.createInstance(
 			dataStore1._context.containerRuntime,
@@ -277,29 +270,6 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		);
 	});
 
-	it("requestResolvedObjectFromContainer can handle url with query params", async () => {
-		const url = await container.getAbsoluteUrl("");
-		assert(url, "url is undefined");
-		const testUrl = `${url}${
-			url.includes("?") ? "&query1=1&query2=2&inspect=1" : "?query1=1&query2=2&inspect=1"
-		}`;
-
-		const newLoader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]]);
-		const resolvedContainer = await newLoader.resolve({ url: testUrl });
-		const response = await requestResolvedObjectFromContainer(resolvedContainer);
-		const searchParams = new URLSearchParams(response.value);
-		assert.strictEqual(
-			searchParams.get("query1"),
-			"1",
-			"request did not pass the right query to the data store",
-		);
-		assert.strictEqual(
-			searchParams.get("query2"),
-			"2",
-			"request did not pass the right query to the data store",
-		);
-	});
-
 	it("can handle requests with headers", async () => {
 		const containerUrl = await container.getAbsoluteUrl("");
 		assert(containerUrl, "url is undefined");
@@ -320,40 +290,6 @@ describeNoCompat("Loader.request", (getTestObjectProvider, apis) => {
 		};
 		// Request to the newly created data store with headers.
 		const response = await container2.request({ url: dataStoreWithRequestHeaders.id, headers });
-
-		assert.strictEqual(response.status, 200, "Did not return the correct status");
-		assert.strictEqual(
-			response.mimeType,
-			"request/headers",
-			"Did not get the correct mimeType",
-		);
-		assert.deepStrictEqual(
-			response.value,
-			headers,
-			"Did not get the correct headers in the response",
-		);
-	});
-
-	it("requestResolvedObjectFromContainer can handle requests with headers", async () => {
-		const dataStoreWithRequestHeaders = await testFactoryWithRequestHeaders.createInstance(
-			dataStore1._context.containerRuntime,
-		);
-		dataStore1._root.set("key", dataStoreWithRequestHeaders.handle);
-
-		// Flush all the ops
-		await provider.ensureSynchronized();
-
-		const url = await container.getAbsoluteUrl(dataStoreWithRequestHeaders.id);
-		assert(url, "Container should return absolute url");
-
-		const headers = { wait: false, [RuntimeHeaders.viaHandle]: true };
-		// Request to the newly created data store with headers.
-		const newLoader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]]);
-		const resolvedContainer = await newLoader.resolve({ url });
-		await waitContainerToCatchUp(resolvedContainer);
-		await provider.ensureSynchronized();
-
-		const response = await requestResolvedObjectFromContainer(resolvedContainer, headers);
 
 		assert.strictEqual(response.status, 200, "Did not return the correct status");
 		assert.strictEqual(


### PR DESCRIPTION
The helper function `requestResolvedObjectFromContainer` has been removed. Please remove all calls to it and instead use the new `entryPoint` pattern. See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

[AB#5453](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5453)