### PR TITLE
An experimental workaround to temporarily fix seed 8 fuzz test of Dir…

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -33,7 +33,7 @@ import {
 import { IChannelFactory, IChannelServices } from "@fluidframework/datastore-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { unreachableCase } from "@fluidframework/core-utils";
-import { FuzzTestMinimizer, MinimizationTransform } from "./minification";
+import { MinimizationTransform } from "./minification";
 
 export interface Client<TChannelFactory extends IChannelFactory> {
 	channel: ReturnType<TChannelFactory["create"]>;
@@ -1068,11 +1068,14 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 				throw error;
 			}
 			const operations = JSON.parse(file.toString()) as TOperation[];
+			/*
 			const minimizer = new FuzzTestMinimizer(model, options, operations, seed, saveInfo, 3);
 
 			const minimized = await minimizer.minimize();
 
-			await saveOpsToFile(saveInfo.filepath, minimized);
+			await saveOpsToFile(saveInfo.filepath, minimized); */
+
+			await saveOpsToFile(saveInfo.filepath, operations);
 
 			throw error;
 		}

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -152,7 +152,7 @@ export class MockContainerRuntime {
 	 */
 	protected readonly deltaConnections: MockDeltaConnection[] = [];
 	protected readonly pendingMessages: IMockContainerRuntimePendingMessage[] = [];
-	private readonly outbox: IInternalMockRuntimeMessage[] = [];
+	protected readonly outbox: IInternalMockRuntimeMessage[] = [];
 	/**
 	 * The runtime options this instance is using. See {@link IMockContainerRuntimeOptions}.
 	 */

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -6,6 +6,7 @@
 import { v4 as uuid } from "uuid";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { assert } from "@fluidframework/core-utils";
+// import { FlushMode } from "@fluidframework/runtime-definitions";
 import {
 	IMockContainerRuntimePendingMessage,
 	MockContainerRuntime,
@@ -82,6 +83,27 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 		if (this.connected) {
 			return super.submit(messageContent, localOpMetadata);
 		}
+
+		/*
+		switch (this.runtimeOptions.flushMode) {
+			case FlushMode.Immediate: {
+				this.addPendingMessage(messageContent, localOpMetadata, -1);
+				break;
+			}
+
+			case FlushMode.TurnBased: {
+				const message = {
+					content: messageContent,
+					localOpMetadata,
+				};
+
+				this.outbox.push(message);
+				break;
+			}
+
+			default:
+				throw new Error(`Unsupported FlushMode ${this.runtimeOptions.flushMode}`);
+		} */
 
 		this.addPendingMessage(messageContent, localOpMetadata, -1);
 		return -1;

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -6,7 +6,7 @@
 import { v4 as uuid } from "uuid";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { assert } from "@fluidframework/core-utils";
-// import { FlushMode } from "@fluidframework/runtime-definitions";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 import {
 	IMockContainerRuntimePendingMessage,
 	MockContainerRuntime,
@@ -84,7 +84,6 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 			return super.submit(messageContent, localOpMetadata);
 		}
 
-		/*
 		switch (this.runtimeOptions.flushMode) {
 			case FlushMode.Immediate: {
 				this.addPendingMessage(messageContent, localOpMetadata, -1);
@@ -103,9 +102,9 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 
 			default:
 				throw new Error(`Unsupported FlushMode ${this.runtimeOptions.flushMode}`);
-		} */
+		}
 
-		this.addPendingMessage(messageContent, localOpMetadata, -1);
+		// this.addPendingMessage(messageContent, localOpMetadata, -1);
 		return -1;
 	}
 


### PR DESCRIPTION
[AB#6044](https://dev.azure.com/fluidframework/internal/_workitems/edit/6044)

This draft PR shows a workaround to resolve the failed fuzz test of seed 8, unfortunately, it is not a comprehensive solution and it will result in some other failures. The following is an explanation and summary of the problems exposed from the seed 8, hopefully it will be helpful for the subsequent investigation.
 
```
containerRuntime3.connect()
containerRuntime3.disconnect()
directory3.deleteSubdirectory("dir1")
containerRuntime3.connect()
containerRuntime3.disconnect()
directory3.createSubdirectory("dir1")
containerRuntime3.rebase()
synchronize() // it includes flush() and processAllMessages
```

The prerequisite knowledge is: there exist two structures to hold the local messages when we enable the group batching: pendingMesages and outbox. From the above code snippet, the expected order for directory3 is to delete dir1 first and then create dir1.

Based on my observation, when directory3 delete dir1 (in disconnected state), the message `deleteSubdirectory("dir1")` is inserted to the pendingMessages. When container3 switch its state to connected, it needs to resubmit all pending mesages. However, now it will follow the submit logic of connected state, so it will move the message `deleteSubdirectory("dir1")` from the pendingMessages to the outbox.

Next, container3 is disconnected again, then directory3 creates dir1, the message `createSubdirectory("dir1")` is added to the pendingMessages. However, when container3 rebase(), the message `deleteSubdirectory("dir1")` in outbox needed to be resubmitted again, which indicates that this message will be moved from the outbox back to the pendingMessages, but now positioned after the message `createSubdirectory("dir1")`! 

Consequently, other clients will process the messages in the order createSubdirectory("dir1") => deleteSubdirectory("dir1"), causing dir1 to disappear in other clients' views while persisting in directory3 locally, resulting in a conflict.
