### PR TITLE
feat(type-tests): explicitly return void in type-test function

### DIFF
--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.28.0",
+	"version": "0.29.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.29.0",
+	"version": "0.28.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
@@ -27,7 +27,7 @@ export function buildTestCase(
 	testString.push(`declare function ${getSig}():`);
 	testString.push(`    ${toTypeString(getAsType.prefix, getAsType)};`);
 	testString.push(`declare function ${useSig}(`);
-	testString.push(`    use: ${toTypeString(useType.prefix, useType)});`);
+	testString.push(`    use: ${toTypeString(useType.prefix, useType)}): void;`);
 	testString.push(`${useSig}(`);
 	if (!isCompatible) {
 		testString.push(expectErrorString);


### PR DESCRIPTION
See https://github.com/microsoft/FluidFramework/pull/18268 for additional context. This is a necessary step in enabling `noImplicitAny` in more packages and globally.

For reviewers: am I bumping the build-tools package correctly?