### PR TITLE
Revert "build: Use link: protocol instead of file: (#18270)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
 		"@changesets/cli": "^2.26.1",
 		"@fluid-private/changelog-generator-wrapper": "file:tools/changelog-generator-wrapper",
 		"@fluid-tools/build-cli": "^0.27.0",
-		"@fluid-tools/markdown-magic": "link:tools/markdown-magic",
+		"@fluid-tools/markdown-magic": "file:tools/markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.27.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       '@changesets/cli': ^2.26.1
       '@fluid-private/changelog-generator-wrapper': file:tools/changelog-generator-wrapper
       '@fluid-tools/build-cli': ^0.27.0
-      '@fluid-tools/markdown-magic': link:tools/markdown-magic
+      '@fluid-tools/markdown-magic': file:tools/markdown-magic
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.27.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -42217,7 +42217,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.21.0
-      webpack: 5.88.2
+      webpack: 5.88.2_webpack-cli@4.10.0
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -44589,6 +44589,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.88.2_webpack-cli@4.10.0:
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}


### PR DESCRIPTION
This reverts commit be5d92d2f02dc0b7e093e15b3eb1d5b52e563d56.

Based on the documentation [here](https://pnpm.io/cli/link#whats-the-difference-between-pnpm-link-and-using-the-file-protocol), `file:` actually seems the more appropriate option over `link:`. There are some issues with `file:` that still need to be investigated (namely the claim that source-code modifications are picked up automatically, which does not always seem to be the case), but there are more immediate issues with `link:` that we wish to avoid.
