### PR TITLE
ci(client): Remove duplicate checks

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -158,7 +158,6 @@ extends:
     - nyc/packages
     checks:
     - checks
-
     additionalBuildSteps:
     - task: Bash@3
       displayName: Inject devtools telemetry logger token

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -158,11 +158,7 @@ extends:
     - nyc/packages
     checks:
     - checks
-    - syncpack:deps
-    - syncpack:versions
-    - check:versions
-    - generate:packageList
-    - prettier
+
     additionalBuildSteps:
     - task: Bash@3
       displayName: Inject devtools telemetry logger token


### PR DESCRIPTION
Now that we have validated the new "checks" script in the client CI pipeline, we can remove the duplicated checks. The "checks" task runs all of the check tasks using fluid-build.