### PR TITLE
fix(tree2): pass and leverage revision metadata in invert

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -86,6 +86,7 @@ export interface FieldChangeRebaser<TChangeset> {
 		invertChild: NodeChangeInverter,
 		genId: IdAllocator,
 		crossFieldManager: CrossFieldManager,
+		revisionMetadata: RevisionMetadataSource,
 	): TChangeset;
 
 	/**
@@ -96,6 +97,7 @@ export interface FieldChangeRebaser<TChangeset> {
 		originalRevision: RevisionTag | undefined,
 		genId: IdAllocator,
 		crossFieldManager: CrossFieldManager,
+		revisionMetadata: RevisionMetadataSource,
 	): TChangeset;
 
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -299,10 +299,14 @@ export class ModularChangeFamily
 		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable = newCrossFieldTable<InvertData>();
 
+		const { revInfos } = getRevInfoFromTaggedChanges([change]);
+		const revisionMetadata = revisionMetadataSourceFromInfo(revInfos);
+
 		const invertedFields = this.invertFieldMap(
 			tagChange(change.change.fieldChanges, change.revision),
 			genId,
 			crossFieldTable,
+			revisionMetadata,
 		);
 
 		if (crossFieldTable.invalidatedFields.size > 0) {
@@ -317,6 +321,7 @@ export class ModularChangeFamily
 					originalRevision,
 					genId,
 					newCrossFieldManager(crossFieldTable),
+					revisionMetadata,
 				);
 				fieldChange.change = brand(amendedChange);
 			}
@@ -345,6 +350,7 @@ export class ModularChangeFamily
 		changes: TaggedChange<FieldChangeMap>,
 		genId: IdAllocator,
 		crossFieldTable: CrossFieldTable<InvertData>,
+		revisionMetadata: RevisionMetadataSource,
 	): FieldChangeMap {
 		const invertedFields: FieldChangeMap = new Map();
 
@@ -362,9 +368,11 @@ export class ModularChangeFamily
 						{ revision, change: childChanges },
 						genId,
 						crossFieldTable,
+						revisionMetadata,
 					),
 				genId,
 				manager,
+				revisionMetadata,
 			);
 
 			const invertedFieldChange: FieldChange = {
@@ -389,6 +397,7 @@ export class ModularChangeFamily
 		change: TaggedChange<NodeChangeset>,
 		genId: IdAllocator,
 		crossFieldTable: CrossFieldTable<InvertData>,
+		revisionMetadata: RevisionMetadataSource,
 	): NodeChangeset {
 		const inverse: NodeChangeset = {};
 
@@ -397,6 +406,7 @@ export class ModularChangeFamily
 				{ ...change, change: change.change.fieldChanges },
 				genId,
 				crossFieldTable,
+				revisionMetadata,
 			);
 		}
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -27,7 +27,7 @@ import {
 	cloneCellId,
 	areOutputCellsEmpty,
 	isNewAttach,
-	getDetachCellId,
+	getDetachOutputId,
 	getInputCellId,
 	isTransientEffect,
 	getOutputCellId,
@@ -380,7 +380,7 @@ function rebaseMarkIgnoreChild<TNodeChange>(
 	let rebasedMark = currMark;
 	if (markEmptiesCells(baseMark)) {
 		assert(isDetach(baseMark), 0x70b /* Only detach marks should empty cells */);
-		const baseCellId = getDetachCellId(baseMark, baseRevision, metadata);
+		const baseCellId = getDetachOutputId(baseMark, baseRevision, metadata);
 
 		// TODO: Should also check if this is a transient move source
 		if (isMoveSource(baseMark)) {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -142,23 +142,23 @@ export function getOutputCellId(
 ): CellId | undefined {
 	if (markEmptiesCells(mark)) {
 		assert(isDetach(mark), 0x750 /* Only detaches can empty cells */);
-		return getDetachCellId(mark, revision, metadata);
+		return getDetachOutputId(mark, revision, metadata);
 	} else if (markFillsCells(mark)) {
 		return undefined;
 	} else if (isTransientEffect(mark)) {
-		return getDetachCellId(mark.detach, revision, metadata);
+		return getDetachOutputId(mark.detach, revision, metadata);
 	}
 
 	return getInputCellId(mark, revision, metadata);
 }
 
-export function getDetachCellId(
+export function getDetachOutputId(
 	mark: Detach,
 	revision: RevisionTag | undefined,
 	metadata: RevisionMetadataSource | undefined,
-): CellId {
+): ChangeAtomId {
 	return (
-		getOverrideCellId(mark) ?? {
+		getOverrideDetachId(mark) ?? {
 			revision: getIntentionIfMetadataProvided(mark.revision ?? revision, metadata),
 			localId: mark.id,
 		}
@@ -172,7 +172,7 @@ function getIntentionIfMetadataProvided(
 	return metadata === undefined ? revision : getIntention(revision, metadata);
 }
 
-function getOverrideCellId(mark: Detach): CellId | undefined {
+function getOverrideDetachId(mark: Detach): ChangeAtomId | undefined {
 	return mark.type !== "MoveOut" && mark.detachIdOverride !== undefined
 		? mark.detachIdOverride
 		: undefined;
@@ -470,7 +470,7 @@ function tryMergeEffects(
 	if (
 		isDetach(lhs) &&
 		isDetach(rhs) &&
-		!areMergeableCellIds(getOverrideCellId(lhs), lhsCount, getOverrideCellId(rhs))
+		!areMergeableCellIds(getOverrideDetachId(lhs), lhsCount, getOverrideDetachId(rhs))
 	) {
 		return undefined;
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -175,11 +175,13 @@ describe("defaultFieldKinds", () => {
 				return nodeChange2;
 			};
 
+			const taggedChange = { revision: mintRevisionTag(), change: change1WithChildChange };
 			const inverted = fieldHandler.rebaser.invert(
-				{ revision: mintRevisionTag(), change: change1WithChildChange },
+				taggedChange,
 				childInverter,
 				fakeIdAllocator,
 				failCrossFieldManager,
+				defaultRevisionMetadataFromChanges([taggedChange]),
 			);
 
 			assert.deepEqual(inverted.childChanges, [["self", nodeChange2]]);

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalChangeRebaser.spec.ts
@@ -114,6 +114,7 @@ function invert(change: TaggedChange<OptionalChangeset>): OptionalChangeset {
 		// Optional fields should not generate IDs during invert
 		fakeIdAllocator,
 		failCrossFieldManager,
+		defaultRevisionMetadataFromChanges([change]),
 	);
 }
 

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/optionalField.spec.ts
@@ -231,6 +231,7 @@ describe("optionalField", () => {
 					childInverter,
 					fakeIdAllocator,
 					failCrossFieldManager,
+					defaultRevisionMetadataFromChanges([change1]),
 				),
 				expected,
 			);
@@ -296,6 +297,7 @@ describe("optionalField", () => {
 						() => assert.fail("Should not need to invert children"),
 						fakeIdAllocator,
 						failCrossFieldManager,
+						defaultRevisionMetadataFromChanges([deletion]),
 					),
 					tag2,
 					tag1,
@@ -561,6 +563,7 @@ describe("optionalField", () => {
 					() => assert.fail("Should not need to invert children"),
 					fakeIdAllocator,
 					failCrossFieldManager,
+					defaultRevisionMetadataFromChanges([clear]),
 				);
 				const actual = Array.from(
 					optionalChangeHandler.relevantRemovedTrees(restore, failingDelegate),
@@ -621,6 +624,7 @@ describe("optionalField", () => {
 						() => assert.fail("Should not need to invert children"),
 						fakeIdAllocator,
 						failCrossFieldManager,
+						defaultRevisionMetadataFromChanges([clear]),
 					),
 					mintRevisionTag(),
 				);

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -21,7 +21,11 @@ import {
 	deltaForSet,
 } from "../../../core";
 import { fakeIdAllocator, brand } from "../../../util";
-import { EncodingTestData, makeEncodingTestSuite } from "../../utils";
+import {
+	EncodingTestData,
+	defaultRevisionMetadataFromChanges,
+	makeEncodingTestSuite,
+} from "../../utils";
 import { IJsonCodec } from "../../../codec";
 import { singleJsonCursor } from "../../../domains";
 import { ValueChangeset, valueField, valueHandler } from "./basicRebasers";
@@ -85,11 +89,13 @@ const childComposer = (nodeChanges: TaggedChange<NodeChangeset>[]): NodeChangese
 
 const childInverter = (nodeChange: NodeChangeset): NodeChangeset => {
 	const valueChange = valueChangeFromNodeChange(nodeChange);
+	const taggedChange = makeAnonChange(valueChange);
 	const inverse = valueHandler.rebaser.invert(
-		makeAnonChange(valueChange),
+		taggedChange,
 		unexpectedDelegate,
 		fakeIdAllocator,
 		crossFieldManager,
+		defaultRevisionMetadataFromChanges([taggedChange]),
 	);
 	return nodeChangeFromValueChange(inverse);
 };
@@ -348,11 +354,13 @@ describe("Generic FieldKind", () => {
 				nodeChange: nodeChange2To1,
 			},
 		];
+		const taggedChange = makeAnonChange(forward);
 		const actual = genericFieldKind.changeHandler.rebaser.invert(
-			makeAnonChange(forward),
+			taggedChange,
 			childInverter,
 			fakeIdAllocator,
 			crossFieldManager,
+			defaultRevisionMetadataFromChanges([taggedChange]),
 		);
 		assert.deepEqual(actual, expected);
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -15,6 +15,7 @@ import {
 	ModularChangeset,
 	RevisionInfo,
 	FieldKindWithEditor,
+	NodeChangeInverter,
 } from "../../../feature-libraries";
 import {
 	makeAnonChange,
@@ -716,6 +717,28 @@ describe("ModularChangeFamily", () => {
 			rebaseWasTested = true;
 			return change;
 		};
+		let invertWasTested = false;
+		const invert: FieldChangeRebaser<RevisionTag[]>["invert"] = (
+			change: TaggedChange<RevisionTag[]>,
+			invertChild: NodeChangeInverter,
+			genId,
+			crossFieldManager,
+			{ getIndex, tryGetInfo },
+		): RevisionTag[] => {
+			const relevantRevisions = [rev3];
+			const revsIndices: number[] = relevantRevisions.map((c) =>
+				ensureIndexDefined(getIndex(c)),
+			);
+			const revsInfos: RevisionInfo[] = relevantRevisions.map(
+				(c) => tryGetInfo(c) ?? assert.fail(),
+			);
+			assert.deepEqual(revsIndices, [0]);
+			const expected: RevisionInfo[] = [{ revision: rev3, rollbackOf: rev0 }];
+			assert.deepEqual(revsInfos, expected);
+			invertWasTested = true;
+			return change.change;
+		};
+
 		const throwCodec = {
 			encode: () => fail("Should not be called"),
 			decode: () => fail("Should not be called"),
@@ -725,6 +748,7 @@ describe("ModularChangeFamily", () => {
 				compose,
 				rebase,
 				amendRebase: (change: RevisionTag[]) => change,
+				invert,
 			},
 			isEmpty: (change: RevisionTag[]) => change.length === 0,
 			codecsFactory: () => makeCodecFamily([[0, throwCodec]]),
@@ -792,6 +816,8 @@ describe("ModularChangeFamily", () => {
 		const expectedRebaseInfo: RevisionInfo[] = [{ revision: rev4, rollbackOf: rev2 }];
 		assert.deepEqual(rebased.revisions, expectedRebaseInfo);
 		assert(rebaseWasTested);
+		dummyFamily.invert(tagRollbackInverse(changeB, rev3, rev0), false);
+		assert(invertWasTested);
 	});
 
 	function ensureIndexDefined(index: number | undefined): number {

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -10,6 +10,7 @@ import {
 	mintRevisionTag,
 	RevisionTag,
 	tagChange,
+	tagRollbackInverse,
 } from "../../../core";
 import { TestChange } from "../../testChange";
 import { deepFreeze } from "../../utils";
@@ -84,18 +85,18 @@ describe("SequenceField - Invert", () => {
 		assert.deepEqual(actual, expected);
 	});
 
-	it("delete => revive (with override ID)", () => {
-		const cellId: ChangeAtomId = { revision: tag2, localId: brand(0) };
-		const input: TestChangeset = [
-			{
-				type: "Delete",
-				count: 2,
-				id: brand(5),
-				detachIdOverride: cellId,
-			},
-		];
+	it("delete => revive (with rollback ID)", () => {
+		const detachId: ChangeAtomId = { revision: tag2, localId: brand(0) };
+		const input = tagRollbackInverse([Mark.delete(2, brand(0))], tag1, tag2);
+		const expected = [Mark.revive(2, detachId)];
+		const actual = invertChange(input);
+		assert.deepEqual(actual, expected);
+	});
 
-		const expected = Change.revive(0, 2, cellId);
+	it("delete => revive (with override ID)", () => {
+		const detachIdOverride: ChangeAtomId = { revision: tag2, localId: brand(0) };
+		const input: TestChangeset = [Mark.delete(2, brand(5), { detachIdOverride })];
+		const expected = [Mark.revive(2, detachIdOverride)];
 		const actual = invert(input);
 		assert.deepEqual(actual, expected);
 	});

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
@@ -159,6 +159,7 @@ export function invert(change: TaggedChange<TestChangeset>): TestChangeset {
 		// Sequence fields should not generate IDs during invert
 		fakeIdAllocator,
 		table,
+		defaultRevisionMetadataFromChanges([change]),
 	);
 
 	if (table.isInvalidated) {


### PR DESCRIPTION
ModularChangeFamily now passes revision metadata into invert calls so that they can leverage it.
This is needed in sequence field to produce revives that target the correct cells.