### PR TITLE
tree2: Layer TreeViews

### DIFF
--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -6,7 +6,7 @@ import {
 	AllowedUpdateType,
 	fail,
 	ISharedTree,
-	ITreeView,
+	FlexTreeView,
 	SharedTreeFactory,
 } from "@fluid-experimental/tree2";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
@@ -20,7 +20,7 @@ const treeKey = "treeKey";
 export class Bubblebench extends DataObject {
 	public static readonly Name = "@fluid-example/bubblebench-sharedtree";
 
-	private view: ITreeView<typeof rootAppStateSchema> | undefined;
+	private view: FlexTreeView<typeof rootAppStateSchema> | undefined;
 	private _appState: AppState | undefined;
 
 	protected async initializingFirstTime() {
@@ -83,7 +83,7 @@ export class Bubblebench extends DataObject {
 	 * Get the SharedTree.
 	 * Cannot be accessed until after initialization has complected.
 	 */
-	private get tree(): ITreeView<typeof rootAppStateSchema> {
+	private get tree(): FlexTreeView<typeof rootAppStateSchema> {
 		return this.view ?? fail("not initialized");
 	}
 

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -759,6 +759,14 @@ InternalTypedSchemaTypes.LazyItem<infer InnerType>
 // @alpha
 type FlexTreeUnknownUnboxed = TreeValue | FlexTreeNode;
 
+// @alpha
+export interface FlexTreeView<in out TRoot extends TreeFieldSchema> extends IDisposable {
+    readonly checkout: ITreeCheckout;
+    readonly context: TreeContext;
+    readonly editableTree: FlexTreeTypedField<TRoot>;
+    fork(): ITreeViewFork<TRoot>;
+}
+
 // @alpha (undocumented)
 interface Forbidden extends FieldKind<typeof forbiddenFieldKindIdentifier, Multiplicity.Forbidden> {
 }
@@ -998,8 +1006,8 @@ export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : fals
 // @alpha
 export interface ISharedTree extends ISharedObject, ITree {
     contentSnapshot(): SharedTreeContentSnapshot;
-    requireSchema<TRoot extends TreeFieldSchema>(schema: TreeSchema<TRoot>, onSchemaIncompatible: () => void): ITreeView<TRoot> | undefined;
-    schematizeInternal<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): ITreeView<TRoot>;
+    requireSchema<TRoot extends TreeFieldSchema>(schema: TreeSchema<TRoot>, onSchemaIncompatible: () => void): FlexTreeView<TRoot> | undefined;
+    schematizeInternal<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): FlexTreeView<TRoot>;
 }
 
 // @alpha (undocumented)
@@ -1095,16 +1103,7 @@ export enum ITreeSubscriptionCursorState {
 }
 
 // @alpha
-export interface ITreeView<in out TRoot extends TreeFieldSchema> extends IDisposable {
-    readonly checkout: ITreeCheckout;
-    readonly context: TreeContext;
-    readonly editableTree: FlexTreeTypedField<TRoot>;
-    fork(): ITreeViewFork<TRoot>;
-    readonly root: ProxyField<TRoot>;
-}
-
-// @alpha
-export interface ITreeViewFork<in out TRoot extends TreeFieldSchema> extends ITreeView<TRoot> {
+export interface ITreeViewFork<in out TRoot extends TreeFieldSchema> extends FlexTreeView<TRoot> {
     // (undocumented)
     readonly checkout: ITreeCheckoutFork;
 }

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -258,7 +258,7 @@ export {
 	TypedTreeOptions,
 	ITree,
 	SharedTreeContentSnapshot,
-	ITreeView,
+	FlexTreeView,
 	TreeView,
 	ITreeViewFork,
 	buildTreeConfiguration,

--- a/experimental/dds/tree2/src/shared-tree/index.ts
+++ b/experimental/dds/tree2/src/shared-tree/index.ts
@@ -31,4 +31,4 @@ export {
 
 export { TypedTreeFactory, TypedTreeOptions, ITree, TreeView } from "./simpleTree";
 
-export { ITreeView, CheckoutView, ITreeViewFork } from "./treeView";
+export { FlexTreeView, CheckoutFlexTreeView, ITreeViewFork } from "./treeView";

--- a/experimental/dds/tree2/src/shared-tree/treeView.ts
+++ b/experimental/dds/tree2/src/shared-tree/treeView.ts
@@ -8,11 +8,9 @@ import {
 	TreeFieldSchema,
 	TreeSchema,
 	FlexTreeTypedField,
-	ProxyField,
 	FlexTreeContext,
 	NodeKeyManager,
 	getTreeContext,
-	getProxyForField,
 	Context,
 } from "../feature-libraries";
 import { IDisposable, disposeSymbol } from "../util";
@@ -26,14 +24,9 @@ import { ITreeCheckoutFork, ITreeCheckout } from "./treeCheckout";
  * 2. This object should be combined with or accessible from the TreeContext to allow easy access to thinks like branching.
  * @alpha
  */
-export interface ITreeView<in out TRoot extends TreeFieldSchema> extends IDisposable {
+export interface FlexTreeView<in out TRoot extends TreeFieldSchema> extends IDisposable {
 	/**
-	 * The current root of the tree.
-	 */
-	readonly root: ProxyField<TRoot>;
-
-	/**
-	 * Context for controlling the EditableTree nodes produced from {@link ITreeView.editableTree}.
+	 * Context for controlling the EditableTree nodes produced from {@link FlexTreeView.editableTree}.
 	 *
 	 * @remarks
 	 * This is an owning reference: disposing of this view disposes its context.
@@ -63,20 +56,20 @@ export interface ITreeView<in out TRoot extends TreeFieldSchema> extends IDispos
 /**
  * Branch (like in a version control system) of SharedTree.
  *
- * {@link ITreeView} that has forked off of the main trunk/branch.
+ * {@link FlexTreeView} that has forked off of the main trunk/branch.
  * @alpha
  */
-export interface ITreeViewFork<in out TRoot extends TreeFieldSchema> extends ITreeView<TRoot> {
+export interface ITreeViewFork<in out TRoot extends TreeFieldSchema> extends FlexTreeView<TRoot> {
 	readonly checkout: ITreeCheckoutFork;
 }
 
 /**
- * Implementation of ITreeView wrapping a ITreeCheckout.
+ * Implementation of FlexTreeView wrapping a ITreeCheckout.
  */
-export class CheckoutView<
+export class CheckoutFlexTreeView<
 	in out TRoot extends TreeFieldSchema,
 	out TCheckout extends ITreeCheckout = ITreeCheckout,
-> implements ITreeView<TRoot>
+> implements FlexTreeView<TRoot>
 {
 	public readonly context: Context;
 	public readonly editableTree: FlexTreeTypedField<TRoot>;
@@ -102,12 +95,13 @@ export class CheckoutView<
 		this.onDispose?.();
 	}
 
-	public get root(): ProxyField<TRoot> {
-		return getProxyForField(this.editableTree);
-	}
-
-	public fork(): CheckoutView<TRoot, ITreeCheckoutFork> {
+	public fork(): CheckoutFlexTreeView<TRoot, ITreeCheckoutFork> {
 		const branch = this.checkout.fork();
-		return new CheckoutView(branch, this.schema, this.nodeKeyManager, this.nodeKeyFieldKey);
+		return new CheckoutFlexTreeView(
+			branch,
+			this.schema,
+			this.nodeKeyManager,
+			this.nodeKeyFieldKey,
+		);
 	}
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/flex-tree/events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/flex-tree/events.spec.ts
@@ -10,9 +10,7 @@ import { FieldKinds } from "../../../feature-libraries";
 import { ForestType, SharedTreeFactory } from "../../../shared-tree";
 import { typeboxValidator } from "../../../external-utilities";
 import { AllowedUpdateType, SchemaBuilder, leaf } from "../../..";
-import { viewWithContent } from "../../utils";
-// eslint-disable-next-line import/no-internal-modules
-import { getEditNode } from "../../../feature-libraries/simple-tree/editNode";
+import { flexTreeViewWithContent } from "../../utils";
 // eslint-disable-next-line import/no-internal-modules
 import { onNextChange } from "../../../feature-libraries/flex-tree/editableTreeTypes";
 
@@ -667,8 +665,8 @@ describe("onNextChange event", () => {
 	const initialTree = { content: 3 };
 
 	it("fires exactly once after a change", () => {
-		const view = viewWithContent({ schema, initialTree });
-		const editNode = getEditNode(view.root);
+		const view = flexTreeViewWithContent({ schema, initialTree });
+		const editNode = view.editableTree.content;
 		let onNextChangeCount = 0;
 		editNode[onNextChange](() => (onNextChangeCount += 1));
 		assert(editNode.is(object));
@@ -679,16 +677,16 @@ describe("onNextChange event", () => {
 	});
 
 	it("can have at most one listener at a time", () => {
-		const view = viewWithContent({ schema, initialTree });
-		const editNode = getEditNode(view.root);
+		const view = flexTreeViewWithContent({ schema, initialTree });
+		const editNode = view.editableTree.content;
 		let onNextChangeEventCount = 0;
 		editNode[onNextChange](() => (onNextChangeEventCount += 1));
 		assert.throws(() => editNode[onNextChange](() => (onNextChangeEventCount += 1)));
 	});
 
 	it("can be subscribed to again after throwing and catching an error", () => {
-		const view = viewWithContent({ schema, initialTree });
-		const editNode = getEditNode(view.root);
+		const view = flexTreeViewWithContent({ schema, initialTree });
+		const editNode = view.editableTree.content;
 		assert(editNode.is(object));
 		editNode[onNextChange](() => {
 			throw new Error();
@@ -698,8 +696,8 @@ describe("onNextChange event", () => {
 	});
 
 	it("can be unsubscribed from", () => {
-		const view = viewWithContent({ schema, initialTree });
-		const editNode = getEditNode(view.root);
+		const view = flexTreeViewWithContent({ schema, initialTree });
+		const editNode = view.editableTree.content;
 		assert(editNode.is(object));
 		let onNextChangeEventFired = false;
 		const off = editNode[onNextChange](() => {
@@ -711,8 +709,8 @@ describe("onNextChange event", () => {
 	});
 
 	it("unsubscription has no effect if the event has already fired", () => {
-		const view = viewWithContent({ schema, initialTree });
-		const editNode = getEditNode(view.root);
+		const view = flexTreeViewWithContent({ schema, initialTree });
+		const editNode = view.editableTree.content;
 		assert(editNode.is(object));
 		const off = editNode[onNextChange](() => {});
 		editNode.content = 7;

--- a/experimental/dds/tree2/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -17,7 +17,7 @@ import {
 	cursorForJsonableTreeField,
 } from "../../../feature-libraries";
 import { FieldAnchor, FieldKey, rootFieldKey, UpPath } from "../../../core";
-import { forestWithContent, viewWithContent } from "../../utils";
+import { forestWithContent, flexTreeViewWithContent } from "../../utils";
 import { leaf, leaf as leafDomain, SchemaBuilder } from "../../../domains";
 import { brand } from "../../../util";
 import {
@@ -275,7 +275,7 @@ describe("LazyOptionalField", () => {
 	});
 
 	it("content", () => {
-		const view = viewWithContent({
+		const view = flexTreeViewWithContent({
 			schema,
 			initialTree: 5,
 		});
@@ -331,7 +331,7 @@ describe("LazyValueField", () => {
 	});
 
 	it("content", () => {
-		const view = viewWithContent({
+		const view = flexTreeViewWithContent({
 			schema,
 			initialTree: "X",
 		});
@@ -361,7 +361,7 @@ describe("LazySequence", () => {
 	}
 
 	function testMutableSequence(data: number[]) {
-		const view = viewWithContent({
+		const view = flexTreeViewWithContent({
 			schema,
 			initialTree: data,
 		});

--- a/experimental/dds/tree2/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
@@ -68,7 +68,7 @@ import { Context, getTreeContext } from "../../../feature-libraries/flex-tree/co
 import { TreeContent } from "../../../shared-tree";
 import { leaf as leafDomain, SchemaBuilder } from "../../../domains";
 import { testTrees, treeContentFromTestTree } from "../../testTrees";
-import { forestWithContent, viewWithContent } from "../../utils";
+import { forestWithContent, flexTreeViewWithContent } from "../../utils";
 import { contextWithContentReadonly } from "./utils";
 
 function collectPropertyNames(obj: object): Set<string> {
@@ -405,7 +405,7 @@ describe("LazyMap", () => {
 	});
 
 	it("set", () => {
-		const view = viewWithContent({ schema, initialTree: {} });
+		const view = flexTreeViewWithContent({ schema, initialTree: {} });
 		const mapNode = view.editableTree.content;
 		assert(mapNode.is(mapNodeSchema));
 
@@ -422,7 +422,7 @@ describe("LazyMap", () => {
 	});
 
 	it("getBoxed empty", () => {
-		const view = viewWithContent({ schema, initialTree: {} });
+		const view = flexTreeViewWithContent({ schema, initialTree: {} });
 		const mapNode = view.editableTree.content;
 		assert(mapNode.is(mapNodeSchema));
 

--- a/experimental/dds/tree2/src/test/feature-libraries/simple-tree/list.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/simple-tree/list.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { viewWithContent } from "../../utils";
+import { treeViewWithContent } from "../../utils";
 import { pretty } from "./utils";
 
 const builder = new SchemaBuilder({ scope: "test" });
@@ -59,7 +59,7 @@ describe("List", () => {
 	/** Helper that creates a new SharedTree with the test schema and returns the root proxy. */
 	function createTree() {
 		// Consider 'readonlyTreeWithContent' for readonly tests?
-		const view = viewWithContent({
+		const view = treeViewWithContent({
 			schema,
 			initialTree: { numbers: { "": [] }, strings: { "": [] } },
 		});

--- a/experimental/dds/tree2/src/test/feature-libraries/simple-tree/object.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/simple-tree/object.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { LeafNodeSchema, NewFieldContent, TreeSchema } from "../../../feature-libraries";
 import { leaf, SchemaBuilder } from "../../../domains";
 import { TreeValue } from "../../../core";
-import { viewWithContent } from "../../utils";
+import { treeViewWithContent } from "../../utils";
 import { itWithRoot, makeSchema, pretty } from "./utils";
 
 interface TestCase {
@@ -39,7 +39,7 @@ function testObjectLike(testCases: TestCase[]) {
 	describe("Object-like", () => {
 		describe("satisfies 'deepEquals'", () => {
 			for (const { schema, initialTree } of testCases) {
-				const view = viewWithContent({
+				const view = treeViewWithContent({
 					schema,
 					initialTree: initialTree as NewFieldContent,
 				});

--- a/experimental/dds/tree2/src/test/feature-libraries/simple-tree/objectFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/simple-tree/objectFactory.spec.ts
@@ -8,7 +8,7 @@ import { SchemaBuilder } from "../../../domains";
 import { ProxyNode, Tree, typeNameSymbol } from "../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { extractFactoryContent } from "../../../feature-libraries/simple-tree/proxies";
-import { viewWithContent } from "../../utils";
+import { treeViewWithContent } from "../../utils";
 import { itWithRoot } from "./utils";
 
 describe("SharedTreeObject factories", () => {
@@ -203,7 +203,7 @@ describe("SharedTreeObject factories", () => {
 		// be the same as the one that is about to be hydrated for the same underlying edit node, and thus hydration
 		// would fail because it tried to map an edit node which already had a proxy to a different proxy.
 		// TODO: remove any cast when `viewWithContent` is properly typed with proxy types
-		const view = viewWithContent({ schema, initialTree: initialTree as any });
+		const view = treeViewWithContent({ schema, initialTree: initialTree as any });
 		function readData() {
 			const objectContent = view.root.child.content;
 			assert(objectContent !== undefined);
@@ -218,7 +218,7 @@ describe("SharedTreeObject factories", () => {
 		Tree.on(view.root, "afterChange", () => {
 			readData();
 		});
-		view.checkout.events.on("afterBatch", () => {
+		view.events.on("afterBatch", () => {
 			readData();
 		});
 		const content = { content: 3 };
@@ -376,7 +376,7 @@ describe("SharedTreeObject factories", () => {
 				for (const child of objectTypes) {
 					// Generate a test for all permutations of object, list and map
 					it(`${root} → ${parent} → ${child}`, () => {
-						const view = viewWithContent({
+						const view = treeViewWithContent({
 							schema: comboSchema,
 							initialTree: { root: undefined },
 						});
@@ -406,7 +406,7 @@ describe("SharedTreeObject factories", () => {
 
 						// Ensure that the proxies can be read during the change, as well as after
 						Tree.on(view.root, "afterChange", () => validate());
-						view.checkout.events.on("afterBatch", () => validate());
+						view.events.on("afterBatch", () => validate());
 						view.root.root = tree;
 						validate();
 					});

--- a/experimental/dds/tree2/src/test/feature-libraries/simple-tree/primitives.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/simple-tree/primitives.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { leaf, SchemaBuilder } from "../../../domains";
-import { viewWithContent } from "../../utils";
+import { treeViewWithContent } from "../../utils";
 import { pretty } from "./utils";
 
 const _ = new SchemaBuilder({ scope: "test", libraries: [leaf.library] });
@@ -45,7 +45,7 @@ const testCases = [
 describe("Primitives", () => {
 	describe("satisfy 'deepEquals'", () => {
 		for (const initialTree of testCases) {
-			const view = viewWithContent({ schema, initialTree });
+			const view = treeViewWithContent({ schema, initialTree });
 			const real = initialTree;
 			const proxy = view.root;
 

--- a/experimental/dds/tree2/src/test/feature-libraries/simple-tree/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/simple-tree/utils.ts
@@ -11,7 +11,7 @@ import {
 	TreeSchema,
 	SchemaAware,
 } from "../../../feature-libraries";
-import { viewWithContent } from "../../utils";
+import { treeViewWithContent } from "../../utils";
 import { SchemaBuilder } from "../../../domains";
 
 /** Helper for making small test schemas. */
@@ -42,7 +42,7 @@ export function itWithRoot<TRoot extends TreeFieldSchema>(
 	fn: (root: ProxyField<(typeof schema)["rootFieldSchema"]>) => void,
 ): void {
 	it(title, () => {
-		const view = viewWithContent({
+		const view = treeViewWithContent({
 			schema,
 			initialTree: initialTree as SchemaAware.TypedField<TRoot, SchemaAware.ApiMode.Flexible>,
 		});

--- a/experimental/dds/tree2/src/test/scalableTestTrees.ts
+++ b/experimental/dds/tree2/src/test/scalableTestTrees.ts
@@ -6,7 +6,7 @@ import { strict as assert } from "assert";
 import { FieldKinds, TreeFieldSchema, SchemaAware, typeNameSymbol } from "../feature-libraries";
 import { leaf, jsonSchema, SchemaBuilder } from "../domains";
 import { brand, requireAssignableTo } from "../util";
-import { ITreeView, TreeContent } from "../shared-tree";
+import { FlexTreeView, TreeContent } from "../shared-tree";
 import { FieldKey, moveToDetachedField, rootFieldKey, UpPath } from "../core";
 
 /**
@@ -158,7 +158,7 @@ export function readWideTreeAsJSObject(tree: JSWideTree): { nodesCount: number; 
 	return { nodesCount: nodes.length, sum };
 }
 
-export function readWideCursorTree(tree: ITreeView<typeof wideSchema.rootFieldSchema>): {
+export function readWideCursorTree(tree: FlexTreeView<typeof wideSchema.rootFieldSchema>): {
 	nodesCount: number;
 	sum: number;
 } {
@@ -176,7 +176,7 @@ export function readWideCursorTree(tree: ITreeView<typeof wideSchema.rootFieldSc
 	return { nodesCount, sum };
 }
 
-export function readDeepCursorTree(tree: ITreeView<typeof deepSchema.rootFieldSchema>): {
+export function readDeepCursorTree(tree: FlexTreeView<typeof deepSchema.rootFieldSchema>): {
 	depth: number;
 	value: number;
 } {
@@ -233,7 +233,7 @@ export function wideLeafPath(index: number): UpPath {
 	return path;
 }
 
-export function readWideEditableTree(tree: ITreeView<typeof wideSchema.rootFieldSchema>): {
+export function readWideEditableTree(tree: FlexTreeView<typeof wideSchema.rootFieldSchema>): {
 	nodesCount: number;
 	sum: number;
 } {
@@ -249,7 +249,7 @@ export function readWideEditableTree(tree: ITreeView<typeof wideSchema.rootField
 	return { nodesCount, sum };
 }
 
-export function readDeepEditableTree(tree: ITreeView<typeof deepSchema.rootFieldSchema>): {
+export function readDeepEditableTree(tree: FlexTreeView<typeof deepSchema.rootFieldSchema>): {
 	depth: number;
 	value: number;
 } {

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "@fluid-private/test-dds-utils";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { SharedTreeTestFactory, toJsonableTree, validateTree } from "../../utils";
-import { ITreeViewFork, ITreeView } from "../../../shared-tree";
+import { ITreeViewFork, FlexTreeView } from "../../../shared-tree";
 import {
 	makeOpGenerator,
 	EditGeneratorOpWeights,
@@ -36,7 +36,7 @@ import { Operation } from "./operationTypes";
  * This interface is meant to be used for tests that require you to store a branch of a tree
  */
 interface BranchedTreeFuzzTestState extends FuzzTestState {
-	main?: ITreeView<typeof fuzzSchema.rootFieldSchema>;
+	main?: FlexTreeView<typeof fuzzSchema.rootFieldSchema>;
 	branch?: ITreeViewFork<typeof fuzzSchema.rootFieldSchema>;
 }
 

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -15,7 +15,7 @@ import { Client, DDSFuzzTestState } from "@fluid-private/test-dds-utils";
 import {
 	ISharedTree,
 	ITreeCheckout,
-	ITreeView,
+	FlexTreeView,
 	SharedTreeFactory,
 	TreeContent,
 } from "../../../shared-tree";
@@ -43,14 +43,14 @@ import { FuzzNode, fuzzNode, fuzzSchema, fuzzViewFromTree } from "./fuzzUtils";
 
 export interface FuzzTestState extends DDSFuzzTestState<SharedTreeFactory> {
 	// Schematized view of clients. Created lazily by viewFromState.
-	view2?: Map<ISharedTree, ITreeView<typeof fuzzSchema.rootFieldSchema>>;
+	view2?: Map<ISharedTree, FlexTreeView<typeof fuzzSchema.rootFieldSchema>>;
 }
 
 export function viewFromState(
 	state: FuzzTestState,
 	client: Client<SharedTreeFactory> = state.client,
 	initialTree: TreeContent<typeof fuzzSchema.rootFieldSchema>["initialTree"] = undefined,
-): ITreeView<typeof fuzzSchema.rootFieldSchema> {
+): FlexTreeView<typeof fuzzSchema.rootFieldSchema> {
 	state.view2 ??= new Map();
 	return getOrCreate(state.view2, client.channel, (tree) =>
 		tree.schematizeInternal({
@@ -606,7 +606,7 @@ function selectField(
 }
 
 function trySelectTreeField(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	random: IRandom,
 	weights: Omit<FieldSelectionWeights, "filter">,
 	filter: FieldFilter = () => true,
@@ -652,7 +652,7 @@ function trySelectTreeField(
 }
 
 function selectTreeField(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	random: IRandom,
 	weights: Omit<FieldSelectionWeights, "filter">,
 	filter: FieldFilter = () => true,

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../feature-libraries";
 import { fail } from "../../../util";
 import { validateTreeConsistency } from "../../utils";
-import { ISharedTree, ITreeCheckout, ITreeView, SharedTreeFactory } from "../../../shared-tree";
+import { ISharedTree, ITreeCheckout, FlexTreeView, SharedTreeFactory } from "../../../shared-tree";
 import { Revertible } from "../../../core";
 import {
 	FieldEdit,
@@ -80,7 +80,7 @@ export function applySynchronizationOp(state: DDSFuzzTestState<SharedTreeFactory
  * TODO: Maybe take in a schema aware strongly typed Tree node or field.
  */
 export function applyFieldEdit(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	fieldEdit: FieldEdit,
 ): void {
 	switch (fieldEdit.change.type) {
@@ -99,7 +99,7 @@ export function applyFieldEdit(
 }
 
 function applySequenceFieldEdit(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	change: FuzzFieldChange,
 ): void {
 	switch (change.type) {
@@ -140,7 +140,7 @@ function applySequenceFieldEdit(
 }
 
 function applyValueFieldEdit(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	change: FuzzSet,
 ): void {
 	assert(change.parent !== undefined, "Value change should not occur at the root.");
@@ -155,7 +155,7 @@ function applyValueFieldEdit(
 }
 
 function navigateToNode(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	path: DownPath | undefined,
 ): FlexTreeNode | undefined {
 	const rootField = tree.editableTree;
@@ -196,7 +196,7 @@ function navigateToNode(
 }
 
 function applyOptionalFieldEdit(
-	tree: ITreeView<typeof fuzzSchema.rootFieldSchema>,
+	tree: FlexTreeView<typeof fuzzSchema.rootFieldSchema>,
 	change: FuzzSet | FuzzDelete,
 ): void {
 	switch (change.type) {

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
@@ -19,10 +19,10 @@ import {
 	insert,
 	TestTreeProviderLite,
 	toJsonableTree,
-	viewWithContent,
+	flexTreeViewWithContent,
 	checkoutWithContent,
 } from "../utils";
-import { ITreeView } from "../../shared-tree";
+import { FlexTreeView } from "../../shared-tree";
 import { rootFieldKey } from "../../core";
 import {
 	deepPath,
@@ -141,12 +141,12 @@ describe("SharedTree benchmarks", () => {
 	});
 	describe("Cursors", () => {
 		for (const [numberOfNodes, benchmarkType] of nodesCountDeep) {
-			let tree: ITreeView<typeof deepSchema.rootFieldSchema>;
+			let tree: FlexTreeView<typeof deepSchema.rootFieldSchema>;
 			benchmark({
 				type: benchmarkType,
 				title: `Deep Tree with cursor: reads with ${numberOfNodes} nodes`,
 				before: () => {
-					tree = viewWithContent(makeDeepContent(numberOfNodes));
+					tree = flexTreeViewWithContent(makeDeepContent(numberOfNodes));
 				},
 				benchmarkFn: () => {
 					const { depth, value } = readDeepCursorTree(tree);
@@ -156,7 +156,7 @@ describe("SharedTree benchmarks", () => {
 			});
 		}
 		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
-			let tree: ITreeView<typeof wideSchema.rootFieldSchema>;
+			let tree: FlexTreeView<typeof wideSchema.rootFieldSchema>;
 			let expected = 0;
 			benchmark({
 				type: benchmarkType,
@@ -167,7 +167,7 @@ describe("SharedTree benchmarks", () => {
 						numbers.push(index);
 						expected += index;
 					}
-					tree = viewWithContent(
+					tree = flexTreeViewWithContent(
 						makeWideContentWithEndValue(numberOfNodes, numberOfNodes - 1),
 					);
 				},
@@ -181,12 +181,12 @@ describe("SharedTree benchmarks", () => {
 	});
 	describe("EditableTree bench", () => {
 		for (const [numberOfNodes, benchmarkType] of nodesCountDeep) {
-			let tree: ITreeView<typeof deepSchema.rootFieldSchema>;
+			let tree: FlexTreeView<typeof deepSchema.rootFieldSchema>;
 			benchmark({
 				type: benchmarkType,
 				title: `Deep Tree with Editable Tree: reads with ${numberOfNodes} nodes`,
 				before: () => {
-					tree = viewWithContent(makeDeepContent(numberOfNodes));
+					tree = flexTreeViewWithContent(makeDeepContent(numberOfNodes));
 				},
 				benchmarkFn: () => {
 					const { depth, value } = readDeepEditableTree(tree);
@@ -196,7 +196,7 @@ describe("SharedTree benchmarks", () => {
 			});
 		}
 		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
-			let tree: ITreeView<typeof wideSchema.rootFieldSchema>;
+			let tree: FlexTreeView<typeof wideSchema.rootFieldSchema>;
 			let expected: number = 0;
 			benchmark({
 				type: benchmarkType,
@@ -207,7 +207,7 @@ describe("SharedTree benchmarks", () => {
 						numbers.push(index);
 						expected += index;
 					}
-					tree = viewWithContent({
+					tree = flexTreeViewWithContent({
 						initialTree: { foo: numbers },
 						schema: wideSchema,
 					});

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -39,7 +39,7 @@ import {
 	ForestType,
 	ISharedTree,
 	ITreeCheckout,
-	ITreeView,
+	FlexTreeView,
 	InitializeAndSchematizeConfiguration,
 	SharedTree,
 	SharedTreeFactory,
@@ -106,7 +106,7 @@ describe("SharedTree", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
 			assert.equal(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 
-			const view = tree.schematizeInternal({
+			const view = tree.schematize({
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: 10,
 				schema,
@@ -119,7 +119,7 @@ describe("SharedTree", () => {
 			tree.storedSchema.update(schema);
 
 			// No op upgrade with AllowedUpdateType.None does not error
-			const schematized = tree.schematizeInternal({
+			const schematized = tree.schematize({
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: 10,
 				schema,
@@ -143,7 +143,7 @@ describe("SharedTree", () => {
 		it("upgrade schema", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
 			tree.storedSchema.update(schema);
-			const schematized = tree.schematizeInternal({
+			const schematized = tree.schematize({
 				allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
 				initialTree: 5,
 				schema: schemaGeneralized,
@@ -1258,7 +1258,7 @@ describe("SharedTree", () => {
 function assertSchema<TRoot extends TreeFieldSchema>(
 	tree: ISharedTree,
 	schema: TreeSchema<TRoot>,
-): ITreeView<TRoot> {
+): FlexTreeView<TRoot> {
 	return tree.requireSchema(schema, () => assert.fail()) ?? assert.fail();
 }
 

--- a/experimental/dds/tree2/src/test/shared-tree/treeCheckout.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/treeCheckout.spec.ts
@@ -12,7 +12,7 @@ import {
 	emptyJsonSequenceConfig,
 	insert,
 	jsonSequenceRootSchema,
-	viewWithContent,
+	flexTreeViewWithContent,
 	checkoutWithContent,
 } from "../utils";
 import {
@@ -34,7 +34,7 @@ describe("sharedTreeView", () => {
 		const schema = builder.intoSchema(builder.optional(rootTreeNodeSchema));
 
 		it("triggers events for local and subtree changes", () => {
-			const view = viewWithContent({
+			const view = flexTreeViewWithContent({
 				schema,
 				initialTree: {
 					x: 24,
@@ -75,7 +75,7 @@ describe("sharedTreeView", () => {
 		});
 
 		it("propagates path args for local and subtree changes", () => {
-			const view = viewWithContent({
+			const view = flexTreeViewWithContent({
 				schema,
 				initialTree: {
 					x: 24,

--- a/experimental/dds/tree2/src/test/shared-tree/treeView.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/treeView.spec.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { emptyStringSequenceConfig, viewWithContent } from "../utils";
+import { emptyStringSequenceConfig, flexTreeViewWithContent } from "../utils";
 
 describe("sharedTreeView", () => {
 	it("reads only one node", () => {
 		// This is a regression test for a scenario in which a transaction would apply its delta twice,
 		// inserting two nodes instead of just one
-		const view = viewWithContent(emptyStringSequenceConfig);
+		const view = flexTreeViewWithContent(emptyStringSequenceConfig);
 		view.editableTree.insertAtStart("x");
 		assert.deepEqual(view.editableTree.asArray, ["x"]);
 	});

--- a/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
+++ b/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
@@ -10,10 +10,11 @@ import {
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils";
-import { ISharedTree, ITreeView, SharedTree, SharedTreeFactory } from "../../shared-tree";
+import { ISharedTree, SharedTree, SharedTreeFactory, TreeView } from "../../shared-tree";
 import { typeboxValidator } from "../../external-utilities";
 import { SchemaBuilder } from "../../domains";
 import { AllowedUpdateType } from "../../core";
+import { ProxyField } from "../../feature-libraries";
 
 const builder = new SchemaBuilder({ scope: "test" });
 const someType = builder.object("foo", {
@@ -28,13 +29,13 @@ const someType = builder.object("foo", {
 
 const schema = builder.intoSchema(SchemaBuilder.required(someType));
 
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof schema.rootFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
-			handles: [],
+			handles: { "": [] },
 			nested: undefined,
 			bump: undefined,
-		} as any,
+		},
 		allowedSchemaModifications: AllowedUpdateType.None,
 		schema,
 	});

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
@@ -29,7 +29,7 @@ type TypeOnly<T> = T extends number
 declare function get_old_TypeAliasDeclaration_DriverError():
     TypeOnly<old.DriverError>;
 declare function use_current_TypeAliasDeclaration_DriverError(
-    use: TypeOnly<current.DriverError>);
+    use: TypeOnly<current.DriverError>): void;
 use_current_TypeAliasDeclaration_DriverError(
     get_old_TypeAliasDeclaration_DriverError());
 
@@ -41,7 +41,7 @@ use_current_TypeAliasDeclaration_DriverError(
 declare function get_current_TypeAliasDeclaration_DriverError():
     TypeOnly<current.DriverError>;
 declare function use_old_TypeAliasDeclaration_DriverError(
-    use: TypeOnly<old.DriverError>);
+    use: TypeOnly<old.DriverError>): void;
 use_old_TypeAliasDeclaration_DriverError(
     get_current_TypeAliasDeclaration_DriverError());
 
@@ -53,7 +53,7 @@ use_old_TypeAliasDeclaration_DriverError(
 declare function get_old_EnumDeclaration_DriverErrorType():
     TypeOnly<old.DriverErrorType>;
 declare function use_current_EnumDeclaration_DriverErrorType(
-    use: TypeOnly<current.DriverErrorType>);
+    use: TypeOnly<current.DriverErrorType>): void;
 use_current_EnumDeclaration_DriverErrorType(
     get_old_EnumDeclaration_DriverErrorType());
 
@@ -65,7 +65,7 @@ use_current_EnumDeclaration_DriverErrorType(
 declare function get_current_EnumDeclaration_DriverErrorType():
     TypeOnly<current.DriverErrorType>;
 declare function use_old_EnumDeclaration_DriverErrorType(
-    use: TypeOnly<old.DriverErrorType>);
+    use: TypeOnly<old.DriverErrorType>): void;
 use_old_EnumDeclaration_DriverErrorType(
     get_current_EnumDeclaration_DriverErrorType());
 
@@ -77,7 +77,7 @@ use_old_EnumDeclaration_DriverErrorType(
 declare function get_old_VariableDeclaration_DriverErrorTypes():
     TypeOnly<typeof old.DriverErrorTypes>;
 declare function use_current_VariableDeclaration_DriverErrorTypes(
-    use: TypeOnly<typeof current.DriverErrorTypes>);
+    use: TypeOnly<typeof current.DriverErrorTypes>): void;
 use_current_VariableDeclaration_DriverErrorTypes(
     get_old_VariableDeclaration_DriverErrorTypes());
 
@@ -89,7 +89,7 @@ use_current_VariableDeclaration_DriverErrorTypes(
 declare function get_current_VariableDeclaration_DriverErrorTypes():
     TypeOnly<typeof current.DriverErrorTypes>;
 declare function use_old_VariableDeclaration_DriverErrorTypes(
-    use: TypeOnly<typeof old.DriverErrorTypes>);
+    use: TypeOnly<typeof old.DriverErrorTypes>): void;
 use_old_VariableDeclaration_DriverErrorTypes(
     get_current_VariableDeclaration_DriverErrorTypes());
 
@@ -101,7 +101,7 @@ use_old_VariableDeclaration_DriverErrorTypes(
 declare function get_old_TypeAliasDeclaration_DriverErrorTypes():
     TypeOnly<old.DriverErrorTypes>;
 declare function use_current_TypeAliasDeclaration_DriverErrorTypes(
-    use: TypeOnly<current.DriverErrorTypes>);
+    use: TypeOnly<current.DriverErrorTypes>): void;
 use_current_TypeAliasDeclaration_DriverErrorTypes(
     get_old_TypeAliasDeclaration_DriverErrorTypes());
 
@@ -113,7 +113,7 @@ use_current_TypeAliasDeclaration_DriverErrorTypes(
 declare function get_current_TypeAliasDeclaration_DriverErrorTypes():
     TypeOnly<current.DriverErrorTypes>;
 declare function use_old_TypeAliasDeclaration_DriverErrorTypes(
-    use: TypeOnly<old.DriverErrorTypes>);
+    use: TypeOnly<old.DriverErrorTypes>): void;
 use_old_TypeAliasDeclaration_DriverErrorTypes(
     get_current_TypeAliasDeclaration_DriverErrorTypes());
 
@@ -125,7 +125,7 @@ use_old_TypeAliasDeclaration_DriverErrorTypes(
 declare function get_old_EnumDeclaration_DriverHeader():
     TypeOnly<old.DriverHeader>;
 declare function use_current_EnumDeclaration_DriverHeader(
-    use: TypeOnly<current.DriverHeader>);
+    use: TypeOnly<current.DriverHeader>): void;
 use_current_EnumDeclaration_DriverHeader(
     get_old_EnumDeclaration_DriverHeader());
 
@@ -137,7 +137,7 @@ use_current_EnumDeclaration_DriverHeader(
 declare function get_current_EnumDeclaration_DriverHeader():
     TypeOnly<current.DriverHeader>;
 declare function use_old_EnumDeclaration_DriverHeader(
-    use: TypeOnly<old.DriverHeader>);
+    use: TypeOnly<old.DriverHeader>): void;
 use_old_EnumDeclaration_DriverHeader(
     get_current_EnumDeclaration_DriverHeader());
 
@@ -149,7 +149,7 @@ use_old_EnumDeclaration_DriverHeader(
 declare function get_old_InterfaceDeclaration_DriverPreCheckInfo():
     TypeOnly<old.DriverPreCheckInfo>;
 declare function use_current_InterfaceDeclaration_DriverPreCheckInfo(
-    use: TypeOnly<current.DriverPreCheckInfo>);
+    use: TypeOnly<current.DriverPreCheckInfo>): void;
 use_current_InterfaceDeclaration_DriverPreCheckInfo(
     get_old_InterfaceDeclaration_DriverPreCheckInfo());
 
@@ -161,7 +161,7 @@ use_current_InterfaceDeclaration_DriverPreCheckInfo(
 declare function get_current_InterfaceDeclaration_DriverPreCheckInfo():
     TypeOnly<current.DriverPreCheckInfo>;
 declare function use_old_InterfaceDeclaration_DriverPreCheckInfo(
-    use: TypeOnly<old.DriverPreCheckInfo>);
+    use: TypeOnly<old.DriverPreCheckInfo>): void;
 use_old_InterfaceDeclaration_DriverPreCheckInfo(
     get_current_InterfaceDeclaration_DriverPreCheckInfo());
 
@@ -173,7 +173,7 @@ use_old_InterfaceDeclaration_DriverPreCheckInfo(
 declare function get_old_EnumDeclaration_FetchSource():
     TypeOnly<old.FetchSource>;
 declare function use_current_EnumDeclaration_FetchSource(
-    use: TypeOnly<current.FetchSource>);
+    use: TypeOnly<current.FetchSource>): void;
 use_current_EnumDeclaration_FetchSource(
     get_old_EnumDeclaration_FetchSource());
 
@@ -185,7 +185,7 @@ use_current_EnumDeclaration_FetchSource(
 declare function get_current_EnumDeclaration_FetchSource():
     TypeOnly<current.FetchSource>;
 declare function use_old_EnumDeclaration_FetchSource(
-    use: TypeOnly<old.FetchSource>);
+    use: TypeOnly<old.FetchSource>): void;
 use_old_EnumDeclaration_FetchSource(
     get_current_EnumDeclaration_FetchSource());
 
@@ -197,7 +197,7 @@ use_old_EnumDeclaration_FetchSource(
 declare function get_old_TypeAliasDeclaration_FiveDaysMs():
     TypeOnly<old.FiveDaysMs>;
 declare function use_current_TypeAliasDeclaration_FiveDaysMs(
-    use: TypeOnly<current.FiveDaysMs>);
+    use: TypeOnly<current.FiveDaysMs>): void;
 use_current_TypeAliasDeclaration_FiveDaysMs(
     get_old_TypeAliasDeclaration_FiveDaysMs());
 
@@ -209,7 +209,7 @@ use_current_TypeAliasDeclaration_FiveDaysMs(
 declare function get_current_TypeAliasDeclaration_FiveDaysMs():
     TypeOnly<current.FiveDaysMs>;
 declare function use_old_TypeAliasDeclaration_FiveDaysMs(
-    use: TypeOnly<old.FiveDaysMs>);
+    use: TypeOnly<old.FiveDaysMs>): void;
 use_old_TypeAliasDeclaration_FiveDaysMs(
     get_current_TypeAliasDeclaration_FiveDaysMs());
 
@@ -221,7 +221,7 @@ use_old_TypeAliasDeclaration_FiveDaysMs(
 declare function get_old_InterfaceDeclaration_IAnyDriverError():
     TypeOnly<old.IAnyDriverError>;
 declare function use_current_InterfaceDeclaration_IAnyDriverError(
-    use: TypeOnly<current.IAnyDriverError>);
+    use: TypeOnly<current.IAnyDriverError>): void;
 use_current_InterfaceDeclaration_IAnyDriverError(
     get_old_InterfaceDeclaration_IAnyDriverError());
 
@@ -233,7 +233,7 @@ use_current_InterfaceDeclaration_IAnyDriverError(
 declare function get_current_InterfaceDeclaration_IAnyDriverError():
     TypeOnly<current.IAnyDriverError>;
 declare function use_old_InterfaceDeclaration_IAnyDriverError(
-    use: TypeOnly<old.IAnyDriverError>);
+    use: TypeOnly<old.IAnyDriverError>): void;
 use_old_InterfaceDeclaration_IAnyDriverError(
     get_current_InterfaceDeclaration_IAnyDriverError());
 
@@ -245,7 +245,7 @@ use_old_InterfaceDeclaration_IAnyDriverError(
 declare function get_old_InterfaceDeclaration_IAuthorizationError():
     TypeOnly<old.IAuthorizationError>;
 declare function use_current_InterfaceDeclaration_IAuthorizationError(
-    use: TypeOnly<current.IAuthorizationError>);
+    use: TypeOnly<current.IAuthorizationError>): void;
 use_current_InterfaceDeclaration_IAuthorizationError(
     get_old_InterfaceDeclaration_IAuthorizationError());
 
@@ -257,7 +257,7 @@ use_current_InterfaceDeclaration_IAuthorizationError(
 declare function get_current_InterfaceDeclaration_IAuthorizationError():
     TypeOnly<current.IAuthorizationError>;
 declare function use_old_InterfaceDeclaration_IAuthorizationError(
-    use: TypeOnly<old.IAuthorizationError>);
+    use: TypeOnly<old.IAuthorizationError>): void;
 use_old_InterfaceDeclaration_IAuthorizationError(
     get_current_InterfaceDeclaration_IAuthorizationError());
 
@@ -269,7 +269,7 @@ use_old_InterfaceDeclaration_IAuthorizationError(
 declare function get_old_InterfaceDeclaration_IContainerPackageInfo():
     TypeOnly<old.IContainerPackageInfo>;
 declare function use_current_InterfaceDeclaration_IContainerPackageInfo(
-    use: TypeOnly<current.IContainerPackageInfo>);
+    use: TypeOnly<current.IContainerPackageInfo>): void;
 use_current_InterfaceDeclaration_IContainerPackageInfo(
     get_old_InterfaceDeclaration_IContainerPackageInfo());
 
@@ -281,7 +281,7 @@ use_current_InterfaceDeclaration_IContainerPackageInfo(
 declare function get_current_InterfaceDeclaration_IContainerPackageInfo():
     TypeOnly<current.IContainerPackageInfo>;
 declare function use_old_InterfaceDeclaration_IContainerPackageInfo(
-    use: TypeOnly<old.IContainerPackageInfo>);
+    use: TypeOnly<old.IContainerPackageInfo>): void;
 use_old_InterfaceDeclaration_IContainerPackageInfo(
     get_current_InterfaceDeclaration_IContainerPackageInfo());
 
@@ -293,7 +293,7 @@ use_old_InterfaceDeclaration_IContainerPackageInfo(
 declare function get_old_InterfaceDeclaration_IDeltaStorageService():
     TypeOnly<old.IDeltaStorageService>;
 declare function use_current_InterfaceDeclaration_IDeltaStorageService(
-    use: TypeOnly<current.IDeltaStorageService>);
+    use: TypeOnly<current.IDeltaStorageService>): void;
 use_current_InterfaceDeclaration_IDeltaStorageService(
     get_old_InterfaceDeclaration_IDeltaStorageService());
 
@@ -305,7 +305,7 @@ use_current_InterfaceDeclaration_IDeltaStorageService(
 declare function get_current_InterfaceDeclaration_IDeltaStorageService():
     TypeOnly<current.IDeltaStorageService>;
 declare function use_old_InterfaceDeclaration_IDeltaStorageService(
-    use: TypeOnly<old.IDeltaStorageService>);
+    use: TypeOnly<old.IDeltaStorageService>): void;
 use_old_InterfaceDeclaration_IDeltaStorageService(
     get_current_InterfaceDeclaration_IDeltaStorageService());
 
@@ -317,7 +317,7 @@ use_old_InterfaceDeclaration_IDeltaStorageService(
 declare function get_old_InterfaceDeclaration_IDeltasFetchResult():
     TypeOnly<old.IDeltasFetchResult>;
 declare function use_current_InterfaceDeclaration_IDeltasFetchResult(
-    use: TypeOnly<current.IDeltasFetchResult>);
+    use: TypeOnly<current.IDeltasFetchResult>): void;
 use_current_InterfaceDeclaration_IDeltasFetchResult(
     get_old_InterfaceDeclaration_IDeltasFetchResult());
 
@@ -329,7 +329,7 @@ use_current_InterfaceDeclaration_IDeltasFetchResult(
 declare function get_current_InterfaceDeclaration_IDeltasFetchResult():
     TypeOnly<current.IDeltasFetchResult>;
 declare function use_old_InterfaceDeclaration_IDeltasFetchResult(
-    use: TypeOnly<old.IDeltasFetchResult>);
+    use: TypeOnly<old.IDeltasFetchResult>): void;
 use_old_InterfaceDeclaration_IDeltasFetchResult(
     get_current_InterfaceDeclaration_IDeltasFetchResult());
 
@@ -341,7 +341,7 @@ use_old_InterfaceDeclaration_IDeltasFetchResult(
 declare function get_old_InterfaceDeclaration_IDocumentDeltaConnection():
     TypeOnly<old.IDocumentDeltaConnection>;
 declare function use_current_InterfaceDeclaration_IDocumentDeltaConnection(
-    use: TypeOnly<current.IDocumentDeltaConnection>);
+    use: TypeOnly<current.IDocumentDeltaConnection>): void;
 use_current_InterfaceDeclaration_IDocumentDeltaConnection(
     get_old_InterfaceDeclaration_IDocumentDeltaConnection());
 
@@ -353,7 +353,7 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnection(
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnection():
     TypeOnly<current.IDocumentDeltaConnection>;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnection(
-    use: TypeOnly<old.IDocumentDeltaConnection>);
+    use: TypeOnly<old.IDocumentDeltaConnection>): void;
 use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     get_current_InterfaceDeclaration_IDocumentDeltaConnection());
 
@@ -365,7 +365,7 @@ use_old_InterfaceDeclaration_IDocumentDeltaConnection(
 declare function get_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents():
     TypeOnly<old.IDocumentDeltaConnectionEvents>;
 declare function use_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
-    use: TypeOnly<current.IDocumentDeltaConnectionEvents>);
+    use: TypeOnly<current.IDocumentDeltaConnectionEvents>): void;
 use_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
     get_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents());
 
@@ -377,7 +377,7 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents():
     TypeOnly<current.IDocumentDeltaConnectionEvents>;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
-    use: TypeOnly<old.IDocumentDeltaConnectionEvents>);
+    use: TypeOnly<old.IDocumentDeltaConnectionEvents>): void;
 use_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
     get_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents());
 
@@ -389,7 +389,7 @@ use_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
 declare function get_old_InterfaceDeclaration_IDocumentDeltaStorageService():
     TypeOnly<old.IDocumentDeltaStorageService>;
 declare function use_current_InterfaceDeclaration_IDocumentDeltaStorageService(
-    use: TypeOnly<current.IDocumentDeltaStorageService>);
+    use: TypeOnly<current.IDocumentDeltaStorageService>): void;
 use_current_InterfaceDeclaration_IDocumentDeltaStorageService(
     get_old_InterfaceDeclaration_IDocumentDeltaStorageService());
 
@@ -401,7 +401,7 @@ use_current_InterfaceDeclaration_IDocumentDeltaStorageService(
 declare function get_current_InterfaceDeclaration_IDocumentDeltaStorageService():
     TypeOnly<current.IDocumentDeltaStorageService>;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaStorageService(
-    use: TypeOnly<old.IDocumentDeltaStorageService>);
+    use: TypeOnly<old.IDocumentDeltaStorageService>): void;
 use_old_InterfaceDeclaration_IDocumentDeltaStorageService(
     get_current_InterfaceDeclaration_IDocumentDeltaStorageService());
 
@@ -413,7 +413,7 @@ use_old_InterfaceDeclaration_IDocumentDeltaStorageService(
 declare function get_old_InterfaceDeclaration_IDocumentService():
     TypeOnly<old.IDocumentService>;
 declare function use_current_InterfaceDeclaration_IDocumentService(
-    use: TypeOnly<current.IDocumentService>);
+    use: TypeOnly<current.IDocumentService>): void;
 use_current_InterfaceDeclaration_IDocumentService(
     get_old_InterfaceDeclaration_IDocumentService());
 
@@ -425,7 +425,7 @@ use_current_InterfaceDeclaration_IDocumentService(
 declare function get_current_InterfaceDeclaration_IDocumentService():
     TypeOnly<current.IDocumentService>;
 declare function use_old_InterfaceDeclaration_IDocumentService(
-    use: TypeOnly<old.IDocumentService>);
+    use: TypeOnly<old.IDocumentService>): void;
 use_old_InterfaceDeclaration_IDocumentService(
     get_current_InterfaceDeclaration_IDocumentService());
 
@@ -437,7 +437,7 @@ use_old_InterfaceDeclaration_IDocumentService(
 declare function get_old_InterfaceDeclaration_IDocumentServiceFactory():
     TypeOnly<old.IDocumentServiceFactory>;
 declare function use_current_InterfaceDeclaration_IDocumentServiceFactory(
-    use: TypeOnly<current.IDocumentServiceFactory>);
+    use: TypeOnly<current.IDocumentServiceFactory>): void;
 use_current_InterfaceDeclaration_IDocumentServiceFactory(
     get_old_InterfaceDeclaration_IDocumentServiceFactory());
 
@@ -449,7 +449,7 @@ use_current_InterfaceDeclaration_IDocumentServiceFactory(
 declare function get_current_InterfaceDeclaration_IDocumentServiceFactory():
     TypeOnly<current.IDocumentServiceFactory>;
 declare function use_old_InterfaceDeclaration_IDocumentServiceFactory(
-    use: TypeOnly<old.IDocumentServiceFactory>);
+    use: TypeOnly<old.IDocumentServiceFactory>): void;
 use_old_InterfaceDeclaration_IDocumentServiceFactory(
     get_current_InterfaceDeclaration_IDocumentServiceFactory());
 
@@ -461,7 +461,7 @@ use_old_InterfaceDeclaration_IDocumentServiceFactory(
 declare function get_old_InterfaceDeclaration_IDocumentServicePolicies():
     TypeOnly<old.IDocumentServicePolicies>;
 declare function use_current_InterfaceDeclaration_IDocumentServicePolicies(
-    use: TypeOnly<current.IDocumentServicePolicies>);
+    use: TypeOnly<current.IDocumentServicePolicies>): void;
 use_current_InterfaceDeclaration_IDocumentServicePolicies(
     get_old_InterfaceDeclaration_IDocumentServicePolicies());
 
@@ -473,7 +473,7 @@ use_current_InterfaceDeclaration_IDocumentServicePolicies(
 declare function get_current_InterfaceDeclaration_IDocumentServicePolicies():
     TypeOnly<current.IDocumentServicePolicies>;
 declare function use_old_InterfaceDeclaration_IDocumentServicePolicies(
-    use: TypeOnly<old.IDocumentServicePolicies>);
+    use: TypeOnly<old.IDocumentServicePolicies>): void;
 use_old_InterfaceDeclaration_IDocumentServicePolicies(
     get_current_InterfaceDeclaration_IDocumentServicePolicies());
 
@@ -485,7 +485,7 @@ use_old_InterfaceDeclaration_IDocumentServicePolicies(
 declare function get_old_InterfaceDeclaration_IDocumentStorageService():
     TypeOnly<old.IDocumentStorageService>;
 declare function use_current_InterfaceDeclaration_IDocumentStorageService(
-    use: TypeOnly<current.IDocumentStorageService>);
+    use: TypeOnly<current.IDocumentStorageService>): void;
 use_current_InterfaceDeclaration_IDocumentStorageService(
     get_old_InterfaceDeclaration_IDocumentStorageService());
 
@@ -497,7 +497,7 @@ use_current_InterfaceDeclaration_IDocumentStorageService(
 declare function get_current_InterfaceDeclaration_IDocumentStorageService():
     TypeOnly<current.IDocumentStorageService>;
 declare function use_old_InterfaceDeclaration_IDocumentStorageService(
-    use: TypeOnly<old.IDocumentStorageService>);
+    use: TypeOnly<old.IDocumentStorageService>): void;
 use_old_InterfaceDeclaration_IDocumentStorageService(
     get_current_InterfaceDeclaration_IDocumentStorageService());
 
@@ -509,7 +509,7 @@ use_old_InterfaceDeclaration_IDocumentStorageService(
 declare function get_old_InterfaceDeclaration_IDocumentStorageServicePolicies():
     TypeOnly<old.IDocumentStorageServicePolicies>;
 declare function use_current_InterfaceDeclaration_IDocumentStorageServicePolicies(
-    use: TypeOnly<current.IDocumentStorageServicePolicies>);
+    use: TypeOnly<current.IDocumentStorageServicePolicies>): void;
 use_current_InterfaceDeclaration_IDocumentStorageServicePolicies(
     get_old_InterfaceDeclaration_IDocumentStorageServicePolicies());
 
@@ -521,7 +521,7 @@ use_current_InterfaceDeclaration_IDocumentStorageServicePolicies(
 declare function get_current_InterfaceDeclaration_IDocumentStorageServicePolicies():
     TypeOnly<current.IDocumentStorageServicePolicies>;
 declare function use_old_InterfaceDeclaration_IDocumentStorageServicePolicies(
-    use: TypeOnly<old.IDocumentStorageServicePolicies>);
+    use: TypeOnly<old.IDocumentStorageServicePolicies>): void;
 use_old_InterfaceDeclaration_IDocumentStorageServicePolicies(
     get_current_InterfaceDeclaration_IDocumentStorageServicePolicies());
 
@@ -533,7 +533,7 @@ use_old_InterfaceDeclaration_IDocumentStorageServicePolicies(
 declare function get_old_InterfaceDeclaration_IDriverBasicError():
     TypeOnly<old.IDriverBasicError>;
 declare function use_current_InterfaceDeclaration_IDriverBasicError(
-    use: TypeOnly<current.IDriverBasicError>);
+    use: TypeOnly<current.IDriverBasicError>): void;
 use_current_InterfaceDeclaration_IDriverBasicError(
     get_old_InterfaceDeclaration_IDriverBasicError());
 
@@ -545,7 +545,7 @@ use_current_InterfaceDeclaration_IDriverBasicError(
 declare function get_current_InterfaceDeclaration_IDriverBasicError():
     TypeOnly<current.IDriverBasicError>;
 declare function use_old_InterfaceDeclaration_IDriverBasicError(
-    use: TypeOnly<old.IDriverBasicError>);
+    use: TypeOnly<old.IDriverBasicError>): void;
 use_old_InterfaceDeclaration_IDriverBasicError(
     get_current_InterfaceDeclaration_IDriverBasicError());
 
@@ -557,7 +557,7 @@ use_old_InterfaceDeclaration_IDriverBasicError(
 declare function get_old_InterfaceDeclaration_IDriverErrorBase():
     TypeOnly<old.IDriverErrorBase>;
 declare function use_current_InterfaceDeclaration_IDriverErrorBase(
-    use: TypeOnly<current.IDriverErrorBase>);
+    use: TypeOnly<current.IDriverErrorBase>): void;
 use_current_InterfaceDeclaration_IDriverErrorBase(
     get_old_InterfaceDeclaration_IDriverErrorBase());
 
@@ -569,7 +569,7 @@ use_current_InterfaceDeclaration_IDriverErrorBase(
 declare function get_current_InterfaceDeclaration_IDriverErrorBase():
     TypeOnly<current.IDriverErrorBase>;
 declare function use_old_InterfaceDeclaration_IDriverErrorBase(
-    use: TypeOnly<old.IDriverErrorBase>);
+    use: TypeOnly<old.IDriverErrorBase>): void;
 use_old_InterfaceDeclaration_IDriverErrorBase(
     get_current_InterfaceDeclaration_IDriverErrorBase());
 
@@ -581,7 +581,7 @@ use_old_InterfaceDeclaration_IDriverErrorBase(
 declare function get_old_InterfaceDeclaration_IDriverHeader():
     TypeOnly<old.IDriverHeader>;
 declare function use_current_InterfaceDeclaration_IDriverHeader(
-    use: TypeOnly<current.IDriverHeader>);
+    use: TypeOnly<current.IDriverHeader>): void;
 use_current_InterfaceDeclaration_IDriverHeader(
     get_old_InterfaceDeclaration_IDriverHeader());
 
@@ -593,7 +593,7 @@ use_current_InterfaceDeclaration_IDriverHeader(
 declare function get_current_InterfaceDeclaration_IDriverHeader():
     TypeOnly<current.IDriverHeader>;
 declare function use_old_InterfaceDeclaration_IDriverHeader(
-    use: TypeOnly<old.IDriverHeader>);
+    use: TypeOnly<old.IDriverHeader>): void;
 use_old_InterfaceDeclaration_IDriverHeader(
     get_current_InterfaceDeclaration_IDriverHeader());
 
@@ -605,7 +605,7 @@ use_old_InterfaceDeclaration_IDriverHeader(
 declare function get_old_InterfaceDeclaration_IGenericNetworkError():
     TypeOnly<old.IGenericNetworkError>;
 declare function use_current_InterfaceDeclaration_IGenericNetworkError(
-    use: TypeOnly<current.IGenericNetworkError>);
+    use: TypeOnly<current.IGenericNetworkError>): void;
 use_current_InterfaceDeclaration_IGenericNetworkError(
     get_old_InterfaceDeclaration_IGenericNetworkError());
 
@@ -617,7 +617,7 @@ use_current_InterfaceDeclaration_IGenericNetworkError(
 declare function get_current_InterfaceDeclaration_IGenericNetworkError():
     TypeOnly<current.IGenericNetworkError>;
 declare function use_old_InterfaceDeclaration_IGenericNetworkError(
-    use: TypeOnly<old.IGenericNetworkError>);
+    use: TypeOnly<old.IGenericNetworkError>): void;
 use_old_InterfaceDeclaration_IGenericNetworkError(
     get_current_InterfaceDeclaration_IGenericNetworkError());
 
@@ -629,7 +629,7 @@ use_old_InterfaceDeclaration_IGenericNetworkError(
 declare function get_old_InterfaceDeclaration_ILocationRedirectionError():
     TypeOnly<old.ILocationRedirectionError>;
 declare function use_current_InterfaceDeclaration_ILocationRedirectionError(
-    use: TypeOnly<current.ILocationRedirectionError>);
+    use: TypeOnly<current.ILocationRedirectionError>): void;
 use_current_InterfaceDeclaration_ILocationRedirectionError(
     get_old_InterfaceDeclaration_ILocationRedirectionError());
 
@@ -641,7 +641,7 @@ use_current_InterfaceDeclaration_ILocationRedirectionError(
 declare function get_current_InterfaceDeclaration_ILocationRedirectionError():
     TypeOnly<current.ILocationRedirectionError>;
 declare function use_old_InterfaceDeclaration_ILocationRedirectionError(
-    use: TypeOnly<old.ILocationRedirectionError>);
+    use: TypeOnly<old.ILocationRedirectionError>): void;
 use_old_InterfaceDeclaration_ILocationRedirectionError(
     get_current_InterfaceDeclaration_ILocationRedirectionError());
 
@@ -653,7 +653,7 @@ use_old_InterfaceDeclaration_ILocationRedirectionError(
 declare function get_old_InterfaceDeclaration_IResolvedUrl():
     TypeOnly<old.IResolvedUrl>;
 declare function use_current_InterfaceDeclaration_IResolvedUrl(
-    use: TypeOnly<current.IResolvedUrl>);
+    use: TypeOnly<current.IResolvedUrl>): void;
 use_current_InterfaceDeclaration_IResolvedUrl(
     get_old_InterfaceDeclaration_IResolvedUrl());
 
@@ -665,7 +665,7 @@ use_current_InterfaceDeclaration_IResolvedUrl(
 declare function get_current_InterfaceDeclaration_IResolvedUrl():
     TypeOnly<current.IResolvedUrl>;
 declare function use_old_InterfaceDeclaration_IResolvedUrl(
-    use: TypeOnly<old.IResolvedUrl>);
+    use: TypeOnly<old.IResolvedUrl>): void;
 use_old_InterfaceDeclaration_IResolvedUrl(
     get_current_InterfaceDeclaration_IResolvedUrl());
 
@@ -677,7 +677,7 @@ use_old_InterfaceDeclaration_IResolvedUrl(
 declare function get_old_InterfaceDeclaration_IStream():
     TypeOnly<old.IStream<any>>;
 declare function use_current_InterfaceDeclaration_IStream(
-    use: TypeOnly<current.IStream<any>>);
+    use: TypeOnly<current.IStream<any>>): void;
 use_current_InterfaceDeclaration_IStream(
     get_old_InterfaceDeclaration_IStream());
 
@@ -689,7 +689,7 @@ use_current_InterfaceDeclaration_IStream(
 declare function get_current_InterfaceDeclaration_IStream():
     TypeOnly<current.IStream<any>>;
 declare function use_old_InterfaceDeclaration_IStream(
-    use: TypeOnly<old.IStream<any>>);
+    use: TypeOnly<old.IStream<any>>): void;
 use_old_InterfaceDeclaration_IStream(
     get_current_InterfaceDeclaration_IStream());
 
@@ -701,7 +701,7 @@ use_old_InterfaceDeclaration_IStream(
 declare function get_old_TypeAliasDeclaration_IStreamResult():
     TypeOnly<old.IStreamResult<any>>;
 declare function use_current_TypeAliasDeclaration_IStreamResult(
-    use: TypeOnly<current.IStreamResult<any>>);
+    use: TypeOnly<current.IStreamResult<any>>): void;
 use_current_TypeAliasDeclaration_IStreamResult(
     get_old_TypeAliasDeclaration_IStreamResult());
 
@@ -713,7 +713,7 @@ use_current_TypeAliasDeclaration_IStreamResult(
 declare function get_current_TypeAliasDeclaration_IStreamResult():
     TypeOnly<current.IStreamResult<any>>;
 declare function use_old_TypeAliasDeclaration_IStreamResult(
-    use: TypeOnly<old.IStreamResult<any>>);
+    use: TypeOnly<old.IStreamResult<any>>): void;
 use_old_TypeAliasDeclaration_IStreamResult(
     get_current_TypeAliasDeclaration_IStreamResult());
 
@@ -725,7 +725,7 @@ use_old_TypeAliasDeclaration_IStreamResult(
 declare function get_old_InterfaceDeclaration_ISummaryContext():
     TypeOnly<old.ISummaryContext>;
 declare function use_current_InterfaceDeclaration_ISummaryContext(
-    use: TypeOnly<current.ISummaryContext>);
+    use: TypeOnly<current.ISummaryContext>): void;
 use_current_InterfaceDeclaration_ISummaryContext(
     get_old_InterfaceDeclaration_ISummaryContext());
 
@@ -737,7 +737,7 @@ use_current_InterfaceDeclaration_ISummaryContext(
 declare function get_current_InterfaceDeclaration_ISummaryContext():
     TypeOnly<current.ISummaryContext>;
 declare function use_old_InterfaceDeclaration_ISummaryContext(
-    use: TypeOnly<old.ISummaryContext>);
+    use: TypeOnly<old.ISummaryContext>): void;
 use_old_InterfaceDeclaration_ISummaryContext(
     get_current_InterfaceDeclaration_ISummaryContext());
 
@@ -749,7 +749,7 @@ use_old_InterfaceDeclaration_ISummaryContext(
 declare function get_old_InterfaceDeclaration_IThrottlingWarning():
     TypeOnly<old.IThrottlingWarning>;
 declare function use_current_InterfaceDeclaration_IThrottlingWarning(
-    use: TypeOnly<current.IThrottlingWarning>);
+    use: TypeOnly<current.IThrottlingWarning>): void;
 use_current_InterfaceDeclaration_IThrottlingWarning(
     get_old_InterfaceDeclaration_IThrottlingWarning());
 
@@ -761,7 +761,7 @@ use_current_InterfaceDeclaration_IThrottlingWarning(
 declare function get_current_InterfaceDeclaration_IThrottlingWarning():
     TypeOnly<current.IThrottlingWarning>;
 declare function use_old_InterfaceDeclaration_IThrottlingWarning(
-    use: TypeOnly<old.IThrottlingWarning>);
+    use: TypeOnly<old.IThrottlingWarning>): void;
 use_old_InterfaceDeclaration_IThrottlingWarning(
     get_current_InterfaceDeclaration_IThrottlingWarning());
 
@@ -773,7 +773,7 @@ use_old_InterfaceDeclaration_IThrottlingWarning(
 declare function get_old_InterfaceDeclaration_IUrlResolver():
     TypeOnly<old.IUrlResolver>;
 declare function use_current_InterfaceDeclaration_IUrlResolver(
-    use: TypeOnly<current.IUrlResolver>);
+    use: TypeOnly<current.IUrlResolver>): void;
 use_current_InterfaceDeclaration_IUrlResolver(
     get_old_InterfaceDeclaration_IUrlResolver());
 
@@ -785,7 +785,7 @@ use_current_InterfaceDeclaration_IUrlResolver(
 declare function get_current_InterfaceDeclaration_IUrlResolver():
     TypeOnly<current.IUrlResolver>;
 declare function use_old_InterfaceDeclaration_IUrlResolver(
-    use: TypeOnly<old.IUrlResolver>);
+    use: TypeOnly<old.IUrlResolver>): void;
 use_old_InterfaceDeclaration_IUrlResolver(
     get_current_InterfaceDeclaration_IUrlResolver());
 
@@ -797,7 +797,7 @@ use_old_InterfaceDeclaration_IUrlResolver(
 declare function get_old_EnumDeclaration_LoaderCachingPolicy():
     TypeOnly<old.LoaderCachingPolicy>;
 declare function use_current_EnumDeclaration_LoaderCachingPolicy(
-    use: TypeOnly<current.LoaderCachingPolicy>);
+    use: TypeOnly<current.LoaderCachingPolicy>): void;
 use_current_EnumDeclaration_LoaderCachingPolicy(
     get_old_EnumDeclaration_LoaderCachingPolicy());
 
@@ -809,6 +809,6 @@ use_current_EnumDeclaration_LoaderCachingPolicy(
 declare function get_current_EnumDeclaration_LoaderCachingPolicy():
     TypeOnly<current.LoaderCachingPolicy>;
 declare function use_old_EnumDeclaration_LoaderCachingPolicy(
-    use: TypeOnly<old.LoaderCachingPolicy>);
+    use: TypeOnly<old.LoaderCachingPolicy>): void;
 use_old_EnumDeclaration_LoaderCachingPolicy(
     get_current_EnumDeclaration_LoaderCachingPolicy());

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
@@ -29,7 +29,7 @@ type TypeOnly<T> = T extends number
 declare function get_old_TypeAliasDeclaration_DriverError():
     TypeOnly<old.DriverError>;
 declare function use_current_TypeAliasDeclaration_DriverError(
-    use: TypeOnly<current.DriverError>): void;
+    use: TypeOnly<current.DriverError>);
 use_current_TypeAliasDeclaration_DriverError(
     get_old_TypeAliasDeclaration_DriverError());
 
@@ -41,7 +41,7 @@ use_current_TypeAliasDeclaration_DriverError(
 declare function get_current_TypeAliasDeclaration_DriverError():
     TypeOnly<current.DriverError>;
 declare function use_old_TypeAliasDeclaration_DriverError(
-    use: TypeOnly<old.DriverError>): void;
+    use: TypeOnly<old.DriverError>);
 use_old_TypeAliasDeclaration_DriverError(
     get_current_TypeAliasDeclaration_DriverError());
 
@@ -53,7 +53,7 @@ use_old_TypeAliasDeclaration_DriverError(
 declare function get_old_EnumDeclaration_DriverErrorType():
     TypeOnly<old.DriverErrorType>;
 declare function use_current_EnumDeclaration_DriverErrorType(
-    use: TypeOnly<current.DriverErrorType>): void;
+    use: TypeOnly<current.DriverErrorType>);
 use_current_EnumDeclaration_DriverErrorType(
     get_old_EnumDeclaration_DriverErrorType());
 
@@ -65,7 +65,7 @@ use_current_EnumDeclaration_DriverErrorType(
 declare function get_current_EnumDeclaration_DriverErrorType():
     TypeOnly<current.DriverErrorType>;
 declare function use_old_EnumDeclaration_DriverErrorType(
-    use: TypeOnly<old.DriverErrorType>): void;
+    use: TypeOnly<old.DriverErrorType>);
 use_old_EnumDeclaration_DriverErrorType(
     get_current_EnumDeclaration_DriverErrorType());
 
@@ -77,7 +77,7 @@ use_old_EnumDeclaration_DriverErrorType(
 declare function get_old_VariableDeclaration_DriverErrorTypes():
     TypeOnly<typeof old.DriverErrorTypes>;
 declare function use_current_VariableDeclaration_DriverErrorTypes(
-    use: TypeOnly<typeof current.DriverErrorTypes>): void;
+    use: TypeOnly<typeof current.DriverErrorTypes>);
 use_current_VariableDeclaration_DriverErrorTypes(
     get_old_VariableDeclaration_DriverErrorTypes());
 
@@ -89,7 +89,7 @@ use_current_VariableDeclaration_DriverErrorTypes(
 declare function get_current_VariableDeclaration_DriverErrorTypes():
     TypeOnly<typeof current.DriverErrorTypes>;
 declare function use_old_VariableDeclaration_DriverErrorTypes(
-    use: TypeOnly<typeof old.DriverErrorTypes>): void;
+    use: TypeOnly<typeof old.DriverErrorTypes>);
 use_old_VariableDeclaration_DriverErrorTypes(
     get_current_VariableDeclaration_DriverErrorTypes());
 
@@ -101,7 +101,7 @@ use_old_VariableDeclaration_DriverErrorTypes(
 declare function get_old_TypeAliasDeclaration_DriverErrorTypes():
     TypeOnly<old.DriverErrorTypes>;
 declare function use_current_TypeAliasDeclaration_DriverErrorTypes(
-    use: TypeOnly<current.DriverErrorTypes>): void;
+    use: TypeOnly<current.DriverErrorTypes>);
 use_current_TypeAliasDeclaration_DriverErrorTypes(
     get_old_TypeAliasDeclaration_DriverErrorTypes());
 
@@ -113,7 +113,7 @@ use_current_TypeAliasDeclaration_DriverErrorTypes(
 declare function get_current_TypeAliasDeclaration_DriverErrorTypes():
     TypeOnly<current.DriverErrorTypes>;
 declare function use_old_TypeAliasDeclaration_DriverErrorTypes(
-    use: TypeOnly<old.DriverErrorTypes>): void;
+    use: TypeOnly<old.DriverErrorTypes>);
 use_old_TypeAliasDeclaration_DriverErrorTypes(
     get_current_TypeAliasDeclaration_DriverErrorTypes());
 
@@ -125,7 +125,7 @@ use_old_TypeAliasDeclaration_DriverErrorTypes(
 declare function get_old_EnumDeclaration_DriverHeader():
     TypeOnly<old.DriverHeader>;
 declare function use_current_EnumDeclaration_DriverHeader(
-    use: TypeOnly<current.DriverHeader>): void;
+    use: TypeOnly<current.DriverHeader>);
 use_current_EnumDeclaration_DriverHeader(
     get_old_EnumDeclaration_DriverHeader());
 
@@ -137,7 +137,7 @@ use_current_EnumDeclaration_DriverHeader(
 declare function get_current_EnumDeclaration_DriverHeader():
     TypeOnly<current.DriverHeader>;
 declare function use_old_EnumDeclaration_DriverHeader(
-    use: TypeOnly<old.DriverHeader>): void;
+    use: TypeOnly<old.DriverHeader>);
 use_old_EnumDeclaration_DriverHeader(
     get_current_EnumDeclaration_DriverHeader());
 
@@ -149,7 +149,7 @@ use_old_EnumDeclaration_DriverHeader(
 declare function get_old_InterfaceDeclaration_DriverPreCheckInfo():
     TypeOnly<old.DriverPreCheckInfo>;
 declare function use_current_InterfaceDeclaration_DriverPreCheckInfo(
-    use: TypeOnly<current.DriverPreCheckInfo>): void;
+    use: TypeOnly<current.DriverPreCheckInfo>);
 use_current_InterfaceDeclaration_DriverPreCheckInfo(
     get_old_InterfaceDeclaration_DriverPreCheckInfo());
 
@@ -161,7 +161,7 @@ use_current_InterfaceDeclaration_DriverPreCheckInfo(
 declare function get_current_InterfaceDeclaration_DriverPreCheckInfo():
     TypeOnly<current.DriverPreCheckInfo>;
 declare function use_old_InterfaceDeclaration_DriverPreCheckInfo(
-    use: TypeOnly<old.DriverPreCheckInfo>): void;
+    use: TypeOnly<old.DriverPreCheckInfo>);
 use_old_InterfaceDeclaration_DriverPreCheckInfo(
     get_current_InterfaceDeclaration_DriverPreCheckInfo());
 
@@ -173,7 +173,7 @@ use_old_InterfaceDeclaration_DriverPreCheckInfo(
 declare function get_old_EnumDeclaration_FetchSource():
     TypeOnly<old.FetchSource>;
 declare function use_current_EnumDeclaration_FetchSource(
-    use: TypeOnly<current.FetchSource>): void;
+    use: TypeOnly<current.FetchSource>);
 use_current_EnumDeclaration_FetchSource(
     get_old_EnumDeclaration_FetchSource());
 
@@ -185,7 +185,7 @@ use_current_EnumDeclaration_FetchSource(
 declare function get_current_EnumDeclaration_FetchSource():
     TypeOnly<current.FetchSource>;
 declare function use_old_EnumDeclaration_FetchSource(
-    use: TypeOnly<old.FetchSource>): void;
+    use: TypeOnly<old.FetchSource>);
 use_old_EnumDeclaration_FetchSource(
     get_current_EnumDeclaration_FetchSource());
 
@@ -197,7 +197,7 @@ use_old_EnumDeclaration_FetchSource(
 declare function get_old_TypeAliasDeclaration_FiveDaysMs():
     TypeOnly<old.FiveDaysMs>;
 declare function use_current_TypeAliasDeclaration_FiveDaysMs(
-    use: TypeOnly<current.FiveDaysMs>): void;
+    use: TypeOnly<current.FiveDaysMs>);
 use_current_TypeAliasDeclaration_FiveDaysMs(
     get_old_TypeAliasDeclaration_FiveDaysMs());
 
@@ -209,7 +209,7 @@ use_current_TypeAliasDeclaration_FiveDaysMs(
 declare function get_current_TypeAliasDeclaration_FiveDaysMs():
     TypeOnly<current.FiveDaysMs>;
 declare function use_old_TypeAliasDeclaration_FiveDaysMs(
-    use: TypeOnly<old.FiveDaysMs>): void;
+    use: TypeOnly<old.FiveDaysMs>);
 use_old_TypeAliasDeclaration_FiveDaysMs(
     get_current_TypeAliasDeclaration_FiveDaysMs());
 
@@ -221,7 +221,7 @@ use_old_TypeAliasDeclaration_FiveDaysMs(
 declare function get_old_InterfaceDeclaration_IAnyDriverError():
     TypeOnly<old.IAnyDriverError>;
 declare function use_current_InterfaceDeclaration_IAnyDriverError(
-    use: TypeOnly<current.IAnyDriverError>): void;
+    use: TypeOnly<current.IAnyDriverError>);
 use_current_InterfaceDeclaration_IAnyDriverError(
     get_old_InterfaceDeclaration_IAnyDriverError());
 
@@ -233,7 +233,7 @@ use_current_InterfaceDeclaration_IAnyDriverError(
 declare function get_current_InterfaceDeclaration_IAnyDriverError():
     TypeOnly<current.IAnyDriverError>;
 declare function use_old_InterfaceDeclaration_IAnyDriverError(
-    use: TypeOnly<old.IAnyDriverError>): void;
+    use: TypeOnly<old.IAnyDriverError>);
 use_old_InterfaceDeclaration_IAnyDriverError(
     get_current_InterfaceDeclaration_IAnyDriverError());
 
@@ -245,7 +245,7 @@ use_old_InterfaceDeclaration_IAnyDriverError(
 declare function get_old_InterfaceDeclaration_IAuthorizationError():
     TypeOnly<old.IAuthorizationError>;
 declare function use_current_InterfaceDeclaration_IAuthorizationError(
-    use: TypeOnly<current.IAuthorizationError>): void;
+    use: TypeOnly<current.IAuthorizationError>);
 use_current_InterfaceDeclaration_IAuthorizationError(
     get_old_InterfaceDeclaration_IAuthorizationError());
 
@@ -257,7 +257,7 @@ use_current_InterfaceDeclaration_IAuthorizationError(
 declare function get_current_InterfaceDeclaration_IAuthorizationError():
     TypeOnly<current.IAuthorizationError>;
 declare function use_old_InterfaceDeclaration_IAuthorizationError(
-    use: TypeOnly<old.IAuthorizationError>): void;
+    use: TypeOnly<old.IAuthorizationError>);
 use_old_InterfaceDeclaration_IAuthorizationError(
     get_current_InterfaceDeclaration_IAuthorizationError());
 
@@ -269,7 +269,7 @@ use_old_InterfaceDeclaration_IAuthorizationError(
 declare function get_old_InterfaceDeclaration_IContainerPackageInfo():
     TypeOnly<old.IContainerPackageInfo>;
 declare function use_current_InterfaceDeclaration_IContainerPackageInfo(
-    use: TypeOnly<current.IContainerPackageInfo>): void;
+    use: TypeOnly<current.IContainerPackageInfo>);
 use_current_InterfaceDeclaration_IContainerPackageInfo(
     get_old_InterfaceDeclaration_IContainerPackageInfo());
 
@@ -281,7 +281,7 @@ use_current_InterfaceDeclaration_IContainerPackageInfo(
 declare function get_current_InterfaceDeclaration_IContainerPackageInfo():
     TypeOnly<current.IContainerPackageInfo>;
 declare function use_old_InterfaceDeclaration_IContainerPackageInfo(
-    use: TypeOnly<old.IContainerPackageInfo>): void;
+    use: TypeOnly<old.IContainerPackageInfo>);
 use_old_InterfaceDeclaration_IContainerPackageInfo(
     get_current_InterfaceDeclaration_IContainerPackageInfo());
 
@@ -293,7 +293,7 @@ use_old_InterfaceDeclaration_IContainerPackageInfo(
 declare function get_old_InterfaceDeclaration_IDeltaStorageService():
     TypeOnly<old.IDeltaStorageService>;
 declare function use_current_InterfaceDeclaration_IDeltaStorageService(
-    use: TypeOnly<current.IDeltaStorageService>): void;
+    use: TypeOnly<current.IDeltaStorageService>);
 use_current_InterfaceDeclaration_IDeltaStorageService(
     get_old_InterfaceDeclaration_IDeltaStorageService());
 
@@ -305,7 +305,7 @@ use_current_InterfaceDeclaration_IDeltaStorageService(
 declare function get_current_InterfaceDeclaration_IDeltaStorageService():
     TypeOnly<current.IDeltaStorageService>;
 declare function use_old_InterfaceDeclaration_IDeltaStorageService(
-    use: TypeOnly<old.IDeltaStorageService>): void;
+    use: TypeOnly<old.IDeltaStorageService>);
 use_old_InterfaceDeclaration_IDeltaStorageService(
     get_current_InterfaceDeclaration_IDeltaStorageService());
 
@@ -317,7 +317,7 @@ use_old_InterfaceDeclaration_IDeltaStorageService(
 declare function get_old_InterfaceDeclaration_IDeltasFetchResult():
     TypeOnly<old.IDeltasFetchResult>;
 declare function use_current_InterfaceDeclaration_IDeltasFetchResult(
-    use: TypeOnly<current.IDeltasFetchResult>): void;
+    use: TypeOnly<current.IDeltasFetchResult>);
 use_current_InterfaceDeclaration_IDeltasFetchResult(
     get_old_InterfaceDeclaration_IDeltasFetchResult());
 
@@ -329,7 +329,7 @@ use_current_InterfaceDeclaration_IDeltasFetchResult(
 declare function get_current_InterfaceDeclaration_IDeltasFetchResult():
     TypeOnly<current.IDeltasFetchResult>;
 declare function use_old_InterfaceDeclaration_IDeltasFetchResult(
-    use: TypeOnly<old.IDeltasFetchResult>): void;
+    use: TypeOnly<old.IDeltasFetchResult>);
 use_old_InterfaceDeclaration_IDeltasFetchResult(
     get_current_InterfaceDeclaration_IDeltasFetchResult());
 
@@ -341,7 +341,7 @@ use_old_InterfaceDeclaration_IDeltasFetchResult(
 declare function get_old_InterfaceDeclaration_IDocumentDeltaConnection():
     TypeOnly<old.IDocumentDeltaConnection>;
 declare function use_current_InterfaceDeclaration_IDocumentDeltaConnection(
-    use: TypeOnly<current.IDocumentDeltaConnection>): void;
+    use: TypeOnly<current.IDocumentDeltaConnection>);
 use_current_InterfaceDeclaration_IDocumentDeltaConnection(
     get_old_InterfaceDeclaration_IDocumentDeltaConnection());
 
@@ -353,7 +353,7 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnection(
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnection():
     TypeOnly<current.IDocumentDeltaConnection>;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnection(
-    use: TypeOnly<old.IDocumentDeltaConnection>): void;
+    use: TypeOnly<old.IDocumentDeltaConnection>);
 use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     get_current_InterfaceDeclaration_IDocumentDeltaConnection());
 
@@ -365,7 +365,7 @@ use_old_InterfaceDeclaration_IDocumentDeltaConnection(
 declare function get_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents():
     TypeOnly<old.IDocumentDeltaConnectionEvents>;
 declare function use_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
-    use: TypeOnly<current.IDocumentDeltaConnectionEvents>): void;
+    use: TypeOnly<current.IDocumentDeltaConnectionEvents>);
 use_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
     get_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents());
 
@@ -377,7 +377,7 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents():
     TypeOnly<current.IDocumentDeltaConnectionEvents>;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
-    use: TypeOnly<old.IDocumentDeltaConnectionEvents>): void;
+    use: TypeOnly<old.IDocumentDeltaConnectionEvents>);
 use_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
     get_current_InterfaceDeclaration_IDocumentDeltaConnectionEvents());
 
@@ -389,7 +389,7 @@ use_old_InterfaceDeclaration_IDocumentDeltaConnectionEvents(
 declare function get_old_InterfaceDeclaration_IDocumentDeltaStorageService():
     TypeOnly<old.IDocumentDeltaStorageService>;
 declare function use_current_InterfaceDeclaration_IDocumentDeltaStorageService(
-    use: TypeOnly<current.IDocumentDeltaStorageService>): void;
+    use: TypeOnly<current.IDocumentDeltaStorageService>);
 use_current_InterfaceDeclaration_IDocumentDeltaStorageService(
     get_old_InterfaceDeclaration_IDocumentDeltaStorageService());
 
@@ -401,7 +401,7 @@ use_current_InterfaceDeclaration_IDocumentDeltaStorageService(
 declare function get_current_InterfaceDeclaration_IDocumentDeltaStorageService():
     TypeOnly<current.IDocumentDeltaStorageService>;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaStorageService(
-    use: TypeOnly<old.IDocumentDeltaStorageService>): void;
+    use: TypeOnly<old.IDocumentDeltaStorageService>);
 use_old_InterfaceDeclaration_IDocumentDeltaStorageService(
     get_current_InterfaceDeclaration_IDocumentDeltaStorageService());
 
@@ -413,7 +413,7 @@ use_old_InterfaceDeclaration_IDocumentDeltaStorageService(
 declare function get_old_InterfaceDeclaration_IDocumentService():
     TypeOnly<old.IDocumentService>;
 declare function use_current_InterfaceDeclaration_IDocumentService(
-    use: TypeOnly<current.IDocumentService>): void;
+    use: TypeOnly<current.IDocumentService>);
 use_current_InterfaceDeclaration_IDocumentService(
     get_old_InterfaceDeclaration_IDocumentService());
 
@@ -425,7 +425,7 @@ use_current_InterfaceDeclaration_IDocumentService(
 declare function get_current_InterfaceDeclaration_IDocumentService():
     TypeOnly<current.IDocumentService>;
 declare function use_old_InterfaceDeclaration_IDocumentService(
-    use: TypeOnly<old.IDocumentService>): void;
+    use: TypeOnly<old.IDocumentService>);
 use_old_InterfaceDeclaration_IDocumentService(
     get_current_InterfaceDeclaration_IDocumentService());
 
@@ -437,7 +437,7 @@ use_old_InterfaceDeclaration_IDocumentService(
 declare function get_old_InterfaceDeclaration_IDocumentServiceFactory():
     TypeOnly<old.IDocumentServiceFactory>;
 declare function use_current_InterfaceDeclaration_IDocumentServiceFactory(
-    use: TypeOnly<current.IDocumentServiceFactory>): void;
+    use: TypeOnly<current.IDocumentServiceFactory>);
 use_current_InterfaceDeclaration_IDocumentServiceFactory(
     get_old_InterfaceDeclaration_IDocumentServiceFactory());
 
@@ -449,7 +449,7 @@ use_current_InterfaceDeclaration_IDocumentServiceFactory(
 declare function get_current_InterfaceDeclaration_IDocumentServiceFactory():
     TypeOnly<current.IDocumentServiceFactory>;
 declare function use_old_InterfaceDeclaration_IDocumentServiceFactory(
-    use: TypeOnly<old.IDocumentServiceFactory>): void;
+    use: TypeOnly<old.IDocumentServiceFactory>);
 use_old_InterfaceDeclaration_IDocumentServiceFactory(
     get_current_InterfaceDeclaration_IDocumentServiceFactory());
 
@@ -461,7 +461,7 @@ use_old_InterfaceDeclaration_IDocumentServiceFactory(
 declare function get_old_InterfaceDeclaration_IDocumentServicePolicies():
     TypeOnly<old.IDocumentServicePolicies>;
 declare function use_current_InterfaceDeclaration_IDocumentServicePolicies(
-    use: TypeOnly<current.IDocumentServicePolicies>): void;
+    use: TypeOnly<current.IDocumentServicePolicies>);
 use_current_InterfaceDeclaration_IDocumentServicePolicies(
     get_old_InterfaceDeclaration_IDocumentServicePolicies());
 
@@ -473,7 +473,7 @@ use_current_InterfaceDeclaration_IDocumentServicePolicies(
 declare function get_current_InterfaceDeclaration_IDocumentServicePolicies():
     TypeOnly<current.IDocumentServicePolicies>;
 declare function use_old_InterfaceDeclaration_IDocumentServicePolicies(
-    use: TypeOnly<old.IDocumentServicePolicies>): void;
+    use: TypeOnly<old.IDocumentServicePolicies>);
 use_old_InterfaceDeclaration_IDocumentServicePolicies(
     get_current_InterfaceDeclaration_IDocumentServicePolicies());
 
@@ -485,7 +485,7 @@ use_old_InterfaceDeclaration_IDocumentServicePolicies(
 declare function get_old_InterfaceDeclaration_IDocumentStorageService():
     TypeOnly<old.IDocumentStorageService>;
 declare function use_current_InterfaceDeclaration_IDocumentStorageService(
-    use: TypeOnly<current.IDocumentStorageService>): void;
+    use: TypeOnly<current.IDocumentStorageService>);
 use_current_InterfaceDeclaration_IDocumentStorageService(
     get_old_InterfaceDeclaration_IDocumentStorageService());
 
@@ -497,7 +497,7 @@ use_current_InterfaceDeclaration_IDocumentStorageService(
 declare function get_current_InterfaceDeclaration_IDocumentStorageService():
     TypeOnly<current.IDocumentStorageService>;
 declare function use_old_InterfaceDeclaration_IDocumentStorageService(
-    use: TypeOnly<old.IDocumentStorageService>): void;
+    use: TypeOnly<old.IDocumentStorageService>);
 use_old_InterfaceDeclaration_IDocumentStorageService(
     get_current_InterfaceDeclaration_IDocumentStorageService());
 
@@ -509,7 +509,7 @@ use_old_InterfaceDeclaration_IDocumentStorageService(
 declare function get_old_InterfaceDeclaration_IDocumentStorageServicePolicies():
     TypeOnly<old.IDocumentStorageServicePolicies>;
 declare function use_current_InterfaceDeclaration_IDocumentStorageServicePolicies(
-    use: TypeOnly<current.IDocumentStorageServicePolicies>): void;
+    use: TypeOnly<current.IDocumentStorageServicePolicies>);
 use_current_InterfaceDeclaration_IDocumentStorageServicePolicies(
     get_old_InterfaceDeclaration_IDocumentStorageServicePolicies());
 
@@ -521,7 +521,7 @@ use_current_InterfaceDeclaration_IDocumentStorageServicePolicies(
 declare function get_current_InterfaceDeclaration_IDocumentStorageServicePolicies():
     TypeOnly<current.IDocumentStorageServicePolicies>;
 declare function use_old_InterfaceDeclaration_IDocumentStorageServicePolicies(
-    use: TypeOnly<old.IDocumentStorageServicePolicies>): void;
+    use: TypeOnly<old.IDocumentStorageServicePolicies>);
 use_old_InterfaceDeclaration_IDocumentStorageServicePolicies(
     get_current_InterfaceDeclaration_IDocumentStorageServicePolicies());
 
@@ -533,7 +533,7 @@ use_old_InterfaceDeclaration_IDocumentStorageServicePolicies(
 declare function get_old_InterfaceDeclaration_IDriverBasicError():
     TypeOnly<old.IDriverBasicError>;
 declare function use_current_InterfaceDeclaration_IDriverBasicError(
-    use: TypeOnly<current.IDriverBasicError>): void;
+    use: TypeOnly<current.IDriverBasicError>);
 use_current_InterfaceDeclaration_IDriverBasicError(
     get_old_InterfaceDeclaration_IDriverBasicError());
 
@@ -545,7 +545,7 @@ use_current_InterfaceDeclaration_IDriverBasicError(
 declare function get_current_InterfaceDeclaration_IDriverBasicError():
     TypeOnly<current.IDriverBasicError>;
 declare function use_old_InterfaceDeclaration_IDriverBasicError(
-    use: TypeOnly<old.IDriverBasicError>): void;
+    use: TypeOnly<old.IDriverBasicError>);
 use_old_InterfaceDeclaration_IDriverBasicError(
     get_current_InterfaceDeclaration_IDriverBasicError());
 
@@ -557,7 +557,7 @@ use_old_InterfaceDeclaration_IDriverBasicError(
 declare function get_old_InterfaceDeclaration_IDriverErrorBase():
     TypeOnly<old.IDriverErrorBase>;
 declare function use_current_InterfaceDeclaration_IDriverErrorBase(
-    use: TypeOnly<current.IDriverErrorBase>): void;
+    use: TypeOnly<current.IDriverErrorBase>);
 use_current_InterfaceDeclaration_IDriverErrorBase(
     get_old_InterfaceDeclaration_IDriverErrorBase());
 
@@ -569,7 +569,7 @@ use_current_InterfaceDeclaration_IDriverErrorBase(
 declare function get_current_InterfaceDeclaration_IDriverErrorBase():
     TypeOnly<current.IDriverErrorBase>;
 declare function use_old_InterfaceDeclaration_IDriverErrorBase(
-    use: TypeOnly<old.IDriverErrorBase>): void;
+    use: TypeOnly<old.IDriverErrorBase>);
 use_old_InterfaceDeclaration_IDriverErrorBase(
     get_current_InterfaceDeclaration_IDriverErrorBase());
 
@@ -581,7 +581,7 @@ use_old_InterfaceDeclaration_IDriverErrorBase(
 declare function get_old_InterfaceDeclaration_IDriverHeader():
     TypeOnly<old.IDriverHeader>;
 declare function use_current_InterfaceDeclaration_IDriverHeader(
-    use: TypeOnly<current.IDriverHeader>): void;
+    use: TypeOnly<current.IDriverHeader>);
 use_current_InterfaceDeclaration_IDriverHeader(
     get_old_InterfaceDeclaration_IDriverHeader());
 
@@ -593,7 +593,7 @@ use_current_InterfaceDeclaration_IDriverHeader(
 declare function get_current_InterfaceDeclaration_IDriverHeader():
     TypeOnly<current.IDriverHeader>;
 declare function use_old_InterfaceDeclaration_IDriverHeader(
-    use: TypeOnly<old.IDriverHeader>): void;
+    use: TypeOnly<old.IDriverHeader>);
 use_old_InterfaceDeclaration_IDriverHeader(
     get_current_InterfaceDeclaration_IDriverHeader());
 
@@ -605,7 +605,7 @@ use_old_InterfaceDeclaration_IDriverHeader(
 declare function get_old_InterfaceDeclaration_IGenericNetworkError():
     TypeOnly<old.IGenericNetworkError>;
 declare function use_current_InterfaceDeclaration_IGenericNetworkError(
-    use: TypeOnly<current.IGenericNetworkError>): void;
+    use: TypeOnly<current.IGenericNetworkError>);
 use_current_InterfaceDeclaration_IGenericNetworkError(
     get_old_InterfaceDeclaration_IGenericNetworkError());
 
@@ -617,7 +617,7 @@ use_current_InterfaceDeclaration_IGenericNetworkError(
 declare function get_current_InterfaceDeclaration_IGenericNetworkError():
     TypeOnly<current.IGenericNetworkError>;
 declare function use_old_InterfaceDeclaration_IGenericNetworkError(
-    use: TypeOnly<old.IGenericNetworkError>): void;
+    use: TypeOnly<old.IGenericNetworkError>);
 use_old_InterfaceDeclaration_IGenericNetworkError(
     get_current_InterfaceDeclaration_IGenericNetworkError());
 
@@ -629,7 +629,7 @@ use_old_InterfaceDeclaration_IGenericNetworkError(
 declare function get_old_InterfaceDeclaration_ILocationRedirectionError():
     TypeOnly<old.ILocationRedirectionError>;
 declare function use_current_InterfaceDeclaration_ILocationRedirectionError(
-    use: TypeOnly<current.ILocationRedirectionError>): void;
+    use: TypeOnly<current.ILocationRedirectionError>);
 use_current_InterfaceDeclaration_ILocationRedirectionError(
     get_old_InterfaceDeclaration_ILocationRedirectionError());
 
@@ -641,7 +641,7 @@ use_current_InterfaceDeclaration_ILocationRedirectionError(
 declare function get_current_InterfaceDeclaration_ILocationRedirectionError():
     TypeOnly<current.ILocationRedirectionError>;
 declare function use_old_InterfaceDeclaration_ILocationRedirectionError(
-    use: TypeOnly<old.ILocationRedirectionError>): void;
+    use: TypeOnly<old.ILocationRedirectionError>);
 use_old_InterfaceDeclaration_ILocationRedirectionError(
     get_current_InterfaceDeclaration_ILocationRedirectionError());
 
@@ -653,7 +653,7 @@ use_old_InterfaceDeclaration_ILocationRedirectionError(
 declare function get_old_InterfaceDeclaration_IResolvedUrl():
     TypeOnly<old.IResolvedUrl>;
 declare function use_current_InterfaceDeclaration_IResolvedUrl(
-    use: TypeOnly<current.IResolvedUrl>): void;
+    use: TypeOnly<current.IResolvedUrl>);
 use_current_InterfaceDeclaration_IResolvedUrl(
     get_old_InterfaceDeclaration_IResolvedUrl());
 
@@ -665,7 +665,7 @@ use_current_InterfaceDeclaration_IResolvedUrl(
 declare function get_current_InterfaceDeclaration_IResolvedUrl():
     TypeOnly<current.IResolvedUrl>;
 declare function use_old_InterfaceDeclaration_IResolvedUrl(
-    use: TypeOnly<old.IResolvedUrl>): void;
+    use: TypeOnly<old.IResolvedUrl>);
 use_old_InterfaceDeclaration_IResolvedUrl(
     get_current_InterfaceDeclaration_IResolvedUrl());
 
@@ -677,7 +677,7 @@ use_old_InterfaceDeclaration_IResolvedUrl(
 declare function get_old_InterfaceDeclaration_IStream():
     TypeOnly<old.IStream<any>>;
 declare function use_current_InterfaceDeclaration_IStream(
-    use: TypeOnly<current.IStream<any>>): void;
+    use: TypeOnly<current.IStream<any>>);
 use_current_InterfaceDeclaration_IStream(
     get_old_InterfaceDeclaration_IStream());
 
@@ -689,7 +689,7 @@ use_current_InterfaceDeclaration_IStream(
 declare function get_current_InterfaceDeclaration_IStream():
     TypeOnly<current.IStream<any>>;
 declare function use_old_InterfaceDeclaration_IStream(
-    use: TypeOnly<old.IStream<any>>): void;
+    use: TypeOnly<old.IStream<any>>);
 use_old_InterfaceDeclaration_IStream(
     get_current_InterfaceDeclaration_IStream());
 
@@ -701,7 +701,7 @@ use_old_InterfaceDeclaration_IStream(
 declare function get_old_TypeAliasDeclaration_IStreamResult():
     TypeOnly<old.IStreamResult<any>>;
 declare function use_current_TypeAliasDeclaration_IStreamResult(
-    use: TypeOnly<current.IStreamResult<any>>): void;
+    use: TypeOnly<current.IStreamResult<any>>);
 use_current_TypeAliasDeclaration_IStreamResult(
     get_old_TypeAliasDeclaration_IStreamResult());
 
@@ -713,7 +713,7 @@ use_current_TypeAliasDeclaration_IStreamResult(
 declare function get_current_TypeAliasDeclaration_IStreamResult():
     TypeOnly<current.IStreamResult<any>>;
 declare function use_old_TypeAliasDeclaration_IStreamResult(
-    use: TypeOnly<old.IStreamResult<any>>): void;
+    use: TypeOnly<old.IStreamResult<any>>);
 use_old_TypeAliasDeclaration_IStreamResult(
     get_current_TypeAliasDeclaration_IStreamResult());
 
@@ -725,7 +725,7 @@ use_old_TypeAliasDeclaration_IStreamResult(
 declare function get_old_InterfaceDeclaration_ISummaryContext():
     TypeOnly<old.ISummaryContext>;
 declare function use_current_InterfaceDeclaration_ISummaryContext(
-    use: TypeOnly<current.ISummaryContext>): void;
+    use: TypeOnly<current.ISummaryContext>);
 use_current_InterfaceDeclaration_ISummaryContext(
     get_old_InterfaceDeclaration_ISummaryContext());
 
@@ -737,7 +737,7 @@ use_current_InterfaceDeclaration_ISummaryContext(
 declare function get_current_InterfaceDeclaration_ISummaryContext():
     TypeOnly<current.ISummaryContext>;
 declare function use_old_InterfaceDeclaration_ISummaryContext(
-    use: TypeOnly<old.ISummaryContext>): void;
+    use: TypeOnly<old.ISummaryContext>);
 use_old_InterfaceDeclaration_ISummaryContext(
     get_current_InterfaceDeclaration_ISummaryContext());
 
@@ -749,7 +749,7 @@ use_old_InterfaceDeclaration_ISummaryContext(
 declare function get_old_InterfaceDeclaration_IThrottlingWarning():
     TypeOnly<old.IThrottlingWarning>;
 declare function use_current_InterfaceDeclaration_IThrottlingWarning(
-    use: TypeOnly<current.IThrottlingWarning>): void;
+    use: TypeOnly<current.IThrottlingWarning>);
 use_current_InterfaceDeclaration_IThrottlingWarning(
     get_old_InterfaceDeclaration_IThrottlingWarning());
 
@@ -761,7 +761,7 @@ use_current_InterfaceDeclaration_IThrottlingWarning(
 declare function get_current_InterfaceDeclaration_IThrottlingWarning():
     TypeOnly<current.IThrottlingWarning>;
 declare function use_old_InterfaceDeclaration_IThrottlingWarning(
-    use: TypeOnly<old.IThrottlingWarning>): void;
+    use: TypeOnly<old.IThrottlingWarning>);
 use_old_InterfaceDeclaration_IThrottlingWarning(
     get_current_InterfaceDeclaration_IThrottlingWarning());
 
@@ -773,7 +773,7 @@ use_old_InterfaceDeclaration_IThrottlingWarning(
 declare function get_old_InterfaceDeclaration_IUrlResolver():
     TypeOnly<old.IUrlResolver>;
 declare function use_current_InterfaceDeclaration_IUrlResolver(
-    use: TypeOnly<current.IUrlResolver>): void;
+    use: TypeOnly<current.IUrlResolver>);
 use_current_InterfaceDeclaration_IUrlResolver(
     get_old_InterfaceDeclaration_IUrlResolver());
 
@@ -785,7 +785,7 @@ use_current_InterfaceDeclaration_IUrlResolver(
 declare function get_current_InterfaceDeclaration_IUrlResolver():
     TypeOnly<current.IUrlResolver>;
 declare function use_old_InterfaceDeclaration_IUrlResolver(
-    use: TypeOnly<old.IUrlResolver>): void;
+    use: TypeOnly<old.IUrlResolver>);
 use_old_InterfaceDeclaration_IUrlResolver(
     get_current_InterfaceDeclaration_IUrlResolver());
 
@@ -797,7 +797,7 @@ use_old_InterfaceDeclaration_IUrlResolver(
 declare function get_old_EnumDeclaration_LoaderCachingPolicy():
     TypeOnly<old.LoaderCachingPolicy>;
 declare function use_current_EnumDeclaration_LoaderCachingPolicy(
-    use: TypeOnly<current.LoaderCachingPolicy>): void;
+    use: TypeOnly<current.LoaderCachingPolicy>);
 use_current_EnumDeclaration_LoaderCachingPolicy(
     get_old_EnumDeclaration_LoaderCachingPolicy());
 
@@ -809,6 +809,6 @@ use_current_EnumDeclaration_LoaderCachingPolicy(
 declare function get_current_EnumDeclaration_LoaderCachingPolicy():
     TypeOnly<current.LoaderCachingPolicy>;
 declare function use_old_EnumDeclaration_LoaderCachingPolicy(
-    use: TypeOnly<old.LoaderCachingPolicy>): void;
+    use: TypeOnly<old.LoaderCachingPolicy>);
 use_old_EnumDeclaration_LoaderCachingPolicy(
     get_current_EnumDeclaration_LoaderCachingPolicy());

--- a/packages/dds/migration-shim/src/test/dataMigration.spec.ts
+++ b/packages/dds/migration-shim/src/test/dataMigration.spec.ts
@@ -31,9 +31,9 @@ import {
 	type ISharedTree,
 	SchemaBuilder,
 	SharedTreeFactory,
-	type FlexTreeTyped,
-	type ITreeView,
 	disposeSymbol,
+	type TreeView,
+	type ProxyField,
 } from "@fluid-experimental/tree2";
 import { LoaderHeader } from "@fluidframework/container-definitions";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
@@ -109,8 +109,8 @@ const inventorySchema = builder.object("abcInventory", {
 const inventoryFieldSchema = SchemaBuilder.required(inventorySchema);
 const schema = builder.intoSchema(inventoryFieldSchema);
 
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof inventoryFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof inventoryFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},
@@ -273,8 +273,8 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 
 		const view1 = getNewTreeView(tree1);
 		const view2 = getNewTreeView(tree2);
-		const treeNode1: FlexTreeTyped<typeof inventorySchema> = view1.editableTree.content;
-		const treeNode2: FlexTreeTyped<typeof inventorySchema> = view2.editableTree.content;
+		const treeNode1 = view1.root;
+		const treeNode2 = view2.root;
 
 		// Validate migrated values of the old tree match the new tree
 		const migratedValue1 = treeNode1.quantity;

--- a/packages/dds/migration-shim/src/test/migrationShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/migrationShim.spec.ts
@@ -28,11 +28,12 @@ import {
 import {
 	AllowedUpdateType,
 	type ISharedTree,
-	type ITreeView,
+	type TreeView,
 	SchemaBuilder,
 	SharedTreeFactory,
 	type ProxyNode,
 	disposeSymbol,
+	type ProxyField,
 } from "@fluid-experimental/tree2";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type IContainerRuntimeOptions } from "@fluidframework/container-runtime";
@@ -65,8 +66,8 @@ const rootType = builder.object("abc", {
 	quantity: builder.number,
 });
 const schema = builder.intoSchema(rootType);
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof schema.rootFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},

--- a/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
+++ b/packages/dds/migration-shim/src/test/sharedTreeShim.spec.ts
@@ -22,8 +22,9 @@ import {
 	type ISharedTree,
 	SchemaBuilder,
 	SharedTreeFactory,
-	type ITreeView,
+	type TreeView,
 	type ProxyNode,
+	type ProxyField,
 } from "@fluid-experimental/tree2";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type IContainerRuntimeOptions } from "@fluidframework/container-runtime";
@@ -55,8 +56,8 @@ const rootType = builder.object("abc", {
 });
 const schema = builder.intoSchema(rootType);
 
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof schema.rootFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},

--- a/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
+++ b/packages/dds/migration-shim/src/test/stampedV2Ops.spec.ts
@@ -31,8 +31,9 @@ import {
 	type ISharedTree,
 	SchemaBuilder,
 	SharedTreeFactory,
-	type ITreeView,
+	type TreeView,
 	disposeSymbol,
+	type ProxyField,
 } from "@fluid-experimental/tree2";
 // eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/dist/EditLog.js";
@@ -122,8 +123,8 @@ const quantityType = builder.object("quantityObj", {
 });
 const schema = builder.intoSchema(quantityType);
 
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof schema.rootFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
 			quantity: 0,
 		},

--- a/packages/dds/migration-shim/src/test/storingHandles.spec.ts
+++ b/packages/dds/migration-shim/src/test/storingHandles.spec.ts
@@ -31,10 +31,11 @@ import {
 import {
 	AllowedUpdateType,
 	type ISharedTree,
-	type ITreeView,
+	type TreeView,
 	SchemaBuilder,
 	SharedTreeFactory,
 	disposeSymbol,
+	type ProxyField,
 } from "@fluid-experimental/tree2";
 // eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/dist/EditLog.js";
@@ -141,8 +142,8 @@ const handleType = builder.object("handleObj", {
 });
 const schema = builder.intoSchema(handleType);
 
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof schema.rootFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
 			handle: undefined,
 		},

--- a/packages/dds/migration-shim/src/test/storingHandlesDetached.spec.ts
+++ b/packages/dds/migration-shim/src/test/storingHandlesDetached.spec.ts
@@ -20,9 +20,10 @@ import {
 import {
 	AllowedUpdateType,
 	type ISharedTree,
-	type ITreeView,
+	type TreeView,
 	SchemaBuilder,
 	SharedTreeFactory,
+	type ProxyField,
 } from "@fluid-experimental/tree2";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { stringToBuffer } from "@fluid-internal/client-utils";
@@ -37,8 +38,8 @@ const handleType = builder.object("handleObj", {
 });
 const schema = builder.intoSchema(handleType);
 
-function getNewTreeView(tree: ISharedTree): ITreeView<typeof schema.rootFieldSchema> {
-	return tree.schematizeInternal({
+function getNewTreeView(tree: ISharedTree): TreeView<ProxyField<typeof schema.rootFieldSchema>> {
+	return tree.schematize({
 		initialTree: {
 			handle: undefined,
 		},

--- a/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
+++ b/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
@@ -29,7 +29,7 @@ type TypeOnly<T> = T extends number
 declare function get_old_ClassDeclaration_DocumentDeltaConnection():
     TypeOnly<old.DocumentDeltaConnection>;
 declare function use_current_ClassDeclaration_DocumentDeltaConnection(
-    use: TypeOnly<current.DocumentDeltaConnection>);
+    use: TypeOnly<current.DocumentDeltaConnection>): void;
 use_current_ClassDeclaration_DocumentDeltaConnection(
     get_old_ClassDeclaration_DocumentDeltaConnection());
 
@@ -41,7 +41,7 @@ use_current_ClassDeclaration_DocumentDeltaConnection(
 declare function get_current_ClassDeclaration_DocumentDeltaConnection():
     TypeOnly<current.DocumentDeltaConnection>;
 declare function use_old_ClassDeclaration_DocumentDeltaConnection(
-    use: TypeOnly<old.DocumentDeltaConnection>);
+    use: TypeOnly<old.DocumentDeltaConnection>): void;
 use_old_ClassDeclaration_DocumentDeltaConnection(
     get_current_ClassDeclaration_DocumentDeltaConnection());
 
@@ -53,7 +53,7 @@ use_old_ClassDeclaration_DocumentDeltaConnection(
 declare function get_old_FunctionDeclaration_getW3CData():
     TypeOnly<typeof old.getW3CData>;
 declare function use_current_FunctionDeclaration_getW3CData(
-    use: TypeOnly<typeof current.getW3CData>);
+    use: TypeOnly<typeof current.getW3CData>): void;
 use_current_FunctionDeclaration_getW3CData(
     get_old_FunctionDeclaration_getW3CData());
 
@@ -65,7 +65,7 @@ use_current_FunctionDeclaration_getW3CData(
 declare function get_current_FunctionDeclaration_getW3CData():
     TypeOnly<typeof current.getW3CData>;
 declare function use_old_FunctionDeclaration_getW3CData(
-    use: TypeOnly<typeof old.getW3CData>);
+    use: TypeOnly<typeof old.getW3CData>): void;
 use_old_FunctionDeclaration_getW3CData(
     get_current_FunctionDeclaration_getW3CData());
 
@@ -77,7 +77,7 @@ use_old_FunctionDeclaration_getW3CData(
 declare function get_old_FunctionDeclaration_promiseRaceWithWinner():
     TypeOnly<typeof old.promiseRaceWithWinner>;
 declare function use_current_FunctionDeclaration_promiseRaceWithWinner(
-    use: TypeOnly<typeof current.promiseRaceWithWinner>);
+    use: TypeOnly<typeof current.promiseRaceWithWinner>): void;
 use_current_FunctionDeclaration_promiseRaceWithWinner(
     get_old_FunctionDeclaration_promiseRaceWithWinner());
 
@@ -89,7 +89,7 @@ use_current_FunctionDeclaration_promiseRaceWithWinner(
 declare function get_current_FunctionDeclaration_promiseRaceWithWinner():
     TypeOnly<typeof current.promiseRaceWithWinner>;
 declare function use_old_FunctionDeclaration_promiseRaceWithWinner(
-    use: TypeOnly<typeof old.promiseRaceWithWinner>);
+    use: TypeOnly<typeof old.promiseRaceWithWinner>): void;
 use_old_FunctionDeclaration_promiseRaceWithWinner(
     get_current_FunctionDeclaration_promiseRaceWithWinner());
 
@@ -101,7 +101,7 @@ use_old_FunctionDeclaration_promiseRaceWithWinner(
 declare function get_old_FunctionDeclaration_validateMessages():
     TypeOnly<typeof old.validateMessages>;
 declare function use_current_FunctionDeclaration_validateMessages(
-    use: TypeOnly<typeof current.validateMessages>);
+    use: TypeOnly<typeof current.validateMessages>): void;
 use_current_FunctionDeclaration_validateMessages(
     get_old_FunctionDeclaration_validateMessages());
 
@@ -113,6 +113,6 @@ use_current_FunctionDeclaration_validateMessages(
 declare function get_current_FunctionDeclaration_validateMessages():
     TypeOnly<typeof current.validateMessages>;
 declare function use_old_FunctionDeclaration_validateMessages(
-    use: TypeOnly<typeof old.validateMessages>);
+    use: TypeOnly<typeof old.validateMessages>): void;
 use_old_FunctionDeclaration_validateMessages(
     get_current_FunctionDeclaration_validateMessages());

--- a/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
+++ b/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
@@ -29,7 +29,7 @@ type TypeOnly<T> = T extends number
 declare function get_old_ClassDeclaration_DocumentDeltaConnection():
     TypeOnly<old.DocumentDeltaConnection>;
 declare function use_current_ClassDeclaration_DocumentDeltaConnection(
-    use: TypeOnly<current.DocumentDeltaConnection>): void;
+    use: TypeOnly<current.DocumentDeltaConnection>);
 use_current_ClassDeclaration_DocumentDeltaConnection(
     get_old_ClassDeclaration_DocumentDeltaConnection());
 
@@ -41,7 +41,7 @@ use_current_ClassDeclaration_DocumentDeltaConnection(
 declare function get_current_ClassDeclaration_DocumentDeltaConnection():
     TypeOnly<current.DocumentDeltaConnection>;
 declare function use_old_ClassDeclaration_DocumentDeltaConnection(
-    use: TypeOnly<old.DocumentDeltaConnection>): void;
+    use: TypeOnly<old.DocumentDeltaConnection>);
 use_old_ClassDeclaration_DocumentDeltaConnection(
     get_current_ClassDeclaration_DocumentDeltaConnection());
 
@@ -53,7 +53,7 @@ use_old_ClassDeclaration_DocumentDeltaConnection(
 declare function get_old_FunctionDeclaration_getW3CData():
     TypeOnly<typeof old.getW3CData>;
 declare function use_current_FunctionDeclaration_getW3CData(
-    use: TypeOnly<typeof current.getW3CData>): void;
+    use: TypeOnly<typeof current.getW3CData>);
 use_current_FunctionDeclaration_getW3CData(
     get_old_FunctionDeclaration_getW3CData());
 
@@ -65,7 +65,7 @@ use_current_FunctionDeclaration_getW3CData(
 declare function get_current_FunctionDeclaration_getW3CData():
     TypeOnly<typeof current.getW3CData>;
 declare function use_old_FunctionDeclaration_getW3CData(
-    use: TypeOnly<typeof old.getW3CData>): void;
+    use: TypeOnly<typeof old.getW3CData>);
 use_old_FunctionDeclaration_getW3CData(
     get_current_FunctionDeclaration_getW3CData());
 
@@ -77,7 +77,7 @@ use_old_FunctionDeclaration_getW3CData(
 declare function get_old_FunctionDeclaration_promiseRaceWithWinner():
     TypeOnly<typeof old.promiseRaceWithWinner>;
 declare function use_current_FunctionDeclaration_promiseRaceWithWinner(
-    use: TypeOnly<typeof current.promiseRaceWithWinner>): void;
+    use: TypeOnly<typeof current.promiseRaceWithWinner>);
 use_current_FunctionDeclaration_promiseRaceWithWinner(
     get_old_FunctionDeclaration_promiseRaceWithWinner());
 
@@ -89,7 +89,7 @@ use_current_FunctionDeclaration_promiseRaceWithWinner(
 declare function get_current_FunctionDeclaration_promiseRaceWithWinner():
     TypeOnly<typeof current.promiseRaceWithWinner>;
 declare function use_old_FunctionDeclaration_promiseRaceWithWinner(
-    use: TypeOnly<typeof old.promiseRaceWithWinner>): void;
+    use: TypeOnly<typeof old.promiseRaceWithWinner>);
 use_old_FunctionDeclaration_promiseRaceWithWinner(
     get_current_FunctionDeclaration_promiseRaceWithWinner());
 
@@ -101,7 +101,7 @@ use_old_FunctionDeclaration_promiseRaceWithWinner(
 declare function get_old_FunctionDeclaration_validateMessages():
     TypeOnly<typeof old.validateMessages>;
 declare function use_current_FunctionDeclaration_validateMessages(
-    use: TypeOnly<typeof current.validateMessages>): void;
+    use: TypeOnly<typeof current.validateMessages>);
 use_current_FunctionDeclaration_validateMessages(
     get_old_FunctionDeclaration_validateMessages());
 
@@ -113,6 +113,6 @@ use_current_FunctionDeclaration_validateMessages(
 declare function get_current_FunctionDeclaration_validateMessages():
     TypeOnly<typeof current.validateMessages>;
 declare function use_old_FunctionDeclaration_validateMessages(
-    use: TypeOnly<typeof old.validateMessages>): void;
+    use: TypeOnly<typeof old.validateMessages>);
 use_old_FunctionDeclaration_validateMessages(
     get_current_FunctionDeclaration_validateMessages());

--- a/packages/test/mocha-test-setup/src/test/types/validateMochaTestSetupPrevious.generated.ts
+++ b/packages/test/mocha-test-setup/src/test/types/validateMochaTestSetupPrevious.generated.ts
@@ -29,7 +29,7 @@ type TypeOnly<T> = T extends number
 declare function get_old_VariableDeclaration_mochaHooks():
     TypeOnly<typeof old.mochaHooks>;
 declare function use_current_VariableDeclaration_mochaHooks(
-    use: TypeOnly<typeof current.mochaHooks>);
+    use: TypeOnly<typeof current.mochaHooks>): void;
 use_current_VariableDeclaration_mochaHooks(
     get_old_VariableDeclaration_mochaHooks());
 
@@ -41,6 +41,6 @@ use_current_VariableDeclaration_mochaHooks(
 declare function get_current_VariableDeclaration_mochaHooks():
     TypeOnly<typeof current.mochaHooks>;
 declare function use_old_VariableDeclaration_mochaHooks(
-    use: TypeOnly<typeof old.mochaHooks>);
+    use: TypeOnly<typeof old.mochaHooks>): void;
 use_old_VariableDeclaration_mochaHooks(
     get_current_VariableDeclaration_mochaHooks());

--- a/packages/test/mocha-test-setup/src/test/types/validateMochaTestSetupPrevious.generated.ts
+++ b/packages/test/mocha-test-setup/src/test/types/validateMochaTestSetupPrevious.generated.ts
@@ -29,7 +29,7 @@ type TypeOnly<T> = T extends number
 declare function get_old_VariableDeclaration_mochaHooks():
     TypeOnly<typeof old.mochaHooks>;
 declare function use_current_VariableDeclaration_mochaHooks(
-    use: TypeOnly<typeof current.mochaHooks>): void;
+    use: TypeOnly<typeof current.mochaHooks>);
 use_current_VariableDeclaration_mochaHooks(
     get_old_VariableDeclaration_mochaHooks());
 
@@ -41,6 +41,6 @@ use_current_VariableDeclaration_mochaHooks(
 declare function get_current_VariableDeclaration_mochaHooks():
     TypeOnly<typeof current.mochaHooks>;
 declare function use_old_VariableDeclaration_mochaHooks(
-    use: TypeOnly<typeof old.mochaHooks>): void;
+    use: TypeOnly<typeof old.mochaHooks>);
 use_old_VariableDeclaration_mochaHooks(
     get_current_VariableDeclaration_mochaHooks());


### PR DESCRIPTION
## Description

Make FlexTreeView not expose simple-tree.
This allows internal tests for flex-trees to not depend on simple-tree.

This will enable moving simple tree further up the dependency stack and act more like a wrapper around the types in the package.

## Breaking Changes

Some interfaces have been renamed.
Access to simple tree now has to be done via TreeView and can not be gotten from FlexTreeView.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
