### PR TITLE
feat(tree2): make delta tree building idempotent

### DIFF
--- a/experimental/dds/tree2/src/core/tree/delta.ts
+++ b/experimental/dds/tree2/src/core/tree/delta.ts
@@ -148,7 +148,10 @@ export interface DetachedNodeChanges<TTree = ProtoNode> {
 }
 
 /**
- * Represents the creation of detached nodes
+ * Represents the creation of detached nodes.
+ *
+ * Tree creation is idempotent: if a tree with the same ID already exists,
+ * then this build is ignored in favor of the existing tree.
  * @alpha
  */
 export interface DetachedNodeBuild<TTree = ProtoNode> {

--- a/experimental/dds/tree2/src/test/tree/visitDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/tree/visitDelta.spec.ts
@@ -87,7 +87,7 @@ const field1: FieldKey = brand("-1");
 const field2: FieldKey = brand("-2");
 const field3: FieldKey = brand("-3");
 
-describe("visit", () => {
+describe("visitDelta", () => {
 	it("empty delta", () => {
 		testTreeVisit({}, [
 			["enterField", rootKey],
@@ -103,6 +103,23 @@ describe("visit", () => {
 			[
 				["enterField", rootKey],
 				["create", [content], field0],
+				["exitField", rootKey],
+				["enterField", rootKey],
+				["attach", field0, 1, 0],
+				["exitField", rootKey],
+			],
+			index,
+		);
+		assert.equal(index.entries().next().done, true);
+	});
+	it("idempotent insert", () => {
+		const index = makeDetachedFieldIndex("");
+		const node = { minor: 42 };
+		index.createEntry(node);
+		testTreeVisit(
+			deltaForSet(content, { minor: 42 }),
+			[
+				["enterField", rootKey],
 				["exitField", rootKey],
 				["enterField", rootKey],
 				["attach", field0, 1, 0],


### PR DESCRIPTION
Makes delta tree building idempotent.
The idempotence will be leveraged by undo/redo as well as sandwich rebasing.