### PR TITLE
fix(tinylicious): Use axios instance with updated httpAgent in requests to Historian

### DIFF
--- a/server/routerlicious/packages/tinylicious/src/index.ts
+++ b/server/routerlicious/packages/tinylicious/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import * as path from "path";
-import Axios from "axios";
+import { default as Axios } from "axios";
 import winston from "winston";
 import Agent from "agentkeepalive";
 import { runService } from "@fluidframework/server-services-shared";
@@ -13,19 +13,44 @@ import { configureLogging } from "@fluidframework/server-services-utils";
 import { TinyliciousResourcesFactory } from "./resourcesFactory";
 import { TinyliciousRunnerFactory } from "./runnerFactory";
 
-// Each TCP connect has a delay to allow it to be reuse after close, and unit test make a lot of connection,
-// which might cause port exhaustion.
+/*
+  Why set the default httpAgent for Axios to the one from agentkeepalive?
 
-// Tinylicious includes end points for the historian for the client. But even though we bundle all the
-// services in a monolithic process, it still uses sockets to communicate with the historian service.
-// For these calls, keep the TCP connection open so that they can be reused. Agent from agentkeepalive sets keep-alive
-// to true by default and uses 4s and 8s timeouts for inactive and active sockets respectively.
-// This should be coordinated with the corresponding timeout on the server's end (historian, in this case).
-// If the timeout on the client is higher than on the server, an inactive connection might be closed by the server but
-// kept around on the client, and when something attempts to reuse it, the client can see an error like ECONNRESET
-// or "socket hang up", indicating that "the other side of the connection closed it abruptly", which in this case isn't
-// really abruptly, it's just that the client doesn't immediately react to the server closing the socket.
-// TODO: Set this globally since the Historian use the global Axios default instance.  Make this encapsulated.
+	General context:
+	By default Axios keeps TCP connections (sockets) open after a request is done using them, so that they can be reused
+	by a subsequent request without having to pay the cost of establishing a new connection.
+	An http client and the server it communicates with can have their own timeouts for how long they keep those connections
+	open.
+	If the timeouts don't match, it can happen that one end closes the connection and the other one will see an error
+	next time it tries to use it.
+	For example, if the timeout on the client is higher than on the server and the server closes a connection that it
+	considers inactive for too long, the client isn't notified immediately, and when it attempts to reuse it it might see
+	an error like ECONNRESET or "socket hang up", indicating that "the other side of the connection closed it abruptly"
+	(which in this case isn't really abruptly, it's just that the client doesn't immediately react to the server closing
+	the connection).
+
+	FF context:
+  Tinylicious includes the code for the Alfred and Historian components of the server.
+	But even though we bundle both of them in a monolithic process, it still uses http requests when Alfred needs to
+	communicate with Historian, so that communication is subject to the considerations above.
+
+	'Agent' from the agentkeepalive package sets keep-alive to true (Axios does this, but not the default Node http agent)
+	and sets the inactive/active TCP connection timeout to 4s and 8s respectively. On the server side, Express defaults to
+	5s, so Agent's values try to guarantee that the client will be the one to close inactive sockets, so it doesn't run
+	into issues	trying to reuse them.
+
+  CAREFUL: setting global Axios settings here might not be reflected in the Axios instance used to make requests if the
+	code that issues the requests is imported from a different package, and that package is using a different version of
+	Axios.
+	For example, requests to Historian end up using BasicRestWrapper from services-client; that class will use the default
+	instance from whichever Axios version the services-client package depends on, unless one is explicitly passed in.
+	Ideally, an Axios instance should	be passed to it to avoid this potential issue.
+
+	CAREFUL: the fact that TCP connections are kept open to allow reuse after a request is done with one of them can lead
+	to port exhaustion if the process issuing requests is using new TCP sockets every time instead of reusing them.
+	This applies to client processes (like running tests) making requests to Alfred, and to Alfred making requests to
+	Historian.
+*/
 Axios.defaults.httpAgent = new Agent();
 
 const configPath = path.join(__dirname, "../config.json");

--- a/server/routerlicious/packages/tinylicious/src/index.ts
+++ b/server/routerlicious/packages/tinylicious/src/index.ts
@@ -19,7 +19,7 @@ import { TinyliciousRunnerFactory } from "./runnerFactory";
 	General context:
 	By default Axios keeps TCP connections (sockets) open after a request is done using them, so that they can be reused
 	by a subsequent request without having to pay the cost of establishing a new connection.
-	An http client and the server it communicates with can have their own timeouts for how long they keep those connections
+	Both the http client and the server it communicates with can have their own timeouts for how long they keep those connections
 	open.
 	If the timeouts don't match, it can happen that one end closes the connection and the other one will see an error
 	next time it tries to use it.
@@ -44,7 +44,7 @@ import { TinyliciousRunnerFactory } from "./runnerFactory";
 	Axios.
 	For example, requests to Historian end up using BasicRestWrapper from services-client; that class will use the default
 	instance from whichever Axios version the services-client package depends on, unless one is explicitly passed in.
-	Ideally, an Axios instance should	be passed to it to avoid this potential issue.
+	Ideally, an Axios instance should be passed to it to avoid this potential issue.
 
 	CAREFUL: the fact that TCP connections are kept open to allow reuse after a request is done with one of them can lead
 	to port exhaustion if the process issuing requests is using new TCP sockets every time instead of reusing them.

--- a/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
+++ b/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
@@ -33,10 +33,10 @@ export class TinyliciousTenant implements ITenant {
 		// version of Axios.
 		const restWrapper = new BasicRestWrapper(
 			historianUrl,
-			undefined, /* defaultQueryString */
-			undefined, /* maxBodyLength */
-			undefined, /* maxContentLength */
-			undefined, /* defaultHeaders */
+			undefined /* defaultQueryString */,
+			undefined /* maxBodyLength */,
+			undefined /* maxContentLength */,
+			undefined /* defaultHeaders */,
 			Axios,
 		);
 		const historian = new Historian(historianUrl, false, false, restWrapper);

--- a/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
+++ b/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
@@ -29,14 +29,14 @@ export class TinyliciousTenant implements ITenant {
 		private readonly historianUrl: string,
 	) {
 		// Using an explicitly constructed rest wrapper so we can pass the Axios instance whose static defaults
-		// were modified by t9s, and avoid issues if the module that contains BasicRestWrapper depends on a different
+		// were modified by Tinylicious, and avoid issues if the module that contains BasicRestWrapper depends on a different
 		// version of Axios.
 		const restWrapper = new BasicRestWrapper(
 			historianUrl,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
+			undefined, /* defaultQueryString */
+			undefined, /* maxBodyLength */
+			undefined, /* maxContentLength */
+			undefined, /* defaultHeaders */
 			Axios,
 		);
 		const historian = new Historian(historianUrl, false, false, restWrapper);

--- a/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
+++ b/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { default as Axios } from "axios";
 import {
 	ITenant,
 	ITenantConfig,
@@ -11,7 +12,7 @@ import {
 	ITenantOrderer,
 	ITenantStorage,
 } from "@fluidframework/server-services-core";
-import { GitManager, Historian, IGitManager } from "@fluidframework/server-services-client";
+import { BasicRestWrapper, GitManager, Historian, IGitManager } from "@fluidframework/server-services-client";
 
 export class TinyliciousTenant implements ITenant {
 	private readonly owner = "tinylicious";
@@ -22,7 +23,12 @@ export class TinyliciousTenant implements ITenant {
 		private readonly url: string,
 		private readonly historianUrl: string,
 	) {
-		const historian = new Historian(historianUrl, false, false);
+		// Using an explicitly constructed rest wrapper so we can pass the Axios instance whose static defaults
+		// were modified by t9s, and avoid issues if the module that contains BasicRestWrapper depends on a different
+		// version of Axios.
+		const restWrapper = new BasicRestWrapper(historianUrl, undefined, undefined, undefined, undefined, Axios);
+		const historian = new Historian(historianUrl, false, false, restWrapper);
+
 		this.manager = new GitManager(historian);
 	}
 

--- a/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
+++ b/server/routerlicious/packages/tinylicious/src/services/tenantManager.ts
@@ -12,7 +12,12 @@ import {
 	ITenantOrderer,
 	ITenantStorage,
 } from "@fluidframework/server-services-core";
-import { BasicRestWrapper, GitManager, Historian, IGitManager } from "@fluidframework/server-services-client";
+import {
+	BasicRestWrapper,
+	GitManager,
+	Historian,
+	IGitManager,
+} from "@fluidframework/server-services-client";
 
 export class TinyliciousTenant implements ITenant {
 	private readonly owner = "tinylicious";
@@ -26,7 +31,14 @@ export class TinyliciousTenant implements ITenant {
 		// Using an explicitly constructed rest wrapper so we can pass the Axios instance whose static defaults
 		// were modified by t9s, and avoid issues if the module that contains BasicRestWrapper depends on a different
 		// version of Axios.
-		const restWrapper = new BasicRestWrapper(historianUrl, undefined, undefined, undefined, undefined, Axios);
+		const restWrapper = new BasicRestWrapper(
+			historianUrl,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			Axios,
+		);
 		const historian = new Historian(historianUrl, false, false, restWrapper);
 
 		this.manager = new GitManager(historian);


### PR DESCRIPTION
## Description

Ensure that the Axios instance that tinylicious modifies to use agentkeepalive is the one used when Alfred makes requests to Historian within tinylicious; otherwise the active/inactive socket timeouts set by agentkeepalive aren't in effect when Alfred makes http requests to Historian, which can result in Historian closing a TCP connection and Alfred running into a 408 error when it tries to use it after that. I think this is one of the issues we've ran into when running tests in our pipelines (more details in the ADO task linked below).

Took the opportunity to revamp the documentation about why we use agentkeepalive.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#6252](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6252)