### PR TITLE
refactor(server): Use existing variable instead of recomputing value

### DIFF
--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -144,12 +144,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			getDefaultHeaders,
 			getCorrelationId,
 		);
-		const historian = new Historian(
-			`${this.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,
-			true,
-			false,
-			tenantRestWrapper,
-		);
+		const historian = new Historian(baseUrl, true, false, tenantRestWrapper);
 		const gitManager = new GitManager(historian);
 
 		return gitManager;


### PR DESCRIPTION
## Description

We already computed `baseUrl` a few lines above this, no need to compute it again. Also makes it clearer that the same value is provided to the `BasicRestWrapper` that the `Historian` constructor receives.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
