### PR TITLE
fix(fluid-build): Ignore --cache flag in prettier

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
@@ -24,7 +24,7 @@ export class PrettierTask extends LeafWithDoneFileTask {
 		}
 		for (let i = 1; i < args.length; i++) {
 			if (args[i].startsWith("--")) {
-				if (args[i] === "--check") {
+				if (args[i] === "--check" || args[i] === "--cache") {
 					continue;
 				}
 				if (args[i] === "--ignore-path" && i + 1 < args.length) {


### PR DESCRIPTION
Prettier has its own support for caching. This change ignores the flag in fluid-build so that fluid-build can continue to work properly even when the cache flag is passed to the prettier command.