### PR TITLE
'RedeemFallback' demoted to regular telemetry event

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -164,7 +164,7 @@ export async function fetchSnapshotWithRedeem(
 				// If redeem failed, that most likely means user has no permissions to access a file,
 				// and thus it's not worth it logging extra errors - same error will be logged by end-to-end
 				// flow (container open) based on a failure above.
-				logger.sendErrorEvent(
+				logger.sendTelemetryEvent(
 					{
 						eventName: "RedeemFallback",
 						errorType: error.errorType,


### PR DESCRIPTION
## Description

This error event is currently the noisiest and I don't believe it is actionable as an error.

Not sure of its usefulness, but I would leave it as a regular telemetry event to maybe help with future investigations by correlating with other signals.
