### PR TITLE
build(property-dds): Use tsc-multi to dual-emit CJS and ESM

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/jest.config.js
+++ b/experimental/PropertyDDS/packages/property-binder/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		],
 	],
 	// The glob patterns Jest uses to detect test files
-	testMatch: ["/**/dist/test/*.spec.js"],
+	testMatch: ["/**/dist/test/*.spec.cjs"],
 
 	testEnvironment: "jsdom",
 

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -11,8 +11,8 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*",
@@ -24,8 +24,8 @@
 		"postbuild": "npm run gen:tscdef",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"build:test": "tsc-multi --config ./tsc-multi.test.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"doc": "cross-var appfw-typedoc $npm_package_name",
 		"eslint": "eslint --format stylish src",
@@ -42,19 +42,19 @@
 		"pretest:coverage": "rimraf --glob coverage/",
 		"test:coverage": "c8 npm test",
 		"test:jest": "jest",
-		"tsc": "tsc"
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json"
 	},
 	"c8": {
 		"all": true,
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.ts",
-			"dist/test/**/*.js"
+			"dist/test/**/*.cjs"
 		],
 		"exclude-after-remap": false,
 		"include": [
 			"src/**/*.ts",
-			"dist/**/*.js"
+			"dist/**/*.cjs"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [
@@ -106,6 +106,7 @@
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^2.0.0",
+		"tsc-multi": "^1.1.0",
 		"typedoc": "^0.12.0",
 		"typescript": "~5.1.6",
 		"webpack": "^5.82.0"

--- a/experimental/PropertyDDS/packages/property-binder/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/tsconfig.json
@@ -1,17 +1,19 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
-	"compilerOptions": {
-		"experimentalDecorators": true,
-		"allowJs": true,
-		"jsx": "react",
-		"types": ["jest", "node"],
-		"rootDir": "./",
-		"outDir": "../../dist/test",
-	},
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"references": [
 		{
 			"path": "../..",
 		},
 	],
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["jest", "node"],
+		"experimentalDecorators": true,
+		"allowJs": true,
+	},
 }

--- a/experimental/PropertyDDS/packages/property-binder/tsc-multi.test.json
+++ b/experimental/PropertyDDS/packages/property-binder/tsc-multi.test.json
@@ -1,0 +1,4 @@
+{
+	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node10" }],
+	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
+}

--- a/experimental/PropertyDDS/packages/property-binder/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-binder/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-binder/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-binder/tsconfig.json
@@ -1,12 +1,14 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
+	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"experimentalDecorators": true,
-		"allowJs": true,
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"composite": true,
+		"experimentalDecorators": true,
+		"allowJs": true,
 	},
-	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -10,8 +10,8 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*",
@@ -22,8 +22,8 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"build:test": "tsc-multi --config ./tsc-multi.test.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"coverage": "npx nyc --silent --cwd --nycrc-path `pwd`/.nycrc npm run test",
 		"eslint": "eslint --format stylish src",
@@ -37,7 +37,7 @@
 		"test:coverage": "c8 npm test",
 		"test:mocha": "mocha --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc"
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json"
 	},
 	"c8": {
 		"all": true,
@@ -88,6 +88,7 @@
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/tsconfig.json
@@ -1,19 +1,20 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
-	"compilerOptions": {
-		"strict": false,
-		"allowJs": true,
-		"checkJs": false,
-		"rootDir": "./",
-		"outDir": "../../dist/test",
-		"types": ["node", "mocha"],
-		"declaration": false,
-		"declarationMap": false,
-	},
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"references": [
 		{
 			"path": "../..",
 		},
 	],
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["node", "mocha"],
+		"allowJs": true,
+		"checkJs": false,
+		"strict": false,
+	},
 }

--- a/experimental/PropertyDDS/packages/property-changeset/tsc-multi.test.json
+++ b/experimental/PropertyDDS/packages/property-changeset/tsc-multi.test.json
@@ -1,0 +1,4 @@
+{
+	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node10" }],
+	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
+}

--- a/experimental/PropertyDDS/packages/property-changeset/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-changeset/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
@@ -1,12 +1,14 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
+	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"strict": false,
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
-		"composite": true,
+		"declarationDir": "./dist",
+		"strict": false,
 	},
-	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -11,15 +11,27 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
-	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"build:test": "tsc-multi --config ./tsc-multi.test.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"eslint": "eslint src",
@@ -34,7 +46,7 @@
 		"test:mocha-ts": "cross-env FLUID_TEST_VERBOSE=1 TS_NODE_PROJECT=./src/test/tsconfig.json mocha --require ts-node/register --extensions ts,tsx  \"src/test/**/*.spec.ts\" --exit -r node_modules/@fluidframework/mocha-test-setup --timeout 1500000",
 		"test:mocha-ts-inspect": "cross-env FLUID_TEST_VERBOSE=1 TS_NODE_PROJECT=./src/test/tsconfig.json mocha --inspect-brk --require ts-node/register --extensions ts,tsx  \"src/test/**/*.spec.ts\" --exit -r node_modules/@fluidframework/mocha-test-setup --timeout 1500000",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc"
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json"
 	},
 	"dependencies": {
 		"@fluid-experimental/property-changeset": "workspace:~",
@@ -85,6 +97,7 @@
 		"moment": "^2.21.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {

--- a/experimental/PropertyDDS/packages/property-dds/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/tsconfig.json
@@ -1,17 +1,18 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
-	"compilerOptions": {
-		"rootDir": "./",
-		"outDir": "../../dist/test",
-		"types": ["node", "mocha"],
-		"declaration": false,
-		"noUnusedLocals": false,
-		"declarationMap": false,
-	},
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"references": [
 		{
 			"path": "../..",
 		},
 	],
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["node", "mocha"],
+    "noUnusedLocals": false,
+	},
 }

--- a/experimental/PropertyDDS/packages/property-dds/tsc-multi.test.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsc-multi.test.json
@@ -1,0 +1,4 @@
+{
+	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node10" }],
+	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
+}

--- a/experimental/PropertyDDS/packages/property-dds/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-dds/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsconfig.json
@@ -1,13 +1,15 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
+	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"composite": true,
-		"downlevelIteration": true,
-		"noUnusedLocals": false,
 		"outDir": "./dist",
 		"rootDir": "./src",
+		"downlevelIteration": true,
+		"noUnusedLocals": false,
 		"types": ["node"],
 	},
-	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -10,9 +10,21 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/src/index.js",
-	"module": "lib/src/index.js",
-	"types": "dist/src/index.d.ts",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist/src",
 		"dist/assets",
@@ -23,7 +35,7 @@
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:copy-resources": "copyfiles -u 2 \"dist/assets/**/*\" lib/assets",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
 		"build:webpack": "webpack --config webpack.svgs.js && copyfiles -u 2 \"dist/assets/**/*\" lib/assets",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --format stylish src",
@@ -37,7 +49,7 @@
 		"test": "npm run test:jest",
 		"test:coverage": "jest --coverage --ci",
 		"test:jest": "jest",
-		"tsc": "tsc",
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json",
 		"webpack": "webpack --config webpack.svgs.js"
 	},
 	"dependencies": {
@@ -105,6 +117,7 @@
 		"svgo-loader": "^2.1.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",
+		"tsc-multi": "^1.1.0",
 		"tsconfig-paths-webpack-plugin": "^3.5.2",
 		"typescript": "~5.1.6",
 		"webpack": "^5.82.0",

--- a/experimental/PropertyDDS/packages/property-inspector-table/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-inspector-table/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/tsconfig.json
@@ -1,7 +1,9 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
 	"compilerOptions": {
-		"jsx": "react",
 		"resolveJsonModule": true,
 		"typeRoots": ["../node_modules/@types"],
 		"declarationDir": "./dist",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -10,9 +10,21 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/index.js",
-	"module": "lib/index.js",
-	"types": "src/index.d.ts",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*",
 		"lib/**/*",
@@ -22,8 +34,8 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"build:test": "tsc-multi --config ./tsc-multi.test.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"coverage": "npx nyc --silent --cwd .. --nycrc-path `pwd`/.nycrc npm run test && npx nyc --no-clean --silent --cwd .. --nycrc-path `pwd`/.nycrc npm run test:changeset && npx nyc --no-clean --cwd .. --nycrc-path `pwd`/.nycrc npm run test:common",
 		"eslint": "eslint --format stylish src",
@@ -37,19 +49,19 @@
 		"test:coverage": "c8 npm test",
 		"test:mocha": "mocha --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc"
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json"
 	},
 	"c8": {
 		"all": true,
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.ts",
-			"dist/test/**/*.js"
+			"dist/test/**/*.cjs"
 		],
 		"exclude-after-remap": false,
 		"include": [
 			"src/**/*.ts",
-			"dist/**/*.js"
+			"dist/**/*.cjs"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [
@@ -88,6 +100,7 @@
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {

--- a/experimental/PropertyDDS/packages/property-properties/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-properties/src/test/tsconfig.json
@@ -1,20 +1,20 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
-	"compilerOptions": {
-		"strict": false,
-		"allowJs": true,
-		"checkJs": false,
-
-		"rootDir": "./",
-		"outDir": "../../dist/test",
-		"types": ["node", "mocha"],
-		"declaration": false,
-		"declarationMap": false,
-	},
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"references": [
 		{
 			"path": "../..",
 		},
 	],
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["node", "mocha"],
+		"strict": false,
+		"allowJs": true,
+		"checkJs": false,
+	},
 }

--- a/experimental/PropertyDDS/packages/property-properties/tsc-multi.test.json
+++ b/experimental/PropertyDDS/packages/property-properties/tsc-multi.test.json
@@ -1,0 +1,4 @@
+{
+	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node10" }],
+	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
+}

--- a/experimental/PropertyDDS/packages/property-properties/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-properties/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-properties/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-properties/tsconfig.json
@@ -1,13 +1,15 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
+	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"strict": false,
-		"allowJs": true,
-		"checkJs": false,
 		"rootDir": "./src",
 		"outDir": "./dist",
-		"composite": true,
+		"allowJs": true,
+		"checkJs": false,
+		"strict": false,
 	},
-	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -10,8 +10,20 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*",
@@ -22,8 +34,8 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"build:test": "tsc-multi --config ./tsc-multi.test.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
@@ -35,7 +47,7 @@
 		"test": "npm run test:jest",
 		"test:coverage": "jest --coverage --ci",
 		"test:jest": "jest",
-		"tsc": "tsc"
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json"
 	},
 	"dependencies": {
 		"@fluid-experimental/property-changeset": "workspace:~",
@@ -59,6 +71,7 @@
 		"source-map-loader": "^2.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6",
 		"webpack": "^5.82.0"
 	},

--- a/experimental/PropertyDDS/packages/property-proxy/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-proxy/src/test/tsconfig.json
@@ -1,11 +1,12 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../dist/test",
 		"types": ["node", "jest"],
-		"declaration": false,
-		"declarationMap": false,
 		"allowJs": true,
 	},
 	"include": ["./**/*"],

--- a/experimental/PropertyDDS/packages/property-proxy/tsc-multi.test.json
+++ b/experimental/PropertyDDS/packages/property-proxy/tsc-multi.test.json
@@ -1,0 +1,4 @@
+{
+	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node10" }],
+	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
+}

--- a/experimental/PropertyDDS/packages/property-proxy/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-proxy/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-proxy/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-proxy/tsconfig.json
@@ -1,10 +1,12 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./dist",
-		"composite": true,
 	},
 	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/packages/property-query/package.json
+++ b/experimental/PropertyDDS/packages/property-query/package.json
@@ -10,8 +10,20 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
 	"main": "src/index.js",
-	"types": "src/index.d.ts",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"clean": "rimraf --glob nyc",
 		"coverage": "npx nyc --silent --cwd .. --nycrc-path `pwd`/.nycrc npm run test && npx nyc --no-clean --silent --cwd .. --nycrc-path `pwd`/.nycrc npm run test:changeset && npx nyc --no-clean --cwd .. --nycrc-path `pwd`/.nycrc npm run test:common",
@@ -52,7 +64,8 @@
 		"nock": "^13.3.3",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
-		"sinon": "^7.4.2"
+		"sinon": "^7.4.2",
+		"tsc-multi": "^1.1.0"
 	},
 	"typeValidation": {
 		"disabled": true,

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
@@ -10,14 +10,26 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "dist/index.cjs",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"build:test": "tsc-multi --config ./tsc-multi.test.json",
 		"clean": "rimraf --glob dist \"**/*.tsbuildinfo\" \"**/*.build.log\" lib nyc",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
@@ -29,7 +41,7 @@
 		"test": "npm run test:jest",
 		"test:coverage": "jest --coverage --ci",
 		"test:jest": "jest",
-		"tsc": "tsc"
+		"tsc": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.cjs.json"
 	},
 	"dependencies": {
 		"@fluid-experimental/property-changeset": "workspace:~",
@@ -50,6 +62,7 @@
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/tsconfig.json
@@ -1,11 +1,12 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../dist/test",
 		"types": ["node", "jest"],
-		"declaration": false,
-		"declarationMap": false,
 		"allowJs": true,
 	},
 	"include": ["./**/*"],

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/tsc-multi.test.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/tsc-multi.test.json
@@ -1,0 +1,4 @@
+{
+	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node10" }],
+	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
+}

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/tsconfig.json
@@ -1,8 +1,10 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"composite": true,
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4634,6 +4634,7 @@ importers:
       prettier: ~3.0.3
       rimraf: ^4.4.0
       source-map-loader: ^2.0.0
+      tsc-multi: ^1.1.0
       typedoc: ^0.12.0
       typescript: ~5.1.6
       underscore: ^1.13.6
@@ -4679,6 +4680,7 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       source-map-loader: 2.0.2_webpack@5.88.2
+      tsc-multi: 1.1.0_typescript@5.1.6
       typedoc: 0.12.0
       typescript: 5.1.6
       webpack: 5.88.2
@@ -4711,6 +4713,7 @@ importers:
       semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
     dependencies:
       '@fluid-experimental/property-common': link:../property-common
@@ -4740,6 +4743,7 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       sinon: 7.5.0
+      tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
 
   experimental/PropertyDDS/packages/property-common:
@@ -4863,6 +4867,7 @@ importers:
       pako: ^2.0.4
       prettier: ~3.0.3
       rimraf: ^4.4.0
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
       uuid: ^9.0.0
     dependencies:
@@ -4913,6 +4918,7 @@ importers:
       moment: 2.29.4
       prettier: 3.0.3
       rimraf: 4.4.1
+      tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
 
   experimental/PropertyDDS/packages/property-inspector-table:
@@ -4979,6 +4985,7 @@ importers:
       svgo-loader: ^2.1.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
+      tsc-multi: ^1.1.0
       tsconfig-paths-webpack-plugin: ^3.5.2
       typescript: ~5.1.6
       webpack: ^5.82.0
@@ -5049,6 +5056,7 @@ importers:
       svgo-loader: 2.2.2_svgo@1.3.2
       ts-jest: 29.1.1_bklqb6uhx3v54kwzu425tj6wzi
       ts-loader: 9.5.0_wlox7xpecxj4rvkt6b6o7frtlu
+      tsc-multi: 1.1.0_typescript@5.1.6
       tsconfig-paths-webpack-plugin: 3.5.2
       typescript: 5.1.6
       webpack: 5.88.2_webpack-cli@4.10.0
@@ -5083,6 +5091,7 @@ importers:
       semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
       underscore: ^1.13.6
     dependencies:
@@ -5113,6 +5122,7 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       sinon: 7.5.0
+      tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
 
   experimental/PropertyDDS/packages/property-proxy:
@@ -5136,6 +5146,7 @@ importers:
       source-map-loader: ^2.0.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
       webpack: ^5.82.0
     dependencies:
@@ -5159,6 +5170,7 @@ importers:
       source-map-loader: 2.0.2_webpack@5.88.2
       ts-jest: 29.1.1_bklqb6uhx3v54kwzu425tj6wzi
       ts-loader: 9.5.0_wlox7xpecxj4rvkt6b6o7frtlu
+      tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
       webpack: 5.88.2
 
@@ -5188,6 +5200,7 @@ importers:
       semver: ^7.5.3
       sinon: ^7.4.2
       traverse: 0.6.6
+      tsc-multi: ^1.1.0
     dependencies:
       '@fluid-experimental/property-changeset': link:../property-changeset
       '@fluid-experimental/property-common': link:../property-common
@@ -5214,6 +5227,7 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       sinon: 7.5.0
+      tsc-multi: 1.1.0
 
   experimental/PropertyDDS/packages/property-shared-tree-interop:
     specifiers:
@@ -5233,6 +5247,7 @@ importers:
       prettier: ~3.0.3
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
     dependencies:
       '@fluid-experimental/property-changeset': link:../property-changeset
@@ -5252,6 +5267,7 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
+      tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
 
   experimental/PropertyDDS/services/property-query-service:
@@ -42811,6 +42827,27 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.6
+    dev: true
+
+  /tsc-multi/1.1.0:
+    resolution: {integrity: sha512-THE6X+sse7EZ2qMhqXvBhd2HMTvXyWwYnx+2T/ijqdp/6Rf7rUc2uPRzPdrrljZCNcYDeL0qP2P7tqm2IwayTg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=4.3.0'
+    dependencies:
+      debug: 4.3.4
+      fast-glob: 3.3.1
+      get-stdin: 8.0.0
+      p-all: 3.0.0
+      picocolors: 1.0.0
+      signal-exit: 3.0.7
+      string-to-stream: 3.0.1
+      superstruct: 1.0.3
+      tslib: 2.6.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /tsc-multi/1.1.0_typescript@5.1.6:


### PR DESCRIPTION
wip

Updates the PropertyDDS packages to use [tsc-multi](https://github.com/tommy351/tsc-multi) to build ESM and CJS with node16 module resolution.