### PR TITLE
Prevent SharedTree from sending ops if the change in the op is invalid

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -42,17 +42,17 @@ import { TransactionStack } from "./transactionStack";
  * transaction completes and all pending commits are replaced with a single squash commit.
  */
 export type SharedTreeBranchChange<TChange> =
-	| { type: "append"; change: TaggedChange<TChange>; newCommits: GraphCommit<TChange>[] }
+	| { type: "append"; change: TaggedChange<TChange>; newCommits: readonly GraphCommit<TChange>[] }
 	| {
 			type: "remove";
 			change: TaggedChange<TChange> | undefined;
-			removedCommits: GraphCommit<TChange>[];
+			removedCommits: readonly GraphCommit<TChange>[];
 	  }
 	| {
 			type: "replace";
 			change: TaggedChange<TChange> | undefined;
-			removedCommits: GraphCommit<TChange>[];
-			newCommits: GraphCommit<TChange>[];
+			removedCommits: readonly GraphCommit<TChange>[];
+			newCommits: readonly GraphCommit<TChange>[];
 	  };
 
 /**
@@ -90,7 +90,13 @@ export function getChangeReplaceType(
  */
 export interface SharedTreeBranchEvents<TEditor extends ChangeFamilyEditor, TChange> {
 	/**
-	 * Fired anytime the head of this branch changes.
+	 * Fired just before the head of this branch changes.
+	 * @param change - the change to this branch's state and commits
+	 */
+	beforeChange(change: SharedTreeBranchChange<TChange>): void;
+
+	/**
+	 * Fired just after the head of this branch changes.
 	 * @param change - the change to this branch's state and commits
 	 */
 	afterChange(change: SharedTreeBranchChange<TChange>): void;
@@ -173,22 +179,27 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	): [change: TChange, newCommit: GraphCommit<TChange>] {
 		this.assertNotDisposed();
 
-		this.head = mintCommit(this.head, {
+		const newHead = mintCommit(this.head, {
 			revision,
 			change,
 		});
 
-		// If this is not part of a transaction, emit a revertible event
-		if (!this.isTransacting()) {
-			this.emit("revertible", this.makeSharedTreeRevertible(this.head, revertibleKind));
-		}
-
-		this.emit("afterChange", {
+		const changeEvent = {
 			type: "append",
 			change: tagChange(change, revision),
-			newCommits: [this.head],
-		});
-		return [change, this.head];
+			newCommits: [newHead],
+		} as const;
+
+		this.emit("beforeChange", changeEvent);
+		this.head = newHead;
+
+		// If this is not part of a transaction, emit a revertible event
+		if (!this.isTransacting()) {
+			this.emit("revertible", this.makeSharedTreeRevertible(newHead, revertibleKind));
+		}
+
+		this.emit("afterChange", changeEvent);
+		return [change, newHead];
 	}
 
 	/**
@@ -244,26 +255,28 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const squashedChange = this.changeFamily.rebaser.compose(anonymousCommits);
 		const revision = mintRevisionTag();
 
-		this.head = mintCommit(startCommit, {
+		const newHead = mintCommit(startCommit, {
 			revision,
 			change: squashedChange,
 		});
 
-		// If this transaction is not nested, emit a revertible event
-		if (!this.isTransacting()) {
-			this.emit(
-				"revertible",
-				this.makeSharedTreeRevertible(this.head, RevertibleKind.Default),
-			);
-		}
-
-		this.emit("afterChange", {
+		const changeEvent = {
 			type: "replace",
 			change: undefined,
 			removedCommits: commits,
-			newCommits: [this.head],
-		});
-		return [commits, this.head];
+			newCommits: [newHead],
+		} as const;
+
+		this.emit("beforeChange", changeEvent);
+		this.head = newHead;
+
+		// If this transaction is not nested, emit a revertible event
+		if (!this.isTransacting()) {
+			this.emit("revertible", this.makeSharedTreeRevertible(newHead, RevertibleKind.Default));
+		}
+
+		this.emit("afterChange", changeEvent);
+		return [commits, newHead];
 	}
 
 	/**
@@ -279,7 +292,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		this.assertNotDisposed();
 		const [startCommit, commits] = this.popTransaction();
 		this.editor.exitTransaction();
-		this.head = startCommit;
 
 		if (commits.length === 0) {
 			return [undefined, []];
@@ -293,11 +305,15 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const change =
 			inverses.length > 0 ? this.changeFamily.rebaser.compose(inverses) : undefined;
 
-		this.emit("afterChange", {
+		const changeEvent = {
 			type: "remove",
 			change: change === undefined ? undefined : makeAnonChange(change),
 			removedCommits: commits,
-		});
+		} as const;
+
+		this.emit("beforeChange", changeEvent);
+		this.head = startCommit;
+		this.emit("afterChange", changeEvent);
 		return [change, commits];
 	}
 
@@ -454,20 +470,23 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const [newHead, change, { deletedSourceCommits, targetCommits, sourceCommits }] =
 			rebaseResult;
 
-		this.head = newHead;
 		const newCommits = targetCommits.concat(sourceCommits);
+		const changeEvent = {
+			type: "replace",
+			change: change === undefined ? undefined : makeAnonChange(change),
+			removedCommits: deletedSourceCommits,
+			newCommits,
+		} as const;
+
+		this.emit("beforeChange", changeEvent);
+		this.head = newHead;
 
 		// update revertible commits that have been rebased
 		sourceCommits.forEach((commit) => {
 			this.updateRevertibleCommit(commit);
 		});
 
-		this.emit("afterChange", {
-			type: "replace",
-			change: change === undefined ? undefined : makeAnonChange(change),
-			removedCommits: deletedSourceCommits,
-			newCommits,
-		});
+		this.emit("afterChange", changeEvent);
 		return [change, deletedSourceCommits, newCommits];
 	}
 
@@ -499,14 +518,16 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		// Compute the net change to this branch
 		const [newHead, _, { sourceCommits }] = rebaseResult;
-
-		this.head = newHead;
 		const change = this.changeFamily.rebaser.compose(sourceCommits);
-		this.emit("afterChange", {
+		const changeEvent = {
 			type: "append",
 			change: makeAnonChange(change),
 			newCommits: sourceCommits,
-		});
+		} as const;
+
+		this.emit("beforeChange", changeEvent);
+		this.head = newHead;
+		this.emit("afterChange", changeEvent);
 		return [change, sourceCommits];
 	}
 

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -93,7 +93,7 @@ export interface SharedTreeBranchEvents<TEditor extends ChangeFamilyEditor, TCha
 	 * Fired anytime the head of this branch changes.
 	 * @param change - the change to this branch's state and commits
 	 */
-	change(change: SharedTreeBranchChange<TChange>): void;
+	afterChange(change: SharedTreeBranchChange<TChange>): void;
 
 	/**
 	 * Fired when a revertible change is made to this branch.
@@ -183,7 +183,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			this.emit("revertible", this.makeSharedTreeRevertible(this.head, revertibleKind));
 		}
 
-		this.emit("change", {
+		this.emit("afterChange", {
 			type: "append",
 			change: tagChange(change, revision),
 			newCommits: [this.head],
@@ -257,7 +257,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			);
 		}
 
-		this.emit("change", {
+		this.emit("afterChange", {
 			type: "replace",
 			change: undefined,
 			removedCommits: commits,
@@ -293,7 +293,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const change =
 			inverses.length > 0 ? this.changeFamily.rebaser.compose(inverses) : undefined;
 
-		this.emit("change", {
+		this.emit("afterChange", {
 			type: "remove",
 			change: change === undefined ? undefined : makeAnonChange(change),
 			removedCommits: commits,
@@ -462,7 +462,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			this.updateRevertibleCommit(commit);
 		});
 
-		this.emit("change", {
+		this.emit("afterChange", {
 			type: "replace",
 			change: change === undefined ? undefined : makeAnonChange(change),
 			removedCommits: deletedSourceCommits,
@@ -502,7 +502,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		this.head = newHead;
 		const change = this.changeFamily.rebaser.compose(sourceCommits);
-		this.emit("change", {
+		this.emit("afterChange", {
 			type: "append",
 			change: makeAnonChange(change),
 			newCommits: sourceCommits,

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -172,7 +172,7 @@ export class EditManager<
 		// Record the sequence id of the branch's base commit on the trunk
 		const trunkBase = { sequenceId: trackBranch(branch) };
 		// Whenever the branch is rebased, update our record of its base trunk commit
-		const offRebase = branch.on("change", (args) => {
+		const offRebase = branch.on("afterChange", (args) => {
 			if (args.type === "replace" && getChangeReplaceType(args) === "rebase") {
 				untrackBranch(branch, trunkBase.sequenceId);
 				trunkBase.sequenceId = trackBranch(branch);

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -100,7 +100,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		// TODO: Change this type to be the Session ID type provided by the IdCompressor when available.
 		const localSessionId = generateStableId();
 		this.editManager = new EditManager(changeFamily, localSessionId);
-		this.editManager.localBranch.on("change", (args) => {
+		this.editManager.localBranch.on("afterChange", (args) => {
 			const { type } = args;
 			switch (type) {
 				case "append":

--- a/experimental/dds/tree2/src/shared-tree/treeCheckout.ts
+++ b/experimental/dds/tree2/src/shared-tree/treeCheckout.ts
@@ -272,7 +272,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			HasListeners<CheckoutEvents>,
 		private readonly removedTrees: DetachedFieldIndex = makeDetachedFieldIndex("repair"),
 	) {
-		branch.on("change", (event) => {
+		branch.on("afterChange", (event) => {
 			if (event.change !== undefined) {
 				const delta = this.changeFamily.intoDelta(event.change);
 				const anchorVisitor = this.forest.anchors.acquireVisitor();

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -551,7 +551,7 @@ describe("Branches", () => {
 
 		const branch = new SharedTreeBranch(initCommit, defaultChangeFamily);
 		if (onChange !== undefined) {
-			branch.on("change", onChange);
+			branch.on("afterChange", onChange);
 		}
 
 		return branch;

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -550,10 +550,16 @@ describe("Branches", () => {
 		};
 
 		const branch = new SharedTreeBranch(initCommit, defaultChangeFamily);
-		if (onChange !== undefined) {
-			branch.on("beforeChange", onChange);
-			branch.on("afterChange", onChange);
-		}
+		let head = branch.getHead();
+		branch.on("beforeChange", (c) => {
+			// Check that the branch head never changes in the "before" event; it should only change after the "after" event.
+			assert.equal(branch.getHead(), head);
+			onChange?.(c);
+		});
+		branch.on("afterChange", (c) => {
+			head = branch.getHead();
+			onChange?.(c);
+		});
 
 		return branch;
 	}

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -183,9 +183,9 @@ describe("Branches", () => {
 		assert.equal(changeEventCount, 0);
 		// Ensure that the change event is emitted once for each change applied
 		change(branch);
-		assert.equal(changeEventCount, 1);
-		change(branch);
 		assert.equal(changeEventCount, 2);
+		change(branch);
+		assert.equal(changeEventCount, 4);
 	});
 
 	it("emit a change event after rebasing", () => {
@@ -203,7 +203,7 @@ describe("Branches", () => {
 		assert.equal(changeEventCount, 0);
 		// Rebase the parent onto the child and ensure another change event is emitted
 		parent.rebaseOnto(child);
-		assert.equal(changeEventCount, 1);
+		assert.equal(changeEventCount, 2);
 	});
 
 	it("do not emit a change event after a rebase with no effect", () => {
@@ -235,10 +235,10 @@ describe("Branches", () => {
 		// Apply changes to both branches
 		change(parent);
 		change(child);
-		assert.equal(changeEventCount, 1);
+		assert.equal(changeEventCount, 2);
 		// Merge the child into the parent and ensure another change event is emitted
 		parent.merge(child);
-		assert.equal(changeEventCount, 2);
+		assert.equal(changeEventCount, 4);
 	});
 
 	it("do not emit a change event after a merge with no effect", () => {
@@ -252,10 +252,10 @@ describe("Branches", () => {
 		const child = parent.fork();
 		// Apply a change to the parent
 		change(parent);
-		assert.equal(changeEventCount, 1);
+		assert.equal(changeEventCount, 2);
 		// Merge the child into the parent and ensure no change is emitted since the child has no new commits
 		parent.merge(child);
-		assert.equal(changeEventCount, 1);
+		assert.equal(changeEventCount, 2);
 	});
 
 	it("emit correct change events during and after committing a transaction", () => {
@@ -273,14 +273,14 @@ describe("Branches", () => {
 		branch.startTransaction();
 		// Ensure that the correct change is emitted when applying changes in a transaction
 		change(branch);
-		assert.equal(changeEventCount, 1);
-		change(branch);
 		assert.equal(changeEventCount, 2);
+		change(branch);
+		assert.equal(changeEventCount, 4);
 		assert.equal(replaceEventCount, 0);
 		// Commit the transaction. No change event should be emitted since the commits, though squashed, are still equivalent
 		branch.commitTransaction();
-		assert.equal(changeEventCount, 2);
-		assert.equal(replaceEventCount, 1);
+		assert.equal(changeEventCount, 4);
+		assert.equal(replaceEventCount, 2);
 	});
 
 	it("do not emit a change event after committing an empty transaction", () => {
@@ -312,7 +312,7 @@ describe("Branches", () => {
 		assert.equal(changeEventCount, 0);
 		// Abort the transaction. A new change event should be emitted since the state rolls back to before the transaction
 		branch.abortTransaction();
-		assert.equal(changeEventCount, 1);
+		assert.equal(changeEventCount, 2);
 	});
 
 	it("do not emit a change event after aborting an empty transaction", () => {
@@ -551,6 +551,7 @@ describe("Branches", () => {
 
 		const branch = new SharedTreeBranch(initCommit, defaultChangeFamily);
 		if (onChange !== undefined) {
+			branch.on("beforeChange", onChange);
 			branch.on("afterChange", onChange);
 		}
 

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -1027,7 +1027,7 @@ function addSequencedChange(
 	...args: Parameters<(typeof editManager)["addSequencedChange"]>
 ): Delta.Root {
 	let delta: Delta.Root = emptyDelta;
-	const offChange = editManager.localBranch.on("change", ({ change }) => {
+	const offChange = editManager.localBranch.on("afterChange", ({ change }) => {
 		if (change !== undefined) {
 			delta = editManager.changeFamily.intoDelta(change);
 		}

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -1135,6 +1135,23 @@ describe("SharedTree", () => {
 			"A",
 		]);
 	});
+
+	it("doesn't submit an op for a change that crashes", () => {
+		const provider = new TestTreeProviderLite(2);
+		const [tree1, tree2] = provider.trees;
+
+		tree2.on("pre-op", () => {
+			assert.fail();
+		});
+
+		assert.throws(() =>
+			// This change is a well-formed change object, but will attempt to do an operation that is illegal given the current (empty) state of the tree
+			tree1.editor.sequenceField({ parent: undefined, field: rootFieldKey }).delete(0, 99),
+		);
+
+		provider.processMessages();
+	});
+
 	describe("Stashed ops", () => {
 		it("can apply and resubmit stashed schema ops", async () => {
 			const provider = await TestTreeProvider.create(2);


### PR DESCRIPTION
## Description

Invalid changes, though not expected, can and will arise due to bugs in editing or forest mutation code. In the event that a change made by a client crashes the client, it should not submit the op containing that change (and making all other clients crash too after that point in the document history). Currently changes are assumed to be valid and are always submitted. We do not currently have a general mechanism for validating a change, therefore, this PR changes the application of the change on the local client to happen before the submission of the op. That way, if the local client crashes because the change is bad, op submission will not happen.