### PR TITLE
tree2: Remove TreeListNode's API mode

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1822,7 +1822,7 @@ export interface TreeFieldStoredSchema {
 }
 
 // @alpha
-export interface TreeListNode<TTypes extends AllowedTypes, API extends "javaScript" | "sharedTree" = "sharedTree"> extends ReadonlyArray<TreeNodeUnion<TTypes, API>> {
+export interface TreeListNode<TTypes extends AllowedTypes> extends ReadonlyArray<TreeNodeUnion<TTypes>> {
     insertAt(index: number, value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
     insertAtEnd(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
     insertAtStart(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
@@ -2002,7 +2002,7 @@ TFields extends {
 ][_InlineTrick];
 
 // @alpha
-export type TypedNode<TSchema extends TreeNodeSchema, API extends "javaScript" | "sharedTree" = "sharedTree"> = TSchema extends LeafNodeSchema ? TreeValue<TSchema["info"]> : TSchema extends MapNodeSchema ? API extends "sharedTree" ? TreeMapNode<TSchema> : ReadonlyMap<string, TreeField<TSchema["info"], API>> : TSchema extends FieldNodeSchema ? API extends "sharedTree" ? TreeListNode<TSchema["info"]["allowedTypes"], API> : readonly TreeNodeUnion<TSchema["info"]["allowedTypes"], API>[] : TSchema extends ObjectNodeSchema ? TreeObjectNode<TSchema, API> : unknown;
+export type TypedNode<TSchema extends TreeNodeSchema, API extends "javaScript" | "sharedTree" = "sharedTree"> = TSchema extends LeafNodeSchema ? TreeValue<TSchema["info"]> : TSchema extends MapNodeSchema ? API extends "sharedTree" ? TreeMapNode<TSchema> : ReadonlyMap<string, TreeField<TSchema["info"], API>> : TSchema extends FieldNodeSchema ? API extends "sharedTree" ? TreeListNode<TSchema["info"]["allowedTypes"]> : readonly TreeNodeUnion<TSchema["info"]["allowedTypes"], API>[] : TSchema extends ObjectNodeSchema ? TreeObjectNode<TSchema, API> : unknown;
 
 // @alpha
 type TypedNode_2<TSchema extends TreeNodeSchema, Mode extends ApiMode> = FlattenKeys<CollectOptions<Mode, TSchema extends ObjectNodeSchema<string, infer TFields extends Fields> ? TypedFields<Mode, TFields> : TSchema extends FieldNodeSchema<string, infer TField extends TreeFieldSchema> ? TypedFields<Mode, {

--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -213,9 +213,8 @@ function createObjectProxy<TSchema extends ObjectNodeSchema>(
 /**
  * Given a list proxy, returns its underlying LazySequence field.
  */
-const getSequenceField = <TTypes extends AllowedTypes>(
-	list: TreeListNode<AllowedTypes, "javaScript">,
-) => getEditNode(list).content as FlexTreeSequenceField<TTypes>;
+const getSequenceField = <TTypes extends AllowedTypes>(list: TreeListNode<AllowedTypes>) =>
+	getEditNode(list).content as FlexTreeSequenceField<TTypes>;
 
 // Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
 // typed data prior to forwarding to 'LazySequence.insert*()'.
@@ -249,16 +248,13 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		value: Array.prototype[Symbol.iterator],
 	},
 	at: {
-		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
-			index: number,
-		): FlexTreeUnknownUnboxed | undefined {
+		value(this: TreeListNode<AllowedTypes>, index: number): FlexTreeUnknownUnboxed | undefined {
 			return getSequenceField(this).at(index);
 		},
 	},
 	insertAt: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			index: number,
 			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
@@ -272,7 +268,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAtStart: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(value, 0);
@@ -285,7 +281,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAtEnd: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(
@@ -300,18 +296,18 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	removeAt: {
-		value(this: TreeListNode<AllowedTypes, "javaScript">, index: number): void {
+		value(this: TreeListNode<AllowedTypes>, index: number): void {
 			getSequenceField(this).removeAt(index);
 		},
 	},
 	removeRange: {
-		value(this: TreeListNode<AllowedTypes, "javaScript">, start?: number, end?: number): void {
+		value(this: TreeListNode<AllowedTypes>, start?: number, end?: number): void {
 			getSequenceField(this).removeRange(start, end);
 		},
 	},
 	moveToStart: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			sourceIndex: number,
 			source?: TreeListNode<AllowedTypes>,
 		): void {
@@ -324,7 +320,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveToEnd: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			sourceIndex: number,
 			source?: TreeListNode<AllowedTypes>,
 		): void {
@@ -337,7 +333,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveToIndex: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			index: number,
 			sourceIndex: number,
 			source?: TreeListNode<AllowedTypes>,
@@ -351,7 +347,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToStart: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			sourceStart: number,
 			sourceEnd: number,
 			source?: TreeListNode<AllowedTypes>,
@@ -369,7 +365,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToEnd: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			sourceStart: number,
 			sourceEnd: number,
 			source?: TreeListNode<AllowedTypes>,
@@ -387,7 +383,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToIndex: {
 		value(
-			this: TreeListNode<AllowedTypes, "javaScript">,
+			this: TreeListNode<AllowedTypes>,
 			index: number,
 			sourceStart: number,
 			sourceEnd: number,
@@ -486,7 +482,7 @@ function createListProxy<TTypes extends AllowedTypes>(): TreeListNode<TTypes> {
 	// Properties normally inherited from 'Array.prototype' are surfaced via the prototype chain.
 	const dispatch: object = Object.create(listPrototype, {
 		length: {
-			get(this: TreeListNode<AllowedTypes, "javaScript">) {
+			get(this: TreeListNode<AllowedTypes>) {
 				return getSequenceField(this).length;
 			},
 			set() {},

--- a/experimental/dds/tree2/src/simple-tree/types.ts
+++ b/experimental/dds/tree2/src/simple-tree/types.ts
@@ -41,10 +41,8 @@ export type TreeNode =
  * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
  * @alpha
  */
-export interface TreeListNode<
-	TTypes extends AllowedTypes,
-	API extends "javaScript" | "sharedTree" = "sharedTree",
-> extends ReadonlyArray<TreeNodeUnion<TTypes, API>> {
+export interface TreeListNode<TTypes extends AllowedTypes>
+	extends ReadonlyArray<TreeNodeUnion<TTypes>> {
 	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
@@ -354,7 +352,7 @@ export type TypedNode<
 		: ReadonlyMap<string, TreeField<TSchema["info"], API>>
 	: TSchema extends FieldNodeSchema
 	? API extends "sharedTree"
-		? TreeListNode<TSchema["info"]["allowedTypes"], API>
+		? TreeListNode<TSchema["info"]["allowedTypes"]>
 		: readonly TreeNodeUnion<TSchema["info"]["allowedTypes"], API>[]
 	: TSchema extends ObjectNodeSchema
 	? TreeObjectNode<TSchema, API>


### PR DESCRIPTION
## Description

The "JavaScript" APi version of Lists is an array, so the List type is not actually used in this mode.
That leaves only one mode, sharedTree, so the mode parameter was removed.

## Breaking Changes

TreeListNode no longer has a mode parameter.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please confirm that my understanding is correct, and this mode is unneeded. It was explicitly used in some places, and I'm unclear why, so I may be missing something.
