### PR TITLE
tree2: Introduce TreeListNodeBase

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -959,7 +959,8 @@ declare namespace InternalTypes {
         Sequence,
         FactoryObjectNodeSchema,
         FactoryObjectNodeSchemaRecursive,
-        testRecursiveDomain
+        testRecursiveDomain,
+        TreeListNodeBase
     }
 }
 export { InternalTypes }
@@ -1822,22 +1823,26 @@ export interface TreeFieldStoredSchema {
 }
 
 // @alpha
-export interface TreeListNode<TTypes extends AllowedTypes> extends ReadonlyArray<TreeNodeUnion<TTypes>> {
-    insertAt(index: number, value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
-    insertAtEnd(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
-    insertAtStart(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+export interface TreeListNode<out TTypes extends AllowedTypes = AllowedTypes> extends TreeListNodeBase<TreeNodeUnion<TTypes>, TreeNodeUnion<TTypes, "javaScript">, TreeListNode> {
+}
+
+// @alpha
+interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T> {
+    insertAt(index: number, value: Iterable<TNew>): void;
+    insertAtEnd(value: Iterable<TNew>): void;
+    insertAtStart(value: Iterable<TNew>): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
-    moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TreeListNode<AllowedTypes>): void;
+    moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TreeListNode<AllowedTypes>): void;
+    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
-    moveRangeToStart(sourceStart: number, sourceEnd: number, source: TreeListNode<AllowedTypes>): void;
+    moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
-    moveToEnd(sourceIndex: number, source: TreeListNode<AllowedTypes>): void;
+    moveToEnd(sourceIndex: number, source: TMoveFrom): void;
     moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TreeListNode<AllowedTypes>): void;
+    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
-    moveToStart(sourceIndex: number, source: TreeListNode<AllowedTypes>): void;
+    moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;
     removeRange(start?: number, end?: number): void;
 }
@@ -1864,7 +1869,7 @@ export const enum TreeNavigationResult {
 }
 
 // @alpha
-export type TreeNode = TreeListNode<AllowedTypes> | TreeObjectNode<ObjectNodeSchema> | TreeMapNode<MapNodeSchema>;
+export type TreeNode = TreeListNode | TreeObjectNode<ObjectNodeSchema> | TreeMapNode<MapNodeSchema>;
 
 // @alpha (undocumented)
 export type TreeNodeSchema = TreeNodeSchemaBase;

--- a/experimental/dds/tree2/src/internal.ts
+++ b/experimental/dds/tree2/src/internal.ts
@@ -42,3 +42,5 @@ export {
 	FactoryObjectNodeSchemaRecursive,
 	testRecursiveDomain,
 } from "./domains";
+
+export { TreeListNodeBase } from "./simple-tree";

--- a/experimental/dds/tree2/src/simple-tree/editNode.ts
+++ b/experimental/dds/tree2/src/simple-tree/editNode.ts
@@ -79,7 +79,7 @@ export function setEditNode<T extends TreeObjectNode<ObjectNodeSchema>>(
 	target: T,
 	editNode: FlexTreeObjectNode,
 ): T;
-export function setEditNode<T extends TreeListNode<AllowedTypes>>(
+export function setEditNode<T extends TreeListNode>(
 	target: T,
 	editNode: FlexTreeFieldNode<FieldNodeSchema>,
 ): T;

--- a/experimental/dds/tree2/src/simple-tree/index.ts
+++ b/experimental/dds/tree2/src/simple-tree/index.ts
@@ -15,6 +15,7 @@ export {
 	TreeObjectNode,
 	TreeRoot,
 	TreeNode,
+	TreeListNodeBase,
 } from "./types";
 export { TreeObjectFactory, FactoryTreeSchema, addFactory } from "./objectFactory";
 export { nodeApi as Tree, TreeApi } from "./node";

--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -213,7 +213,7 @@ function createObjectProxy<TSchema extends ObjectNodeSchema>(
 /**
  * Given a list proxy, returns its underlying LazySequence field.
  */
-const getSequenceField = <TTypes extends AllowedTypes>(list: TreeListNode<AllowedTypes>) =>
+const getSequenceField = <TTypes extends AllowedTypes>(list: TreeListNode) =>
 	getEditNode(list).content as FlexTreeSequenceField<TTypes>;
 
 // Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
@@ -248,13 +248,13 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		value: Array.prototype[Symbol.iterator],
 	},
 	at: {
-		value(this: TreeListNode<AllowedTypes>, index: number): FlexTreeUnknownUnboxed | undefined {
+		value(this: TreeListNode, index: number): FlexTreeUnknownUnboxed | undefined {
 			return getSequenceField(this).at(index);
 		},
 	},
 	insertAt: {
 		value(
-			this: TreeListNode<AllowedTypes>,
+			this: TreeListNode,
 			index: number,
 			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
@@ -268,7 +268,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAtStart: {
 		value(
-			this: TreeListNode<AllowedTypes>,
+			this: TreeListNode,
 			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(value, 0);
@@ -281,7 +281,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAtEnd: {
 		value(
-			this: TreeListNode<AllowedTypes>,
+			this: TreeListNode,
 			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(
@@ -296,21 +296,17 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	removeAt: {
-		value(this: TreeListNode<AllowedTypes>, index: number): void {
+		value(this: TreeListNode, index: number): void {
 			getSequenceField(this).removeAt(index);
 		},
 	},
 	removeRange: {
-		value(this: TreeListNode<AllowedTypes>, start?: number, end?: number): void {
+		value(this: TreeListNode, start?: number, end?: number): void {
 			getSequenceField(this).removeRange(start, end);
 		},
 	},
 	moveToStart: {
-		value(
-			this: TreeListNode<AllowedTypes>,
-			sourceIndex: number,
-			source?: TreeListNode<AllowedTypes>,
-		): void {
+		value(this: TreeListNode, sourceIndex: number, source?: TreeListNode): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveToStart(sourceIndex, getSequenceField(source));
 			} else {
@@ -319,11 +315,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	moveToEnd: {
-		value(
-			this: TreeListNode<AllowedTypes>,
-			sourceIndex: number,
-			source?: TreeListNode<AllowedTypes>,
-		): void {
+		value(this: TreeListNode, sourceIndex: number, source?: TreeListNode): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveToEnd(sourceIndex, getSequenceField(source));
 			} else {
@@ -332,12 +324,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	moveToIndex: {
-		value(
-			this: TreeListNode<AllowedTypes>,
-			index: number,
-			sourceIndex: number,
-			source?: TreeListNode<AllowedTypes>,
-		): void {
+		value(this: TreeListNode, index: number, sourceIndex: number, source?: TreeListNode): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveToIndex(index, sourceIndex, getSequenceField(source));
 			} else {
@@ -347,10 +334,10 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToStart: {
 		value(
-			this: TreeListNode<AllowedTypes>,
+			this: TreeListNode,
 			sourceStart: number,
 			sourceEnd: number,
-			source?: TreeListNode<AllowedTypes>,
+			source?: TreeListNode,
 		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveRangeToStart(
@@ -365,10 +352,10 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToEnd: {
 		value(
-			this: TreeListNode<AllowedTypes>,
+			this: TreeListNode,
 			sourceStart: number,
 			sourceEnd: number,
-			source?: TreeListNode<AllowedTypes>,
+			source?: TreeListNode,
 		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveRangeToEnd(
@@ -383,11 +370,11 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToIndex: {
 		value(
-			this: TreeListNode<AllowedTypes>,
+			this: TreeListNode,
 			index: number,
 			sourceStart: number,
 			sourceEnd: number,
-			source?: TreeListNode<AllowedTypes>,
+			source?: TreeListNode,
 		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveRangeToIndex(
@@ -482,7 +469,7 @@ function createListProxy<TTypes extends AllowedTypes>(): TreeListNode<TTypes> {
 	// Properties normally inherited from 'Array.prototype' are surfaced via the prototype chain.
 	const dispatch: object = Object.create(listPrototype, {
 		length: {
-			get(this: TreeListNode<AllowedTypes>) {
+			get(this: TreeListNode) {
 				return getSequenceField(this).length;
 			},
 			set() {},

--- a/experimental/dds/tree2/src/simple-tree/types.ts
+++ b/experimental/dds/tree2/src/simple-tree/types.ts
@@ -32,36 +32,43 @@ import {
  * Using default parameters, this could be combined with TypedNode.
  * @alpha
  */
-export type TreeNode =
-	| TreeListNode<AllowedTypes>
-	| TreeObjectNode<ObjectNodeSchema>
-	| TreeMapNode<MapNodeSchema>;
+export type TreeNode = TreeListNode | TreeObjectNode<ObjectNodeSchema> | TreeMapNode<MapNodeSchema>;
 
 /**
  * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
  * @alpha
  */
-export interface TreeListNode<TTypes extends AllowedTypes>
-	extends ReadonlyArray<TreeNodeUnion<TTypes>> {
+export interface TreeListNode<out TTypes extends AllowedTypes = AllowedTypes>
+	extends TreeListNodeBase<
+		TreeNodeUnion<TTypes>,
+		TreeNodeUnion<TTypes, "javaScript">,
+		TreeListNode
+	> {}
+
+/**
+ * A generic List type, used to defined types like {@link TreeListNode}.
+ * @alpha
+ */
+export interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T> {
 	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
 	 */
-	insertAt(index: number, value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+	insertAt(index: number, value: Iterable<TNew>): void;
 
 	/**
 	 * Inserts new item(s) at the start of the list.
 	 * @param value - The content to insert.
 	 */
-	insertAtStart(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+	insertAtStart(value: Iterable<TNew>): void;
 
 	/**
 	 * Inserts new item(s) at the end of the list.
 	 * @param value - The content to insert.
 	 */
-	insertAtEnd(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+	insertAtEnd(value: Iterable<TNew>): void;
 
 	/**
 	 * Removes the item at the specified location.
@@ -93,7 +100,7 @@ export interface TreeListNode<TTypes extends AllowedTypes>
 	 * @param source - The source list to move the item out of.
 	 * @throws Throws if `sourceIndex` is not in the range [0, `list.length`).
 	 */
-	moveToStart(sourceIndex: number, source: TreeListNode<AllowedTypes>): void;
+	moveToStart(sourceIndex: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified item to the end of the list.
@@ -108,7 +115,7 @@ export interface TreeListNode<TTypes extends AllowedTypes>
 	 * @param source - The source list to move the item out of.
 	 * @throws Throws if `sourceIndex` is not in the range [0, `list.length`).
 	 */
-	moveToEnd(sourceIndex: number, source: TreeListNode<AllowedTypes>): void;
+	moveToEnd(sourceIndex: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified item to the desired location in the list.
@@ -126,7 +133,7 @@ export interface TreeListNode<TTypes extends AllowedTypes>
 	 * @param source - The source list to move the item out of.
 	 * @throws Throws if any of the input indices are not in the range [0, `list.length`).
 	 */
-	moveToIndex(index: number, sourceIndex: number, source: TreeListNode<AllowedTypes>): void;
+	moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified items to the start of the list.
@@ -144,11 +151,7 @@ export interface TreeListNode<TTypes extends AllowedTypes>
 	 * @throws Throws if the types of any of the items being moved are not allowed in the destination list,
 	 * if either of the input indices are not in the range [0, `list.length`) or if `sourceStart` is greater than `sourceEnd`.
 	 */
-	moveRangeToStart(
-		sourceStart: number,
-		sourceEnd: number,
-		source: TreeListNode<AllowedTypes>,
-	): void;
+	moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified items to the end of the list.
@@ -166,11 +169,7 @@ export interface TreeListNode<TTypes extends AllowedTypes>
 	 * @throws Throws if the types of any of the items being moved are not allowed in the destination list,
 	 * if either of the input indices are not in the range [0, `list.length`) or if `sourceStart` is greater than `sourceEnd`.
 	 */
-	moveRangeToEnd(
-		sourceStart: number,
-		sourceEnd: number,
-		source: TreeListNode<AllowedTypes>,
-	): void;
+	moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified items to the desired location within the list.
@@ -195,7 +194,7 @@ export interface TreeListNode<TTypes extends AllowedTypes>
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source: TreeListNode<AllowedTypes>,
+		source: TMoveFrom,
 	): void;
 }
 


### PR DESCRIPTION
## Description

Split TreeListNode into two interfaces.
The new "base" interface no longer includes any schema related typing, and simply defines a generic list concept.
This change has a few benefits:
1. It deduplicates the type expressions for the various schema derived types in list.
2. Makes the type safety issues around moves from other lists much clearer and easier to fix.
3. Adds a list base type which can be reused in the new class based schema API, which has different schema derived typing.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
