### PR TITLE
Add Strong Typing to Interval Collection Ops

### DIFF
--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -264,6 +264,9 @@ export const IntervalOpType: {
     readonly POSITION_REMOVE: "positionRemove";
 };
 
+// @alpha (undocumented)
+export type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
+
 // @alpha
 export type IntervalRevertible = {
     event: typeof IntervalOpType.CHANGE;
@@ -390,9 +393,9 @@ export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval
     findIntervalsWithStartpointInRange(start: number, end: number): TInterval[];
 }
 
-// @internal
+// @internal @deprecated
 export interface IValueOpEmitter {
-    emit(opName: string, previousValue: any, params: any, localOpMetadata: IMapMessageLocalMetadata): void;
+    emit(opName: IntervalOpType, previousValue: unknown, params: SerializedIntervalDelta, localOpMetadata: IMapMessageLocalMetadata): void;
 }
 
 // @alpha

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -393,7 +393,7 @@ export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval
     findIntervalsWithStartpointInRange(start: number, end: number): TInterval[];
 }
 
-// @internal
+// @internal @deprecated
 export interface IValueOpEmitter {
     // @deprecated
     emit(opName: IntervalOpType, previousValue: undefined, params: SerializedIntervalDelta, localOpMetadata: IMapMessageLocalMetadata): void;

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -393,8 +393,9 @@ export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval
     findIntervalsWithStartpointInRange(start: number, end: number): TInterval[];
 }
 
-// @internal @deprecated
+// @internal
 export interface IValueOpEmitter {
+    // @deprecated
     emit(opName: IntervalOpType, previousValue: undefined, params: SerializedIntervalDelta, localOpMetadata: IMapMessageLocalMetadata): void;
 }
 

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -395,7 +395,7 @@ export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval
 
 // @internal @deprecated
 export interface IValueOpEmitter {
-    emit(opName: IntervalOpType, previousValue: unknown, params: SerializedIntervalDelta, localOpMetadata: IMapMessageLocalMetadata): void;
+    emit(opName: IntervalOpType, previousValue: undefined, params: SerializedIntervalDelta, localOpMetadata: IMapMessageLocalMetadata): void;
 }
 
 // @alpha

--- a/packages/dds/sequence/src/defaultMap.ts
+++ b/packages/dds/sequence/src/defaultMap.ts
@@ -411,12 +411,11 @@ export class DefaultMap<T> {
 				assert(localValue !== undefined, 0x3f8 /* Local value expected on resubmission */);
 
 				const handler = localValue.getOpHandler(op.value.opName);
-				const { rebasedOp, rebasedLocalOpMetadata } = handler.rebase(
-					localValue.value,
-					op.value,
-					localOpMetadata,
-				);
-				this.submitMessage({ ...op, value: rebasedOp }, rebasedLocalOpMetadata);
+				const rebased = handler.rebase(localValue.value, op.value, localOpMetadata);
+				if (rebased !== undefined) {
+					const { rebasedOp, rebasedLocalOpMetadata } = rebased;
+					this.submitMessage({ ...op, value: rebasedOp }, rebasedLocalOpMetadata);
+				}
 			},
 			getStashedOpLocalMetadata: (op: IMapValueTypeOperation) => {
 				assert(

--- a/packages/dds/sequence/src/defaultMapInterfaces.ts
+++ b/packages/dds/sequence/src/defaultMapInterfaces.ts
@@ -6,6 +6,7 @@
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISharedObjectEvents } from "@fluidframework/shared-object-base";
 import { IEventThisPlaceHolder } from "@fluidframework/core-interfaces";
+import { ISerializedInterval, IntervalOpType, SerializedIntervalDelta } from "./intervals";
 
 /**
  * Type of "valueChanged" event parameter.
@@ -25,6 +26,7 @@ export interface IValueChanged {
 /**
  * Value types are given an IValueOpEmitter to emit their ops through the container type that holds them.
  * @internal
+ * @deprecated - will be remove from public api
  */
 export interface IValueOpEmitter {
 	/**
@@ -36,9 +38,9 @@ export interface IValueOpEmitter {
 	 * @internal
 	 */
 	emit(
-		opName: string,
-		previousValue: any,
-		params: any,
+		opName: IntervalOpType,
+		previousValue: unknown,
+		params: SerializedIntervalDelta,
 		localOpMetadata: IMapMessageLocalMetadata,
 	): void;
 }
@@ -123,7 +125,7 @@ export interface IValueOperation<T> {
 	 */
 	process(
 		value: T,
-		params: any,
+		params: ISerializedInterval,
 		local: boolean,
 		message: ISequencedDocumentMessage | undefined,
 		localOpMetadata: IMapMessageLocalMetadata | undefined,
@@ -164,7 +166,7 @@ export interface IValueType<T> {
 	 * Operations that can be applied to the value type.
 	 * @alpha
 	 */
-	ops: Map<string, IValueOperation<T>>;
+	ops: Map<IntervalOpType, IValueOperation<T>>;
 }
 
 export interface ISharedDefaultMapEvents extends ISharedObjectEvents {
@@ -182,7 +184,7 @@ export interface ISharedDefaultMapEvents extends ISharedObjectEvents {
  * JSON.stringify and comes out of JSON.parse. This format is used both for snapshots (loadCore/populate)
  * and ops (set).
  *
- * The DefaultMap impelmentation for sequence has been specialized to only support a single ValueType, which serializes
+ * The DefaultMap implementation for sequence has been specialized to only support a single ValueType, which serializes
  * and deserializes via .store() and .load().
  */
 export interface ISerializableValue {
@@ -222,10 +224,10 @@ export interface IValueTypeOperationValue {
 	/**
 	 * The name of the operation.
 	 */
-	opName: string;
+	opName: IntervalOpType;
 
 	/**
 	 * The payload that is submitted along with the operation.
 	 */
-	value: any;
+	value: SerializedIntervalDelta | undefined;
 }

--- a/packages/dds/sequence/src/defaultMapInterfaces.ts
+++ b/packages/dds/sequence/src/defaultMapInterfaces.ts
@@ -26,7 +26,7 @@ export interface IValueChanged {
 /**
  * Value types are given an IValueOpEmitter to emit their ops through the container type that holds them.
  * @internal
- *
+ * @deprecated - will be remove from public api as there is no public used of this type
  */
 export interface IValueOpEmitter {
 	/**

--- a/packages/dds/sequence/src/defaultMapInterfaces.ts
+++ b/packages/dds/sequence/src/defaultMapInterfaces.ts
@@ -26,20 +26,20 @@ export interface IValueChanged {
 /**
  * Value types are given an IValueOpEmitter to emit their ops through the container type that holds them.
  * @internal
- * @deprecated - will be remove from public api
+ *
  */
 export interface IValueOpEmitter {
 	/**
 	 * Called by the value type to emit a value type operation through the container type holding it.
 	 * @param opName - Name of the emitted operation
-	 * @param previousValue - JSONable previous value as defined by the value type
+	 * @param previousValue -  JSONable previous value as defined by the value type @deprecated unused
 	 * @param params - JSONable params for the operation as defined by the value type
 	 * @param localOpMetadata - JSONable local metadata which should be submitted with the op
 	 * @internal
 	 */
 	emit(
 		opName: IntervalOpType,
-		previousValue: unknown,
+		previousValue: undefined,
 		params: SerializedIntervalDelta,
 		localOpMetadata: IMapMessageLocalMetadata,
 	): void;

--- a/packages/dds/sequence/src/defaultMapInterfaces.ts
+++ b/packages/dds/sequence/src/defaultMapInterfaces.ts
@@ -32,7 +32,7 @@ export interface IValueOpEmitter {
 	/**
 	 * Called by the value type to emit a value type operation through the container type holding it.
 	 * @param opName - Name of the emitted operation
-	 * @param previousValue -  JSONable previous value as defined by the value type @deprecated unused
+	 * @param previousValue - JSONable previous value as defined by the value type @deprecated unused
 	 * @param params - JSONable params for the operation as defined by the value type
 	 * @param localOpMetadata - JSONable local metadata which should be submitted with the op
 	 * @internal

--- a/packages/dds/sequence/src/defaultMapInterfaces.ts
+++ b/packages/dds/sequence/src/defaultMapInterfaces.ts
@@ -143,7 +143,9 @@ export interface IValueOperation<T> {
 		value: T,
 		op: IValueTypeOperationValue,
 		localOpMetadata: IMapMessageLocalMetadata,
-	): { rebasedOp: IValueTypeOperationValue; rebasedLocalOpMetadata: IMapMessageLocalMetadata };
+	):
+		| { rebasedOp: IValueTypeOperationValue; rebasedLocalOpMetadata: IMapMessageLocalMetadata }
+		| undefined;
 }
 
 /**
@@ -229,5 +231,5 @@ export interface IValueTypeOperationValue {
 	/**
 	 * The payload that is submitted along with the operation.
 	 */
-	value: SerializedIntervalDelta | undefined;
+	value: SerializedIntervalDelta;
 }

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -570,8 +570,10 @@ export function makeOpsMap<T extends ISerializableInterval>(): Map<
 		localOpMetadata,
 	) => {
 		const { localSeq } = localOpMetadata;
-		assert(op.value !== undefined, "op must have value");
 		const rebasedValue = collection.rebaseLocalInterval(op.opName, op.value, localSeq);
+		if (rebasedValue === undefined) {
+			return undefined;
+		}
 		const rebasedOp = { ...op, value: rebasedValue };
 		return { rebasedOp, rebasedLocalOpMetadata: localOpMetadata };
 	};

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -35,7 +35,6 @@ import {
 	IValueOpEmitter,
 	IValueOperation,
 	IValueType,
-	IValueTypeOperationValue,
 	SequenceOptions,
 } from "./defaultMapInterfaces";
 import {
@@ -512,7 +511,7 @@ export class SequenceIntervalCollectionValueType
 		return SequenceIntervalCollectionValueType._factory;
 	}
 
-	public get ops(): Map<string, IValueOperation<IntervalCollection<SequenceInterval>>> {
+	public get ops(): Map<IntervalOpType, IValueOperation<IntervalCollection<SequenceInterval>>> {
 		return SequenceIntervalCollectionValueType._ops;
 	}
 
@@ -552,7 +551,7 @@ export class IntervalCollectionValueType implements IValueType<IntervalCollectio
 		return IntervalCollectionValueType._factory;
 	}
 
-	public get ops(): Map<string, IValueOperation<IntervalCollection<Interval>>> {
+	public get ops(): Map<IntervalOpType, IValueOperation<IntervalCollection<Interval>>> {
 		return IntervalCollectionValueType._ops;
 	}
 
@@ -562,21 +561,22 @@ export class IntervalCollectionValueType implements IValueType<IntervalCollectio
 }
 
 export function makeOpsMap<T extends ISerializableInterval>(): Map<
-	string,
+	IntervalOpType,
 	IValueOperation<IntervalCollection<T>>
 > {
-	const rebase = (
-		collection: IntervalCollection<T>,
-		op: IValueTypeOperationValue,
-		localOpMetadata: IMapMessageLocalMetadata,
+	const rebase: IValueOperation<IntervalCollection<T>>["rebase"] = (
+		collection,
+		op,
+		localOpMetadata,
 	) => {
 		const { localSeq } = localOpMetadata;
+		assert(op.value !== undefined, "op must have value");
 		const rebasedValue = collection.rebaseLocalInterval(op.opName, op.value, localSeq);
 		const rebasedOp = { ...op, value: rebasedValue };
 		return { rebasedOp, rebasedLocalOpMetadata: localOpMetadata };
 	};
 
-	return new Map<string, IValueOperation<IntervalCollection<T>>>([
+	return new Map<IntervalOpType, IValueOperation<IntervalCollection<T>>>([
 		[
 			IntervalOpType.ADD,
 			{
@@ -1867,7 +1867,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 	): void {
 		if (local) {
 			// Local ops were applied when the message was created and there's no "pending delete"
-			// state to bookkeep: remote operation application takes into account possibility of
+			// state to book keep: remote operation application takes into account possibility of
 			// locally deleted interval whenever a lookup happens.
 			return;
 		}

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -81,7 +81,10 @@ export const IntervalOpType = {
 	PROPERTY_CHANGED: "propertyChanged",
 	POSITION_REMOVE: "positionRemove",
 } as const;
-
+/**
+ * @alpha
+ */
+export type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
 /**
  * @public
  */

--- a/packages/dds/sequence/src/localValues.ts
+++ b/packages/dds/sequence/src/localValues.ts
@@ -11,6 +11,7 @@ import {
 	IValueOperation,
 	IValueType,
 } from "./defaultMapInterfaces";
+import { IntervalOpType } from "./intervals";
 
 /**
  * A local value to be stored in a container type DDS.
@@ -88,7 +89,7 @@ export class ValueTypeLocalValue<T> implements ILocalValue<T> {
 	 * @param opName - The name of the operation that needs processing
 	 * @returns The object which can process the given op
 	 */
-	public getOpHandler(opName: string): IValueOperation<T> {
+	public getOpHandler(opName: IntervalOpType): IValueOperation<T> {
 		const handler = this.valueType.ops.get(opName);
 		if (!handler) {
 			throw new Error("Unknown type message");

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -37,8 +37,6 @@ export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertib
 
 const idMap = new Map<string, string>();
 
-type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
-
 /**
  * Data for undoing edits affecting Intervals.
  *

--- a/packages/dds/sequence/src/test/v1IntervalCollectionHelpers.ts
+++ b/packages/dds/sequence/src/test/v1IntervalCollectionHelpers.ts
@@ -29,6 +29,7 @@ import {
 	SequenceInterval,
 	IIntervalHelpers,
 	createSequenceInterval,
+	IntervalOpType,
 } from "../intervals";
 import { pkgVersion } from "../packageVersion";
 import { SharedString } from "../sharedString";
@@ -81,7 +82,7 @@ export class V1SequenceIntervalCollectionValueType
 		return V1SequenceIntervalCollectionValueType._factory;
 	}
 
-	public get ops(): Map<string, IValueOperation<V1IntervalCollection<SequenceInterval>>> {
+	public get ops(): Map<IntervalOpType, IValueOperation<V1IntervalCollection<SequenceInterval>>> {
 		return V1SequenceIntervalCollectionValueType._ops;
 	}
 


### PR DESCRIPTION
Interval collection ops didn't have strong typing all the way through due to legacy coupling to value type infrastructure. The coupling is still there, but the value type infrastructure isn't used generically, it is only used for interval collections. this change changes the typing to reflect that, and it makes the interval collection code easier to follow.