### PR TITLE
refactor(tree2): unify move-out and return-from marks

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -274,12 +274,13 @@ export const Delete = Type.Composite(
  * Rebasing this mark never causes it to target different set of nodes.
  * Rebasing this mark can cause it to clear a different set of cells.
  */
-export interface MoveOut extends HasMoveFields {
+export interface MoveOut extends HasMoveFields, InverseAttachFields {
 	type: "MoveOut";
 }
 export const MoveOut = Type.Composite(
 	[
 		HasMoveFields,
+		InverseAttachFields,
 		Type.Object({
 			type: Type.Literal("MoveOut"),
 		}),
@@ -287,31 +288,8 @@ export const MoveOut = Type.Composite(
 	noAdditionalProps,
 );
 
-/**
- * Removes nodes from their cells so they can be moved into other cells.
- * Always brings about the desired outcome: the targeted nodes are removed from their cells.
- * Note that this may not require any changes if targeted nodes are already removed when this mark is applied.
- *
- * Rebasing this mark never causes it to target different set of nodes.
- * Rebasing this mark can cause it to clear a different set of cells.
- * TODO: unify with `MoveOut`.
- */
-export interface ReturnFrom extends HasMoveFields, InverseAttachFields {
-	type: "ReturnFrom";
-}
-export const ReturnFrom = Type.Composite(
-	[
-		HasMoveFields,
-		InverseAttachFields,
-		Type.Object({
-			type: Type.Literal("ReturnFrom"),
-		}),
-	],
-	noAdditionalProps,
-);
-
-export type MoveSource = MoveOut | ReturnFrom;
-export const MoveSource = Type.Union([MoveOut, ReturnFrom]);
+export type MoveSource = MoveOut;
+export const MoveSource = MoveOut;
 
 export type Attach = Insert | MoveIn;
 export const Attach = Type.Union([Insert, MoveIn]);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -288,14 +288,11 @@ export const MoveOut = Type.Composite(
 	noAdditionalProps,
 );
 
-export type MoveSource = MoveOut;
-export const MoveSource = MoveOut;
-
 export type Attach = Insert | MoveIn;
 export const Attach = Type.Union([Insert, MoveIn]);
 
-export type Detach = Delete | MoveSource;
-export const Detach = Type.Union([Delete, MoveSource]);
+export type Detach = Delete | MoveOut;
+export const Detach = Type.Union([Delete, MoveOut]);
 
 /**
  * Mark used during compose to temporarily remember the position of nodes which were being moved

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/helperTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/helperTypes.ts
@@ -11,7 +11,7 @@ import {
 	CellMark,
 	AttachAndDetach,
 	MoveIn,
-	MoveSource,
+	MoveOut,
 } from "./format";
 
 export type EmptyInputCellMark<TNodeChange> = Mark<TNodeChange> & DetachedCellMark;
@@ -22,7 +22,6 @@ export interface DetachedCellMark extends HasMarkFields {
 
 export type EmptyOutputCellMark<TNodeChange> = CellMark<Detach | AttachAndDetach, TNodeChange>;
 
-export type MoveDestination = MoveIn;
-export type MoveMarkEffect = MoveSource | MoveDestination;
+export type MoveMarkEffect = MoveOut | MoveIn;
 export type DetachOfRemovedNodes = Detach & { cellId: CellId };
 export type CellRename = AttachAndDetach | DetachOfRemovedNodes;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/index.ts
@@ -19,7 +19,6 @@ export {
 	MoveId,
 	ProtoNode,
 	Attach,
-	ReturnFrom,
 	NoopMark,
 	LineageEvent,
 	CellId,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -11,7 +11,6 @@ import {
 	Changeset,
 	Mark,
 	MarkList,
-	ReturnFrom,
 	NoopMarkType,
 	MoveOut,
 	NoopMark,
@@ -140,8 +139,7 @@ function invertMark<TNodeChange>(
 			const inverse = withNodeChange(deleteMark, invertNodeChange(mark.changes, invertChild));
 			return [inverse];
 		}
-		case "MoveOut":
-		case "ReturnFrom": {
+		case "MoveOut": {
 			if (mark.changes !== undefined) {
 				assert(
 					mark.count === 1,
@@ -191,8 +189,8 @@ function invertMark<TNodeChange>(
 			return [{ ...effect, count: mark.count, cellId }];
 		}
 		case "MoveIn": {
-			const invertedMark: CellMark<ReturnFrom, TNodeChange> = {
-				type: "ReturnFrom",
+			const invertedMark: CellMark<MoveOut, TNodeChange> = {
+				type: "MoveOut",
 				id: mark.id,
 				count: mark.count,
 			};
@@ -310,7 +308,7 @@ function invertMark<TNodeChange>(
 }
 
 function applyMovedChanges<TNodeChange>(
-	mark: CellMark<MoveOut | ReturnFrom, TNodeChange>,
+	mark: CellMark<MoveOut, TNodeChange>,
 	revision: RevisionTag | undefined,
 	manager: CrossFieldManager<TNodeChange>,
 ): Mark<TNodeChange>[] {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -18,7 +18,6 @@ import {
 	CellMark,
 	MoveIn,
 	MarkEffect,
-	MoveSource,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {
@@ -325,7 +324,7 @@ function applyMovedChanges<TNodeChange>(
 		const [mark1, mark2] = splitMark(mark, entry.length);
 		const mark1WithChanges =
 			entry.value !== undefined
-				? withNodeChange<CellMark<MoveSource, TNodeChange>, MoveSource, TNodeChange>(
+				? withNodeChange<CellMark<MoveOut, TNodeChange>, MoveOut, TNodeChange>(
 						mark1,
 						entry.value,
 				  )
@@ -336,10 +335,7 @@ function applyMovedChanges<TNodeChange>(
 
 	if (entry.value !== undefined) {
 		return [
-			withNodeChange<CellMark<MoveSource, TNodeChange>, MoveSource, TNodeChange>(
-				mark,
-				entry.value,
-			),
+			withNodeChange<CellMark<MoveOut, TNodeChange>, MoveOut, TNodeChange>(mark, entry.value),
 		];
 	}
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -90,22 +90,11 @@ export function isMoveMark(effect: MarkEffect): effect is MoveMarkEffect {
 }
 
 export function isMoveSource(effect: MarkEffect): effect is MoveSource {
-	switch (effect.type) {
-		case "MoveOut":
-		case "ReturnFrom":
-			return true;
-		default:
-			return false;
-	}
+	return effect.type === "MoveOut";
 }
 
 export function isMoveDestination(effect: MarkEffect): effect is MoveDestination {
-	switch (effect.type) {
-		case "MoveIn":
-			return true;
-		default:
-			return false;
-	}
+	return effect.type === "MoveIn";
 }
 
 function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: MoveId): MoveEffect<T> {
@@ -362,8 +351,7 @@ export function applyMoveEffectsToMark<T>(
 	} else if (isMoveMark(mark)) {
 		const type = mark.type;
 		switch (type) {
-			case "MoveOut":
-			case "ReturnFrom": {
+			case "MoveOut": {
 				const effect = getMoveEffect(
 					effects,
 					CrossFieldTarget.Source,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -7,9 +7,9 @@ import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { ChangeAtomId, RevisionTag } from "../../core";
 import { CrossFieldManager, CrossFieldTarget } from "../modular-schema";
 import { RangeQueryResult, brand } from "../../util";
-import { CellMark, Mark, MarkEffect, MoveId, MoveSource } from "./format";
+import { CellMark, Mark, MarkEffect, MoveId, MoveIn, MoveOut } from "./format";
 import { areEqualCellIds, cloneMark, isAttachAndDetachEffect, splitMark } from "./utils";
-import { MoveDestination, MoveMarkEffect } from "./helperTypes";
+import { MoveMarkEffect } from "./helperTypes";
 
 export type MoveEffectTable<T> = CrossFieldManager<MoveEffect<T>>;
 
@@ -86,14 +86,14 @@ export function getMoveEffect<T>(
 export type MoveMark<T> = CellMark<MoveMarkEffect, T>;
 
 export function isMoveMark(effect: MarkEffect): effect is MoveMarkEffect {
-	return isMoveSource(effect) || isMoveDestination(effect);
+	return isMoveOut(effect) || isMoveIn(effect);
 }
 
-export function isMoveSource(effect: MarkEffect): effect is MoveSource {
+export function isMoveOut(effect: MarkEffect): effect is MoveOut {
 	return effect.type === "MoveOut";
 }
 
-export function isMoveDestination(effect: MarkEffect): effect is MoveDestination {
+export function isMoveIn(effect: MarkEffect): effect is MoveIn {
 	return effect.type === "MoveIn";
 }
 
@@ -122,7 +122,7 @@ function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: Move
 }
 
 function applyMoveEffectsToDest(
-	markEffect: MoveDestination,
+	markEffect: MoveIn,
 	count: number,
 	revision: RevisionTag | undefined,
 	effects: MoveEffectTable<unknown>,
@@ -139,7 +139,7 @@ function applyMoveEffectsToDest(
 }
 
 function applyMoveEffectsToSource<T>(
-	mark: CellMark<MoveSource, T>,
+	mark: CellMark<MoveOut, T>,
 	revision: RevisionTag | undefined,
 	effects: MoveEffectTable<T>,
 	consumeEffect: boolean,
@@ -174,7 +174,7 @@ function applyMoveEffectsToSource<T>(
 }
 
 function applySourceEffects(
-	markEffect: MoveSource,
+	markEffect: MoveOut,
 	count: number,
 	revision: RevisionTag | undefined,
 	effects: MoveEffectTable<unknown>,
@@ -218,8 +218,8 @@ export function applyMoveEffectsToMark<T>(
 	composeChildren?: (a: T | undefined, b: T | undefined) => T | undefined,
 ): Mark<T>[] {
 	if (isAttachAndDetachEffect(mark)) {
-		if (isMoveDestination(mark.attach)) {
-			if (isMoveSource(mark.detach)) {
+		if (isMoveIn(mark.attach)) {
+			if (isMoveOut(mark.detach)) {
 				// Move effects should not be applied to intermediate move locations.
 				return [mark];
 			}
@@ -234,7 +234,7 @@ export function applyMoveEffectsToMark<T>(
 
 			if (effect.length < mark.count) {
 				const [firstMark, secondMark] = splitMark(mark, effect.length);
-				const updatedAttach = firstMark.attach as MoveDestination;
+				const updatedAttach = firstMark.attach as MoveIn;
 				applyMoveEffectsToDest(
 					updatedAttach,
 					firstMark.count,
@@ -273,7 +273,7 @@ export function applyMoveEffectsToMark<T>(
 			}
 		}
 
-		if (isMoveSource(mark.detach)) {
+		if (isMoveOut(mark.detach)) {
 			const detachRevision = mark.detach.revision ?? revision;
 			const effect = getMoveEffect(
 				effects,
@@ -286,7 +286,7 @@ export function applyMoveEffectsToMark<T>(
 			if (effect.length < mark.count) {
 				const [firstMark, secondMark] = splitMark(mark, effect.length);
 				applySourceEffects(
-					firstMark.detach as MoveSource,
+					firstMark.detach as MoveOut,
 					firstMark.count,
 					detachRevision,
 					effects,
@@ -323,7 +323,7 @@ export function applyMoveEffectsToMark<T>(
 
 			const newMark = cloneMark(mark);
 			applySourceEffects(
-				newMark.detach as MoveSource,
+				newMark.detach as MoveOut,
 				mark.count,
 				detachRevision,
 				effects,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -48,7 +48,7 @@ import {
 	CellMark,
 	CellId,
 	MarkEffect,
-	ReturnFrom,
+	MoveOut,
 	MoveIn,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
@@ -204,7 +204,7 @@ function mergeMarkList<T>(marks: Mark<T>[]): Mark<T>[] {
 function isInverseAttach(effect: MarkEffect): boolean {
 	switch (effect.type) {
 		case "Delete":
-		case "ReturnFrom":
+		case "MoveOut":
 			return effect.detachIdOverride !== undefined;
 		case "AttachAndDetach":
 			return isInverseAttach(effect.detach);
@@ -343,7 +343,7 @@ class RebaseQueue<T> {
 }
 
 function fuseMarks<T>(newMark: Mark<T>, movedMark: Mark<T>): Mark<T> {
-	if (isMoveDestination(newMark) && movedMark.type === "ReturnFrom") {
+	if (isMoveDestination(newMark) && isMoveSource(movedMark)) {
 		const fusedMark: Mark<T> = {
 			type: "Insert",
 			count: newMark.count,
@@ -474,7 +474,6 @@ function separateEffectsForMove(mark: MarkEffect): { remains?: MarkEffect; follo
 	switch (type) {
 		case "Delete":
 		case "MoveOut":
-		case "ReturnFrom":
 			return { follows: mark };
 		case "AttachAndDetach":
 			return { follows: mark.detach, remains: mark.attach };
@@ -483,8 +482,8 @@ function separateEffectsForMove(mark: MarkEffect): { remains?: MarkEffect; follo
 		case NoopMarkType:
 			return {};
 		case "Insert": {
-			const follows: ReturnFrom = {
-				type: "ReturnFrom",
+			const follows: MoveOut = {
+				type: "MoveOut",
 				id: mark.id,
 			};
 			const remains: MoveIn = {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -58,8 +58,8 @@ import {
 	isMoveMark,
 	MoveEffect,
 	MoveEffectTable,
-	isMoveSource,
-	isMoveDestination,
+	isMoveOut,
+	isMoveIn,
 } from "./moveEffectTable";
 import { MarkQueue } from "./markQueue";
 import { EmptyInputCellMark } from "./helperTypes";
@@ -343,7 +343,7 @@ class RebaseQueue<T> {
 }
 
 function fuseMarks<T>(newMark: Mark<T>, movedMark: Mark<T>): Mark<T> {
-	if (isMoveDestination(newMark) && isMoveSource(movedMark)) {
+	if (isMoveIn(newMark) && isMoveOut(movedMark)) {
 		const fusedMark: Mark<T> = {
 			type: "Insert",
 			count: newMark.count,
@@ -414,7 +414,7 @@ function rebaseMarkIgnoreChild<TNodeChange>(
 		);
 		const baseCellId = getDetachOutputId(baseMark, baseRevision, metadata);
 
-		if (isMoveSource(baseMark)) {
+		if (isMoveOut(baseMark)) {
 			assert(isMoveMark(baseMark), 0x6f0 /* Only move marks have move IDs */);
 			assert(
 				!isNewAttach(currMark),
@@ -589,14 +589,14 @@ function getMovedMarkFromBaseMark<T>(
 	baseMark: Mark<T>,
 	baseRevision: RevisionTag | undefined,
 ): Mark<T> | undefined {
-	if (isMoveDestination(baseMark)) {
+	if (isMoveIn(baseMark)) {
 		return getMovedMark(
 			moveEffects,
 			baseMark.revision ?? baseRevision,
 			baseMark.id,
 			baseMark.count,
 		);
-	} else if (isAttachAndDetachEffect(baseMark) && isMoveDestination(baseMark.attach)) {
+	} else if (isAttachAndDetachEffect(baseMark) && isMoveIn(baseMark.attach)) {
 		return getMovedMark(
 			moveEffects,
 			baseMark.attach.revision ?? baseRevision,

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
@@ -23,7 +23,6 @@ function makeV0Codec<TNodeChange>(
 			case "Insert":
 			case "Delete":
 			case "MoveOut":
-			case "ReturnFrom":
 				return { ...(effect as JsonCompatibleReadOnly & object) };
 			case "AttachAndDetach":
 				return {
@@ -46,7 +45,6 @@ function makeV0Codec<TNodeChange>(
 			case "Insert":
 			case "Delete":
 			case "MoveOut":
-			case "ReturnFrom":
 				return { ...effect };
 			case "AttachAndDetach":
 				return {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -16,7 +16,7 @@ import {
 	Mark,
 	MoveId,
 	NodeChangeType,
-	ReturnFrom,
+	MoveOut,
 	MoveIn,
 	MarkList,
 	MoveSource,
@@ -138,8 +138,8 @@ export const sequenceFieldEditor = {
 		detachEvent: CellId,
 	): Changeset<never> {
 		const id = brand<MoveId>(0);
-		const returnFrom: CellMark<ReturnFrom, never> = {
-			type: "ReturnFrom",
+		const moveOut: CellMark<MoveOut, never> = {
+			type: "MoveOut",
 			id,
 			count,
 		};
@@ -151,7 +151,7 @@ export const sequenceFieldEditor = {
 			cellId: detachEvent,
 		};
 
-		return moveMarksToMarkList(sourceIndex, count, destIndex, returnFrom, returnTo);
+		return moveMarksToMarkList(sourceIndex, count, destIndex, moveOut, returnTo);
 	},
 } satisfies SequenceFieldEditor;
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -19,11 +19,9 @@ import {
 	MoveOut,
 	MoveIn,
 	MarkList,
-	MoveSource,
 } from "./format";
 import { MarkListFactory } from "./markListFactory";
 import { splitMark } from "./utils";
-import { MoveDestination } from "./helperTypes";
 
 export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 	/**
@@ -159,8 +157,8 @@ function moveMarksToMarkList(
 	sourceIndex: number,
 	count: number,
 	destIndex: number,
-	detach: CellMark<MoveSource, never>,
-	attach: CellMark<MoveDestination, never>,
+	detach: CellMark<MoveOut, never>,
+	attach: CellMark<MoveIn, never>,
 ): MarkList<never> {
 	if (count === 0) {
 		return [];

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -19,7 +19,7 @@ import {
 	isAttachAndDetachEffect,
 	getDetachOutputId,
 } from "./utils";
-import { isMoveDestination, isMoveSource } from "./moveEffectTable";
+import { isMoveIn, isMoveOut } from "./moveEffectTable";
 
 export type ToDelta<TNodeChange> = (child: TNodeChange) => Delta.FieldMap;
 
@@ -60,7 +60,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 			);
 			// The cell starting and ending empty means the cell content has not changed,
 			// unless transient content was inserted/attached.
-			if (isMoveDestination(mark.attach) && isMoveSource(mark.detach)) {
+			if (isMoveIn(mark.attach) && isMoveOut(mark.detach)) {
 				assert(
 					mark.changes === undefined,
 					0x81f /* AttachAndDetach moves should not have changes */,
@@ -74,7 +74,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 				0x820 /* AttachAndDetach mark should have defined output cell ID */,
 			);
 			const oldId = nodeIdFromChangeAtom(
-				isMoveDestination(mark.attach) ? getEndpoint(mark.attach, revision) : inputCellId,
+				isMoveIn(mark.attach) ? getEndpoint(mark.attach, revision) : inputCellId,
 			);
 			if (!areEqualChangeAtomIds(inputCellId, outputId)) {
 				if (mark.attach.type === "Insert" && mark.attach.content !== undefined) {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -131,8 +131,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 					}
 					break;
 				}
-				case "MoveOut":
-				case "ReturnFrom": {
+				case "MoveOut": {
 					// The move destination will look for the detach ID of the source, so we can ignore `finalEndpoint`.
 					const detachId = makeDetachedNodeId(mark.revision ?? revision, mark.id);
 					if (inputCellId === undefined) {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -47,7 +47,6 @@ import { isMoveMark, MoveEffectTable } from "./moveEffectTable";
 import {
 	EmptyInputCellMark,
 	DetachedCellMark,
-	MoveDestination,
 	MoveMarkEffect,
 	DetachOfRemovedNodes,
 	CellRename,
@@ -998,7 +997,7 @@ function splitMarkEffect<TEffect extends MarkEffect>(
 		}
 		case "MoveIn": {
 			const effect2: TEffect = { ...effect, id: (effect.id as number) + length };
-			const move2 = effect2 as MoveDestination;
+			const move2 = effect2 as MoveIn;
 			if (move2.finalEndpoint !== undefined) {
 				move2.finalEndpoint = splitDetachEvent(move2.finalEndpoint, length);
 			}

--- a/experimental/dds/tree2/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -360,7 +360,7 @@ describe("ModularChangeFamily integration", () => {
 			};
 
 			const fieldBExpected = [
-				MarkMaker.returnFrom(1, brand(1), { changes: node2Expected }),
+				MarkMaker.moveOut(1, brand(1), { changes: node2Expected }),
 				{ count: 1 },
 				MarkMaker.returnTo(1, brand(1), { revision: tag1, localId: brand(1) }),
 			];
@@ -372,7 +372,7 @@ describe("ModularChangeFamily integration", () => {
 			};
 
 			const fieldAExpected = [
-				MarkMaker.returnFrom(1, brand(0), { changes: node1Expected }),
+				MarkMaker.moveOut(1, brand(0), { changes: node1Expected }),
 				{ count: 1 },
 				MarkMaker.returnTo(1, brand(0), { revision: tag1, localId: brand(0) }),
 			];

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -101,14 +101,6 @@ describe("SequenceField - Compose", () => {
 				{ changes, cellId: { revision: tag1, localId: brand(2) } },
 			),
 			Mark.moveIn(1, { localId: brand(3) }),
-			Mark.returnFrom(1, { localId: brand(4) }, { changes }),
-			Mark.returnTo(1, { localId: brand(4) }, { revision: tag1, localId: brand(3) }),
-			Mark.returnFrom(
-				1,
-				{ localId: brand(5) },
-				{ changes, cellId: { revision: tag1, localId: brand(4) } },
-			),
-			Mark.returnTo(1, { localId: brand(5) }, { revision: tag1, localId: brand(5) }),
 			Mark.attachAndDetach(
 				Mark.insert(1, { localId: brand(6) }),
 				Mark.delete(1, { localId: brand(0) }),
@@ -121,7 +113,7 @@ describe("SequenceField - Compose", () => {
 			callCount += 1;
 			return changes;
 		});
-		assert.equal(callCount, 12);
+		assert.equal(callCount, 10);
 	});
 
 	it("delete ○ revive => Noop", () => {
@@ -800,7 +792,7 @@ describe("SequenceField - Compose", () => {
 			{ count: 4 },
 			Mark.attachAndDetach(
 				Mark.returnTo(1, { revision: tag3, localId: brand(0) }, cellId1),
-				Mark.returnFrom(1, { revision: tag4, localId: brand(0) }),
+				Mark.moveOut(1, { revision: tag4, localId: brand(0) }),
 			),
 		];
 		assert.deepEqual(actual, expected);
@@ -818,8 +810,8 @@ describe("SequenceField - Compose", () => {
 				{ revision: tag1, localId: brand(0) },
 			),
 			{ count: 3 },
-			Mark.returnFrom(1, brand(0), { revision: tag4, changes }),
-			Mark.returnFrom(1, brand(1), { revision: tag4 }),
+			Mark.moveOut(1, brand(0), { revision: tag4, changes }),
+			Mark.moveOut(1, brand(1), { revision: tag4 }),
 		];
 		assert.deepEqual(actual, expected);
 	});
@@ -1051,7 +1043,7 @@ describe("SequenceField - Compose", () => {
 			[
 				Mark.returnTo(1, brand(0), { revision: tag1, localId: brand(0) }),
 				{ count: 1 },
-				Mark.returnFrom(1, brand(0), {
+				Mark.moveOut(1, brand(0), {
 					detachIdOverride: { revision: tag1, localId: brand(0) },
 				}),
 			],
@@ -1159,7 +1151,7 @@ describe("SequenceField - Compose", () => {
 			{ count: 1 },
 			Mark.attachAndDetach(
 				Mark.moveIn(1, { revision: tag2, localId: brand(0) }),
-				Mark.returnFrom(1, { revision: tag3, localId: brand(0) }),
+				Mark.moveOut(1, { revision: tag3, localId: brand(0) }),
 			),
 		];
 

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -141,11 +141,11 @@ describe("SequenceField - Invert", () => {
 		const expected: TestChangeset = [
 			Mark.returnTo(2, brand(0), cellId),
 			{ count: 3 },
-			Mark.returnFrom(1, brand(0), {
+			Mark.moveOut(1, brand(0), {
 				detachIdOverride: cellId,
 				changes: inverseChildChange1,
 			}),
-			Mark.returnFrom(1, brand(1), {
+			Mark.moveOut(1, brand(1), {
 				detachIdOverride: { revision: tag1, localId: brand(1) },
 			}),
 		];
@@ -207,7 +207,7 @@ describe("SequenceField - Invert", () => {
 				Mark.delete(1, brand(0)),
 			),
 			{ count: 1 },
-			Mark.returnFrom(1, brand(1), { changes: inverseChildChange1 }),
+			Mark.moveOut(1, brand(1), { changes: inverseChildChange1 }),
 		];
 
 		assert.deepEqual(inverse, expected);
@@ -224,7 +224,7 @@ describe("SequenceField - Invert", () => {
 		const expected = [
 			Mark.returnTo(1, brand(0), { revision: tag1, localId: brand(0) }),
 			{ count: 1 },
-			Mark.returnFrom(1, brand(0), {
+			Mark.moveOut(1, brand(0), {
 				cellId: { revision: tag1, localId: brand(1) },
 				changes: inverseChildChange1,
 			}),
@@ -256,10 +256,10 @@ describe("SequenceField - Invert", () => {
 			{ count: 1 },
 			Mark.attachAndDetach(
 				Mark.returnTo(1, brand(1), { revision: tag1, localId: brand(1) }),
-				Mark.returnFrom(1, brand(0)),
+				Mark.moveOut(1, brand(0)),
 			),
 			{ count: 1 },
-			Mark.returnFrom(1, brand(1), {
+			Mark.moveOut(1, brand(1), {
 				changes: inverseChildChange1,
 				finalEndpoint: { localId: brand(0) },
 			}),

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -105,7 +105,7 @@ describe("SequenceField - MarkListFactory", () => {
 		assert.deepStrictEqual(factory.list, [delete1, delete2]);
 	});
 
-	it("Can merge adjacent moves ", () => {
+	it("Can merge adjacent moves", () => {
 		const factory = new SF.MarkListFactory();
 		const moveOut1 = Mark.moveOut(1, brand(0));
 		const moveOut2 = Mark.moveOut(1, brand(1));
@@ -124,7 +124,7 @@ describe("SequenceField - MarkListFactory", () => {
 		]);
 	});
 
-	it("Can merge three adjacent moves ", () => {
+	it("Can merge three adjacent moves", () => {
 		const factory = new SF.MarkListFactory();
 		const moveOut1 = Mark.moveOut(1, brand(0));
 		const moveOut2 = Mark.moveOut(1, brand(1));
@@ -185,28 +185,28 @@ describe("SequenceField - MarkListFactory", () => {
 		assert.deepStrictEqual(factory.list, [expected]);
 	});
 
-	it("Can merge consecutive return-from", () => {
+	it("Can merge consecutive move-out", () => {
 		const factory = new SF.MarkListFactory();
-		const return1 = Mark.returnFrom(1, brand(0), {
+		const return1 = Mark.moveOut(1, brand(0), {
 			detachIdOverride: { revision: detachedBy, localId: brand(10) },
 		});
-		const return2 = Mark.returnFrom(2, brand(1), {
+		const return2 = Mark.moveOut(2, brand(1), {
 			detachIdOverride: { revision: detachedBy, localId: brand(11) },
 		});
 		factory.pushContent(return1);
 		factory.pushContent(return2);
-		const expected = Mark.returnFrom(3, brand(0), {
+		const expected = Mark.moveOut(3, brand(0), {
 			detachIdOverride: { revision: detachedBy, localId: brand(10) },
 		});
 		assert.deepStrictEqual(factory.list, [expected]);
 	});
 
-	it("Does not merge consecutive return-from with discontinuous detach overrides", () => {
+	it("Does not merge consecutive move-out with discontinuous detach overrides", () => {
 		const factory = new SF.MarkListFactory();
-		const return1 = Mark.returnFrom(1, brand(0), {
+		const return1 = Mark.moveOut(1, brand(0), {
 			detachIdOverride: { revision: detachedBy, localId: brand(10) },
 		});
-		const return2 = Mark.returnFrom(2, brand(1), {
+		const return2 = Mark.moveOut(2, brand(1), {
 			detachIdOverride: { revision: detachedBy, localId: brand(42) },
 		});
 		factory.pushContent(return1);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -561,11 +561,7 @@ describe("SequenceField - Rebase", () => {
 			revision: tag3,
 			localId: brand(0),
 		};
-		const move = [
-			Mark.returnTo(1, brand(0), cellId),
-			{ count: 2 },
-			Mark.returnFrom(1, brand(0)),
-		];
+		const move = [Mark.returnTo(1, brand(0), cellId), { count: 2 }, Mark.moveOut(1, brand(0))];
 		const expected = [Mark.pin(1, brand(0))];
 		const rebased = rebase(move, move);
 		assert.deepEqual(rebased, expected);
@@ -576,11 +572,7 @@ describe("SequenceField - Rebase", () => {
 			revision: tag3,
 			localId: brand(0),
 		};
-		const move = [
-			Mark.returnFrom(1, brand(0)),
-			{ count: 2 },
-			Mark.returnTo(1, brand(0), cellId),
-		];
+		const move = [Mark.moveOut(1, brand(0)), { count: 2 }, Mark.returnTo(1, brand(0), cellId)];
 		const expected = [{ count: 2 }, Mark.pin(1, brand(0))];
 		const rebased = rebase(move, move);
 		assert.deepEqual(rebased, expected);
@@ -597,11 +589,11 @@ describe("SequenceField - Rebase", () => {
 				localId: brand(0),
 			}),
 			{ count: 2 },
-			Mark.returnFrom(1, brand(0)),
+			Mark.moveOut(1, brand(0)),
 		];
 		const return2 = [
 			{ count: 2 },
-			Mark.returnFrom(1, brand(0)),
+			Mark.moveOut(1, brand(0)),
 			{ count: 2 },
 			Mark.returnTo(1, brand(0), {
 				revision: tag3,
@@ -609,7 +601,7 @@ describe("SequenceField - Rebase", () => {
 			}),
 		];
 		const expected = [
-			Mark.returnFrom(1, brand(0)),
+			Mark.moveOut(1, brand(0)),
 			{ count: 4 },
 			Mark.returnTo(1, brand(0), {
 				revision: tag3,
@@ -624,7 +616,7 @@ describe("SequenceField - Rebase", () => {
 		const move = [Mark.moveIn(2, brand(0)), { count: 2 }, Mark.moveOut(2, brand(0))];
 		const pin = [{ count: 2 }, Mark.pin(2, brand(0))];
 		const expected = [
-			Mark.returnFrom(2, brand(0)),
+			Mark.moveOut(2, brand(0)),
 			{ count: 2 },
 			Mark.returnTo(2, brand(0), {
 				revision: tag1,
@@ -769,7 +761,7 @@ describe("SequenceField - Rebase", () => {
 				adjacentCells: [{ id: brand(1), count: 1 }],
 			}),
 			{ count: 1 },
-			Mark.returnFrom(1, brand(0)),
+			Mark.moveOut(1, brand(0)),
 		];
 		assert.deepEqual(rebased, expected);
 	});
@@ -796,7 +788,7 @@ describe("SequenceField - Rebase", () => {
 					localId: brand(2),
 					adjacentCells: [{ id: brand(2), count: 1 }],
 				},
-				Mark.returnFrom(1, brand(0)),
+				Mark.moveOut(1, brand(0)),
 			),
 		];
 		assert.deepEqual(rebased, expected);
@@ -861,7 +853,7 @@ describe("SequenceField - Rebase", () => {
 		const cellSrc: ChangeAtomId = { revision: tag1, localId: brand(0) };
 		const cellDst: ChangeAtomId = { revision: tag3, localId: brand(0) };
 		const reviveAndMove = [
-			Mark.returnFrom(1, brand(1), { cellId: cellSrc }),
+			Mark.moveOut(1, brand(1), { cellId: cellSrc }),
 			{ count: 2 },
 			Mark.returnTo(1, brand(1), cellDst),
 		];
@@ -875,19 +867,19 @@ describe("SequenceField - Rebase", () => {
 		const cellDst1: ChangeAtomId = { revision: tag3, localId: brand(1) };
 		const cellDst2: ChangeAtomId = { revision: tag3, localId: brand(2) };
 		const reviveAndMove1 = [
-			Mark.returnFrom(1, brand(1), { cellId: cellSrc }),
+			Mark.moveOut(1, brand(1), { cellId: cellSrc }),
 			{ count: 2 },
 			Mark.returnTo(1, brand(1), cellDst1),
 		];
 		const reviveAndMove2 = [
-			Mark.returnFrom(1, brand(1), { cellId: cellSrc }),
+			Mark.moveOut(1, brand(1), { cellId: cellSrc }),
 			{ count: 4 },
 			Mark.returnTo(1, brand(1), cellDst2),
 		];
 		const rebased = rebase(reviveAndMove2, reviveAndMove1);
 		const expected = [
 			{ count: 2 },
-			Mark.returnFrom(1, brand(1)),
+			Mark.moveOut(1, brand(1)),
 			{ count: 2 },
 			Mark.returnTo(1, brand(1), cellDst2),
 		];

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/relevantRemovedTrees.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/relevantRemovedTrees.spec.ts
@@ -82,21 +82,6 @@ describe("SequenceField - relevantRemovedTrees", () => {
 			const array = Array.from(actual);
 			assert.deepEqual(array, []);
 		});
-		it("a tree being returned", () => {
-			const input: TestChangeset = [Mark.returnFrom(1, atomId), Mark.returnTo(1, atomId)];
-			const actual = SF.relevantRemovedTrees(input, noTreeDelegate);
-			const array = Array.from(actual);
-			assert.deepEqual(array, []);
-		});
-		it("a tree with child changes being returned", () => {
-			const input: TestChangeset = [
-				Mark.returnFrom(1, atomId, { changes: childChange }),
-				Mark.returnTo(1, atomId),
-			];
-			const actual = SF.relevantRemovedTrees(input, noTreeDelegate);
-			const array = Array.from(actual);
-			assert.deepEqual(array, []);
-		});
 		it("a tree being transiently inserted", () => {
 			const input: TestChangeset = [
 				Mark.attachAndDetach(Mark.insert(1, atomId), Mark.delete(1, atomId)),
@@ -207,15 +192,6 @@ describe("SequenceField - relevantRemovedTrees", () => {
 			const input: TestChangeset = [
 				Mark.moveOut(1, atomId, { changes: childChange }),
 				Mark.moveIn(1, atomId),
-			];
-			const actual = SF.relevantRemovedTrees(input, oneTreeDelegate);
-			const array = Array.from(actual);
-			assert.deepEqual(array, [relevantNestedTree]);
-		});
-		it("relevant trees from nested changes under a tree being returned", () => {
-			const input: TestChangeset = [
-				Mark.returnFrom(1, atomId, { changes: childChange }),
-				Mark.returnTo(1, atomId),
 			];
 			const actual = SF.relevantRemovedTrees(input, oneTreeDelegate);
 			const array = Array.from(actual);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -284,29 +284,6 @@ function createMoveInMark(
 }
 
 /**
- * @param count - The number of nodes to be detached.
- * @param markId - The id to associate with the mark.
- * Defines how later edits refer the emptied cells.
- * @param overrides - Any additional properties to add to the mark.
- */
-function createReturnFromMark<TChange = never>(
-	count: number,
-	markId: ChangesetLocalId | ChangeAtomId,
-	overrides?: Partial<SF.CellMark<SF.ReturnFrom, TChange>>,
-): SF.CellMark<SF.ReturnFrom, TChange> {
-	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
-	const mark: SF.CellMark<SF.ReturnFrom, TChange> = {
-		type: "ReturnFrom",
-		count,
-		id: atomId.localId,
-	};
-	if (atomId.revision !== undefined) {
-		mark.revision = atomId.revision;
-	}
-	return { ...mark, ...overrides };
-}
-
-/**
  * @param count - The number of nodes to attach.
  * @param markId - The id to associate with the mark.
  * @param cellId - The cell to return the nodes to.
@@ -398,7 +375,6 @@ export const MarkMaker = {
 	modify: createModifyMark,
 	moveOut: createMoveOutMark,
 	moveIn: createMoveInMark,
-	returnFrom: createReturnFromMark,
 	returnTo: createReturnToMark,
 	attachAndDetach: createAttachAndDetachMark,
 };


### PR DESCRIPTION
Unifies move-out and return-from marks since they no longer have different semantics.