### PR TITLE
Update SharedTree lists to allow spread when inserting

### DIFF
--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -110,15 +110,13 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 	private readonly _inventoryItems = new Map<string, NewTreeInventoryItem>();
 
 	public readonly addItem = (name: string, quantity: number) => {
-		this.inventoryItemList.insertAtEnd([
-			{
-				// In a real-world scenario, this is probably a known unique inventory ID (rather than
-				// randomly generated).  Randomly generating here just for convenience.
-				id: uuid(),
-				name,
-				quantity,
-			},
-		]);
+		this.inventoryItemList.insertAtEnd({
+			// In a real-world scenario, this is probably a known unique inventory ID (rather than
+			// randomly generated).  Randomly generating here just for convenience.
+			id: uuid(),
+			name,
+			quantity,
+		});
 	};
 
 	public readonly getItems = (): IInventoryItem[] => {

--- a/examples/version-migration/tree-shim/src/model/newTreeInventoryListController.ts
+++ b/examples/version-migration/tree-shim/src/model/newTreeInventoryListController.ts
@@ -189,15 +189,13 @@ export class NewTreeInventoryListController extends EventEmitter implements IInv
 	}
 
 	public readonly addItem = (name: string, quantity: number) => {
-		this._inventoryItemList.insertAtEnd([
-			{
-				// In a real-world scenario, this is probably a known unique inventory ID (rather than
-				// randomly generated).  Randomly generating here just for convenience.
-				id: uuid(),
-				name,
-				quantity,
-			},
-		]);
+		this._inventoryItemList.insertAtEnd({
+			// In a real-world scenario, this is probably a known unique inventory ID (rather than
+			// randomly generated).  Randomly generating here just for convenience.
+			id: uuid(),
+			name,
+			quantity,
+		});
 	};
 
 	public readonly getItems = (): IInventoryItem[] => {

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -886,6 +886,13 @@ export interface InitializeAndSchematizeConfiguration<TRoot extends TreeFieldSch
 }
 
 // @alpha
+export class InlineTreeListContent<T> implements Iterable<T> {
+    // (undocumented)
+    [Symbol.iterator](): Iterator<T>;
+    constructor(content: Iterable<T>);
+}
+
+// @alpha
 type _InlineTrick = 0;
 
 declare namespace InternalEditableTreeTypes {
@@ -1823,9 +1830,10 @@ export interface TreeFieldStoredSchema {
 
 // @alpha
 export interface TreeListNode<TTypes extends AllowedTypes> extends ReadonlyArray<TreeNodeUnion<TTypes>> {
-    insertAt(index: number, value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
-    insertAtEnd(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
-    insertAtStart(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+    inline: <T>(content: Iterable<T>) => InlineTreeListContent<T>;
+    insertAt(index: number, ...value: (TreeNodeUnion<TTypes, "javaScript"> | InlineTreeListContent<TreeNodeUnion<TTypes, "javaScript">>)[]): void;
+    insertAtEnd(...value: (TreeNodeUnion<TTypes, "javaScript"> | InlineTreeListContent<TreeNodeUnion<TTypes, "javaScript">>)[]): void;
+    insertAtStart(...value: (TreeNodeUnion<TTypes, "javaScript"> | InlineTreeListContent<TreeNodeUnion<TTypes, "javaScript">>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TreeListNode<AllowedTypes>): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -886,13 +886,6 @@ export interface InitializeAndSchematizeConfiguration<TRoot extends TreeFieldSch
 }
 
 // @alpha
-export class InlineTreeListContent<T> implements Iterable<T> {
-    // (undocumented)
-    [Symbol.iterator](): Iterator<T>;
-    constructor(content: Iterable<T>);
-}
-
-// @alpha
 type _InlineTrick = 0;
 
 declare namespace InternalEditableTreeTypes {
@@ -1030,6 +1023,14 @@ export function isNeverField(policy: FullSchemaPolicy, originalData: TreeStoredS
 // @alpha
 export interface ISubscribable<E extends Events<E>> {
     on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
+}
+
+// @alpha
+export class IterableTreeListContent<T> implements Iterable<T> {
+    // (undocumented)
+    static [create]<T>(content: Iterable<T>): IterableTreeListContent<T>;
+    // (undocumented)
+    [Symbol.iterator](): Iterator<T>;
 }
 
 // @alpha
@@ -1834,11 +1835,15 @@ export interface TreeListNode<out TTypes extends AllowedTypes = AllowedTypes> ex
 }
 
 // @alpha
-interface TreeListNodeBase<out T, in out TNew, in TMoveFrom> extends ReadonlyArray<T> {
-    inline: (content: Iterable<TNew>) => InlineTreeListContent<TNew>;
-    insertAt(index: number, ...value: (TNew | InlineTreeListContent<TNew>)[]): void;
-    insertAtEnd(...value: (TNew | InlineTreeListContent<TNew>)[]): void;
-    insertAtStart(...value: (TNew | InlineTreeListContent<TNew>)[]): void;
+export const TreeListNode: {
+    inline: <T>(content: Iterable<T>) => IterableTreeListContent<T>;
+};
+
+// @alpha
+interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T> {
+    insertAt(index: number, ...value: (TNew | IterableTreeListContent<TNew>)[]): void;
+    insertAtEnd(...value: (TNew | IterableTreeListContent<TNew>)[]): void;
+    insertAtStart(...value: (TNew | IterableTreeListContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;

--- a/experimental/dds/tree2/src/domains/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/domains/schemaBuilder.ts
@@ -112,7 +112,7 @@ export class SchemaBuilder<
 	}
 
 	/**
-	 * Define (and add to this library if not already present) a structurally typed {@link FieldNodeSchema} for a {@link TreeListNode}.
+	 * Define (and add to this library if not already present) a structurally typed {@link FieldNodeSchema} for a {@link (TreeListNode:interface)}.
 	 *
 	 * @remarks
 	 * The {@link TreeNodeSchemaIdentifier} for this List is defined as a function of the provided types.
@@ -136,7 +136,7 @@ export class SchemaBuilder<
 	>;
 
 	/**
-	 * Define (and add to this library) a {@link FieldNodeSchema} for a {@link TreeListNode}.
+	 * Define (and add to this library) a {@link FieldNodeSchema} for a {@link (TreeListNode:interface)}.
 	 *
 	 * The name must be unique among all TreeNodeSchema in the the document schema.
 	 */
@@ -172,7 +172,7 @@ export class SchemaBuilder<
 	}
 
 	/**
-	 * Define (and add to this library) a {@link FieldNodeSchema} for a {@link TreeListNode}.
+	 * Define (and add to this library) a {@link FieldNodeSchema} for a {@link (TreeListNode:interface)}.
 	 *
 	 * The name must be unique among all TreeNodeSchema in the the document schema.
 	 *

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -228,6 +228,7 @@ export {
 } from "./feature-libraries";
 
 export {
+	InlineTreeListContent,
 	TreeObjectNodeFields,
 	TreeField,
 	TreeFieldInner,

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -228,7 +228,7 @@ export {
 } from "./feature-libraries";
 
 export {
-	InlineTreeListContent,
+	IterableTreeListContent,
 	TreeObjectNodeFields,
 	TreeField,
 	TreeFieldInner,

--- a/experimental/dds/tree2/src/simple-tree/index.ts
+++ b/experimental/dds/tree2/src/simple-tree/index.ts
@@ -5,7 +5,6 @@
 
 export { getProxyForField } from "./proxies";
 export {
-	InlineTreeListContent,
 	TreeListNode,
 	TreeObjectNodeFields,
 	TreeField,
@@ -18,5 +17,6 @@ export {
 	TreeNode,
 	TreeListNodeBase,
 } from "./types";
+export { IterableTreeListContent } from "./iterableTreeListContent";
 export { TreeObjectFactory, FactoryTreeSchema, addFactory } from "./objectFactory";
 export { nodeApi as Tree, TreeApi } from "./node";

--- a/experimental/dds/tree2/src/simple-tree/index.ts
+++ b/experimental/dds/tree2/src/simple-tree/index.ts
@@ -5,6 +5,7 @@
 
 export { getProxyForField } from "./proxies";
 export {
+	InlineTreeListContent,
 	TreeListNode,
 	TreeObjectNodeFields,
 	TreeField,

--- a/experimental/dds/tree2/src/simple-tree/iterableTreeListContent.ts
+++ b/experimental/dds/tree2/src/simple-tree/iterableTreeListContent.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const create = Symbol("Create IterableTreeListContent");
+
+/**
+ * Used to insert iterable content into a {@link (TreeListNode:interface)}.
+ * @alpha
+ */
+export class IterableTreeListContent<T> implements Iterable<T> {
+	private constructor(private readonly content: Iterable<T>) {}
+	public static [create]<T>(content: Iterable<T>): IterableTreeListContent<T> {
+		return new IterableTreeListContent(content);
+	}
+	public [Symbol.iterator](): Iterator<T> {
+		return this.content[Symbol.iterator]();
+	}
+}
+
+/**
+ * Create an instance of an {@link IterableTreeListContent};
+ */
+export function createIterableTreeListContent<T>(content: Iterable<T>): IterableTreeListContent<T> {
+	return IterableTreeListContent[create](content);
+}

--- a/experimental/dds/tree2/src/simple-tree/node.ts
+++ b/experimental/dds/tree2/src/simple-tree/node.ts
@@ -46,7 +46,7 @@ export interface TreeApi {
 	/**
 	 * The key of the given node under its parent.
 	 * @remarks
-	 * If `node` is an element in a {@link TreeListNode}, this returns the index of `node` in the list (a `number`).
+	 * If `node` is an element in a {@link (TreeListNode:interface)}, this returns the index of `node` in the list (a `number`).
 	 * Otherwise, this returns the key of the field that it is under (a `string`).
 	 */
 	readonly key: (node: TreeNode) => string | number;

--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -45,9 +45,9 @@ import {
 	TreeListNode,
 	TreeMapNode,
 	TreeObjectNode,
-	InlineTreeListContent,
 } from "./types";
 import { tryGetEditNodeTarget, setEditNode, getEditNode, tryGetEditNode } from "./editNode";
+import { IterableTreeListContent } from "./iterableTreeListContent";
 
 /** Retrieve the associated proxy for the given field. */
 export function getProxyForField<TSchema extends TreeFieldSchema>(
@@ -223,12 +223,12 @@ function contextualizeInsertedListContent(
 	insertedAtIndex: number,
 	content: (
 		| TreeNodeUnion<AllowedTypes, "javaScript">
-		| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+		| IterableTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
 	)[],
 ): ExtractedFactoryContent<ContextuallyTypedNodeData[]> {
 	return extractContentArray(
 		content.flatMap((c) =>
-			c instanceof InlineTreeListContent ? Array.from(c) : c,
+			c instanceof IterableTreeListContent ? Array.from(c) : c,
 		) as ContextuallyTypedNodeData[],
 		insertedAtIndex,
 	);
@@ -259,7 +259,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			index: number,
 			...value: (
 				| TreeNodeUnion<AllowedTypes, "javaScript">
-				| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+				| IterableTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
 			)[]
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(index, value);
@@ -275,7 +275,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			this: TreeListNode,
 			...value: (
 				| TreeNodeUnion<AllowedTypes, "javaScript">
-				| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+				| IterableTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
 			)[]
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(0, value);
@@ -291,7 +291,7 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			this: TreeListNode,
 			...value: (
 				| TreeNodeUnion<AllowedTypes, "javaScript">
-				| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+				| IterableTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
 			)[]
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(
@@ -396,11 +396,6 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			} else {
 				getSequenceField(this).moveRangeToIndex(index, sourceStart, sourceEnd);
 			}
-		},
-	},
-	inline: {
-		value<T>(this: TreeListNode, content: Iterable<T>): InlineTreeListContent<T> {
-			return new InlineTreeListContent(content);
 		},
 	},
 };

--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -398,6 +398,11 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 			}
 		},
 	},
+	inline: {
+		value<T>(this: TreeListNode, content: Iterable<T>): InlineTreeListContent<T> {
+			return new InlineTreeListContent(content);
+		},
+	},
 };
 
 /* eslint-disable @typescript-eslint/unbound-method */

--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -45,6 +45,7 @@ import {
 	TreeListNode,
 	TreeMapNode,
 	TreeObjectNode,
+	InlineTreeListContent,
 } from "./types";
 import { tryGetEditNodeTarget, setEditNode, getEditNode, tryGetEditNode } from "./editNode";
 
@@ -219,16 +220,16 @@ const getSequenceField = <TTypes extends AllowedTypes>(list: TreeListNode<Allowe
 // Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
 // typed data prior to forwarding to 'LazySequence.insert*()'.
 function contextualizeInsertedListContent(
-	iterable: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
 	insertedAtIndex: number,
+	content: (
+		| TreeNodeUnion<AllowedTypes, "javaScript">
+		| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+	)[],
 ): ExtractedFactoryContent<ContextuallyTypedNodeData[]> {
-	if (typeof iterable === "string") {
-		throw new TypeError(
-			"Attempted to directly insert a string as iterable list content. Wrap the input string 's' in an array ('[s]') to insert it as a single item or, supply the iterator of the string directly via 's[Symbol.iterator]()' if intending to insert each Unicode code point as a separate item.",
-		);
-	}
 	return extractContentArray(
-		(Array.isArray(iterable) ? iterable : Array.from(iterable)) as ContextuallyTypedNodeData[],
+		content.flatMap((c) =>
+			c instanceof InlineTreeListContent ? Array.from(c) : c,
+		) as ContextuallyTypedNodeData[],
 		insertedAtIndex,
 	);
 }
@@ -256,9 +257,12 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 		value(
 			this: TreeListNode<AllowedTypes>,
 			index: number,
-			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
+			...value: (
+				| TreeNodeUnion<AllowedTypes, "javaScript">
+				| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+			)[]
 		): void {
-			const { content, hydrateProxies } = contextualizeInsertedListContent(value, index);
+			const { content, hydrateProxies } = contextualizeInsertedListContent(index, value);
 			modifyChildren(
 				getEditNode(this),
 				() => getSequenceField(this).insertAt(index, content),
@@ -269,9 +273,12 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	insertAtStart: {
 		value(
 			this: TreeListNode<AllowedTypes>,
-			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
+			...value: (
+				| TreeNodeUnion<AllowedTypes, "javaScript">
+				| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+			)[]
 		): void {
-			const { content, hydrateProxies } = contextualizeInsertedListContent(value, 0);
+			const { content, hydrateProxies } = contextualizeInsertedListContent(0, value);
 			modifyChildren(
 				getEditNode(this),
 				() => getSequenceField(this).insertAtStart(content),
@@ -282,11 +289,14 @@ const listPrototypeProperties: PropertyDescriptorMap = {
 	insertAtEnd: {
 		value(
 			this: TreeListNode<AllowedTypes>,
-			value: Iterable<TreeNodeUnion<AllowedTypes, "javaScript">>,
+			...value: (
+				| TreeNodeUnion<AllowedTypes, "javaScript">
+				| InlineTreeListContent<TreeNodeUnion<AllowedTypes, "javaScript">>
+			)[]
 		): void {
 			const { content, hydrateProxies } = contextualizeInsertedListContent(
-				value,
 				this.length,
+				value,
 			);
 			modifyChildren(
 				getEditNode(this),

--- a/experimental/dds/tree2/src/simple-tree/types.ts
+++ b/experimental/dds/tree2/src/simple-tree/types.ts
@@ -20,6 +20,7 @@ import {
 	TreeSchema,
 	AssignableFieldKinds,
 } from "../feature-libraries";
+import { IterableTreeListContent, createIterableTreeListContent } from "./iterableTreeListContent";
 
 /**
  * A non-{@link LeafNodeSchema|leaf} SharedTree node. Includes objects, lists, and maps.
@@ -35,17 +36,6 @@ import {
 export type TreeNode = TreeListNode | TreeObjectNode<ObjectNodeSchema> | TreeMapNode<MapNodeSchema>;
 
 /**
- * Used to insert iterable content into a {@link TreeListNode}.
- * @alpha
- */
-export class InlineTreeListContent<T> implements Iterable<T> {
-	public constructor(private readonly content: Iterable<T>) {}
-	public [Symbol.iterator](): Iterator<T> {
-		return this.content[Symbol.iterator]();
-	}
-}
-
-/**
  * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
  * @alpha
  */
@@ -57,41 +47,47 @@ export interface TreeListNode<out TTypes extends AllowedTypes = AllowedTypes>
 	> {}
 
 /**
- * A generic List type, used to defined types like {@link TreeListNode}.
+ * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
  * @alpha
  */
-export interface TreeListNodeBase<out T, in out TNew, in TMoveFrom> extends ReadonlyArray<T> {
+export const TreeListNode = {
 	/**
-	 * Wrap an iterable of content to be inserted into this list.
+	 * Wrap an iterable of content to be inserted into a list.
 	 * @remarks
-	 * The object returned by this function can be inserted into this list as an element.
+	 * The object returned by this function can be inserted into a list as an element.
 	 * Its contents will be inserted sequentially in the corresponding location in the list.
 	 * @example
 	 * ```ts
 	 * list.insertAtEnd(list.inline(iterable))
 	 * ```
 	 */
-	inline: (content: Iterable<TNew>) => InlineTreeListContent<TNew>;
+	inline: <T>(content: Iterable<T>) => createIterableTreeListContent(content),
+};
 
+/**
+ * A generic List type, used to defined types like {@link (TreeListNode:interface)}.
+ * @alpha
+ */
+export interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T> {
 	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
 	 */
-	insertAt(index: number, ...value: (TNew | InlineTreeListContent<TNew>)[]): void;
+	insertAt(index: number, ...value: (TNew | IterableTreeListContent<TNew>)[]): void;
 
 	/**
 	 * Inserts new item(s) at the start of the list.
 	 * @param value - The content to insert.
 	 */
-	insertAtStart(...value: (TNew | InlineTreeListContent<TNew>)[]): void;
+	insertAtStart(...value: (TNew | IterableTreeListContent<TNew>)[]): void;
 
 	/**
 	 * Inserts new item(s) at the end of the list.
 	 * @param value - The content to insert.
 	 */
-	insertAtEnd(...value: (TNew | InlineTreeListContent<TNew>)[]): void;
+	insertAtEnd(...value: (TNew | IterableTreeListContent<TNew>)[]): void;
 
 	/**
 	 * Removes the item at the specified location.

--- a/experimental/dds/tree2/src/simple-tree/types.ts
+++ b/experimental/dds/tree2/src/simple-tree/types.ts
@@ -38,30 +38,69 @@ export type TreeNode =
 	| TreeMapNode<MapNodeSchema>;
 
 /**
+ * Used to insert iterable content into a {@link TreeListNode}.
+ * @alpha
+ */
+export class InlineTreeListContent<T> implements Iterable<T> {
+	public constructor(private readonly content: Iterable<T>) {}
+	public [Symbol.iterator](): Iterator<T> {
+		return this.content[Symbol.iterator]();
+	}
+}
+
+/**
  * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
  * @alpha
  */
 export interface TreeListNode<TTypes extends AllowedTypes>
 	extends ReadonlyArray<TreeNodeUnion<TTypes>> {
 	/**
+	 * Wrap an iterable of content to be inserted into this list.
+	 * @remarks
+	 * The object returned by this function can be inserted into this list as an element.
+	 * Its contents will be inserted sequentially in the corresponding location in the list.
+	 * @example
+	 * ```ts
+	 * list.insertAtEnd(list.inline(iterable))
+	 * ```
+	 */
+	inline: <T>(content: Iterable<T>) => InlineTreeListContent<T>;
+
+	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
 	 */
-	insertAt(index: number, value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+	insertAt(
+		index: number,
+		...value: (
+			| TreeNodeUnion<TTypes, "javaScript">
+			| InlineTreeListContent<TreeNodeUnion<TTypes, "javaScript">>
+		)[]
+	): void;
 
 	/**
 	 * Inserts new item(s) at the start of the list.
 	 * @param value - The content to insert.
 	 */
-	insertAtStart(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+	insertAtStart(
+		...value: (
+			| TreeNodeUnion<TTypes, "javaScript">
+			| InlineTreeListContent<TreeNodeUnion<TTypes, "javaScript">>
+		)[]
+	): void;
 
 	/**
 	 * Inserts new item(s) at the end of the list.
 	 * @param value - The content to insert.
 	 */
-	insertAtEnd(value: Iterable<TreeNodeUnion<TTypes, "javaScript">>): void;
+	insertAtEnd(
+		...value: (
+			| TreeNodeUnion<TTypes, "javaScript">
+			| InlineTreeListContent<TreeNodeUnion<TTypes, "javaScript">>
+		)[]
+	): void;
 
 	/**
 	 * Removes the item at the specified location.

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -824,7 +824,7 @@ describe("SharedTree", () => {
 					validateTreeContent(tree2.view.checkout, content);
 
 					// edit subtree
-					tree2.root[0].insertAtEnd(["b"]);
+					tree2.root[0].insertAtEnd("b");
 					provider.processMessages();
 					assert.deepEqual(tree1.root, [["a", "b"]]);
 					assert.deepEqual(tree2.root, [["a", "b"]]);

--- a/experimental/dds/tree2/src/test/simple-tree/list.spec.ts
+++ b/experimental/dds/tree2/src/test/simple-tree/list.spec.ts
@@ -70,7 +70,7 @@ describe("List", () => {
 	/** Helper that creates a new List<number> proxy */
 	function createNumberList(items: readonly number[]) {
 		const list = createTree().numbers;
-		list.insertAtStart(items);
+		list.insertAtStart(...items);
 		assert.deepEqual(list, items);
 		return list;
 	}
@@ -79,7 +79,7 @@ describe("List", () => {
 	/** Helper that creates a new List<string> proxy */
 	function createStringList(items: readonly string[]) {
 		const list = createTree().strings;
-		list.insertAtStart(items);
+		list.insertAtStart(...items);
 		assert.deepEqual(list, items);
 		return list;
 	}
@@ -720,7 +720,7 @@ describe("List", () => {
 				(subject as any)[0] = "a";
 			});
 
-			subject.insertAtStart(["a", "b", "c"]);
+			subject.insertAtStart("a", "b", "c");
 
 			assert.throws(() => {
 				(subject as any)[0] = "a";
@@ -734,7 +734,7 @@ describe("List", () => {
 				(subject as any).length = 0;
 			});
 
-			subject.insertAtStart(["a", "b", "c"]);
+			subject.insertAtStart("a", "b", "c");
 
 			assert.throws(() => {
 				(subject as any).length = 0;

--- a/experimental/dds/tree2/src/test/simple-tree/node.spec.ts
+++ b/experimental/dds/tree2/src/test/simple-tree/node.spec.ts
@@ -168,7 +168,7 @@ describe("node API", () => {
 		});
 
 		describe("list", () => {
-			check((root) => root.list.insertAtEnd([{ content: root.list.length }]));
+			check((root) => root.list.insertAtEnd({ content: root.list.length }));
 		});
 
 		// TODO: map

--- a/experimental/dds/tree2/src/test/simple-tree/objectFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/simple-tree/objectFactory.spec.ts
@@ -224,7 +224,7 @@ describe("SharedTreeObject factories", () => {
 		});
 		const content = { content: 3 };
 		view.root.child = childA.create(content);
-		view.root.grand.child.list.insertAtEnd([childA.create(content)]);
+		view.root.grand.child.list.insertAtEnd(childA.create(content));
 		view.root.grand.child.map.set("a", childA.create(content));
 	});
 

--- a/experimental/dds/tree2/src/test/simple-tree/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/simple-tree/proxies.spec.ts
@@ -189,8 +189,8 @@ describe("SharedTreeList", () => {
 		itWithRoot("insertAtStart()", schema, [{ id: "B" }], (list) => {
 			assert.deepEqual(list, [{ id: "B" }]);
 			const newItem = obj.create({ id: "A" });
-			list.insertAtStart([newItem]);
-			list.insertAtStart([]); // Check that we can do a "no-op" change (a change which does not change the tree's content).
+			list.insertAtStart(newItem);
+			list.insertAtStart(); // Check that we can do a "no-op" change (a change which does not change the tree's content).
 			assert.equal(newItem, list[0]); // Check that the inserted and read proxies are the same object
 			assert.deepEqual(list, [newItem, { id: "B" }]);
 		});
@@ -198,8 +198,8 @@ describe("SharedTreeList", () => {
 		itWithRoot("insertAtEnd()", schema, [{ id: "A" }], (list) => {
 			assert.deepEqual(list, [{ id: "A" }]);
 			const newItem = obj.create({ id: "B" });
-			list.insertAtEnd([newItem]);
-			list.insertAtEnd([]); // Check that we can do a "no-op" change (a change which does not change the tree's content).
+			list.insertAtEnd(newItem);
+			list.insertAtEnd(); // Check that we can do a "no-op" change (a change which does not change the tree's content).
 			assert.equal(newItem, list[1]); // Check that the inserted and read proxies are the same object
 			assert.deepEqual(list, [{ id: "A" }, newItem]);
 		});
@@ -207,10 +207,48 @@ describe("SharedTreeList", () => {
 		itWithRoot("insertAt()", schema, [{ id: "A" }, { id: "C" }], (list) => {
 			assert.deepEqual(list, [{ id: "A" }, { id: "C" }]);
 			const newItem = obj.create({ id: "B" });
-			list.insertAt(1, [newItem]);
-			list.insertAt(1, []); // Check that we can do a "no-op" change (a change which does not change the tree's content).
+			list.insertAt(1, newItem);
+			list.insertAt(1); // Check that we can do a "no-op" change (a change which does not change the tree's content).
 			assert.equal(newItem, list[1]); // Check that the inserted and read proxies are the same object
 			assert.deepEqual(list, [{ id: "A" }, newItem, { id: "C" }]);
+		});
+	});
+
+	describe("inserting inlined content", () => {
+		const _ = new SchemaBuilder({ scope: "test" });
+		const schema = _.intoSchema(_.list(_.number));
+
+		itWithRoot("insertAtStart()", schema, [], (list) => {
+			list.insertAtStart(list.inline([0, 1]));
+			assert.deepEqual(list, [0, 1]);
+			list.removeRange();
+			list.insertAtStart(0, list.inline([1]), 2);
+			assert.deepEqual(list, [0, 1, 2]);
+			list.removeRange();
+			list.insertAtStart(0, 1, list.inline([2, 3]), 4, list.inline([5, 6]));
+			assert.deepEqual(list, [0, 1, 2, 3, 4, 5, 6]);
+		});
+
+		itWithRoot("insertAtEnd()", schema, [], (list) => {
+			list.insertAtEnd(list.inline([0, 1]));
+			assert.deepEqual(list, [0, 1]);
+			list.removeRange();
+			list.insertAtEnd(0, list.inline([1]), 2);
+			assert.deepEqual(list, [0, 1, 2]);
+			list.removeRange();
+			list.insertAtEnd(0, 1, list.inline([2, 3]), 4, list.inline([5, 6]));
+			assert.deepEqual(list, [0, 1, 2, 3, 4, 5, 6]);
+		});
+
+		itWithRoot("insertAt()", schema, [], (list) => {
+			list.insertAt(0, list.inline([0, 1]));
+			assert.deepEqual(list, [0, 1]);
+			list.removeRange();
+			list.insertAt(0, 0, list.inline([1]), 2);
+			assert.deepEqual(list, [0, 1, 2]);
+			list.removeRange();
+			list.insertAt(0, 0, 1, list.inline([2, 3]), 4, list.inline([5, 6]));
+			assert.deepEqual(list, [0, 1, 2, 3, 4, 5, 6]);
 		});
 	});
 
@@ -225,84 +263,26 @@ describe("SharedTreeList", () => {
 		const schema = _.intoSchema(obj);
 		const initialTree = { numbers: [], strings: [], booleans: [], poly: [] };
 		itWithRoot("numbers", schema, initialTree, (root) => {
-			root.numbers.insertAtStart([0]);
-			root.numbers.insertAt(1, [1]);
-			root.numbers.insertAtEnd([2]);
+			root.numbers.insertAtStart(0);
+			root.numbers.insertAt(1, 1);
+			root.numbers.insertAtEnd(2);
 			assert.deepEqual(root.numbers, [0, 1, 2]);
 		});
 
-		itWithRoot("strings", schema, initialTree, (root) => {
-			// This test catches a usability regression in which strings can be passed directly as content to insert,
-			// because strings are also iterables of strings. Passing a string directly as an iterable is very likely not what the user intends.
-			root.strings.insertAtStart(["a"]);
-			root.strings.insertAt(1, ["b"]);
-			root.strings.insertAtEnd(["c"]);
-
-			const string: string = "hello";
-			const stringLiteral: "hello" = "hello" as const;
-			assert.throws(() => {
-				root.strings.insertAtStart(string);
-			});
-			assert.throws(() => {
-				root.strings.insertAtStart(stringLiteral);
-			});
-			assert.throws(() => {
-				root.strings.insertAt(0, string);
-			});
-			assert.throws(() => {
-				root.strings.insertAt(0, stringLiteral);
-			});
-			assert.throws(() => {
-				root.strings.insertAtEnd(string);
-			});
-			assert.throws(() => {
-				root.strings.insertAtEnd(stringLiteral);
-			});
-
-			const iterableOrString: Iterable<string> | string = "hello";
-			const iterableOrLiteral: Iterable<string> | "hello" = "hello";
-			assert.throws(() => {
-				root.strings.insertAtStart(iterableOrString);
-			});
-			assert.throws(() => {
-				root.strings.insertAtStart(iterableOrLiteral);
-			});
-			assert.throws(() => {
-				root.strings.insertAt(0, iterableOrString);
-			});
-			assert.throws(() => {
-				root.strings.insertAt(0, iterableOrLiteral);
-			});
-			assert.throws(() => {
-				root.strings.insertAtEnd(iterableOrString);
-			});
-			assert.throws(() => {
-				root.strings.insertAtEnd(iterableOrLiteral);
-			});
-
-			const de: Iterable<string> = "de"[Symbol.iterator]();
-			root.strings.insertAtStart(de);
-			const fg: Iterable<string> = "fg"[Symbol.iterator]();
-			root.strings.insertAt(3, fg);
-			const hi: Iterable<string> = "hi"[Symbol.iterator]();
-			root.strings.insertAtEnd(hi);
-			assert.deepEqual(root.strings, ["d", "e", "a", "f", "g", "b", "c", "h", "i"]);
-		});
-
 		itWithRoot("booleans", schema, initialTree, (root) => {
-			root.booleans.insertAtStart([true]);
-			root.booleans.insertAt(1, [false]);
-			root.booleans.insertAtEnd([true]);
+			root.booleans.insertAtStart(true);
+			root.booleans.insertAt(1, false);
+			root.booleans.insertAtEnd(true);
 			assert.deepEqual(root.booleans, [true, false, true]);
 		});
 
 		itWithRoot("of multiple possible types", schema, initialTree, (root) => {
 			const allowsStrings: typeof root.numbers | typeof root.poly = root.poly;
-			allowsStrings.insertAtStart([42]);
+			allowsStrings.insertAtStart(42);
 			const allowsStsrings: typeof root.strings | typeof root.poly = root.poly;
-			allowsStsrings.insertAt(1, ["s"]);
+			allowsStsrings.insertAt(1, "s");
 			const allowsBooleans: typeof root.booleans | typeof root.poly = root.poly;
-			allowsBooleans.insertAtEnd([true]);
+			allowsBooleans.insertAtEnd(true);
 			assert.deepEqual(root.poly, [42, "s", true]);
 		});
 	});

--- a/experimental/dds/tree2/src/test/simple-tree/proxies.spec.ts
+++ b/experimental/dds/tree2/src/test/simple-tree/proxies.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { MockHandle } from "@fluidframework/test-runtime-utils";
 import { SchemaBuilder } from "../../domains";
-import { TypedNode, TreeRoot, Tree } from "../../simple-tree";
+import { TypedNode, TreeRoot, Tree, TreeListNode } from "../../simple-tree";
 import { typeNameSymbol } from "../../feature-libraries";
 import { itWithRoot, pretty } from "./utils";
 
@@ -219,35 +219,35 @@ describe("SharedTreeList", () => {
 		const schema = _.intoSchema(_.list(_.number));
 
 		itWithRoot("insertAtStart()", schema, [], (list) => {
-			list.insertAtStart(list.inline([0, 1]));
+			list.insertAtStart(TreeListNode.inline([0, 1]));
 			assert.deepEqual(list, [0, 1]);
 			list.removeRange();
-			list.insertAtStart(0, list.inline([1]), 2);
+			list.insertAtStart(0, TreeListNode.inline([1]), 2);
 			assert.deepEqual(list, [0, 1, 2]);
 			list.removeRange();
-			list.insertAtStart(0, 1, list.inline([2, 3]), 4, list.inline([5, 6]));
+			list.insertAtStart(0, 1, TreeListNode.inline([2, 3]), 4, TreeListNode.inline([5, 6]));
 			assert.deepEqual(list, [0, 1, 2, 3, 4, 5, 6]);
 		});
 
 		itWithRoot("insertAtEnd()", schema, [], (list) => {
-			list.insertAtEnd(list.inline([0, 1]));
+			list.insertAtEnd(TreeListNode.inline([0, 1]));
 			assert.deepEqual(list, [0, 1]);
 			list.removeRange();
-			list.insertAtEnd(0, list.inline([1]), 2);
+			list.insertAtEnd(0, TreeListNode.inline([1]), 2);
 			assert.deepEqual(list, [0, 1, 2]);
 			list.removeRange();
-			list.insertAtEnd(0, 1, list.inline([2, 3]), 4, list.inline([5, 6]));
+			list.insertAtEnd(0, 1, TreeListNode.inline([2, 3]), 4, TreeListNode.inline([5, 6]));
 			assert.deepEqual(list, [0, 1, 2, 3, 4, 5, 6]);
 		});
 
 		itWithRoot("insertAt()", schema, [], (list) => {
-			list.insertAt(0, list.inline([0, 1]));
+			list.insertAt(0, TreeListNode.inline([0, 1]));
 			assert.deepEqual(list, [0, 1]);
 			list.removeRange();
-			list.insertAt(0, 0, list.inline([1]), 2);
+			list.insertAt(0, 0, TreeListNode.inline([1]), 2);
 			assert.deepEqual(list, [0, 1, 2]);
 			list.removeRange();
-			list.insertAt(0, 0, 1, list.inline([2, 3]), 4, list.inline([5, 6]));
+			list.insertAt(0, 0, 1, TreeListNode.inline([2, 3]), 4, TreeListNode.inline([5, 6]));
 			assert.deepEqual(list, [0, 1, 2, 3, 4, 5, 6]);
 		});
 	});

--- a/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
+++ b/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
@@ -94,7 +94,7 @@ describe("Garbage Collection", () => {
 			const subtree1 = createLocalTree(`tree-${++this.treeCount}`);
 			const subtree2 = createLocalTree(`tree-${++this.treeCount}`);
 
-			this.tree1View.handles.insertAtEnd([subtree1.handle, subtree2.handle]);
+			this.tree1View.handles.insertAtEnd(subtree1.handle, subtree2.handle);
 
 			this._expectedRoutes.push(subtree1.handle.absolutePath, subtree2.handle.absolutePath);
 			this.containerRuntimeFactory.processAllMessages();


### PR DESCRIPTION
## Description

This improves the ergonomics of inserting content into lists. The "inline" option is reserved to allow more efficient, and customizable, insertion of large iterables in the future.