### PR TITLE
(odsp-client): Return file name

### DIFF
--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -268,6 +268,8 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     // (undocumented)
     dataStorePath: string;
     // (undocumented)
+    fileName?: string;
+    // (undocumented)
     fileVersion?: string;
 }
 

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -14,6 +14,7 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 	containerPackageName?: string;
 	fileVersion?: string;
 	context?: string;
+	fileName?: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -103,6 +103,7 @@ export async function createNewFluidFile(
 		);
 	}
 
+	// `newFileInfo` has the file name
 	const odspUrl = createOdspUrl({ ...newFileInfo, itemId, dataStorePath: "/" });
 	const resolver = new OdspDriverUrlResolver();
 	const odspResolvedUrl = await resolver.resolve({

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -24,6 +24,9 @@ export function createOdspUrl(l: OdspFluidDataStoreLocator): string {
 	if (l.fileVersion) {
 		odspUrl += `&fileVersion=${encodeURIComponent(l.fileVersion)}`;
 	}
+	if (l.fileName) {
+		odspUrl += `&fileName=${encodeURIComponent(l.fileName)}`;
+	}
 
 	return odspUrl;
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -210,7 +210,7 @@ export class OdspDocumentServiceFactoryCore
 								?.forceAccessTokenViaAuthorizationHeader,
 							odspResolvedUrl.isClpCompliantApp,
 					  );
-				const docService = this.createDocumentServiceCore(
+				const docService = this.createDocumentServiceCore( // fileName is empty
 					odspResolvedUrl,
 					odspLogger,
 					cacheAndTracker,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -210,7 +210,8 @@ export class OdspDocumentServiceFactoryCore
 								?.forceAccessTokenViaAuthorizationHeader,
 							odspResolvedUrl.isClpCompliantApp,
 					  );
-				const docService = this.createDocumentServiceCore( // fileName is empty
+				const docService = this.createDocumentServiceCore(
+					// fileName is empty
 					odspResolvedUrl,
 					odspLogger,
 					cacheAndTracker,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -137,9 +137,15 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 				isClpCompliantApp: request.headers?.[ClpCompliantAppHeader.isClpCompliantApp],
 			};
 		}
-		const { siteUrl, driveId, itemId, path, containerPackageName, fileVersion } = decodeOdspUrl(
-			request.url,
-		);
+		const {
+			siteUrl,
+			driveId,
+			itemId,
+			path,
+			fileName: fileAlias,
+			containerPackageName,
+			fileVersion,
+		} = decodeOdspUrl(request.url);
 		const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
 		assert(!hashedDocumentId.includes("/"), 0x0a8 /* "Docid should not contain slashes!!" */);
 
@@ -170,7 +176,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 			driveId,
 			itemId,
 			dataStorePath: path,
-			fileName: "",
+			fileName: fileAlias ?? "",
 			summarizer,
 			codeHint: {
 				containerPackageName,
@@ -234,6 +240,7 @@ function decodeOdspUrl(url: string): {
 	driveId: string;
 	itemId: string;
 	path: string;
+	fileName?: string;
 	containerPackageName?: string;
 	fileVersion?: string;
 } {
@@ -246,6 +253,7 @@ function decodeOdspUrl(url: string): {
 	const path = searchParams.get("path");
 	const containerPackageName = searchParams.get("containerPackageName");
 	const fileVersion = searchParams.get("fileVersion");
+	const fileName = searchParams.get("fileName");
 
 	if (driveId === null) {
 		throw new Error("ODSP URL did not contain a drive id");
@@ -264,6 +272,7 @@ function decodeOdspUrl(url: string): {
 		driveId: decodeURIComponent(driveId),
 		itemId: decodeURIComponent(itemId),
 		path: decodeURIComponent(path),
+		fileName: fileName ?? "",
 		containerPackageName: containerPackageName
 			? decodeURIComponent(containerPackageName)
 			: undefined,


### PR DESCRIPTION
The file name returned was OdspUrlResolver an empty string. This change returns the file name. 

Questions:
1. Any reason why this is returned as an empty string?
