### PR TITLE
feat(build-common): Add `ae-undocumented` rule to base API-Extractor config

### DIFF
--- a/common/build/build-common/CHANGELOG.md
+++ b/common/build/build-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+## `3.0.0`
+
+
+### ⚠ BREAKING CHANGES
+
+Adds `ae-undocumented` rule to `api-extractor-base.json`.
+This rule adds the requirement that all API items bundled into roll-ups by API-Extractor contain TSDoc-formatted comments.

--- a/common/build/build-common/CHANGELOG.md
+++ b/common/build/build-common/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## `3.0.0`
 
-
 ### ⚠ BREAKING CHANGES
 
 Adds `ae-undocumented` rule to `api-extractor-base.json`.

--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -159,7 +159,7 @@
 			// Require documentation on all package-exported API items.
 			"ae-undocumented": {
 				"logLevel": "error",
-				"addToApiReportFile": true // TODO: promote this to `false` once violations in consumers have been addressed.
+				"addToApiReportFile": false
 			},
 
 			// The @inheritDoc tag needs a TSDoc declaration reference.

--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -156,6 +156,12 @@
 				"addToApiReportFile": false
 			},
 
+			// Require documentation on all package-exported API items.
+			"ae-undocumented": {
+				"logLevel": "error",
+				"addToApiReportFile": true // TODO: promote this to `false` once violations in consumers have been addressed.
+			},
+
 			// The @inheritDoc tag needs a TSDoc declaration reference.
 			"ae-unresolved-inheritdoc-base": {
 				"logLevel": "error",

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-common",
-	"version": "2.0.4",
+	"version": "3.0.0",
 	"description": "Package containing common configs",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-common",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "Package containing common configs",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
The `ae-undocumented` rule enforces that items bundled in the package exports rollup contain TSDoc comment content.

For now, the rule is enabled to log violations to the generated API report documents, rather than failing the build. We will consider promoting this to a build failure in the future, and packages can opt into build failure policy as desired in the interim.