### PR TITLE
tree2: Split out still useful utilities from contextuallyTyped

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1424,7 +1424,7 @@ export function prefixFieldPath(prefix: PathRootPrefix | undefined, path: FieldU
 // @alpha
 export function prefixPath(prefix: PathRootPrefix | undefined, path: UpPath | undefined): UpPath | undefined;
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export type PrimitiveValue = string | boolean | number;
 
 // @alpha

--- a/experimental/dds/tree2/src/domains/json/jsonCursor.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonCursor.ts
@@ -13,7 +13,7 @@ import {
 	ITreeCursorSynchronous,
 } from "../../core";
 import { JsonCompatible } from "../../util";
-import { CursorAdapter, isPrimitiveValue, stackTreeNodeCursor } from "../../feature-libraries";
+import { CursorAdapter, isFluidHandle, stackTreeNodeCursor } from "../../feature-libraries";
 import { leaf } from "../leafDomain";
 import { jsonArray, jsonObject } from "./jsonDomainSchema";
 
@@ -109,8 +109,9 @@ export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
 		case leaf.number.name:
 		case leaf.boolean.name:
 		case leaf.string.name:
-			assert(isPrimitiveValue(reader.value), 0x41f /* expected a primitive value */);
-			return reader.value as JsonCompatible;
+			assert(reader.value !== undefined, "out of schema: missing value");
+			assert(!isFluidHandle(reader.value), "out of schema: unexpected fluid handle");
+			return reader.value;
 		case jsonArray.name: {
 			reader.enterField(EmptyKey);
 			const result = mapCursorField(reader, cursorToJsonObject);

--- a/experimental/dds/tree2/src/domains/json/jsonCursor.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonCursor.ts
@@ -110,7 +110,7 @@ export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
 		case leaf.boolean.name:
 		case leaf.string.name:
 			assert(reader.value !== undefined, "out of schema: missing value");
-			assert(!isFluidHandle(reader.value), "out of schema: unexpected fluid handle");
+			assert(!isFluidHandle(reader.value), "out of schema: unexpected FluidHandle");
 			return reader.value;
 		case jsonArray.name: {
 			reader.enterField(EmptyKey);

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/core-utils";
 import { _InlineTrick, assertValidIndex, fail, objectToMap } from "../../../util";
 import { TreeChunk } from "../chunk";
-import { FluidSerializableReadOnly, assertAllowedValue } from "../../contextuallyTyped";
+import { FluidSerializableReadOnly, assertAllowedValue } from "../../valueUtilities";
 import { TreeValue } from "../../../core";
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
@@ -5,7 +5,7 @@
 
 import { TreeValue } from "../../../core";
 import { fail } from "../../../util";
-import { FluidSerializableReadOnly } from "../../contextuallyTyped";
+import { FluidSerializableReadOnly } from "../../valueUtilities";
 import { EncodedChunkGeneric } from "./formatGeneric";
 import {
 	Counter,

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/uncompressedEncode.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/uncompressedEncode.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITreeCursorSynchronous, forEachField, forEachNode } from "../../../core";
-import { FluidSerializableReadOnly } from "../../contextuallyTyped";
+import { FluidSerializableReadOnly } from "../../valueUtilities";
 import { EncodedChunk, version, EncodedTreeShape, EncodedNestedArray } from "./format";
 import { ShapeIndex } from "./formatGeneric";
 

--- a/experimental/dds/tree2/src/feature-libraries/fieldGenerator.ts
+++ b/experimental/dds/tree2/src/feature-libraries/fieldGenerator.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { FieldKey, TreeFieldStoredSchema, MapTree, TreeStoredSchema } from "../core";
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/fieldGenerator.ts
+++ b/experimental/dds/tree2/src/feature-libraries/fieldGenerator.ts
@@ -1,0 +1,43 @@
+import { FieldKey, TreeFieldStoredSchema, MapTree, TreeStoredSchema } from "../core";
+
+/**
+ * Information needed to interpret a subtree described by {@link ContextuallyTypedNodeData} and {@link ContextuallyTypedFieldData}.
+ * @alpha
+ * TODO:
+ * Currently being exposed at the package level which also requires us to export MapTree at the package level.
+ * Refactor the FieldGenerator to use JsonableTree instead of MapTree, and convert them internally.
+ */
+export interface TreeDataContext {
+	/**
+	 * Schema for the document which the tree will be used in.
+	 */
+	readonly schema: TreeStoredSchema;
+
+	/**
+	 * Procedural data generator for fields.
+	 * Fields which provide generators here can be omitted in the input contextually typed data.
+	 *
+	 * @remarks
+	 * TODO:
+	 * For implementers of this which are not pure (like identifier generation),
+	 * order of invocation should be made consistent and documented.
+	 * This will be important for identifier elision optimizations in tree encoding for session based identifier generation.
+	 */
+	fieldSource?(key: FieldKey, schema: TreeFieldStoredSchema): undefined | FieldGenerator;
+}
+
+/**
+ * Generates field content for a MapTree on demand.
+ * @alpha
+ * TODO:
+ * Currently being exposed at the package level which also requires us to export MapTree at the package level.
+ * Refactor the FieldGenerator to use JsonableTree instead of MapTree, and convert them internally.
+ */
+export type FieldGenerator = () => MapTree[];
+/**
+ * Information needed to interpret a subtree described by {@link ContextuallyTypedNodeData} and {@link ContextuallyTypedFieldData}.
+ * @alpha
+ * TODO:
+ * Currently being exposed at the package level which also requires us to export MapTree at the package level.
+ * Refactor the FieldGenerator to use JsonableTree instead of MapTree, and convert them internally.
+ */

--- a/experimental/dds/tree2/src/feature-libraries/flex-tree/context.ts
+++ b/experimental/dds/tree2/src/feature-libraries/flex-tree/context.ts
@@ -14,7 +14,7 @@ import {
 import { ISubscribable } from "../../events";
 import { IDefaultEditBuilder } from "../default-schema";
 import { NodeKeyIndex, NodeKeyManager } from "../node-key";
-import { FieldGenerator } from "../contextuallyTyped";
+import { FieldGenerator } from "../fieldGenerator";
 import { TreeSchema } from "../typed-schema";
 import { disposeSymbol, IDisposable } from "../../util";
 import { FlexTreeField } from "./flexTreeTypes";

--- a/experimental/dds/tree2/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+// TODO: remove flexible types from "schema-aware", and just accept cursors.
 import * as SchemaAware from "../schema-aware";
 import { FieldKey, ITreeCursorSynchronous, TreeNodeSchemaIdentifier, TreeValue } from "../../core";
 import { Assume, FlattenKeys, _InlineTrick } from "../../util";

--- a/experimental/dds/tree2/src/feature-libraries/flex-tree/lazyField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/flex-tree/lazyField.ts
@@ -20,6 +20,7 @@ import {
 	mapCursorField,
 } from "../../core";
 import { FieldKind } from "../modular-schema";
+// TODO: stop depending on contextuallyTyped
 import { cursorFromContextualData } from "../contextuallyTyped";
 import {
 	FieldKinds,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -60,13 +60,13 @@ export {
 	cursorForTypedData,
 	cursorForTypedTreeData,
 	cursorsForTypedFieldData,
-	FieldGenerator,
-	TreeDataContext,
 	normalizeNewFieldContent,
 	NewFieldContent,
-	assertAllowedValue,
-	isFluidHandle,
 } from "./contextuallyTyped";
+
+export { assertAllowedValue, isFluidHandle } from "./valueUtilities";
+
+export { FieldGenerator, TreeDataContext } from "./fieldGenerator";
 
 export { ForestSummarizer } from "./forestSummarizer";
 export { cursorForMapTreeField, cursorForMapTreeNode, mapTreeFromCursor } from "./mapTreeCursor";

--- a/experimental/dds/tree2/src/feature-libraries/valueUtilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/valueUtilities.ts
@@ -1,0 +1,88 @@
+import { assert, unreachableCase } from "@fluidframework/core-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { Value, ValueSchema, TreeValue } from "../core";
+
+export function allowsValue(schema: ValueSchema | undefined, nodeValue: Value): boolean {
+	if (schema === undefined) {
+		return nodeValue === undefined;
+	}
+	return valueSchemaAllows(schema, nodeValue);
+}
+
+export function valueSchemaAllows<TSchema extends ValueSchema>(
+	schema: TSchema,
+	nodeValue: Value,
+): nodeValue is TreeValue<TSchema> {
+	switch (schema) {
+		case ValueSchema.String:
+			return typeof nodeValue === "string";
+		case ValueSchema.Number:
+			return typeof nodeValue === "number";
+		case ValueSchema.Boolean:
+			return typeof nodeValue === "boolean";
+		case ValueSchema.FluidHandle:
+			return isFluidHandle(nodeValue);
+		case ValueSchema.Null:
+			return nodeValue === null;
+		default:
+			unreachableCase(schema);
+	}
+}
+
+/**
+ * Use for readonly view of Json compatible data that can also contain IFluidHandles.
+ *
+ * Note that this does not robustly forbid non json comparable data via type checking,
+ * but instead mostly restricts access to it.
+ */
+export type FluidSerializableReadOnly =
+	| IFluidHandle
+	| string
+	| number
+	| boolean
+	// eslint-disable-next-line @rushstack/no-new-null
+	| null
+	| readonly FluidSerializableReadOnly[]
+	| {
+			readonly [P in string]?: FluidSerializableReadOnly;
+	  };
+
+// TODO: replace test in FluidSerializer.encodeValue with this.
+export function isFluidHandle(value: unknown): value is IFluidHandle {
+	if (typeof value !== "object" || value === null || !("IFluidHandle" in value)) {
+		return false;
+	}
+
+	const handle = (value as Partial<IFluidHandle>).IFluidHandle;
+	// Regular Json compatible data can have fields named "IFluidHandle" (especially if field names come from user data).
+	// Separate this case from actual Fluid handles by checking for a circular reference: Json data can't have this circular reference so it is a safe way to detect IFluidHandles.
+	const isHandle = handle === value;
+	// Since the requirement for this reference to be cyclic isn't particularly clear in the interface (typescript can't model that very well)
+	// do an extra test.
+	// Since json compatible data shouldn't have methods, and IFluidHandle requires one, use that as a redundant check:
+	const getMember = (value as Partial<IFluidHandle>).get;
+	if (typeof getMember !== "function") {
+		return false;
+	}
+
+	return isHandle;
+}
+
+export function assertAllowedValue(
+	value: undefined | FluidSerializableReadOnly,
+): asserts value is Value {
+	assert(isAllowedValue(value), 1903 /* invalid value */);
+}
+
+export function isAllowedValue(value: undefined | FluidSerializableReadOnly): value is Value {
+	switch (typeof value) {
+		case "string":
+		case "number":
+		case "boolean":
+			return true;
+		case "object":
+			return value === null || isFluidHandle(value);
+		default:
+			return false;
+	}
+}

--- a/experimental/dds/tree2/src/feature-libraries/valueUtilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/valueUtilities.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { Value, ValueSchema, TreeValue } from "../core";
@@ -71,7 +76,7 @@ export function isFluidHandle(value: unknown): value is IFluidHandle {
 export function assertAllowedValue(
 	value: undefined | FluidSerializableReadOnly,
 ): asserts value is Value {
-	assert(isAllowedValue(value), 1903 /* invalid value */);
+	assert(isAllowedValue(value), "invalid value");
 }
 
 export function isAllowedValue(value: undefined | FluidSerializableReadOnly): value is Value {

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -5,15 +5,13 @@
 
 import { strict as assert } from "assert";
 import { MockHandle } from "@fluidframework/test-runtime-utils";
-import { EmptyKey, MapTree, ValueSchema } from "../../core";
+import { EmptyKey, MapTree } from "../../core";
 
 import {
-	allowsValue,
 	isPrimitiveValue,
 	applyTypesFromContext,
 	ContextuallyTypedNodeDataObject,
 	cursorFromContextualData,
-	isFluidHandle,
 	// Allow importing from this specific file which is being tested:
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../feature-libraries/contextuallyTyped";
@@ -33,68 +31,6 @@ describe("ContextuallyTyped", () => {
 		assert(!isPrimitiveValue(null));
 		assert(!isPrimitiveValue([]));
 		assert(!isPrimitiveValue(new MockHandle(5)));
-	});
-
-	it("isFluidHandle", () => {
-		assert(!isFluidHandle(0));
-		assert(!isFluidHandle({}));
-		assert(!isFluidHandle(undefined));
-		assert(!isFluidHandle(null));
-		assert(!isFluidHandle([]));
-		assert(!isFluidHandle({ get: () => {} }));
-		assert(!isFluidHandle({ IFluidHandle: 5, get: () => {} }));
-		assert(isFluidHandle(new MockHandle(5)));
-		assert(!isFluidHandle({ IFluidHandle: 5 }));
-		assert(!isFluidHandle({ IFluidHandle: {} }));
-		const loopy = { IFluidHandle: {} };
-		loopy.IFluidHandle = loopy;
-		// isFluidHandle has extra logic to check the handle is valid if it passed the detection via cyclic ref.
-		assert(!isFluidHandle(loopy));
-	});
-
-	it("allowsValue", () => {
-		assert(!allowsValue(ValueSchema.FluidHandle, undefined));
-		assert(!allowsValue(ValueSchema.Boolean, undefined));
-		assert(allowsValue(undefined, undefined));
-		assert(!allowsValue(ValueSchema.String, undefined));
-		assert(!allowsValue(ValueSchema.Number, undefined));
-		assert(!allowsValue(ValueSchema.Null, undefined));
-
-		assert(!allowsValue(ValueSchema.FluidHandle, false));
-		assert(allowsValue(ValueSchema.Boolean, false));
-		assert(!allowsValue(undefined, false));
-		assert(!allowsValue(ValueSchema.String, false));
-		assert(!allowsValue(ValueSchema.Number, false));
-		assert(!allowsValue(ValueSchema.Null, false));
-
-		assert(!allowsValue(ValueSchema.FluidHandle, 5));
-		assert(!allowsValue(ValueSchema.Boolean, 5));
-		assert(!allowsValue(undefined, 5));
-		assert(!allowsValue(ValueSchema.String, 5));
-		assert(allowsValue(ValueSchema.Number, 5));
-		assert(!allowsValue(ValueSchema.Null, 5));
-
-		assert(!allowsValue(ValueSchema.FluidHandle, ""));
-		assert(!allowsValue(ValueSchema.Boolean, ""));
-		assert(!allowsValue(undefined, ""));
-		assert(allowsValue(ValueSchema.String, ""));
-		assert(!allowsValue(ValueSchema.Number, ""));
-		assert(!allowsValue(ValueSchema.Null, ""));
-
-		const handle = new MockHandle(5);
-		assert(allowsValue(ValueSchema.FluidHandle, handle));
-		assert(!allowsValue(ValueSchema.Boolean, handle));
-		assert(!allowsValue(undefined, handle));
-		assert(!allowsValue(ValueSchema.String, handle));
-		assert(!allowsValue(ValueSchema.Number, handle));
-		assert(!allowsValue(ValueSchema.Null, handle));
-
-		assert(!allowsValue(ValueSchema.FluidHandle, null));
-		assert(!allowsValue(ValueSchema.Boolean, null));
-		assert(!allowsValue(undefined, null));
-		assert(!allowsValue(ValueSchema.String, null));
-		assert(!allowsValue(ValueSchema.Number, null));
-		assert(allowsValue(ValueSchema.Null, null));
 	});
 
 	it("applyTypesFromContext omits empty fields", () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/valueUtilities.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/valueUtilities.spec.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { MockHandle } from "@fluidframework/test-runtime-utils";
+import { ValueSchema } from "../../core";
+
+import {
+	allowsValue,
+	isFluidHandle,
+	// Allow importing from this specific file which is being tested:
+	/* eslint-disable-next-line import/no-internal-modules */
+} from "../../feature-libraries/valueUtilities";
+
+describe("valueUtilities", () => {
+	it("isFluidHandle", () => {
+		assert(!isFluidHandle(0));
+		assert(!isFluidHandle({}));
+		assert(!isFluidHandle(undefined));
+		assert(!isFluidHandle(null));
+		assert(!isFluidHandle([]));
+		assert(!isFluidHandle({ get: () => {} }));
+		assert(!isFluidHandle({ IFluidHandle: 5, get: () => {} }));
+		assert(isFluidHandle(new MockHandle(5)));
+		assert(!isFluidHandle({ IFluidHandle: 5 }));
+		assert(!isFluidHandle({ IFluidHandle: {} }));
+		const loopy = { IFluidHandle: {} };
+		loopy.IFluidHandle = loopy;
+		// isFluidHandle has extra logic to check the handle is valid if it passed the detection via cyclic ref.
+		assert(!isFluidHandle(loopy));
+	});
+
+	it("allowsValue", () => {
+		assert(!allowsValue(ValueSchema.FluidHandle, undefined));
+		assert(!allowsValue(ValueSchema.Boolean, undefined));
+		assert(allowsValue(undefined, undefined));
+		assert(!allowsValue(ValueSchema.String, undefined));
+		assert(!allowsValue(ValueSchema.Number, undefined));
+		assert(!allowsValue(ValueSchema.Null, undefined));
+
+		assert(!allowsValue(ValueSchema.FluidHandle, false));
+		assert(allowsValue(ValueSchema.Boolean, false));
+		assert(!allowsValue(undefined, false));
+		assert(!allowsValue(ValueSchema.String, false));
+		assert(!allowsValue(ValueSchema.Number, false));
+		assert(!allowsValue(ValueSchema.Null, false));
+
+		assert(!allowsValue(ValueSchema.FluidHandle, 5));
+		assert(!allowsValue(ValueSchema.Boolean, 5));
+		assert(!allowsValue(undefined, 5));
+		assert(!allowsValue(ValueSchema.String, 5));
+		assert(allowsValue(ValueSchema.Number, 5));
+		assert(!allowsValue(ValueSchema.Null, 5));
+
+		assert(!allowsValue(ValueSchema.FluidHandle, ""));
+		assert(!allowsValue(ValueSchema.Boolean, ""));
+		assert(!allowsValue(undefined, ""));
+		assert(allowsValue(ValueSchema.String, ""));
+		assert(!allowsValue(ValueSchema.Number, ""));
+		assert(!allowsValue(ValueSchema.Null, ""));
+
+		const handle = new MockHandle(5);
+		assert(allowsValue(ValueSchema.FluidHandle, handle));
+		assert(!allowsValue(ValueSchema.Boolean, handle));
+		assert(!allowsValue(undefined, handle));
+		assert(!allowsValue(ValueSchema.String, handle));
+		assert(!allowsValue(ValueSchema.Number, handle));
+		assert(!allowsValue(ValueSchema.Null, handle));
+
+		assert(!allowsValue(ValueSchema.FluidHandle, null));
+		assert(!allowsValue(ValueSchema.Boolean, null));
+		assert(!allowsValue(undefined, null));
+		assert(!allowsValue(ValueSchema.String, null));
+		assert(!allowsValue(ValueSchema.Number, null));
+		assert(allowsValue(ValueSchema.Null, null));
+	});
+});


### PR DESCRIPTION
## Description

Split out still useful utilities from contextuallyTyped that should live past the removal of the contextually typed data format (which is getting replaced by cursors in the flex tree API level and unhydrated nodes produced by schema factories in the simple one).

This also resolves some potential dependency cycles that upcoming code would have added.

Additionally, assertAllowedValue has been fixed to allow null.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

