### PR TITLE
Mark Experimental Packages Internal

### DIFF
--- a/examples/utils/example-utils/api-report/example-utils.api.md
+++ b/examples/utils/example-utils/api-report/example-utils.api.md
@@ -195,7 +195,7 @@ export class MigrationTool extends DataObject implements IMigrationTool {
     // (undocumented)
     protected initializingFirstTime(): Promise<void>;
     // (undocumented)
-    get migrationState(): "collaborating" | "stopping" | "migrating" | "migrated";
+    get migrationState(): "collaborating" | "migrated" | "stopping" | "migrating";
     // (undocumented)
     get newContainerId(): string | undefined;
     // (undocumented)
@@ -269,7 +269,7 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
     // (undocumented)
     protected initializingFirstTime(): Promise<void>;
     // (undocumented)
-    get migrationState(): "collaborating" | "migrated" | "proposingMigration" | "stoppingCollaboration" | "proposingV2Code" | "waitingForV2ProposalCompletion" | "readyForMigration";
+    get migrationState(): "collaborating" | "proposingMigration" | "stoppingCollaboration" | "proposingV2Code" | "waitingForV2ProposalCompletion" | "readyForMigration" | "migrated";
     // (undocumented)
     get proposedVersion(): string | undefined;
     // (undocumented)

--- a/examples/utils/example-utils/api-report/example-utils.api.md
+++ b/examples/utils/example-utils/api-report/example-utils.api.md
@@ -195,7 +195,7 @@ export class MigrationTool extends DataObject implements IMigrationTool {
     // (undocumented)
     protected initializingFirstTime(): Promise<void>;
     // (undocumented)
-    get migrationState(): "collaborating" | "migrated" | "stopping" | "migrating";
+    get migrationState(): "collaborating" | "stopping" | "migrating" | "migrated";
     // (undocumented)
     get newContainerId(): string | undefined;
     // (undocumented)
@@ -269,7 +269,7 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
     // (undocumented)
     protected initializingFirstTime(): Promise<void>;
     // (undocumented)
-    get migrationState(): "collaborating" | "proposingMigration" | "stoppingCollaboration" | "proposingV2Code" | "waitingForV2ProposalCompletion" | "readyForMigration" | "migrated";
+    get migrationState(): "collaborating" | "migrated" | "proposingMigration" | "stoppingCollaboration" | "proposingV2Code" | "waitingForV2ProposalCompletion" | "readyForMigration";
     // (undocumented)
     get proposedVersion(): string | undefined;
     // (undocumented)

--- a/experimental/PropertyDDS/examples/schemas/src/index.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/index.ts
@@ -9,6 +9,9 @@ export { registerSchemas } from "./schemasRegisterer";
 // eslint-disable-next-line unicorn/prefer-export-from
 export { SQUARES_DEMO_SCHEMAS };
 
+/**
+ * @internal
+ */
 export const ALL_SCHEMAS = {
 	SQUARES_DEMO_SCHEMAS,
 };

--- a/experimental/PropertyDDS/examples/schemas/src/schemasRegisterer.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/schemasRegisterer.ts
@@ -5,6 +5,10 @@
 import { ALL_SCHEMAS } from "./";
 
 // TODO: Use something other than `any`
+// eslint-disable-next-line jsdoc/require-description
+/**
+ * @internal
+ */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export const registerSchemas = function (propertyFactory: any): void {
 	for (const schemas of Object.values(ALL_SCHEMAS)) {

--- a/experimental/PropertyDDS/examples/schemas/src/squares_demo/index.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/squares_demo/index.ts
@@ -7,6 +7,9 @@ import point2D from "./2DPoint-1.0.0";
 import coloredSquare from "./coloredSquare-1.0.0";
 import square from "./square-1.0.0";
 
+/**
+ * @internal
+ */
 export const schemas = {
 	board,
 	point2D,

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/IActivateDataBindingOptions.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/IActivateDataBindingOptions.ts
@@ -5,6 +5,7 @@
 
 /**
  * Definition of the options block for {@link DataBinder.activateDataBinding}.
+ * @internal
  */
 export interface IActivateDataBindingOptions {
 	/**

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/IDefineRepresentationOptions.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/IDefineRepresentationOptions.ts
@@ -5,6 +5,9 @@
 import { BaseProperty } from "@fluid-experimental/property-properties";
 import { UpgradeType } from "../internal/semvermap";
 
+/**
+ * @internal
+ */
 export type representationGenerator =
 	/**
 	 * Callback signature for generating a runtime representation for a property. A runtime representation is an
@@ -27,6 +30,9 @@ export type representationGenerator =
 	 */
 	(property: BaseProperty, bindingType: string, userData?: any) => any;
 
+/**
+ * @internal
+ */
 export type representationInitializer =
 	/**
 	 * Callback signature for finalizing a runtime representation for a property, used with
@@ -48,6 +54,9 @@ export type representationInitializer =
 	 */
 	(runtimeObject: any, property: BaseProperty, bindingType: string, userData?: any) => void;
 
+/**
+ * @internal
+ */
 export type representationDestroyer =
 	/**
 	 * Callback signature for destroying a runtime representation associated with a property, used
@@ -66,6 +75,7 @@ export type representationDestroyer =
 
 /**
  * Options for {@link DataBinder.defineRepresentation}
+ * @internal
  */
 export interface IDefineRepresentationOptions {
 	/**

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/IRegisterOnPathOptions.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/IRegisterOnPathOptions.ts
@@ -5,6 +5,7 @@
 
 /**
  * Options to be used with {@link DataBinder.registerOnPath}
+ * @internal
  */
 export interface IRegisterOnPathOptions {
 	replaceExisting?: boolean;

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBinder.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBinder.ts
@@ -177,6 +177,7 @@ const _popUserData = function (in_context: Utils.TraversalContext) {
  * const workspace = databinder.getPropertyTree();
  * // ...
  * ```
+ * @internal
  */
 export class DataBinder {
 	_dataBinderId: number;
@@ -292,7 +293,6 @@ export class DataBinder {
 	 * @param in_options - An object containing optional parameters.
 	 *
 	 * @returns A handle that can be used to unregister this data binding
-	 * @public
 	 */
 	registerStateless(
 		in_bindingType: string,
@@ -321,8 +321,6 @@ export class DataBinder {
 	 * @param in_typeID                  - The id to use for this registration, usually the type id of the
 	 *                                              objects being represented (like a PropertySet template id).
 	 * @returns True if and only if there is a binding for this combination
-	 *
-	 * @public
 	 */
 	hasDataBinding(in_bindingType: string, in_typeID: string): boolean {
 		return this._registry.has(in_bindingType, in_typeID);
@@ -343,7 +341,6 @@ export class DataBinder {
 	 * @param in_options - An object containing additional parameters.
 	 *
 	 * @returns A handle that can be used to unregister this data binding.
-	 * @public
 	 * @throws Will throw an error if the constructor is missing or invalid.
 	 */
 	register(
@@ -395,8 +392,6 @@ export class DataBinder {
 	 *                                              as its only argument.
 	 * @param in_options - optional options for the new databinding
 	 * @returns A handle that can be used to undefine the binding.
-	 *
-	 * @public
 	 * @throws If the constructor is missing or invalid.
 	 * @throws If the bindingType/typeID pairing is already defined.
 	 */
@@ -503,7 +498,6 @@ export class DataBinder {
 	 *
 	 * @returns A handle that can be used to deactivate this instance of the binding. See
 	 * {@link DataBinderHandle.destroy}.
-	 * @public
 	 */
 	activateDataBinding(
 		in_bindingType: string,
@@ -594,8 +588,6 @@ export class DataBinder {
 	 * This functionality should be used with care, since unbalanced push/pop bracketing can render
 	 * the DataBinder permanently disabled. Consider doing push/pop scopes using try/catch blocks,
 	 * for example.
-	 *
-	 * @public
 	 */
 	pushBindingActivationScope() {
 		this._activationScope++;
@@ -606,8 +598,6 @@ export class DataBinder {
 	 * binding activations will be done, and all the corresponding bindings will be created.
 	 *
 	 * See {@link DataBinder.pushBindingActivationScope}.
-	 *
-	 * @public
 	 */
 	popBindingActivationScope() {
 		if (this._activationScope === 0) {
@@ -1374,7 +1364,6 @@ export class DataBinder {
 	 * @param in_options -  Additional user specified options for the
 	 * callback and its registration
 	 * @returns A handle that can be used to unregister the callback.
-	 * @public
 	 */
 	registerOnPath(
 		in_absolutePath: string | Array<string>,
@@ -1726,8 +1715,6 @@ export class DataBinder {
 	 *  created from {@link DataBinder.activateDataBinding} or {@link DataBinder.register}
 	 * @param in_undefine - if true (the default), undefine all bindings for this binding type
 	 *    {@link DataBinder.defineDataBinding} or {@link DataBinder.register}
-	 *
-	 * @public
 	 */
 	unregisterDataBindings(
 		in_bindingType?: string,
@@ -1750,7 +1737,6 @@ export class DataBinder {
 	 * Return true if this DataBinder is attached to a Workspace.
 	 *
 	 * @returns True if the DataBinder is attached to a Workspace.
-	 * @public
 	 */
 	isAttached(): boolean {
 		return !!this._propertyTree;
@@ -2470,8 +2456,6 @@ export class DataBinder {
 	 * bindings (either all in registration order or an empty array if no suitable bindings are present at the given path
 	 * or Property). If a binding type is given it's either a single data binding or undefined if no suitable bindings
 	 * are present at the given path or Property.
-	 *
-	 * @public
 	 */
 	resolve<T = DataBinding>(
 		in_pathOrProperty: string | BaseProperty,
@@ -2549,7 +2533,6 @@ export class DataBinder {
 	 *   after the ChangeSet has been processed
 	 * @param in_context - Optional value to be passed as
 	 *   the ```this``` parameter to the target function when the bound function is called
-	 * @public
 	 */
 	requestChangesetPostProcessing(in_callback: Function, in_context?: any) {
 		this._postProcessingCallbackQueue.push(in_callback.bind(in_context));
@@ -2559,7 +2542,6 @@ export class DataBinder {
 	 * Return the Workspace the DataBinder is currently attached to, or undefined if not attached.
 	 *
 	 * @returns The Workspace the DataBinder is attached to.
-	 * @public
 	 */
 	getPropertyTree(): SharedPropertyTree | undefined {
 		return this._propertyTree;
@@ -2606,8 +2588,6 @@ export class DataBinder {
 	 * @returns A handle to permit unregistering of the runtime representation.
 	 *
 	 * @throws If there is already runtime representation associated with the provided bindingType/typeID.
-	 *
-	 * @public
 	 */
 	defineRepresentation(
 		bindingType: string,
@@ -2786,8 +2766,6 @@ export class DataBinder {
 	 * @throws If not connected to a workspace
 	 * @throws If the property is not in the workspace the DataBinder is attached to.
 	 * @throws If the given property is undefined
-	 *
-	 * @public
 	 */
 	getRepresentation<T>(property: BaseProperty, bindingType: string): T | undefined {
 		if (!this.isAttached()) {
@@ -2819,8 +2797,6 @@ export class DataBinder {
 	 * @throws If the generator or a recursively-used generator fails to return a runtime representation when called.
 	 * @throws If not connected to a workspace
 	 * @throws If the property does not exist at the provided path
-	 *
-	 * @public
 	 */
 	getRepresentationAtPath<T>(path: string, bindingType: string): T | undefined {
 		if (!this.isAttached()) {
@@ -3203,7 +3179,6 @@ export class DataBinder {
 	 * A unique key per running application; each instance of the databinder will have a different Id.
 	 *
 	 * @returns  The id of this DataBinder instance.
-	 * @public
 	 */
 	getDataBinderId(): number {
 		return this._dataBinderId;

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBinding.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBinding.ts
@@ -96,9 +96,8 @@ export interface CallbackOptions {
  * to get the expected behaviors.
  * In addition, {@link DataBinding.registerOnPath} can be used to register for more granular events regarding
  * insert, modify and delete for subpaths rooted at the associated property.
- *
- * @public
  * @alias DataBinding
+ * @internal
  */
 export class DataBinding {
 	static __absolutePathInternalBinding: boolean;
@@ -137,7 +136,6 @@ export class DataBinding {
 	 * the DataBinding was activated using {@link DataBinder.activateDataBinding}.
 	 *
 	 * @returns The userData, or undefined if it wasn't specified during activation.
-	 * @public
 	 */
 	getUserData(): any | undefined {
 		return this._activationInfo.userData;
@@ -179,7 +177,6 @@ export class DataBinding {
 	 * Returns the property for which this DataBinding was instantiated.
 	 *
 	 * @returns The corresponding property.
-	 * @public
 	 */
 	getProperty(): BaseProperty | undefined {
 		return this._property;
@@ -190,7 +187,6 @@ export class DataBinding {
 	 * registered with the DataBinder using {@link DataBinder.activateDataBinding}.
 	 *
 	 * @returns The binding type of this DataBinding.
-	 * @public
 	 */
 	getDataBindingType(): string {
 		return this._activationInfo.bindingType;
@@ -200,7 +196,6 @@ export class DataBinding {
 	 * Returns the DataBinder instance associated with this DataBinding.
 	 *
 	 * @returns The DataBinder instance.
-	 * @public
 	 */
 	getDataBinder(): DataBinder {
 		return this._activationInfo.dataBinder;
@@ -1929,7 +1924,6 @@ export class DataBinding {
 	 * the property found via path, and a key / index if it gets triggered for one of the collection events.
 	 * @param in_options  Additional user specified options on how the callback should be
 	 * registered.
-	 * @public
 	 */
 	static registerOnProperty(
 		in_path: string,
@@ -1974,7 +1968,6 @@ export class DataBinding {
 	 * @param in_callback The function to call when the property behind the relative path changes.
 	 * @param in_options Additional user specified options on how the callback should be
 	 * registered.
-	 * @public
 	 */
 	static registerOnPath(
 		in_path: Array<string> | string,
@@ -1996,8 +1989,6 @@ export class DataBinding {
 	 * @param in_callback The function to call, when the property behind the relative path changes.
 	 * @param in_options Additional user specified options on how the callback should be
 	 * registered.
-	 *
-	 * @public
 	 */
 	static registerOnValues(
 		in_path: string,
@@ -2096,7 +2087,7 @@ export class DataBinding {
  * @param in_options Additional user specified options on how the callback should be
  * registered.
  * @returns A function that registers the decorated callback using registerOnValues.
- * @public
+ * @internal
  */
 export const onValuesChanged = function (
 	_in_path: string,
@@ -2119,7 +2110,7 @@ export const onValuesChanged = function (
  * @param in_options Additional user specified options on how the callback should be
  * registered.
  * @returns  function that registers the decorated callback using registerOnProperty.
- * @public
+ * @internal
  */
 export const onPropertyChanged = function (
 	_in_path: string,
@@ -2144,7 +2135,7 @@ export const onPropertyChanged = function (
  * @param in_options Additional user specified options on how the callback should be
  * registered.
  * @returns A function that registers the decorated callback using registerOnPath.
- * @public
+ * @internal
  */
 export const onPathChanged = function (
 	_in_path: Array<string> | string,

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/internalUtils.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/internalUtils.ts
@@ -742,7 +742,7 @@ const isPrimitiveCollection = function (in_property: BaseProperty): boolean {
  *
  * @param in_rootProperty - the property from which to recurse from
  * @param in_callback - function to call for each path. Recursion continues if the function returns true.
- *
+ * @internal
  */
 const forEachProperty = function (
 	in_rootProperty: BaseProperty,

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/removalContext.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/removalContext.ts
@@ -14,7 +14,7 @@ import { NodeType } from "./dataBindingTree";
  * Context which describes a remove operation
  * @extends BaseContext
  * @alias RemovalContext
- * @public
+ * @internal
  */
 export class RemovalContext extends BaseContext {
 	private _subTree: NodeType;
@@ -50,7 +50,6 @@ export class RemovalContext extends BaseContext {
 	 *     bindingType as the DataBinding that triggered this removal context.
 	 * @returns A data binding (defined for the given bindingType
 	 *     or the one associated with the data binding) or undefined if no binding is present.
-	 * @public
 	 */
 	getDataBinding(in_bindingType: string = ""): DataBinding | undefined {
 		var originalDataBindingType = this._baseDataBinding

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/statelessDataBinding.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/statelessDataBinding.ts
@@ -19,6 +19,7 @@ import { RemovalContext } from "./removalContext";
  * this class. Only one instance of ```D``` will be created.
  *
  * @extends DataBinding
+ * @internal
  */
 export class StatelessDataBinding extends DataBinding {
 	/**

--- a/experimental/PropertyDDS/packages/property-binder/src/internal/dataBinderHandle.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/internal/dataBinderHandle.ts
@@ -22,8 +22,7 @@ type PathCallback = {
  * if the creation of a data binding is delayed by a {@link DataBinder.pushBindingActivationScope},
  * it can still be removed using destroy() before the final {@link DataBinder.popBindingActivationScope}
  * actually instantiates any bindings.
- *
- * @public
+ * @internal
  */
 export class DataBinderHandle {
 	_destroyCallback: DestroyCallbackType | undefined;

--- a/experimental/PropertyDDS/packages/property-binder/src/internal/propertyElement.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/internal/propertyElement.ts
@@ -37,6 +37,7 @@ let Options: IOptions = {
 /**
  * Currently not exposed to the world
  * @hidden
+ * @internal
  */
 export class PropertyElement {
 	_property: Property;

--- a/experimental/PropertyDDS/packages/property-binder/src/internal/semvermap.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/internal/semvermap.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @internal
+ */
 export enum UpgradeType {
 	NONE = 0, // Only applies for exact matches
 	PATCH = 1, // Allow a higher patch version

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
@@ -51,6 +51,7 @@ export interface RebaseChangeSetOptions extends ApplyChangeSetOptions {
 
 /**
  * The plain serialization data structure used to encode a ChangeSet.
+ * @internal
  */
 export type SerializedChangeSet = any; // @TODO Maybe we should add full type for the ChangeSet
 export type ChangeSetType = any;
@@ -71,6 +72,7 @@ export interface ConflictInfo {
  * The ChangeSet represents an operation to be done (or that was done) on the data. It encapsulate one or
  * many addition/insertion and deletion of properties. The ChangeSetObject also provides functionality
  * to merge and swap change sets.
+ * @internal
  */
 export class ChangeSet {
 	static ConflictType = ConflictType;

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/arrayChangesetIterator.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/arrayChangesetIterator.ts
@@ -77,7 +77,7 @@ export type GenericOperation = NoneNOPOperation | NOPOperation;
  * Iterator class which iterates over an array ChangeSet. It will successively return the operations ordered by their
  * position within the array. Additionally, it will keep track of the modifications to the array indices caused
  * by the previous operations.
- *
+ * @internal
  */
 export class ArrayChangeSetIterator {
 	static types = ArrayIteratorOperationTypes; // @TODO Not sure if this is still required if we export it separately.

--- a/experimental/PropertyDDS/packages/property-changeset/src/helpers/typeidHelper.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/helpers/typeidHelper.ts
@@ -17,6 +17,9 @@ export declare interface ExtractedVersion {
 	typeidWithoutVersion: string;
 }
 
+/**
+ * @internal
+ */
 export declare interface ExtractedContext {
 	typeid: string;
 	context: string;
@@ -25,8 +28,8 @@ export declare interface ExtractedContext {
 
 /**
  * Helper for Type IDs
- * @public
  * @description Helper functions to work with typeid strings
+ * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace TypeIdHelper {
@@ -35,6 +38,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid we want to check
 	 * @returns Is this a base type?
+	 * @internal
 	 */
 	export function isPrimitiveType(in_typeid: string): boolean {
 		const primitiveTypes = templateSchemaJson["$defs"]["primitive-typeid"]["enum"];
@@ -55,6 +59,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid we want to check
 	 * @returns Is this a base template typeid?
+	 * @internal
 	 */
 	export function isTemplateTypeid(in_typeid: string): boolean {
 		return in_typeid.indexOf(":") !== -1;
@@ -65,6 +70,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid we want to check
 	 * @returns Is this a reserved type?
+	 * @internal
 	 */
 	export function isReservedType(in_typeid: string): boolean {
 		const reservedTypes = templateSchemaJson["$defs"]["reserved-typeid"]["enum"];
@@ -75,6 +81,7 @@ export namespace TypeIdHelper {
 	 * Extract the version number from the given typeid
 	 * @param in_typeid - The typeid to check against
 	 * @returns Extracted version
+	 * @internal
 	 */
 	export function extractVersion(in_typeid): ExtractedVersion {
 		if (!in_typeid) {
@@ -93,6 +100,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid to process
 	 * @returns The typeid without context, the context and if we have an enum type
+	 * @internal
 	 */
 	export function extractContext(in_typeid: string | undefined): ExtractedContext {
 		const bracketIndex = in_typeid.indexOf("<");
@@ -145,6 +153,7 @@ export namespace TypeIdHelper {
 	 * @param in_enum - Set to true if the type should get an enum tag
 	 *
 	 * @returns The combined typeid string
+	 * @internal
 	 */
 	export function createSerializationTypeId(
 		in_typeid: string,
@@ -172,6 +181,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid to check
 	 * @returns Is this a reference property typeid?
+	 * @internal
 	 */
 	export function isReferenceTypeId(in_typeid: string | undefined): boolean {
 		// in_enum
@@ -186,6 +196,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid to process
 	 * @return The type of the referenced property
+	 * @internal
 	 */
 	export function extractReferenceTargetTypeIdFromReference(in_typeid: string): string {
 		// in_enum
@@ -199,6 +210,7 @@ export namespace TypeIdHelper {
 	 *
 	 * @param in_typeid - The typeid we want to check
 	 * @returns Is this a base template typeid?
+	 * @internal
 	 */
 	export function isSchemaTypeid(in_typeid: string): boolean {
 		return typeof in_typeid === "string" && in_typeid.indexOf(":") !== -1;
@@ -210,6 +222,7 @@ export namespace TypeIdHelper {
 	 * @param in_typeid - typeid
 	 *
 	 * @return referenced typeid or in_param if it is not a reference
+	 * @internal
 	 */
 	export function extractTypeId(in_typeid): string {
 		const matches = in_typeid.match(/\<(.*?)\>/);
@@ -227,6 +240,7 @@ export namespace TypeIdHelper {
 	 * @param in_baseTypeid - The base typeId to check for.
 	 * @throws If in_typeid or in_baseTypeid are not native typeid.
 	 * @returns True if in_baseTypeid is a parent of in_typeid.
+	 * @internal
 	 */
 	export function nativeInheritsFrom(in_typeid: string, in_baseTypeid: string): boolean {
 		if (!in_typeid || !in_baseTypeid) {
@@ -272,6 +286,7 @@ export namespace TypeIdHelper {
 	 * return all primitive typeIds
 	 *
 	 * @returns return a list of primitiveTypeIds
+	 * @internal
 	 */
 	export function getPrimitiveTypeIds(): string[] {
 		return templateSchemaJson["$defs"]["primitive-typeid"]["enum"];
@@ -281,6 +296,7 @@ export namespace TypeIdHelper {
 	 * return all reserved typeIds
 	 *
 	 * @returns return a list of reservedTypeIds
+	 * @internal
 	 */
 	export function getReservedTypeIds(): string[] {
 		return templateSchemaJson["$defs"]["reserved-typeid"]["enum"];

--- a/experimental/PropertyDDS/packages/property-changeset/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/index.ts
@@ -11,6 +11,9 @@ import { TemplateSchema } from "./templateSchema";
 import { TemplateValidator } from "./templateValidator";
 import { Utils } from "./utils";
 
+/**
+ * @internal
+ */
 const { TraversalContext } = Utils;
 
 export {

--- a/experimental/PropertyDDS/packages/property-changeset/src/pathHelper.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/pathHelper.ts
@@ -15,6 +15,7 @@ export type PathTree = Map<String, PathTree>;
 
 /**
  * Helper functions for string processing
+ * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PathHelper {
@@ -23,6 +24,7 @@ export namespace PathHelper {
 	/**
 	 * Token Types
 	 * Type of the token in the path string
+	 * @internal
 	 */
 	export enum TOKEN_TYPES {
 		/** A normal path segment, separated via . */
@@ -44,6 +46,7 @@ export namespace PathHelper {
 	 * @param out_types - The types of the tokens
 	 *
 	 * @returns the tokens from the path string
+	 * @internal
 	 */
 	export const tokenizePathString = function (
 		in_path: string,
@@ -329,6 +332,7 @@ export namespace PathHelper {
 	 * @param in_pathSegment - The path string to put in quotes
 	 *
 	 * @returns quoted path string
+	 * @internal
 	 */
 	export const quotePathSegment = function (in_pathSegment: string): string {
 		// WARNING: I use RegExps here, as the normal replace
@@ -350,6 +354,7 @@ export namespace PathHelper {
 	 * @param in_quotedPathSegment - The quoted/escaped path string to put in quotes
 	 *
 	 * @return unquoted path string
+	 * @internal
 	 */
 	export const unquotePathSegment = function (in_quotedPathSegment: string): string {
 		if (typeof in_quotedPathSegment !== "string") {
@@ -376,6 +381,7 @@ export namespace PathHelper {
 	 * @param in_pathSegment - The path string to put in quotes
 	 *
 	 * @returns quoted path string
+	 * @internal
 	 */
 	export const quotePathSegmentIfNeeded = function (in_pathSegment: string): string {
 		return in_pathSegment.indexOf(PROPERTY_PATH_DELIMITER) !== -1 ||
@@ -396,6 +402,7 @@ export namespace PathHelper {
 	 * It has to be either an empty string, or a path starting with a /
 	 *
 	 * @param in_path - The path to check
+	 * @internal
 	 */
 	export const checkValidRepositoryAbsolutePath = function (in_path: string) {
 		if (
@@ -414,6 +421,7 @@ export namespace PathHelper {
 	 *
 	 * @param in_absolutePath - The absolute path to make canonical
 	 * @return Absolute path in canonical form
+	 * @internal
 	 */
 	export const convertAbsolutePathToCanonical = function (in_absolutePath: string): string {
 		const tokenTypes = [];
@@ -456,6 +464,7 @@ export namespace PathHelper {
 	 * @param in_parentAbsolutePathCanonical - The absolute path of the parent property in canonical form
 	 * @param in_childId - The name of the child property in its parent
 	 * @returns Absolute path of the child property in canonical form
+	 * @internal
 	 */
 	export const getChildAbsolutePathCanonical = function (
 		in_parentAbsolutePathCanonical: string,
@@ -467,6 +476,9 @@ export namespace PathHelper {
 			: childPath;
 	};
 
+	/**
+	 * @internal
+	 */
 	export enum CoverageExtent {
 		// The base path is not covered by any path from a given list of paths.
 		// This means a property with this path and all its children would not be covered.
@@ -494,6 +506,7 @@ export namespace PathHelper {
 	 * @param in_paths - The array of paths that must cover the property and its children
 	 * @returns The coverage of the property and its children. For a coverage of
 	 * 'FULLY_COVERED', only the first matching path is returned.
+	 * @internal
 	 */
 	export const getPathCoverage = function (
 		in_basePath: string,

--- a/experimental/PropertyDDS/packages/property-changeset/src/rebase.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/rebase.ts
@@ -36,6 +36,9 @@ const loop = (
 		.then(fn)
 		.then((result) => (result === null ? result : loop(makePromise(result), fn, makePromise)));
 
+/**
+ * @internal
+ */
 export function rebaseToRemoteChanges(
 	change: any,
 	getUnrebasedChange: any,

--- a/experimental/PropertyDDS/packages/property-changeset/src/templateSchema.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/templateSchema.ts
@@ -173,6 +173,9 @@ const originalSchema = {
 	required: ["typeid"],
 };
 
+/**
+ * @internal
+ */
 const TemplateSchema = {
 	$schema: "http://json-schema.org/schema",
 	title: "Property set template schema",

--- a/experimental/PropertyDDS/packages/property-changeset/src/templateValidator.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/templateValidator.ts
@@ -1025,6 +1025,7 @@ const Utils = {
 /**
  * Instantiates a new TemplateValidator. Must be provided with a set of inheritsFrom and hasSchema
  * function or inheritsFromAsync and hasSchemaAsync, but not both.
+ * @internal
  */
 export class TemplateValidator {
 	static Utils = Utils;

--- a/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
@@ -30,10 +30,17 @@ type NextFn = (err?: Error | null | undefined | string, result?: unknown) => voi
  * Utils
  * @alias property-changeset.Utils
  * @class
+ * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Utils {
+	/**
+	 * @internal
+	 */
 	export type OperationType = "modify" | "insert" | "remove";
+	/**
+	 * @internal
+	 */
 	export type PropertyContainerType =
 		| "array"
 		| "map"
@@ -1049,6 +1056,7 @@ export namespace Utils {
 
 	/**
 	 * Provides traversal information when parsing ChangeSets via the traverseChangeSetRecursively function.
+	 * @internal
 	 */
 	export class TraversalContext {
 		public _fullPath: string;
@@ -1447,6 +1455,7 @@ export namespace Utils {
 	 * At least one of the pre- or post-order callbacks must be specified. Both may be specified as well.
 	 *
 	 * @param in_changeSet - The ChangeSet to process
+	 * @internal
 	 */
 	export function traverseChangeSetRecursively(
 		in_changeSet: SerializedChangeSet,
@@ -1484,7 +1493,7 @@ export namespace Utils {
 	 *
 	 * @param in_changeSet - The ChangeSet to process
 	 * @param in_finalizer - A callback when traversal is completed
-	 *
+	 * @internal
 	 */
 	export function traverseChangeSetRecursivelyAsync(
 		in_changeSet: SerializedChangeSet,
@@ -1527,6 +1536,7 @@ export namespace Utils {
 	 * @param in_changeSet - The ChangeSet to process
 	 *
 	 * @returns All typeids that appear in the ChangeSet
+	 * @internal
 	 */
 	export function extractTypeids(in_changeSet: SerializedChangeSet): string[] {
 		const result = {};
@@ -1553,6 +1563,7 @@ export namespace Utils {
 	 *
 	 * @returns All templates that appear in the ChangeSet.
 	 * The returned object has members key (string), corresponding to the type and value with the definition (object)
+	 * @internal
 	 */
 	export function enumerateSchemas(
 		in_changeSet: SerializedChangeSet,
@@ -1588,6 +1599,7 @@ export namespace Utils {
 	 * This is a private functions, it is only exported for the tests.
 	 *
 	 * @param io_changeSet - The ChangeSet to process
+	 * @internal
 	 */
 	export function _stripTypeids(io_changeSet: SerializedChangeSet) {
 		const result = {};
@@ -1658,6 +1670,7 @@ export namespace Utils {
 	 * @param in_changeSet - The ChangeSet to process
 	 * @param in_excludeTypeids - Exclude all typeids from the returned ChangeSet
 	 * @returns Returns the applied operations to entries of the given typeid. The returned maps for insert and modify map paths to ChangeSets
+	 * @internal
 	 */
 	export function getChangesByType(
 		in_typeid: string,
@@ -1715,6 +1728,7 @@ export namespace Utils {
 	 * {insert: Object|undefined, modify: Object|undefined, remove: boolean|undefined}
 	 * </pre>
 	 * ```
+	 * @internal
 	 */
 	export function getChangesByPath(
 		in_path: string,
@@ -1873,6 +1887,7 @@ export namespace Utils {
 	 * @param in_options.escapeLeadingDoubleUnderscore - If this is set to true, keys which start with '__' will be
 	 * escaped (by adding an additional '_') before the lookup into the paths map. This frees the keyspace with
 	 * duplicated underscores for the use by the calling application.
+	 * @internal
 	 */
 	export function getChangesToTokenizedPaths(
 		in_paths: Map<string, Map<string, any>> | { [key: string]: any },
@@ -2105,6 +2120,7 @@ export namespace Utils {
 	 *
 	 * @throws If a path given resolves into an array or set.
 	 * @returns The filtered ChangeSet
+	 * @internal
 	 */
 	export function getFilteredChangeSetByPaths(
 		in_changeSet: SerializedChangeSet,
@@ -2333,6 +2349,7 @@ export namespace Utils {
 	 * @param in_paths - An array with paths
 	 * @returns {Map} A tree structured representation of the tokenized paths that can be
 	 * passed to getChangesToTokenizedPaths and getFilteredChangeSetByPaths.
+	 * @internal
 	 */
 	export function convertPathArrayToTree(in_paths: string[]): PathTree {
 		in_paths = Array.isArray(in_paths) ? in_paths : [in_paths];
@@ -2411,6 +2428,7 @@ export namespace Utils {
 	 * including ones that encompasse other paths
 	 * @throws if a path given resolves into an array or set
 	 * @returns Filtered ChangeSet
+	 * @internal
 	 */
 	export function excludePathsFromChangeSet(
 		in_changeSet: SerializedChangeSet,
@@ -2467,6 +2485,7 @@ export namespace Utils {
 	 * @param in_options.includeOperation - Flag to include the operation
 	 * @param in_options.includeTypeidInfo - Flag to include the typeid info
 	 * @returns Flat list of paths
+	 * @internal
 	 */
 	export function extractPathsFromChangeSet(
 		in_changeSet: SerializedChangeSet,

--- a/experimental/PropertyDDS/packages/property-common/src/chronometer.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/chronometer.ts
@@ -132,6 +132,7 @@ if (typeof process !== "undefined" && typeof process.hrtime !== "undefined") {
 
 /**
  * Creates and starts a new Chronometer.
+ * @internal
  */
 export class Chronometer {
 	constructor() {

--- a/experimental/PropertyDDS/packages/property-common/src/consoleUtils.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/consoleUtils.ts
@@ -5,6 +5,7 @@
 
 /**
  * Used to replace console.assert to make sure that it always throws an error, both in the browser and in Node
+ * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ConsoleUtils {

--- a/experimental/PropertyDDS/packages/property-common/src/constants.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/constants.ts
@@ -1733,6 +1733,9 @@ const MESSAGE_CONSTANTS = {
 	...ServerError,
 };
 
+/**
+ * @internal
+ */
 export const constants = {
 	MSG: MESSAGE_CONSTANTS,
 	PROPERTY_PATH_DELIMITER,

--- a/experimental/PropertyDDS/packages/property-common/src/datastructures/collection.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/datastructures/collection.ts
@@ -17,6 +17,9 @@ const MSGS = {
 	KEY_NOT_VALID: "Key must be of type String or Number",
 };
 
+/**
+ * @internal
+ */
 export class Collection<T> {
 	protected _items: { [key: string]: T } = {};
 	protected _order: (string | number)[] = [];

--- a/experimental/PropertyDDS/packages/property-common/src/datastructures/dataArray.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/datastructures/dataArray.ts
@@ -13,6 +13,7 @@
 /**
  * A typed data container that is persistable, high-performance, and can be used
  * as a backing store for collaborative property sets.
+ * @internal
  */
 class BaseDataArray {
 	protected _buffer: any;
@@ -279,48 +280,72 @@ class BaseDataArray {
 	}
 }
 
+/**
+ * @internal
+ */
 class Int8DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Int8Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Int16DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Int16Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Int32DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Int32Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Uint8DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Uint8Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Uint16DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Uint16Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Uint32DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Uint32Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Float32DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Float32Array, size);
 	}
 }
 
+/**
+ * @internal
+ */
 class Float64DataArray extends BaseDataArray {
 	constructor(size: number) {
 		super(Float64Array, size);
@@ -331,6 +356,7 @@ class Float64DataArray extends BaseDataArray {
  * A data container that can contain every native type
  *
  * @param size - The initial size with which to allocate the array.
+ * @internal
  */
 class UniversalDataArray extends BaseDataArray {
 	constructor(bufferConstructor: any, size: number);
@@ -445,6 +471,7 @@ class UniversalDataArray extends BaseDataArray {
 
 /**
  * A data container that contains a string
+ * @internal
  */
 class StringDataArray extends BaseDataArray {
 	constructor() {
@@ -511,6 +538,7 @@ class StringDataArray extends BaseDataArray {
 
 /**
  * A data container that can contain boolean type
+ * @internal
  */
 class BoolDataArray extends UniversalDataArray {
 	/**

--- a/experimental/PropertyDDS/packages/property-common/src/datastructures/integer64.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/datastructures/integer64.ts
@@ -24,6 +24,7 @@ const { MSG } = constants;
  *
  * @param low - Lower 32 bit
  * @param high - Higher 32 bit
+ * @internal
  */
 export class Integer64 {
 	constructor(
@@ -129,6 +130,7 @@ function _stringToInt64(in_signed: boolean, in_string: string, in_radix = 10): n
 
 /**
  * A data representation class for the signed 64 bit integer type
+ * @internal
  */
 export class Int64 extends Integer64 {
 	static fromString = function (in_string: string, radix = 10) {
@@ -147,6 +149,7 @@ export class Int64 extends Integer64 {
 
 /**
  * A data representation class for the unsigned 64 bit integer type
+ * @internal
  */
 export class Uint64 extends Integer64 {
 	static fromString(in_string: string, in_radix = 10) {

--- a/experimental/PropertyDDS/packages/property-common/src/datastructures/sortedCollection.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/datastructures/sortedCollection.ts
@@ -11,6 +11,9 @@
 import _ from "lodash";
 import { Collection } from "./collection";
 
+/**
+ * @internal
+ */
 export class SortedCollection<T> extends Collection<T> {
 	private _sortedKeys: string[] = [];
 	private _comparisonFunction?: (x: string, y: string) => number = undefined;

--- a/experimental/PropertyDDS/packages/property-common/src/deferredPromise.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/deferredPromise.ts
@@ -8,6 +8,7 @@
  * through the constructor's executor).
  * For example, a deferred promise could be fulfilled after waiting for many asynchronous
  * tasks to terminate. This class becomes useful when combining classic async calls with promises.
+ * @internal
  */
 export class DeferredPromise<T> implements Promise<T> {
 	private _resolveSelf;

--- a/experimental/PropertyDDS/packages/property-common/src/deterministicRandomGenerator.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/deterministicRandomGenerator.ts
@@ -19,6 +19,7 @@ import { calculateHash } from "./hashCalculator";
  * @remarks Warning: This is a very straight forward implementation based on the hashCombine4xUint32 function.
  * It probably doesn't produce very high quality random numbers (do not use this for cryptography!) and it is not very
  * efficient.
+ * @internal
  */
 export class DeterministicRandomGenerator {
 	_guid1: Uint32Array;

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/flaggedError.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/flaggedError.ts
@@ -14,6 +14,9 @@ const _isFlagSet = (flags: number, flag: number) => {
 	return (flags & flag) === flag;
 };
 
+/**
+ * @internal
+ */
 export class FlaggedError {
 	/**
 	 * Flags that may be set on an error instance.

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/httpError.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/httpError.ts
@@ -12,6 +12,7 @@ import { FlaggedError } from "./flaggedError";
  * @param method - The HTTP method used in the request
  * @param url - The URL that the request was sent to
  * @param flags - Flags that characterize the error. See {@link FlaggedError.FLAGS}.
+ * @internal
  */
 export class HTTPError extends Error {
 	constructor(

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/httpErrorNoStack.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/httpErrorNoStack.ts
@@ -7,6 +7,7 @@ import { FlaggedError } from "./flaggedError";
 
 /**
  * Class extending HTTPError without storing the stack
+ * @internal
  */
 export class HTTPErrorNoStack extends HTTPError {
 	static FLAGS = FlaggedError.FLAGS;

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/operationError.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/operationError.ts
@@ -12,6 +12,9 @@
 import _ from "lodash";
 import { FlaggedError } from "./flaggedError";
 
+/**
+ * @internal
+ */
 export class OperationError extends Error {
 	static FLAGS = FlaggedError.FLAGS;
 	public stack: string | undefined;

--- a/experimental/PropertyDDS/packages/property-common/src/guidUtils.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/guidUtils.ts
@@ -326,6 +326,9 @@ const initializeGUIDGenerator = (...args) => {
 	guidRNG.initialize(...args);
 };
 
+/**
+ * @internal
+ */
 export const GuidUtils = {
 	uint32x4ToGUID,
 	guidToUint32x4,

--- a/experimental/PropertyDDS/packages/property-common/src/hashCalculator.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/hashCalculator.ts
@@ -10,6 +10,9 @@
 
 import murmurHash3 from "murmurhash3js";
 
+/**
+ * @internal
+ */
 export function calculateHash(key, seed = 0) {
 	const str = murmurHash3.x86.hash128(key, seed);
 	return `${str.substr(0, 8)}-${str.substr(8, 4)}-${str.substr(12, 4)}-${str.substr(

--- a/experimental/PropertyDDS/packages/property-common/src/joinPaths.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/joinPaths.ts
@@ -16,6 +16,7 @@
  * @param in_separator - The path separator
  *
  * @returns The joined path
+ * @internal
  */
 export function joinPaths(
 	in_string1: string = "",

--- a/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
+++ b/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
@@ -17,7 +17,7 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { NodeProperty } from '@fluid-experimental/property-properties';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
-// @public (undocumented)
+// @internal (undocumented)
 export abstract class CompressedPropertyTreeFactory implements IChannelFactory {
     // (undocumented)
     abstract get attributes(): any;
@@ -37,7 +37,7 @@ export abstract class CompressedPropertyTreeFactory implements IChannelFactory {
     abstract get type(): any;
 }
 
-// @public
+// @internal
 export class DeflatedPropertyTree extends SharedPropertyTree {
     // (undocumented)
     static create(runtime: IFluidDataStoreRuntime, id?: string, queryString?: string): DeflatedPropertyTree;
@@ -45,7 +45,7 @@ export class DeflatedPropertyTree extends SharedPropertyTree {
     static getFactory(): IChannelFactory;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export class DeflatedPropertyTreeFactory extends CompressedPropertyTreeFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -67,13 +67,13 @@ export class DeflatedPropertyTreeFactory extends CompressedPropertyTreeFactory {
     get type(): string;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface IPropertyTreeConfig {
     // (undocumented)
     encDec: ISharedPropertyTreeEncDec;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface IPropertyTreeMessage {
     // (undocumented)
     changeSet: SerializedChangeSet;
@@ -95,13 +95,13 @@ export interface IPropertyTreeMessage {
     useMH?: boolean;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface IRemotePropertyTreeMessage extends IPropertyTreeMessage {
     // (undocumented)
     sequenceNumber: number;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface ISharedPropertyTreeEncDec {
     // (undocumented)
     messageEncoder: {
@@ -115,7 +115,7 @@ export interface ISharedPropertyTreeEncDec {
     };
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface ISnapshotSummary {
     // (undocumented)
     remoteChanges?: IPropertyTreeMessage[];
@@ -127,7 +127,7 @@ export interface ISnapshotSummary {
     unrebasedRemoteChanges?: Record<string, IRemotePropertyTreeMessage>;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export class LZ4PropertyTree extends SharedPropertyTree {
     // (undocumented)
     static create(runtime: IFluidDataStoreRuntime, id?: string, queryString?: string): LZ4PropertyTree;
@@ -135,7 +135,7 @@ export class LZ4PropertyTree extends SharedPropertyTree {
     static getFactory(): IChannelFactory;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export class LZ4PropertyTreeFactory extends CompressedPropertyTreeFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -157,16 +157,16 @@ export class LZ4PropertyTreeFactory extends CompressedPropertyTreeFactory {
     get type(): string;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export type Metadata = any;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const enum OpKind {
     // (undocumented)
     ChangeSet = 0
 }
 
-// @public
+// @internal
 export class PropertyTreeFactory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -182,10 +182,10 @@ export class PropertyTreeFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export type SerializedChangeSet = any;
 
-// @public
+// @internal
 export class SharedPropertyTree extends SharedObject {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, options: SharedPropertyTreeOptions, propertyTreeConfig?: IPropertyTreeConfig);
     // (undocumented)
@@ -259,7 +259,7 @@ export class SharedPropertyTree extends SharedObject {
     useMH: boolean;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface SharedPropertyTreeOptions {
     // (undocumented)
     clientFiltering?: boolean;

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -42,18 +42,30 @@ import { v4 as uuidv4 } from "uuid";
 import axios from "axios";
 import { PropertyTreeFactory } from "./propertyTreeFactory";
 
+/**
+ * @internal
+ */
 export type SerializedChangeSet = any;
 
+/**
+ * @internal
+ */
 export type Metadata = any;
 
 type FetchUnrebasedChangeFn = (guid: string) => IRemotePropertyTreeMessage;
 type FetchRebasedChangesFn = (startGuid: string, endGuid?: string) => IPropertyTreeMessage[];
 
+/**
+ * @internal
+ */
 export const enum OpKind {
 	// eslint-disable-next-line @typescript-eslint/no-shadow
 	ChangeSet = 0,
 }
 
+/**
+ * @internal
+ */
 export interface IPropertyTreeMessage {
 	op: OpKind;
 	changeSet: SerializedChangeSet;
@@ -66,6 +78,9 @@ export interface IPropertyTreeMessage {
 	useMH?: boolean;
 }
 
+/**
+ * @internal
+ */
 export interface IRemotePropertyTreeMessage extends IPropertyTreeMessage {
 	sequenceNumber: number;
 }
@@ -75,6 +90,9 @@ interface ISnapshot {
 	useMH: boolean;
 	numChunks: number;
 }
+/**
+ * @internal
+ */
 export interface ISnapshotSummary {
 	remoteTipView?: SerializedChangeSet;
 	remoteChanges?: IPropertyTreeMessage[];
@@ -82,6 +100,9 @@ export interface ISnapshotSummary {
 	remoteHeadGuid: string;
 }
 
+/**
+ * @internal
+ */
 export interface SharedPropertyTreeOptions {
 	paths?: string[];
 	clientFiltering?: boolean;
@@ -89,6 +110,9 @@ export interface SharedPropertyTreeOptions {
 	disablePartialCheckout?: boolean;
 }
 
+/**
+ * @internal
+ */
 export interface ISharedPropertyTreeEncDec {
 	messageEncoder: {
 		encode: (IPropertyTreeMessage) => IPropertyTreeMessage;
@@ -97,6 +121,9 @@ export interface ISharedPropertyTreeEncDec {
 	summaryEncoder: { encode: (ISnapshotSummary) => Buffer; decode: (Buffer) => ISnapshotSummary };
 }
 
+/**
+ * @internal
+ */
 export interface IPropertyTreeConfig {
 	encDec: ISharedPropertyTreeEncDec;
 }
@@ -131,6 +158,7 @@ const defaultEncDec: ISharedPropertyTreeEncDec = {
  * consensus by simply applying the same number of rolls.  (A fun addition would be logging
  * who received which roll, which would need to change as clients learn how races are resolved
  * in the total order)
+ * @internal
  */
 export class SharedPropertyTree extends SharedObject {
 	tipView: SerializedChangeSet = {};

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTreeExt.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTreeExt.ts
@@ -10,6 +10,7 @@ import { DeflatedPropertyTreeFactory, LZ4PropertyTreeFactory } from "./propertyT
 /**
  * This class is the extension of SharedPropertyTree which compresses
  * the deltas and summaries communicated to the server by Deflate.
+ * @internal
  */
 export class DeflatedPropertyTree extends SharedPropertyTree {
 	public static create(runtime: IFluidDataStoreRuntime, id?: string, queryString?: string) {
@@ -21,6 +22,9 @@ export class DeflatedPropertyTree extends SharedPropertyTree {
 	}
 }
 
+/**
+ * @internal
+ */
 export class LZ4PropertyTree extends SharedPropertyTree {
 	public static create(runtime: IFluidDataStoreRuntime, id?: string, queryString?: string) {
 		return runtime.createChannel(id, LZ4PropertyTreeFactory.Type) as LZ4PropertyTree;

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTreeExtFactories.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTreeExtFactories.ts
@@ -22,6 +22,9 @@ import {
 } from "./propertyTree";
 import { DeflatedPropertyTree, LZ4PropertyTree } from "./propertyTreeExt";
 
+/**
+ * @internal
+ */
 export abstract class CompressedPropertyTreeFactory implements IChannelFactory {
 	public abstract get attributes();
 	public abstract get type();
@@ -119,6 +122,9 @@ export abstract class CompressedPropertyTreeFactory implements IChannelFactory {
 	}
 }
 
+/**
+ * @internal
+ */
 export class DeflatedPropertyTreeFactory extends CompressedPropertyTreeFactory {
 	public static readonly Type = "DeflatedPropertyTree:84534a0fe613522101f6";
 
@@ -171,6 +177,9 @@ export class DeflatedPropertyTreeFactory extends CompressedPropertyTreeFactory {
 	}
 }
 
+/**
+ * @internal
+ */
 export class LZ4PropertyTreeFactory extends CompressedPropertyTreeFactory {
 	public static readonly Type = "LZ4PropertyTree:84534a0fe613522101f6";
 

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTreeFactory.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTreeFactory.ts
@@ -13,6 +13,7 @@ import { SharedPropertyTree, SharedPropertyTreeOptions } from "./propertyTree";
 
 /**
  * The factory that defines the map
+ * @internal
  */
 export class PropertyTreeFactory implements IChannelFactory {
 	public static readonly Type = "PropertyTree:01EP5J4Y6C284JR6ATVPPHRJ4E";

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/CustomChip.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/CustomChip.tsx
@@ -28,6 +28,9 @@ interface IChipProps {
 	className: string;
 }
 
+/**
+ * @internal
+ */
 export const CustomChip: React.FunctionComponent<IChipProps> = (props) => {
 	const classes = useStyles(props);
 	return <span className={`${classes.chip} ${props.className}`}>{props.label}</span>;

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -173,6 +173,7 @@ const getRandomRowsNum = () => {
  * The default implementation for the InspectorTable `childGetter` callback.
  * @param child - The hierarchical child of the property the row represents.
  * @returns The passed in child.
+ * @internal
  */
 export const defaultInspectorTableChildGetter = (child: any): any => child;
 
@@ -180,12 +181,14 @@ export const defaultInspectorTableChildGetter = (child: any): any => child;
  * The default implementation for the InspectorTable `nameGetter` callback.
  * @param name - The id of the property the row represents.
  * @returns The passed in id.
+ * @internal
  */
 export const defaultInspectorTableNameGetter = (name: string): any => name;
 
 /**
  * The default implementation of the `dataGetter` callback for the Inspector table
  * @param params - function handle
+ * @internal
  */
 export const defaultInspectorTableDataGetter = (
 	params: IDataGetterParameter,
@@ -954,5 +957,8 @@ class InspectorTable<
 	};
 }
 
+/**
+ * @internal
+ */
 const StyledInspectorTable = withStyles(styles, { name: "InspectorTable" })(InspectorTable as any);
 export { StyledInspectorTable as InspectorTable };

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
@@ -9,11 +9,17 @@ import { BaseProperty } from "@fluid-experimental/property-properties";
 import { BaseTableProps, SortOrder } from "react-base-table";
 import { IRepoExpiryGetter, IRepoExpirySetter } from "./CommonTypes";
 
+/**
+ * @internal
+ */
 export interface SearchResult {
 	foundMatches?: IInspectorSearchMatch[];
 	matchesMap?: IInspectorSearchMatchMap;
 	currentResult?: number;
 }
+/**
+ * @internal
+ */
 export interface IShowNextResultResult {
 	/**
 	 * New rows needed to expand to show next results
@@ -34,6 +40,9 @@ interface ISearchLevelState {
 	index: number;
 }
 
+/**
+ * @internal
+ */
 export interface IInspectorSearchState {
 	abort?: boolean;
 	newMatchFound?: boolean;
@@ -47,10 +56,16 @@ export interface IInspectorSearchState {
 	childToParentMap: { [key: string]: string };
 }
 
+/**
+ * @internal
+ */
 export interface IInspectorSearchControls {
 	abortHandler: IInspectorSearchAbortHandler;
 	state: IInspectorSearchState;
 }
+/**
+ * @internal
+ */
 export interface IRowData<T = never> {
 	/**
 	 * The raw data to be visualized.
@@ -64,6 +79,9 @@ export interface IRowData<T = never> {
 	isNewDataRow?: boolean;
 }
 
+/**
+ * @internal
+ */
 export type IToTableRowsProps = Pick<
 	IInspectorTableProps,
 	| "dataCreationHandler"
@@ -73,6 +91,9 @@ export type IToTableRowsProps = Pick<
 	| "readOnly"
 >;
 
+/**
+ * @internal
+ */
 export interface IToTableRowsOptions {
 	depth: number;
 	addDummy: boolean;
@@ -81,11 +102,17 @@ export interface IToTableRowsOptions {
 	parentIsConstant?: boolean;
 }
 
+/**
+ * @internal
+ */
 export interface IPropertyToTableRowOptions extends Partial<IToTableRowsOptions> {
 	depth: number;
 	dataCreation: boolean;
 }
 
+/**
+ * @internal
+ */
 export interface IColumns {
 	dataGetter?: (params: IDataGetterParameter) => React.ReactNode | null;
 	key: string;
@@ -99,6 +126,7 @@ export interface IColumns {
 
 /**
  * The interface for an entry of the visualization data array.
+ * @internal
  */
 export interface IInspectorRow extends IRowData<BaseProxifiedProperty> {
 	context: string;
@@ -115,6 +143,7 @@ export interface IInspectorRow extends IRowData<BaseProxifiedProperty> {
 }
 /**
  * The interface for the cell data getter function parameter
+ * @internal
  */
 export interface IDataGetterParameter {
 	columns: IColumns[];
@@ -124,6 +153,9 @@ export interface IDataGetterParameter {
 	rowIndex: number;
 }
 
+/**
+ * @internal
+ */
 export interface IDataCreationOptions {
 	/**
 	 * The name that is shown in the table row that allows the creation of new data.
@@ -135,10 +167,16 @@ export interface IDataCreationOptions {
 	options?: any;
 }
 
+/**
+ * @internal
+ */
 export type IInspectorColumnsKeys = "name" | "type" | "value";
 
 type BaseTablePropsPartial<T> = Omit<BaseTableProps<T>, "columns">;
 
+/**
+ * @internal
+ */
 export interface IInspectorTableProps<T extends IRowData<T> = any>
 	extends BaseTablePropsPartial<T> {
 	/**
@@ -281,6 +319,9 @@ export interface IInspectorTableProps<T extends IRowData<T> = any>
 	columnsRenderers?: Record<string, (...props: any) => any>;
 }
 
+/**
+ * @internal
+ */
 export interface IInspectorSearchMatch {
 	/**
 	 * Index of column, containing match
@@ -293,6 +334,9 @@ export interface IInspectorSearchMatch {
 	rowId: string;
 }
 
+/**
+ * @internal
+ */
 export type IInspectorSearchCallback = (
 	foundMatches: IInspectorSearchMatch[],
 	matchesMap: IInspectorSearchMatchMap,
@@ -300,16 +344,28 @@ export type IInspectorSearchCallback = (
 	childToParentMap: { [key: string]: string },
 ) => void;
 
+/**
+ * @internal
+ */
 export type IInspectorSearchAbortHandler = () => void;
 
+/**
+ * @internal
+ */
 export interface IInspectorSearchMatchMap {
 	[key: string]: boolean[];
 }
 
+/**
+ * @internal
+ */
 export interface IExpandedMap {
 	[key: string]: boolean;
 }
 
+/**
+ * @internal
+ */
 export interface IInspectorTableState<T = any> {
 	childToParentMap: { [key: string]: string };
 	commitHistoryVisible?: boolean;
@@ -333,6 +389,9 @@ export interface IInspectorTableState<T = any> {
 	tableRows: T[];
 }
 
+/**
+ * @internal
+ */
 export interface ColumnRendererType {
 	rowData: IInspectorRow;
 	cellData: React.ReactNode | undefined;
@@ -346,6 +405,9 @@ export interface ColumnRendererType {
 	};
 }
 
+/**
+ * @internal
+ */
 export interface IEditableValueCellProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	/**
 	 * Indicates whether we are following references or not.

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/ModalManager.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/ModalManager.tsx
@@ -27,6 +27,9 @@ interface IModalContext<P = any> {
 	hideModal: () => void;
 	showModal: showModalSignature;
 }
+/**
+ * @internal
+ */
 export const ModalContext = React.createContext<IModalContext>({
 	closeHandler: undefined,
 	component: null,
@@ -39,6 +42,9 @@ export const ModalContext = React.createContext<IModalContext>({
 	},
 });
 
+/**
+ * @internal
+ */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export class ModalManager extends React.Component<{}, IModalContext> {
 	constructor(props) {
@@ -78,4 +84,7 @@ export class ModalManager extends React.Component<{}, IModalContext> {
 	};
 }
 
+/**
+ * @internal
+ */
 export const ModalConsumer = ModalContext.Consumer;

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/ModalRoot.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/ModalRoot.tsx
@@ -6,6 +6,9 @@
 import * as React from "react";
 import { ModalConsumer } from "./ModalManager";
 
+/**
+ * @internal
+ */
 export const ModalRoot: React.FunctionComponent = () => (
 	<ModalConsumer>
 		{({ component, props }) => {

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyDataCreationHandlers.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyDataCreationHandlers.ts
@@ -10,6 +10,9 @@ import { IDataCreationOptions, IInspectorRow } from "./InspectorTableTypes";
 
 const EXCLUDE_PROPS = ["BaseProperty", "Enum", "ContainerProperty"];
 
+/**
+ * @internal
+ */
 export const fetchRegisteredTemplates = () => {
 	const toTemplateList = (x: string) => ({ value: x, label: x });
 	// extract primitive templates
@@ -32,6 +35,9 @@ export const fetchRegisteredTemplates = () => {
 	return templates;
 };
 
+/**
+ * @internal
+ */
 export const handlePropertyDataCreationOptionGeneration = (
 	rowData: IInspectorRow,
 	nameOnly: boolean,
@@ -81,6 +87,9 @@ const createProperty = (name: string, typeid: string, context: string, parent: a
 	return parent.getProperty().getRoot().getWorkspace().commit();
 };
 
+/**
+ * @internal
+ */
 export const handlePropertyDataCreation = (
 	rowData: IInspectorRow,
 	name: string,

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/TypeColumn.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/TypeColumn.tsx
@@ -54,6 +54,9 @@ interface ITypeColumn {
 	rowData: IInspectorRow;
 }
 
+/**
+ * @internal
+ */
 export const TypeColumn: React.FunctionComponent<ITypeColumn> = ({ rowData }) => {
 	const classes = useStyles();
 	const mapTypeToColor = {
@@ -116,4 +119,7 @@ export const TypeColumn: React.FunctionComponent<ITypeColumn> = ({ rowData }) =>
 	);
 };
 
+/**
+ * @internal
+ */
 export const useChipStyles = useStyles;

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/icons.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/icons.tsx
@@ -29,6 +29,9 @@ const typeIdToColor = {
 	set: "#4679B9",
 };
 
+/**
+ * @internal
+ */
 export const typeidToIconMap = {
 	Array: <SvgIcon svgId={"array-24"} height={iconHeight} width={iconWidth} />,
 	Bool: <SvgIcon svgId={"boolean-24"} height={iconHeight} width={iconWidth} />,
@@ -61,6 +64,7 @@ export const typeidToIconMap = {
  * returns the icon corresponding to a typeid
  * @param inTypeid - the property typeid
  * @return the Svg Icon corresponding to the typeid in the map
+ * @internal
  */
 export const getIconFromTypeId = (inTypeid): React.ReactNode => {
 	if (inTypeid.includes("enum<")) {
@@ -76,6 +80,7 @@ export const getIconFromTypeId = (inTypeid): React.ReactNode => {
 /**
  * Returns the default inspector table icon based on the row data.
  * @param rowData - The row data.
+ * @internal
  */
 export const getDefaultInspectorTableIcons = (rowData: IInspectorRow): React.ReactNode => {
 	let icon;

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/propertyInspectorUtils.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/propertyInspectorUtils.tsx
@@ -53,8 +53,14 @@ const {
 	isReferenceMapProperty,
 } = Utils;
 
+/**
+ * @internal
+ */
 export const idSeparator = "/";
 
+/**
+ * @internal
+ */
 export const isPrimitive = memoize((typeid: string): boolean => {
 	return TypeIdHelper.isPrimitiveType(typeid);
 });
@@ -65,12 +71,18 @@ const getTypeid = memoize((property: BaseProperty): string => {
 		: property.getTypeid();
 });
 
+/**
+ * @internal
+ */
 export const getCollectionTypeid = memoize((property: BaseProperty): string => {
 	return isEnumArrayProperty(property)
 		? (property as any).getFullTypeid(true)
 		: property.getTypeid();
 });
 
+/**
+ * @internal
+ */
 export const getReferenceValue = (rowData: IInspectorRow) => {
 	const parentProp = rowData.parent! as ContainerProperty;
 	let path = "";
@@ -118,6 +130,9 @@ function editReferenceView({
 	);
 }
 
+/**
+ * @internal
+ */
 export const EditReferenceView = withStyles(styles)(editReferenceView);
 
 const getShortId = (parentPath: string, childId: string | undefined = undefined): string => {
@@ -195,6 +210,9 @@ const compareNameDesc = (a: string, b: string) => {
 	return compareName(a, b) * -1;
 };
 
+/**
+ * @internal
+ */
 export const dummyChild = {
 	children: undefined,
 	context: "d",
@@ -216,6 +234,9 @@ const OPTION_DEFAULTS = {
 	parentIsConstant: false,
 };
 
+/**
+ * @internal
+ */
 export const toTableRows = (
 	{ data, id = "" }: IInspectorRow,
 	props: IToTableRowsProps,
@@ -307,6 +328,7 @@ const createInvalidReference = (
 };
 /**
  * Construct a table row for an entry in a property that is not a collection.
+ * @internal
  */
 
 export const singlePropertyTableRow = (
@@ -412,6 +434,7 @@ export const singlePropertyTableRow = (
 };
 /**
  * Construct a table row for an entry in a collection property.
+ * @internal
  */
 
 export const collectionChildTableRow = (
@@ -568,10 +591,16 @@ export const collectionChildTableRow = (
 	return newRow;
 };
 
+/**
+ * @internal
+ */
 export interface ISanitizer {
 	searchFor: RegExp;
 	replaceWith: string;
 }
+/**
+ * @internal
+ */
 export const sanitizePath = (inPath: string, sanitizer: ISanitizer[]) => {
 	let outPath = inPath;
 	sanitizer.forEach((replaceCase) => {
@@ -580,6 +609,9 @@ export const sanitizePath = (inPath: string, sanitizer: ISanitizer[]) => {
 	return outPath;
 };
 
+/**
+ * @internal
+ */
 export const expandAll = (proxyNode: BaseProxifiedProperty) => {
 	const expanded: IExpandedMap = {};
 	const root = proxyNode.getProperty().getRoot();
@@ -595,6 +627,9 @@ export const expandAll = (proxyNode: BaseProxifiedProperty) => {
 	return expanded;
 };
 
+/**
+ * @internal
+ */
 export const fillExpanded = (
 	expanded: IExpandedMap,
 	innerRows: IInspectorRow[],
@@ -639,6 +674,7 @@ const invalidReference = (parentProxy: BaseProxifiedProperty, id: string | numbe
  * @param parent - The parent of the property in question.
  * @param id - The id of the child property that we want to extract the value from.
  * @return The property value.
+ * @internal
  */
 
 export const getPropertyValue = (
@@ -722,6 +758,9 @@ export const getPropertyValue = (
 	return determinedValue;
 };
 
+/**
+ * @internal
+ */
 export const handleReferencePropertyEdit = async (rowData: IInspectorRow, newPath: string) => {
 	const parentProp = rowData!.parent!;
 	if (Utils.isReferenceArrayProperty(parentProp) || Utils.isReferenceMapProperty(parentProp)) {
@@ -753,6 +792,9 @@ export const handleReferencePropertyEdit = async (rowData: IInspectorRow, newPat
 	parentProp!.getRoot().getWorkspace()!.commit();
 };
 
+/**
+ * @internal
+ */
 export const generateForm = (rowData: IInspectorRow, handleCreateData: any) => {
 	if (rowData.parent!.getContext() === "array" && rowData.parent!.isPrimitiveType()) {
 		handleCreateData(rowData, "", rowData.parent!.getTypeid(), "single");
@@ -762,6 +804,9 @@ export const generateForm = (rowData: IInspectorRow, handleCreateData: any) => {
 };
 
 // @TODO: Revisit method arguments
+/**
+ * @internal
+ */
 export function nameCellRenderer({
 	rowData,
 	cellData,
@@ -796,6 +841,9 @@ export function nameCellRenderer({
 }
 
 // @TODO: Revisit method arguments
+/**
+ * @internal
+ */
 export function typeCellRenderer({
 	rowData,
 	tableProps,
@@ -862,6 +910,9 @@ const determineCellClassName = (
 };
 
 // @TODO: Revisit method arguments
+/**
+ * @internal
+ */
 export function valueCellRenderer({
 	rowData,
 	cellData,
@@ -901,6 +952,9 @@ export function valueCellRenderer({
 	}
 }
 
+/**
+ * @internal
+ */
 export const addDataForm = ({
 	handleCancelCreate,
 	handleCreateData,
@@ -918,6 +972,9 @@ export const addDataForm = ({
 	</div>
 );
 
+/**
+ * @internal
+ */
 export const getDefaultPropertyTableProps = () => ({
 	editReferenceHandler: handleReferencePropertyEdit,
 	followReferences: true,

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/utils.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/utils.tsx
@@ -29,6 +29,7 @@ import { fillExpanded as defaultFillExpanded } from "./propertyInspectorUtils";
  * @param filteredExpanded - List of hashes of nodes, which have to be expanded to make matching elements visible
  * @param allMatches - List of @type{IInspectorSearchMatch} containing information about matching rows
  * @param resultIndex - Index of desired matching item, starting from 0
+ * @internal
  */
 export const showNextResult = (
 	data: IInspectorRow[],
@@ -148,6 +149,7 @@ const updateHandler = (
  * Users don't need to mind this.
  * @return An object that gives access to the search state and abort handler. While the state object needs to be passed
  * to future search calls, the abort handler is a function that can be used to abort the search process at any time.
+ * @internal
  */
 export const search = (
 	searchExpression: string,

--- a/experimental/PropertyDDS/packages/property-properties/src/enableValidations.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/enableValidations.ts
@@ -12,6 +12,7 @@ export let validationsEnabled = {
  * the tree, etc...)
  *
  * @param enabled - Are the validations enabled?
+ * @internal
  */
 export function enableValidations(enabled: boolean) {
 	validationsEnabled.enabled = enabled;

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -147,6 +147,9 @@ var _getLongestIncreasingSubsequenceSegments = function (in_segmentStarts, in_se
 	return longestSequence;
 };
 
+/**
+ * @internal
+ */
 export class ArrayProperty extends AbstractStaticCollectionProperty {
 	/**
 	 * Default constructor for ArrayProperty

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/baseProperty.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/baseProperty.ts
@@ -100,6 +100,7 @@ interface ISerializeOptions {
  * Thus, with the filtering options, it is NOT possible to prevent a part of a ChangeSet from being
  * processed (in `applyChangeSet()` for example), it is NOT possible to prevent a property from being
  * created by a direct call to a function like `deserialize()` or `createProperty()`.
+ * @internal
  */
 export abstract class BaseProperty {
 	protected _id: string | undefined;

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/containerProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/containerProperty.js
@@ -16,6 +16,7 @@ const { IndexedCollectionBaseProperty } = require("./indexedCollectionBaseProper
 
 /**
  * A property object that allows to add child properties dynamically.
+ * @internal
  */
 export class ContainerProperty extends IndexedCollectionBaseProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/enumArrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/enumArrayProperty.js
@@ -14,6 +14,7 @@ const { ValueArrayProperty } = require("./valueArrayProperty");
  * efficient and convenient. Additionally, we provide direct access
  * methods to the enums in the array, e.g. .getEnumString(3) directly
  * returns the enum string at position 3 of the array
+ * @internal
  */
 export class EnumArrayProperty extends ValueArrayProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/enumProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/enumProperty.js
@@ -16,6 +16,7 @@ const { ValueProperty } = require("./valueProperty");
 
 /**
  * A primitive property for enums.
+ * @internal
  */
 export class EnumProperty extends Int32Property {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/intProperties.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/intProperties.js
@@ -273,6 +273,7 @@ export class Integer64Property extends ValueProperty {
 
 /**
  * A primitive property class for big signed integer values.
+ * @internal
  */
 export class Int64Property extends Integer64Property {
 	/**
@@ -292,6 +293,7 @@ Int64Property.prototype._castFunctor = _castFunctors.Int64;
 
 /**
  * A primitive property class for big unsingned integer values.
+ * @internal
  */
 export class Uint64Property extends Integer64Property {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
@@ -26,6 +26,7 @@ const PATH_TOKENS = BaseProperty.PATH_TOKENS;
 
 /**
  * A MapProperty is a collection class that can contain an dictionary that maps from strings to properties.
+ * @internal
  */
 export class MapProperty extends IndexedCollectionBaseProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/nodeProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/nodeProperty.js
@@ -10,6 +10,7 @@ const { ContainerProperty } = require("./containerProperty");
 
 /**
  * A property object that allows to add child properties dynamically.
+ * @internal
  */
 export class NodeProperty extends ContainerProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/referenceArrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/referenceArrayProperty.js
@@ -16,6 +16,7 @@ const { ValueArrayProperty } = require("./valueArrayProperty");
 
 /**
  * An ArrayProperty which stores reference values
+ * @internal
  */
 export class ReferenceArrayProperty extends ValueArrayProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/referenceMapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/referenceMapProperty.js
@@ -15,6 +15,7 @@ const { StringMapProperty } = require("./valueMapProperty");
 
 /**
  * A StringMapProperty which stores reference values
+ * @internal
  */
 export class ReferenceMapProperty extends StringMapProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/referenceProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/referenceProperty.js
@@ -19,6 +19,7 @@ const { ValueProperty } = require("./valueProperty");
  * object's value field. To do this we simply keep a pointer to the object and
  * it's associated data field that we are interested in. If no data field is
  * present this property will have an undefined value.
+ * @internal
  */
 export class ReferenceProperty extends ValueProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
@@ -20,6 +20,7 @@ var PATH_TOKENS = BaseProperty.PATH_TOKENS;
 /**
  * A SetProperty is a collection class that can contain an unordered set of properties. These properties
  * must derive from NamedProperty and their URN is used to identify them within the set.
+ * @internal
  */
 export class SetProperty extends IndexedCollectionBaseProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
@@ -55,6 +55,7 @@ var STRING_PROPERTY_SET_PROPERTY_VALUE_STATE_FLAGS = [
 
 /**
  * A primitive property for a string value.
+ * @internal
  */
 export class StringProperty extends ValueArrayProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/valueArrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/valueArrayProperty.js
@@ -23,6 +23,7 @@ const { BaseProperty } = require("./baseProperty");
 
 /**
  * An array property which stores primitive values
+ * @internal
  */
 export class ValueArrayProperty extends ArrayProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/valueMapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/valueMapProperty.js
@@ -17,6 +17,7 @@ const { MapProperty } = require("./mapProperty");
 
 /**
  * A ValueMapProperty is a collection class that can contain an dictionary that maps from strings to primitive types.
+ * @internal
  */
 export class ValueMapProperty extends MapProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/valueProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/valueProperty.js
@@ -11,6 +11,7 @@ const { BaseProperty } = require("./baseProperty");
  * object's value field. To do this we simply keep a pointer to the object and
  * its associated data field that we are interested in. If no data field is
  * present this property will fail constructing.
+ * @internal
  */
 export class ValueProperty extends BaseProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
@@ -2454,6 +2454,9 @@ class PropertyFactory {
 	}
 }
 
+/**
+ * @internal
+ */
 const PropertyFactorySingleton = new PropertyFactory();
 export { PropertyFactorySingleton as PropertyFactory };
 

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyTemplate.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyTemplate.js
@@ -13,6 +13,9 @@ const deepCopy = fastestJSONCopy.copy;
 const { ConsoleUtils } = require("@fluid-experimental/property-common");
 const { MSG } = require("@fluid-experimental/property-common").constants;
 
+/**
+ * @internal
+ */
 export class PropertyTemplate {
 	/**
 	 * Constructor for creating a PropertyTemplate based on the given parameters.
@@ -331,8 +334,6 @@ export class PropertyTemplate {
 	 * @param {object} in_param - Parameter to assess
 	 *
 	 * @return {Boolean} true if in_param is a template
-	 *
-	 * @public
 	 */
 	static isTemplate(in_param) {
 		if (in_param.typeid && in_param.typeid.indexOf(":") !== -1) {
@@ -347,8 +348,6 @@ export class PropertyTemplate {
 	 * @param {object} template - Structure from which to extract dependencies
 	 *
 	 * @return {Array} List of typeids this template refers directly to
-	 *
-	 * @public
 	 */
 	static extractDependencies(template) {
 		var dependencies = {};

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyUtils.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyUtils.js
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @internal
+ */
 export class PropertyUtils {
 	/**
 	 * Gather all properties that pass an arbitrary predicate function

--- a/experimental/PropertyDDS/packages/property-proxy/src/IParentAndPathOfReferencedProperty.ts
+++ b/experimental/PropertyDDS/packages/property-proxy/src/IParentAndPathOfReferencedProperty.ts
@@ -7,6 +7,7 @@ import { BaseProperty } from "@fluid-experimental/property-properties";
 
 /**
  * Returned only from the [[PropertyProxy]].[[getParentOfReferencedProperty]] method.
+ * @internal
  */
 export interface IParentAndPathOfReferencedProperty {
 	/**

--- a/experimental/PropertyDDS/packages/property-proxy/src/interfaces.ts
+++ b/experimental/PropertyDDS/packages/property-proxy/src/interfaces.ts
@@ -17,27 +17,48 @@ import {
 	ReferenceMapProperty,
 } from "@fluid-experimental/property-properties";
 
+/**
+ * @internal
+ */
 export abstract class ProxifiedPropertyValueArray {
 	public abstract getProperty(): ValueArrayProperty;
 	public abstract swap(index0: number, index1: number);
 }
+/**
+ * @internal
+ */
 export abstract class BaseProxifiedProperty<T = BaseProperty> {
 	public abstract getProperty(input?: any): T;
 }
+/**
+ * @internal
+ */
 export abstract class ProxifiedArrayProperty extends Array {
 	public abstract getProperty(): ArrayProperty;
 	public abstract swap(index0: number, index1: number);
 }
+/**
+ * @internal
+ */
 export abstract class ProxifiedSetProperty extends Set {
 	public abstract getProperty(): BaseProperty;
 }
+/**
+ * @internal
+ */
 export abstract class ProxifiedMapProperty extends Map {
 	public abstract getProperty(): MapProperty;
 }
+/**
+ * @internal
+ */
 export type GenericProxify<TProperty> = {
 	[P in keyof TProperty]: ProxyType<TProperty[P]>;
 };
 
+/**
+ * @internal
+ */
 export type ProxyType<TProperty> = TProperty extends ContainerProperty
 	? BaseProxifiedProperty<ContainerProperty> & { [key: string]: any }
 	: TProperty extends ValueProperty
@@ -54,14 +75,26 @@ export type ProxyType<TProperty> = TProperty extends ContainerProperty
 	? ProxifiedSetProperty
 	: GenericProxify<TProperty>;
 
+/**
+ * @internal
+ */
 export type CollectionTypes =
 	| ValueArrayProperty
 	| ArrayProperty
 	| MapProperty
 	| ValueMapProperty
 	| SetProperty;
+/**
+ * @internal
+ */
 export type PrimitiveTypes = ValueProperty;
+/**
+ * @internal
+ */
 export type PropertyTypes = BaseProperty | ContainerProperty | PrimitiveTypes | CollectionTypes;
 export type NonPrimitiveTypes = ContainerProperty | CollectionTypes;
 
+/**
+ * @internal
+ */
 export type ReferenceType = ReferenceProperty | ReferenceArrayProperty | ReferenceMapProperty;

--- a/experimental/PropertyDDS/packages/property-proxy/src/propertyProxy.ts
+++ b/experimental/PropertyDDS/packages/property-proxy/src/propertyProxy.ts
@@ -28,14 +28,14 @@ import { ProxyType, PropertyTypes, ReferenceType } from "./interfaces";
 
 /**
  * This symbol is available on properties proxied via {@link PropertyProxy.proxify}.
+ * @internal
  */
 export const proxySymbol = Symbol("property-proxy");
 
 /**
  * Namespace that contains the {@link PropertyProxy.proxify} and {@link PropertyProxy.getParentOfReferencedProperty}
  * functions.
- *
- * @public
+ * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PropertyProxy {
@@ -43,7 +43,7 @@ export namespace PropertyProxy {
 	 * This utility function returns the parent property of a referenced property.
 	 * @param property - The ReferenceProperty/ReferenceArrayProperty/ReferenceMapProperty.
 	 * @param key - The key of the referenced property in the Reference(Array/Map)Property.
-	 * @public
+	 * @internal
 	 */
 	export function getParentOfReferencedProperty(
 		property: ReferenceType,
@@ -143,8 +143,7 @@ export namespace PropertyProxy {
 	 * @param property - The BaseProperty to be proxied.
 	 *
 	 * @returns The newly created proxy if `property` is of a non-primitive type otherwise the value.
-	 *
-	 * @public
+	 * @internal
 	 */
 	export function proxify<T extends PropertyTypes>(property: T): ProxyType<T> {
 		if (PropertyFactory.instanceOf(property, "BaseProperty")) {

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -335,6 +335,7 @@ const builtinLibrary = builtinBuilder.intoLibrary();
  * @param extraTypes - The extra types which can't be found when traversing across
  * the PropertyDDS schema inheritances / dependencies starting from
  * the root schema or built-in node property schemas.
+ * @internal
  */
 export function convertPropertyToSharedTreeSchema<Kind extends FieldKind = FieldKind>(
 	rootFieldKind: Kind,

--- a/experimental/dds/attributable-map/api-report/attributable-map.api.md
+++ b/experimental/dds/attributable-map/api-report/attributable-map.api.md
@@ -20,12 +20,12 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
-// @public
+// @internal
 export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
     [Symbol.iterator](): IterableIterator<[string, any]>;
     readonly [Symbol.toStringTag]: string;
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    // @internal (undocumented)
+    // (undocumented)
     protected applyStashedOp(content: unknown): unknown;
     clear(): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): AttributableMap;
@@ -38,70 +38,70 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
     static getFactory(): IChannelFactory;
     has(key: string): boolean;
     keys(): IterableIterator<string>;
-    // @internal (undocumented)
+    // (undocumented)
     protected loadCore(storage: IChannelStorageService): Promise<void>;
-    // @internal (undocumented)
+    // (undocumented)
     protected onDisconnect(): void;
-    // @internal (undocumented)
+    // (undocumented)
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    // @internal (undocumented)
+    // (undocumented)
     protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
-    // @internal (undocumented)
+    // (undocumented)
     protected rollback(content: unknown, localOpMetadata: unknown): void;
     set(key: string, value: unknown): this;
     get size(): number;
-    // @internal (undocumented)
+    // (undocumented)
     protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     values(): IterableIterator<any>;
 }
 
-// @public
+// @internal
 export interface ILocalValue {
     makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle, attribution?: AttributionKey | number): ISerializedValue;
     readonly type: string;
     readonly value: any;
 }
 
-// @public @deprecated
+// @internal @deprecated
 export interface ISerializableValue {
     attribution?: AttributionKey | number;
     type: string;
     value: any;
 }
 
-// @public
+// @internal
 export interface ISerializedValue {
     attribution?: string;
     type: string;
     value: string | undefined;
 }
 
-// @public
+// @internal
 export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
     get<T = any>(key: string): T | undefined;
     set<T = unknown>(key: string, value: T): this;
 }
 
-// @public
+// @internal
 export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @public
+// @internal
 export interface IValueChanged {
     key: string;
     previousValue: any;
 }
 
-// @public
+// @internal
 export class LocalValueMaker {
     constructor(serializer: IFluidSerializer);
     fromInMemory(value: unknown): ILocalValue;
     fromSerializable(serializable: ISerializableValue): ILocalValue;
 }
 
-// @public @sealed
+// @internal @sealed
 export class MapFactory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;

--- a/experimental/dds/attributable-map/src/interfaces.ts
+++ b/experimental/dds/attributable-map/src/interfaces.ts
@@ -8,8 +8,7 @@ import { IEventThisPlaceHolder } from "@fluidframework/core-interfaces";
 import { AttributionKey } from "@fluidframework/runtime-definitions";
 /**
  * Type of "valueChanged" event parameter.
- *
- * @public
+ * @internal
  */
 export interface IValueChanged {
 	/**
@@ -27,8 +26,7 @@ export interface IValueChanged {
 
 /**
  * Events emitted in response to changes to the {@link ISharedMap | map} data.
- *
- * @public
+ * @internal
  */
 export interface ISharedMapEvents extends ISharedObjectEvents {
 	/**
@@ -67,8 +65,7 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
  * {@link @fluidframework/datastore#FluidObjectHandle}.
  *
  * For more information, including example usages, see {@link https://fluidframework.com/docs/data-structures/map/}.
- *
- * @public
+ * @internal
  */
 // TODO: Use `unknown` instead (breaking change).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -113,8 +110,7 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
  * channel ID.
  *
  * @deprecated This type is legacy and deprecated.
- *
- * @public
+ * @internal
  */
 export interface ISerializableValue {
 	/**
@@ -136,8 +132,7 @@ export interface ISerializableValue {
 
 /**
  * Serialized {@link ISerializableValue} counterpart.
- *
- * @public
+ * @internal
  */
 export interface ISerializedValue {
 	/**

--- a/experimental/dds/attributable-map/src/localValues.ts
+++ b/experimental/dds/attributable-map/src/localValues.ts
@@ -17,8 +17,7 @@ import { ISerializableValue, ISerializedValue } from "./interfaces";
 
 /**
  * A local value to be stored in a container type Distributed Data Store (DDS).
- *
- * @public
+ * @internal
  */
 export interface ILocalValue {
 	/**
@@ -110,8 +109,7 @@ export class PlainLocalValue implements ILocalValue {
 /**
  * Enables a container type {@link https://fluidframework.com/docs/build/dds/ | DDS} to produce and store local
  * values with minimal awareness of how those objects are stored, serialized, and deserialized.
- *
- * @public
+ * @internal
  */
 export class LocalValueMaker {
 	/**

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -34,7 +34,7 @@ const snapshotFileName = "header";
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link AttributableMap}.
  *
  * @sealed
- * @public
+ * @internal
  */
 export class MapFactory implements IChannelFactory {
 	/**
@@ -93,8 +93,7 @@ export class MapFactory implements IChannelFactory {
 
 /**
  * {@inheritDoc ISharedMap}
- *
- * @public
+ * @internal
  */
 export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
 	/**
@@ -274,7 +273,6 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.summarizeCore}
-	 * @internal
 	 */
 	protected summarizeCore(
 		serializer: IFluidSerializer,
@@ -367,7 +365,6 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.loadCore}
-	 * @internal
 	 */
 	protected async loadCore(storage: IChannelStorageService): Promise<void> {
 		const json = await readAndParse<object>(storage, snapshotFileName);
@@ -387,13 +384,11 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.onDisconnect}
-	 * @internal
 	 */
 	protected onDisconnect(): void {}
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.reSubmitCore}
-	 * @internal
 	 */
 	protected reSubmitCore(content: unknown, localOpMetadata: unknown): void {
 		this.kernel.trySubmitMessage(content as IMapOperation, localOpMetadata);
@@ -401,7 +396,6 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObjectCore.applyStashedOp}
-	 * @internal
 	 */
 	protected applyStashedOp(content: unknown): unknown {
 		return this.kernel.tryApplyStashedOp(content as IMapOperation);
@@ -409,7 +403,6 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processCore}
-	 * @internal
 	 */
 	protected processCore(
 		message: ISequencedDocumentMessage,
@@ -423,7 +416,6 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.rollback}
-	 * @internal
 	 */
 	protected rollback(content: unknown, localOpMetadata: unknown): void {
 		this.kernel.rollback(content, localOpMetadata);

--- a/experimental/dds/ot/ot/api-report/ot.api.md
+++ b/experimental/dds/ot/ot/api-report/ot.api.md
@@ -12,7 +12,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
-// @public (undocumented)
+// @internal (undocumented)
 export abstract class SharedOT<TState, TOp> extends SharedObject {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, initialValue: TState);
     // (undocumented)

--- a/experimental/dds/ot/ot/src/ot.ts
+++ b/experimental/dds/ot/ot/src/ot.ts
@@ -25,7 +25,7 @@ interface ISequencedOpInfo<TOp> {
 }
 
 /**
- * @public
+ * @internal
  */
 export abstract class SharedOT<TState, TOp> extends SharedObject {
 	/**

--- a/experimental/dds/ot/sharejs/json1/api-report/sharejs-json1.api.md
+++ b/experimental/dds/ot/sharejs/json1/api-report/sharejs-json1.api.md
@@ -15,7 +15,7 @@ import { Path } from 'ot-json1';
 import { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedOT } from '@fluid-experimental/ot';
 
-// @public (undocumented)
+// @internal (undocumented)
 export class Json1Factory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -31,7 +31,7 @@ export class Json1Factory implements IChannelFactory {
     get type(): string;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export class SharedJson1 extends SharedOT<Doc, JSONOp> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // (undocumented)

--- a/experimental/dds/ot/sharejs/json1/src/factory.ts
+++ b/experimental/dds/ot/sharejs/json1/src/factory.ts
@@ -14,7 +14,7 @@ import { pkgVersion } from "./packageVersion";
 import { SharedJson1 } from "./json1";
 
 /**
- * @public
+ * @internal
  */
 export class Json1Factory implements IChannelFactory {
 	public static Type = "https://graph.microsoft.com/types/sharedjson1";

--- a/experimental/dds/ot/sharejs/json1/src/json1.ts
+++ b/experimental/dds/ot/sharejs/json1/src/json1.ts
@@ -22,7 +22,7 @@ import {
 import { Json1Factory } from "./factory";
 
 /**
- * @public
+ * @internal
  */
 export class SharedJson1 extends SharedOT<Doc, JSONOp> {
 	public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedJson1 {

--- a/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
+++ b/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
@@ -23,25 +23,25 @@ import { SubSequence } from '@fluidframework/sequence';
 
 export { IJSONRunSegment }
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export type MatrixSegment = RunSegment | PaddingSegment;
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export const maxCellPosition: number;
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export const maxCol = 2097152;
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export const maxCols: number;
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export const maxRow = 4294967295;
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export const maxRows: number;
 
-// @public @deprecated
+// @internal @deprecated
 export class PaddingSegment extends BaseSegment {
     constructor(size: number);
     // (undocumented)
@@ -71,16 +71,16 @@ export class PaddingSegment extends BaseSegment {
     static readonly typeString = "PaddingSegment";
 }
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export function positionToRowCol(position: number): {
     row: number;
     col: number;
 };
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export const rowColToPosition: (row: number, col: number) => number;
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export class RunSegment extends SubSequence<SparseMatrixItem> {
     constructor(items: SparseMatrixItem[]);
     // (undocumented)
@@ -107,7 +107,7 @@ export class RunSegment extends SubSequence<SparseMatrixItem> {
     static readonly typeString = "RunSegment";
 }
 
-// @public @deprecated
+// @internal @deprecated
 export class SharedNumberSequence extends SharedSequence<number> {
     // @deprecated
     constructor(document: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes);
@@ -121,7 +121,7 @@ export class SharedNumberSequence extends SharedSequence<number> {
     id: string;
 }
 
-// @public @deprecated
+// @internal @deprecated
 export class SharedObjectSequence<T> extends SharedSequence<T> {
     // @deprecated
     constructor(document: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes);
@@ -137,7 +137,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
 
 export { SharedSequence }
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     constructor(document: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes);
     // (undocumented)
@@ -169,7 +169,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     setTag(row: number, col: number, tag: any): void;
 }
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export class SparseMatrixFactory implements IChannelFactory {
     // (undocumented)
     static Attributes: IChannelAttributes;
@@ -187,7 +187,7 @@ export class SparseMatrixFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @public @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export type SparseMatrixItem = Serializable;
 
 export { SubSequence }

--- a/experimental/dds/sequence-deprecated/src/sharedNumberSequence.ts
+++ b/experimental/dds/sequence-deprecated/src/sharedNumberSequence.ts
@@ -15,6 +15,7 @@ import { SharedSequence } from "./sharedSequence";
  *
  * @deprecated SharedNumberSequence is not recommended for use and will be removed in an upcoming release.
  * For more info, please see {@link https://github.com/microsoft/FluidFramework/issues/8526 | Github issue 8526}.
+ * @internal
  */
 export class SharedNumberSequence extends SharedSequence<number> {
 	/**

--- a/experimental/dds/sequence-deprecated/src/sharedObjectSequence.ts
+++ b/experimental/dds/sequence-deprecated/src/sharedObjectSequence.ts
@@ -19,6 +19,7 @@ import { SharedSequence } from "./sharedSequence";
  *
  * @deprecated SharedObjectSequence is not recommended for use and will be removed in an upcoming release.
  * For more info, please see {@link https://github.com/microsoft/FluidFramework/issues/8526 | Github issue 8526}.
+ * @internal
  */
 export class SharedObjectSequence<T> extends SharedSequence<T> {
 	/**

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -25,6 +25,7 @@ import { SubSequence } from "./sharedSequence";
  *
  * @deprecated `PaddingSegment` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export class PaddingSegment extends BaseSegment {
 	public static readonly typeString = "PaddingSegment";
@@ -89,12 +90,14 @@ export class PaddingSegment extends BaseSegment {
 /**
  * @deprecated `SparseMatrixItem` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export type SparseMatrixItem = Serializable;
 
 /**
  * @deprecated `RunSegment` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export class RunSegment extends SubSequence<SparseMatrixItem> {
 	public static readonly typeString = "RunSegment";
@@ -176,48 +179,56 @@ export class RunSegment extends SubSequence<SparseMatrixItem> {
 /**
  * @deprecated `MatrixSegment` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export type MatrixSegment = RunSegment | PaddingSegment;
 
 /**
  * @deprecated `maxCol` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export const maxCol = 0x200000; // X128 Excel maximum of 16,384 columns
 
 /**
  * @deprecated `maxCols` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export const maxCols = maxCol + 1;
 
 /**
  * @deprecated `maxRow` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export const maxRow = 0xffffffff; // X4096 Excel maximum of 1,048,576 rows
 
 /**
  * @deprecated `maxRows` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export const maxRows = maxRow + 1;
 
 /**
  * @deprecated `maxCellPosition` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export const maxCellPosition = maxCol * maxRow;
 
 /**
  * @deprecated `positionToRowCol` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export const rowColToPosition = (row: number, col: number) => row * maxCols + col;
 
 /**
  * @deprecated `positionToRowCol` is part of an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export function positionToRowCol(position: number) {
 	const row = Math.floor(position / maxCols);
@@ -228,6 +239,7 @@ export function positionToRowCol(position: number) {
 /**
  * @deprecated `SparseMatrix` is an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
+ * @internal
  */
 export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 	/**
@@ -363,6 +375,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 /**
  * @deprecated `SparseMatrixFactory` is an abandoned prototype.
  * Use {@link @fluidframework/matrix#SharedMatrixFactory} instead.
+ * @internal
  */
 export class SparseMatrixFactory implements IChannelFactory {
 	public static Type = "https://graph.microsoft.com/types/mergeTree/sparse-matrix";

--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -31,19 +31,19 @@ import { SharedObject } from '@fluidframework/shared-object-base';
 import { TreeFactory } from '@fluid-experimental/tree2';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
-// @public
+// @internal
 export function areRevisionViewsSemanticallyEqual(treeViewA: TreeView, idConverterA: NodeIdConverter, treeViewB: TreeView, idConverterB: NodeIdConverter): boolean;
 
-// @public
+// @internal
 export type AttributionId = UuidString;
 
-// @public
+// @internal
 export type BadPlaceValidationResult = Exclude<PlaceValidationResult, PlaceValidationResult.Valid>;
 
-// @public
+// @internal
 export type BadRangeValidationResult = Exclude<RangeValidationResult, RangeValidationResultKind.Valid>;
 
-// @public
+// @internal
 export interface Build {
     // (undocumented)
     readonly destination: number;
@@ -53,13 +53,13 @@ export interface Build {
     readonly type: typeof ChangeType.Build;
 }
 
-// @public
+// @internal
 export interface BuildInternal extends Omit<BuildInternal_0_0_2, 'source'> {
     // (undocumented)
     readonly source: TreeNodeSequence<BuildNodeInternal>;
 }
 
-// @public
+// @internal
 export interface BuildInternal_0_0_2 {
     // (undocumented)
     readonly destination: DetachedSequenceId;
@@ -69,16 +69,16 @@ export interface BuildInternal_0_0_2 {
     readonly type: typeof ChangeTypeInternal.Build;
 }
 
-// @public
+// @internal
 export type BuildNode = BuildTreeNode | number;
 
-// @public
+// @internal
 export type BuildNodeInternal = TreeNode<BuildNodeInternal, NodeId> | DetachedSequenceId;
 
-// @public
+// @internal
 export type BuildNodeInternal_0_0_2 = TreeNode<BuildNodeInternal_0_0_2, StableNodeId> | DetachedSequenceId;
 
-// @public
+// @internal
 export interface BuildTreeNode extends HasVariadicTraits<BuildNode> {
     // (undocumented)
     definition: string;
@@ -88,10 +88,10 @@ export interface BuildTreeNode extends HasVariadicTraits<BuildNode> {
     payload?: Payload;
 }
 
-// @public
+// @internal
 export type Change = Insert | Detach | Build | SetValue | Constraint;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const Change: {
     build: (source: BuildNode | TreeNodeSequence<BuildNode>, destination: number) => Build;
     insert: (source: number, destination: StablePlace) => Insert;
@@ -104,10 +104,10 @@ export const Change: {
     move: (source: StableRange, destination: StablePlace) => Change[];
 };
 
-// @public
+// @internal
 export type ChangeInternal = InsertInternal | DetachInternal | BuildInternal | SetValueInternal | ConstraintInternal;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const ChangeInternal: {
     build: (source: TreeNodeSequence<BuildNodeInternal>, destination: DetachedSequenceId) => BuildInternal;
     insert: (source: DetachedSequenceId, destination: StablePlaceInternal) => InsertInternal;
@@ -120,16 +120,16 @@ export const ChangeInternal: {
     move: (source: StableRangeInternal, destination: StablePlaceInternal) => ChangeInternal[];
 };
 
-// @public
+// @internal
 export type ChangeNode = TreeNode<ChangeNode, NodeId>;
 
-// @public
+// @internal
 export type ChangeNode_0_0_2 = TreeNode<ChangeNode_0_0_2, StableNodeId>;
 
-// @public
+// @internal
 export type ChangeResult = Result<TransactionView, TransactionFailure>;
 
-// @public
+// @internal
 export enum ChangeType {
     // (undocumented)
     Build = 2,
@@ -143,7 +143,7 @@ export enum ChangeType {
     SetValue = 3
 }
 
-// @public
+// @internal
 export enum ChangeTypeInternal {
     // (undocumented)
     Build = 2,
@@ -159,7 +159,7 @@ export enum ChangeTypeInternal {
     SetValue = 3
 }
 
-// @public
+// @internal
 export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEvents> implements IDisposable {
     protected constructor(tree: SharedTree, currentView: RevisionView, onEditCommitted: EditCommittedHandler);
     abortEdit(): void;
@@ -179,7 +179,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
     // (undocumented)
     getEditStatus(): EditStatus;
     protected handleNewEdit(id: EditId, result: ValidEditingResult): void;
-    // @internal (undocumented)
+    // (undocumented)
     hasOpenEdit(): boolean;
     protected hintKnownEditingResult(edit: Edit<ChangeInternal>, result: ValidEditingResult): void;
     protected abstract get latestCommittedView(): RevisionView;
@@ -199,18 +199,18 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
     abstract waitForPendingUpdates(): Promise<void>;
 }
 
-// @public
+// @internal
 export enum CheckoutEvent {
     ViewChange = "viewChange"
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export function comparePayloads(a: Payload, b: Payload): boolean;
 
-// @public
+// @internal
 export type CompressedId = FinalCompressedId | LocalCompressedId;
 
-// @public
+// @internal
 export interface Constraint {
     readonly contentHash?: UuidString;
     readonly effect: ConstraintEffect;
@@ -222,20 +222,20 @@ export interface Constraint {
     readonly type: typeof ChangeType.Constraint;
 }
 
-// @public
+// @internal
 export enum ConstraintEffect {
     InvalidAndDiscard = 0,
     InvalidRetry = 1,
     ValidRetry = 2
 }
 
-// @public
+// @internal
 export interface ConstraintInternal extends Omit<ConstraintInternal_0_0_2, 'toConstrain' | 'parentNode'> {
     readonly parentNode?: NodeId;
     readonly toConstrain: StableRangeInternal;
 }
 
-// @public
+// @internal
 export interface ConstraintInternal_0_0_2 {
     readonly contentHash?: UuidString;
     readonly effect: ConstraintEffect;
@@ -247,19 +247,19 @@ export interface ConstraintInternal_0_0_2 {
     readonly type: typeof ChangeTypeInternal.Constraint;
 }
 
-// @public
+// @internal
 export type Definition = UuidString & {
     readonly Definition: 'c0ef9488-2a78-482d-aeed-37fba996354c';
 };
 
-// @public
+// @internal
 export interface Delta<NodeId> {
     readonly added: readonly NodeId[];
     readonly changed: readonly NodeId[];
     readonly removed: readonly NodeId[];
 }
 
-// @public
+// @internal
 export interface Detach {
     // (undocumented)
     readonly destination?: number;
@@ -269,18 +269,18 @@ export interface Detach {
     readonly type: typeof ChangeType.Detach;
 }
 
-// @public
+// @internal
 export type DetachedSequenceId = number & {
     readonly DetachedSequenceId: 'f7d7903a-194e-45e7-8e82-c9ef4333577d';
 };
 
-// @public
+// @internal
 export interface DetachInternal extends Omit<DetachInternal_0_0_2, 'source'> {
     // (undocumented)
     readonly source: StableRangeInternal;
 }
 
-// @public
+// @internal
 export interface DetachInternal_0_0_2 {
     // (undocumented)
     readonly destination?: DetachedSequenceId;
@@ -290,7 +290,7 @@ export interface DetachInternal_0_0_2 {
     readonly type: typeof ChangeTypeInternal.Detach;
 }
 
-// @public @sealed
+// @internal @sealed
 export class EagerCheckout extends Checkout {
     constructor(tree: SharedTree);
     // (undocumented)
@@ -301,12 +301,12 @@ export class EagerCheckout extends Checkout {
     waitForPendingUpdates(): Promise<void>;
 }
 
-// @public
+// @internal
 export interface Edit<TChange> extends EditBase<TChange> {
     readonly id: EditId;
 }
 
-// @public
+// @internal
 export type EditApplicationOutcome = {
     readonly view: RevisionView;
     readonly status: EditStatus.Applied;
@@ -315,23 +315,23 @@ export type EditApplicationOutcome = {
     readonly status: EditStatus.Invalid | EditStatus.Malformed;
 };
 
-// @public
+// @internal
 export interface EditBase<TChange> {
     readonly changes: readonly TChange[];
     readonly pastAttemptCount?: number;
 }
 
-// @public
+// @internal
 export interface EditCommittedEventArguments {
     readonly editId: EditId;
     readonly local: boolean;
     readonly tree: SharedTree;
 }
 
-// @public
+// @internal
 export type EditCommittedHandler = (args: EditCommittedEventArguments) => void;
 
-// @public @deprecated
+// @internal @deprecated
 export interface EditHandle<TChange> {
     // (undocumented)
     readonly baseHandle: FluidEditHandle;
@@ -339,15 +339,15 @@ export interface EditHandle<TChange> {
     readonly get: () => Promise<EditWithoutId<TChange>[]>;
 }
 
-// @public
+// @internal
 export type EditId = UuidString & {
     readonly EditId: '56897beb-53e4-4e66-85da-4bf5cd5d0d49';
 };
 
-// @public
+// @internal
 export type EditingResult = FailedEditingResult | ValidEditingResult;
 
-// @public
+// @internal
 export interface EditingResultBase {
     readonly before: RevisionView;
     readonly changes: readonly ChangeInternal[];
@@ -355,7 +355,7 @@ export interface EditingResultBase {
     readonly steps: readonly ReconciliationChange[];
 }
 
-// @public
+// @internal
 export interface EditLogSummary<TChange, THandle> {
     readonly editChunks: readonly {
         readonly startRevision: number;
@@ -364,26 +364,26 @@ export interface EditLogSummary<TChange, THandle> {
     readonly editIds: readonly EditId[];
 }
 
-// @public
+// @internal
 export enum EditStatus {
     Applied = 2,
     Invalid = 1,
     Malformed = 0
 }
 
-// @public
+// @internal
 export enum EditValidationResult {
     Invalid = 1,
     Malformed = 0,
     Valid = 2
 }
 
-// @public
+// @internal
 export interface EditWithoutId<TChange> extends EditBase<TChange> {
     readonly id?: never;
 }
 
-// @public
+// @internal
 export interface FailedEditingResult extends EditingResultBase {
     readonly changes: readonly ChangeInternal[];
     readonly failure: TransactionInternal.Failure;
@@ -391,20 +391,20 @@ export interface FailedEditingResult extends EditingResultBase {
     readonly steps: readonly ReconciliationChange[];
 }
 
-// @public
+// @internal
 export interface FailingTransactionState extends TransactionFailure {
     readonly changes: readonly ChangeInternal[];
     readonly steps: readonly ReconciliationChange[];
     readonly view: TransactionView;
 }
 
-// @public
+// @internal
 export type FinalCompressedId = number & {
     readonly FinalCompressedId: '5d83d1e2-98b7-4e4e-a889-54c855cfa73d';
     readonly OpNormalized: '9209432d-a959-4df7-b2ad-767ead4dbcae';
 };
 
-// @public
+// @internal
 export interface FluidEditHandle {
     // (undocumented)
     readonly absolutePath: string;
@@ -412,7 +412,7 @@ export interface FluidEditHandle {
     readonly get: () => Promise<ArrayBuffer>;
 }
 
-// @public
+// @internal
 export class Forest {
     add(nodes: Iterable<ForestNode>): Forest;
     assertConsistent(): void;
@@ -439,13 +439,13 @@ export class Forest {
     tryGetParent(id: NodeId): ParentData | undefined;
 }
 
-// @public
+// @internal
 export interface ForestNode extends NodeData<NodeId> {
     // (undocumented)
     readonly traits: ReadonlyMap<TraitLabel, readonly NodeId[]>;
 }
 
-// @public
+// @internal
 export class GenericTransaction {
     constructor(view: RevisionView, policy: GenericTransactionPolicy);
     applyChange(change: ChangeInternal, path?: ReconciliationPath): this;
@@ -462,28 +462,28 @@ export class GenericTransaction {
     get view(): TransactionView;
 }
 
-// @public
+// @internal
 export interface GenericTransactionPolicy {
     dispatchChange(state: SucceedingTransactionState, change: ChangeInternal): ChangeResult;
     tryResolveChange(state: SucceedingTransactionState, change: ChangeInternal, path: ReconciliationPath): Result<ChangeInternal, TransactionFailure>;
     validateOnClose(state: SucceedingTransactionState): ChangeResult;
 }
 
-// @public @deprecated
+// @internal @deprecated
 function getSerializedUploadedEditChunkContents(sharedTree: SharedTree): Promise<string>;
 export { getSerializedUploadedEditChunkContents }
 export { getSerializedUploadedEditChunkContents as getUploadedEditChunkContents }
 
-// @public
+// @internal
 export function getTraitLocationOfRange(view: TreeView, range: StableRange): TraitLocation;
 
-// @public
+// @internal
 export interface HasTraits<TChild> {
     // (undocumented)
     readonly traits: TraitMap<TChild>;
 }
 
-// @public
+// @internal
 export interface HasVariadicTraits<TChild> {
     // (undocumented)
     readonly traits?: {
@@ -491,7 +491,7 @@ export interface HasVariadicTraits<TChild> {
     };
 }
 
-// @public
+// @internal
 export interface ICheckoutEvents extends IErrorEvent {
     // (undocumented)
     (event: 'viewChange', listener: (before: TreeView, after: TreeView) => void): any;
@@ -502,10 +502,10 @@ export interface IMigrationEvent extends IEvent {
     (event: 'migrated', listener: () => void): any;
 }
 
-// @public
+// @internal
 export const initialTree: ChangeNode_0_0_2;
 
-// @public
+// @internal
 export interface Insert {
     // (undocumented)
     readonly destination: StablePlace;
@@ -515,13 +515,13 @@ export interface Insert {
     readonly type: typeof ChangeType.Insert;
 }
 
-// @public
+// @internal
 export interface InsertInternal extends Omit<InsertInternal_0_0_2, 'destination'> {
     // (undocumented)
     readonly destination: StablePlaceInternal;
 }
 
-// @public
+// @internal
 export interface InsertInternal_0_0_2 {
     // (undocumented)
     readonly destination: StablePlaceInternal_0_0_2;
@@ -531,13 +531,13 @@ export interface InsertInternal_0_0_2 {
     readonly type: typeof ChangeTypeInternal.Insert;
 }
 
-// @public
+// @internal
 export interface InternalizedChange {
     // (undocumented)
     InternalChangeBrand: '2cae1045-61cf-4ef7-a6a3-8ad920cb7ab3';
 }
 
-// @public
+// @internal
 export type InternedStringId = number & {
     readonly InternedStringId: 'e221abc9-9d17-4493-8db0-70c871a1c27c';
 };
@@ -545,7 +545,7 @@ export type InternedStringId = number & {
 // @internal
 export function isDetachedSequenceId(node: DetachedSequenceId | object): node is DetachedSequenceId;
 
-// @public
+// @internal
 export interface ISharedTreeEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: 'committedEdit', listener: EditCommittedHandler): any;
@@ -563,10 +563,10 @@ export interface IShim extends IChannel {
     load(channelServices: IChannelServices): Promise<void>;
 }
 
-// @public
+// @internal
 export function isSharedTreeEvent(event: ITelemetryBaseEvent): boolean;
 
-// @public @sealed
+// @internal @sealed
 export class LazyCheckout extends Checkout {
     constructor(tree: SharedTree);
     // (undocumented)
@@ -579,12 +579,12 @@ export class LazyCheckout extends Checkout {
     waitForPendingUpdates(): Promise<void>;
 }
 
-// @public
+// @internal
 export type LocalCompressedId = number & {
     readonly LocalCompressedId: '6fccb42f-e2a4-4243-bd29-f13d12b9c6d1';
 } & SessionUnique;
 
-// @public
+// @internal
 export interface LogViewer {
     // @deprecated
     getRevisionView(revision: Revision): Promise<RevisionView>;
@@ -593,7 +593,7 @@ export interface LogViewer {
     getRevisionViewInSession(revision: Revision): RevisionView;
 }
 
-// @public
+// @internal
 export interface MergeHealthStats {
     badPlaceCount: number;
     badRangeCount: number;
@@ -659,27 +659,27 @@ export class MigrationShimFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @public
+// @internal
 export interface NodeData<TId> {
     readonly definition: Definition;
     readonly identifier: TId;
     readonly payload?: Payload;
 }
 
-// @public
+// @internal
 export type NodeId = number & SessionSpaceCompressedId & NodeIdBrand;
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface NodeIdBrand {
     // (undocumented)
     readonly NodeId: 'e53e7d6b-c8b9-431a-8805-4843fc639342';
 }
 
-// @public
+// @internal
 export interface NodeIdContext extends NodeIdGenerator, NodeIdConverter {
 }
 
-// @public
+// @internal
 export interface NodeIdConverter {
     convertToNodeId(id: StableNodeId): NodeId;
     convertToStableNodeId(id: NodeId): StableNodeId;
@@ -687,12 +687,12 @@ export interface NodeIdConverter {
     tryConvertToStableNodeId(id: NodeId): StableNodeId | undefined;
 }
 
-// @public
+// @internal
 export interface NodeIdGenerator {
     generateNodeId(override?: string): NodeId;
 }
 
-// @public
+// @internal
 export interface NodeInTrait {
     // (undocumented)
     readonly index: TraitNodeIndex;
@@ -700,7 +700,7 @@ export interface NodeInTrait {
     readonly trait: TraitLocation;
 }
 
-// @public @sealed
+// @internal @sealed
 export interface OrderedEditSet<TChange = unknown> {
     readonly editIds: readonly EditId[];
     // @deprecated (undocumented)
@@ -722,7 +722,7 @@ export interface OrderedEditSet<TChange = unknown> {
     tryGetIndexOfId(editId: EditId): number | undefined;
 }
 
-// @public
+// @internal
 export interface ParentData {
     // (undocumented)
     readonly parentId: NodeId;
@@ -730,21 +730,21 @@ export interface ParentData {
     readonly traitParent: TraitLabel;
 }
 
-// @public
+// @internal
 export type Payload = Serializable;
 
-// @public
+// @internal
 export function placeFromStablePlace(view: TreeView, stablePlace: StablePlace): TreeViewPlace;
 
-// @public
+// @internal
 export type PlaceholderTree<TPlaceholder = never> = TreeNode<PlaceholderTree<TPlaceholder>, NodeId> | TPlaceholder;
 
-// @public
+// @internal
 export type PlaceIndex = number & {
     readonly PlaceIndex: unique symbol;
 };
 
-// @public
+// @internal
 export enum PlaceValidationResult {
     // (undocumented)
     Malformed = "Malformed",
@@ -758,17 +758,17 @@ export enum PlaceValidationResult {
     Valid = "Valid"
 }
 
-// @public
+// @internal
 export function rangeFromStableRange(view: TreeView, range: StableRange): TreeViewRange;
 
-// @public
+// @internal
 export type RangeValidationResult = RangeValidationResultKind.Valid | RangeValidationResultKind.PlacesInDifferentTraits | RangeValidationResultKind.Inverted | {
     kind: RangeValidationResultKind.BadPlace;
     place: StablePlaceInternal;
     placeFailure: BadPlaceValidationResult;
 };
 
-// @public
+// @internal
 export enum RangeValidationResultKind {
     // (undocumented)
     BadPlace = "BadPlace",
@@ -780,13 +780,13 @@ export enum RangeValidationResultKind {
     Valid = "Valid"
 }
 
-// @public
+// @internal
 export interface ReconciliationChange {
     readonly after: TransactionView;
     readonly resolvedChange: ChangeInternal;
 }
 
-// @public
+// @internal
 export interface ReconciliationEdit {
     readonly [index: number]: ReconciliationChange;
     readonly after: TreeView;
@@ -794,16 +794,16 @@ export interface ReconciliationEdit {
     readonly length: number;
 }
 
-// @public
+// @internal
 export interface ReconciliationPath {
     readonly [index: number]: ReconciliationEdit;
     readonly length: number;
 }
 
-// @public
+// @internal
 export type Result<TOk, TError> = Result.Ok<TOk> | Result.Error<TError>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export namespace Result {
     export interface Error<TError> {
         // (undocumented)
@@ -829,10 +829,10 @@ export namespace Result {
     }
 }
 
-// @public
+// @internal
 export type Revision = number;
 
-// @public
+// @internal
 export class RevisionView extends TreeView {
     // (undocumented)
     equals(view: TreeView): boolean;
@@ -841,7 +841,7 @@ export class RevisionView extends TreeView {
     openForTransaction(): TransactionView;
 }
 
-// @public
+// @internal
 export interface SequencedEditAppliedEventArguments {
     readonly edit: Edit<ChangeInternal>;
     readonly logger: ITelemetryLoggerExt;
@@ -851,22 +851,22 @@ export interface SequencedEditAppliedEventArguments {
     readonly wasLocal: boolean;
 }
 
-// @public
+// @internal
 export type SequencedEditAppliedHandler = (args: SequencedEditAppliedEventArguments) => void;
 
-// @public
+// @internal
 export type SessionSpaceCompressedId = CompressedId & SessionUnique;
 
-// @public
+// @internal
 export interface SessionUnique {
     // (undocumented)
     readonly SessionUnique: 'cea55054-6b82-4cbf-ad19-1fa645ea3b3e';
 }
 
-// @public
+// @internal
 export function setTrait(trait: TraitLocation, nodes: BuildNode | TreeNodeSequence<BuildNode>): Change[];
 
-// @public
+// @internal
 export interface SetValue {
     // (undocumented)
     readonly nodeToModify: NodeId;
@@ -875,13 +875,13 @@ export interface SetValue {
     readonly type: typeof ChangeType.SetValue;
 }
 
-// @public
+// @internal
 export interface SetValueInternal extends Omit<SetValueInternal_0_0_2, 'nodeToModify'> {
     // (undocumented)
     readonly nodeToModify: NodeId;
 }
 
-// @public
+// @internal
 export interface SetValueInternal_0_0_2 {
     // (undocumented)
     readonly nodeToModify: StableNodeId;
@@ -890,14 +890,13 @@ export interface SetValueInternal_0_0_2 {
     readonly type: typeof ChangeTypeInternal.SetValue;
 }
 
-// @public
+// @internal
 export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeIdContext {
     constructor(runtime: IFluidDataStoreRuntime, id: string, ...args: SharedTreeArgs<WriteFormat.v0_0_2>);
     constructor(runtime: IFluidDataStoreRuntime, id: string, ...args: SharedTreeArgs<WriteFormat.v0_1_1>);
     applyEdit(...changes: readonly Change[]): Edit<InternalizedChange>;
     // (undocumented)
     applyEdit(changes: readonly Change[]): Edit<InternalizedChange>;
-    // @internal
     applyEditInternal(editOrChanges: Edit<ChangeInternal> | readonly ChangeInternal[]): Edit<ChangeInternal>;
     protected applyStashedOp(op: unknown): StashedLocalOpMetadata;
     attributeNodeId(id: NodeId): AttributionId;
@@ -909,7 +908,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     get currentView(): RevisionView;
     // (undocumented)
     get edits(): OrderedEditSet<InternalizedChange>;
-    // @internal
     equals(sharedTree: SharedTree): boolean;
     generateNodeId(override?: string): NodeId;
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_0_2>): SharedTreeFactory;
@@ -919,13 +917,10 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     // (undocumented)
     getRuntime(): IFluidDataStoreRuntime;
     getWriteFormat(): WriteFormat;
-    // @internal
     internalizeChange(change: Change): ChangeInternal;
     // (undocumented)
     protected loadCore(storage: IChannelStorageService): Promise<void>;
-    // @internal
     loadSerializedSummary(blobData: string): ITelemetryProperties;
-    // @internal
     loadSummary(summary: SharedTreeSummaryBase): void;
     readonly logger: ITelemetryLoggerExt;
     get logViewer(): LogViewer;
@@ -939,13 +934,10 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     // (undocumented)
     protected reSubmitCore(op: unknown, localOpMetadata?: StashedLocalOpMetadata): void;
     revert(editId: EditId): EditId | undefined;
-    // @internal
     revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined;
-    // @internal
     saveSerializedSummary(options?: {
         serializer?: IFluidSerializer;
     }): string;
-    // @internal
     saveSummary(): SharedTreeSummaryBase;
     // (undocumented)
     summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
@@ -953,19 +945,19 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     tryConvertToStableNodeId(id: NodeId): StableNodeId | undefined;
 }
 
-// @public
+// @internal
 export type SharedTreeArgs<WF extends WriteFormat = WriteFormat> = [writeFormat: WF, options?: SharedTreeOptions<WF>];
 
-// @public
+// @internal
 export const sharedTreeAssertionErrorType = "SharedTreeAssertion";
 
-// @public
+// @internal
 export interface SharedTreeBaseOptions {
     editEvictionFrequency?: number;
     inMemoryHistorySize?: number;
 }
 
-// @public
+// @internal
 export enum SharedTreeDiagnosticEvent {
     AppliedEdit = "appliedEdit",
     CatchUpBlobUploaded = "uploadedCatchUpBlob",
@@ -976,13 +968,13 @@ export enum SharedTreeDiagnosticEvent {
     WriteVersionChanged = "writeVersionChanged"
 }
 
-// @public
+// @internal
 export enum SharedTreeEvent {
     EditCommitted = "committedEdit",
     SequencedEditApplied = "sequencedEditApplied"
 }
 
-// @public
+// @internal
 export class SharedTreeFactory implements IChannelFactory {
     constructor(...args: SharedTreeArgs);
     // (undocumented)
@@ -998,7 +990,7 @@ export class SharedTreeFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @public
+// @internal
 export class SharedTreeMergeHealthTelemetryHeartbeat {
     attachTree(tree: SharedTree): void;
     clearData(): void;
@@ -1011,15 +1003,15 @@ export class SharedTreeMergeHealthTelemetryHeartbeat {
     stopHeartbeat(): void;
 }
 
-// @public
+// @internal
 export type SharedTreeOptions<WF extends WriteFormat, HistoryCompatibility extends 'Forwards' | 'None' = 'Forwards'> = SharedTreeBaseOptions & Omit<WF extends WriteFormat.v0_0_2 ? SharedTreeOptions_0_0_2 : WF extends WriteFormat.v0_1_1 ? SharedTreeOptions_0_1_1 : never, HistoryCompatibility extends 'Forwards' ? 'summarizeHistory' : never>;
 
-// @public
+// @internal
 export interface SharedTreeOptions_0_0_2 {
     summarizeHistory?: boolean;
 }
 
-// @public
+// @internal
 export interface SharedTreeOptions_0_1_1 {
     attributionId?: AttributionId;
     summarizeHistory?: false | {
@@ -1069,12 +1061,12 @@ export class SharedTreeShimFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @public
+// @internal
 export interface SharedTreeSummaryBase {
     readonly version: WriteFormat;
 }
 
-// @public
+// @internal
 export enum Side {
     // (undocumented)
     After = 1,
@@ -1082,19 +1074,19 @@ export enum Side {
     Before = 0
 }
 
-// @public
+// @internal
 export type StableNodeId = string & {
     readonly StableNodeId: 'a0843b38-699d-4bb2-aa7a-16c502a71151';
 };
 
-// @public
+// @internal
 export interface StablePlace {
     readonly referenceSibling?: NodeId;
     readonly referenceTrait?: TraitLocation;
     readonly side: Side;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const StablePlace: {
     before: (node: NodeData<NodeId> | NodeId) => StablePlace;
     after: (node: NodeData<NodeId> | NodeId) => StablePlace;
@@ -1102,13 +1094,13 @@ export const StablePlace: {
     atEndOf: (trait: TraitLocation) => StablePlace;
 };
 
-// @public
+// @internal
 export interface StablePlaceInternal extends Omit<StablePlaceInternal_0_0_2, 'referenceSibling' | 'referenceTrait'> {
     readonly referenceSibling?: NodeId;
     readonly referenceTrait?: TraitLocationInternal;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const StablePlaceInternal: {
     before: (node: NodeData<NodeId> | NodeId) => StablePlaceInternal;
     after: (node: NodeData<NodeId> | NodeId) => StablePlaceInternal;
@@ -1116,14 +1108,14 @@ export const StablePlaceInternal: {
     atEndOf: (trait: TraitLocationInternal) => StablePlaceInternal;
 };
 
-// @public
+// @internal
 export interface StablePlaceInternal_0_0_2 {
     readonly referenceSibling?: StableNodeId;
     readonly referenceTrait?: TraitLocationInternal_0_0_2;
     readonly side: Side;
 }
 
-// @public
+// @internal
 export interface StableRange {
     // (undocumented)
     readonly end: StablePlace;
@@ -1131,7 +1123,7 @@ export interface StableRange {
     readonly start: StablePlace;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const StableRange: {
     from: (start: StablePlace) => {
         to: (end: StablePlace) => StableRange;
@@ -1140,7 +1132,7 @@ export const StableRange: {
     all: (trait: TraitLocation) => StableRange;
 };
 
-// @public
+// @internal
 export interface StableRangeInternal {
     // (undocumented)
     readonly end: StablePlaceInternal;
@@ -1148,7 +1140,7 @@ export interface StableRangeInternal {
     readonly start: StablePlaceInternal;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const StableRangeInternal: {
     from: (start: StablePlaceInternal) => {
         to: (end: StablePlaceInternal) => StableRangeInternal;
@@ -1157,7 +1149,7 @@ export const StableRangeInternal: {
     all: (trait: TraitLocationInternal) => StableRangeInternal;
 };
 
-// @public
+// @internal
 export interface StableRangeInternal_0_0_2 {
     // (undocumented)
     readonly end: StablePlaceInternal_0_0_2;
@@ -1165,12 +1157,12 @@ export interface StableRangeInternal_0_0_2 {
     readonly start: StablePlaceInternal_0_0_2;
 }
 
-// @public
+// @internal
 export interface StashedLocalOpMetadata {
     transformedEdit?: Edit<ChangeInternal>;
 }
 
-// @public
+// @internal
 export interface StringInterner {
     // (undocumented)
     getInternedId(input: string): InternedStringId | undefined;
@@ -1180,7 +1172,7 @@ export interface StringInterner {
     getString(internedId: number): string;
 }
 
-// @public
+// @internal
 export interface SucceedingTransactionState {
     readonly changes: readonly ChangeInternal[];
     readonly status: EditStatus.Applied;
@@ -1188,12 +1180,12 @@ export interface SucceedingTransactionState {
     readonly view: TransactionView;
 }
 
-// @public
+// @internal
 export type TraitLabel = UuidString & {
     readonly TraitLabel: '613826ed-49cc-4df3-b2b8-bfc6866af8e3';
 };
 
-// @public
+// @internal
 export interface TraitLocation {
     // (undocumented)
     readonly label: TraitLabel;
@@ -1201,13 +1193,13 @@ export interface TraitLocation {
     readonly parent: NodeId;
 }
 
-// @public
+// @internal
 export interface TraitLocationInternal extends Omit<TraitLocationInternal_0_0_2, 'parent'> {
     // (undocumented)
     readonly parent: NodeId;
 }
 
-// @public
+// @internal
 export interface TraitLocationInternal_0_0_2 {
     // (undocumented)
     readonly label: TraitLabel;
@@ -1215,18 +1207,18 @@ export interface TraitLocationInternal_0_0_2 {
     readonly parent: StableNodeId;
 }
 
-// @public
+// @internal
 export interface TraitMap<TChild> {
     // (undocumented)
     readonly [key: string]: TreeNodeSequence<TChild>;
 }
 
-// @public
+// @internal
 export type TraitNodeIndex = number & {
     readonly TraitNodeIndex: unique symbol;
 };
 
-// @public
+// @internal
 export class Transaction extends TypedEventEmitter<TransactionEvents> {
     constructor(tree: SharedTree);
     apply(...changes: readonly Change[]): EditStatus;
@@ -1241,24 +1233,24 @@ export class Transaction extends TypedEventEmitter<TransactionEvents> {
     readonly tree: SharedTree;
 }
 
-// @public
+// @internal
 export enum TransactionEvent {
     ViewChange = "viewChange"
 }
 
-// @public
+// @internal
 export interface TransactionEvents extends IErrorEvent {
     // (undocumented)
     (event: TransactionEvent.ViewChange, listener: (before: TreeView, after: TreeView) => void): any;
 }
 
-// @public
+// @internal
 export interface TransactionFailure {
     readonly failure: TransactionInternal.Failure;
     readonly status: EditStatus.Invalid | EditStatus.Malformed;
 }
 
-// @public
+// @internal
 export namespace TransactionInternal {
     export interface BadPlaceFailure {
         readonly change: ChangeInternal;
@@ -1350,10 +1342,10 @@ export namespace TransactionInternal {
         {};
 }
 
-// @public
+// @internal
 export type TransactionState = SucceedingTransactionState | FailingTransactionState;
 
-// @public
+// @internal
 export class TransactionView extends TreeView {
     addNodes(sequence: Iterable<TreeViewNode>): TransactionView;
     attachRange(nodesToAttach: readonly NodeId[], place: TreeViewPlace): TransactionView;
@@ -1368,11 +1360,11 @@ export class TransactionView extends TreeView {
     setNodeValue(nodeId: NodeId, value: Payload): TransactionView;
 }
 
-// @public
+// @internal
 export interface TreeNode<TChild, TId> extends NodeData<TId>, HasTraits<TChild> {
 }
 
-// @public
+// @internal
 export class TreeNodeHandle implements TreeNode<TreeNodeHandle, NodeId> {
     constructor(view: TreeView, nodeId: NodeId);
     // (undocumented)
@@ -1386,10 +1378,10 @@ export class TreeNodeHandle implements TreeNode<TreeNodeHandle, NodeId> {
     get traits(): TraitMap<TreeNodeHandle>;
 }
 
-// @public
+// @internal
 export type TreeNodeSequence<TChild> = readonly TChild[];
 
-// @public
+// @internal
 export abstract class TreeView {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<TreeViewNode>;
@@ -1434,13 +1426,13 @@ export abstract class TreeView {
     tryGetViewNode(id: NodeId): TreeViewNode | undefined;
 }
 
-// @public
+// @internal
 export interface TreeViewNode extends NodeData<NodeId> {
     readonly parentage?: TraitLocation;
     readonly traits: ReadonlyMap<TraitLabel, readonly NodeId[]>;
 }
 
-// @public
+// @internal
 export interface TreeViewPlace {
     // (undocumented)
     readonly sibling?: NodeId;
@@ -1450,7 +1442,7 @@ export interface TreeViewPlace {
     readonly trait: TraitLocation;
 }
 
-// @public
+// @internal
 export interface TreeViewRange {
     // (undocumented)
     readonly end: TreeViewPlace;
@@ -1458,23 +1450,23 @@ export interface TreeViewRange {
     readonly start: TreeViewPlace;
 }
 
-// @public
+// @internal
 export function useFailedSequencedEditTelemetry(tree: SharedTree): {
     disable: () => void;
 };
 
-// @public
+// @internal
 export type UuidString = string & {
     readonly UuidString: '9d40d0ae-90d9-44b1-9482-9f55d59d5465';
 };
 
-// @public
+// @internal
 export interface ValidEditingResult extends EditingResultBase {
     readonly after: RevisionView;
     readonly status: EditStatus.Applied;
 }
 
-// @public
+// @internal
 export enum WriteFormat {
     v0_0_2 = "0.0.2",
     v0_1_1 = "0.1.1"

--- a/experimental/dds/tree/src/ChangeTypes.ts
+++ b/experimental/dds/tree/src/ChangeTypes.ts
@@ -12,7 +12,7 @@ import { getNodeId } from './NodeIdUtilities';
 
 /**
  * An object which may have traits with children of the given type underneath it
- * @public
+ * @internal
  */
 export interface HasVariadicTraits<TChild> {
 	readonly traits?: {
@@ -22,7 +22,7 @@ export interface HasVariadicTraits<TChild> {
 
 /**
  * The type of a Change
- * @public
+ * @internal
  */
 export enum ChangeType {
 	Insert,
@@ -44,15 +44,14 @@ export enum ChangeType {
  * ```typescript
  * Change.insert(sourceId, destination)
  * ```
- *
- * @public
+ * @internal
  */
 export type Change = Insert | Detach | Build | SetValue | Constraint;
 
 /**
  * Node or a detached sequence of nodes (referred to by a detached sequence ID) for use in a Build change.
  * See `BuildTreeNode` for more.
- * @public
+ * @internal
  */
 export type BuildNode = BuildTreeNode | number;
 
@@ -63,6 +62,7 @@ export type BuildNode = BuildTreeNode | number;
  * BuildTreeNode can be observed. If `identifier` is not supplied, one will be generated for it in an especially efficient manner
  * that allows for compact storage and transmission and thus this property should be omitted if convenient.
  * See the SharedTree readme for more on the tree format.
+ * @internal
  */
 export interface BuildTreeNode extends HasVariadicTraits<BuildNode> {
 	definition: string;
@@ -76,8 +76,7 @@ export interface BuildTreeNode extends HasVariadicTraits<BuildNode> {
  *
  * Valid if (transitively) all DetachedSequenceId are used according to their rules (use here counts as a destination),
  * and all Nodes' identifiers are previously unused.
- *
- * @public
+ * @internal
  */
 export interface Build {
 	readonly destination: number;
@@ -88,7 +87,7 @@ export interface Build {
 /**
  * Inserts a sequence of nodes at the specified destination.
  * The source can be constructed either by a Build (used to insert new nodes) or a Detach (amounts to a "move" operation).
- * @public
+ * @internal
  */
 export interface Insert {
 	readonly destination: StablePlace;
@@ -101,7 +100,7 @@ export interface Insert {
  * If a destination is specified, the detached sequence is associated with that ID and held for possible reuse
  * by later changes in this same Edit (such as by an Insert).
  * A Detach without a destination is a deletion of the specified sequence, as is a Detach with a destination that is not used later.
- * @public
+ * @internal
  */
 export interface Detach {
 	readonly destination?: number;
@@ -111,7 +110,7 @@ export interface Detach {
 
 /**
  * Modifies the payload of a node.
- * @public
+ * @internal
  */
 export interface SetValue {
 	readonly nodeToModify: NodeId;
@@ -132,7 +131,7 @@ export interface SetValue {
  * non-semantic ways. It is processed in order like any other Change in an Edit. It can cause an edit to fail if the
  * various constraints are not met at the time of evaluation (ex: the parentNode has changed due to concurrent editing).
  * Does not modify the document.
- * @public
+ * @internal
  */
 export interface Constraint {
 	/**
@@ -190,7 +189,7 @@ export interface Constraint {
 
 // Note: Documentation of this constant is merged with documentation of the `Change` interface.
 /**
- * @public
+ * @internal
  */
 export const Change = {
 	build: (source: BuildNode | TreeNodeSequence<BuildNode>, destination: number): Build => ({
@@ -289,8 +288,7 @@ export const Change = {
  * StablePlace.before(node)
  * StablePlace.atStartOf(trait)
  * ```
- *
- * @public
+ * @internal
  */
 export interface StablePlace {
 	/**
@@ -328,8 +326,7 @@ export interface StablePlace {
  * ```typescript
  * StableRange.from(StablePlace.before(startNode)).to(StablePlace.after(endNode))
  * ```
- *
- * @public
+ * @internal
  */
 export interface StableRange {
 	readonly start: StablePlace;
@@ -346,7 +343,7 @@ export interface StableRange {
 
 // Note: Documentation of this constant is merged with documentation of the `StablePlace` interface.
 /**
- * @public
+ * @internal
  */
 export const StablePlace = {
 	/**
@@ -372,7 +369,7 @@ export const StablePlace = {
 
 // Note: Documentation of this constant is merged with documentation of the `StableRange` interface.
 /**
- * @public
+ * @internal
  */
 export const StableRange = {
 	/**

--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -20,7 +20,7 @@ import { Change } from './ChangeTypes';
 
 /**
  * An event emitted by a `Checkout` to indicate a state change. See {@link ICheckoutEvents} for event argument information.
- * @public
+ * @internal
  */
 export enum CheckoutEvent {
 	/**
@@ -32,6 +32,7 @@ export enum CheckoutEvent {
 
 /**
  * Events which may be emitted by `Checkout`. See {@link CheckoutEvent} for documentation of event semantics.
+ * @internal
  */
 export interface ICheckoutEvents extends IErrorEvent {
 	(event: 'viewChange', listener: (before: TreeView, after: TreeView) => void);
@@ -39,7 +40,7 @@ export interface ICheckoutEvents extends IErrorEvent {
 
 /**
  * The result of validation of an Edit.
- * @public
+ * @internal
  */
 export enum EditValidationResult {
 	/**
@@ -73,7 +74,7 @@ export enum EditValidationResult {
  * Events emitted by `Checkout` are documented in {@link CheckoutEvent}.
  * Exceptions thrown during event handling will be emitted as error events, which are automatically surfaced as error events on the
  * `SharedTree` used at construction time.
- * @public
+ * @internal
  */
 export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEvents> implements IDisposable {
 	/**
@@ -145,7 +146,6 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 
 	/**
 	 * @returns true iff there is an open edit.
-	 * @internal
 	 */
 	public hasOpenEdit(): boolean {
 		return this.currentEdit !== undefined;

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -14,8 +14,7 @@ const defaultFailMessage = 'Assertion failed';
  * https://github.com/microsoft/FluidFramework/blob/main/packages/loader/container-utils/src/error.ts
  *
  * Exporting this enables users to safely filter telemetry handling of errors based on their type.
- *
- * @public
+ * @internal
  */
 export const sharedTreeAssertionErrorType = 'SharedTreeAssertion';
 
@@ -28,6 +27,7 @@ export interface SharedTreeTelemetryProperties extends ITelemetryProperties {
 
 /**
  * Returns if the supplied event is a SharedTree telemetry event.
+ * @internal
  */
 export function isSharedTreeEvent(event: ITelemetryBaseEvent): boolean {
 	return (event as unknown as SharedTreeTelemetryProperties).isSharedTreeEvent === true;
@@ -398,14 +398,19 @@ export type ErrorString = string;
 
 /**
  * Discriminated union instance that wraps either a result of type `TOk` or an error of type `TError`.
+ * @internal
  */
 export type Result<TOk, TError> = Result.Ok<TOk> | Result.Error<TError>;
 
+/**
+ * @internal
+ */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Result {
 	/**
 	 * Factory function for making a successful Result.
 	 * @param result - The result to wrap in the Result.
+	 * @internal
 	 */
 	export function ok<TOk>(result: TOk): Ok<TOk> {
 		return { type: ResultType.Ok, result };
@@ -413,6 +418,7 @@ export namespace Result {
 	/**
 	 * Factory function for making a unsuccessful Result.
 	 * @param error - The error to wrap in the Result.
+	 * @internal
 	 */
 	export function error<TError>(error: TError): Error<TError> {
 		return { type: ResultType.Error, error };
@@ -420,6 +426,7 @@ export namespace Result {
 	/**
 	 * Type guard for successful Result.
 	 * @returns True if `result` is successful.
+	 * @internal
 	 */
 	export function isOk<TOk, TError>(result: Result<TOk, TError>): result is Ok<TOk> {
 		return result.type === ResultType.Ok;
@@ -427,6 +434,7 @@ export namespace Result {
 	/**
 	 * Type guard for unsuccessful Result.
 	 * @returns True if `result` is unsuccessful.
+	 * @internal
 	 */
 	export function isError<TOk, TError>(result: Result<TOk, TError>): result is Error<TError> {
 		return result.type === ResultType.Error;
@@ -436,6 +444,7 @@ export namespace Result {
 	 * @param result - The result to map.
 	 * @param map - The function to apply to derive the new result.
 	 * @returns The given result if it is not ok, the mapped result otherwise.
+	 * @internal
 	 */
 	export function mapOk<TOkIn, TOkOut, TError>(
 		result: Result<TOkIn, TError>,
@@ -448,6 +457,7 @@ export namespace Result {
 	 * @param result - The result to map.
 	 * @param map - The function to apply to derive the new error.
 	 * @returns The given result if it is ok, the mapped result otherwise.
+	 * @internal
 	 */
 	export function mapError<TOk, TErrorIn, TErrorOut>(
 		result: Result<TOk, TErrorIn>,
@@ -457,6 +467,7 @@ export namespace Result {
 	}
 	/**
 	 * Tag value use to differentiate the members of the `Result` discriminated union.
+	 * @internal
 	 */
 	export enum ResultType {
 		/** Signals a successful result. */
@@ -466,6 +477,7 @@ export namespace Result {
 	}
 	/**
 	 * Wraps a result of type `TOk`.
+	 * @internal
 	 */
 	export interface Ok<TOk> {
 		readonly type: ResultType.Ok;
@@ -473,6 +485,7 @@ export namespace Result {
 	}
 	/**
 	 * Wraps an error of type `TError`.
+	 * @internal
 	 */
 	export interface Error<TError> {
 		readonly type: ResultType.Error;

--- a/experimental/dds/tree/src/EagerCheckout.ts
+++ b/experimental/dds/tree/src/EagerCheckout.ts
@@ -10,9 +10,8 @@ import { EditCommittedEventArguments, SharedTree } from './SharedTree';
 /**
  * Checkout that always stays up to date with the SharedTree.
  * This means that {@link EagerCheckout.waitForPendingUpdates} is always a no-op since EagerCheckout is always up to date.
- *
- * @public
  * @sealed
+ * @internal
  */
 export class EagerCheckout extends Checkout {
 	/**

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -17,8 +17,8 @@ import type { ChangeCompressor } from './ChangeCompression';
 /**
  * An ordered set of Edits associated with a SharedTree.
  * Supports fast lookup of edits by ID and enforces idempotence.
- * @public
  * @sealed
+ * @internal
  */
 export interface OrderedEditSet<TChange = unknown> {
 	/**
@@ -147,7 +147,7 @@ export interface EditChunk<TChange> {
  * EditHandles are used to load edit chunks stored outside of the EditLog.
  * This is typically implemented by a wrapper around an IFluidHandle<ArrayBufferLike>.
  * @deprecated Edit virtualization is no longer supported.
- * @public
+ * @internal
  */
 export interface EditHandle<TChange> {
 	readonly get: () => Promise<EditWithoutId<TChange>[]>;

--- a/experimental/dds/tree/src/EditUtilities.ts
+++ b/experimental/dds/tree/src/EditUtilities.ts
@@ -295,6 +295,7 @@ export function compareNodes(
 
 /**
  * Compare two views such that semantically equivalent node IDs are considered equal.
+ * @internal
  */
 export function areRevisionViewsSemanticallyEqual(
 	treeViewA: TreeView,
@@ -313,7 +314,7 @@ export function areRevisionViewsSemanticallyEqual(
 
 /**
  * Create a sequence of changes that resets the contents of `trait`.
- * @public
+ * @internal
  */
 export function setTrait(trait: TraitLocation, nodes: BuildNode | TreeNodeSequence<BuildNode>): Change[] {
 	const id = 0 as DetachedSequenceId;
@@ -402,6 +403,7 @@ export function validateStablePlace(
 
 /**
  * The result of validating a place.
+ * @internal
  */
 export enum PlaceValidationResult {
 	Valid = 'Valid',
@@ -413,6 +415,7 @@ export enum PlaceValidationResult {
 
 /**
  * The result of validating a bad place.
+ * @internal
  */
 export type BadPlaceValidationResult = Exclude<PlaceValidationResult, PlaceValidationResult.Valid>;
 
@@ -468,6 +471,7 @@ export function validateStableRange(
 
 /**
  * The kinds of result of validating a range.
+ * @internal
  */
 export enum RangeValidationResultKind {
 	Valid = 'Valid',
@@ -478,6 +482,7 @@ export enum RangeValidationResultKind {
 
 /**
  * The result of validating a range.
+ * @internal
  */
 export type RangeValidationResult =
 	| RangeValidationResultKind.Valid
@@ -491,6 +496,7 @@ export type RangeValidationResult =
 
 /**
  * The result of validating a bad range.
+ * @internal
  */
 export type BadRangeValidationResult = Exclude<RangeValidationResult, RangeValidationResultKind.Valid>;
 

--- a/experimental/dds/tree/src/EventTypes.ts
+++ b/experimental/dds/tree/src/EventTypes.ts
@@ -6,7 +6,7 @@
 /**
  * An event emitted by a `SharedTree` to indicate a state change. See {@link ISharedTreeEvents} for event
  * argument information.
- * @public
+ * @internal
  */
 export enum SharedTreeEvent {
 	/**
@@ -49,6 +49,7 @@ export enum SharedTreeEvent {
 /**
  * An event emitted by a `SharedTree` for diagnostic purposes.
  * See {@link ISharedTreeEvents} for event argument information.
+ * @internal
  */
 export enum SharedTreeDiagnosticEvent {
 	/**

--- a/experimental/dds/tree/src/Forest.ts
+++ b/experimental/dds/tree/src/Forest.ts
@@ -12,8 +12,7 @@ import { NodeData, Payload } from './persisted-types';
 
 /**
  * A node that can be contained within a Forest
- *
- * @public
+ * @internal
  */
 export interface ForestNode extends NodeData<NodeId> {
 	readonly traits: ReadonlyMap<TraitLabel, readonly NodeId[]>;
@@ -41,8 +40,7 @@ export function isParentedForestNode(node: ForestNode): node is ParentedForestNo
 
 /**
  * Information about a ForestNode's parent
- *
- * @public
+ * @internal
  */
 export interface ParentData {
 	readonly parentId: NodeId;
@@ -51,6 +49,7 @@ export interface ParentData {
 
 /**
  * Differences from one forest to another.
+ * @internal
  */
 export interface Delta<NodeId> {
 	/**
@@ -75,8 +74,7 @@ interface ForestState {
 /**
  * An immutable forest of ForestNode.
  * Enforces single parenting, and allows querying the parent.
- *
- * @public
+ * @internal
  */
 export class Forest {
 	/**

--- a/experimental/dds/tree/src/Identifiers.ts
+++ b/experimental/dds/tree/src/Identifiers.ts
@@ -11,12 +11,13 @@
  * A 128-bit Universally Unique IDentifier. Represented here
  * with a string of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
  * where x is a lowercase hex digit.
- * @public
+ * @internal
  */
 export type UuidString = string & { readonly UuidString: '9d40d0ae-90d9-44b1-9482-9f55d59d5465' };
 
 /**
  * An identifier associated with a session for the purpose of attributing its created content to some user/entity.
+ * @internal
  */
 export type AttributionId = UuidString;
 
@@ -34,7 +35,7 @@ export type SessionId = StableId & { readonly SessionId: '4498f850-e14e-4be9-8db
 
 /**
  * Edit identifier
- * @public
+ * @internal
  */
 export type EditId = UuidString & { readonly EditId: '56897beb-53e4-4e66-85da-4bf5cd5d0d49' };
 
@@ -44,24 +45,25 @@ export type EditId = UuidString & { readonly EditId: '56897beb-53e4-4e66-85da-4b
  * Within a given Edit, any DetachedSequenceId must be a source at most once, and a destination at most once.
  * If used as a source, it must be after it is used as a destination.
  * If this is violated, the Edit is considered malformed.
- * @public
+ * @internal
  */
 export type DetachedSequenceId = number & { readonly DetachedSequenceId: 'f7d7903a-194e-45e7-8e82-c9ef4333577d' };
 
 /**
  * An identifier (UUID) that has been shortened by a distributed compression algorithm.
- * @public
+ * @internal
  */
 export type CompressedId = FinalCompressedId | LocalCompressedId;
 
 /**
  * The ID of the string that has been interned, which can be used by a {@link StringInterner} to retrieve the original string.
- * @public
+ * @internal
  */
 export type InternedStringId = number & { readonly InternedStringId: 'e221abc9-9d17-4493-8db0-70c871a1c27c' };
 
 /**
  * A brand for identity types that are unique within a particular session (SharedTree instance).
+ * @internal
  */
 export interface SessionUnique {
 	readonly SessionUnique: 'cea55054-6b82-4cbf-ad19-1fa645ea3b3e';
@@ -71,7 +73,7 @@ export interface SessionUnique {
  * A compressed ID that has been normalized into "session space" (see `IdCompressor` for more).
  * Consumer-facing APIs and data structures should use session-space IDs as their lifetime and equality is stable and tied to the
  * compressor that produced them.
- * @public
+ * @internal
  */
 export type SessionSpaceCompressedId = CompressedId & SessionUnique;
 
@@ -89,7 +91,7 @@ export type OpSpaceCompressedId = CompressedId & {
  * A compressed ID that is local to a document. Stable across all revisions of a document starting from the one in which it was created.
  * It should not be persisted outside of the history as it can only be decompressed in the context of the originating document.
  * If external persistence is needed (e.g. by a client), a StableId should be used instead.
- * @public
+ * @internal
  */
 export type FinalCompressedId = number & {
 	readonly FinalCompressedId: '5d83d1e2-98b7-4e4e-a889-54c855cfa73d';
@@ -102,12 +104,15 @@ export type FinalCompressedId = number & {
  * A compressed ID that is local to a session (can only be decompressed when paired with a SessionId).
  * It should not be persisted outside of the history as it can only be decompressed in the context of the originating session.
  * If external persistence is needed (e.g. by a client), a StableId should be used instead.
- * @public
+ * @internal
  */
 export type LocalCompressedId = number & {
 	readonly LocalCompressedId: '6fccb42f-e2a4-4243-bd29-f13d12b9c6d1';
 } & SessionUnique; // Same brand as CompressedId, as local IDs are always locally normalized
 
+/**
+ * @internal
+ */
 export interface NodeIdBrand {
 	readonly NodeId: 'e53e7d6b-c8b9-431a-8805-4843fc639342';
 }
@@ -115,7 +120,7 @@ export interface NodeIdBrand {
 /**
  * Node identifier.
  * Identifies a node within a document.
- * @public
+ * @internal
  */
 export type NodeId = number & SessionSpaceCompressedId & NodeIdBrand;
 
@@ -130,21 +135,21 @@ export type OpSpaceNodeId = number & OpSpaceCompressedId & NodeIdBrand;
 /**
  * Globally unique node identifier.
  * Uniquely identifies a node within and across documents. Can be used across SharedTree instances.
- * @public
+ * @internal
  */
 export type StableNodeId = string & { readonly StableNodeId: 'a0843b38-699d-4bb2-aa7a-16c502a71151' };
 
 /**
  * Definition.
  * A full (Uuid) persistable definition.
- * @public
+ * @internal
  */
 export type Definition = UuidString & { readonly Definition: 'c0ef9488-2a78-482d-aeed-37fba996354c' };
 
 /**
  * Definition.
  * A full (Uuid) persistable label for a trait.
- * @public
+ * @internal
  */
 export type TraitLabel = UuidString & { readonly TraitLabel: '613826ed-49cc-4df3-b2b8-bfc6866af8e3' };
 

--- a/experimental/dds/tree/src/InitialTree.ts
+++ b/experimental/dds/tree/src/InitialTree.ts
@@ -9,7 +9,7 @@ import { ChangeNode_0_0_2 } from './persisted-types';
 
 /**
  * The initial tree.
- * @public
+ * @internal
  */
 export const initialTree: ChangeNode_0_0_2 = {
 	traits: {},

--- a/experimental/dds/tree/src/LazyCheckout.ts
+++ b/experimental/dds/tree/src/LazyCheckout.ts
@@ -12,9 +12,8 @@ import { ValidEditingResult } from './TransactionInternal';
 /**
  * Checkout that only updates its view of the tree when explicitly requested.
  * This means that the {@link Checkout.currentView} field will never change unless {@link LazyCheckout.waitForPendingUpdates} is called.
- *
- * @public
  * @sealed
+ * @internal
  */
 export class LazyCheckout extends Checkout {
 	private latestView: RevisionView;

--- a/experimental/dds/tree/src/LogViewer.ts
+++ b/experimental/dds/tree/src/LogViewer.ts
@@ -143,6 +143,7 @@ export type CachedEditingResult = AttemptedEditResultCacheEntry & {
 
 /**
  * Creates `RevisionView`s for the revisions in an `EditLog`
+ * @internal
  */
 export interface LogViewer {
 	/**

--- a/experimental/dds/tree/src/MergeHealth.ts
+++ b/experimental/dds/tree/src/MergeHealth.ts
@@ -15,6 +15,7 @@ import { TransactionInternal } from './TransactionInternal';
  * Logs generic telemetry for failed sequenced edits.
  * Only failing edits that were originally made locally are logged.
  * @param tree - The tree for which to log the telemetry.
+ * @internal
  */
 export function useFailedSequencedEditTelemetry(tree: SharedTree): { disable: () => void } {
 	function onEdit({ wasLocal, logger, outcome }: SequencedEditAppliedEventArguments): void {
@@ -37,6 +38,7 @@ export function useFailedSequencedEditTelemetry(tree: SharedTree): { disable: ()
 /**
  * Statistics about the health of collaborative edit merging when using {@link SharedTree}.
  * All of those numbers constitute a tally since the last heartbeat was logged or cleared.
+ * @internal
  */
 export interface MergeHealthStats {
 	/** Number of sequenced edits applied (failed or not). */
@@ -204,6 +206,7 @@ export interface MergeHealthStats {
 
 /**
  * Aggregates and logs telemetry about the success of concurrent edits.
+ * @internal
  */
 export class SharedTreeMergeHealthTelemetryHeartbeat {
 	private heartbeatTimerId = 0;

--- a/experimental/dds/tree/src/NodeIdUtilities.ts
+++ b/experimental/dds/tree/src/NodeIdUtilities.ts
@@ -10,13 +10,13 @@ import { assertWithMessage } from './Common';
 
 /**
  * An object which can generate node IDs and convert node IDs between compressed and stable variants
- * @public
+ * @internal
  */
 export interface NodeIdContext extends NodeIdGenerator, NodeIdConverter {}
 
 /**
  * An object which can generate node IDs
- * @public
+ * @internal
  */
 export interface NodeIdGenerator {
 	/**
@@ -35,7 +35,7 @@ export interface NodeIdGenerator {
 
 /**
  * An object which can convert node IDs between compressed and stable variants
- * @public
+ * @internal
  */
 export interface NodeIdConverter {
 	/**

--- a/experimental/dds/tree/src/PayloadUtilities.ts
+++ b/experimental/dds/tree/src/PayloadUtilities.ts
@@ -40,7 +40,7 @@ import { Payload } from './persisted-types';
  * IFluidHandle instances (detected via JavaScript feature detection pattern) are only compared by absolutePath.
  *
  * TODO:#54095: Is there a better way to do this comparison?
- * @public
+ * @internal
  */
 export function comparePayloads(a: Payload, b: Payload): boolean {
 	// === is not reflective because of how NaN is handled, so use Object.is instead.

--- a/experimental/dds/tree/src/ReconciliationPath.ts
+++ b/experimental/dds/tree/src/ReconciliationPath.ts
@@ -12,7 +12,7 @@ import { TreeView } from './TreeView';
  * change is actually applied.
  * The path only contains edits that were successfully applied.
  * This path is always empty for a change that has no concurrent edits.
- * @public
+ * @internal
  */
 export interface ReconciliationPath {
 	/**
@@ -28,7 +28,7 @@ export interface ReconciliationPath {
 
 /**
  * An edit in the `ReconciliationPath`.
- * @public
+ * @internal
  */
 export interface ReconciliationEdit {
 	/**
@@ -52,7 +52,7 @@ export interface ReconciliationEdit {
 
 /**
  * A change in the `ReconciliationPath`.
- * @public
+ * @internal
  */
 export interface ReconciliationChange {
 	/**

--- a/experimental/dds/tree/src/RevisionValueCache.ts
+++ b/experimental/dds/tree/src/RevisionValueCache.ts
@@ -17,6 +17,7 @@ import { fail, compareFiniteNumbers } from './Common';
  * - revision 0 corresponds to the initialRevision.
  *
  * - revision 1 corresponds to the output of editLog[0] applied to the initialRevision.
+ * @internal
  */
 export type Revision = number;
 

--- a/experimental/dds/tree/src/RevisionView.ts
+++ b/experimental/dds/tree/src/RevisionView.ts
@@ -13,7 +13,7 @@ import { HasVariadicTraits } from './ChangeTypes';
 
 /**
  * An immutable view of a distributed tree.
- * @public
+ * @internal
  */
 export class RevisionView extends TreeView {
 	/**
@@ -86,7 +86,7 @@ export class RevisionView extends TreeView {
 
 /**
  * An view of a distributed tree that is part of an ongoing transaction between `RevisionView`s.
- * @public
+ * @internal
  */
 export class TransactionView extends TreeView {
 	/** Conclude a transaction by generating an immutable `RevisionView` from this view */

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -103,13 +103,13 @@ import { nilUuid } from './UuidUtilities';
 
 /**
  * The write format and associated options used to construct a `SharedTree`
- * @public
+ * @internal
  */
 export type SharedTreeArgs<WF extends WriteFormat = WriteFormat> = [writeFormat: WF, options?: SharedTreeOptions<WF>];
 
 /**
  * The type of shared tree options for a given write format
- * @public
+ * @internal
  */
 export type SharedTreeOptions<
 	WF extends WriteFormat,
@@ -126,7 +126,7 @@ export type SharedTreeOptions<
 
 /**
  * Configuration options for SharedTree that are independent of write format versions.
- * @public
+ * @internal
  */
 export interface SharedTreeBaseOptions {
 	/**
@@ -147,7 +147,7 @@ export interface SharedTreeBaseOptions {
 
 /**
  * Configuration options for a SharedTree with write format 0.0.2
- * @public
+ * @internal
  */
 export interface SharedTreeOptions_0_0_2 {
 	/**
@@ -169,7 +169,7 @@ export interface SharedTreeOptions_0_0_2 {
 
 /**
  * Configuration options for a SharedTree with write format 0.1.1
- * @public
+ * @internal
  */
 export interface SharedTreeOptions_0_1_1 {
 	/**
@@ -194,7 +194,7 @@ export interface SharedTreeOptions_0_1_1 {
 /**
  * Factory for SharedTree.
  * Includes history in the summary.
- * @public
+ * @internal
  */
 export class SharedTreeFactory implements IChannelFactory {
 	/**
@@ -288,7 +288,7 @@ const sortedWriteVersions = [WriteFormat.v0_0_2, WriteFormat.v0_1_1];
 
 /**
  * The arguments included when the EditCommitted SharedTreeEvent is emitted.
- * @public
+ * @internal
  */
 export interface EditCommittedEventArguments {
 	/** The ID of the edit committed. */
@@ -301,7 +301,7 @@ export interface EditCommittedEventArguments {
 
 /**
  * The arguments included when the {@link SharedTreeEvent.SequencedEditApplied} SharedTreeEvent is emitted.
- * @public
+ * @internal
  */
 export interface SequencedEditAppliedEventArguments {
 	/** The ID of the edit committed. */
@@ -320,7 +320,7 @@ export interface SequencedEditAppliedEventArguments {
 
 /**
  * The outcome of an edit.
- * @public
+ * @internal
  */
 export type EditApplicationOutcome =
 	| {
@@ -346,7 +346,7 @@ export type EditApplicationOutcome =
 
 /**
  * Events which may be emitted by `SharedTree`. See {@link SharedTreeEvent} for documentation of event semantics.
- * @public
+ * @internal
  */
 export interface ISharedTreeEvents extends ISharedObjectEvents {
 	(event: 'committedEdit', listener: EditCommittedHandler);
@@ -355,13 +355,13 @@ export interface ISharedTreeEvents extends ISharedObjectEvents {
 
 /**
  * Expected type for a handler of the `EditCommitted` event.
- * @public
+ * @internal
  */
 export type EditCommittedHandler = (args: EditCommittedEventArguments) => void;
 
 /**
  * Expected type for a handler of the {@link SharedTreeEvent.SequencedEditApplied} event.
- * @public
+ * @internal
  */
 export type SequencedEditAppliedHandler = (args: SequencedEditAppliedEventArguments) => void;
 
@@ -369,7 +369,7 @@ const sharedTreeTelemetryProperties: ITelemetryLoggerPropertyBags = { all: { isS
 
 /**
  * Contains information resulting from processing stashed shared tree ops
- * @public
+ * @internal
  */
 export interface StashedLocalOpMetadata {
 	/** A modified version of the edit in an edit op that should be resubmitted rather than the original edit */
@@ -381,7 +381,7 @@ const stashedSessionId = '8477b8d5-cf6c-4673-8345-8f076a8f9bc6' as SessionId;
 
 /**
  * A [distributed tree](../Readme.md).
- * @public
+ * @internal
  */
 export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeIdContext {
 	/**
@@ -425,7 +425,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * The UUID used for attribution of nodes created by this SharedTree. All shared trees with a write format of 0.1.1 or
 	 * greater have a unique attribution ID which may be configured in the constructor. All other shared trees (i.e. those
 	 * with a write format of 0.0.2) use the nil UUID as their attribution ID.
-	 * @public
 	 */
 	public get attributionId(): AttributionId {
 		switch (this.writeFormat) {
@@ -657,7 +656,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @param override - if supplied, calls to `convertToStableNodeId` using the returned node ID will return the override instead of
 	 * the UUID. Calls to `generateNodeId` with the same override always return the same ID. Performance note: passing an override string
 	 * incurs a storage cost that is significantly higher that a node ID without one, and should be avoided if possible.
-	 * @public
 	 */
 	public generateNodeId(override?: string): NodeId {
 		return this.idCompressor.generateCompressedId(override) as NodeId;
@@ -668,7 +666,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * may not be used across SharedTree instances, see `generateNodeId` for more).
 	 * The returned value will be a UUID, unless the creation of `id` used an override string (see `generateNodeId` for more).
 	 * The result is safe to persist and re-use across `SharedTree` instances, unlike `NodeId`.
-	 * @public
 	 */
 	public convertToStableNodeId(id: NodeId): StableNodeId {
 		return (this.idCompressor.tryDecompress(id) as StableNodeId) ?? fail('Node id is not known to this SharedTree');
@@ -680,7 +677,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * The returned stable ID is undefined if `id` was never created with this SharedTree. If a stable ID is returned, this does not imply
 	 * that there is a node with `id` in the current revision of the tree, only that `id` was at some point generated by some instance of
 	 * this tree.
-	 * @public
 	 */
 	public tryConvertToStableNodeId(id: NodeId): StableNodeId | undefined {
 		return this.idCompressor.tryDecompress(id) as StableNodeId | undefined;
@@ -691,7 +687,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * as a UUID corresponding to a `NodeId` or as an override passed to `generateNodeId`.
 	 * If a stable ID is returned, this does not imply that there is a node with `id` in the current revision of the tree, only that
 	 * `id` was at some point generated by an instance of this SharedTree.
-	 * @public
 	 */
 	public convertToNodeId(id: StableNodeId): NodeId {
 		return (
@@ -704,7 +699,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * either as a UUID corresponding to a `NodeId` or as an override passed to `generateNodeId`.
 	 * If a stable ID is returned, this does not imply that there is a node with `id` in the current revision of the tree, only that
 	 * `id` was at some point generated by an instance of this SharedTree.
-	 * @public
 	 */
 	public tryConvertToNodeId(id: StableNodeId): NodeId | undefined {
 		return this.idCompressor.tryRecompress(id) as NodeId | undefined;
@@ -714,7 +708,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * Returns the attribution ID associated with the SharedTree that generated the given node ID. This is generally only useful for clients
 	 * with a write format of 0.1.1 or greater since older clients cannot be given an attribution ID and will always use the default
 	 * `attributionId` of the tree.
-	 * @public
 	 */
 	public attributeNodeId(id: NodeId): AttributionId {
 		switch (this.writeFormat) {
@@ -732,7 +725,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 
 	/**
 	 * @returns the edit history of the tree.
-	 * @public
 	 */
 	public get edits(): OrderedEditSet<InternalizedChange> {
 		return this.editLog as unknown as OrderedEditSet<InternalizedChange>;
@@ -749,7 +741,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * Saves this SharedTree into a serialized summary. This is used for testing.
 	 *
 	 * @param summarizer - Optional summarizer to use. If not passed in, SharedTree's summarizer is used.
-	 * @internal
 	 */
 	public saveSerializedSummary(options?: { serializer?: IFluidSerializer }): string {
 		const { serializer } = options ?? {};
@@ -759,7 +750,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	/**
 	 * Initialize shared tree with a serialized summary. This is used for testing.
 	 * @returns Statistics about the loaded summary.
-	 * @internal
 	 */
 	public loadSerializedSummary(blobData: string): ITelemetryProperties {
 		const summary = deserialize(blobData, this.serializer);
@@ -769,7 +759,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 
 	/**
 	 * Saves this SharedTree into a deserialized summary.
-	 * @internal
 	 */
 	public saveSummary(): SharedTreeSummaryBase {
 		// If local changes exist, emulate the sequencing of those changes.
@@ -828,7 +817,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 
 	/**
 	 * Initialize shared tree with a deserialized summary.
-	 * @internal
 	 */
 	public loadSummary(summary: SharedTreeSummaryBase): void {
 		const { version: loadedSummaryVersion } = summary;
@@ -976,8 +964,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * - registered event listeners
 	 *
 	 * - state of caches
-	 *
-	 * @internal
 	 */
 	public equals(sharedTree: SharedTree): boolean {
 		if (!areRevisionViewsSemanticallyEqual(this.currentView, this, sharedTree.currentView, sharedTree)) {
@@ -1205,7 +1191,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * This method does not allow for snapshot isolation, as the changes are always applied to the most recent revision.
 	 * If it is desireable to read from and apply changes to a fixed view that does not change when remote changes arrive, `Checkout`
 	 * should be used instead.
-	 * @public
 	 */
 	public applyEdit(...changes: readonly Change[]): Edit<InternalizedChange>;
 	public applyEdit(changes: readonly Change[]): Edit<InternalizedChange>;
@@ -1253,7 +1238,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * External users should use one of the more specialized functions, like `applyEdit` which handles constructing the actual `Edit`
 	 * and uses public Change types.
 	 * This is exposed for internal use only.
-	 * @internal
 	 */
 	public applyEditInternal(editOrChanges: Edit<ChangeInternal> | readonly ChangeInternal[]): Edit<ChangeInternal> {
 		let edit: Edit<ChangeInternal>;
@@ -1271,7 +1255,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	/**
 	 * Converts a public Change type to an internal representation.
 	 * This is exposed for internal use only.
-	 * @internal
 	 */
 	public internalizeChange(change: Change): ChangeInternal {
 		switch (change.type) {
@@ -1360,7 +1343,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * Reverts a previous edit by applying a new edit containing the inverse of the original edit's changes.
 	 * @param editId - the edit to revert
 	 * @returns the id of the new edit, or undefined if the original edit could not be inverted given the current tree state.
-	 * @public
 	 */
 	public revert(editId: EditId): EditId | undefined {
 		const index = this.edits.getIndexOfId(editId);
@@ -1379,7 +1361,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @param changes - the changes to revert
 	 * @param before - the revision view before the changes were originally applied
 	 * @returns the inverse of `changes` or undefined if the changes could not be inverted for the given tree state.
-	 * @internal
 	 */
 	public revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined {
 		return revert(changes as unknown as readonly ChangeInternal[], before, this.logger, this.emit.bind(this));

--- a/experimental/dds/tree/src/StringInterner.ts
+++ b/experimental/dds/tree/src/StringInterner.ts
@@ -8,6 +8,7 @@ import type { InternedStringId } from './Identifiers';
 
 /**
  * Interns strings as integers.
+ * @internal
  */
 export interface StringInterner {
 	getInternedId(input: string): InternedStringId | undefined;

--- a/experimental/dds/tree/src/SummaryTestUtilities.ts
+++ b/experimental/dds/tree/src/SummaryTestUtilities.ts
@@ -49,7 +49,7 @@ export async function getUploadedEditChunkContents(sharedTree: SharedTree): Prom
 /**
  * Returns a serialized description of blob paths and their associated contents for all uploaded edit chunks in the given edit log.
  * @deprecated Edit virtualization is no longer supported. Do not use this.
- * @public
+ * @internal
  */
 export async function getSerializedUploadedEditChunkContents(sharedTree: SharedTree): Promise<string> {
 	return JSON.stringify(await getUploadedEditChunkContents(sharedTree));

--- a/experimental/dds/tree/src/Transaction.ts
+++ b/experimental/dds/tree/src/Transaction.ts
@@ -16,7 +16,7 @@ import { RestOrArray, unwrapRestOrArray } from './Common';
 
 /**
  * An event emitted by a `Transaction` to indicate a state change. See {@link TransactionEvents} for event argument information.
- * @public
+ * @internal
  */
 export enum TransactionEvent {
 	/**
@@ -27,7 +27,7 @@ export enum TransactionEvent {
 
 /**
  * Events which may be emitted by `Transaction`
- * @public
+ * @internal
  */
 export interface TransactionEvents extends IErrorEvent {
 	(event: TransactionEvent.ViewChange, listener: (before: TreeView, after: TreeView) => void);
@@ -36,6 +36,7 @@ export interface TransactionEvents extends IErrorEvent {
 /**
  * Buffers changes to be applied to an isolated view of a `SharedTree` over time before applying them directly to the tree itself as a
  * single edit
+ * @internal
  */
 export class Transaction extends TypedEventEmitter<TransactionEvents> {
 	/** The view of the tree when this transaction was created */

--- a/experimental/dds/tree/src/TransactionInternal.ts
+++ b/experimental/dds/tree/src/TransactionInternal.ts
@@ -37,13 +37,13 @@ import { TreeViewNode } from './TreeView';
 
 /**
  * Result of applying a transaction.
- * @public
+ * @internal
  */
 export type EditingResult = FailedEditingResult | ValidEditingResult;
 
 /**
  * Basic result of applying a transaction.
- * @public
+ * @internal
  */
 export interface EditingResultBase {
 	/**
@@ -66,7 +66,7 @@ export interface EditingResultBase {
 
 /**
  * Result of applying an invalid or malformed transaction.
- * @public
+ * @internal
  */
 export interface FailedEditingResult extends EditingResultBase {
 	/**
@@ -91,7 +91,7 @@ export interface FailedEditingResult extends EditingResultBase {
 
 /**
  * Result of applying a valid transaction.
- * @public
+ * @internal
  */
 export interface ValidEditingResult extends EditingResultBase {
 	/**
@@ -106,18 +106,19 @@ export interface ValidEditingResult extends EditingResultBase {
 
 /**
  * The result of applying a change within a transaction.
- * @public
+ * @internal
  */
 export type ChangeResult = Result<TransactionView, TransactionFailure>;
 
 /**
  * The ongoing state of a transaction.
- * @public
+ * @internal
  */
 export type TransactionState = SucceedingTransactionState | FailingTransactionState;
 
 /**
  * The state of a transaction that has not encountered an error.
+ * @internal
  */
 export interface SucceedingTransactionState {
 	/**
@@ -140,6 +141,7 @@ export interface SucceedingTransactionState {
 
 /**
  * The state of a transaction that has encountered an error.
+ * @internal
  */
 export interface FailingTransactionState extends TransactionFailure {
 	/**
@@ -158,6 +160,7 @@ export interface FailingTransactionState extends TransactionFailure {
 
 /**
  * The failure state of a transaction.
+ * @internal
  */
 export interface TransactionFailure {
 	/**
@@ -182,6 +185,7 @@ export interface TransactionFailure {
  *
  * No data outside the Transaction is modified by Transaction:
  * the results from `close` must be used to actually submit an `Edit`.
+ * @internal
  */
 export class GenericTransaction {
 	private readonly policy: GenericTransactionPolicy;
@@ -380,6 +384,7 @@ export class GenericTransaction {
  * - The kind of situations that might lead to a transaction failure
  *
  * Instances of this type are passed to the {@link GenericTransaction} constructor.
+ * @internal
  */
 export interface GenericTransactionPolicy {
 	/**
@@ -425,12 +430,13 @@ export interface GenericTransactionPolicy {
  *
  * No data outside the Transaction is modified by Transaction:
  * the results from `close` must be used to actually submit an `Edit`.
- * @public
+ * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace TransactionInternal {
 	/**
 	 * Makes a new {@link GenericTransaction} that follows the {@link TransactionInternal.Policy} policy.
+	 * @internal
 	 */
 	export function factory(view: RevisionView): GenericTransaction {
 		return new GenericTransaction(view, new Policy());
@@ -440,6 +446,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * The policy followed by a {@link TransactionInternal}.
+	 * @internal
 	 */
 	export class Policy implements GenericTransactionPolicy {
 		/**
@@ -829,6 +836,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * The kinds of failures that a transaction might encounter.
+	 * @internal
 	 */
 	export enum FailureKind {
 		/**
@@ -871,6 +879,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * A failure encountered by a transaction.
+	 * @internal
 	 */
 	export type Failure =
 		| UnusedDetachedSequenceFailure
@@ -885,6 +894,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error returned when a transaction is closed while there is an unused detached sequence.
+	 * @internal
 	 */
 	export interface UnusedDetachedSequenceFailure {
 		/**
@@ -899,6 +909,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a transaction encounters a build operation using an already in use DetachedSequenceID.
+	 * @internal
 	 */
 	export interface DetachedSequenceIdAlreadyInUseFailure {
 		/**
@@ -917,6 +928,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a transaction tries to operate on an unknown DetachedSequenceID
+	 * @internal
 	 */
 	export interface DetachedSequenceNotFoundFailure {
 		/**
@@ -935,6 +947,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a build uses a duplicated NodeId
+	 * @internal
 	 */
 	export interface DuplicateIdInBuildFailure {
 		/**
@@ -953,6 +966,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a build node ID is already used in the current state
+	 * @internal
 	 */
 	export interface IdAlreadyInUseFailure {
 		/**
@@ -971,6 +985,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a change is attempted on an unknown NodeId
+	 * @internal
 	 */
 	export interface UnknownIdFailure {
 		/**
@@ -989,6 +1004,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when an insert change uses an invalid Place
+	 * @internal
 	 */
 	export interface BadPlaceFailure {
 		/**
@@ -1011,6 +1027,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a detach operation is given an invalid or malformed Range
+	 * @internal
 	 */
 	export interface BadRangeFailure {
 		/**
@@ -1033,6 +1050,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Error thrown when a constraint fails to apply
+	 * @internal
 	 */
 	export interface ConstraintViolationFailure {
 		/**
@@ -1051,6 +1069,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * The details of what kind of constraint was violated and caused a ConstraintViolationFailure error to occur
+	 * @internal
 	 */
 	export type ConstraintViolationResult =
 		| {
@@ -1072,6 +1091,7 @@ export namespace TransactionInternal {
 
 	/**
 	 * Enum of possible kinds of constraint violations that can be encountered
+	 * @internal
 	 */
 	export enum ConstraintViolationKind {
 		/**

--- a/experimental/dds/tree/src/TreeNodeHandle.ts
+++ b/experimental/dds/tree/src/TreeNodeHandle.ts
@@ -12,7 +12,7 @@ import { TreeView, TreeViewNode } from './TreeView';
  * A handle to a `TreeNode` that exists within a specific `TreeView`. This type provides a convenient
  * API for traversing trees of nodes in a TreeView and is not designed to provide maximum runtime
  * performance; if performance is a concern, consider using the TreeView and TreeViewNode APIs directly.
- * @public
+ * @internal
  */
 export class TreeNodeHandle implements TreeNode<TreeNodeHandle, NodeId> {
 	private readonly view: TreeView;

--- a/experimental/dds/tree/src/TreeView.ts
+++ b/experimental/dds/tree/src/TreeView.ts
@@ -11,7 +11,7 @@ import { NodeData, Side } from './persisted-types';
 
 /**
  * Specifies the location of a trait (a labeled sequence of nodes) within the tree.
- * @public
+ * @internal
  */
 export interface TraitLocation {
 	readonly parent: NodeId;
@@ -20,7 +20,7 @@ export interface TraitLocation {
 
 /**
  * An immutable view of a distributed tree node.
- * @public
+ * @internal
  */
 export interface TreeViewNode extends NodeData<NodeId> {
 	/** The IDs of the children under this node */
@@ -34,7 +34,7 @@ export interface TreeViewNode extends NodeData<NodeId> {
  * 0 = before all nodes,
  * 1 = after first node,
  * etc.
- * @public
+ * @internal
  */
 export type PlaceIndex = number & { readonly PlaceIndex: unique symbol };
 
@@ -43,14 +43,14 @@ export type PlaceIndex = number & { readonly PlaceIndex: unique symbol };
  * 0 = first node,
  * 1 = second node,
  * etc.
- * @public
+ * @internal
  */
 export type TraitNodeIndex = number & { readonly TraitNodeIndex: unique symbol };
 
 /**
  * A place within a particular `TreeView` that is anchored relative to a specific node in the tree, or relative to the outside of the trait.
  * Valid iff 'trait' is valid and, if provided, sibling is in the Location specified by 'trait'.
- * @public
+ * @internal
  */
 export interface TreeViewPlace {
 	readonly sibling?: NodeId;
@@ -61,7 +61,7 @@ export interface TreeViewPlace {
 /**
  * Specifies the range of nodes from `start` to `end` within a trait within a particular `TreeView`.
  * Valid iff start and end are valid and are within the same trait.
- * @public
+ * @internal
  */
 export interface TreeViewRange {
 	readonly start: TreeViewPlace;
@@ -70,7 +70,7 @@ export interface TreeViewRange {
 
 /**
  * Contains some redundant information. Use only in computations between edits. Do not store.
- * @public
+ * @internal
  */
 export interface NodeInTrait {
 	readonly trait: TraitLocation;
@@ -79,7 +79,7 @@ export interface NodeInTrait {
 
 /**
  * A view of a distributed tree.
- * @public
+ * @internal
  */
 export abstract class TreeView {
 	public readonly root: NodeId;

--- a/experimental/dds/tree/src/TreeViewUtilities.ts
+++ b/experimental/dds/tree/src/TreeViewUtilities.ts
@@ -9,6 +9,7 @@ import { TraitLocation, TreeView, TreeViewPlace, TreeViewRange } from './TreeVie
 
 /**
  * Express the given {@link (StableRange:interface)} as a {@link TreeViewRange}
+ * @internal
  */
 export function rangeFromStableRange(view: TreeView, range: StableRange): TreeViewRange {
 	const location = getTraitLocationOfRange(view, range);
@@ -21,6 +22,7 @@ export function rangeFromStableRange(view: TreeView, range: StableRange): TreeVi
 
 /**
  * Express the given {@link (StablePlace:interface)} as a {@link TreeViewPlace}
+ * @internal
  */
 export function placeFromStablePlace(view: TreeView, stablePlace: StablePlace): TreeViewPlace {
 	const { side } = stablePlace;
@@ -42,6 +44,7 @@ export function placeFromStablePlace(view: TreeView, stablePlace: StablePlace): 
  * Return the trait under which the given range resides
  * @param view - the {@link TreeView} within which to retrieve the trait location
  * @param range - must be well formed and valid
+ * @internal
  */
 export function getTraitLocationOfRange(view: TreeView, range: StableRange): TraitLocation {
 	const referenceTrait = range.start.referenceTrait ?? range.end.referenceTrait;

--- a/experimental/dds/tree/src/persisted-types/0.0.2.ts
+++ b/experimental/dds/tree/src/persisted-types/0.0.2.ts
@@ -31,7 +31,7 @@ import type {
  * Each place can be specified, (aka 'anchored') in two ways (relative to the sibling before or after):
  * the choice of which way to anchor a place only matters when the kept across an edit, and thus evaluated in multiple contexts where the
  * two place description may no longer evaluate to the same place.
- * @public
+ * @internal
  */
 export enum Side {
 	Before = 0,
@@ -41,7 +41,7 @@ export enum Side {
 /**
  * A collection of changes to the tree that are applied atomically along with a unique identifier for the edit.
  * If any individual change fails to apply, the entire Edit will fail to apply.
- * @public
+ * @internal
  */
 export interface Edit<TChange> extends EditBase<TChange> {
 	/**
@@ -54,7 +54,7 @@ export interface Edit<TChange> extends EditBase<TChange> {
 /**
  * A collection of changes to the tree that are applied atomically. If any individual change fails to apply,
  * the entire Edit will fail to apply.
- * @public
+ * @internal
  */
 export interface EditWithoutId<TChange> extends EditBase<TChange> {
 	/**
@@ -65,7 +65,7 @@ export interface EditWithoutId<TChange> extends EditBase<TChange> {
 
 /**
  * The information included in an edit.
- * @public
+ * @internal
  */
 export interface EditBase<TChange> {
 	/**
@@ -92,8 +92,7 @@ export interface EditBase<TChange> {
  * See {@link comparePayloads} for equality semantics and related details (like what is allowed to be lost when serializing)
  *
  * TODO:#51984: Allow opting into heuristic blobbing in snapshots with a special IFluid key.
- *
- * @public
+ * @internal
  */
 export type Payload = Serializable;
 
@@ -101,7 +100,7 @@ export type Payload = Serializable;
  * Json compatible map as object.
  * Keys are TraitLabels,
  * Values are the content of the trait specified by the key.
- * @public
+ * @internal
  */
 export interface TraitMap<TChild> {
 	readonly [key: string]: TreeNodeSequence<TChild>;
@@ -109,13 +108,13 @@ export interface TraitMap<TChild> {
 
 /**
  * A sequence of Nodes that make up a trait under a Node
- * @public
+ * @internal
  */
 export type TreeNodeSequence<TChild> = readonly TChild[];
 
 /**
  * An object which may have traits with children of the given type underneath it
- * @public
+ * @internal
  */
 export interface HasTraits<TChild> {
 	readonly traits: TraitMap<TChild>;
@@ -123,7 +122,7 @@ export interface HasTraits<TChild> {
 
 /**
  * The fields required by a node in a tree
- * @public
+ * @internal
  */
 export interface NodeData<TId> {
 	/**
@@ -145,18 +144,19 @@ export interface NodeData<TId> {
 
 /**
  * Satisfies `NodeData` and may contain children under traits (which may or may not be `TreeNodes`)
- * @public
+ * @internal
  */
 export interface TreeNode<TChild, TId> extends NodeData<TId>, HasTraits<TChild> {}
 
 /**
  * A tree whose nodes are either TreeNodes or a placeholder
+ * @internal
  */
 export type PlaceholderTree<TPlaceholder = never> = TreeNode<PlaceholderTree<TPlaceholder>, NodeId> | TPlaceholder;
 
 /**
  * Specifies the location of a trait (a labeled sequence of nodes) within the tree.
- * @public
+ * @internal
  */
 export interface TraitLocationInternal_0_0_2 {
 	readonly parent: StableNodeId;
@@ -165,13 +165,13 @@ export interface TraitLocationInternal_0_0_2 {
 
 /**
  * JSON-compatible Node type. Objects of this type will be persisted in internal change objects (under Edits) in the SharedTree history.
- * @public
+ * @internal
  */
 export type ChangeNode_0_0_2 = TreeNode<ChangeNode_0_0_2, StableNodeId>;
 
 /**
  * The status code of an attempt to apply the changes in an Edit.
- * @public
+ * @internal
  */
 export enum EditStatus {
 	/**
@@ -246,7 +246,7 @@ export interface SharedTreeEditOp_0_0_2 extends VersionedOp<WriteFormat.v0_0_2> 
 
 /**
  * Format versions that SharedTree supports writing. Changes to op or summary formats necessitate updates.
- * @public
+ * @internal
  */
 export enum WriteFormat {
 	/** Stores all edits in their raw format. */
@@ -257,6 +257,7 @@ export enum WriteFormat {
 
 /**
  * The minimal information on a SharedTree summary. Contains the summary format version.
+ * @internal
  */
 export interface SharedTreeSummaryBase {
 	/**
@@ -282,7 +283,7 @@ export interface SharedTreeSummary_0_0_2 extends SharedTreeSummaryBase {
 
 /**
  * {@inheritdoc ChangeType}
- * @public
+ * @internal
  */
 export enum ChangeTypeInternal {
 	Insert,
@@ -306,13 +307,13 @@ export type ChangeInternal_0_0_2 =
 
 /**
  * {@inheritdoc BuildNode}
- * @public
+ * @internal
  */
 export type BuildNodeInternal_0_0_2 = TreeNode<BuildNodeInternal_0_0_2, StableNodeId> | DetachedSequenceId;
 
 /**
  * {@inheritdoc Build}
- * @public
+ * @internal
  */
 export interface BuildInternal_0_0_2 {
 	/** {@inheritdoc Build.destination } */
@@ -325,7 +326,7 @@ export interface BuildInternal_0_0_2 {
 
 /**
  * {@inheritdoc (Insert:interface)}
- * @public
+ * @internal
  */
 export interface InsertInternal_0_0_2 {
 	/** {@inheritdoc (Insert:interface).destination } */
@@ -338,7 +339,7 @@ export interface InsertInternal_0_0_2 {
 
 /**
  * {@inheritdoc Detach}
- * @public
+ * @internal
  */
 export interface DetachInternal_0_0_2 {
 	/** {@inheritdoc Detach.destination } */
@@ -351,7 +352,7 @@ export interface DetachInternal_0_0_2 {
 
 /**
  * {@inheritdoc SetValue}
- * @public
+ * @internal
  */
 export interface SetValueInternal_0_0_2 {
 	/** {@inheritdoc SetValue.nodeToModify } */
@@ -365,7 +366,7 @@ export interface SetValueInternal_0_0_2 {
 
 /**
  * What to do when a Constraint is violated.
- * @public
+ * @internal
  */
 export enum ConstraintEffect {
 	/**
@@ -388,7 +389,7 @@ export enum ConstraintEffect {
 
 /**
  * {@inheritdoc Constraint}
- * @public
+ * @internal
  */
 export interface ConstraintInternal_0_0_2 {
 	/** {@inheritdoc Constraint.toConstrain } */
@@ -411,7 +412,7 @@ export interface ConstraintInternal_0_0_2 {
 
 /**
  * {@inheritdoc (StablePlace:interface) }
- * @public
+ * @internal
  */
 export interface StablePlaceInternal_0_0_2 {
 	/**
@@ -432,7 +433,7 @@ export interface StablePlaceInternal_0_0_2 {
 
 /**
  * {@inheritdoc (StableRange:interface) }
- * @public
+ * @internal
  */
 export interface StableRangeInternal_0_0_2 {
 	/** {@inheritdoc (StableRange:interface).start } */

--- a/experimental/dds/tree/src/persisted-types/0.1.1.ts
+++ b/experimental/dds/tree/src/persisted-types/0.1.1.ts
@@ -50,7 +50,7 @@ import {
 
 /**
  * Specifies the location of a trait (a labeled sequence of nodes) within the tree.
- * @public
+ * @internal
  */
 export interface TraitLocationInternal extends Omit<TraitLocationInternal_0_0_2, 'parent'> {
 	readonly parent: NodeId;
@@ -91,7 +91,7 @@ export type CompressedPlaceholderTree<TId extends OpSpaceNodeId, TPlaceholder ex
 
 /**
  * JSON-compatible Node type. Objects of this type will be persisted in internal change objects (under Edits) in the SharedTree history.
- * @public
+ * @internal
  */
 export type ChangeNode = TreeNode<ChangeNode, NodeId>;
 
@@ -135,7 +135,7 @@ export interface SharedTreeSummary extends SharedTreeSummaryBase {
  * where calling `FluidEditHandle.get` returns an array buffer of compressed `editChunk` contents.
  * The type is parameterized to avoid nearly identical type definitions for uncompressed forms of the edit
  * log, and abstracting away the fact that handle fetching needs to invoke decompression.
- * @public
+ * @internal
  */
 export interface EditLogSummary<TChange, THandle> {
 	/**
@@ -161,7 +161,7 @@ export interface EditLogSummary<TChange, THandle> {
  * Can be satisfied by IFluidHandle<ArrayBufferLike>.
  * Note that though this is in `PersistedTypes`, it isn't directly serializable (e.g. `get` is a function).
  * Its serialization relies on being encoded via an IFluidSerializer.
- * @public
+ * @internal
  */
 export interface FluidEditHandle {
 	readonly get: () => Promise<ArrayBuffer>;
@@ -206,7 +206,7 @@ export type CompressedBuildNode<TId extends OpSpaceNodeId> = CompressedPlacehold
  * This type should be used as an opaque handle in the public API for `ChangeInternal` objects.
  * This is useful for supporting public APIs which involve working with a tree's edit history,
  * which will involve changes that have already been internalized.
- * @public
+ * @internal
  */
 export interface InternalizedChange {
 	InternalChangeBrand: '2cae1045-61cf-4ef7-a6a3-8ad920cb7ab3';
@@ -214,19 +214,19 @@ export interface InternalizedChange {
 
 /**
  * {@inheritdoc (Change:type)}
- * @public
+ * @internal
  */
 export type ChangeInternal = InsertInternal | DetachInternal | BuildInternal | SetValueInternal | ConstraintInternal;
 
 /**
  * {@inheritdoc BuildNode}
- * @public
+ * @internal
  */
 export type BuildNodeInternal = TreeNode<BuildNodeInternal, NodeId> | DetachedSequenceId;
 
 /**
  * {@inheritdoc Build}
- * @public
+ * @internal
  */
 export interface BuildInternal extends Omit<BuildInternal_0_0_2, 'source'> {
 	readonly source: TreeNodeSequence<BuildNodeInternal>;
@@ -234,7 +234,7 @@ export interface BuildInternal extends Omit<BuildInternal_0_0_2, 'source'> {
 
 /**
  * {@inheritdoc (Insert:interface)}
- * @public
+ * @internal
  */
 export interface InsertInternal extends Omit<InsertInternal_0_0_2, 'destination'> {
 	/** {@inheritdoc (Insert:interface).destination } */
@@ -243,7 +243,7 @@ export interface InsertInternal extends Omit<InsertInternal_0_0_2, 'destination'
 
 /**
  * {@inheritdoc Detach}
- * @public
+ * @internal
  */
 export interface DetachInternal extends Omit<DetachInternal_0_0_2, 'source'> {
 	/** {@inheritdoc Detach.source } */
@@ -252,7 +252,7 @@ export interface DetachInternal extends Omit<DetachInternal_0_0_2, 'source'> {
 
 /**
  * {@inheritdoc SetValue}
- * @public
+ * @internal
  */
 export interface SetValueInternal extends Omit<SetValueInternal_0_0_2, 'nodeToModify'> {
 	/** {@inheritdoc SetValue.nodeToModify } */
@@ -261,7 +261,7 @@ export interface SetValueInternal extends Omit<SetValueInternal_0_0_2, 'nodeToMo
 
 /**
  * {@inheritdoc Constraint}
- * @public
+ * @internal
  */
 export interface ConstraintInternal extends Omit<ConstraintInternal_0_0_2, 'toConstrain' | 'parentNode'> {
 	/** {@inheritdoc Constraint.toConstrain } */
@@ -272,7 +272,7 @@ export interface ConstraintInternal extends Omit<ConstraintInternal_0_0_2, 'toCo
 
 // Note: Documentation of this constant is merged with documentation of the `ChangeInternal` interface.
 /**
- * @public
+ * @internal
  */
 export const ChangeInternal = {
 	build: (source: TreeNodeSequence<BuildNodeInternal>, destination: DetachedSequenceId): BuildInternal => ({
@@ -343,7 +343,7 @@ export const ChangeInternal = {
 
 /**
  * {@inheritdoc (StablePlace:interface) }
- * @public
+ * @internal
  */
 export interface StablePlaceInternal extends Omit<StablePlaceInternal_0_0_2, 'referenceSibling' | 'referenceTrait'> {
 	/**
@@ -359,7 +359,7 @@ export interface StablePlaceInternal extends Omit<StablePlaceInternal_0_0_2, 're
 
 /**
  * {@inheritdoc (StableRange:interface) }
- * @public
+ * @internal
  */
 export interface StableRangeInternal {
 	/** {@inheritdoc (StableRange:interface).start } */
@@ -374,7 +374,7 @@ export interface StableRangeInternal {
  */
 
 /**
- * @public
+ * @internal
  */
 export const StablePlaceInternal = {
 	/**
@@ -408,7 +408,7 @@ export const StablePlaceInternal = {
 };
 
 /**
- * @public
+ * @internal
  */
 export const StableRangeInternal = {
 	/**

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -15,12 +15,16 @@ import { IErrorEvent } from "@fluidframework/core-interfaces";
 // add way to mark with current sequence number for ordering signals relative to ops
 // throttling and batching
 
+/**
+ * @internal
+ */
 export type SignalListener = (clientId: string, local: boolean, payload: Jsonable) => void;
 
 /**
  * ISignaler defines an interface for working with signals that is similar to the more common
  * eventing patterns of EventEmitter.  In addition to sending and responding to signals, it
  * provides explicit methods around signal requests to other connected clients.
+ * @internal
  */
 export interface ISignaler {
 	/**
@@ -50,6 +54,7 @@ export interface ISignaler {
 /**
  * Duck type of something that provides the expected signalling functionality:
  * A way to verify we can signal, a way to send a signal, and a way to listen for incoming signals
+ * @internal
  */
 export interface IRuntimeSignaler {
 	connected: boolean;
@@ -128,6 +133,7 @@ class InternalSignaler extends TypedEventEmitter<IErrorEvent> implements ISignal
 /**
  * DataObject implementation of ISignaler for fluid-static plug-and-play.  Allows fluid-static
  * users to get an ISignaler without a custom DO.
+ * @internal
  */
 export class Signaler
 	extends DataObject<{ Events: IErrorEvent }>

--- a/experimental/framework/last-edited/api-report/last-edited.api.md
+++ b/experimental/framework/last-edited/api-report/last-edited.api.md
@@ -11,16 +11,16 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { IUser } from '@fluidframework/protocol-definitions';
 import { SharedSummaryBlock } from '@fluidframework/shared-summary-block';
 
-// @public (undocumented)
+// @internal (undocumented)
 export const IFluidLastEditedTracker: keyof IProvideFluidLastEditedTracker;
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface IFluidLastEditedTracker extends IProvideFluidLastEditedTracker {
     getLastEditDetails(): ILastEditDetails | undefined;
     updateLastEditDetails(lastEditDetails: ILastEditDetails): void;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface ILastEditDetails {
     // (undocumented)
     timestamp: number;
@@ -28,13 +28,13 @@ export interface ILastEditDetails {
     user: IUser;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface IProvideFluidLastEditedTracker {
     // (undocumented)
     readonly IFluidLastEditedTracker: IFluidLastEditedTracker;
 }
 
-// @public
+// @internal
 export class LastEditedTracker implements IFluidLastEditedTracker {
     constructor(sharedSummaryBlock: SharedSummaryBlock);
     getLastEditDetails(): ILastEditDetails | undefined;
@@ -43,7 +43,7 @@ export class LastEditedTracker implements IFluidLastEditedTracker {
     updateLastEditDetails(lastEditDetails: ILastEditDetails): void;
 }
 
-// @public
+// @internal
 export class LastEditedTrackerDataObject extends DataObject implements IProvideFluidLastEditedTracker {
     // (undocumented)
     static getFactory(): DataObjectFactory<LastEditedTrackerDataObject>;
@@ -55,7 +55,7 @@ export class LastEditedTrackerDataObject extends DataObject implements IProvideF
     protected initializingFirstTime(): Promise<void>;
 }
 
-// @public
+// @internal
 export function setupLastEditedTrackerForContainer(lastEditedTracker: IFluidLastEditedTracker, runtime: IContainerRuntime, shouldDiscardMessageFn?: (message: ISequencedDocumentMessage) => boolean): void;
 
 // (No @packageDocumentation comment for this package)

--- a/experimental/framework/last-edited/src/interfaces.ts
+++ b/experimental/framework/last-edited/src/interfaces.ts
@@ -6,20 +6,20 @@
 import { IUser } from "@fluidframework/protocol-definitions";
 
 /**
- * @public
+ * @internal
  */
 export const IFluidLastEditedTracker: keyof IProvideFluidLastEditedTracker =
 	"IFluidLastEditedTracker";
 
 /**
- * @public
+ * @internal
  */
 export interface IProvideFluidLastEditedTracker {
 	readonly IFluidLastEditedTracker: IFluidLastEditedTracker;
 }
 
 /**
- * @public
+ * @internal
  */
 export interface IFluidLastEditedTracker extends IProvideFluidLastEditedTracker {
 	/**
@@ -34,7 +34,7 @@ export interface IFluidLastEditedTracker extends IProvideFluidLastEditedTracker 
 }
 
 /**
- * @public
+ * @internal
  */
 export interface ILastEditDetails {
 	user: IUser;

--- a/experimental/framework/last-edited/src/lastEditedTracker.ts
+++ b/experimental/framework/last-edited/src/lastEditedTracker.ts
@@ -10,8 +10,7 @@ import { IFluidLastEditedTracker, ILastEditDetails } from "./interfaces";
  * Tracks the last edit details such as the last edited user details and the last edited timestamp. The last edited
  * details should be updated (via updateLastEditDetails) in response to a remote op since it uses shared summary block
  * as storage.
- *
- * @public
+ * @internal
  */
 export class LastEditedTracker implements IFluidLastEditedTracker {
 	private readonly lastEditedDetailsKey = "lastEditDetailsKey";

--- a/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
+++ b/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
@@ -11,8 +11,7 @@ import { IProvideFluidLastEditedTracker } from "./interfaces";
 
 /**
  * LastEditedTrackerDataObject creates a LastEditedTracker that keeps track of the latest edits to the document.
- *
- * @public
+ * @internal
  */
 export class LastEditedTrackerDataObject
 	extends DataObject

--- a/experimental/framework/last-edited/src/setup.ts
+++ b/experimental/framework/last-edited/src/setup.ts
@@ -56,8 +56,7 @@ function getLastEditDetailsFromMessage(
  * @param lastEditedTracker - The last edited tracker.
  * @param runtime - The container runtime whose messages are to be tracked.
  * @param shouldDiscardMessageFn - Function that tells if a message should not be considered in computing last edited.
- *
- * @public
+ * @internal
  */
 export function setupLastEditedTrackerForContainer(
 	lastEditedTracker: IFluidLastEditedTracker,

--- a/experimental/framework/react-inputs/api-report/react-inputs.api.md
+++ b/experimental/framework/react-inputs/api-report/react-inputs.api.md
@@ -10,7 +10,7 @@ import { SharedCell } from '@fluidframework/cell';
 import { SharedString } from '@fluidframework/sequence';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
-// @public
+// @internal
 export class CollaborativeCheckbox extends React_2.Component<ICollaborativeCheckboxProps, ICollaborativeCheckboxState> {
     constructor(props: ICollaborativeCheckboxProps);
     // (undocumented)
@@ -19,7 +19,7 @@ export class CollaborativeCheckbox extends React_2.Component<ICollaborativeCheck
     render(): React_2.JSX.Element;
 }
 
-// @public
+// @internal
 export class CollaborativeInput extends React_2.Component<ICollaborativeInputProps, ICollaborativeInputState> {
     constructor(props: ICollaborativeInputProps);
     // (undocumented)
@@ -30,10 +30,10 @@ export class CollaborativeInput extends React_2.Component<ICollaborativeInputPro
     render(): React_2.JSX.Element;
 }
 
-// @public
+// @internal
 export const CollaborativeTextArea: React_2.FC<ICollaborativeTextAreaProps>;
 
-// @public
+// @internal
 export interface ICollaborativeCheckboxProps {
     // (undocumented)
     className?: string;
@@ -44,13 +44,13 @@ export interface ICollaborativeCheckboxProps {
     style?: React_2.CSSProperties;
 }
 
-// @public
+// @internal
 export interface ICollaborativeCheckboxState {
     // (undocumented)
     checked: boolean;
 }
 
-// @public
+// @internal
 export interface ICollaborativeInputProps {
     // (undocumented)
     className?: string;
@@ -65,7 +65,7 @@ export interface ICollaborativeInputProps {
     style?: React_2.CSSProperties;
 }
 
-// @public
+// @internal
 export interface ICollaborativeInputState {
     // (undocumented)
     selectionEnd: number;
@@ -73,7 +73,7 @@ export interface ICollaborativeInputState {
     selectionStart: number;
 }
 
-// @public
+// @internal
 export interface ICollaborativeTextAreaProps {
     // (undocumented)
     className?: string;
@@ -84,19 +84,19 @@ export interface ICollaborativeTextAreaProps {
     style?: React_2.CSSProperties;
 }
 
-// @public
+// @internal
 export interface ISharedStringHelperEvents extends IEvent {
     // (undocumented)
     (event: "textChanged", listener: (event: ISharedStringHelperTextChangedEventArgs) => void): any;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface ISharedStringHelperTextChangedEventArgs {
     isLocal: boolean;
     transformPosition: (oldPosition: number) => number;
 }
 
-// @public
+// @internal
 export class SharedStringHelper extends TypedEventEmitter<ISharedStringHelperEvents> {
     constructor(sharedString: SharedString);
     // (undocumented)

--- a/experimental/framework/react-inputs/src/CollaborativeCheckbox.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeCheckbox.tsx
@@ -7,8 +7,7 @@ import React from "react";
 
 /**
  * {@link CollaborativeCheckbox} input props.
- *
- * @public
+ * @internal
  */
 export interface ICollaborativeCheckboxProps {
 	/**
@@ -33,8 +32,7 @@ export interface ICollaborativeCheckboxProps {
 
 /**
  * {@link CollaborativeCheckbox} component state.
- *
- * @public
+ * @internal
  */
 export interface ICollaborativeCheckboxState {
 	checked: boolean;
@@ -42,8 +40,7 @@ export interface ICollaborativeCheckboxState {
 
 /**
  * Given a SharedCell will produce a collaborative checkbox.
- *
- * @public
+ * @internal
  */
 export class CollaborativeCheckbox extends React.Component<
 	ICollaborativeCheckboxProps,

--- a/experimental/framework/react-inputs/src/CollaborativeInput.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeInput.tsx
@@ -7,8 +7,7 @@ import React from "react";
 
 /**
  * {@link CollaborativeInput} input props.
- *
- * @public
+ * @internal
  */
 export interface ICollaborativeInputProps {
 	/**
@@ -35,8 +34,7 @@ export interface ICollaborativeInputProps {
 
 /**
  * {@link CollaborativeInput} component state.
- *
- * @public
+ * @internal
  */
 export interface ICollaborativeInputState {
 	selectionEnd: number;
@@ -45,8 +43,7 @@ export interface ICollaborativeInputState {
 
 /**
  * Given a {@link @fluidframework/sequence#SharedString}, will produce a collaborative input element.
- *
- * @public
+ * @internal
  */
 export class CollaborativeInput extends React.Component<
 	ICollaborativeInputProps,

--- a/experimental/framework/react-inputs/src/CollaborativeTextArea.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeTextArea.tsx
@@ -8,8 +8,7 @@ import { ISharedStringHelperTextChangedEventArgs, SharedStringHelper } from "./S
 
 /**
  * {@link CollaborativeTextArea} input props.
- *
- * @public
+ * @internal
  */
 export interface ICollaborativeTextAreaProps {
 	/**
@@ -35,8 +34,7 @@ export interface ICollaborativeTextAreaProps {
 
 /**
  * Given a {@link SharedStringHelper}, will produce a collaborative text area element.
- *
- * @public
+ * @internal
  */
 export const CollaborativeTextArea: React.FC<ICollaborativeTextAreaProps> = (
 	props: ICollaborativeTextAreaProps,

--- a/experimental/framework/react-inputs/src/SharedStringHelper.ts
+++ b/experimental/framework/react-inputs/src/SharedStringHelper.ts
@@ -9,7 +9,7 @@ import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
 import { SequenceDeltaEvent, SharedString } from "@fluidframework/sequence";
 
 /**
- * @public
+ * @internal
  */
 export interface ISharedStringHelperTextChangedEventArgs {
 	/**
@@ -27,8 +27,7 @@ export interface ISharedStringHelperTextChangedEventArgs {
 
 /**
  * Events emitted by {@link SharedStringHelper}.
- *
- * @public
+ * @internal
  */
 export interface ISharedStringHelperEvents extends IEvent {
 	(event: "textChanged", listener: (event: ISharedStringHelperTextChangedEventArgs) => void);
@@ -36,8 +35,7 @@ export interface ISharedStringHelperEvents extends IEvent {
 
 /**
  * Given a {@link @fluidframework/sequence#SharedString}, will provide a friendly API for use.
- *
- * @public
+ * @internal
  */
 export class SharedStringHelper extends TypedEventEmitter<ISharedStringHelperEvents> {
 	private readonly _sharedString: SharedString;

--- a/experimental/framework/tree-react-api/src/useTree.ts
+++ b/experimental/framework/tree-react-api/src/useTree.ts
@@ -8,6 +8,7 @@ import React from "react";
 
 /**
  * React Hook to trigger invalidation of the current component if anything in the document changes.
+ * @internal
  */
 export function useTreeContext(document: TreeContext): void {
 	// This proof-of-concept implementation allocates a state variable this is modified
@@ -26,6 +27,7 @@ export function useTreeContext(document: TreeContext): void {
 /**
  * React Hook to trigger invalidation of the current component if anything in the provided subtree changes.
  * This does NOT include if this subtree is moved into a different parent!
+ * @internal
  */
 export function useSubtree(tree: FlexTreeNode): void {
 	// This proof-of-concept implementation allocates a state variable this is modified

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="mocha" />
+
 // @public (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @public (undocumented)
 export const mochaHooks: {
     beforeAll(): void;


### PR DESCRIPTION
For our next major version Fluid Framework will be using explicit release tagging, and d.ts rollups to support public, beta, alpha, and internal. In preparation for that we are tagging everything internal to start, and then will carve out our other releases. Marking everything internal serves 2 purposes. 1) tags are inconsistently applied today, and it is easier to carve out a consistent set for each release type, rather than finding and fixing each miss application 2) which supports 1, inconsistent tags make tooling very hard and error prone to rollout, by making everything internal we have a consistent surface to enable our tooling upon, and this tooling will be used to inform our official carve outs.

related: 
https://github.com/microsoft/FluidFramework/pull/18409
https://github.com/microsoft/FluidFramework/pull/18408
https://github.com/microsoft/FluidFramework/pull/18411
https://github.com/microsoft/FluidFramework/pull/18412
https://github.com/microsoft/FluidFramework/pull/18410
https://github.com/microsoft/FluidFramework/pull/18413