### PR TITLE
build: Bundle packages whose contents are re-exported by `fluid-framework` via API-Extractor's `bundledPackages` feature

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -2293,7 +2293,7 @@ The `@fluid-internal/client-api` package was deprecated in 0.20 and has now been
 
 ### SignalManager removed from fluid-framework export
 
-The `SignalManager` and `Signaler` classes have been removed from the `@fluid-framework/fluid-static` and `fluid-framework` package exports and moved to the `@fluid-experimental/data-objects` package. This is because of its experimental state and the intentional omission of experimental features from `fluid-framework`. Users should instead import the classes from the `@fluid-experimental/data-objects` package.
+The `SignalManager` and `Signaler` classes have been removed from the `@fluidframework/fluid-static` and `fluid-framework` package exports and moved to the `@fluid-experimental/data-objects` package. This is because of its experimental state and the intentional omission of experimental features from `fluid-framework`. Users should instead import the classes from the `@fluid-experimental/data-objects` package.
 
 ### MockLogger removed from @fluidframework/test-runtime-utils
 

--- a/packages/framework/fluid-framework/api-extractor.json
+++ b/packages/framework/fluid-framework/api-extractor.json
@@ -3,5 +3,31 @@
 	"extends": "@fluidframework/build-common/api-extractor-base.json",
 	"dtsRollup": {
 		"enabled": true
-	}
+	},
+	"messages": {
+		"extractorMessageReporting": {
+			// This package has some existing exports that require re-exporting many members from other packages we
+			// don't wish to expose here.
+			// The exports in question have been marked as deprecated. Once they have been removed, we should remove
+			// this rule override.
+			"ae-forgotten-export": {
+				"logLevel": "error",
+				"addToApiReportFile": true
+			},
+			// TODO: Fix violations and remove this rule override
+			"ae-missing-release-tag": {
+				"logLevel": "none"
+			}
+		}
+	},
+	// TODO: update this to either use glob patterns if/when supported (see https://github.com/microsoft/rushstack/issues/4426)
+	// or utilize some base config to enumerate all of our packages so we don't have to manage a list like this here.
+	"bundledPackages": [
+		"@fluidframework/container-definitions",
+		"@fluidframework/container-loader",
+		"@fluidframework/driver-definitions",
+		"@fluidframework/fluid-static",
+		"@fluidframework/map",
+		"@fluidframework/sequence"
+	]
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -4,251 +4,1091 @@
 
 ```ts
 
-import { AttachState } from '@fluidframework/container-definitions';
-import { ConnectionState } from '@fluidframework/container-loader';
-import { ContainerErrorType } from '@fluidframework/container-definitions';
-import { ContainerSchema } from '@fluidframework/fluid-static';
-import { DataObjectClass } from '@fluidframework/fluid-static';
-import { DeserializeCallback } from '@fluidframework/sequence';
-import { DirectoryFactory } from '@fluidframework/map';
-import { DOProviderContainerRuntimeFactory } from '@fluidframework/fluid-static';
-import { DriverErrorType } from '@fluidframework/driver-definitions';
-import { FluidContainer } from '@fluidframework/fluid-static';
-import { getTextAndMarkers } from '@fluidframework/sequence';
-import { IConnection } from '@fluidframework/fluid-static';
-import { ICriticalContainerError } from '@fluidframework/container-definitions';
-import { IDirectory } from '@fluidframework/map';
-import { IDirectoryClearOperation } from '@fluidframework/map';
-import { IDirectoryCreateSubDirectoryOperation } from '@fluidframework/map';
-import { IDirectoryDataObject } from '@fluidframework/map';
-import { IDirectoryDeleteOperation } from '@fluidframework/map';
-import { IDirectoryDeleteSubDirectoryOperation } from '@fluidframework/map';
-import { IDirectoryEvents } from '@fluidframework/map';
-import { IDirectoryKeyOperation } from '@fluidframework/map';
-import { IDirectoryNewStorageFormat } from '@fluidframework/map';
-import { IDirectoryOperation } from '@fluidframework/map';
-import { IDirectorySetOperation } from '@fluidframework/map';
-import { IDirectoryStorageOperation } from '@fluidframework/map';
-import { IDirectorySubDirectoryOperation } from '@fluidframework/map';
-import { IDirectoryValueChanged } from '@fluidframework/map';
-import { IFluidContainer } from '@fluidframework/fluid-static';
-import { IFluidContainerEvents } from '@fluidframework/fluid-static';
-import { IInterval } from '@fluidframework/sequence';
-import { IIntervalCollection } from '@fluidframework/sequence';
-import { IIntervalCollectionEvent } from '@fluidframework/sequence';
-import { IIntervalHelpers } from '@fluidframework/sequence';
-import { IJSONRunSegment } from '@fluidframework/sequence';
-import { ILocalValue } from '@fluidframework/map';
-import { IMapMessageLocalMetadata } from '@fluidframework/sequence';
-import { IMember } from '@fluidframework/fluid-static';
-import { Interval } from '@fluidframework/sequence';
-import { IntervalLocator } from '@fluidframework/sequence';
-import { intervalLocatorFromEndpoint } from '@fluidframework/sequence';
-import { IntervalType } from '@fluidframework/sequence';
-import { IRootDataObject } from '@fluidframework/fluid-static';
-import { ISequenceDeltaRange } from '@fluidframework/sequence';
-import { ISerializableInterval } from '@fluidframework/sequence';
-import { ISerializableValue } from '@fluidframework/map';
-import { ISerializedInterval } from '@fluidframework/sequence';
-import { ISerializedValue } from '@fluidframework/map';
-import { IServiceAudience } from '@fluidframework/fluid-static';
-import { IServiceAudienceEvents } from '@fluidframework/fluid-static';
-import { ISharedDirectory } from '@fluidframework/map';
-import { ISharedDirectoryEvents } from '@fluidframework/map';
-import { ISharedIntervalCollection } from '@fluidframework/sequence';
-import { ISharedMap } from '@fluidframework/map';
-import { ISharedMapEvents } from '@fluidframework/map';
-import { ISharedSegmentSequenceEvents } from '@fluidframework/sequence';
-import { ISharedString } from '@fluidframework/sequence';
-import { IValueChanged } from '@fluidframework/map';
-import { IValueOpEmitter } from '@fluidframework/sequence';
-import { LoadableObjectClass } from '@fluidframework/fluid-static';
-import { LoadableObjectClassRecord } from '@fluidframework/fluid-static';
-import { LoadableObjectCtor } from '@fluidframework/fluid-static';
-import { LoadableObjectRecord } from '@fluidframework/fluid-static';
-import { LocalValueMaker } from '@fluidframework/map';
-import { MapFactory } from '@fluidframework/map';
-import { MemberChangedListener } from '@fluidframework/fluid-static';
-import { SequenceDeltaEvent } from '@fluidframework/sequence';
-import { SequenceEvent } from '@fluidframework/sequence';
-import { SequenceInterval } from '@fluidframework/sequence';
-import { SequenceMaintenanceEvent } from '@fluidframework/sequence';
-import { SerializedIntervalDelta } from '@fluidframework/sequence';
-import { ServiceAudience } from '@fluidframework/fluid-static';
-import { SharedDirectory } from '@fluidframework/map';
-import { SharedIntervalCollection } from '@fluidframework/sequence';
-import { SharedIntervalCollectionFactory } from '@fluidframework/sequence';
-import { SharedMap } from '@fluidframework/map';
-import { SharedObjectClass } from '@fluidframework/fluid-static';
-import { SharedSegmentSequence } from '@fluidframework/sequence';
-import { SharedSequence } from '@fluidframework/sequence';
-import { SharedString } from '@fluidframework/sequence';
-import { SharedStringFactory } from '@fluidframework/sequence';
-import { SharedStringSegment } from '@fluidframework/sequence';
-import { SubSequence } from '@fluidframework/sequence';
-
-export { AttachState }
-
-export { ConnectionState }
-
-export { ContainerErrorType }
-
-export { ContainerSchema }
-
-export { DataObjectClass }
-
-export { DeserializeCallback }
-
-export { DirectoryFactory }
-
-export { DOProviderContainerRuntimeFactory }
-
-export { DriverErrorType }
-
-export { FluidContainer }
-
-export { getTextAndMarkers }
-
-export { IConnection }
-
-export { ICriticalContainerError }
-
-export { IDirectory }
-
-export { IDirectoryClearOperation }
-
-export { IDirectoryCreateSubDirectoryOperation }
-
-export { IDirectoryDataObject }
-
-export { IDirectoryDeleteOperation }
-
-export { IDirectoryDeleteSubDirectoryOperation }
-
-export { IDirectoryEvents }
-
-export { IDirectoryKeyOperation }
-
-export { IDirectoryNewStorageFormat }
-
-export { IDirectoryOperation }
-
-export { IDirectorySetOperation }
-
-export { IDirectoryStorageOperation }
-
-export { IDirectorySubDirectoryOperation }
-
-export { IDirectoryValueChanged }
-
-export { IFluidContainer }
-
-export { IFluidContainerEvents }
-
-export { IInterval }
-
-export { IIntervalCollection }
-
-export { IIntervalCollectionEvent }
-
-export { IIntervalHelpers }
-
-export { IJSONRunSegment }
-
-export { ILocalValue }
-
-export { IMapMessageLocalMetadata }
-
-export { IMember }
-
-export { Interval }
-
-export { IntervalLocator }
-
-export { intervalLocatorFromEndpoint }
-
-export { IntervalType }
-
-export { IRootDataObject }
-
-export { ISequenceDeltaRange }
-
-export { ISerializableInterval }
-
-export { ISerializableValue }
-
-export { ISerializedInterval }
-
-export { ISerializedValue }
-
-export { IServiceAudience }
-
-export { IServiceAudienceEvents }
-
-export { ISharedDirectory }
-
-export { ISharedDirectoryEvents }
-
-export { ISharedIntervalCollection }
-
-export { ISharedMap }
-
-export { ISharedMapEvents }
-
-export { ISharedSegmentSequenceEvents }
-
-export { ISharedString }
-
-export { IValueChanged }
-
-export { IValueOpEmitter }
-
-export { LoadableObjectClass }
-
-export { LoadableObjectClassRecord }
-
-export { LoadableObjectCtor }
-
-export { LoadableObjectRecord }
-
-export { LocalValueMaker }
-
-export { MapFactory }
-
-export { MemberChangedListener }
-
-export { SequenceDeltaEvent }
-
-export { SequenceEvent }
-
-export { SequenceInterval }
-
-export { SequenceMaintenanceEvent }
-
-export { SerializedIntervalDelta }
-
-export { ServiceAudience }
-
-export { SharedDirectory }
-
-export { SharedIntervalCollection }
-
-export { SharedIntervalCollectionFactory }
-
-export { SharedMap }
-
-export { SharedObjectClass }
-
-export { SharedSegmentSequence }
-
-export { SharedSequence }
-
-export { SharedString }
-
-export { SharedStringFactory }
-
-export { SharedStringSegment }
-
-export { SubSequence }
+import { BaseContainerRuntimeFactory } from '@fluidframework/aqueduct';
+import { BaseSegment } from '@fluidframework/merge-tree';
+import { Client } from '@fluidframework/merge-tree';
+import { Deferred } from '@fluidframework/core-utils';
+import { EventEmitter } from 'events';
+import { FluidObject } from '@fluidframework/core-interfaces';
+import { IChannelAttributes } from '@fluidframework/datastore-definitions';
+import { IChannelFactory } from '@fluidframework/datastore-definitions';
+import { IChannelServices } from '@fluidframework/datastore-definitions';
+import { IChannelStorageService } from '@fluidframework/datastore-definitions';
+import { IClient } from '@fluidframework/protocol-definitions';
+import { IClientConfiguration } from '@fluidframework/protocol-definitions';
+import { IClientDetails } from '@fluidframework/protocol-definitions';
+import { ICombiningOp } from '@fluidframework/merge-tree';
+import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
+import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDocumentMessage } from '@fluidframework/protocol-definitions';
+import { IErrorBase } from '@fluidframework/core-interfaces';
+import { IErrorEvent } from '@fluidframework/core-interfaces';
+import { IEvent } from '@fluidframework/core-interfaces';
+import { IEventProvider } from '@fluidframework/core-interfaces';
+import { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';
+import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
+import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
+import { IFluidHandle } from '@fluidframework/core-interfaces';
+import { IFluidLoadable } from '@fluidframework/core-interfaces';
+import { IFluidRouter } from '@fluidframework/core-interfaces';
+import { IFluidSerializer } from '@fluidframework/shared-object-base';
+import { IJSONSegment } from '@fluidframework/merge-tree';
+import { IMergeTreeDeltaCallbackArgs } from '@fluidframework/merge-tree';
+import { IMergeTreeDeltaOpArgs } from '@fluidframework/merge-tree';
+import { IMergeTreeGroupMsg } from '@fluidframework/merge-tree';
+import { IMergeTreeInsertMsg } from '@fluidframework/merge-tree';
+import { IMergeTreeMaintenanceCallbackArgs } from '@fluidframework/merge-tree';
+import { IMergeTreeOp } from '@fluidframework/merge-tree';
+import { IMergeTreeRemoveMsg } from '@fluidframework/merge-tree';
+import { IQuorumClients } from '@fluidframework/protocol-definitions';
+import { IRelativePosition } from '@fluidframework/merge-tree';
+import { IRequest } from '@fluidframework/core-interfaces';
+import { IResponse } from '@fluidframework/core-interfaces';
+import { ISegment } from '@fluidframework/merge-tree';
+import { ISegmentAction } from '@fluidframework/merge-tree';
+import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
+import { ISequencedProposal } from '@fluidframework/protocol-definitions';
+import { ISharedObject } from '@fluidframework/shared-object-base';
+import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
+import { ISignalMessage } from '@fluidframework/protocol-definitions';
+import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import { ITelemetryContext } from '@fluidframework/runtime-definitions';
+import { ITokenClaims } from '@fluidframework/protocol-definitions';
+import { LocalReferencePosition } from '@fluidframework/merge-tree';
+import { Marker } from '@fluidframework/merge-tree';
+import { MergeTreeDeltaOperationType } from '@fluidframework/merge-tree';
+import { MergeTreeDeltaOperationTypes } from '@fluidframework/merge-tree';
+import { MergeTreeMaintenanceType } from '@fluidframework/merge-tree';
+import { MergeTreeRevertibleDriver } from '@fluidframework/merge-tree';
+import { PropertiesManager } from '@fluidframework/merge-tree';
+import { PropertySet } from '@fluidframework/merge-tree';
+import { RangeStackMap } from '@fluidframework/merge-tree';
+import { ReferencePosition } from '@fluidframework/merge-tree';
+import { ReferenceType } from '@fluidframework/merge-tree';
+import { Serializable } from '@fluidframework/datastore-definitions';
+import { SharedObject } from '@fluidframework/shared-object-base';
+import { SlidingPreference } from '@fluidframework/merge-tree';
+import { SummarySerializer } from '@fluidframework/shared-object-base';
+import { TextSegment } from '@fluidframework/merge-tree';
+import { TypedEventEmitter } from '@fluid-internal/client-utils';
+
+// @public
+export enum AttachState {
+    Attached = "Attached",
+    Attaching = "Attaching",
+    Detached = "Detached"
+}
+
+// @public (undocumented)
+export enum ConnectionState {
+    CatchingUp = 1,
+    Connected = 2,
+    Disconnected = 0,
+    EstablishingConnection = 3
+}
+
+// @public @deprecated
+export enum ContainerErrorType {
+    clientSessionExpiredError = "clientSessionExpiredError",
+    dataCorruptionError = "dataCorruptionError",
+    dataProcessingError = "dataProcessingError",
+    genericError = "genericError",
+    throttlingError = "throttlingError",
+    usageError = "usageError"
+}
+
+// @public
+export interface ContainerSchema {
+    dynamicObjectTypes?: LoadableObjectClass<any>[];
+    initialObjects: LoadableObjectClassRecord;
+}
+
+// @public
+export type DataObjectClass<T extends IFluidLoadable> = {
+    readonly factory: IFluidDataStoreFactory;
+} & LoadableObjectCtor<T>;
+
+// @public (undocumented)
+export type DeserializeCallback = (properties: PropertySet) => void;
+
+// @public @sealed
+export class DirectoryFactory implements IChannelFactory {
+    // (undocumented)
+    static readonly Attributes: IChannelAttributes;
+    // (undocumented)
+    get attributes(): IChannelAttributes;
+    // (undocumented)
+    create(runtime: IFluidDataStoreRuntime, id: string): ISharedDirectory;
+    // (undocumented)
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<ISharedDirectory>;
+    // (undocumented)
+    static readonly Type = "https://graph.microsoft.com/types/directory";
+    // (undocumented)
+    get type(): string;
+}
+
+// @public @deprecated
+export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
+    constructor(schema: ContainerSchema);
+    // (undocumented)
+    protected containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void>;
+}
+
+// @public @deprecated
+export enum DriverErrorType {
+    authorizationError = "authorizationError",
+    deltaStreamConnectionForbidden = "deltaStreamConnectionForbidden",
+    fetchFailure = "fetchFailure",
+    fetchTokenError = "fetchTokenError",
+    fileIsLocked = "fileIsLocked",
+    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
+    fileOverwrittenInStorage = "fileOverwrittenInStorage",
+    fluidInvalidSchema = "fluidInvalidSchema",
+    genericError = "genericError",
+    genericNetworkError = "genericNetworkError",
+    incorrectServerResponse = "incorrectServerResponse",
+    locationRedirection = "locationRedirection",
+    offlineError = "offlineError",
+    outOfStorageError = "outOfStorageError",
+    throttlingError = "throttlingError",
+    // (undocumented)
+    unsupportedClientProtocolVersion = "unsupportedClientProtocolVersion",
+    usageError = "usageError",
+    writeError = "writeError"
+}
+
+// @public
+export const DriverErrorTypes: {
+    readonly genericNetworkError: "genericNetworkError";
+    readonly authorizationError: "authorizationError";
+    readonly fileNotFoundOrAccessDeniedError: "fileNotFoundOrAccessDeniedError";
+    readonly offlineError: "offlineError";
+    readonly unsupportedClientProtocolVersion: "unsupportedClientProtocolVersion";
+    readonly writeError: "writeError";
+    readonly fetchFailure: "fetchFailure";
+    readonly fetchTokenError: "fetchTokenError";
+    readonly incorrectServerResponse: "incorrectServerResponse";
+    readonly fileOverwrittenInStorage: "fileOverwrittenInStorage";
+    readonly deltaStreamConnectionForbidden: "deltaStreamConnectionForbidden";
+    readonly locationRedirection: "locationRedirection";
+    readonly fluidInvalidSchema: "fluidInvalidSchema";
+    readonly fileIsLocked: "fileIsLocked";
+    readonly outOfStorageError: "outOfStorageError";
+    readonly genericError: "genericError";
+    readonly throttlingError: "throttlingError";
+    readonly usageError: "usageError";
+};
+
+// @public (undocumented)
+export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
+
+// @public @deprecated
+export class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer<TContainerSchema> {
+    // Warning: (ae-forgotten-export) The symbol "IContainer" needs to be exported by the entry point index.d.ts
+    constructor(container: IContainer, rootDataObject: IRootDataObject);
+    attach(): Promise<string>;
+    get attachState(): AttachState;
+    connect(): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "ConnectionState_2" needs to be exported by the entry point index.d.ts
+    get connectionState(): ConnectionState_2;
+    create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
+    disconnect(): Promise<void>;
+    dispose(): void;
+    get disposed(): boolean;
+    get initialObjects(): InitialObjects<TContainerSchema>;
+    // @internal
+    readonly INTERNAL_CONTAINER_DO_NOT_USE?: () => IContainer;
+    get isDirty(): boolean;
+}
+
+// @public
+export function getTextAndMarkers(sharedString: SharedString, label: string, start?: number, end?: number): {
+    parallelText: string[];
+    parallelMarkers: Marker[];
+};
+
+// @public
+export interface IConnection {
+    id: string;
+    mode: "write" | "read";
+}
+
+// @public
+export interface ICreateInfo {
+    ccIds: string[];
+    csn: number;
+}
+
+// @public
+export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryEvents>, Partial<IDisposable> {
+    readonly absolutePath: string;
+    countSubDirectory?(): number;
+    createSubDirectory(subdirName: string): IDirectory;
+    deleteSubDirectory(subdirName: string): boolean;
+    get<T = any>(key: string): T | undefined;
+    getSubDirectory(subdirName: string): IDirectory | undefined;
+    getWorkingDirectory(relativePath: string): IDirectory | undefined;
+    hasSubDirectory(subdirName: string): boolean;
+    set<T = unknown>(key: string, value: T): this;
+    subdirectories(): IterableIterator<[string, IDirectory]>;
+}
+
+// @public
+export interface IDirectoryClearOperation {
+    path: string;
+    type: "clear";
+}
+
+// @public
+export interface IDirectoryCreateSubDirectoryOperation {
+    path: string;
+    subdirName: string;
+    type: "createSubDirectory";
+}
+
+// @public
+export interface IDirectoryDataObject {
+    ci?: ICreateInfo;
+    storage?: {
+        [key: string]: ISerializableValue;
+    };
+    subdirectories?: {
+        [subdirName: string]: IDirectoryDataObject;
+    };
+}
+
+// @public
+export interface IDirectoryDeleteOperation {
+    key: string;
+    path: string;
+    type: "delete";
+}
+
+// @public
+export interface IDirectoryDeleteSubDirectoryOperation {
+    path: string;
+    subdirName: string;
+    type: "deleteSubDirectory";
+}
+
+// @public
+export interface IDirectoryEvents extends IEvent {
+    (event: "containedValueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "disposed", listener: (target: IEventThisPlaceHolder) => void): any;
+    (event: "undisposed", listener: (target: IEventThisPlaceHolder) => void): any;
+}
+
+// @public
+export type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
+
+// @internal
+export interface IDirectoryNewStorageFormat {
+    blobs: string[];
+    content: IDirectoryDataObject;
+}
+
+// @public
+export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOperation;
+
+// @public
+export interface IDirectorySetOperation {
+    key: string;
+    path: string;
+    type: "set";
+    value: ISerializableValue;
+}
+
+// @public
+export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
+
+// @public
+export type IDirectorySubDirectoryOperation = IDirectoryCreateSubDirectoryOperation | IDirectoryDeleteSubDirectoryOperation;
+
+// @public
+export interface IDirectoryValueChanged extends IValueChanged {
+    path: string;
+}
+
+// @public
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(): Promise<string>;
+    readonly attachState: AttachState;
+    connect(): void;
+    readonly connectionState: ConnectionState_2;
+    create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
+    disconnect(): void;
+    dispose(): void;
+    readonly disposed: boolean;
+    readonly initialObjects: InitialObjects<TContainerSchema>;
+    readonly isDirty: boolean;
+}
+
+// @public
+export interface IFluidContainerEvents extends IEvent {
+    (event: "connected", listener: () => void): void;
+    (event: "disconnected", listener: () => void): void;
+    (event: "saved", listener: () => void): void;
+    (event: "dirty", listener: () => void): void;
+    // Warning: (ae-forgotten-export) The symbol "ICriticalContainerError" needs to be exported by the entry point index.d.ts
+    (event: "disposed", listener: (error?: ICriticalContainerError) => void): any;
+}
+
+// @public
+export interface IInterval {
+    // (undocumented)
+    clone(): IInterval;
+    compare(b: IInterval): number;
+    compareEnd(b: IInterval): number;
+    compareStart(b: IInterval): number;
+    // @internal
+    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): IInterval | undefined;
+    // (undocumented)
+    overlaps(b: IInterval): boolean;
+    // @internal
+    union(b: IInterval): IInterval;
+}
+
+// @public
+export interface IIntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
+    // (undocumented)
+    [Symbol.iterator](): Iterator<TInterval>;
+    // @deprecated
+    add(start: SequencePlace, end: SequencePlace, intervalType: IntervalType, props?: PropertySet): TInterval;
+    add({ start, end, props, }: {
+        start: SequencePlace;
+        end: SequencePlace;
+        props?: PropertySet;
+    }): TInterval;
+    // (undocumented)
+    attachDeserializer(onDeserialize: DeserializeCallback): void;
+    // (undocumented)
+    readonly attached: boolean;
+    attachIndex(index: IntervalIndex<TInterval>): void;
+    change(id: string, start: SequencePlace, end: SequencePlace): TInterval | undefined;
+    changeProperties(id: string, props: PropertySet): any;
+    // (undocumented)
+    CreateBackwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
+    // (undocumented)
+    CreateBackwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
+    // (undocumented)
+    CreateForwardIteratorWithEndPosition(endPosition: number): Iterator<TInterval>;
+    // (undocumented)
+    CreateForwardIteratorWithStartPosition(startPosition: number): Iterator<TInterval>;
+    detachIndex(index: IntervalIndex<TInterval>): boolean;
+    // (undocumented)
+    findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[];
+    gatherIterationResults(results: TInterval[], iteratesForward: boolean, start?: number, end?: number): void;
+    // (undocumented)
+    getIntervalById(id: string): TInterval | undefined;
+    map(fn: (interval: TInterval) => void): void;
+    // (undocumented)
+    nextInterval(pos: number): TInterval | undefined;
+    // (undocumented)
+    previousInterval(pos: number): TInterval | undefined;
+    removeIntervalById(id: string): TInterval | undefined;
+}
+
+// @public
+export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
+    (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): any;
+    (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): any;
+    (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): any;
+}
+
+// @public @sealed @deprecated (undocumented)
+export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
+    // (undocumented)
+    create(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, client: Client | undefined, intervalType: IntervalType, op?: ISequencedDocumentMessage, fromSnapshot?: boolean, useNewSlidingBehavior?: boolean): TInterval;
+}
+
+// @public @deprecated (undocumented)
+export interface IJSONRunSegment<T> extends IJSONSegment {
+    // (undocumented)
+    items: Serializable<T>[];
+}
+
+// @public
+export interface ILocalValue {
+    makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue;
+    readonly type: string;
+    readonly value: any;
+}
+
+// @internal (undocumented)
+export interface IMapMessageLocalMetadata {
+    // (undocumented)
+    localSeq: number;
+}
+
+// @public
+export interface IMember {
+    connections: IConnection[];
+    userId: string;
+}
+
+// @public
+export type InitialObjects<T extends ContainerSchema> = {
+    [K in keyof T["initialObjects"]]: T["initialObjects"][K] extends LoadableObjectClass<infer TChannel> ? TChannel : never;
+};
+
+// @public
+export interface InteriorSequencePlace {
+    // (undocumented)
+    pos: number;
+    // (undocumented)
+    side: Side;
+}
+
+// @public
+export class Interval implements ISerializableInterval {
+    constructor(start: number, end: number, props?: PropertySet);
+    // @internal (undocumented)
+    addProperties(newProps: PropertySet, collaborating?: boolean, seq?: number, op?: ICombiningOp): PropertySet | undefined;
+    addPropertySet(props: PropertySet): void;
+    // @internal (undocumented)
+    auxProps: PropertySet[] | undefined;
+    // (undocumented)
+    clone(): Interval;
+    compare(b: Interval): number;
+    compareEnd(b: Interval): number;
+    compareStart(b: Interval): number;
+    // (undocumented)
+    end: number;
+    // (undocumented)
+    getAdditionalPropertySets(): PropertySet[];
+    getIntervalId(): string;
+    // (undocumented)
+    getProperties(): PropertySet;
+    // @internal
+    modify(label: string, start?: SequencePlace, end?: SequencePlace, op?: ISequencedDocumentMessage): Interval | undefined;
+    // (undocumented)
+    overlaps(b: Interval): boolean;
+    properties: PropertySet;
+    // @internal (undocumented)
+    propertyManager: PropertiesManager;
+    // @internal (undocumented)
+    serialize(): ISerializedInterval;
+    // (undocumented)
+    start: number;
+    // @internal
+    union(b: Interval): Interval;
+}
+
+// @public
+export interface IntervalIndex<TInterval extends ISerializableInterval> {
+    add(interval: TInterval): void;
+    remove(interval: TInterval): void;
+}
+
+// @public
+export interface IntervalLocator {
+    interval: SequenceInterval;
+    label: string;
+}
+
+// @public
+export function intervalLocatorFromEndpoint(potentialEndpoint: LocalReferencePosition): IntervalLocator | undefined;
+
+// @alpha
+export const IntervalOpType: {
+    readonly ADD: "add";
+    readonly DELETE: "delete";
+    readonly CHANGE: "change";
+    readonly PROPERTY_CHANGED: "propertyChanged";
+    readonly POSITION_REMOVE: "positionRemove";
+};
+
+// @alpha (undocumented)
+export type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
+
+// @internal
+export const IntervalStickiness: {
+    readonly NONE: 0;
+    readonly START: 1;
+    readonly END: 2;
+    readonly FULL: 3;
+};
+
+// @internal
+export type IntervalStickiness = (typeof IntervalStickiness)[keyof typeof IntervalStickiness];
+
+// @public (undocumented)
+export enum IntervalType {
+    // @deprecated (undocumented)
+    Nest = 1,
+    // (undocumented)
+    Simple = 0,
+    SlideOnRemove = 2,
+    // @internal
+    Transient = 4
+}
+
+// @public
+export interface IRootDataObject {
+    create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
+    readonly initialObjects: LoadableObjectRecord;
+}
+
+// @public
+export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
+    operation: TOperation;
+    position: number;
+    propertyDeltas: PropertySet;
+    segment: ISegment;
+}
+
+// @public (undocumented)
+export interface ISerializableInterval extends IInterval {
+    // @internal (undocumented)
+    addProperties(props: PropertySet, collaborating?: boolean, seq?: number): PropertySet | undefined;
+    getIntervalId(): string | undefined;
+    properties: PropertySet;
+    // @internal (undocumented)
+    propertyManager: PropertiesManager;
+    // @internal (undocumented)
+    serialize(): ISerializedInterval;
+}
+
+// @public @deprecated
+export interface ISerializableValue {
+    type: string;
+    value: any;
+}
+
+// @internal
+export interface ISerializedInterval {
+    end: number | "start" | "end";
+    // (undocumented)
+    endSide?: Side;
+    intervalType: IntervalType;
+    properties?: PropertySet;
+    sequenceNumber: number;
+    start: number | "start" | "end";
+    // (undocumented)
+    startSide?: Side;
+    stickiness?: IntervalStickiness;
+}
+
+// @public
+export interface ISerializedValue {
+    type: string;
+    value: string | undefined;
+}
+
+// @public
+export interface IServiceAudience<M extends IMember> extends IEventProvider<IServiceAudienceEvents<M>> {
+    getMembers(): Map<string, M>;
+    getMyself(): Myself<M> | undefined;
+}
+
+// @public
+export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
+    // @eventProperty
+    (event: "membersChanged", listener: () => void): void;
+    // @eventProperty
+    (event: "memberAdded", listener: MemberChangedListener<M>): void;
+    // @eventProperty
+    (event: "memberRemoved", listener: MemberChangedListener<M>): void;
+}
+
+// @public
+export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>, Omit<IDirectory, "on" | "once" | "off"> {
+    // (undocumented)
+    [Symbol.iterator](): IterableIterator<[string, any]>;
+    // (undocumented)
+    readonly [Symbol.toStringTag]: string;
+}
+
+// @public
+export interface ISharedDirectoryEvents extends ISharedObjectEvents {
+    (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+}
+
+// @public (undocumented)
+export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
+    // (undocumented)
+    getIntervalCollection(label: string): IIntervalCollection<TInterval>;
+}
+
+// @public
+export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
+    get<T = any>(key: string): T | undefined;
+    set<T = unknown>(key: string, value: T): this;
+}
+
+// @public
+export interface ISharedMapEvents extends ISharedObjectEvents {
+    (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+}
+
+// @public
+export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
+    // (undocumented)
+    (event: "createIntervalCollection", listener: (label: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    // (undocumented)
+    (event: "sequenceDelta", listener: (event: SequenceDeltaEvent, target: IEventThisPlaceHolder) => void): any;
+    // (undocumented)
+    (event: "maintenance", listener: (event: SequenceMaintenanceEvent, target: IEventThisPlaceHolder) => void): any;
+}
+
+// @public
+export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
+    insertMarker(pos: number, refType: ReferenceType, props?: PropertySet): IMergeTreeInsertMsg | undefined;
+    insertText(pos: number, text: string, props?: PropertySet): void;
+    posFromRelativePos(relativePos: IRelativePosition): number;
+}
+
+// @public
+export interface IValueChanged {
+    key: string;
+    previousValue: any;
+}
+
+// @internal @deprecated
+export interface IValueOpEmitter {
+    // @deprecated
+    emit(opName: IntervalOpType, previousValue: undefined, params: SerializedIntervalDelta, localOpMetadata: IMapMessageLocalMetadata): void;
+}
+
+// @public
+export type LoadableObjectClass<T extends IFluidLoadable> = DataObjectClass<T> | SharedObjectClass<T>;
+
+// @public
+export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>;
+
+// @public
+export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) => T;
+
+// @public
+export type LoadableObjectRecord = Record<string, IFluidLoadable>;
+
+// @public
+export class LocalValueMaker {
+    constructor(serializer: IFluidSerializer);
+    fromInMemory(value: unknown): ILocalValue;
+    fromSerializable(serializable: ISerializableValue): ILocalValue;
+}
+
+// @public @sealed
+export class MapFactory implements IChannelFactory {
+    // (undocumented)
+    static readonly Attributes: IChannelAttributes;
+    // (undocumented)
+    get attributes(): IChannelAttributes;
+    // (undocumented)
+    create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap;
+    // (undocumented)
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<ISharedMap>;
+    // (undocumented)
+    static readonly Type = "https://graph.microsoft.com/types/map";
+    // (undocumented)
+    get type(): string;
+}
+
+// @public
+export type MemberChangedListener<M extends IMember> = (clientId: string, member: M) => void;
+
+// @public
+export type Myself<M extends IMember = IMember> = M & {
+    currentConnection: string;
+};
+
+// @public
+export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
+    constructor(opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client);
+    readonly isLocal: boolean;
+    // (undocumented)
+    readonly opArgs: IMergeTreeDeltaOpArgs;
+}
+
+// @public
+export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
+    constructor(deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>, mergeTreeClient: Client);
+    get clientId(): string | undefined;
+    // (undocumented)
+    readonly deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>;
+    // (undocumented)
+    readonly deltaOperation: TOperation;
+    get first(): Readonly<ISequenceDeltaRange<TOperation>>;
+    get last(): Readonly<ISequenceDeltaRange<TOperation>>;
+    get ranges(): readonly Readonly<ISequenceDeltaRange<TOperation>>[];
+}
+
+// @public
+export class SequenceInterval implements ISerializableInterval {
+    constructor(client: Client,
+    start: LocalReferencePosition,
+    end: LocalReferencePosition, intervalType: IntervalType, props?: PropertySet, startSide?: Side, endSide?: Side);
+    // @internal
+    addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
+    // @internal (undocumented)
+    addProperties(newProps: PropertySet, collab?: boolean, seq?: number, op?: ICombiningOp): PropertySet | undefined;
+    // (undocumented)
+    clone(): SequenceInterval;
+    compare(b: SequenceInterval): number;
+    compareEnd(b: SequenceInterval): number;
+    compareStart(b: SequenceInterval): number;
+    end: LocalReferencePosition;
+    // (undocumented)
+    readonly endSide: Side;
+    getIntervalId(): string;
+    // (undocumented)
+    intervalType: IntervalType;
+    // @internal
+    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
+    // (undocumented)
+    overlaps(b: SequenceInterval): boolean;
+    // (undocumented)
+    overlapsPos(bstart: number, bend: number): boolean;
+    properties: PropertySet;
+    // @internal (undocumented)
+    propertyManager: PropertiesManager;
+    // @internal
+    removePositionChangeListeners(): void;
+    // @internal (undocumented)
+    serialize(): ISerializedInterval;
+    start: LocalReferencePosition;
+    // (undocumented)
+    readonly startSide: Side;
+    // @internal (undocumented)
+    get stickiness(): IntervalStickiness;
+    // @internal
+    union(b: SequenceInterval): SequenceInterval;
+}
+
+// @public
+export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
+    constructor(opArgs: IMergeTreeDeltaOpArgs | undefined, deltaArgs: IMergeTreeMaintenanceCallbackArgs, mergeTreeClient: Client);
+    // (undocumented)
+    readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
+}
+
+// @public
+export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
+
+// @internal
+export type SerializedIntervalDelta = Omit<ISerializedInterval, "start" | "end" | "properties"> & Partial<Pick<ISerializedInterval, "start" | "end" | "properties">>;
+
+// @public @deprecated
+export abstract class ServiceAudience<M extends IMember = IMember> extends TypedEventEmitter<IServiceAudienceEvents<M>> implements IServiceAudience<M> {
+    constructor(
+    container: IContainer);
+    // Warning: (ae-forgotten-export) The symbol "IAudience" needs to be exported by the entry point index.d.ts
+    protected readonly audience: IAudience;
+    protected readonly container: IContainer;
+    protected abstract createServiceMember(audienceMember: IClient): M;
+    getMembers(): Map<string, M>;
+    getMyself(): Myself<M> | undefined;
+    protected lastMembers: Map<string, M>;
+    protected shouldIncludeAsMember(member: IClient): boolean;
+}
+
+// @public @sealed
+export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implements ISharedDirectory {
+    [Symbol.iterator](): IterableIterator<[string, any]>;
+    [Symbol.toStringTag]: string;
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
+    get absolutePath(): string;
+    // @internal (undocumented)
+    protected applyStashedOp(op: unknown): unknown;
+    clear(): void;
+    countSubDirectory(): number;
+    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedDirectory;
+    createSubDirectory(subdirName: string): IDirectory;
+    delete(key: string): boolean;
+    deleteSubDirectory(subdirName: string): boolean;
+    // (undocumented)
+    dispose(error?: Error): void;
+    // (undocumented)
+    get disposed(): boolean;
+    entries(): IterableIterator<[string, any]>;
+    forEach(callback: (value: any, key: string, map: Map<string, any>) => void): void;
+    get<T = any>(key: string): T | undefined;
+    static getFactory(): IChannelFactory;
+    getSubDirectory(subdirName: string): IDirectory | undefined;
+    getWorkingDirectory(relativePath: string): IDirectory | undefined;
+    has(key: string): boolean;
+    hasSubDirectory(subdirName: string): boolean;
+    keys(): IterableIterator<string>;
+    // @internal (undocumented)
+    protected loadCore(storage: IChannelStorageService): Promise<void>;
+    // @internal (undocumented)
+    readonly localValueMaker: LocalValueMaker;
+    // @internal (undocumented)
+    protected onDisconnect(): void;
+    // @internal
+    protected populate(data: IDirectoryDataObject): void;
+    // @internal (undocumented)
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected rollback(content: unknown, localOpMetadata: unknown): void;
+    set<T = unknown>(key: string, value: T): this;
+    get size(): number;
+    subdirectories(): IterableIterator<[string, IDirectory]>;
+    // @internal
+    submitDirectoryMessage(op: IDirectoryOperation, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    values(): IterableIterator<any>;
+}
+
+// @public @deprecated (undocumented)
+export class SharedIntervalCollection extends SharedObject implements ISharedIntervalCollection<Interval> {
+    // (undocumented)
+    readonly [Symbol.toStringTag]: string;
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
+    // (undocumented)
+    protected applyStashedOp(): void;
+    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedIntervalCollection;
+    static getFactory(): IChannelFactory;
+    // (undocumented)
+    getIntervalCollection(label: string): IIntervalCollection<Interval>;
+    protected getIntervalCollectionPath(label: string): string;
+    // (undocumented)
+    protected loadCore(storage: IChannelStorageService): Promise<void>;
+    // (undocumented)
+    protected onDisconnect(): void;
+    // (undocumented)
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    // (undocumented)
+    protected reSubmitCore(content: any, localOpMetadata: unknown): void;
+    // (undocumented)
+    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
+}
+
+// @public @deprecated
+export class SharedIntervalCollectionFactory implements IChannelFactory {
+    // (undocumented)
+    static readonly Attributes: IChannelAttributes;
+    // (undocumented)
+    get attributes(): IChannelAttributes;
+    // (undocumented)
+    create(runtime: IFluidDataStoreRuntime, id: string): SharedIntervalCollection;
+    // (undocumented)
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<SharedIntervalCollection>;
+    // (undocumented)
+    static readonly Type = "https://graph.microsoft.com/types/sharedIntervalCollection";
+    // (undocumented)
+    get type(): string;
+}
+
+// @public
+export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
+    [Symbol.iterator](): IterableIterator<[string, any]>;
+    readonly [Symbol.toStringTag]: string;
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
+    // @internal (undocumented)
+    protected applyStashedOp(content: unknown): unknown;
+    clear(): void;
+    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMap;
+    delete(key: string): boolean;
+    entries(): IterableIterator<[string, any]>;
+    forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void;
+    get<T = any>(key: string): T | undefined;
+    static getFactory(): IChannelFactory;
+    has(key: string): boolean;
+    keys(): IterableIterator<string>;
+    // @internal (undocumented)
+    protected loadCore(storage: IChannelStorageService): Promise<void>;
+    // @internal (undocumented)
+    protected onDisconnect(): void;
+    // @internal (undocumented)
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected rollback(content: unknown, localOpMetadata: unknown): void;
+    set(key: string, value: unknown): this;
+    get size(): number;
+    // @internal (undocumented)
+    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    values(): IterableIterator<any>;
+}
+
+// @public
+export type SharedObjectClass<T extends IFluidLoadable> = {
+    readonly getFactory: () => IChannelFactory;
+} & LoadableObjectCtor<T>;
+
+// @public (undocumented)
+export abstract class SharedSegmentSequence<T extends ISegment> extends SharedObject<ISharedSegmentSequenceEvents> implements ISharedIntervalCollection<SequenceInterval>, MergeTreeRevertibleDriver {
+    constructor(dataStoreRuntime: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes, segmentFromSpec: (spec: IJSONSegment) => ISegment);
+    annotateRange(start: number, end: number, props: PropertySet, combiningOp?: ICombiningOp): void;
+    // (undocumented)
+    protected applyStashedOp(content: any): unknown;
+    // (undocumented)
+    protected client: Client;
+    createLocalReferencePosition(segment: T, offset: number, refType: ReferenceType, properties: PropertySet | undefined, slidingPreference?: SlidingPreference, canSlideToEndpoint?: boolean): LocalReferencePosition;
+    // (undocumented)
+    protected didAttach(): void;
+    getContainingSegment(pos: number): {
+        segment: T | undefined;
+        offset: number | undefined;
+    };
+    // (undocumented)
+    getCurrentSeq(): number;
+    getIntervalCollection(label: string): IIntervalCollection<SequenceInterval>;
+    // (undocumented)
+    getIntervalCollectionLabels(): IterableIterator<string>;
+    getLength(): number;
+    getPosition(segment: ISegment): number;
+    // (undocumented)
+    getPropertiesAtPosition(pos: number): PropertySet | undefined;
+    // (undocumented)
+    getRangeExtentsOfPosition(pos: number): {
+        posStart: number | undefined;
+        posAfterEnd: number | undefined;
+    };
+    // @deprecated (undocumented)
+    getStackContext(startPos: number, rangeLabels: string[]): RangeStackMap;
+    // @deprecated (undocumented)
+    groupOperation(groupOp: IMergeTreeGroupMsg): void;
+    // @internal
+    protected guardReentrancy: <TRet>(callback: () => TRet) => TRet;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    protected initializeLocalCore(): void;
+    insertAtReferencePosition(pos: ReferencePosition, segment: T): void;
+    insertFromSpec(pos: number, spec: IJSONSegment): void;
+    // (undocumented)
+    protected loadCore(storage: IChannelStorageService): Promise<void>;
+    // (undocumented)
+    get loaded(): Promise<void>;
+    protected loadedDeferred: Deferred<void>;
+    localReferencePositionToPosition(lref: ReferencePosition): number;
+    // (undocumented)
+    protected onConnect(): void;
+    // (undocumented)
+    protected onDisconnect(): void;
+    posFromRelativePos(relativePos: IRelativePosition): number;
+    // (undocumented)
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    protected processGCDataCore(serializer: SummarySerializer): void;
+    removeLocalReferencePosition(lref: LocalReferencePosition): LocalReferencePosition | undefined;
+    // (undocumented)
+    removeRange(start: number, end: number): IMergeTreeRemoveMsg;
+    protected replaceRange(start: number, end: number, segment: ISegment): void;
+    resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number | undefined;
+    // (undocumented)
+    protected reSubmitCore(content: any, localOpMetadata: unknown): void;
+    // (undocumented)
+    readonly segmentFromSpec: (spec: IJSONSegment) => ISegment;
+    // @deprecated (undocumented)
+    submitSequenceMessage(message: IMergeTreeOp): void;
+    // (undocumented)
+    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    walkSegments<TClientData>(handler: ISegmentAction<TClientData>, start?: number, end?: number, accum?: TClientData, splitRange?: boolean): void;
+}
+
+// @public @deprecated (undocumented)
+export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
+    constructor(document: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes, specToSegment: (spec: IJSONSegment) => ISegment);
+    getItemCount(): number;
+    getItems(start: number, end?: number): Serializable<T>[];
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    insert(pos: number, items: Serializable<T>[], props?: PropertySet): void;
+    // (undocumented)
+    remove(start: number, end: number): void;
+}
+
+// @public
+export class SharedString extends SharedSegmentSequence<SharedStringSegment> implements ISharedString {
+    constructor(document: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes);
+    annotateMarker(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): void;
+    annotateMarkerNotifyConsensus(marker: Marker, props: PropertySet, callback: (m: Marker) => void): void;
+    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedString;
+    // @deprecated
+    findTile(startPos: number | undefined, tileLabel: string, preceding?: boolean): {
+        tile: ReferencePosition;
+        pos: number;
+    } | undefined;
+    static getFactory(): SharedStringFactory;
+    getMarkerFromId(id: string): ISegment | undefined;
+    getText(start?: number, end?: number): string;
+    // (undocumented)
+    getTextRangeWithMarkers(start: number, end: number): string;
+    getTextWithPlaceholders(start?: number, end?: number): string;
+    // (undocumented)
+    id: string;
+    insertMarker(pos: number, refType: ReferenceType, props?: PropertySet): IMergeTreeInsertMsg | undefined;
+    insertMarkerRelative(relativePos1: IRelativePosition, refType: ReferenceType, props?: PropertySet): void;
+    insertText(pos: number, text: string, props?: PropertySet): void;
+    insertTextRelative(relativePos1: IRelativePosition, text: string, props?: PropertySet): void;
+    // (undocumented)
+    get ISharedString(): ISharedString;
+    removeText(start: number, end: number): IMergeTreeRemoveMsg;
+    replaceText(start: number, end: number, text: string, props?: PropertySet): void;
+    protected rollback(content: any, localOpMetadata: unknown): void;
+    searchForMarker(startPos: number, markerLabel: string, forwards?: boolean): Marker | undefined;
+}
+
+// @public (undocumented)
+export class SharedStringFactory implements IChannelFactory {
+    // (undocumented)
+    static readonly Attributes: IChannelAttributes;
+    // (undocumented)
+    get attributes(): IChannelAttributes;
+    // (undocumented)
+    create(document: IFluidDataStoreRuntime, id: string): SharedString;
+    // (undocumented)
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<SharedString>;
+    // (undocumented)
+    static segmentFromSpec(spec: any): SharedStringSegment;
+    // (undocumented)
+    static Type: string;
+    // (undocumented)
+    get type(): string;
+}
+
+// @public (undocumented)
+export type SharedStringSegment = TextSegment | Marker;
+
+// @public
+export enum Side {
+    // (undocumented)
+    After = 1,
+    // (undocumented)
+    Before = 0
+}
+
+// @public @deprecated (undocumented)
+export class SubSequence<T> extends BaseSegment {
+    constructor(items: Serializable<T>[]);
+    // (undocumented)
+    append(segment: ISegment): void;
+    // (undocumented)
+    canAppend(segment: ISegment): boolean;
+    // (undocumented)
+    clone(start?: number, end?: number): SubSequence<T>;
+    // (undocumented)
+    protected createSplitSegmentAt(pos: number): SubSequence<T> | undefined;
+    // (undocumented)
+    static fromJSONObject<U>(spec: Serializable): SubSequence<U> | undefined;
+    // (undocumented)
+    static is(segment: ISegment): segment is SubSequence<any>;
+    // (undocumented)
+    items: Serializable<T>[];
+    // (undocumented)
+    removeRange(start: number, end: number): boolean;
+    // (undocumented)
+    toJSONObject(): IJSONRunSegment<T>;
+    // (undocumented)
+    toString(): string;
+    // (undocumented)
+    readonly type: string;
+    // (undocumented)
+    static readonly typeString: string;
+}
 
 ```

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -11,9 +11,8 @@
  * @packageDocumentation
  */
 
-export type { ICriticalContainerError } from "@fluidframework/container-definitions";
 export { AttachState, ContainerErrorType } from "@fluidframework/container-definitions";
-export { DriverErrorType } from "@fluidframework/driver-definitions";
+export { DriverErrorType, DriverErrorTypes } from "@fluidframework/driver-definitions";
 export { ConnectionState } from "@fluidframework/container-loader";
 export type {
 	ContainerSchema,
@@ -22,6 +21,7 @@ export type {
 	IFluidContainer,
 	IFluidContainerEvents,
 	IMember,
+	InitialObjects,
 	IRootDataObject,
 	IServiceAudience,
 	IServiceAudienceEvents,
@@ -30,14 +30,25 @@ export type {
 	LoadableObjectCtor,
 	LoadableObjectRecord,
 	MemberChangedListener,
+	Myself,
 	SharedObjectClass,
 } from "@fluidframework/fluid-static";
 export {
+	/**
+	 * @deprecated No intended replacement in this package.
+	 */
 	DOProviderContainerRuntimeFactory,
+	/**
+	 * @deprecated No intended replacement in this package.
+	 */
 	FluidContainer,
+	/**
+	 * @deprecated No intended replacement in this package.
+	 */
 	ServiceAudience,
 } from "@fluidframework/fluid-static";
 export type {
+	ICreateInfo,
 	IDirectory,
 	IDirectoryClearOperation,
 	IDirectoryCreateSubDirectoryOperation,
@@ -75,8 +86,12 @@ export type {
 	IIntervalHelpers,
 	IJSONRunSegment,
 	IMapMessageLocalMetadata,
+	InteriorSequencePlace,
 	IIntervalCollection,
+	IntervalIndex,
 	IntervalLocator,
+	IntervalOpType,
+	IntervalStickiness,
 	ISequenceDeltaRange,
 	ISerializableInterval,
 	ISerializedInterval,
@@ -84,8 +99,10 @@ export type {
 	ISharedSegmentSequenceEvents,
 	ISharedString,
 	IValueOpEmitter,
+	SequencePlace,
 	SerializedIntervalDelta,
 	SharedStringSegment,
+	Side,
 } from "@fluidframework/sequence";
 export {
 	getTextAndMarkers,

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -225,7 +225,7 @@ export function createFluidContainer<
  *
  * Note: this implementation is not complete. Consumers who rely on {@link IFluidContainer.attach}
  * will need to utilize or provide a service-specific implementation of this type that implements that method.
- * @deprecated use {@link createFluidContainer} and {@link IFluidContainer} instead
+ * @deprecated use {@link @fluidframework/fluid-static#createFluidContainer} and {@link @fluidframework/fluid-static#IFluidContainer} instead
  */
 export class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema>
 	extends TypedEventEmitter<IFluidContainerEvents>

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -153,7 +153,7 @@ export function createDOProviderContainerRuntimeFactory(props: {
  *
  * This data object is dynamically customized (registry and initial objects) based on the schema provided.
  * to the container runtime factory.
- * @deprecated use {@link createDOProviderContainerRuntimeFactory} instead
+ * @deprecated use {@link @fluidframework/fluid-static#createDOProviderContainerRuntimeFactory} instead
  */
 export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 	private readonly rootDataObjectFactory: DataObjectFactory<

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -24,7 +24,7 @@ export function createServiceAudience<M extends IMember = IMember>(props: {
  * the user and client details returned in {@link IMember}.
  *
  * @typeParam M - A service-specific {@link IMember} implementation.
- * @deprecated use {@link createServiceAudience} and {@link IServiceAudience} instead
+ * @deprecated use {@link @fluidframework/fluid-static#createServiceAudience} and {@link IServiceAudience} instead
  */
 export abstract class ServiceAudience<M extends IMember = IMember>
 	extends TypedEventEmitter<IServiceAudienceEvents<M>>


### PR DESCRIPTION
NOTE: THIS IS A DRAFT. WE MAY OR MAY NOT WISH TO MERGE THESE CHANGES. THIS IS PRIMARILY INTENDED AS AN EXAMPLE.

Updates `fluid-framework`'s exports to include missing exports as required, except for items marked as `@deprecated` in the re-exports.

Updates code comment links to work around https://github.com/microsoft/rushstack/issues/3521