### PR TITLE
Remove arbitrary timeout on pong e2e test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -19,7 +19,7 @@ import { describeNoCompat } from "@fluid-private/test-version-utils";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describe.only("Pong", () => {
+describe("Pong", () => {
 	describeNoCompat("Pong", (getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
 		const loaderContainerTracker = new LoaderContainerTracker();

--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -18,9 +18,8 @@ import {
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
-const timeoutMs = 500;
 
-describe("Pong", () => {
+describe.only("Pong", () => {
 	describeNoCompat("Pong", (getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
 		const loaderContainerTracker = new LoaderContainerTracker();
@@ -48,7 +47,6 @@ describe("Pong", () => {
 		async function createConnectedContainer(): Promise<IContainer> {
 			const container = await provider.makeTestContainer();
 			await waitForContainerConnection(container, true, {
-				durationMs: timeoutMs,
 				errorMsg: "Container initial connection timeout",
 			});
 			assert.strictEqual(


### PR DESCRIPTION
The `"Delta manager receives pong event"` e2e test has been failing for ODSP on a timeout. I removed this timeout as it doesn't serve any real purpose.

[AB#6037](https://dev.azure.com/fluidframework/internal/_workitems/edit/6037)