### PR TITLE
Use package.json main field to load legacy versions (#18433)

### DIFF
--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -271,8 +271,13 @@ export function checkInstalled(requested: string) {
 	);
 }
 
-export const loadPackage = async (modulePath: string, pkg: string): Promise<any> =>
-	import(pathToFileURL(path.join(modulePath, "node_modules", pkg, "dist", "index.js")).href);
+export const loadPackage = async (modulePath: string, pkg: string): Promise<any> => {
+	const pkgPath = path.join(modulePath, "node_modules", pkg);
+	const pkgJson: { main: string } = JSON.parse(
+		readFileSync(path.join(pkgPath, "package.json"), { encoding: "utf8" }),
+	);
+	return import(pathToFileURL(path.join(pkgPath, pkgJson.main)).href);
+};
 
 /**
  *


### PR DESCRIPTION
## Description

Recent changes to FF package structure caused this brittle assumption to break PRs into next. This fixes the legacy package module loading logic to not assume the main entrypoint is under `dist/index.js`.

Cherry-pick of #18433