### PR TITLE
style(tree2): Un-apply prettier formatting from prettier-ignored generated file

### DIFF
--- a/experimental/dds/tree2/.dependency-cruiser-known-violations.json
+++ b/experimental/dds/tree2/.dependency-cruiser-known-violations.json
@@ -1,111 +1,111 @@
 [
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/flex-tree/context.ts",
-		"to": "src/feature-libraries/flex-tree/lazyField.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/flex-tree/lazyField.ts",
-			"src/feature-libraries/node-key/index.ts",
-			"src/feature-libraries/node-key/nodeKeyIndex.ts",
-			"src/feature-libraries/flex-tree/index.ts",
-			"src/feature-libraries/flex-tree/context.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/flex-tree/context.ts",
-		"to": "src/feature-libraries/node-key/index.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/node-key/index.ts",
-			"src/feature-libraries/node-key/nodeKeyIndex.ts",
-			"src/feature-libraries/flex-tree/index.ts",
-			"src/feature-libraries/flex-tree/context.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/flex-tree/lazyField.ts",
-		"to": "src/feature-libraries/flex-tree/lazyNode.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/flex-tree/lazyNode.ts",
-			"src/feature-libraries/flex-tree/lazyField.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/flex-tree/lazyField.ts",
-		"to": "src/feature-libraries/flex-tree/unboxed.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/flex-tree/unboxed.ts",
-			"src/feature-libraries/flex-tree/lazyField.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/flex-tree/lazyNode.ts",
-		"to": "src/feature-libraries/flex-tree/unboxed.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/flex-tree/unboxed.ts",
-			"src/feature-libraries/flex-tree/lazyNode.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/modular-schema/comparison.ts",
-		"to": "src/feature-libraries/modular-schema/fieldKind.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/modular-schema/fieldKind.ts",
-			"src/feature-libraries/modular-schema/comparison.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/sequence-field/markListFactory.ts",
-		"to": "src/feature-libraries/sequence-field/utils.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/sequence-field/utils.ts",
-			"src/feature-libraries/sequence-field/markListFactory.ts"
-		]
-	},
-	{
-		"type": "cycle",
-		"from": "src/feature-libraries/sequence-field/moveEffectTable.ts",
-		"to": "src/feature-libraries/sequence-field/utils.ts",
-		"rule": {
-			"severity": "error",
-			"name": "no-circular"
-		},
-		"cycle": [
-			"src/feature-libraries/sequence-field/utils.ts",
-			"src/feature-libraries/sequence-field/moveEffectTable.ts"
-		]
-	}
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/flex-tree/context.ts",
+    "to": "src/feature-libraries/flex-tree/lazyField.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/flex-tree/lazyField.ts",
+      "src/feature-libraries/node-key/index.ts",
+      "src/feature-libraries/node-key/nodeKeyIndex.ts",
+      "src/feature-libraries/flex-tree/index.ts",
+      "src/feature-libraries/flex-tree/context.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/flex-tree/context.ts",
+    "to": "src/feature-libraries/node-key/index.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/node-key/index.ts",
+      "src/feature-libraries/node-key/nodeKeyIndex.ts",
+      "src/feature-libraries/flex-tree/index.ts",
+      "src/feature-libraries/flex-tree/context.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/flex-tree/lazyField.ts",
+    "to": "src/feature-libraries/flex-tree/lazyNode.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/flex-tree/lazyNode.ts",
+      "src/feature-libraries/flex-tree/lazyField.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/flex-tree/lazyField.ts",
+    "to": "src/feature-libraries/flex-tree/unboxed.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/flex-tree/unboxed.ts",
+      "src/feature-libraries/flex-tree/lazyField.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/flex-tree/lazyNode.ts",
+    "to": "src/feature-libraries/flex-tree/unboxed.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/flex-tree/unboxed.ts",
+      "src/feature-libraries/flex-tree/lazyNode.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/modular-schema/comparison.ts",
+    "to": "src/feature-libraries/modular-schema/fieldKind.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/modular-schema/fieldKind.ts",
+      "src/feature-libraries/modular-schema/comparison.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/sequence-field/markListFactory.ts",
+    "to": "src/feature-libraries/sequence-field/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/sequence-field/utils.ts",
+      "src/feature-libraries/sequence-field/markListFactory.ts"
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/feature-libraries/sequence-field/moveEffectTable.ts",
+    "to": "src/feature-libraries/sequence-field/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      "src/feature-libraries/sequence-field/utils.ts",
+      "src/feature-libraries/sequence-field/moveEffectTable.ts"
+    ]
+  }
 ]


### PR DESCRIPTION
The depcruiser report was removed from prettier format checking previously, but was at some point re-checked in with prettier formatting. This PR removes the formatting.