### PR TITLE
api(core-utils): mark all APIs internal

### DIFF
--- a/packages/common/core-utils/api-report/core-utils.api.md
+++ b/packages/common/core-utils/api-report/core-utils.api.md
@@ -4,13 +4,13 @@
 
 ```ts
 
-// @public
+// @internal
 export function assert(condition: boolean, message: string | number): asserts condition;
 
 // @internal
 export const compareArrays: <T>(left: readonly T[], right: readonly T[], comparator?: (leftItem: T, rightItem: T, index: number) => boolean) => boolean;
 
-// @public
+// @internal
 export class Deferred<T> {
     constructor();
     get isCompleted(): boolean;
@@ -19,10 +19,10 @@ export class Deferred<T> {
     resolve(value: T | PromiseLike<T>): void;
 }
 
-// @public
+// @internal
 export const delay: (timeMs: number) => Promise<void>;
 
-// @public
+// @internal
 export class Heap<T> {
     constructor(comp: IComparer<T>);
     add(x: T): IHeapNode<T>;
@@ -35,13 +35,13 @@ export class Heap<T> {
     update(node: IHeapNode<T>): void;
 }
 
-// @public
+// @internal
 export interface IComparer<T> {
     compare(a: T, b: T): number;
     min: T;
 }
 
-// @public
+// @internal
 export interface IHeapNode<T> {
     // (undocumented)
     position: number;
@@ -49,32 +49,32 @@ export interface IHeapNode<T> {
     value: T;
 }
 
-// @public
+// @internal
 export interface IPromiseTimer extends ITimer {
     start(): Promise<IPromiseTimerResult>;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface IPromiseTimerResult {
     // (undocumented)
     timerResult: "timeout" | "cancel";
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export interface ITimer {
     clear(): void;
     readonly hasTimer: boolean;
     start(): void;
 }
 
-// @public
+// @internal
 export class Lazy<T> {
     constructor(valueGenerator: () => T);
     get evaluated(): boolean;
     get value(): T;
 }
 
-// @public
+// @internal
 export class LazyPromise<T> implements Promise<T> {
     // (undocumented)
     get [Symbol.toStringTag](): string;
@@ -87,10 +87,10 @@ export class LazyPromise<T> implements Promise<T> {
     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined): Promise<TResult1 | TResult2>;
 }
 
-// @public
+// @internal
 export const NumberComparer: IComparer<number>;
 
-// @public
+// @internal
 export class PromiseCache<TKey, TResult> {
     constructor({ expiry, removeOnError, }?: PromiseCacheOptions);
     add(key: TKey, asyncFn: () => Promise<TResult>): boolean;
@@ -102,7 +102,7 @@ export class PromiseCache<TKey, TResult> {
     remove(key: TKey): boolean;
 }
 
-// @public
+// @internal
 export type PromiseCacheExpiry = {
     policy: "indefinite";
 } | {
@@ -110,13 +110,13 @@ export type PromiseCacheExpiry = {
     durationMs: number;
 };
 
-// @public
+// @internal
 export interface PromiseCacheOptions {
     expiry?: PromiseCacheExpiry;
     removeOnError?: (error: any) => boolean;
 }
 
-// @public
+// @internal
 export class PromiseTimer implements IPromiseTimer {
     constructor(defaultTimeout: number, defaultHandler: () => void);
     // (undocumented)
@@ -127,10 +127,10 @@ export class PromiseTimer implements IPromiseTimer {
     protected wrapHandler(handler: () => void): void;
 }
 
-// @public
+// @internal
 export function setLongTimeout(timeoutFn: () => void, timeoutMs: number, setTimeoutIdFn?: (timeoutId: ReturnType<typeof setTimeout>) => void): ReturnType<typeof setTimeout>;
 
-// @public
+// @internal
 export class Timer implements ITimer {
     constructor(defaultTimeout: number, defaultHandler: () => void, getCurrentTick?: () => number);
     clear(): void;
@@ -139,7 +139,7 @@ export class Timer implements ITimer {
     start(ms?: number, handler?: () => void): void;
 }
 
-// @public
+// @internal
 export function unreachableCase(_: never, message?: string): never;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/common/core-utils/src/assert.ts
+++ b/packages/common/core-utils/src/assert.ts
@@ -12,7 +12,7 @@
  * A number should not be specified manually: use a string.
  * Before a release, policy-check should be run, which will convert any asserts still using strings to
  * use numbered error codes instead.
- * @public
+ * @internal
  */
 export function assert(condition: boolean, message: string | number): asserts condition {
 	if (!condition) {

--- a/packages/common/core-utils/src/delay.ts
+++ b/packages/common/core-utils/src/delay.ts
@@ -6,7 +6,7 @@
 /**
  * Returns a promise that resolves after `timeMs`.
  * @param timeMs - Time in milliseconds to wait.
- * @public
+ * @internal
  */
 export const delay = async (timeMs: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(() => resolve(), timeMs));

--- a/packages/common/core-utils/src/heap.ts
+++ b/packages/common/core-utils/src/heap.ts
@@ -5,7 +5,7 @@
 
 /**
  * Interface for a comparer.
- * @public
+ * @internal
  */
 export interface IComparer<T> {
 	/**
@@ -23,7 +23,7 @@ export interface IComparer<T> {
 
 /**
  * A comparer for numbers.
- * @public
+ * @internal
  */
 export const NumberComparer: IComparer<number> = {
 	/**
@@ -40,7 +40,7 @@ export const NumberComparer: IComparer<number> = {
 
 /**
  * Interface to a node in {@link Heap}.
- * @public
+ * @internal
  */
 export interface IHeapNode<T> {
 	value: T;
@@ -49,7 +49,7 @@ export interface IHeapNode<T> {
 
 /**
  * Ordered {@link https://en.wikipedia.org/wiki/Heap_(data_structure) | Heap} data structure implementation.
- * @public
+ * @internal
  */
 export class Heap<T> {
 	private L: IHeapNode<T>[];

--- a/packages/common/core-utils/src/lazy.ts
+++ b/packages/common/core-utils/src/lazy.ts
@@ -5,7 +5,7 @@
 
 /**
  * Helper class for lazy initialized values. Ensures the value is only generated once, and remain immutable.
- * @public
+ * @internal
  */
 export class Lazy<T> {
 	private _value: T | undefined;
@@ -41,7 +41,7 @@ export class Lazy<T> {
  * the promise is used, e.g. await, then, catch ...
  * The execute function is only called once.
  * All calls are then proxied to the promise returned by the execute method.
- * @public
+ * @internal
  */
 export class LazyPromise<T> implements Promise<T> {
 	public get [Symbol.toStringTag](): string {

--- a/packages/common/core-utils/src/promiseCache.ts
+++ b/packages/common/core-utils/src/promiseCache.ts
@@ -8,7 +8,7 @@
  * - indefinite: entries don't expire and must be explicitly removed
  * - absolute: entries expire after the given duration in MS, even if accessed multiple times in the mean time
  * - sliding: entries expire after the given duration in MS of inactivity (i.e. get resets the clock)
- * @public
+ * @internal
  */
 export type PromiseCacheExpiry =
 	| {
@@ -21,7 +21,7 @@ export type PromiseCacheExpiry =
 
 /**
  * Options for configuring the {@link PromiseCache}
- * @public
+ * @internal
  */
 export interface PromiseCacheOptions {
 	/**
@@ -89,7 +89,7 @@ class GarbageCollector<TKey> {
 /**
  * A specialized cache for async work, allowing you to safely cache the promised result of some async work
  * without fear of running it multiple times or losing track of errors.
- * @public
+ * @internal
  */
 export class PromiseCache<TKey, TResult> {
 	private readonly cache = new Map<TKey, Promise<TResult>>();

--- a/packages/common/core-utils/src/promises.ts
+++ b/packages/common/core-utils/src/promises.ts
@@ -5,7 +5,7 @@
 
 /**
  * A deferred creates a promise and the ability to resolve or reject it
- * @public
+ * @internal
  */
 export class Deferred<T> {
 	private readonly p: Promise<T>;

--- a/packages/common/core-utils/src/timer.ts
+++ b/packages/common/core-utils/src/timer.ts
@@ -7,7 +7,7 @@ import { assert } from "./assert";
 import { Deferred } from "./promises";
 
 /**
- * @public
+ * @internal
  */
 export interface ITimer {
 	/**
@@ -71,7 +71,7 @@ const maxSetTimeoutMs = 0x7fffffff; // setTimeout limit is MAX_INT32=(2^31-1).
  * @param setTimeoutIdFn - Executed to update the timeout if multiple timeouts are required when
  * timeoutMs greater than maxTimeout
  * @returns The initial timeout
- * @public
+ * @internal
  */
 export function setLongTimeout(
 	timeoutFn: () => void,
@@ -99,7 +99,7 @@ export function setLongTimeout(
  * makes it simpler to keep track of recurring timeouts with the same
  * or similar handlers and timeouts. This class supports long timeouts
  * or timeouts exceeding (2^31)-1 ms or approximately 24.8 days.
- * @public
+ * @internal
  */
 export class Timer implements ITimer {
 	/**
@@ -221,7 +221,7 @@ export class Timer implements ITimer {
 }
 
 /**
- * @public
+ * @internal
  */
 export interface IPromiseTimerResult {
 	timerResult: "timeout" | "cancel";
@@ -230,7 +230,7 @@ export interface IPromiseTimerResult {
 /**
  * Timer which offers a promise that fulfills when the timer
  * completes.
- * @public
+ * @internal
  */
 export interface IPromiseTimer extends ITimer {
 	/**
@@ -245,7 +245,7 @@ export interface IPromiseTimer extends ITimer {
  * makes it simpler to keep track of recurring timeouts with the
  * same handlers and timeouts, while also providing a promise that
  * resolves when it times out.
- * @public
+ * @internal
  */
 export class PromiseTimer implements IPromiseTimer {
 	private deferred?: Deferred<IPromiseTimerResult>;

--- a/packages/common/core-utils/src/unreachable.ts
+++ b/packages/common/core-utils/src/unreachable.ts
@@ -17,7 +17,7 @@
  *   default: unreachableCase(bool);
  * }
  * ```
- * @public
+ * @internal
  */
 export function unreachableCase(_: never, message = "Unreachable Case"): never {
 	throw new Error(message);


### PR DESCRIPTION
Mark all APIs in core-utils `@internal`. The readme for this package says this package shouldn't be used and all APIs should be marked internal, but in practice some APIs are marked `@public.