### PR TITLE
(odsp-client) Move resolvedUrl check to after container.attach

### DIFF
--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -163,13 +163,13 @@ export class OdspClient {
 			if (container.attachState !== AttachState.Detached) {
 				throw new Error("Cannot attach container. Container is not in detached state");
 			}
+			await container.attach(createNewRequest);
 
 			const resolvedUrl = container.resolvedUrl;
 
 			if (resolvedUrl === undefined || !isOdspResolvedUrl(resolvedUrl)) {
 				throw new Error("Resolved Url not available on attached container");
 			}
-			await container.attach(createNewRequest);
 
 			/**
 			 * A unique identifier for the file within the provided RaaS drive ID. When you attach a container,


### PR DESCRIPTION
## Description

After testing odsp-client, I noticed that we were checking for the container.resolvedUrl field before attaching the container. However, resolvedUrl is undefined until after we attach the container.
For reference, this is how [azure-client is implemented currently](https://github.com/microsoft/FluidFramework/blob/main/azure/packages/azure-client/src/AzureClient.ts#L293-L296). 

## Breaking Changes

No breaking changes
