### PR TITLE
fix(tree2): propagation of nested changes in compose of cancelling moves

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -331,7 +331,10 @@ function composeMarks<TNodeChange>(
 
 		if (areEqualCellIds(getOutputCellId(newMark, newRev, revisionMetadata), baseMark.cellId)) {
 			// The output and input cell IDs are the same, so this mark has no effect.
-			return withNodeChange({ count: baseMark.count, cellId: baseMark.cellId }, nodeChange);
+			return withNodeChange(
+				{ count: baseMark.count, cellId: baseMark.cellId },
+				localNodeChange,
+			);
 		}
 		return normalizeCellRename(
 			{

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -696,6 +696,22 @@ describe("SequenceField - Compose", () => {
 		assert.deepEqual(actual, expected);
 	});
 
+	it("move ○ modify and return", () => {
+		const move = [Mark.moveIn(1, brand(0)), { count: 1 }, Mark.moveOut(1, brand(0))];
+		const changes = TestChange.mint([], 42);
+		const moveBack = [
+			Mark.moveOut(1, brand(0), { changes }),
+			{ count: 1 },
+			Mark.returnTo(1, brand(0), { revision: tag1, localId: brand(0) }),
+		];
+		const expected = [{ count: 1 }, Mark.modify(changes)];
+		const actual = shallowCompose([
+			tagChange(move, tag1),
+			tagRollbackInverse(moveBack, tag3, tag1),
+		]);
+		assert.deepEqual(actual, expected);
+	});
+
 	it("move ○ delete", () => {
 		const move = Change.move(1, 1, 4, brand(0));
 		const deletion = Change.delete(3, 1, brand(1));


### PR DESCRIPTION
Fixes a bug in composition of sequence changes. Adds a test to match.