### PR TITLE
test(tree2): add move-remove-restore test

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -629,6 +629,40 @@ describe("Editing", () => {
 			expectJsonTree(tree1, ["x", { foo: ["b", "a"] }]);
 		});
 
+		it("move, remove, restore", () => {
+			const tree1 = makeTreeFromJson(["a", "b"]);
+			const tree2 = tree1.fork();
+
+			const cursor = tree1.forest.allocateCursor();
+			moveToDetachedField(tree1.forest, cursor);
+			cursor.enterNode(1);
+			const anchorB = cursor.buildAnchor();
+			cursor.free();
+
+			const { undoStack } = createTestUndoRedoStacks(tree2.events);
+
+			tree2.editor.sequenceField(rootField).move(1, 1, 0);
+			tree2.editor.sequenceField(rootField).delete(0, 1);
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			undoStack.pop()!.revert();
+
+			// This merge causes the move, remove, and restore to be composed and applied in one changeset on tree1
+			tree1.merge(tree2, false);
+			tree2.rebaseOnto(tree1);
+
+			expectJsonTree([tree1, tree2], ["b", "a"]);
+
+			const nodeBPath = tree1.locate(anchorB) ?? assert.fail();
+			const actual = {
+				parent: nodeBPath.parent,
+				parentField: nodeBPath.parentField,
+				parentIndex: nodeBPath.parentIndex,
+			};
+			const expected = { parent: undefined, parentField: rootFieldKey, parentIndex: 0 };
+			assert.deepEqual(actual, expected);
+		});
+
 		it("move adjacent nodes to separate destinations", () => {
 			const tree = makeTreeFromJson(["A", "B", "C", "D"]);
 			const tree2 = tree.fork();


### PR DESCRIPTION
Adds a test to verify that applying the composition of a move, remove, and restore (of the same node) leads to the correct forest state, and updates anchors appropriately.