### PR TITLE
perf(tree2): Opportunistic branch rebasing

### DIFF
--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -185,7 +185,7 @@ export function rebaseBranch<TChange>(
 		if (sourceSet.has(revision)) {
 			sourceSet.delete(revision);
 			newBaseIndex = Math.max(newBaseIndex, i);
-		} else if (i >= targetCommitIndex) {
+		} else if (i > targetCommitIndex) {
 			break;
 		}
 	}

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -252,7 +252,7 @@ export function rebaseBranch<TChange>(
 	}
 
 	const netChange = computeSourceChange
-		? composeChanges(changeRebaser, [...inverses, ...targetRebasePath])
+		? changeRebaser.compose([...inverses, ...targetRebasePath])
 		: undefined;
 	return [
 		newHead,
@@ -263,13 +263,6 @@ export function rebaseBranch<TChange>(
 			sourceCommits,
 		},
 	];
-}
-
-function composeChanges<TChange>(
-	changeRebaser: ChangeRebaser<TChange>,
-	changes: TaggedChange<TChange>[],
-): TChange {
-	return changes.length === 1 ? changes[0].change : changeRebaser.compose(changes);
 }
 
 /**

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -243,7 +243,7 @@ export function rebaseBranch<TChange>(
 	}
 
 	const toCompose = [...inverses, ...targetRebasePath];
-	const composed = changeRebaser.compose(toCompose);
+	const composed = composeChanges(changeRebaser, toCompose);
 	return [
 		newHead,
 		composed,
@@ -253,6 +253,13 @@ export function rebaseBranch<TChange>(
 			sourceCommits,
 		},
 	];
+}
+
+function composeChanges<TChange>(
+	changeRebaser: ChangeRebaser<TChange>,
+	changes: TaggedChange<TChange>[],
+): TChange {
+	return changes.length === 1 ? changes[0].change : changeRebaser.compose(changes);
 }
 
 /**

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -489,7 +489,6 @@ export class EditManager<
 		sequenceNumber: SeqNumber,
 		referenceSequenceNumber: SeqNumber,
 	): void {
-		console.debug(newCommit, "seq:", sequenceNumber, "ref:", referenceSequenceNumber);
 		assert(
 			sequenceNumber > this.minimumSequenceNumber,
 			0x713 /* Expected change sequence number to exceed the last known minimum sequence number */,

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -489,6 +489,7 @@ export class EditManager<
 		sequenceNumber: SeqNumber,
 		referenceSequenceNumber: SeqNumber,
 	): void {
+		console.debug(newCommit, "seq:", sequenceNumber, "ref:", referenceSequenceNumber);
 		assert(
 			sequenceNumber > this.minimumSequenceNumber,
 			0x713 /* Expected change sequence number to exceed the last known minimum sequence number */,

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -576,7 +576,8 @@ export class EditManager<
 	 *   +------(P1) <= previous peer commit
 	 *```
 	 * A new peer commit `P2` is received with a ref that indicates it is based on `X1`.
-	 * This function will detect that, because `P1` was sequenced after `X1`, `P2` is effectively based on `P1'`.
+	 * This function will detect that, because `P1` was sequenced after `X1`, and because the peer knew of `X1` at the
+	 * time it sent `P2`, `P2` is effectively based on `P1'`.
 	 * This is due to the fact that all clients rebase their local changes and only emit new changes based on those
 	 * rebased changes.
 	 *

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -527,7 +527,6 @@ export class EditManager<
 
 		// Get the revision that the remote change is based on
 		const [, baseRevisionInTrunk] = this.getClosestTrunkCommit(referenceSequenceNumber);
-
 		// Rebase that branch over the part of the trunk up to the base revision
 		// This will be a no-op if the sending client has not advanced since the last time we received an edit from it
 		const peerLocalBranch = getOrCreate(
@@ -535,7 +534,6 @@ export class EditManager<
 			newCommit.sessionId,
 			() => new SharedTreeBranch(baseRevisionInTrunk, this.changeFamily),
 		);
-
 		peerLocalBranch.rebaseOnto(this.trunk, baseRevisionInTrunk);
 
 		if (peerLocalBranch.getHead() === this.trunk.getHead()) {

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -536,12 +536,7 @@ export class EditManager<
 			() => new SharedTreeBranch(baseRevisionInTrunk, this.changeFamily),
 		);
 
-		const effectiveBaseRevisionInTrunk = this.fastForwardReferencePoint(
-			baseRevisionInTrunk,
-			peerLocalBranch.getHead(),
-		);
-
-		peerLocalBranch.rebaseOnto(this.trunk, effectiveBaseRevisionInTrunk);
+		peerLocalBranch.rebaseOnto(this.trunk, baseRevisionInTrunk);
 
 		if (peerLocalBranch.getHead() === this.trunk.getHead()) {
 			// If the branch is fully caught up and empty after being rebased, then push to the trunk directly
@@ -564,48 +559,6 @@ export class EditManager<
 		}
 
 		this.localBranch.rebaseOnto(this.trunk);
-	}
-
-	/**
-	 * Attempts to find a more recent trunk commit that a new peer commit is effectively based on.
-	 *
-	 * This function is used to detect scenarios of the following form:
-	 * ```text
-	 * (X0)-(X1)-(P1') <= the trunk
-	 *   |    +--------(P2) <= new peer commit
-	 *   +------(P1) <= previous peer commit
-	 *```
-	 * A new peer commit `P2` is received with a ref that indicates it is based on `X1`.
-	 * This function will detect that, because `P1` was sequenced after `X1`, and because the peer knew of `X1` at the
-	 * time it sent `P2`, `P2` is effectively based on `P1'`.
-	 * This is due to the fact that all clients rebase their local changes and only emit new changes based on those
-	 * rebased changes.
-	 *
-	 * @param newPeerCommitRef - The trunk commit that a new peer commit (not passed in) is based on.
-	 * @param previousPeerCommit - The previous commit (i.e., before the new one) from the same peer.
-	 * Note: passing a trunk commit from a different peer is safe (and will result in `newPeerCommitRef`
-	 * being returned).
-	 * @returns The most recent trunk commit that the new peer commit is effectively based on
-	 * when accounting for fast-forward opportunities.
-	 * This may be the same as `newPeerCommitRef` or it may be a more recent trunk commit.
-	 */
-	private fastForwardReferencePoint(
-		newPeerCommitRef: GraphCommit<TChangeset>,
-		previousPeerCommit: GraphCommit<TChangeset>,
-	): GraphCommit<TChangeset> {
-		let effectiveRef = newPeerCommitRef;
-		const trunkTail = getPath("FromAfter", newPeerCommitRef, "ToAfter", this.trunk.getHead());
-		const branchTail = getPathFromBase(previousPeerCommit, this.trunk.getHead());
-		for (
-			let iBase = 0;
-			iBase < branchTail.length &&
-			iBase < trunkTail.length &&
-			branchTail[iBase].revision === trunkTail[iBase].revision;
-			iBase += 1
-		) {
-			effectiveRef = trunkTail[iBase];
-		}
-		return effectiveRef;
 	}
 
 	public findLocalCommit(
@@ -688,35 +641,5 @@ function getPathFromBase<TCommit extends { parent?: TCommit }>(
 		findCommonAncestor([branchHead, path], baseBranchHead) !== undefined,
 		0x573 /* Expected branches to be related */,
 	);
-	return path;
-}
-
-/**
- * @returns the path of commits from the ancestor to the descendant, ordered oldest to newest.
- * The ancestor and descendant are not included in the path.
- */
-function getPath<TCommit extends { parent?: TCommit }>(
-	from: "FromBefore" | "FromAfter",
-	ancestor: TCommit,
-	to: "ToBefore" | "ToAfter",
-	descendant: TCommit,
-): TCommit[] {
-	const path: TCommit[] = [];
-	if (from === "FromBefore") {
-		path.push(ancestor);
-	}
-	if (ancestor !== descendant) {
-		let current = descendant.parent;
-		while (current !== ancestor) {
-			assert(current !== undefined, "Expected ancestor to be an ancestor of descendant");
-			path.unshift(current);
-			current = current.parent;
-		}
-		if (to === "ToAfter") {
-			path.push(descendant);
-		}
-	} else {
-		assert(!(from === "FromAfter" && to === "ToBefore"), "Invalid path request");
-	}
 	return path;
 }

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -198,6 +198,34 @@ describe("rebaseBranch", () => {
 		assert.deepEqual(commits.sourceCommits, newPath);
 	});
 
+	it("rebases the source branch farther than `newBase` if the source branch's next commits after `newBase` match those on the target branch", () => {
+		// 1 ─ 2 ─ 3 ─ 4 ─ 5
+		// └─ 3' ─ 4' ─ 6
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
+		const n4 = newCommit(4, n3);
+		const n5 = newCommit(5, n4);
+		const n3_1 = newCommit(3, n1);
+		const n4_1 = newCommit(4, n3_1);
+		const n6 = newCommit(6, n4_1);
+
+		// 1 ─(2)─ 3 ─ 4 ─ 5
+		//             └─ 6
+		const [n6_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n6, n2, n5);
+		const newPath = getPath(n2, n6_1);
+		assertChanges(
+			newPath,
+			TestChange.mint([1, 2], 3),
+			TestChange.mint([1, 2, 3], 4),
+			TestChange.mint([1, 2, 3, 4], 6),
+		);
+		assertOutputContext(change, 1, 2, 3, 4, 6);
+		assert.deepEqual(commits.deletedSourceCommits, [n3_1, n4_1, n6]);
+		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
+		assert.deepEqual(commits.sourceCommits, [n6_1]);
+	});
+
 	it("reports no change for equivalent branches", () => {
 		// 1 ─ 2 ─ 3 ─ 4
 		// └─ 2'─ 3'

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -71,12 +71,12 @@ describe("rebaseBranch", () => {
 		const n3 = newCommit(3);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), n3, n2),
+			() => rebaseBranch(new TestChangeRebaser(), true, n3, n2),
 			(e: Error) => validateAssertionError(e, "branches must be related"),
 		);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), n2, n3, n1),
+			() => rebaseBranch(new TestChangeRebaser(), true, n2, n3, n1),
 			(e: Error) => validateAssertionError(e, "target commit is not in target branch"),
 		);
 	});
@@ -90,7 +90,7 @@ describe("rebaseBranch", () => {
 
 		// (1)
 		//  └─ 2 ─ 3
-		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n3, n1);
+		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n3, n1);
 		assert.equal(n3_1, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
@@ -109,7 +109,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)
 		//         └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n3);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n3);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(
 			newPath,
@@ -133,7 +133,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3
 		//     └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n3);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n2, n3);
 		const newPath = getPath(n2, n5_1);
 		assertChanges(
 			newPath,
@@ -159,7 +159,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4
 		//         └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n4);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n2, n4);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3],
@@ -185,7 +185,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n4);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n4);
 		const newPath = getPath(n4, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3, 4],
@@ -210,7 +210,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)─ 4
 		//         └─
-		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), n3_1, n3, n4);
+		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n3_1, n3, n4);
 		assert.equal(n3_2, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
@@ -231,7 +231,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1] = rebaseBranch(new TestChangeRebaser(), n5, n4);
+		const [n5_1] = rebaseBranch(new TestChangeRebaser(), true, n5, n4);
 	});
 });
 

--- a/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
@@ -130,6 +130,7 @@ describe("rebaser", () => {
 
 				const [result] = rebaseBranch(
 					new DummyChangeRebaser(),
+					true,
 					tester.branch,
 					base,
 					tester.main,

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.bench.ts
@@ -80,6 +80,7 @@ describe("EditManager - Bench", () => {
 							rebasedEditCount,
 							trunkEditCount,
 							rebaser,
+							"None",
 							true,
 						);
 

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.bench.ts
@@ -12,7 +12,7 @@ import {
 	rebasePeerEditsOverTrunkEdits,
 } from "./editManagerTestUtils";
 
-describe.only("EditManager - Bench", () => {
+describe("EditManager - Bench", () => {
 	interface Scenario {
 		readonly type: BenchmarkType;
 		readonly rebasedEditCount: number;
@@ -20,12 +20,12 @@ describe.only("EditManager - Bench", () => {
 	}
 
 	const scenarios: Scenario[] = [
-		// { type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1 },
-		// { type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },
-		// { type: BenchmarkType.Perspective, rebasedEditCount: 100, trunkEditCount: 1 },
+		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1 },
+		{ type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },
+		{ type: BenchmarkType.Perspective, rebasedEditCount: 100, trunkEditCount: 1 },
 		{ type: BenchmarkType.Perspective, rebasedEditCount: 1000, trunkEditCount: 1 },
-		// { type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 10 },
-		// { type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 100 },
+		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 10 },
+		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 100 },
 		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1000 },
 		{ type: BenchmarkType.Measurement, rebasedEditCount: 100, trunkEditCount: 100 },
 	];

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.bench.ts
@@ -12,7 +12,7 @@ import {
 	rebasePeerEditsOverTrunkEdits,
 } from "./editManagerTestUtils";
 
-describe("EditManager - Bench", () => {
+describe.only("EditManager - Bench", () => {
 	interface Scenario {
 		readonly type: BenchmarkType;
 		readonly rebasedEditCount: number;
@@ -20,12 +20,12 @@ describe("EditManager - Bench", () => {
 	}
 
 	const scenarios: Scenario[] = [
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 100, trunkEditCount: 1 },
+		// { type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1 },
+		// { type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },
+		// { type: BenchmarkType.Perspective, rebasedEditCount: 100, trunkEditCount: 1 },
 		{ type: BenchmarkType.Perspective, rebasedEditCount: 1000, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 10 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 100 },
+		// { type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 10 },
+		// { type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 100 },
 		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1000 },
 		{ type: BenchmarkType.Measurement, rebasedEditCount: 100, trunkEditCount: 100 },
 	];

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -719,12 +719,7 @@ describe("EditManager", () => {
 						// However, we avoid recomputing the inverse for the same change,
 						// so in the end we only invert (once) each peer edit that has peer edit after it.
 						inverted: peerCount - 1,
-						// For each peer edit received (factor of P),
-						// we compose...
-						// - the rebased version of that peer edit: 1
-						// This compose is part of the code path updating the local branch.
-						// Note: that the composition doesn't appear to be needed.
-						composed: peerCount,
+						composed: 0,
 					};
 					assert.deepEqual(actual, expected);
 				});
@@ -781,10 +776,7 @@ describe("EditManager", () => {
 						// - the trunk edits: T
 						// - the rebased version of the phase-1 peer edits: P
 						// Note: that the composition doesn't appear to be needed.
-						// As part of rebasing the local branch, we compose...
-						// - the phase-2 peer edit: 1
-						// Note: that the composition doesn't appear to be needed.
-						composed: peerCount + trunkCount + peerCount + 1,
+						composed: peerCount + trunkCount + peerCount,
 					};
 					assert.deepEqual(actual, expected);
 				});
@@ -840,10 +832,7 @@ describe("EditManager", () => {
 						// - the inverse of the phase-1 peer edits: P
 						// - the trunk edits up to the ref# of P+: T
 						// - the rebased version of the phase-1 peer edits: P
-						// As part of rebasing the local branch, we compose...
-						// - the phase-2 peer edit P+: 1
-						// Note: that the composition doesn't appear to be needed.
-						composed: peerCount + trunkCount + peerCount + 1,
+						composed: peerCount + trunkCount + peerCount,
 					};
 					assert.deepEqual(actual, expected);
 				});

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -840,6 +840,7 @@ describe("EditManager", () => {
 						// - the inverse of the phase-1 peer edits: P
 						// - the trunk edits up to the ref# of P+: T
 						// - the rebased version of the phase-1 peer edits: P
+						// Note: the output of the composition doesn't appear to be consumed.
 						// As part of rebasing the local branch, we compose...
 						// - the phase-2 peer edit P+: 1
 						// Note: this that composition is only needed to bake the RevisionTag into the changeset.

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -719,7 +719,12 @@ describe("EditManager", () => {
 						// However, we avoid recomputing the inverse for the same change,
 						// so in the end we only invert (once) each peer edit that has peer edit after it.
 						inverted: peerCount - 1,
-						composed: 0,
+						// For each peer edit received (factor of P),
+						// we compose...
+						// - the rebased version of that peer edit: 1
+						// This compose is part of the code path updating the local branch.
+						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
+						composed: peerCount,
 					};
 					assert.deepEqual(actual, expected);
 				});
@@ -771,7 +776,10 @@ describe("EditManager", () => {
 						// - each of the phase-1 peer edits: P
 						// This is so that we can rebase P+ over the their inverse.
 						inverted: peerCount + peerCount,
-						composed: 0,
+						// As part of rebasing the local branch, we compose...
+						// - the phase-2 peer edit: 1
+						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
+						composed: 1,
 					};
 					assert.deepEqual(actual, expected);
 				});
@@ -823,7 +831,10 @@ describe("EditManager", () => {
 						// - each of the phase-1 peer edits (which are based on commit Tc): P
 						// This is so that we can rebase P+ over the inverse of the phase-1 peer edits and up to T+.
 						inverted: peerCount + peerCount,
-						composed: 0,
+						// As part of rebasing the local branch, we compose...
+						// - the phase-2 peer edit P+: 1
+						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
+						composed: 1,
 					};
 					assert.deepEqual(actual, expected);
 				});

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -723,7 +723,7 @@ describe("EditManager", () => {
 						// we compose...
 						// - the rebased version of that peer edit: 1
 						// This compose is part of the code path updating the local branch.
-						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
+						// Note: this composition is only needed to bake the RevisionTag into the changeset.
 						composed: peerCount,
 					};
 					assert.deepEqual(actual, expected);
@@ -783,7 +783,7 @@ describe("EditManager", () => {
 						// Note: the output of the composition doesn't appear to be consumed.
 						// As part of rebasing the local branch, we compose...
 						// - the phase-2 peer edit: 1
-						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
+						// Note: this composition is only needed to bake the RevisionTag into the changeset.
 						composed: peerCount + trunkCount + peerCount + 1,
 					};
 					assert.deepEqual(actual, expected);
@@ -843,7 +843,7 @@ describe("EditManager", () => {
 						// Note: the output of the composition doesn't appear to be consumed.
 						// As part of rebasing the local branch, we compose...
 						// - the phase-2 peer edit P+: 1
-						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
+						// Note: this composition is only needed to bake the RevisionTag into the changeset.
 						composed: peerCount + trunkCount + peerCount + 1,
 					};
 					assert.deepEqual(actual, expected);

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -771,12 +771,7 @@ describe("EditManager", () => {
 						// - each of the phase-1 peer edits: P
 						// This is so that we can rebase P+ over the their inverse.
 						inverted: peerCount + peerCount,
-						// As part of rebasing the peer branch, we compose...
-						// - the inverse of the phase-1 peer edits: P
-						// - the trunk edits: T
-						// - the rebased version of the phase-1 peer edits: P
-						// Note: that the composition doesn't appear to be needed.
-						composed: peerCount + trunkCount + peerCount,
+						composed: 0,
 					};
 					assert.deepEqual(actual, expected);
 				});
@@ -828,11 +823,7 @@ describe("EditManager", () => {
 						// - each of the phase-1 peer edits (which are based on commit Tc): P
 						// This is so that we can rebase P+ over the inverse of the phase-1 peer edits and up to T+.
 						inverted: peerCount + peerCount,
-						// As part of rebasing the peer branch, we compose...
-						// - the inverse of the phase-1 peer edits: P
-						// - the trunk edits up to the ref# of P+: T
-						// - the rebased version of the phase-1 peer edits: P
-						composed: peerCount + trunkCount + peerCount,
+						composed: 0,
 					};
 					assert.deepEqual(actual, expected);
 				});

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -723,7 +723,7 @@ describe("EditManager", () => {
 						// we compose...
 						// - the rebased version of that peer edit: 1
 						// This compose is part of the code path updating the local branch.
-						// Note: that the composition doesn't appear to be needed.
+						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
 						composed: peerCount,
 					};
 					assert.deepEqual(actual, expected);
@@ -765,13 +765,13 @@ describe("EditManager", () => {
 						// we rebase P+ (factor of 1) over...
 						// - the inverse of each peer edit before it: P
 						// - the trunk edits since its inception, which are the rebased phase-1 edits: P
-						// Note: that last rebase phase doesn't seem to be needed for this scenario.
+						// Note: this last rebase phase doesn't seem to be needed for this scenario.
 						rebased:
 							peerCount * (peerCount - 1 + trunkCount) + 1 * (peerCount + peerCount),
 						// As part of rebasing the peer branch, we invert...
 						// - each of the phase-1 peer edits: P
 						// This is so that we can rebase them over the trunk edits.
-						// Note: that the last phase-1 peer edit does not actually need to be inverted.
+						// Note: the last of the phase-1 peer edit does not actually need to be inverted.
 						// As part of rebasing P+, we invert...
 						// - each of the phase-1 peer edits: P
 						// This is so that we can rebase P+ over the their inverse.
@@ -780,10 +780,10 @@ describe("EditManager", () => {
 						// - the inverse of the phase-1 peer edits: P
 						// - the trunk edits: T
 						// - the rebased version of the phase-1 peer edits: P
-						// Note: that the composition doesn't appear to be needed.
+						// Note: the output of the composition doesn't appear to be consumed.
 						// As part of rebasing the local branch, we compose...
 						// - the phase-2 peer edit: 1
-						// Note: that the composition doesn't appear to be needed.
+						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
 						composed: peerCount + trunkCount + peerCount + 1,
 					};
 					assert.deepEqual(actual, expected);
@@ -842,7 +842,7 @@ describe("EditManager", () => {
 						// - the rebased version of the phase-1 peer edits: P
 						// As part of rebasing the local branch, we compose...
 						// - the phase-2 peer edit P+: 1
-						// Note: that the composition doesn't appear to be needed.
+						// Note: this that composition is only needed to bake the RevisionTag into the changeset.
 						composed: peerCount + trunkCount + peerCount + 1,
 					};
 					assert.deepEqual(actual, expected);

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -757,25 +757,17 @@ describe("EditManager", () => {
 					};
 					const expected = {
 						// As part of rebasing the peer branch that contains the phase-1 edits,
-						// we rebase each peer (factor of P) edit over...
-						// - the inverse of each peer edit before it: (P - 1) / 2
-						// - each the trunk edits: T
-						// - the fully rebased version of each peer edit before it: (P - 1) / 2
+						// for each peer edit (factor of P)...
+						// - we realize that the trunk already contains those edits, they therefore undergo no rebasing: 0
 						// As part of rebasing P+,
-						// we rebase P+ (factor of 1) over...
-						// - the inverse of each peer edit before it: P
-						// - the trunk edits since its inception, which are the rebased phase-1 edits: P
-						// Note: this last rebase phase doesn't seem to be needed for this scenario.
-						rebased:
-							peerCount * (peerCount - 1 + trunkCount) + 1 * (peerCount + peerCount),
+						// - we realize that it is effectively based on the tip of the trunk,
+						//   it therefore undergoes no rebasing: 0
+						rebased: peerCount * 0 + 1 * 0,
 						// As part of rebasing the peer branch, we invert...
 						// - each of the phase-1 peer edits: P
 						// This is so that we can rebase them over the trunk edits.
-						// Note: the last of the phase-1 peer edit does not actually need to be inverted.
-						// As part of rebasing P+, we invert...
-						// - each of the phase-1 peer edits: P
-						// This is so that we can rebase P+ over the their inverse.
-						inverted: peerCount + peerCount,
+						// Note: none of those edits actually need to be inverted because all of them are already on the trunk.
+						inverted: peerCount,
 						// As part of rebasing the local branch, we compose...
 						// - the phase-2 peer edit: 1
 						// Note: this composition is only needed to bake the RevisionTag into the changeset.

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
@@ -113,6 +113,19 @@ export function rebasePeerEditsOverTrunkEdits(
 			brand(iChange),
 		);
 	}
+	let totalTrunkEdits = trunkEditCount;
+	if (extraPeerEdit === "NotCaughtUp") {
+		manager.addSequencedChange(
+			{
+				change: TestChange.emptyChange,
+				revision: mintRevisionTag(),
+				sessionId: "trunk",
+			},
+			brand(trunkEditCount + 1),
+			brand(trunkEditCount),
+		);
+		totalTrunkEdits += 1;
+	}
 	const peerEdits = makeArray(peerEditCount, () => ({
 		change: TestChange.emptyChange,
 		revision: mintRevisionTag(),
@@ -122,7 +135,7 @@ export function rebasePeerEditsOverTrunkEdits(
 		for (let iChange = 0; iChange < peerEditCount; iChange++) {
 			manager.addSequencedChange(
 				peerEdits[iChange],
-				brand(iChange + trunkEditCount + 1),
+				brand(iChange + totalTrunkEdits + 1),
 				brand(0),
 			);
 		}
@@ -134,8 +147,8 @@ export function rebasePeerEditsOverTrunkEdits(
 				revision: mintRevisionTag(),
 				sessionId: "peer",
 			},
-			brand(peerEditCount + trunkEditCount + 1),
-			brand(trunkEditCount + (extraPeerEdit === "CaughtUp" ? 0 : -1)),
+			brand(peerEditCount + totalTrunkEdits + 1),
+			brand(totalTrunkEdits + (extraPeerEdit === "CaughtUp" ? 0 : -1)),
 		);
 	};
 	let run: () => void;

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
@@ -65,6 +65,8 @@ export function rebaseLocalEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	const manager = editManagerFactory({ rebaser }).manager;
+	// Subscribe to the local branch to emulate the behavior of SharedTree
+	manager.localBranch.on("afterChange", () => {});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
 		manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
 	}
@@ -102,6 +104,8 @@ export function rebasePeerEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	const manager = editManagerFactory({ rebaser }).manager;
+	// Subscribe to the local branch to emulate the behavior of SharedTree
+	manager.localBranch.on("afterChange", () => {});
 	for (let iChange = 0; iChange < trunkEditCount; iChange++) {
 		manager.addSequencedChange(
 			{


### PR DESCRIPTION
Consider the following situation where we want to rebase branch `X` onto commit `B`.
```text
A ─(B)─ X'
└─ X
```

This PR changes the branch rebasing code to ensure that when we rebase the branch with head `X` onto `B`, we rebase the branch farther along the trunk to include the peer edits that they would otherwise have in common.

It means we end up with this:
```text
A ─ B ─ X'
        └─
```
instead of this:
```text
A ─ B ─ X'
    └─ X
```

Note that this makes the rebasing much cheaper because we detect that the destination branch has the source commits, and we therefore don't actually (re)rebase them.

In practice, this has two benefits that manifest when we receive an edit from a peer which would lead to such a situation:
* We avoid paying the full cost of a rebase of the branch.
* The rebasing of further edits from the same peer don't have to rebase backward over the peer branch and forward over the trunk

See the updated perf test expectations for details.