### PR TITLE
fix(ci): Run step to filter skipped tests even if some tests failed

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -316,6 +316,7 @@ jobs:
       # filter report
       - task: Bash@3
         displayName: Filter skipped test from report
+        condition: succeededOrFailed()
         inputs:
           workingDir: ${{ variables.testPackageDir }}/nyc
           targetType: 'inline'


### PR DESCRIPTION
## Description

We run a step in the end-to-end tests pipeline to filter out skipped tests from the report file, so they don't contribute to the test pass percentage that is reported. This step currently only runs when all previous steps passed, so when a test fails it doesn't run, the skipped tests aren't removed from the report, and the test pass percentage ends up artificially low (e.g. [this run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=212327&view=results), msft internal, reporting 75% when only 1 test out of 2300 failed, but 763 were skipped).

This PR makes it so the step to filter out skipped tests runs even if one or more tests failed so the test pass percentage is correct in that case.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
