### PR TITLE
add checkpoint location to logs

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1977,6 +1977,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					deliCheckpointPartition: checkpointParams.deliCheckpointMessage.partition,
 					kafkaCheckpointOffset: checkpointParams.kafkaCheckpointMessage?.offset,
 					kafkaCheckpointPartition: checkpointParams.kafkaCheckpointMessage?.partition,
+					localCheckpoint:
+						this.checkpointService?.getLocalCheckpointEnabled() &&
+						!this.globalCheckpointOnly,
 				};
 				const checkpointReason = CheckpointReason[checkpointParams.reason];
 				lumberjackProperties.checkpointReason = checkpointReason;

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1977,6 +1977,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					deliCheckpointPartition: checkpointParams.deliCheckpointMessage.partition,
 					kafkaCheckpointOffset: checkpointParams.kafkaCheckpointMessage?.offset,
 					kafkaCheckpointPartition: checkpointParams.kafkaCheckpointMessage?.partition,
+					localCheckpointEnabled: this.checkpointService?.getLocalCheckpointEnabled(),
+					globalCheckpointOnly: this.globalCheckpointOnly,
 					localCheckpoint:
 						this.checkpointService?.getLocalCheckpointEnabled() &&
 						!this.globalCheckpointOnly,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -487,6 +487,8 @@ export class ScribeLambda implements IPartitionLambda {
 			kafkaCheckpointPartition: this.checkpointInfo.currentKafkaCheckpointMessage?.partition,
 			clientCount: checkpoint.protocolState.members.length,
 			clients: getClientIds(checkpoint.protocolState, 5),
+			localCheckpointEnabled: this.localCheckpointEnabled,
+			globalCheckpointOnly: this.globalCheckpointOnly,
 			localCheckpoint: this.localCheckpointEnabled && !this.globalCheckpointOnly,
 		};
 		Lumberjack.info(checkpointResult, lumberjackProperties);
@@ -875,6 +877,8 @@ export class ScribeLambda implements IPartitionLambda {
 							this.checkpointInfo.currentKafkaCheckpointMessage?.partition,
 						clientCount: checkpoint.protocolState.members.length,
 						clients: getClientIds(checkpoint.protocolState, 5),
+						localCheckpointEnabled: this.localCheckpointEnabled,
+						globalCheckpointOnly: this.globalCheckpointOnly,
 						localCheckpoint: this.localCheckpointEnabled && !this.globalCheckpointOnly,
 					};
 					Lumberjack.info(checkpointResult, lumberjackProperties);

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -114,6 +114,7 @@ export class ScribeLambda implements IPartitionLambda {
 		private readonly restartOnCheckpointFailure: boolean,
 		private readonly kafkaCheckpointOnReprocessingOp: boolean,
 		private readonly isEphemeralContainer: boolean,
+		private readonly localCheckpointEnabled: boolean,
 	) {
 		this.lastOffset = scribe.logOffset;
 		this.setStateFromCheckpoint(scribe);
@@ -486,6 +487,7 @@ export class ScribeLambda implements IPartitionLambda {
 			kafkaCheckpointPartition: this.checkpointInfo.currentKafkaCheckpointMessage?.partition,
 			clientCount: checkpoint.protocolState.members.length,
 			clients: getClientIds(checkpoint.protocolState, 5),
+			localCheckpoint: this.localCheckpointEnabled && !this.globalCheckpointOnly,
 		};
 		Lumberjack.info(checkpointResult, lumberjackProperties);
 	}
@@ -873,6 +875,7 @@ export class ScribeLambda implements IPartitionLambda {
 							this.checkpointInfo.currentKafkaCheckpointMessage?.partition,
 						clientCount: checkpoint.protocolState.members.length,
 						clients: getClientIds(checkpoint.protocolState, 5),
+						localCheckpoint: this.localCheckpointEnabled && !this.globalCheckpointOnly,
 					};
 					Lumberjack.info(checkpointResult, lumberjackProperties);
 				}

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -323,6 +323,7 @@ export class ScribeLambdaFactory
 			this.restartOnCheckpointFailure,
 			this.kafkaCheckpointOnReprocessingOp,
 			document.isEphemeralContainer ?? false,
+			this.checkpointService.getLocalCheckpointEnabled(),
 		);
 
 		await this.sendLambdaStartResult(tenantId, documentId, {

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -397,6 +397,7 @@ export class LocalOrderer implements IOrderer {
 			true,
 			true,
 			this.details.value.isEphemeralContainer,
+			checkpointService.getLocalCheckpointEnabled(),
 		);
 	}
 


### PR DESCRIPTION
## Description

> Adding a property, `localCheckpoint` to our checkpoint logs to track which service scribe and deli will try to use for checkpointing.