### PR TITLE
Remove Deprecated FluidStatic Classes

### DIFF
--- a/.changeset/wet-hornets-trade.md
+++ b/.changeset/wet-hornets-trade.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/azure-client": major
+"fluid-framework": major
+"@fluidframework/fluid-static": major
+"@fluidframework/tinylicious-client": major
+---
+
+Removes Deprecated FluidStatic Classes
+
+This change removes a number of deprecated and unnecessarily exposed FluidStatic classes.
+The removed classes are as follows:
+
+-   AzureAudience
+-   TinyliciousAudience
+-   DOProviderContainerRuntimeFactory
+-   FluidContainer
+-   ServiceAudience

--- a/azure/packages/azure-client/api-report/azure-client.api.md
+++ b/azure/packages/azure-client/api-report/azure-client.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { ContainerSchema } from '@fluidframework/fluid-static';
-import { IClient } from '@fluidframework/protocol-definitions';
 import { ICompressionStorageConfig } from '@fluidframework/driver-utils';
 import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
 import { IFluidContainer } from '@fluidframework/fluid-static';
@@ -18,13 +17,6 @@ import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/protocol-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
-import { ServiceAudience } from '@fluidframework/fluid-static';
-
-// @public @deprecated
-export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {
-    // @internal
-    protected createServiceMember(audienceMember: IClient): AzureMember;
-}
 
 // @public
 export class AzureClient {

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -111,6 +111,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedClassDeclaration_AzureAudience": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/azure/packages/azure-client/src/AzureAudience.ts
+++ b/azure/packages/azure-client/src/AzureAudience.ts
@@ -3,33 +3,9 @@
  * Licensed under the MIT License.
  */
 import { assert } from "@fluidframework/core-utils";
-import { ServiceAudience } from "@fluidframework/fluid-static";
 import { type IClient } from "@fluidframework/protocol-definitions";
 
-import { type AzureMember, type AzureUser, type IAzureAudience } from "./interfaces";
-
-/**
- * Azure-specific {@link @fluidframework/fluid-static#ServiceAudience} implementation.
- *
- * @remarks Operates in terms of {@link AzureMember}s.
- *
- * @public
- * @deprecated This class will be removed. use {@link IAzureAudience} instead
- */
-export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {
-	/**
-	 * Creates a {@link @fluidframework/fluid-static#ServiceAudience} from the provided
-	 * {@link @fluidframework/protocol-definitions#IClient | audience member}.
-	 *
-	 * @param audienceMember - Audience member for which the `ServiceAudience` will be generated.
-	 * Note: its {@link @fluidframework/protocol-definitions#IClient.user} is required to be an {@link AzureUser}.
-	 *
-	 * @internal
-	 */
-	protected createServiceMember(audienceMember: IClient): AzureMember {
-		return createAzureAudienceMember(audienceMember);
-	}
-}
+import { type AzureMember, type AzureUser } from "./interfaces";
 
 /**
  * Creates Azure-specific audience member

--- a/azure/packages/azure-client/src/index.ts
+++ b/azure/packages/azure-client/src/index.ts
@@ -9,7 +9,6 @@
  * @packageDocumentation
  */
 
-export { AzureAudience } from "./AzureAudience";
 export { AzureClient } from "./AzureClient";
 export { AzureFunctionTokenProvider } from "./AzureFunctionTokenProvider";
 export type {

--- a/azure/packages/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
+++ b/azure/packages/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
@@ -24,26 +24,14 @@ type TypeOnly<T> = T extends number
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_AzureAudience": {"forwardCompat": false}
+* "RemovedClassDeclaration_AzureAudience": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_AzureAudience():
-    TypeOnly<old.AzureAudience>;
-declare function use_current_ClassDeclaration_AzureAudience(
-    use: TypeOnly<current.AzureAudience>): void;
-use_current_ClassDeclaration_AzureAudience(
-    get_old_ClassDeclaration_AzureAudience());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_AzureAudience": {"backCompat": false}
+* "RemovedClassDeclaration_AzureAudience": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_AzureAudience():
-    TypeOnly<current.AzureAudience>;
-declare function use_old_ClassDeclaration_AzureAudience(
-    use: TypeOnly<old.AzureAudience>): void;
-use_old_ClassDeclaration_AzureAudience(
-    get_current_ClassDeclaration_AzureAudience());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/azure/packages/external-controller/tests/index.ts
+++ b/azure/packages/external-controller/tests/index.ts
@@ -12,7 +12,6 @@ import {
 	IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
-import { DOProviderContainerRuntimeFactory, FluidContainer } from "@fluidframework/fluid-static";
 import {
 	LocalDocumentServiceFactory,
 	LocalResolver,
@@ -25,6 +24,10 @@ import {
 
 import { DiceRollerController } from "../src/controller";
 import { makeAppView } from "../src/view";
+import {
+	IFluidContainer,
+	createDOProviderContainerRuntimeFactory,
+} from "@fluidframework/fluid-static";
 
 // Since this is a single page Fluid application we are generating a new document id
 // if one was not provided
@@ -101,7 +104,7 @@ export const containerConfig = {
 	},
 };
 
-async function initializeNewContainer(container: FluidContainer): Promise<void> {
+async function initializeNewContainer(container: IFluidContainer): Promise<void> {
 	// We now get the first SharedMap from the container
 	const sharedMap1 = container.initialObjects.map1 as SharedMap;
 	const sharedMap2 = container.initialObjects.map2 as SharedMap;
@@ -123,12 +126,12 @@ export async function createContainerAndRenderInElement(
 	// to store ops.
 	const { container, attach } = await getSessionStorageContainer(
 		documentId,
-		new DOProviderContainerRuntimeFactory(containerConfig),
+		createDOProviderContainerRuntimeFactory({ schema: containerConfig }),
 		createNewFlag,
 	);
 
 	// Get the Default Object from the Container
-	const fluidContainer = (await container.getEntryPoint()) as FluidContainer;
+	const fluidContainer = (await container.getEntryPoint()) as IFluidContainer;
 	if (createNewFlag) {
 		await initializeNewContainer(fluidContainer);
 		await attach?.();

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -11,9 +11,7 @@ import { ContainerSchema } from '@fluidframework/fluid-static';
 import { DataObjectClass } from '@fluidframework/fluid-static';
 import { DeserializeCallback } from '@fluidframework/sequence';
 import { DirectoryFactory } from '@fluidframework/map';
-import { DOProviderContainerRuntimeFactory } from '@fluidframework/fluid-static';
 import { DriverErrorType } from '@fluidframework/driver-definitions';
-import { FluidContainer } from '@fluidframework/fluid-static';
 import { getTextAndMarkers } from '@fluidframework/sequence';
 import { IConnection } from '@fluidframework/fluid-static';
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
@@ -74,7 +72,6 @@ import { SequenceEvent } from '@fluidframework/sequence';
 import { SequenceInterval } from '@fluidframework/sequence';
 import { SequenceMaintenanceEvent } from '@fluidframework/sequence';
 import { SerializedIntervalDelta } from '@fluidframework/sequence';
-import { ServiceAudience } from '@fluidframework/fluid-static';
 import { SharedDirectory } from '@fluidframework/map';
 import { SharedIntervalCollection } from '@fluidframework/sequence';
 import { SharedIntervalCollectionFactory } from '@fluidframework/sequence';
@@ -101,11 +98,7 @@ export { DeserializeCallback }
 
 export { DirectoryFactory }
 
-export { DOProviderContainerRuntimeFactory }
-
 export { DriverErrorType }
-
-export { FluidContainer }
 
 export { getTextAndMarkers }
 
@@ -226,8 +219,6 @@ export { SequenceInterval }
 export { SequenceMaintenanceEvent }
 
 export { SerializedIntervalDelta }
-
-export { ServiceAudience }
 
 export { SharedDirectory }
 

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -32,11 +32,6 @@ export type {
 	MemberChangedListener,
 	SharedObjectClass,
 } from "@fluidframework/fluid-static";
-export {
-	DOProviderContainerRuntimeFactory,
-	FluidContainer,
-	ServiceAudience,
-} from "@fluidframework/fluid-static";
 export type {
 	IDirectory,
 	IDirectoryClearOperation,

--- a/packages/framework/fluid-static/api-report/fluid-static.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.api.md
@@ -5,20 +5,16 @@
 ```ts
 
 import { AttachState } from '@fluidframework/container-definitions';
-import { BaseContainerRuntimeFactory } from '@fluidframework/aqueduct';
 import { ConnectionState } from '@fluidframework/container-definitions';
-import { IAudience } from '@fluidframework/container-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IContainer } from '@fluidframework/container-definitions';
-import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IRuntimeFactory } from '@fluidframework/container-definitions';
-import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @public
 export interface ContainerSchema {
@@ -47,30 +43,6 @@ export function createServiceAudience<M extends IMember = IMember>(props: {
 export type DataObjectClass<T extends IFluidLoadable> = {
     readonly factory: IFluidDataStoreFactory;
 } & LoadableObjectCtor<T>;
-
-// @public @deprecated
-export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
-    constructor(schema: ContainerSchema);
-    // (undocumented)
-    protected containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void>;
-}
-
-// @public @deprecated
-export class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer<TContainerSchema> {
-    constructor(container: IContainer, rootDataObject: IRootDataObject);
-    attach(): Promise<string>;
-    get attachState(): AttachState;
-    connect(): Promise<void>;
-    get connectionState(): ConnectionState;
-    create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
-    disconnect(): Promise<void>;
-    dispose(): void;
-    get disposed(): boolean;
-    get initialObjects(): InitialObjects<TContainerSchema>;
-    // @internal
-    readonly INTERNAL_CONTAINER_DO_NOT_USE?: () => IContainer;
-    get isDirty(): boolean;
-}
 
 // @public
 export interface IConnection {
@@ -153,19 +125,6 @@ export type MemberChangedListener<M extends IMember> = (clientId: string, member
 export type Myself<M extends IMember = IMember> = M & {
     currentConnection: string;
 };
-
-// @public @deprecated
-export abstract class ServiceAudience<M extends IMember = IMember> extends TypedEventEmitter<IServiceAudienceEvents<M>> implements IServiceAudience<M> {
-    constructor(
-    container: IContainer);
-    protected readonly audience: IAudience;
-    protected readonly container: IContainer;
-    protected abstract createServiceMember(audienceMember: IClient): M;
-    getMembers(): Map<string, M>;
-    getMyself(): Myself<M> | undefined;
-    protected lastMembers: Map<string, M>;
-    protected shouldIncludeAsMember(member: IClient): boolean;
-}
 
 // @public
 export type SharedObjectClass<T extends IFluidLoadable> = {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -124,6 +124,19 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedClassDeclaration_DOProviderContainerRuntimeFactory": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedClassDeclaration_FluidContainer": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedClassDeclaration_ServiceAudience": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -225,9 +225,8 @@ export function createFluidContainer<
  *
  * Note: this implementation is not complete. Consumers who rely on {@link IFluidContainer.attach}
  * will need to utilize or provide a service-specific implementation of this type that implements that method.
- * @deprecated use {@link createFluidContainer} and {@link IFluidContainer} instead
  */
-export class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema>
+class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema>
 	extends TypedEventEmitter<IFluidContainerEvents>
 	implements IFluidContainer<TContainerSchema>
 {

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -10,17 +10,13 @@
  */
 
 export {
-	FluidContainer,
 	createFluidContainer,
 	IFluidContainer,
 	IFluidContainerEvents,
 	InitialObjects,
 } from "./fluidContainer";
-export {
-	DOProviderContainerRuntimeFactory,
-	createDOProviderContainerRuntimeFactory,
-} from "./rootDataObject";
-export { ServiceAudience, createServiceAudience } from "./serviceAudience";
+export { createDOProviderContainerRuntimeFactory } from "./rootDataObject";
+export { createServiceAudience } from "./serviceAudience";
 export {
 	ContainerSchema,
 	DataObjectClass,

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -153,9 +153,8 @@ export function createDOProviderContainerRuntimeFactory(props: {
  *
  * This data object is dynamically customized (registry and initial objects) based on the schema provided.
  * to the container runtime factory.
- * @deprecated use {@link createDOProviderContainerRuntimeFactory} instead
  */
-export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
+class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 	private readonly rootDataObjectFactory: DataObjectFactory<
 		RootDataObject,
 		{

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -12,13 +12,7 @@ export function createServiceAudience<M extends IMember = IMember>(props: {
 	container: IContainer;
 	createServiceMember: (audienceMember: IClient) => M;
 }): IServiceAudience<M> {
-	// todo: once ServiceAudience isn't exported, we can remove abstract from it, and just use that here
-	const c = class NewServiceAudience extends ServiceAudience<M> {
-		protected createServiceMember(audienceMember: IClient) {
-			return props.createServiceMember(audienceMember);
-		}
-	};
-	return new c(props.container);
+	return new ServiceAudience(props.container, props.createServiceMember);
 }
 
 /**
@@ -30,16 +24,15 @@ export function createServiceAudience<M extends IMember = IMember>(props: {
  * the user and client details returned in {@link IMember}.
  *
  * @typeParam M - A service-specific {@link IMember} implementation.
- * @deprecated use {@link createServiceAudience} and {@link IServiceAudience} instead
  */
-export abstract class ServiceAudience<M extends IMember = IMember>
+class ServiceAudience<M extends IMember = IMember>
 	extends TypedEventEmitter<IServiceAudienceEvents<M>>
 	implements IServiceAudience<M>
 {
 	/**
 	 * Audience object which includes all the existing members of the {@link IFluidContainer | container}.
 	 */
-	protected readonly audience: IAudience;
+	private readonly audience: IAudience;
 
 	/**
 	 * Retain the most recent member list.
@@ -58,13 +51,14 @@ export abstract class ServiceAudience<M extends IMember = IMember>
 	 * every `addMember` event. It is mapped `clientId` to `M` to be better work with what the {@link IServiceAudience}
 	 * events provide.
 	 */
-	protected lastMembers = new Map<string, M>();
+	private lastMembers = new Map<string, M>();
 
 	constructor(
 		/**
 		 * Fluid Container to read the audience from.
 		 */
-		protected readonly container: IContainer,
+		private readonly container: IContainer,
+		private readonly createServiceMember: (audienceMember: IClient) => M,
 	) {
 		super();
 		this.audience = container.audience;
@@ -90,13 +84,6 @@ export abstract class ServiceAudience<M extends IMember = IMember>
 
 		this.container.on("connected", () => this.emit("membersChanged"));
 	}
-
-	/**
-	 * Provides ability for inheriting class to modify/extend the audience object.
-	 *
-	 * @param audienceMember - Record of a specific audience member.
-	 */
-	protected abstract createServiceMember(audienceMember: IClient): M;
 
 	/**
 	 * {@inheritDoc IServiceAudience.getMembers}
@@ -166,7 +153,7 @@ export abstract class ServiceAudience<M extends IMember = IMember>
 	 *
 	 * @param member - Member to be included/omitted.
 	 */
-	protected shouldIncludeAsMember(member: IClient): boolean {
+	private shouldIncludeAsMember(member: IClient): boolean {
 		// Include only human members
 		return member.details.capabilities.interactive;
 	}

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -48,26 +48,14 @@ use_old_InterfaceDeclaration_ContainerSchema(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DOProviderContainerRuntimeFactory": {"forwardCompat": false}
+* "RemovedClassDeclaration_DOProviderContainerRuntimeFactory": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_DOProviderContainerRuntimeFactory():
-    TypeOnly<old.DOProviderContainerRuntimeFactory>;
-declare function use_current_ClassDeclaration_DOProviderContainerRuntimeFactory(
-    use: TypeOnly<current.DOProviderContainerRuntimeFactory>): void;
-use_current_ClassDeclaration_DOProviderContainerRuntimeFactory(
-    get_old_ClassDeclaration_DOProviderContainerRuntimeFactory());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DOProviderContainerRuntimeFactory": {"backCompat": false}
+* "RemovedClassDeclaration_DOProviderContainerRuntimeFactory": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_DOProviderContainerRuntimeFactory():
-    TypeOnly<current.DOProviderContainerRuntimeFactory>;
-declare function use_old_ClassDeclaration_DOProviderContainerRuntimeFactory(
-    use: TypeOnly<old.DOProviderContainerRuntimeFactory>): void;
-use_old_ClassDeclaration_DOProviderContainerRuntimeFactory(
-    get_current_ClassDeclaration_DOProviderContainerRuntimeFactory());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -96,26 +84,14 @@ use_old_TypeAliasDeclaration_DataObjectClass(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_FluidContainer": {"forwardCompat": false}
+* "RemovedClassDeclaration_FluidContainer": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_FluidContainer():
-    TypeOnly<old.FluidContainer>;
-declare function use_current_ClassDeclaration_FluidContainer(
-    use: TypeOnly<current.FluidContainer>): void;
-use_current_ClassDeclaration_FluidContainer(
-    get_old_ClassDeclaration_FluidContainer());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_FluidContainer": {"backCompat": false}
+* "RemovedClassDeclaration_FluidContainer": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_FluidContainer():
-    TypeOnly<current.FluidContainer>;
-declare function use_old_ClassDeclaration_FluidContainer(
-    use: TypeOnly<old.FluidContainer>): void;
-use_old_ClassDeclaration_FluidContainer(
-    get_current_ClassDeclaration_FluidContainer());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -432,26 +408,14 @@ use_old_TypeAliasDeclaration_Myself(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_ServiceAudience": {"forwardCompat": false}
+* "RemovedClassDeclaration_ServiceAudience": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_ServiceAudience():
-    TypeOnly<old.ServiceAudience>;
-declare function use_current_ClassDeclaration_ServiceAudience(
-    use: TypeOnly<current.ServiceAudience>): void;
-use_current_ClassDeclaration_ServiceAudience(
-    get_old_ClassDeclaration_ServiceAudience());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_ServiceAudience": {"backCompat": false}
+* "RemovedClassDeclaration_ServiceAudience": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_ServiceAudience():
-    TypeOnly<current.ServiceAudience>;
-declare function use_old_ClassDeclaration_ServiceAudience(
-    use: TypeOnly<old.ServiceAudience>): void;
-use_old_ClassDeclaration_ServiceAudience(
-    get_current_ClassDeclaration_ServiceAudience());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/framework/tinylicious-client/api-report/tinylicious-client.api.md
+++ b/packages/framework/tinylicious-client/api-report/tinylicious-client.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { ContainerSchema } from '@fluidframework/fluid-static';
-import { IClient } from '@fluidframework/protocol-definitions';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
@@ -13,7 +12,6 @@ import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/protocol-definitions';
-import { ServiceAudience } from '@fluidframework/fluid-static';
 
 export { ITelemetryBaseEvent }
 
@@ -21,12 +19,6 @@ export { ITelemetryBaseLogger }
 
 // @public
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
-
-// @public @deprecated
-export class TinyliciousAudience extends ServiceAudience<TinyliciousMember> implements ITinyliciousAudience {
-    // @internal (undocumented)
-    protected createServiceMember(audienceMember: IClient): TinyliciousMember;
-}
 
 // @public
 class TinyliciousClient {

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -105,6 +105,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedClassDeclaration_TinyliciousAudience": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/tinylicious-client/src/TinyliciousAudience.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousAudience.ts
@@ -4,27 +4,8 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { ServiceAudience } from "@fluidframework/fluid-static";
 import { IClient } from "@fluidframework/protocol-definitions";
-import { ITinyliciousAudience, TinyliciousMember, TinyliciousUser } from "./interfaces";
-
-/**
- * {@inheritDoc ITinyliciousAudience}
- *
- * @public
- * @deprecated use {@link ITinyliciousAudience} instead
- */
-export class TinyliciousAudience
-	extends ServiceAudience<TinyliciousMember>
-	implements ITinyliciousAudience
-{
-	/**
-	 * @internal
-	 */
-	protected createServiceMember(audienceMember: IClient): TinyliciousMember {
-		return createTinyliciousAudienceMember(audienceMember);
-	}
-}
+import { TinyliciousMember, TinyliciousUser } from "./interfaces";
 
 export function createTinyliciousAudienceMember(audienceMember: IClient): TinyliciousMember {
 	const tinyliciousUser = audienceMember.user as TinyliciousUser;

--- a/packages/framework/tinylicious-client/src/index.ts
+++ b/packages/framework/tinylicious-client/src/index.ts
@@ -26,7 +26,6 @@ export {
 	TinyliciousMember,
 	TinyliciousUser,
 } from "./interfaces";
-export { TinyliciousAudience } from "./TinyliciousAudience";
 export { TinyliciousClient } from "./TinyliciousClient";
 // eslint-disable-next-line import/no-default-export
 export default TinyliciousClient;

--- a/packages/framework/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
+++ b/packages/framework/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
@@ -96,26 +96,14 @@ use_old_TypeAliasDeclaration_ITinyliciousAudience(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_TinyliciousAudience": {"forwardCompat": false}
+* "RemovedClassDeclaration_TinyliciousAudience": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_TinyliciousAudience():
-    TypeOnly<old.TinyliciousAudience>;
-declare function use_current_ClassDeclaration_TinyliciousAudience(
-    use: TypeOnly<current.TinyliciousAudience>): void;
-use_current_ClassDeclaration_TinyliciousAudience(
-    get_old_ClassDeclaration_TinyliciousAudience());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_TinyliciousAudience": {"backCompat": false}
+* "RemovedClassDeclaration_TinyliciousAudience": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_TinyliciousAudience():
-    TypeOnly<current.TinyliciousAudience>;
-declare function use_old_ClassDeclaration_TinyliciousAudience(
-    use: TypeOnly<old.TinyliciousAudience>): void;
-use_old_ClassDeclaration_TinyliciousAudience(
-    get_current_ClassDeclaration_TinyliciousAudience());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
Removes Deprecated FluidStatic Classes

This change removes a number of deprecated and unnecessarily exposed FluidStatic classes.
The removed classes are as follows:

-   AzureAudience
-   TinyliciousAudience
-   DOProviderContainerRuntimeFactory
-   FluidContainer
-   ServiceAudience

this is a follow up to #18402