### PR TITLE
Fix example for flub release

### DIFF
--- a/build-tools/packages/build-cli/docs/release.md
+++ b/build-tools/packages/build-cli/docs/release.md
@@ -23,7 +23,7 @@ FLAGS
   -g, --releaseGroup=<option>  Name of a release group.
                                <options: client|server|azure|build-tools|gitrest|historian>
   -p, --package=<value>        Name of package. You can use scoped or unscoped package names. For example, both
-                               @fluid-tools/markdown-magic and markdown-magic are valid.
+                               @fluid-tools/benchmark and benchmark are valid.
   -t, --bumpType=<option>      Version bump type.
                                <options: major|minor|patch>
   -x, --skipChecks             Skip all checks.
@@ -104,7 +104,7 @@ FLAGS
   -l, --limit=<value>          Limits the number of displayed releases for each release group. Results are sorted by
                                semver, so '--limit 10' will return the 10 highest semver releases for the release group.
   -p, --package=<value>        Name of package. You can use scoped or unscoped package names. For example, both
-                               @fluid-tools/markdown-magic and markdown-magic are valid.
+                               @fluid-tools/benchmark and benchmark are valid.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -69,7 +69,7 @@ export const releaseGroupWithAllFlag = Flags.custom<ReleaseGroup | "all">({
 export const packageSelectorFlag = Flags.custom({
 	char: "p",
 	description:
-		"Name of package. You can use scoped or unscoped package names. For example, both @fluid-tools/markdown-magic and markdown-magic are valid.",
+		"Name of package. You can use scoped or unscoped package names. For example, both @fluid-tools/benchmark and benchmark are valid.",
 	multiple: false,
 });
 


### PR DESCRIPTION
## Description

markdown-magic is not a publish package, so it should not be an example for how to publish packages: trying to pushligh it errors that the package is not found.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
