### PR TITLE
Revert "PropertyDDS: Summary generation Bug Fix"

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
+++ b/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
@@ -223,7 +223,7 @@ export class SharedPropertyTree extends SharedObject {
     // (undocumented)
     propertyTreeConfig: IPropertyTreeConfig;
     // (undocumented)
-    static prune(minimumSequenceNumber: number, remoteChanges: IPropertyTreeMessage[], unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>, remoteHeadGuid: string): {
+    static prune(minimumSequenceNumber: number, remoteChanges: IPropertyTreeMessage[], unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>): {
         remoteChanges: IPropertyTreeMessage[];
         unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>;
         prunedCount: number;

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -391,7 +391,6 @@ export class SharedPropertyTree extends SharedObject {
 		minimumSequenceNumber: number,
 		remoteChanges: IPropertyTreeMessage[],
 		unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage>,
-		remoteHeadGuid: string,
 	) {
 		// for faster lookup of remote change guids
 		const remoteChangeMap = new Map<string, number>();
@@ -423,7 +422,7 @@ export class SharedPropertyTree extends SharedObject {
 					visitedUnrebasedRemoteChanges.has(visitor.referenceGuid)
 				) {
 					const guid = visitor.referenceGuid;
-					if (guid === "" || guid === remoteHeadGuid) {
+					if (guid === "") {
 						break;
 					}
 					// since the change is not in remote it must be in unrebased
@@ -442,9 +441,9 @@ export class SharedPropertyTree extends SharedObject {
 					visitedRemoteChanges.add(visitor.referenceGuid);
 				}
 
-				// If we have a change that refers to the start of the history (remoteHeadGuid === "" or the
-				//  provided remote head guid), we have to keep all remote Changes until this change has been processed
-				if (visitor.remoteHeadGuid === "" || visitor.remoteHeadGuid === remoteHeadGuid) {
+				// If we have a change that refers to the start of the history (remoteHeadGuid === ""), we have to
+				// keep all remote Changes until this change has been processed
+				if (visitor.remoteHeadGuid === "") {
 					visitedRemoteChanges.add(remoteChanges[0].guid);
 				}
 			}
@@ -478,22 +477,10 @@ export class SharedPropertyTree extends SharedObject {
 	public pruneHistory() {
 		const msn = this.runtime.deltaManager.minimumSequenceNumber;
 
-		let lastKnownRemoteGuid = this.headCommitGuid;
-		// We use the reference GUID of the first change in the list
-		// of remote changes as lastKnownRemoteGuid, because there
-		// might still be unrebased changes that reference this GUID
-		// as referenceGUID / remoteHeadGuid and if this happens
-		// we must make sure we preserve the remote changes and
-		// unrebased remote changes
-		if (this.remoteChanges.length > 0) {
-			lastKnownRemoteGuid = this.remoteChanges[0].referenceGuid;
-		}
-
 		const { remoteChanges, unrebasedRemoteChanges } = SharedPropertyTree.prune(
 			msn,
 			this.remoteChanges,
 			this.unrebasedRemoteChanges,
-			lastKnownRemoteGuid,
 		);
 
 		this.remoteChanges = remoteChanges;
@@ -813,14 +800,7 @@ export class SharedPropertyTree extends SharedObject {
 
 	getRebasedChanges(startGuid: string, endGuid?: string) {
 		const startIndex = findIndex(this.remoteChanges, (c) => c.guid === startGuid);
-		if (
-			startIndex === -1 &&
-			startGuid !== "" &&
-			// If the start GUID is the referenceGUID of the first change,
-			// we still can get the correct range, because the change with the startGuid itself
-			// if not included in the range.
-			(this.remoteChanges.length === 0 || startGuid !== this.remoteChanges[0].referenceGuid)
-		) {
+		if (startIndex === -1 && startGuid !== "") {
 			// TODO: Consider throwing an error once clients have picked up PR #16277.
 			console.error("Unknown start GUID specified.");
 		}

--- a/experimental/PropertyDDS/packages/property-dds/src/test/prune.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/prune.spec.ts
@@ -55,7 +55,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 
 			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
@@ -103,7 +102,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 			expect(prundedData.prunedCount).to.equal(0);
 			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
@@ -164,7 +162,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 			expect(prundedData.prunedCount).to.equal(0);
 			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
@@ -212,7 +209,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(1);
@@ -273,7 +269,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(1);
@@ -344,7 +339,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(3);
@@ -415,7 +409,6 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(0);
@@ -455,70 +448,11 @@ describe("PropertyTree", () => {
 				msn,
 				remoteChanges,
 				unrebasedRemoteChanges,
-				"",
 			);
 
 			expect(prundedData.prunedCount).to.equal(0);
 			expect(prundedData.remoteChanges.length).to.be.equal(1);
 			expect(Object.keys(prundedData.unrebasedRemoteChanges).length).to.equal(1);
-		});
-		it("Prune does nothing if unrebased changes point to remote head that is not in the remote changes", () => {
-			/**
-			 * REMOTE CHANGES:      (remoteHead X) - (A,0) - (B,1)
-			 * UNREBASED CHANGES:                 \- (A,0) - (B,1)
-			 * minimum sequence number: 0
-			 */
-			const msn = 0;
-			const remoteChanges: IPropertyTreeMessage[] = [
-				{
-					op: OpKind.ChangeSet,
-					metadata: {},
-					changeSet: {},
-					guid: "A",
-					referenceGuid: "X",
-					remoteHeadGuid: "X",
-					localBranchStart: undefined,
-				},
-				{
-					op: OpKind.ChangeSet,
-					metadata: {},
-					changeSet: {},
-					guid: "B",
-					referenceGuid: "A",
-					remoteHeadGuid: "X",
-					localBranchStart: undefined,
-				},
-			];
-			const unrebasedRemoteChanges: Record<string, IRemotePropertyTreeMessage> = {};
-			unrebasedRemoteChanges.A = {
-				op: OpKind.ChangeSet,
-				metadata: {},
-				changeSet: {},
-				guid: "A",
-				referenceGuid: "X",
-				remoteHeadGuid: "X",
-				localBranchStart: undefined,
-				sequenceNumber: 2,
-			};
-			unrebasedRemoteChanges.B = {
-				op: OpKind.ChangeSet,
-				metadata: {},
-				changeSet: {},
-				guid: "B",
-				referenceGuid: "A",
-				remoteHeadGuid: "X",
-				localBranchStart: undefined,
-				sequenceNumber: 2,
-			};
-			const prundedData = SharedPropertyTree.prune(
-				msn,
-				remoteChanges,
-				unrebasedRemoteChanges,
-				"X",
-			);
-
-			expect(remoteChanges).to.deep.equal(prundedData.remoteChanges);
-			expect(unrebasedRemoteChanges).to.deep.equal(prundedData.unrebasedRemoteChanges);
 		});
 	});
 });


### PR DESCRIPTION
Reverts microsoft/FluidFramework#18072

Internal `Build - client packages` failing with identical error after merging [18072](https://github.com/microsoft/FluidFramework/pull/18072)

Failed Task: `@***-experimental/property-dds: tsc --project ./src/test/tsconfig.json`
Error Log: `src/test/propertyTree.spec.ts:226:38 - error TS2304: Cannot find name 'requestFluidObject'.`

#### Subsequent Pipeline Failures
- [214310](https://dev.azure.com/fluidframework/internal/_build/results?buildId=214310&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bfe27d5f-9219-57c0-0d67-1b2946a32921&l=923)
- [214366](https://dev.azure.com/fluidframework/internal/_build/results?buildId=214366&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bfe27d5f-9219-57c0-0d67-1b2946a32921&l=922)
- [214405](https://dev.azure.com/fluidframework/internal/_build/results?buildId=214405&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bfe27d5f-9219-57c0-0d67-1b2946a32921&l=927)