### PR TITLE
Specify version for entryPoint loader compat tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -4,7 +4,11 @@
  */
 
 import { strict as assert } from "assert";
-import { describeLoaderCompat, describeNoCompat } from "@fluid-private/test-version-utils";
+import {
+	describeInstallVersions,
+	describeNoCompat,
+	getVersionedTestObjectProvider,
+} from "@fluid-private/test-version-utils";
 import {
 	ContainerRuntimeFactoryWithDefaultDataStore,
 	DataObject,
@@ -14,6 +18,7 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { pkgVersion } from "../packageVersion.js";
 
 describe("entryPoint compat", () => {
 	let provider: ITestObjectProvider;
@@ -78,10 +83,19 @@ describe("entryPoint compat", () => {
 		});
 	});
 
-	// Simulating old loader code
-	describeLoaderCompat("loader compat", (getTestObjectProvider) => {
+	const loaderWithRequest = "2.0.0-internal.7.0.0";
+	describeInstallVersions({
+		requestAbsoluteVersions: [loaderWithRequest],
+	})("loader compat", (_) => {
 		beforeEach(async () => {
-			provider = getTestObjectProvider();
+			provider = await getVersionedTestObjectProvider(
+				pkgVersion, // base version
+				loaderWithRequest,
+			);
+		});
+
+		afterEach(() => {
+			provider.reset();
 		});
 
 		it("request pattern works", async () => {


### PR DESCRIPTION
The `entryPoint` compat tests are currently just doing `describeLoaderCompat`, which will fail in `2.0.0-internal.8.0.0` when `request` methods are removed.

We should use specifically version `2.0.0-internal.7.0.0` to capture the compat at its boundary.