### PR TITLE
Make 0x589 and 0x588 data processing errors

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -577,7 +577,7 @@ export class DataStores implements IDisposable {
 					// state indicates an op was sent to attach a local data store, and the the attach op
 					// had not yet round tripped back to the client.
 					if (context.attachState === AttachState.Attaching) {
-						// Formerly assert 0x589
+						// Formerly assert 0x588
 						const error = DataProcessingError.create(
 							"Local data store detected in attaching state during summarize",
 							"summarize",
@@ -683,6 +683,7 @@ export class DataStores implements IDisposable {
 					// Summarizer client and hence GC works only with clients with no local changes. A data store in
 					// attaching state indicates an op was sent to attach a local data store, and the the attach op
 					// had not yet round tripped back to the client.
+					// Formerly assert 0x589
 					if (context.attachState === AttachState.Attaching) {
 						const error = DataProcessingError.create(
 							"Local data store detected in attaching state while running GC",

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -577,6 +577,7 @@ export class DataStores implements IDisposable {
 					// state indicates an op was sent to attach a local data store, and the the attach op
 					// had not yet round tripped back to the client.
 					if (context.attachState === AttachState.Attaching) {
+						// Formerly assert 0x589
 						const error = DataProcessingError.create(
 							"Local data store detected in attaching state during summarize",
 							"summarize",

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -40,6 +40,7 @@ import {
 import {
 	createChildMonitoringContext,
 	DataCorruptionError,
+	DataProcessingError,
 	extractSafePropertiesFromMessage,
 	LoggingError,
 	MonitoringContext,
@@ -573,11 +574,15 @@ export class DataStores implements IDisposable {
 			Array.from(this.contexts)
 				.filter(([_, context]) => {
 					// Summarizer works only with clients with no local changes. A data store in attaching
-					// state indicates an op was sent to attach a local data store.
-					assert(
-						context.attachState !== AttachState.Attaching,
-						0x588 /* Local data store detected in attaching state during summarize */,
-					);
+					// state indicates an op was sent to attach a local data store, and the the attach op
+					// had not yet round tripped back to the client.
+					if (context.attachState === AttachState.Attaching) {
+						const error = DataProcessingError.create(
+							"Local data store detected in attaching state during summarize",
+							"summarize",
+						);
+						throw error;
+					}
 					return context.attachState === AttachState.Attached;
 				})
 				.map(async ([contextId, context]) => {
@@ -675,11 +680,16 @@ export class DataStores implements IDisposable {
 			Array.from(this.contexts)
 				.filter(([_, context]) => {
 					// Summarizer client and hence GC works only with clients with no local changes. A data store in
-					// attaching state indicates an op was sent to attach a local data store.
-					assert(
-						context.attachState !== AttachState.Attaching,
-						0x589 /* Local data store detected in attaching state while running GC */,
-					);
+					// attaching state indicates an op was sent to attach a local data store, and the the attach op
+					// had not yet round tripped back to the client.
+					if (context.attachState === AttachState.Attaching) {
+						const error = DataProcessingError.create(
+							"Local data store detected in attaching state while running GC",
+							"getGCData",
+						);
+						throw error;
+					}
+
 					return context.attachState === AttachState.Attached;
 				})
 				.map(async ([contextId, context]) => {


### PR DESCRIPTION
[AB#6358](https://dev.azure.com/fluidframework/internal/_workitems/edit/6358)

## Background
On the investigation of [AB#6262](https://dev.azure.com/fluidframework/internal/_workitems/edit/6262/), it was determined that `0x589` and `0x588` are data processing errors as it means that local changes in the summarizer were made (an attaching datastore was found while running gc/summarizing).

`0x589` and `0x588` were in this cased caused when a summarizer client creates a datastore during load and submits an attach op, and before the attach op roundtrips, it summarizes. As summarizing an attaching datastore leaves us in an indeterministic state, we do not summarize the container.