### PR TITLE
separate summarize and getAttachSummary codepaths

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -294,7 +294,7 @@ describe("SharedTree", () => {
 		validateTreeConsistency(provider.trees[0], joinedLaterTree);
 	});
 
-	it("can summarize and load", async () => {
+	it.only("can summarize and load", async () => {
 		const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
 		const value = 42;
 		const summarizingTree = provider.trees[0].schematize({


### PR DESCRIPTION
## Description

This PR separate `summarize` and `getAttachSummary` codepaths in SharedTree