### PR TITLE
perf(tree2): Avoid composing branch changes when not needed

### DIFF
--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -170,6 +170,7 @@ export {
 	mintCommit,
 	mintRevisionTag,
 	rebaseBranch,
+	BranchRebaseResult,
 	rebaseChange,
 } from "./rebase";
 

--- a/experimental/dds/tree2/src/core/rebase/index.ts
+++ b/experimental/dds/tree2/src/core/rebase/index.ts
@@ -35,4 +35,10 @@ export {
 	verifyChangeRebaser,
 	Violation,
 } from "./verifyChangeRebaser";
-export { findAncestor, findCommonAncestor, rebaseBranch, rebaseChange } from "./utils";
+export {
+	findAncestor,
+	findCommonAncestor,
+	rebaseBranch,
+	BranchRebaseResult,
+	rebaseChange,
+} from "./utils";

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -73,10 +73,7 @@ export interface BranchRebaseResult<TChange> {
  * @param changeRebaser - the change rebaser responsible for rebasing the changes in the commits of each branch
  * @param sourceHead - the head of the source branch, which will be rebased onto `targetHead`
  * @param targetHead - the commit to rebase the source branch onto
- * @returns a tuple containing:
- * - the head of a rebased source branch
- * - a thunk that can compute the cumulative change to the source branch (undefined if no change occurred),
- * - details about how the commits on the source branch changed
+ * @returns a {@link BranchRebaseResult}
  * @remarks While a single branch must not have multiple commits with the same revision tag (that will result in undefined
  * behavior), there may be a commit on the source branch with the same revision tag as a commit on the target branch. If such
  * a pair is encountered while rebasing, it will be "cancelled out" in the new branch. For example:
@@ -109,10 +106,7 @@ export function rebaseBranch<TChange>(
  * @param sourceHead - the head of the source branch, which will be rebased onto `newBase`
  * @param targetCommit - the commit on the target branch to rebase the source branch onto.
  * @param targetHead - the head of the branch that `newBase` belongs to. Must be `newBase` or a descendent of `newBase`.
- * @returns a tuple containing:
- * - the head of a rebased source branch
- * - a thunk that can compute the cumulative change to the source branch (undefined if no change occurred),
- * - details about how the commits on the source branch changed
+ * @returns a {@link BranchRebaseResult}
  * @remarks While a single branch must not have multiple commits with the same revision tag (that will result in undefined
  * behavior), there may be a commit on the source branch with the same revision tag as a commit on the target branch. If such
  * a pair is encountered while rebasing, it will be "cancelled out" in the new branch. Additionally, this function will rebase

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -57,7 +57,7 @@ export interface BranchRebaseResult<TChange> {
 	/**
 	 * A thunk that computes the cumulative change to the source branch (undefined if no change occurred)
 	 */
-	readonly sourceChange: () => TChange | undefined;
+	readonly sourceChange: TChange | undefined;
 	/**
 	 * Details about how the commits on the source branch changed
 	 */
@@ -166,7 +166,7 @@ export function rebaseBranch<TChange>(
 		);
 		return {
 			newSourceHead: sourceHead,
-			sourceChange: () => undefined,
+			sourceChange: undefined,
 			commits: { deletedSourceCommits: [], targetCommits: [], sourceCommits: sourcePath },
 		};
 	}
@@ -217,7 +217,7 @@ export function rebaseBranch<TChange>(
 		}
 		return {
 			newSourceHead: sourceCommits[sourceCommits.length - 1] ?? newBase,
-			sourceChange: () => undefined,
+			sourceChange: undefined,
 			commits: {
 				deletedSourceCommits,
 				targetCommits,
@@ -252,7 +252,7 @@ export function rebaseBranch<TChange>(
 	let netChange: TChange | undefined;
 	return {
 		newSourceHead: newHead,
-		sourceChange: () => {
+		get sourceChange() {
 			if (netChange === undefined) {
 				netChange = changeRebaser.compose([...inverses, ...targetRebasePath]);
 			}

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -56,10 +56,13 @@ export interface RebasedCommits<TChange> {
  *
  * The source and target branch must share an ancestor.
  * @param changeRebaser - the change rebaser responsible for rebasing the changes in the commits of each branch
+ * @param computeSourceChange - if `true` the returned tuple will include the net change to the source branch.
  * @param sourceHead - the head of the source branch, which will be rebased onto `targetHead`
  * @param targetHead - the commit to rebase the source branch onto
- * @returns the head of a rebased source branch, the cumulative change to the source branch (undefined if no change occurred),
- * and details about how the commits on the source branch changed
+ * @returns a tuple containing:
+ * - the head of a rebased source branch
+ * - the cumulative change to the source branch (undefined if no change occurred or if `computeSourceChange` is not `true`),
+ * - details about how the commits on the source branch changed
  * @remarks While a single branch must not have multiple commits with the same revision tag (that will result in undefined
  * behavior), there may be a commit on the source branch with the same revision tag as a commit on the target branch. If such
  * a pair is encountered while rebasing, it will be "cancelled out" in the new branch. For example:
@@ -78,6 +81,7 @@ export interface RebasedCommits<TChange> {
  */
 export function rebaseBranch<TChange>(
 	changeRebaser: ChangeRebaser<TChange>,
+	computeSourceChange: boolean,
 	sourceHead: GraphCommit<TChange>,
 	targetHead: GraphCommit<TChange>,
 ): [
@@ -93,11 +97,14 @@ export function rebaseBranch<TChange>(
  *
  * The source and target branch must share an ancestor.
  * @param changeRebaser - the change rebaser responsible for rebasing the changes in the commits of each branch
+ * @param computeSourceChange - if `true` the returned tuple will include the net change to the source branch.
  * @param sourceHead - the head of the source branch, which will be rebased onto `newBase`
  * @param targetCommit - the commit on the target branch to rebase the source branch onto.
  * @param targetHead - the head of the branch that `newBase` belongs to. Must be `newBase` or a descendent of `newBase`.
- * @returns the head of a rebased source branch, the cumulative change to the source branch (undefined if no change occurred),
- * and details about how the commits on the source branch changed
+ * @returns a tuple containing:
+ * - the head of a rebased source branch
+ * - the cumulative change to the source branch (undefined if no change occurred or if `computeSourceChange` is not `true`),
+ * - details about how the commits on the source branch changed
  * @remarks While a single branch must not have multiple commits with the same revision tag (that will result in undefined
  * behavior), there may be a commit on the source branch with the same revision tag as a commit on the target branch. If such
  * a pair is encountered while rebasing, it will be "cancelled out" in the new branch. Additionally, this function will rebase
@@ -123,6 +130,7 @@ export function rebaseBranch<TChange>(
  */
 export function rebaseBranch<TChange>(
 	changeRebaser: ChangeRebaser<TChange>,
+	computeSourceChange: boolean,
 	sourceHead: GraphCommit<TChange>,
 	targetCommit: GraphCommit<TChange>,
 	targetHead: GraphCommit<TChange>,
@@ -133,6 +141,7 @@ export function rebaseBranch<TChange>(
 ];
 export function rebaseBranch<TChange>(
 	changeRebaser: ChangeRebaser<TChange>,
+	computeSourceChange: boolean,
 	sourceHead: GraphCommit<TChange>,
 	targetCommit: GraphCommit<TChange>,
 	targetHead = targetCommit,
@@ -242,11 +251,12 @@ export function rebaseBranch<TChange>(
 		);
 	}
 
-	const toCompose = [...inverses, ...targetRebasePath];
-	const composed = changeRebaser.compose(toCompose);
+	const netChange = computeSourceChange
+		? changeRebaser.compose([...inverses, ...targetRebasePath])
+		: undefined;
 	return [
 		newHead,
-		composed,
+		netChange,
 		{
 			deletedSourceCommits,
 			targetCommits,

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -478,14 +478,14 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		}
 
 		// The net change to this branch is provided by the `rebaseBranch` API
-		const { newSourceHead, sourceChange, commits } = rebaseResult;
+		const { newSourceHead, commits } = rebaseResult;
 		const { deletedSourceCommits, targetCommits, sourceCommits } = commits;
 
 		const newCommits = targetCommits.concat(sourceCommits);
 		const changeEvent = {
 			type: "replace",
 			get change() {
-				const change = sourceChange();
+				const change = rebaseResult.sourceChange;
 				return change === undefined ? undefined : makeAnonChange(change);
 			},
 			removedCommits: deletedSourceCommits,
@@ -500,7 +500,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		});
 
 		this.emit("afterChange", changeEvent);
-		return [sourceChange, deletedSourceCommits, newCommits];
+		return [() => rebaseResult.sourceChange, deletedSourceCommits, newCommits];
 	}
 
 	/**

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -189,12 +189,9 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			change,
 		});
 
-		const taggedChange = tagChange(change, revision);
 		const changeEvent = {
 			type: "append",
-			get change() {
-				return taggedChange;
-			},
+			change: tagChange(change, revision),
 			newCommits: [newHead],
 		} as const;
 
@@ -270,9 +267,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		const changeEvent = {
 			type: "replace",
-			get change() {
-				return undefined;
-			},
+			change: undefined,
 			removedCommits: commits,
 			newCommits: [newHead],
 		} as const;
@@ -315,12 +310,9 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const change =
 			inverses.length > 0 ? this.changeFamily.rebaser.compose(inverses) : undefined;
 
-		const taggedChange = change === undefined ? undefined : makeAnonChange(change);
 		const changeEvent = {
 			type: "remove",
-			get change() {
-				return taggedChange;
-			},
+			change: change === undefined ? undefined : makeAnonChange(change),
 			removedCommits: commits,
 		} as const;
 

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -459,6 +459,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	 *
 	 * @param branch - the branch to rebase onto
 	 * @param upTo - the furthest commit on `branch` over which to rebase (inclusive). Defaults to the head commit of `branch`.
+	 * @returns the result of the rebase or undefined if nothing changed
 	 */
 	public rebaseOnto(
 		branch: SharedTreeBranch<TEditor, TChange>,

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -188,9 +188,10 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			change,
 		});
 
+		const taggedChange = tagChange(change, revision);
 		const changeEvent = {
 			type: "append",
-			change: () => tagChange(change, revision),
+			change: () => taggedChange,
 			newCommits: [newHead],
 		} as const;
 
@@ -309,9 +310,10 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const change =
 			inverses.length > 0 ? this.changeFamily.rebaser.compose(inverses) : undefined;
 
+		const taggedChange = change === undefined ? undefined : makeAnonChange(change);
 		const changeEvent = {
 			type: "remove",
-			change: () => (change === undefined ? undefined : makeAnonChange(change)),
+			change: () => taggedChange,
 			removedCommits: commits,
 		} as const;
 

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -44,17 +44,17 @@ import { TransactionStack } from "./transactionStack";
 export type SharedTreeBranchChange<TChange> =
 	| {
 			type: "append";
-			change: () => TaggedChange<TChange>;
+			change: TaggedChange<TChange>;
 			newCommits: readonly GraphCommit<TChange>[];
 	  }
 	| {
 			type: "remove";
-			change: () => TaggedChange<TChange> | undefined;
+			change: TaggedChange<TChange> | undefined;
 			removedCommits: readonly GraphCommit<TChange>[];
 	  }
 	| {
 			type: "replace";
-			change: () => TaggedChange<TChange> | undefined;
+			change: TaggedChange<TChange> | undefined;
 			removedCommits: readonly GraphCommit<TChange>[];
 			newCommits: readonly GraphCommit<TChange>[];
 	  };
@@ -191,7 +191,9 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const taggedChange = tagChange(change, revision);
 		const changeEvent = {
 			type: "append",
-			change: () => taggedChange,
+			get change() {
+				return taggedChange;
+			},
 			newCommits: [newHead],
 		} as const;
 
@@ -267,7 +269,9 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		const changeEvent = {
 			type: "replace",
-			change: () => undefined,
+			get change() {
+				return undefined;
+			},
 			removedCommits: commits,
 			newCommits: [newHead],
 		} as const;
@@ -313,7 +317,9 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const taggedChange = change === undefined ? undefined : makeAnonChange(change);
 		const changeEvent = {
 			type: "remove",
-			change: () => taggedChange,
+			get change() {
+				return taggedChange;
+			},
 			removedCommits: commits,
 		} as const;
 
@@ -478,7 +484,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const newCommits = targetCommits.concat(sourceCommits);
 		const changeEvent = {
 			type: "replace",
-			change: () => {
+			get change() {
 				const change = changeThunk();
 				return change === undefined ? undefined : makeAnonChange(change);
 			},
@@ -526,9 +532,12 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		// Compute the net change to this branch
 		const [newHead, _, { sourceCommits }] = rebaseResult;
 		const change = this.changeFamily.rebaser.compose(sourceCommits);
+		const taggedChange = makeAnonChange(change);
 		const changeEvent = {
 			type: "append",
-			change: () => makeAnonChange(change),
+			get change(): TaggedChange<TChange> {
+				return taggedChange;
+			},
 			newCommits: sourceCommits,
 		} as const;
 

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -21,6 +21,7 @@ import {
 	RevertibleKind,
 	RevertResult,
 	DiscardResult,
+	BranchRebaseResult,
 } from "../core";
 import { EventEmitter, ISubscribable } from "../events";
 import { fail } from "../util";
@@ -462,13 +463,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	public rebaseOnto(
 		branch: SharedTreeBranch<TEditor, TChange>,
 		upTo = branch.getHead(),
-	):
-		| [
-				change: () => TChange | undefined,
-				removedCommits: GraphCommit<TChange>[],
-				newCommits: GraphCommit<TChange>[],
-		  ]
-		| undefined {
+	): BranchRebaseResult<TChange> | undefined {
 		this.assertNotDisposed();
 
 		// Rebase this branch onto the given branch
@@ -500,7 +495,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		});
 
 		this.emit("afterChange", changeEvent);
-		return [() => rebaseResult.sourceChange, deletedSourceCommits, newCommits];
+		return rebaseResult;
 	}
 
 	/**

--- a/experimental/dds/tree2/src/shared-tree/treeCheckout.ts
+++ b/experimental/dds/tree2/src/shared-tree/treeCheckout.ts
@@ -279,8 +279,9 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		// In such a case we will crash here, preventing the change from being added to the commit graph, and preventing `afterChange` from firing.
 		// One important consequence of this is that we will not submit the op containing the invalid change, since op submissions happens in response to `afterChange`.
 		branch.on("beforeChange", (event) => {
-			if (event.change !== undefined) {
-				const delta = intoDelta(event.change);
+			const change = event.change();
+			if (change !== undefined) {
+				const delta = intoDelta(change);
 				const anchorVisitor = this.forest.anchors.acquireVisitor();
 				const combinedVisitor = combineVisitors(
 					[this.forest.acquireVisitor(), anchorVisitor],

--- a/experimental/dds/tree2/src/shared-tree/treeCheckout.ts
+++ b/experimental/dds/tree2/src/shared-tree/treeCheckout.ts
@@ -279,9 +279,8 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		// In such a case we will crash here, preventing the change from being added to the commit graph, and preventing `afterChange` from firing.
 		// One important consequence of this is that we will not submit the op containing the invalid change, since op submissions happens in response to `afterChange`.
 		branch.on("beforeChange", (event) => {
-			const change = event.change();
-			if (change !== undefined) {
-				const delta = intoDelta(change);
+			if (event.change !== undefined) {
+				const delta = intoDelta(event.change);
 				const anchorVisitor = this.forest.anchors.acquireVisitor();
 				const combinedVisitor = combineVisitors(
 					[this.forest.acquireVisitor(), anchorVisitor],

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -90,9 +90,13 @@ describe("rebaseBranch", () => {
 
 		// (1)
 		//  └─ 2 ─ 3
-		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n3, n1);
+		const {
+			newSourceHead: n3_1,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n3, n1);
 		assert.equal(n3_1, n3);
-		assert.equal(change(), undefined);
+		assert.equal(sourceChange(), undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
 		assert.deepEqual(commits.targetCommits, []);
 		assert.deepEqual(commits.sourceCommits, [n2, n3]);
@@ -109,14 +113,18 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)
 		//         └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n3);
+		const {
+			newSourceHead: n5_1,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n5, n3);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(
 			newPath,
 			{ inputContext: [1, 2, 3], intentions: [4], outputContext: [1, 2, 3, 4] },
 			{ inputContext: [1, 2, 3, 4], intentions: [5], outputContext: [1, 2, 3, 4, 5] },
 		);
-		assertOutputContext(change(), 1, 2, 3, 4, 5);
+		assertOutputContext(sourceChange(), 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -133,14 +141,18 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3
 		//     └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n3);
+		const {
+			newSourceHead: n5_1,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n5, n2, n3);
 		const newPath = getPath(n2, n5_1);
 		assertChanges(
 			newPath,
 			{ inputContext: [1, 2], intentions: [4], outputContext: [1, 2, 4] },
 			{ inputContext: [1, 2, 4], intentions: [5], outputContext: [1, 2, 4, 5] },
 		);
-		assertOutputContext(change(), 1, 2, 4, 5);
+		assertOutputContext(sourceChange(), 1, 2, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
 		assert.deepEqual(commits.targetCommits, [n2]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -159,14 +171,18 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4
 		//         └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n4);
+		const {
+			newSourceHead: n5_1,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n5, n2, n4);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3],
 			intentions: [5],
 			outputContext: [1, 2, 3, 5],
 		});
-		assert.equal(change(), undefined);
+		assert.equal(sourceChange(), undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -185,14 +201,18 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n4);
+		const {
+			newSourceHead: n5_1,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n5, n4);
 		const newPath = getPath(n4, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3, 4],
 			intentions: [5],
 			outputContext: [1, 2, 3, 4, 5],
 		});
-		assertOutputContext(change(), 1, 2, 3, 4, 5);
+		assertOutputContext(sourceChange(), 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -212,7 +232,11 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4 ─ 5
 		//             └─ 6
-		const [n6_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n6, n2, n5);
+		const {
+			newSourceHead: n6_1,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n6, n2, n5);
 		const newPath = getPath(n2, n6_1);
 		assertChanges(
 			newPath,
@@ -220,7 +244,7 @@ describe("rebaseBranch", () => {
 			TestChange.mint([1, 2, 3], 4),
 			TestChange.mint([1, 2, 3, 4], 6),
 		);
-		assertOutputContext(change(), 1, 2, 3, 4, 6);
+		assertOutputContext(sourceChange(), 1, 2, 3, 4, 6);
 		assert.deepEqual(commits.deletedSourceCommits, [n3_1, n4_1, n6]);
 		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.sourceCommits, [n6_1]);
@@ -238,9 +262,13 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)─ 4
 		//         └─
-		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), n3_1, n3, n4);
+		const {
+			newSourceHead: n3_2,
+			sourceChange,
+			commits,
+		} = rebaseBranch(new TestChangeRebaser(), n3_1, n3, n4);
 		assert.equal(n3_2, n3);
-		assert.equal(change(), undefined);
+		assert.equal(sourceChange(), undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, []);

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -96,7 +96,7 @@ describe("rebaseBranch", () => {
 			commits,
 		} = rebaseBranch(new TestChangeRebaser(), n3, n1);
 		assert.equal(n3_1, n3);
-		assert.equal(sourceChange(), undefined);
+		assert.equal(sourceChange, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
 		assert.deepEqual(commits.targetCommits, []);
 		assert.deepEqual(commits.sourceCommits, [n2, n3]);
@@ -124,7 +124,7 @@ describe("rebaseBranch", () => {
 			{ inputContext: [1, 2, 3], intentions: [4], outputContext: [1, 2, 3, 4] },
 			{ inputContext: [1, 2, 3, 4], intentions: [5], outputContext: [1, 2, 3, 4, 5] },
 		);
-		assertOutputContext(sourceChange(), 1, 2, 3, 4, 5);
+		assertOutputContext(sourceChange, 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -152,7 +152,7 @@ describe("rebaseBranch", () => {
 			{ inputContext: [1, 2], intentions: [4], outputContext: [1, 2, 4] },
 			{ inputContext: [1, 2, 4], intentions: [5], outputContext: [1, 2, 4, 5] },
 		);
-		assertOutputContext(sourceChange(), 1, 2, 4, 5);
+		assertOutputContext(sourceChange, 1, 2, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
 		assert.deepEqual(commits.targetCommits, [n2]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -182,7 +182,7 @@ describe("rebaseBranch", () => {
 			intentions: [5],
 			outputContext: [1, 2, 3, 5],
 		});
-		assert.equal(sourceChange(), undefined);
+		assert.equal(sourceChange, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -212,7 +212,7 @@ describe("rebaseBranch", () => {
 			intentions: [5],
 			outputContext: [1, 2, 3, 4, 5],
 		});
-		assertOutputContext(sourceChange(), 1, 2, 3, 4, 5);
+		assertOutputContext(sourceChange, 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -244,7 +244,7 @@ describe("rebaseBranch", () => {
 			TestChange.mint([1, 2, 3], 4),
 			TestChange.mint([1, 2, 3, 4], 6),
 		);
-		assertOutputContext(sourceChange(), 1, 2, 3, 4, 6);
+		assertOutputContext(sourceChange, 1, 2, 3, 4, 6);
 		assert.deepEqual(commits.deletedSourceCommits, [n3_1, n4_1, n6]);
 		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.sourceCommits, [n6_1]);
@@ -268,7 +268,7 @@ describe("rebaseBranch", () => {
 			commits,
 		} = rebaseBranch(new TestChangeRebaser(), n3_1, n3, n4);
 		assert.equal(n3_2, n3);
-		assert.equal(sourceChange(), undefined);
+		assert.equal(sourceChange, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, []);

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -71,12 +71,12 @@ describe("rebaseBranch", () => {
 		const n3 = newCommit(3);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), true, n3, n2),
+			() => rebaseBranch(new TestChangeRebaser(), n3, n2),
 			(e: Error) => validateAssertionError(e, "branches must be related"),
 		);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), true, n2, n3, n1),
+			() => rebaseBranch(new TestChangeRebaser(), n2, n3, n1),
 			(e: Error) => validateAssertionError(e, "target commit is not in target branch"),
 		);
 	});
@@ -90,9 +90,9 @@ describe("rebaseBranch", () => {
 
 		// (1)
 		//  └─ 2 ─ 3
-		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n3, n1);
+		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n3, n1);
 		assert.equal(n3_1, n3);
-		assert.equal(change, undefined);
+		assert.equal(change(), undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
 		assert.deepEqual(commits.targetCommits, []);
 		assert.deepEqual(commits.sourceCommits, [n2, n3]);
@@ -109,14 +109,14 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)
 		//         └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n3);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n3);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(
 			newPath,
 			{ inputContext: [1, 2, 3], intentions: [4], outputContext: [1, 2, 3, 4] },
 			{ inputContext: [1, 2, 3, 4], intentions: [5], outputContext: [1, 2, 3, 4, 5] },
 		);
-		assertOutputContext(change, 1, 2, 3, 4, 5);
+		assertOutputContext(change(), 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -133,14 +133,14 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3
 		//     └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n2, n3);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n3);
 		const newPath = getPath(n2, n5_1);
 		assertChanges(
 			newPath,
 			{ inputContext: [1, 2], intentions: [4], outputContext: [1, 2, 4] },
 			{ inputContext: [1, 2, 4], intentions: [5], outputContext: [1, 2, 4, 5] },
 		);
-		assertOutputContext(change, 1, 2, 4, 5);
+		assertOutputContext(change(), 1, 2, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
 		assert.deepEqual(commits.targetCommits, [n2]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -159,14 +159,14 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4
 		//         └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n2, n4);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n4);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3],
 			intentions: [5],
 			outputContext: [1, 2, 3, 5],
 		});
-		assert.equal(change, undefined);
+		assert.equal(change(), undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -185,14 +185,14 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n4);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n4);
 		const newPath = getPath(n4, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3, 4],
 			intentions: [5],
 			outputContext: [1, 2, 3, 4, 5],
 		});
-		assertOutputContext(change, 1, 2, 3, 4, 5);
+		assertOutputContext(change(), 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
 		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.sourceCommits, newPath);
@@ -212,7 +212,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4 ─ 5
 		//             └─ 6
-		const [n6_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n6, n2, n5);
+		const [n6_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n6, n2, n5);
 		const newPath = getPath(n2, n6_1);
 		assertChanges(
 			newPath,
@@ -220,7 +220,7 @@ describe("rebaseBranch", () => {
 			TestChange.mint([1, 2, 3], 4),
 			TestChange.mint([1, 2, 3, 4], 6),
 		);
-		assertOutputContext(change, 1, 2, 3, 4, 6);
+		assertOutputContext(change(), 1, 2, 3, 4, 6);
 		assert.deepEqual(commits.deletedSourceCommits, [n3_1, n4_1, n6]);
 		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.sourceCommits, [n6_1]);
@@ -238,28 +238,12 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)─ 4
 		//         └─
-		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n3_1, n3, n4);
+		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), n3_1, n3, n4);
 		assert.equal(n3_2, n3);
-		assert.equal(change, undefined);
+		assert.equal(change(), undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
 		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.sourceCommits, []);
-	});
-
-	it("generates and stores repair data for rebased changes", () => {
-		// 1 ─ 2 ─ 3 ─ 4
-		// └─ 2'─ 3'─ 5
-		const n1 = newCommit(1);
-		const n2 = newCommit(2, n1);
-		const n3 = newCommit(3, n2);
-		const n4 = newCommit(4, n3);
-		const n2_1 = newCommit(2, n1);
-		const n3_1 = newCommit(3, n2_1);
-		const n5 = newCommit(5, n3_1);
-
-		// 1 ─ 2 ─ 3 ─(4)
-		//             └─ 5'
-		const [n5_1] = rebaseBranch(new TestChangeRebaser(), true, n5, n4);
 	});
 });
 

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -71,12 +71,12 @@ describe("rebaseBranch", () => {
 		const n3 = newCommit(3);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), n3, n2),
+			() => rebaseBranch(new TestChangeRebaser(), true, n3, n2),
 			(e: Error) => validateAssertionError(e, "branches must be related"),
 		);
 
 		assert.throws(
-			() => rebaseBranch(new TestChangeRebaser(), n2, n3, n1),
+			() => rebaseBranch(new TestChangeRebaser(), true, n2, n3, n1),
 			(e: Error) => validateAssertionError(e, "target commit is not in target branch"),
 		);
 	});
@@ -90,7 +90,7 @@ describe("rebaseBranch", () => {
 
 		// (1)
 		//  └─ 2 ─ 3
-		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n3, n1);
+		const [n3_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n3, n1);
 		assert.equal(n3_1, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
@@ -109,7 +109,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)
 		//         └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n3);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n3);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(
 			newPath,
@@ -133,7 +133,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3
 		//     └─ 4'─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n3);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n2, n3);
 		const newPath = getPath(n2, n5_1);
 		assertChanges(
 			newPath,
@@ -159,7 +159,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4
 		//         └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n2, n4);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n2, n4);
 		const newPath = getPath(n3, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3],
@@ -185,7 +185,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n5, n4);
+		const [n5_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n5, n4);
 		const newPath = getPath(n4, n5_1);
 		assertChanges(newPath, {
 			inputContext: [1, 2, 3, 4],
@@ -210,7 +210,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─(3)─ 4
 		//         └─
-		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), n3_1, n3, n4);
+		const [n3_2, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n3_1, n3, n4);
 		assert.equal(n3_2, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
@@ -231,7 +231,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
-		const [n5_1] = rebaseBranch(new TestChangeRebaser(), n5, n4);
+		const [n5_1] = rebaseBranch(new TestChangeRebaser(), true, n5, n4);
 	});
 });
 

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -212,7 +212,7 @@ describe("rebaseBranch", () => {
 
 		// 1 ─(2)─ 3 ─ 4 ─ 5
 		//             └─ 6
-		const [n6_1, change, commits] = rebaseBranch(new TestChangeRebaser(), n6, n2, n5);
+		const [n6_1, change, commits] = rebaseBranch(new TestChangeRebaser(), true, n6, n2, n5);
 		const newPath = getPath(n2, n6_1);
 		assertChanges(
 			newPath,

--- a/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
@@ -128,7 +128,7 @@ describe("rebaser", () => {
 						? tester[baseInMain] ?? fail("Expected baseInMain to be in main")
 						: tester.main;
 
-				const [result] = rebaseBranch(
+				const { newSourceHead } = rebaseBranch(
 					new DummyChangeRebaser(),
 					tester.branch,
 					base,
@@ -139,7 +139,7 @@ describe("rebaser", () => {
 				const expectedBaseIndex = main.indexOf(expected[0]);
 				assert.notEqual(expectedBaseIndex, -1, "Expected expected base to be in main");
 				const mainBeforeExpected = main.slice(0, expectedBaseIndex);
-				tester.assertParentage(result, ...[...mainBeforeExpected, ...expected]);
+				tester.assertParentage(newSourceHead, ...[...mainBeforeExpected, ...expected]);
 			});
 		}
 

--- a/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
@@ -130,7 +130,6 @@ describe("rebaser", () => {
 
 				const [result] = rebaseBranch(
 					new DummyChangeRebaser(),
-					true,
 					tester.branch,
 					base,
 					tester.main,

--- a/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
@@ -130,6 +130,7 @@ describe("rebaser", () => {
 
 				const [result] = rebaseBranch(
 					new DummyChangeRebaser(),
+					true,
 					tester.branch,
 					base,
 					tester.main,

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -836,23 +836,12 @@ describe("EditManager", () => {
 						// Adding both terms:
 						inverted: (P - 1) * P,
 						// As part of rebasing the peer branch that contains the prior peer edits,
-						//   for the Ith peer edit there are I - 1 edits on the branch.
-						//   We therefore compose...
-						//     - the inverse of all peer edits: I - 1
-						//     - the one new trunk edit: 1
-						//     - the rebased version of each peer edit: I - 1
-						//   This adds up to 2I - 1 edits composed for the Ith branch rebase.
-						//   Summing over all P transforms I into P(P + 1)/2
-						//   Which gives us: 2P(P + 1)/2 - P
-						//   Which simplifies to: P²
-						//   However, the branch rebase for I=1 is skipped (there are no prior edits then)
-						//   This mean which means we don't get the +1 composed edit it would otherwise contribute.
-						//   Accounting for that gives us: P² - 1
+						//  the composition is skipped because no subscribers exist to read the net change.
 						// As part of updating the local branch,
 						//   for the Ith peer edit we compose that peer edit: 1
 						//   Summing over all P branch rebases gives us: P
 						// Adding both terms:
-						composed: P * P - 1 + P,
+						composed: P,
 					};
 					assert.deepEqual(actual, expected);
 				});
@@ -929,16 +918,13 @@ describe("EditManager", () => {
 							//   - each of the phase-1 peer edits: P
 							// Adding both terms and simplifying:
 							inverted: P * 2,
-							// As part of rebasing the peer branch, we compose...
-							//   - the inverse of the phase-1 peer edits: P
-							//   - the trunk edits: T
-							//   - the rebased version of the phase-1 peer edits: P
-							// Note: the output of the composition doesn't appear to be consumed.
+							// As part of rebasing the peer branch that contains the phase-1 edits,
+							//  the composition is skipped because no subscribers exist to read the net change.
 							// As part of rebasing the local branch, we compose...
 							//   - the phase-2 peer edit: 1
 							// Note: this composition is only needed to bake the RevisionTag into the changeset.
 							// Adding both terms and simplifying:
-							composed: P * 2 + T + 1,
+							composed: 1,
 						};
 						assert.deepEqual(actual, expected);
 					});
@@ -1021,20 +1007,15 @@ describe("EditManager", () => {
 							//   This adds up P inverts.
 							// Adding both terms:
 							inverted: 2 * P,
-							// As part of rebasing the peer branch,
-							//   we compose...
-							//     - the inverse of the phase-1 peer edits: P
-							//     - the trunk edits up to the ref# of P+: T
-							//     - the rebased version of the phase-1 peer edits: P
-							//   This adds up 2P + T edits composed.
-							// Note: the output of the composition doesn't appear to be consumed.
+							// As part of rebasing the peer branch that contains the phase-1 edits,
+							//  the composition is skipped because no subscribers exist to read the net change.
 							// As part of rebasing the local branch,
 							//   we compose...
 							//     - the phase-2 peer edit P+: 1
 							//   This adds up 1 edit composed.
 							// Note: this composition is only needed to bake the RevisionTag into the changeset.
 							// Adding both terms:
-							composed: 2 * P + T + 1,
+							composed: 1,
 						};
 						assert.deepEqual(actual, expected);
 					});

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -1373,9 +1373,8 @@ function addSequencedChange(
 ): Delta.Root {
 	let delta: Delta.Root = emptyDelta;
 	const offChange = editManager.localBranch.on("afterChange", ({ change }) => {
-		const changeset = change();
-		if (changeset !== undefined) {
-			delta = asDelta(changeset.change.intentions);
+		if (change !== undefined) {
+			delta = asDelta(change.change.intentions);
 		}
 	});
 	editManager.addSequencedChange(...args);

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -1373,8 +1373,9 @@ function addSequencedChange(
 ): Delta.Root {
 	let delta: Delta.Root = emptyDelta;
 	const offChange = editManager.localBranch.on("afterChange", ({ change }) => {
-		if (change !== undefined) {
-			delta = asDelta(change.change.intentions);
+		const changeset = change();
+		if (changeset !== undefined) {
+			delta = asDelta(changeset.change.intentions);
 		}
 	});
 	editManager.addSequencedChange(...args);

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
@@ -65,9 +65,7 @@ export function rebaseLocalEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", ({ change }) => {
-		change();
-	});
+	manager.localBranch.on("afterChange", ({ change }) => {});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
 		manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
 	}
@@ -102,9 +100,7 @@ export function rebasePeerEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", ({ change }) => {
-		change();
-	});
+	manager.localBranch.on("afterChange", ({ change }) => {});
 	for (let iChange = 0; iChange < trunkEditCount; iChange++) {
 		manager.addSequencedChange(
 			{
@@ -157,9 +153,7 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", ({ change }) => {
-		change();
-	});
+	manager.localBranch.on("afterChange", ({ change }) => {});
 	for (let iChange = 0; iChange < editCount; iChange++) {
 		manager.addSequencedChange(
 			{
@@ -207,9 +201,7 @@ export function rebaseConcurrentPeerEdits(
 ): void | (() => void) {
 	const manager = editManagerFactory({ rebaser }).manager;
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", ({ change }) => {
-		change();
-	});
+	manager.localBranch.on("afterChange", ({ change }) => {});
 	const peerEdits: Commit<TestChange>[] = [];
 	for (let iChange = 0; iChange < editsPerPeerCount; iChange++) {
 		for (let iPeer = 0; iPeer < peerCount; iPeer++) {

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
@@ -64,6 +64,8 @@ export function rebaseLocalEditsOverTrunkEdits(
 	manager: TestEditManager,
 	defer: boolean = false,
 ): void | (() => void) {
+	// Subscribe to the local branch to emulate the behavior of SharedTree
+	manager.localBranch.on("afterChange", () => {});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
 		manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
 	}
@@ -97,6 +99,8 @@ export function rebasePeerEditsOverTrunkEdits(
 	manager: TestEditManager,
 	defer: boolean = false,
 ): void | (() => void) {
+	// Subscribe to the local branch to emulate the behavior of SharedTree
+	manager.localBranch.on("afterChange", () => {});
 	for (let iChange = 0; iChange < trunkEditCount; iChange++) {
 		manager.addSequencedChange(
 			{
@@ -148,6 +152,8 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits(
 	manager: TestEditManager,
 	defer: boolean = false,
 ): void | (() => void) {
+	// Subscribe to the local branch to emulate the behavior of SharedTree
+	manager.localBranch.on("afterChange", () => {});
 	for (let iChange = 0; iChange < editCount; iChange++) {
 		manager.addSequencedChange(
 			{
@@ -194,6 +200,8 @@ export function rebaseConcurrentPeerEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	const manager = editManagerFactory({ rebaser }).manager;
+	// Subscribe to the local branch to emulate the behavior of SharedTree
+	manager.localBranch.on("afterChange", () => {});
 	const peerEdits: Commit<TestChange>[] = [];
 	for (let iChange = 0; iChange < editsPerPeerCount; iChange++) {
 		for (let iPeer = 0; iPeer < peerCount; iPeer++) {

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManagerTestUtils.ts
@@ -65,7 +65,9 @@ export function rebaseLocalEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", () => {});
+	manager.localBranch.on("afterChange", ({ change }) => {
+		change();
+	});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
 		manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
 	}
@@ -100,7 +102,9 @@ export function rebasePeerEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", () => {});
+	manager.localBranch.on("afterChange", ({ change }) => {
+		change();
+	});
 	for (let iChange = 0; iChange < trunkEditCount; iChange++) {
 		manager.addSequencedChange(
 			{
@@ -153,7 +157,9 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits(
 	defer: boolean = false,
 ): void | (() => void) {
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", () => {});
+	manager.localBranch.on("afterChange", ({ change }) => {
+		change();
+	});
 	for (let iChange = 0; iChange < editCount; iChange++) {
 		manager.addSequencedChange(
 			{
@@ -201,7 +207,9 @@ export function rebaseConcurrentPeerEdits(
 ): void | (() => void) {
 	const manager = editManagerFactory({ rebaser }).manager;
 	// Subscribe to the local branch to emulate the behavior of SharedTree
-	manager.localBranch.on("afterChange", () => {});
+	manager.localBranch.on("afterChange", ({ change }) => {
+		change();
+	});
 	const peerEdits: Commit<TestChange>[] = [];
 	for (let iChange = 0; iChange < editsPerPeerCount; iChange++) {
 		for (let iPeer = 0; iPeer < peerCount; iPeer++) {


### PR DESCRIPTION
Such a composition is needed when rebasing branches that want to maintain a view.  We maintain a view for the local branch but not for peer branches.

Changes:
* Adds a new parameter to the `rebaseBranch` function so that it does not always compute the composition of net changes.
* Changes the signature of `rebaseOnto` so that it does not return anything (no code path seemed to need what it was returning, and keeping it made it hard to determine whether or not the composition of net changes was needed).
* Adds some logic to only request the composition of net changes when a branch has event listeners.
