### PR TITLE
(odsp-client): Remove private field

### DIFF
--- a/feeds/internal-build.txt
+++ b/feeds/internal-build.txt
@@ -11,6 +11,7 @@
 @fluidframework/test-driver-definitions
 @fluid-internal/test-app-insights-logger
 @fluidframework/mocha-test-setup
+@fluid-experimental/odsp-client
 @fluidframework/test-runtime-utils
 @fluidframework/runtime-utils
 @fluidframework/runtime-definitions

--- a/feeds/internal-test.txt
+++ b/feeds/internal-test.txt
@@ -16,6 +16,7 @@
 @fluid-internal/test-app-insights-logger
 @fluid-private/stochastic-test-utils
 @fluidframework/mocha-test-setup
+@fluid-experimental/odsp-client
 @fluidframework/test-runtime-utils
 @fluidframework/runtime-utils
 @fluidframework/runtime-definitions

--- a/feeds/public.txt
+++ b/feeds/public.txt
@@ -9,6 +9,7 @@
 @fluidframework/test-utils
 @fluidframework/test-driver-definitions
 @fluidframework/mocha-test-setup
+@fluid-experimental/odsp-client
 @fluidframework/test-runtime-utils
 @fluidframework/runtime-utils
 @fluidframework/runtime-definitions

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@fluid-experimental/odsp-client",
 	"version": "2.0.0-internal.7.4.0",
-	"private": true,
 	"description": "A tool to enable creation and loading of Fluid containers using the ODSP service",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Marking odsp-client package as ready for release. The APIs are still marked as alpha and we believe this package is ready for experimental purpose.

[AB#6221](https://dev.azure.com/fluidframework/internal/_workitems/edit/6221)