### PR TITLE
fix(ci): Trigger server pipelines on changes to fluidBuild.config.cjs

### DIFF
--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -45,6 +45,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/gitrest
     - tools/pipelines/server-gitrest.yml
     - tools/pipelines/templates/build-docker-service.yml
@@ -70,6 +71,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/gitrest
     - tools/pipelines/server-gitrest.yml
     - tools/pipelines/templates/build-docker-service.yml

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -35,6 +35,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
     - tools/pipelines/templates/build-docker-service.yml
@@ -55,6 +56,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
     - tools/pipelines/templates/build-docker-service.yml

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -45,6 +45,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/historian
     - tools/pipelines/server-historian.yml
     - tools/pipelines/templates/build-docker-service.yml
@@ -70,6 +71,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/historian
     - tools/pipelines/server-historian.yml
     - tools/pipelines/templates/build-docker-service.yml

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -56,6 +56,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/routerlicious
     - tools/pipelines/server-routerlicious.yml
     - tools/pipelines/templates/build-docker-service.yml
@@ -83,6 +84,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - server/routerlicious
     - tools/pipelines/server-routerlicious.yml
     - tools/pipelines/templates/build-docker-service.yml


### PR DESCRIPTION
## Description

Make sure that the server build pipelines trigger when we change the `fluidBuild.config.cjs` file.

This was prompted by the fact that after we merged https://github.com/microsoft/FluidFramework/pull/18446, none of the server build pipelines triggered in CI. I'm not sure why; particularly the `server - routerlicious` pipeline has `server/routerlicious` as a path that should kick it off, and the PR changed the files under `server/routerlicious/feeds/`. Also all four pipelines should trigger on changes to `tools/pipelines/templates/build-docker-service.yml` which that PR modified, but none did.

Independent of that issue, the change we made to `fluidBuild.config.cjs` had an intended effect on the `server - routerlicious` pipeline so it seems correct that changes to this file trigger that one, and for good measure the other three.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
