### PR TITLE
refactor(ci): Remove workaround for good-fences installation issue in perf tests pipeline

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -127,7 +127,16 @@ stages:
               mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
 
         # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
-        # and run tests.
+        - task: Bash@3
+          displayName: Install dependencies - ${{ testPackage }}
+          inputs:
+            targetType: 'inline'
+            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
+            script: |
+              cp ${{ variables.testWorkspace }}/.npmrc . ;
+              npm i;
+
+        # Run tests
         - task: Bash@3
           displayName: Run execution-time tests - ${{ testPackage }}
           inputs:
@@ -135,23 +144,6 @@ stages:
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
             script: |
               echo "Run execution-time tests for ${{ testPackage }}"
-              cp ${{ variables.testWorkspace }}/.npmrc . ;
-
-              # Hacky workaround to prevent issues because nodegit fails to install in Node 18.
-                # good-fences is the one that transitively brings in the dependency on nodegit, so we remove it from
-                # the package whose tests we're going to run if it's there (we don't need it to run the tests).
-                # TODO: remove this once the packages for which we run perf tests don't depend on good-fences anymore
-                # or we have a better solution.
-                GOOD_FENCES_FOUND=$(cat package.json | grep "good-fences" | wc -l)
-                if [[ $GOOD_FENCES_FOUND == 1 ]]; then
-                  echo "good-fences found in package.json for '${{ testPackage }}'. Removing it to avoid nodegit install issues."
-                  npm uninstall good-fences;
-                  echo "Deleting fence.spec.js files that use good-fences."
-                  # 'rm **/fence.spec.js' works in zsh but not bash
-                  find . -type f -name 'fence.spec.js' -delete;
-                fi
-
-              npm i;
               npm run test:benchmark:report;
 
         # Consolidate output files

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -126,25 +126,27 @@ stages:
               mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
               mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
 
-        # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
-        - task: Bash@3
+        # Install package dependencies (this gets devDependencies installed so we can then run the package's tests).
+        # Note: the required .npmrc file is created by the include-test-perf-benchmarks.yml template above.
+        - task: CopyFiles@2
+          displayName: Copy .npmrc to test package folder - ${{ testPackage }}
+          inputs:
+            sourceFolder: ${{ variables.testWorkspace }}
+            contents: '.npmrc'
+            targetFolder: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
+        - task: Npm@1
           displayName: Install dependencies - ${{ testPackage }}
           inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
-            script: |
-              cp ${{ variables.testWorkspace }}/.npmrc . ;
-              npm i;
+            command: 'install'
+            workingDir: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
 
         # Run tests
-        - task: Bash@3
+        - task: Npm@1
           displayName: Run execution-time tests - ${{ testPackage }}
           inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
-            script: |
-              echo "Run execution-time tests for ${{ testPackage }}"
-              npm run test:benchmark:report;
+            command: 'custom'
+            workingDir: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
+            customCommand: 'run test:benchmark:report'
 
         # Consolidate output files
         - task: CopyFiles@2


### PR DESCRIPTION
## Description

[Previously](https://github.com/microsoft/FluidFramework/pull/17928) we added this workaround to make the execution time performance tests succeed again. Now that `good-fences` is not used in tree2 anymore, the workaround is unnecessary.

Also split the installation of dependencies and running of tests into more granular steps. This will let us more clearly identify what exactly went wrong, if installing deps fails.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
