### PR TITLE
tree2: Sort out TreeListNode vs TreeListNodeOld

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -2036,6 +2036,11 @@ TreeListNode> {
 }
 
 // @alpha
+export const TreeListNode: {
+    inline: <T>(content: Iterable<T>) => IterableTreeListContent<T>;
+};
+
+// @alpha
 interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T> {
     insertAt(index: number, ...value: (TNew | IterableTreeListContent<TNew>)[]): void;
     insertAtEnd(...value: (TNew | IterableTreeListContent<TNew>)[]): void;
@@ -2059,11 +2064,6 @@ interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T
 // @alpha
 export interface TreeListNodeOld<out TTypes extends AllowedTypes = AllowedTypes> extends TreeListNodeBase<TreeNodeUnion<TTypes>, InsertableTreeNodeUnion<TTypes>, TreeListNodeOld> {
 }
-
-// @alpha
-export const TreeListNodeOld: {
-    inline: <T>(content: Iterable<T>) => IterableTreeListContent<T>;
-};
 
 // @alpha (undocumented)
 export interface TreeLocation {

--- a/experimental/dds/tree2/src/class-tree/index.ts
+++ b/experimental/dds/tree2/src/class-tree/index.ts
@@ -11,10 +11,11 @@ export {
 	TreeNodeSchemaClass,
 	TreeNodeSchemaNonClass,
 	TreeNodeSchemaCore,
-	TreeListNode,
 	NodeBase,
 	ImplicitFieldSchema,
 	TreeFieldFromImplicitField,
+	ImplicitAllowedTypes,
+	TreeNodeFromImplicitAllowedTypes,
 } from "./schemaTypes";
 export { SchemaFactory } from "./schemaFactory";
 export { nodeApi as Tree, TreeApi, TreeNodeEvents } from "./treeApi";

--- a/experimental/dds/tree2/src/class-tree/schemaFactory.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaFactory.ts
@@ -15,7 +15,7 @@ import {
 } from "../feature-libraries";
 import { leaf } from "../domains";
 import { TreeNodeSchemaIdentifier, TreeValue } from "../core";
-import { TreeMapNodeBase } from "../simple-tree";
+import { TreeListNode, TreeMapNodeBase } from "../simple-tree";
 import {
 	createNodeProxy,
 	createRawObjectProxy,
@@ -39,7 +39,6 @@ import {
 	NodeFromSchema,
 	NodeKind,
 	ObjectFromSchemaRecord,
-	TreeListNode,
 	TreeNodeFromImplicitAllowedTypes,
 	TreeNodeSchema,
 	TreeNodeSchemaClass,
@@ -363,7 +362,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 	}
 
 	/**
-	 * Define a structurally typed {@link TreeNodeSchema} for a {@link TreeListNode}.
+	 * Define a structurally typed {@link TreeNodeSchema} for a {@link (TreeListNode:interface)}.
 	 *
 	 * @remarks
 	 * The identifier for this List is defined as a function of the provided types.
@@ -403,7 +402,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 	>;
 
 	/**
-	 * Define (and add to this library) a {@link FieldNodeSchema} for a {@link TreeListNode}.
+	 * Define (and add to this library) a {@link FieldNodeSchema} for a {@link (TreeListNode:interface)}.
 	 *
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 *
@@ -447,7 +446,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 	}
 
 	/**
-	 * Define a {@link TreeNodeSchema} for a {@link TreeListNode}.
+	 * Define a {@link TreeNodeSchema} for a {@link (TreeListNode:interface)}.
 	 *
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 */

--- a/experimental/dds/tree2/src/class-tree/schemaTypes.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaTypes.ts
@@ -5,7 +5,7 @@
 
 import { MakeNominal, RestrictiveReadonlyRecord } from "../util";
 import { FlexListToUnion, LazyItem } from "../feature-libraries";
-import { TreeListNodeBase, Unhydrated } from "../simple-tree";
+import { Unhydrated } from "../simple-tree";
 
 /**
  * Base type which all nodes extend.
@@ -13,17 +13,6 @@ import { TreeListNodeBase, Unhydrated } from "../simple-tree";
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class NodeBase {}
-
-/**
- * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
- * @alpha
- */
-export interface TreeListNode<TTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes>
-	extends TreeListNodeBase<
-		TreeNodeFromImplicitAllowedTypes<TTypes>,
-		Unhydrated<TreeNodeFromImplicitAllowedTypes<TTypes>>, // TODO: insertion type.
-		TreeListNode
-	> {}
 
 /**
  * Helper used to produce types for object nodes.

--- a/experimental/dds/tree2/src/class-tree/treeApi.ts
+++ b/experimental/dds/tree2/src/class-tree/treeApi.ts
@@ -42,7 +42,7 @@ export interface TreeApi {
 	/**
 	 * The key of the given node under its parent.
 	 * @remarks
-	 * If `node` is an element in a {@link TreeListNode}, this returns the index of `node` in the list (a `number`).
+	 * If `node` is an element in a {@link (TreeListNode:interface)}, this returns the index of `node` in the list (a `number`).
 	 * Otherwise, this returns the key of the field that it is under (a `string`).
 	 */
 	key(node: NodeBase): string | number;

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -228,13 +228,13 @@ export {
 } from "./feature-libraries";
 
 export {
-	IterableTreeListContent,
 	TreeObjectNodeFields,
 	TreeField,
 	TreeFieldInner,
 	TypedNode,
 	TreeNodeUnion,
-	TreeListNode as TreeListNodeOld,
+	TreeListNode,
+	TreeListNodeOld,
 	TreeMapNode,
 	TreeObjectNode,
 	Tree as TreeOld,
@@ -244,6 +244,7 @@ export {
 	FactoryTreeSchema,
 	TreeMapNodeBase,
 	Unhydrated,
+	IterableTreeListContent,
 } from "./simple-tree";
 
 export {
@@ -276,7 +277,6 @@ export {
 	TreeConfiguration,
 	TreeView,
 	SchemaFactory,
-	TreeListNode,
 	Tree,
 	TreeApi,
 	NodeBase,

--- a/experimental/dds/tree2/src/simple-tree/editNode.ts
+++ b/experimental/dds/tree2/src/simple-tree/editNode.ts
@@ -16,7 +16,7 @@ import {
 	FlexTreeMapNode,
 } from "../feature-libraries";
 import { TreeObjectNode, TreeMapNode, TreeNode } from "./types";
-import { TreeListNode } from "./treeListNode";
+import { TreeListNodeOld } from "./treeListNode";
 
 /** Associates an edit node with a target object  */
 const targetSymbol = Symbol("EditNodeTarget");
@@ -40,7 +40,7 @@ export function getEditNode<TSchema extends ObjectNodeSchema>(
 	target: TreeObjectNode<TSchema>,
 ): FlexTreeObjectNode;
 export function getEditNode<TTypes extends AllowedTypes>(
-	target: TreeListNode<TTypes>,
+	target: TreeListNodeOld<TTypes>,
 ): FlexTreeFieldNode<FieldNodeSchema>;
 export function getEditNode<TSchema extends MapNodeSchema>(
 	target: TreeMapNode<TSchema>,

--- a/experimental/dds/tree2/src/simple-tree/index.ts
+++ b/experimental/dds/tree2/src/simple-tree/index.ts
@@ -18,7 +18,7 @@ export {
 	TreeListNodeBase,
 	TreeMapNodeBase,
 } from "./types";
-export { TreeListNode, IterableTreeListContent } from "./treeListNode";
+export { TreeListNodeOld, TreeListNode, IterableTreeListContent } from "./treeListNode";
 export { TreeObjectFactory, FactoryTreeSchema, addFactory } from "./objectFactory";
 export { nodeApi as Tree, TreeApi } from "./node";
 export {

--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -40,7 +40,7 @@ import { LazyObjectNode, getBoxedField } from "../feature-libraries/flex-tree/la
 import { type TreeNodeSchema as TreeNodeSchemaClass } from "../class-tree";
 import { createRawObjectNode, extractRawNodeContent } from "./rawObjectNode";
 import { TreeField, TypedNode, TreeMapNode, TreeObjectNode, TreeNode, Unhydrated } from "./types";
-import { TreeListNode, IterableTreeListContent } from "./treeListNode";
+import { IterableTreeListContent, TreeListNodeOld } from "./treeListNode";
 import { tryGetEditNodeTarget, setEditNode, getEditNode, tryGetEditNode } from "./editNode";
 import { InsertableTreeNodeUnion, InsertableTypedNode } from "./insertable";
 import { cursorFromFieldData, cursorFromNodeData } from "./toMapTree";
@@ -270,7 +270,7 @@ export function createObjectProxy<TSchema extends ObjectNodeSchema>(
 /**
  * Given a list proxy, returns its underlying LazySequence field.
  */
-export const getSequenceField = <TTypes extends AllowedTypes>(list: TreeListNode) =>
+export const getSequenceField = <TTypes extends AllowedTypes>(list: TreeListNodeOld) =>
 	getEditNode(list).content as FlexTreeSequenceField<TTypes>;
 
 // Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
@@ -305,7 +305,7 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 		value: Array.prototype[Symbol.iterator],
 	},
 	at: {
-		value(this: TreeListNode, index: number): FlexTreeUnknownUnboxed | undefined {
+		value(this: TreeListNodeOld, index: number): FlexTreeUnknownUnboxed | undefined {
 			const field = getSequenceField(this);
 			const val = field.boxedAt(index);
 
@@ -318,7 +318,7 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAt: {
 		value(
-			this: TreeListNode,
+			this: TreeListNodeOld,
 			index: number,
 			...value: (
 				| InsertableTreeNodeUnion<AllowedTypes>
@@ -343,7 +343,7 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAtStart: {
 		value(
-			this: TreeListNode,
+			this: TreeListNodeOld,
 			...value: (
 				| InsertableTreeNodeUnion<AllowedTypes>
 				| IterableTreeListContent<InsertableTreeNodeUnion<AllowedTypes>>
@@ -367,7 +367,7 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	insertAtEnd: {
 		value(
-			this: TreeListNode,
+			this: TreeListNodeOld,
 			...value: (
 				| InsertableTreeNodeUnion<AllowedTypes>
 				| IterableTreeListContent<InsertableTreeNodeUnion<AllowedTypes>>
@@ -393,17 +393,17 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	removeAt: {
-		value(this: TreeListNode, index: number): void {
+		value(this: TreeListNodeOld, index: number): void {
 			getSequenceField(this).removeAt(index);
 		},
 	},
 	removeRange: {
-		value(this: TreeListNode, start?: number, end?: number): void {
+		value(this: TreeListNodeOld, start?: number, end?: number): void {
 			getSequenceField(this).removeRange(start, end);
 		},
 	},
 	moveToStart: {
-		value(this: TreeListNode, sourceIndex: number, source?: TreeListNode): void {
+		value(this: TreeListNodeOld, sourceIndex: number, source?: TreeListNodeOld): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveToStart(sourceIndex, getSequenceField(source));
 			} else {
@@ -412,7 +412,7 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	moveToEnd: {
-		value(this: TreeListNode, sourceIndex: number, source?: TreeListNode): void {
+		value(this: TreeListNodeOld, sourceIndex: number, source?: TreeListNodeOld): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveToEnd(sourceIndex, getSequenceField(source));
 			} else {
@@ -421,7 +421,12 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 		},
 	},
 	moveToIndex: {
-		value(this: TreeListNode, index: number, sourceIndex: number, source?: TreeListNode): void {
+		value(
+			this: TreeListNodeOld,
+			index: number,
+			sourceIndex: number,
+			source?: TreeListNodeOld,
+		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveToIndex(index, sourceIndex, getSequenceField(source));
 			} else {
@@ -431,10 +436,10 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToStart: {
 		value(
-			this: TreeListNode,
+			this: TreeListNodeOld,
 			sourceStart: number,
 			sourceEnd: number,
-			source?: TreeListNode,
+			source?: TreeListNodeOld,
 		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveRangeToStart(
@@ -449,10 +454,10 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToEnd: {
 		value(
-			this: TreeListNode,
+			this: TreeListNodeOld,
 			sourceStart: number,
 			sourceEnd: number,
-			source?: TreeListNode,
+			source?: TreeListNodeOld,
 		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveRangeToEnd(
@@ -467,11 +472,11 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	},
 	moveRangeToIndex: {
 		value(
-			this: TreeListNode,
+			this: TreeListNodeOld,
 			index: number,
 			sourceStart: number,
 			sourceEnd: number,
-			source?: TreeListNode,
+			source?: TreeListNodeOld,
 		): void {
 			if (source !== undefined) {
 				getSequenceField(this).moveRangeToIndex(
@@ -567,7 +572,7 @@ function asIndex(key: string | symbol, length: number) {
 function createListProxy<TTypes extends AllowedTypes>(
 	allowAdditionalProperties: boolean,
 	customTargetObject?: object,
-): TreeListNode<TTypes> {
+): TreeListNodeOld<TTypes> {
 	const targetObject = customTargetObject ?? [];
 
 	// Create a 'dispatch' object that this Proxy forwards to instead of the proxy target, because we need
@@ -580,7 +585,7 @@ function createListProxy<TTypes extends AllowedTypes>(
 		customTargetObject ??
 		Object.create(listPrototype, {
 			length: {
-				get(this: TreeListNode) {
+				get(this: TreeListNodeOld) {
 					return getSequenceField(this).length;
 				},
 				set() {},
@@ -592,7 +597,7 @@ function createListProxy<TTypes extends AllowedTypes>(
 	// To satisfy 'deepEquals' level scrutiny, the target of the proxy must be an array literal in order
 	// to pass 'Object.getPrototypeOf'.  It also satisfies 'Array.isArray' and 'Object.prototype.toString'
 	// requirements without use of Array[Symbol.species], which is potentially on a path ot deprecation.
-	const proxy: TreeListNode<TTypes> = new Proxy<TreeListNode<TTypes>>(targetObject as any, {
+	const proxy: TreeListNodeOld<TTypes> = new Proxy<TreeListNodeOld<TTypes>>(targetObject as any, {
 		get: (target, key) => {
 			const field = getSequenceField(proxy);
 			const maybeIndex = asIndex(key, field.length);

--- a/experimental/dds/tree2/src/simple-tree/treeListNode.ts
+++ b/experimental/dds/tree2/src/simple-tree/treeListNode.ts
@@ -4,17 +4,29 @@
  */
 
 import { AllowedTypes } from "../feature-libraries";
+import { type ImplicitAllowedTypes, type TreeNodeFromImplicitAllowedTypes } from "../class-tree";
 import { InsertableTreeNodeUnion } from "./insertable";
-import { TreeListNodeBase, TreeNodeUnion } from "./types";
+import { TreeListNodeBase, TreeNodeUnion, Unhydrated } from "./types";
 
 /**
  * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
  * @alpha
  */
-export interface TreeListNode<out TTypes extends AllowedTypes = AllowedTypes>
+export interface TreeListNodeOld<out TTypes extends AllowedTypes = AllowedTypes>
 	extends TreeListNodeBase<
 		TreeNodeUnion<TTypes>,
 		InsertableTreeNodeUnion<TTypes>,
+		TreeListNodeOld
+	> {}
+
+/**
+ * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
+ * @alpha
+ */
+export interface TreeListNode<TTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes>
+	extends TreeListNodeBase<
+		TreeNodeFromImplicitAllowedTypes<TTypes>,
+		Unhydrated<TreeNodeFromImplicitAllowedTypes<TTypes>>, // TODO: insertion type.
 		TreeListNode
 	> {}
 
@@ -26,7 +38,7 @@ export const TreeListNode = {
 	/**
 	 * Wrap an iterable of items to inserted as consecutive items in a list.
 	 * @remarks
-	 * The object returned by this function can be inserted into a {@link TreeListNode}.
+	 * The object returned by this function can be inserted into a {@link TreeListNodeOld}.
 	 * Its contents will be inserted consecutively in the corresponding location in the list.
 	 * @example
 	 * ```ts
@@ -43,7 +55,7 @@ const create = Symbol("Create IterableTreeListContent");
 
 /**
  * Used to insert iterable content into a {@link (TreeListNode:interface)}.
- * Use {@link (TreeListNodeOld:variable).inline} to create an instance of this type.
+ * Use {@link (TreeListNode:variable).inline} to create an instance of this type.
  * @privateRemarks
  * TODO: Figure out how to link {@link TreeListNode.inline} above such that it works with API-Extractor.
  * @alpha

--- a/experimental/dds/tree2/src/simple-tree/types.ts
+++ b/experimental/dds/tree2/src/simple-tree/types.ts
@@ -20,7 +20,7 @@ import {
 	TreeSchema,
 	AssignableFieldKinds,
 } from "../feature-libraries";
-import { IterableTreeListContent, TreeListNode } from "./treeListNode";
+import { IterableTreeListContent, TreeListNodeOld } from "./treeListNode";
 
 /**
  * Type alias to document which values are un-hydrated.
@@ -44,7 +44,7 @@ export type Unhydrated<T> = T;
  * Using default parameters, this could be combined with TypedNode.
  * @alpha
  */
-export type TreeNode = TreeListNode | TreeObjectNode<ObjectNodeSchema> | TreeMapNode;
+export type TreeNode = TreeListNodeOld | TreeObjectNode<ObjectNodeSchema> | TreeMapNode;
 
 /**
  * A generic List type, used to defined types like {@link (TreeListNode:interface)}.
@@ -349,7 +349,7 @@ export type TypedNode<TSchema extends TreeNodeSchema> = TSchema extends LeafNode
 	: TSchema extends MapNodeSchema
 	? TreeMapNode<TSchema>
 	: TSchema extends FieldNodeSchema
-	? TreeListNode<TSchema["info"]["allowedTypes"]>
+	? TreeListNodeOld<TSchema["info"]["allowedTypes"]>
 	: TSchema extends ObjectNodeSchema
 	? TreeObjectNode<TSchema>
 	: // TODO: this should be able to be replaced with `TreeNode` to provide stronger typing in some edge cases, like TypedNode<TreeNodeSchema>


### PR DESCRIPTION
## Description

Fix TreeListNode interface and constant old vs new exporting. Now the constant and the new interface are both TreeListNode, instead of the constant ending up TreeListNodeOld despite being usable in both APIs.

## Breaking Changes

TreeListNodeOld.inline is now TreeListNode.inline.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
