### PR TITLE
improvement(client)!: enhance Jsonable types

### DIFF
--- a/.changeset/easy-deer-retire.md
+++ b/.changeset/easy-deer-retire.md
@@ -11,6 +11,10 @@
 "@fluid-experimental/tree2": major
 ---
 
-Update `Jsonable` and `Serializable` types from @fluidframework-definitions to require a generic parameter and if that type is `any` or `unknown` use a new result `JsonableTypeWith<>` that more accurate represents the limitation of serialization. `Jsonable`'s `TReplacement` parameter default has also been changed from `void` to `never`, which no disallows `void`.
+Update `Jsonable` and `Serializable` types from @fluidframework-definitions to require a generic parameter and if that type is `any` or `unknown` use a new result `JsonableTypeWith<>` that more accurately represents the limitation of serialization. Additional modifications:
+
+-   `Jsonable`'s `TReplacement` parameter default has also been changed from `void` to `never`, which now disallows `void`.
+-   Unrecognized primitive types like `symbol` are now filtered to `never` instead of `{}`.
+-   Recursive types with arrays (`[]`) are now supported.
 
 `Serializable` is commonly used for DDS values and now requires more precision when using them. For example SharedMatrix (unqualified) has an `any` default that meant values were `Serializable<any>` (i.e. `any`), but now `Serializable<any>` is `JsonableTypeWith<IFluidHandle>` which may be problematic for reading or writing. Preferred correction is to specify the value type but casting through `any` may provide a quick fix.

--- a/.changeset/easy-deer-retire.md
+++ b/.changeset/easy-deer-retire.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/datastore-definitions": major
+"@fluid-experimental/devtools-core": major
+"@fluidframework/map": major
+"@fluidframework/matrix": major
+"@fluidframework/sequence": major
+"@fluidframework/shared-summary-block": major
+"@fluid-experimental/sharejs-json1": major
+"@fluid-private/test-end-to-end-tests": major
+"@fluidframework/test-runtime-utils": major
+"@fluid-experimental/tree2": major
+---
+
+Update `Jsonable` and `Serializable` types from @fluidframework-definitions to require a generic parameter and if that type is `any` or `unknown` use a new result `JsonableTypeWith<>` that more accurate represents the limitation of serialization. `Jsonable`'s `TReplacement` parameter default has also been changed from `void` to `never`, which no disallows `void`.
+
+`Serializable` is commonly used for DDS values and now requires more precision when using them. For example SharedMatrix (unqualified) has an `any` default that meant values were `Serializable<any>` (i.e. `any`), but now `Serializable<any>` is `JsonableTypeWith<IFluidHandle>` which may be problematic for reading or writing. Preferred correction is to specify the value type but casting through `any` may provide a quick fix.

--- a/examples/apps/data-object-grid/src/dataObjectGrid.ts
+++ b/examples/apps/data-object-grid/src/dataObjectGrid.ts
@@ -62,7 +62,7 @@ export interface IDataObjectGridItem {
 	/**
 	 * The unknown blob of data that backs the instance of the item.  Probably contains handles, etc.
 	 */
-	readonly serializableData: Serializable;
+	readonly serializableData: Serializable<unknown>;
 	/**
 	 * The react grid layout of the item.
 	 */

--- a/examples/benchmarks/bubblebench/common/src/types.ts
+++ b/examples/benchmarks/bubblebench/common/src/types.ts
@@ -30,7 +30,7 @@ export interface IBubble {
 export interface IClient {
 	clientId: string;
 	color: string;
-	bubbles: IArrayish<IBubble>;
+	bubbles: IBubble[];
 }
 
 /**

--- a/examples/benchmarks/bubblebench/ot/src/main.ts
+++ b/examples/benchmarks/bubblebench/ot/src/main.ts
@@ -19,7 +19,10 @@ export class Bubblebench extends DataObject {
 
 	protected async initializingFirstTime() {
 		const tree = (this.maybeTree = SharedJson1.create(this.runtime));
-		tree.replace([], tree.get(), { clients: [] });
+		const initialTree = { clients: [] };
+		// unknown used to workaround recursive Doc type that otherwise results in
+		// "Type instantiation is excessively deep and possibly infinite" error.
+		tree.replace<unknown, typeof initialTree>([], tree.get(), initialTree);
 		this.root.set("tree", this.maybeTree.handle);
 	}
 

--- a/examples/benchmarks/bubblebench/sharedtree/src/proxy/treeutils.ts
+++ b/examples/benchmarks/bubblebench/sharedtree/src/proxy/treeutils.ts
@@ -13,23 +13,24 @@ export const enum NodeKind {
 }
 
 // Helper for creating Scalar nodes in SharedTree
-export const makeScalar = <T>(idContext: NodeIdContext, value: Serializable<T>): ChangeNode => ({
+export const makeScalar = (
+	idContext: NodeIdContext,
+	value: Exclude<Serializable<unknown>, object>,
+): ChangeNode => ({
 	identifier: idContext.generateNodeId(),
 	definition: NodeKind.scalar as Definition,
 	traits: {},
 	payload: value,
 });
 
-export function fromJson<T>(idContext: NodeIdContext, value: Serializable<T>): ChangeNode {
+export function fromJson(idContext: NodeIdContext, value: Serializable<unknown>): ChangeNode {
 	if (typeof value === "object") {
 		if (Array.isArray(value)) {
 			return {
 				identifier: idContext.generateNodeId(),
 				definition: NodeKind.array as Definition,
 				traits: {
-					items: value.map(
-						(property: Serializable<T>): ChangeNode => fromJson(idContext, property),
-					),
+					items: value.map((property): ChangeNode => fromJson(idContext, property)),
 				},
 			};
 		} else if (value === null) {

--- a/examples/benchmarks/bubblebench/sharedtree/src/proxy/treeutils.ts
+++ b/examples/benchmarks/bubblebench/sharedtree/src/proxy/treeutils.ts
@@ -23,7 +23,7 @@ export const makeScalar = (
 	payload: value,
 });
 
-export function fromJson(idContext: NodeIdContext, value: Serializable<unknown>): ChangeNode {
+export function fromJson<T>(idContext: NodeIdContext, value: Serializable<T>): ChangeNode {
 	if (typeof value === "object") {
 		if (Array.isArray(value)) {
 			return {

--- a/examples/benchmarks/bubblebench/sharedtree/src/state.ts
+++ b/examples/benchmarks/bubblebench/sharedtree/src/state.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Serializable } from "@fluidframework/datastore-definitions";
 import { Change, SharedTree } from "@fluid-experimental/tree";
 import {
 	IAppState,
@@ -48,7 +47,7 @@ export class AppState implements IAppState {
 		this.root = TreeObjectProxy<IApp>(this.tree, this.tree.currentView.root, this.update);
 
 		const json = makeClient(_width, _height, numBubbles);
-		const clientNode = fromJson(tree, json as Serializable<IClient>);
+		const clientNode = fromJson(tree, json);
 		(this.clients as unknown as TreeArrayProxy<IClient>).pushNode(clientNode);
 		this.localClient = TreeObjectProxy(this.tree, clientNode.identifier, this.update);
 

--- a/examples/benchmarks/bubblebench/sharedtree/src/state.ts
+++ b/examples/benchmarks/bubblebench/sharedtree/src/state.ts
@@ -48,7 +48,7 @@ export class AppState implements IAppState {
 		this.root = TreeObjectProxy<IApp>(this.tree, this.tree.currentView.root, this.update);
 
 		const json = makeClient(_width, _height, numBubbles);
-		const clientNode = fromJson<IClient>(tree, json as Serializable<IClient>);
+		const clientNode = fromJson(tree, json as Serializable<IClient>);
 		(this.clients as unknown as TreeArrayProxy<IClient>).pushNode(clientNode);
 		this.localClient = TreeObjectProxy(this.tree, clientNode.identifier, this.update);
 

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -51,6 +51,7 @@
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/view-interfaces": "workspace:~",
 		"@tiny-calc/micro": "0.0.0-alpha.5",
+		"@tiny-calc/nano": "0.0.0-alpha.5",
 		"react": "^17.0.1"
 	},
 	"devDependencies": {

--- a/examples/data-objects/table-view/src/grid.ts
+++ b/examples/data-objects/table-view/src/grid.ts
@@ -6,6 +6,7 @@
 import { colIndexToName } from "@fluid-example/table-document";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { ISheetlet, createSheetletProducer } from "@tiny-calc/micro";
+import type { IMatrixProducer } from "@tiny-calc/nano";
 import { BorderRect } from "./borderstyle";
 import * as styles from "./index.css";
 
@@ -21,6 +22,11 @@ const enum KeyCode {
 	arrowRight = "ArrowRight", // 39
 	arrowDown = "ArrowDown", // 40
 }
+
+// Extract Value type from createSheetletProducer requirements. (Value is not exported.)
+type GridContentType = Parameters<typeof createSheetletProducer>[0] extends IMatrixProducer<infer T>
+	? T
+	: never;
 
 export class GridView {
 	private get numRows() {
@@ -73,7 +79,7 @@ export class GridView {
 	}
 
 	constructor(
-		private readonly matrix: SharedMatrix,
+		private readonly matrix: SharedMatrix<GridContentType>,
 		private readonly getFormula: () => string,
 		private readonly setFormula: (val: string) => void,
 		private readonly setSelectionSummary: (val: string) => void,

--- a/experimental/dds/ot/sharejs/json1/api-report/sharejs-json1.api.md
+++ b/experimental/dds/ot/sharejs/json1/api-report/sharejs-json1.api.md
@@ -45,13 +45,13 @@ export class SharedJson1 extends SharedOT<Doc, JSONOp> {
     // (undocumented)
     static getFactory(): Json1Factory;
     // (undocumented)
-    insert(path: Path, value: Serializable<unknown>): void;
+    insert<T>(path: Path, value: Serializable<T>): void;
     // (undocumented)
     move(from: Path, to: Path): void;
     // (undocumented)
     remove(path: Path, value?: boolean): void;
     // (undocumented)
-    replace(path: Path, oldValue: Serializable<unknown>, newValue: Serializable<unknown>): void;
+    replace<T, U>(path: Path, oldValue: Serializable<T>, newValue: Serializable<U>): void;
     // (undocumented)
     protected transform(input: JSONOp, transform: JSONOp): JSONOp;
 }

--- a/experimental/dds/ot/sharejs/json1/api-report/sharejs-json1.api.md
+++ b/experimental/dds/ot/sharejs/json1/api-report/sharejs-json1.api.md
@@ -45,13 +45,13 @@ export class SharedJson1 extends SharedOT<Doc, JSONOp> {
     // (undocumented)
     static getFactory(): Json1Factory;
     // (undocumented)
-    insert(path: Path, value: Serializable): void;
+    insert(path: Path, value: Serializable<unknown>): void;
     // (undocumented)
     move(from: Path, to: Path): void;
     // (undocumented)
     remove(path: Path, value?: boolean): void;
     // (undocumented)
-    replace(path: Path, oldValue: Serializable, newValue: Serializable): void;
+    replace(path: Path, oldValue: Serializable<unknown>, newValue: Serializable<unknown>): void;
     // (undocumented)
     protected transform(input: JSONOp, transform: JSONOp): JSONOp;
 }

--- a/experimental/dds/ot/sharejs/json1/src/json1.ts
+++ b/experimental/dds/ot/sharejs/json1/src/json1.ts
@@ -54,7 +54,7 @@ export class SharedJson1 extends SharedOT<Doc, JSONOp> {
 		return Json1OTType.apply(state, op) as Doc;
 	}
 
-	public insert(path: Path, value: Serializable) {
+	public insert(path: Path, value: Serializable<unknown>) {
 		this.apply(insertOp(path, value as Doc));
 	}
 
@@ -66,7 +66,7 @@ export class SharedJson1 extends SharedOT<Doc, JSONOp> {
 		this.apply(removeOp(path, value));
 	}
 
-	public replace(path: Path, oldValue: Serializable, newValue: Serializable) {
+	public replace(path: Path, oldValue: Serializable<unknown>, newValue: Serializable<unknown>) {
 		this.apply(replaceOp(path, oldValue as Doc, newValue as Doc));
 	}
 }

--- a/experimental/dds/ot/sharejs/json1/src/json1.ts
+++ b/experimental/dds/ot/sharejs/json1/src/json1.ts
@@ -54,7 +54,7 @@ export class SharedJson1 extends SharedOT<Doc, JSONOp> {
 		return Json1OTType.apply(state, op) as Doc;
 	}
 
-	public insert(path: Path, value: Serializable<unknown>) {
+	public insert<T>(path: Path, value: Serializable<T>) {
 		this.apply(insertOp(path, value as Doc));
 	}
 
@@ -66,7 +66,7 @@ export class SharedJson1 extends SharedOT<Doc, JSONOp> {
 		this.apply(removeOp(path, value));
 	}
 
-	public replace(path: Path, oldValue: Serializable<unknown>, newValue: Serializable<unknown>) {
+	public replace<T, U>(path: Path, oldValue: Serializable<T>, newValue: Serializable<U>) {
 		this.apply(replaceOp(path, oldValue as Doc, newValue as Doc));
 	}
 }

--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -31,6 +31,11 @@ function createConnectedOT(id: string, runtimeFactory: MockContainerRuntimeFacto
 	return ot;
 }
 
+interface ITestObject {
+	x: number;
+	y: number;
+}
+
 describe("SharedJson1", () => {
 	describe("Local state", () => {
 		let ot: SharedJson1;
@@ -66,6 +71,12 @@ describe("SharedJson1", () => {
 
 					ot.insert(["x", 0], 1);
 					expect({ x: [1] });
+				});
+
+				it("object", () => {
+					const obj: ITestObject = { x: 1, y: 2 };
+					ot.insert(["o"], obj);
+					expect({ o: { x: 1, y: 2 } });
 				});
 			});
 

--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -40,7 +40,7 @@ describe("SharedJson1", () => {
 			ot.replace([], null, {});
 		});
 
-		const expect = (expected: Jsonable) => {
+		const expect = (expected: Jsonable<unknown>) => {
 			assert.deepEqual(ot.get(), expected);
 		};
 
@@ -109,7 +109,7 @@ describe("SharedJson1", () => {
 				expect([]);
 			});
 
-			const expect = (expected?: Jsonable) => {
+			const expect = (expected?: Jsonable<unknown>) => {
 				containerRuntimeFactory.processAllMessages();
 
 				const actual1 = doc1.get();

--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -45,7 +45,7 @@ describe("SharedJson1", () => {
 			ot.replace([], null, {});
 		});
 
-		const expect = (expected: Jsonable<unknown>) => {
+		const expect = <T>(expected: Jsonable<T>) => {
 			assert.deepEqual(ot.get(), expected);
 		};
 
@@ -120,7 +120,7 @@ describe("SharedJson1", () => {
 				expect([]);
 			});
 
-			const expect = (expected?: Jsonable<unknown>) => {
+			const expect = <T>(expected?: Jsonable<T>) => {
 				containerRuntimeFactory.processAllMessages();
 
 				const actual1 = doc1.get();

--- a/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
+++ b/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
@@ -224,7 +224,7 @@ export class SparseMatrixFactory implements IChannelFactory {
 }
 
 // @internal @deprecated (undocumented)
-export type SparseMatrixItem = Serializable;
+export type SparseMatrixItem = any;
 
 export { SubSequence }
 

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -11,7 +11,6 @@ import {
 	IFluidDataStoreRuntime,
 	IChannelServices,
 	IChannelFactory,
-	Serializable,
 	Jsonable,
 } from "@fluidframework/datastore-definitions";
 import { ISharedObject } from "@fluidframework/shared-object-base";
@@ -92,7 +91,7 @@ export class PaddingSegment extends BaseSegment {
  * Use {@link @fluidframework/matrix#SharedMatrix} instead.
  * @internal
  */
-export type SparseMatrixItem = Serializable;
+export type SparseMatrixItem = any;
 
 /**
  * @deprecated `RunSegment` is part of an abandoned prototype.

--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -26,7 +26,6 @@ import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { ITelemetryProperties } from '@fluidframework/core-interfaces';
 import { ITree } from '@fluid-experimental/tree2';
-import type { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 import { TreeFactory } from '@fluid-experimental/tree2';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
@@ -731,7 +730,7 @@ export interface ParentData {
 }
 
 // @internal
-export type Payload = Serializable;
+export type Payload = any;
 
 // @internal
 export function placeFromStablePlace(view: TreeView, stablePlace: StablePlace): TreeViewPlace;

--- a/experimental/dds/tree/src/persisted-types/0.0.2.ts
+++ b/experimental/dds/tree/src/persisted-types/0.0.2.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { Serializable } from '@fluidframework/datastore-definitions';
 import type {
 	EditId,
 	Definition,
@@ -94,7 +93,7 @@ export interface EditBase<TChange> {
  * TODO:#51984: Allow opting into heuristic blobbing in snapshots with a special IFluid key.
  * @internal
  */
-export type Payload = Serializable;
+export type Payload = any;
 
 /**
  * Json compatible map as object.

--- a/experimental/dds/tree2/src/test/domains/json/benchmarks.ts
+++ b/experimental/dds/tree2/src/test/domains/json/benchmarks.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Jsonable } from "@fluidframework/datastore-definitions";
 import { forEachNode, forEachField, ITreeCursor } from "../../../core";
 
 export function sum(cursor: ITreeCursor): number {
@@ -38,7 +37,7 @@ export function sumMap(cursor: ITreeCursor): number {
 	return total;
 }
 
-export function sumDirect(jsonObj: Jsonable): number {
+export function sumDirect(jsonObj: any): number {
 	let total = 0;
 	for (const value of Object.values(jsonObj)) {
 		if (typeof value === "object" && value !== null) {

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -7,7 +7,6 @@ import { EventEmitter } from "events";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils";
-import { Jsonable } from "@fluidframework/datastore-definitions";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import { IErrorEvent } from "@fluidframework/core-interfaces";
 
@@ -18,7 +17,7 @@ import { IErrorEvent } from "@fluidframework/core-interfaces";
 /**
  * @internal
  */
-export type SignalListener = (clientId: string, local: boolean, payload: Jsonable) => void;
+export type SignalListener = (clientId: string, local: boolean, payload: any) => void;
 
 /**
  * ISignaler defines an interface for working with signals that is similar to the more common
@@ -48,7 +47,7 @@ export interface ISignaler {
 	 * @param signalName - The name of the signal
 	 * @param payload - The data to send with the signal
 	 */
-	submitSignal(signalName: string, payload?: Jsonable);
+	submitSignal(signalName: string, payload?: any);
 }
 
 /**
@@ -122,7 +121,7 @@ class InternalSignaler extends TypedEventEmitter<IErrorEvent> implements ISignal
 		return this;
 	}
 
-	public submitSignal(signalName: string, payload?: Jsonable) {
+	public submitSignal(signalName: string, payload?: any) {
 		const signalerSignalName = this.getSignalerSignalName(signalName);
 		if (this.signaler.connected) {
 			this.signaler.submitSignal(signalerSignalName, payload);
@@ -168,7 +167,7 @@ export class Signaler
 		return this;
 	}
 
-	public submitSignal(signalName: string, payload?: Jsonable) {
+	public submitSignal(signalName: string, payload?: any) {
 		this.signaler.submitSignal(signalName, payload);
 	}
 }

--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -6,7 +6,7 @@
 import * as path from "path";
 import { strict as assert } from "assert";
 import { DDSFuzzModel, DDSFuzzTestState, createDDSFuzzSuite } from "@fluid-private/test-dds-utils";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { JsonableType } from "@fluidframework/datastore-definitions";
 import {
 	combineReducers,
 	createWeightedGenerator,
@@ -25,7 +25,7 @@ interface Clear {
 interface SetKey {
 	type: "setKey";
 	key: string;
-	value: Jsonable;
+	value: JsonableType;
 }
 
 interface DeleteKey {

--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -6,7 +6,7 @@
 import * as path from "path";
 import { strict as assert } from "assert";
 import { DDSFuzzModel, DDSFuzzTestState, createDDSFuzzSuite } from "@fluid-private/test-dds-utils";
-import { JsonableType } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/datastore-definitions";
 import {
 	combineReducers,
 	createWeightedGenerator,
@@ -25,7 +25,7 @@ interface Clear {
 interface SetKey {
 	type: "setKey";
 	key: string;
-	value: JsonableType;
+	value: Jsonable<unknown>;
 }
 
 interface DeleteKey {

--- a/packages/dds/matrix/src/ops.ts
+++ b/packages/dds/matrix/src/ops.ts
@@ -26,7 +26,7 @@ export interface IMatrixCellMsg extends IMatrixMsg {
 	type: MatrixOp.set;
 	row: number;
 	col: number;
-	value: Serializable;
+	value: Serializable<unknown>;
 }
 
 export interface IMatrixSwitchSetCellPolicy extends IMatrixMsg {

--- a/packages/dds/matrix/src/serialization.ts
+++ b/packages/dds/matrix/src/serialization.ts
@@ -12,7 +12,7 @@ import { bufferToString } from "@fluid-internal/client-utils";
 export const serializeBlob = (
 	handle: IFluidHandle,
 	path: string,
-	snapshot: Serializable,
+	snapshot: Serializable<unknown>,
 	serializer: IFluidSerializer,
 ) => new BlobTreeEntry(path, serializer.stringify(snapshot, handle));
 

--- a/packages/dds/matrix/src/serialization.ts
+++ b/packages/dds/matrix/src/serialization.ts
@@ -9,10 +9,10 @@ import { BlobTreeEntry } from "@fluidframework/driver-utils";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
 import { bufferToString } from "@fluid-internal/client-utils";
 
-export const serializeBlob = (
+export const serializeBlob = <T>(
 	handle: IFluidHandle,
 	path: string,
-	snapshot: Serializable<unknown>,
+	snapshot: Serializable<T>,
 	serializer: IFluidSerializer,
 ) => new BlobTreeEntry(path, serializer.stringify(snapshot, handle));
 

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -74,7 +74,7 @@ describe("Matrix1", () => {
 				let matrix: SharedMatrix<number>;
 
 				// Test IMatrixConsumer that builds a copy of `matrix` via observed events.
-				let consumer: TestConsumer<undefined | null | number>;
+				let consumer: TestConsumer<number>;
 
 				// Summarizes the given `SharedMatrix`, loads the summarize into a 2nd SharedMatrix, vets that the two are
 				// equivalent, and then returns the 2nd matrix.

--- a/packages/dds/matrix/src/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.undo.spec.ts
@@ -21,7 +21,7 @@ import { UndoRedoStackManager } from "./undoRedoStackManager";
 			let dataStoreRuntime: MockFluidDataStoreRuntime;
 			let matrix1: SharedMatrix<number | string>;
 			// Test IMatrixConsumer that builds a copy of `matrix` via observed events.
-			let consumer1: TestConsumer<undefined | null | number | string>;
+			let consumer1: TestConsumer<number | string>;
 			let undo1: UndoRedoStackManager;
 			let expect: <T>(expected: readonly (readonly MatrixItem<T>[])[]) => Promise<void>;
 

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -711,7 +711,7 @@ export class SubSequence<T> extends BaseSegment {
     // (undocumented)
     protected createSplitSegmentAt(pos: number): SubSequence<T> | undefined;
     // (undocumented)
-    static fromJSONObject<U>(spec: Serializable): SubSequence<U> | undefined;
+    static fromJSONObject<U>(spec: any): SubSequence<U> | undefined;
     // (undocumented)
     static is(segment: ISegment): segment is SubSequence<any>;
     // (undocumented)

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -31,7 +31,7 @@ export class SubSequence<T> extends BaseSegment {
 	public static is(segment: ISegment): segment is SubSequence<any> {
 		return segment.type === SubSequence.typeString;
 	}
-	public static fromJSONObject<U>(spec: Serializable) {
+	public static fromJSONObject<U>(spec: any) {
 		if (spec && typeof spec === "object" && "items" in spec) {
 			const segment = new SubSequence<U>(spec.items);
 			if (spec.props) {
@@ -76,7 +76,10 @@ export class SubSequence<T> extends BaseSegment {
 	public append(segment: ISegment) {
 		assert(SubSequence.is(segment), 0x448 /* can only append to another run segment */);
 		super.append(segment);
-		this.items = this.items.concat(segment.items);
+		// assert above checks that segment is a SubSequence but not that generic T matches.
+		// Since SubSequence is already deprecated, assume that usage is generic T consistent
+		// and just cast here to satisfy concat.
+		this.items = this.items.concat((segment as SubSequence<T>).items);
 	}
 
 	// TODO: retain removed items for undo
@@ -169,7 +172,10 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
 					if (firstSegment === undefined) {
 						firstSegment = segment;
 					}
-					items.push(...segment.items);
+					// Condition above checks that segment is a SubSequence but not that
+					// generic T matches. Since SubSequence is already deprecated, assume
+					// that walk only has SubSequence<T> segments and just cast here.
+					items.push(...(segment as SubSequence<T>).items);
 				}
 				return true;
 			},

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -18,6 +18,9 @@ export interface ISharedSummaryBlock extends ISharedObject {
 	 * Retrieves the given key from the map.
 	 * @param key - Key to retrieve from.
 	 * @returns The stored value, or undefined if the key is not set.
+	 *
+	 * @privateRemarks
+	 * The return type is underspecified to allow for the possibility of objects with function or undefined values.
 	 */
 	get<T>(key: string): Jsonable<T>;
 

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -28,7 +28,7 @@ const snapshotFileName = "header";
  * Directly used in JSON.stringify, direct result from JSON.parse.
  */
 interface ISharedSummaryBlockDataSerializable {
-	[key: string]: Jsonable;
+	[key: string]: Jsonable<unknown>;
 }
 
 /**
@@ -60,7 +60,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
 	/**
 	 * The data held by this object.
 	 */
-	private readonly data = new Map<string, Jsonable>();
+	private readonly data = new Map<string, Jsonable<unknown>>();
 
 	/**
 	 * Constructs a new SharedSummaryBlock. If the object is non-local, an id and service interfaces will

--- a/packages/framework/attributor/src/encoders.ts
+++ b/packages/framework/attributor/src/encoders.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 import { assert } from "@fluidframework/core-utils";
-import { Jsonable } from "@fluidframework/datastore-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { AttributionInfo } from "@fluidframework/runtime-definitions";
 import { IAttributor } from "./attributor";
@@ -29,10 +28,10 @@ export const deltaEncoder: TimestampEncoder = {
 		}
 		return deltaTimestamps;
 	},
-	decode: (encoded: Jsonable) => {
+	decode: (encoded: unknown) => {
 		assert(
 			Array.isArray(encoded),
-			0x4b0 /* Encoded timestamps should be an array of nummbers */,
+			0x4b0 /* Encoded timestamps should be an array of numbers */,
 		);
 		const timestamps: number[] = new Array(encoded.length);
 		let cumulativeSum = 0;

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -149,9 +149,6 @@ export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? 
 } : never;
 
 // @alpha
-export type JsonableType = JsonableTypeWith<never>;
-
-// @alpha
 export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
 
 // @alpha

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -144,9 +144,9 @@ export interface Internal_InterfaceOfJsonableTypesWith<T> {
 }
 
 // @alpha
-export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? {
+export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? T extends object ? T extends (infer U)[] ? Jsonable<U, TReplaced>[] : {
     [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
-} : never;
+} : never : never;
 
 // @alpha
 export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -137,12 +137,24 @@ export interface IFluidDataStoreRuntimeEvents extends IEvent {
     (event: "connected", listener: (clientId: string) => void): any;
 }
 
+// @alpha (undocumented)
+export interface Internal_InterfaceOfJsonableTypesWith<T> {
+    // (undocumented)
+    [index: string | number]: JsonableTypeWith<T>;
+}
+
 // @alpha
-export type Jsonable<T = any, TReplaced = void> = T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? {
+export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? {
     [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
 } : never;
 
 // @alpha
-export type Serializable<T = any> = Jsonable<T, IFluidHandle>;
+export type JsonableType = JsonableTypeWith<never>;
+
+// @alpha
+export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
+
+// @alpha
+export type Serializable<T> = Jsonable<T, IFluidHandle>;
 
 ```

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -19,11 +19,6 @@ export {
 	IDeltaHandler,
 } from "./channel";
 export { IFluidDataStoreRuntime, IFluidDataStoreRuntimeEvents } from "./dataStoreRuntime";
-export type {
-	Jsonable,
-	JsonableType,
-	JsonableTypeWith,
-	Internal_InterfaceOfJsonableTypesWith,
-} from "./jsonable";
+export type { Jsonable, JsonableTypeWith, Internal_InterfaceOfJsonableTypesWith } from "./jsonable";
 export { Serializable } from "./serializable";
 export { IChannelAttributes } from "./storage";

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -19,6 +19,11 @@ export {
 	IDeltaHandler,
 } from "./channel";
 export { IFluidDataStoreRuntime, IFluidDataStoreRuntimeEvents } from "./dataStoreRuntime";
-export { Jsonable } from "./jsonable";
+export type {
+	Jsonable,
+	JsonableType,
+	JsonableTypeWith,
+	Internal_InterfaceOfJsonableTypesWith,
+} from "./jsonable";
 export { Serializable } from "./serializable";
 export { IChannelAttributes } from "./storage";

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -10,6 +10,9 @@
  * @remarks
  * Use `JsonableTypeWith<never>` for just JSON serializable types.
  * See {@link Jsonable} for serialization pitfalls.
+ *
+ * @privateRemarks
+ * Perfer using `Jsonable<unknown>` over this type that is an implementation detail.
  * @alpha
  */
 export type JsonableTypeWith<T> =
@@ -35,12 +38,6 @@ export type JsonableTypeWith<T> =
 export interface Internal_InterfaceOfJsonableTypesWith<T> {
 	[index: string | number]: JsonableTypeWith<T>;
 }
-
-/**
- * Type constraint for types that are serializable as JSON.
- * @alpha
- */
-export type JsonableType = JsonableTypeWith<never>;
 
 /**
  * Used to constrain a type `T` to types that are serializable as JSON.
@@ -70,8 +67,8 @@ export type JsonableType = JsonableTypeWith<never>;
  *
  * Also, `Jsonable<T>` does not prevent the construction of circular references.
  *
- * Using `Jsonable<unknown>`, or `Jsonable<any>` is just a type alias for
- * {@link JsonableType} and should not be used if precise type safety is desired.
+ * Using `Jsonable<unknown>` or `Jsonable<any>` is a type alias for
+ * {@link JsonableTypeWith}`<never>` and should not be used if precise type safety is desired.
  *
  * @example Typical usage
  *

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -24,4 +24,4 @@ import { Jsonable } from "./jsonable";
  * ```
  * @alpha
  */
-export type Serializable<T = any> = Jsonable<T, IFluidHandle>;
+export type Serializable<T> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
@@ -55,9 +55,25 @@ interface IA2 {
 declare const a2: IA2;
 foo(a2);
 
-// test complex indexed interface
+// test complex indexed type
 declare const a3: { [key: string]: string };
 foo(a3);
+
+// test "unknown" cannonical Json content
+type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
+declare const json: Json;
+foo(json);
+
+// test "unknown" Jsonable content
+declare const unknownJsonable: Jsonable<unknown>;
+foo(unknownJsonable);
+
+// test "unknown" cannonical Json content in an interface
+interface A4 {
+	payload: Json;
+}
+declare const a4: A4;
+foo(a4);
 
 // test interface with multiple properties
 interface A5 {
@@ -196,6 +212,14 @@ const isym: ISymbol = {
 // @ts-expect-error should not be jsonable
 foo(isym);
 
+// *disabled* test that array-like types are fully arrays
+// Jsonable allows ArrayLike to be an object as base JsonableTypeWith<never>
+// uses ArrayLike to avoid TypeOnly type test limitation. If that is addressed
+// then this test should be enabled.
+declare const mayNotBeArray: ArrayLike<number>;
+// @disable ts-expect-error should not be jsonable
+foo(mayNotBeArray);
+
 /**
  * TypeAliasOf creates a type equivalent version of an interface.
  * @remarks
@@ -253,6 +277,8 @@ foo<unknown>(a2);
 // no error for _type_ to Jsonable<unknown>
 foo<unknown>(a3);
 // @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(a4);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
 foo<unknown>(a5);
 // @ts-expect-error interfaces are not assignable to Jsonable<unknown>
 foo<unknown>(a6);
@@ -270,6 +296,7 @@ foo<unknown>(selfReferencing);
 foo<unknown>(a as Jsonable<typeof a>);
 foo<unknown>(a2 as Jsonable<typeof a2>);
 foo<unknown>(a3 as Jsonable<typeof a3>);
+foo<unknown>(a4 as Jsonable<typeof a4>);
 foo<unknown>(a5 as Jsonable<typeof a5>);
 foo<unknown>(a6 as Jsonable<typeof a6>);
 foo<unknown>(a7 as Jsonable<typeof a7>);

--- a/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
@@ -55,8 +55,8 @@ interface IA2 {
 declare const a2: IA2;
 foo(a2);
 
-// text complex indexed interface
-declare const a3: { [key: string]: Jsonable<string> };
+// test complex indexed interface
+declare const a3: { [key: string]: string };
 foo(a3);
 
 // test interface with multiple properties
@@ -100,7 +100,30 @@ const nested: INested = {
 };
 foo(nested);
 
+// test `any` type
+declare const anAny: any;
+foo(anAny);
+
+// test "recursive" type compiles
+// Infinite recursion not supported nor desired but is not prevented
+// and this test exists simply to demonstrate that limitation.
+interface SelfReferencing {
+	me: SelfReferencing;
+}
+declare const selfReferencing: SelfReferencing;
+foo(selfReferencing);
+
 // --- should not work
+
+// test unknown
+declare const aUnknown: unknown;
+// @ts-expect-error should not be jsonable
+foo(aUnknown);
+
+// test interface with unknown
+declare const nestedUnknown: { a: unknown };
+// @ts-expect-error should not be jsonable
+foo(nestedUnknown);
 
 // test interface with method, and member
 interface IA11 {

--- a/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
@@ -152,7 +152,7 @@ foo(a13);
 
 // test type with primative and object with classes union
 interface IA14 {
-	a: number | Date;
+	a: number | bar;
 }
 declare const a14: IA14;
 // @ts-expect-error should not be jsonable
@@ -195,3 +195,98 @@ const isym: ISymbol = {
 };
 // @ts-expect-error should not be jsonable
 foo(isym);
+
+/**
+ * TypeAliasOf creates a type equivalent version of an interface.
+ * @remarks
+ * It is used below to bypass the early "Index signature for type 'string'" issue for interfaces.
+ */
+type TypeAliasOf<T> = T extends object
+	? T extends () => any | null
+		? T
+		: { [K in keyof T]: TypeAliasOf<T[K]> }
+	: T;
+
+// test foo<T>(value: Jsonable<T>) remains an error for troublesome values even when coercing T to `any`
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(aUnknown);
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(nestedUnknown);
+declare const a11t: TypeAliasOf<typeof a11>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(a11t);
+declare const a12t: TypeAliasOf<typeof a12>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(a12t);
+declare const a13t: TypeAliasOf<typeof a13>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(a13t);
+declare const a14t: TypeAliasOf<typeof a14>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(a14t);
+const aBar = new bar();
+declare const aBarT: TypeAliasOf<typeof aBar>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(aBarT);
+declare const anMtT: TypeAliasOf<typeof mt>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(anMtT);
+declare const anNmtT: TypeAliasOf<typeof nmt>;
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(anNmtT);
+// @ts-expect-error unsupported types cannot circumnavigate with Jsonable<any>
+foo<any>(isym);
+
+// --- tests that are not part of the Jsonable specification but are included
+//  to demonstrate limitations.
+
+// test interfaces passed for Jsonable<unknown> are not assignable
+// Typescript makes an allowance for types regarding index signatures but does not for
+// interfaces which may be augmented. Test that
+//   Index signature for type 'string' is missing in type 'X'. ts(2345)
+// occurs for interfaces but not for types.
+// See https://github.com/microsoft/TypeScript/issues/15300#issuecomment-657218214
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(a);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(a2);
+// no error for _type_ to Jsonable<unknown>
+foo<unknown>(a3);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(a5);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(a6);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(a7);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(nested);
+// no error for any to Jsonable<unknown>
+foo<unknown>(anAny);
+// @ts-expect-error interfaces are not assignable to Jsonable<unknown>
+foo<unknown>(selfReferencing);
+
+// Show that cast to Jsonable version of self (a type alias) does compile
+// to be passed to Jsonable<unknown>. This is not a recommended practice.
+foo<unknown>(a as Jsonable<typeof a>);
+foo<unknown>(a2 as Jsonable<typeof a2>);
+foo<unknown>(a3 as Jsonable<typeof a3>);
+foo<unknown>(a5 as Jsonable<typeof a5>);
+foo<unknown>(a6 as Jsonable<typeof a6>);
+foo<unknown>(a7 as Jsonable<typeof a7>);
+foo<unknown>(nested as Jsonable<typeof nested>);
+foo<unknown>(anAny as Jsonable<typeof anAny>);
+foo<unknown>(selfReferencing as Jsonable<typeof selfReferencing>);
+
+// Show that cast to Jsonable version of self does compile even if not
+// respecting the limitations. This is a dangerous practice, but can
+// be useful if very careful.
+foo(aUnknown as Jsonable<typeof aUnknown>);
+foo(nestedUnknown as Jsonable<typeof nestedUnknown>);
+foo(a11 as Jsonable<typeof a11>);
+foo(a12 as Jsonable<typeof a12>);
+foo(a13 as Jsonable<typeof a13>);
+foo(a14 as Jsonable<typeof a14>);
+foo(aBar as Jsonable<typeof aBar>);
+foo(mt as Jsonable<typeof mt>);
+foo(nmt as Jsonable<typeof nmt>);
+foo(isym as Jsonable<typeof isym>);

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -246,7 +246,7 @@ use_old_InterfaceDeclaration_IFluidDataStoreRuntimeEvents(
 declare function get_old_TypeAliasDeclaration_Jsonable():
     TypeOnly<old.Jsonable>;
 declare function use_current_TypeAliasDeclaration_Jsonable(
-    use: TypeOnly<current.Jsonable>): void;
+    use: TypeOnly<current.Jsonable<any,any>>): void;
 use_current_TypeAliasDeclaration_Jsonable(
     get_old_TypeAliasDeclaration_Jsonable());
 
@@ -256,7 +256,7 @@ use_current_TypeAliasDeclaration_Jsonable(
 * "TypeAliasDeclaration_Jsonable": {"backCompat": false}
 */
 declare function get_current_TypeAliasDeclaration_Jsonable():
-    TypeOnly<current.Jsonable>;
+    TypeOnly<current.Jsonable<any,any>>;
 declare function use_old_TypeAliasDeclaration_Jsonable(
     use: TypeOnly<old.Jsonable>): void;
 use_old_TypeAliasDeclaration_Jsonable(
@@ -270,7 +270,7 @@ use_old_TypeAliasDeclaration_Jsonable(
 declare function get_old_TypeAliasDeclaration_Serializable():
     TypeOnly<old.Serializable>;
 declare function use_current_TypeAliasDeclaration_Serializable(
-    use: TypeOnly<current.Serializable>): void;
+    use: TypeOnly<current.Serializable<any>>): void;
 use_current_TypeAliasDeclaration_Serializable(
     get_old_TypeAliasDeclaration_Serializable());
 
@@ -280,7 +280,7 @@ use_current_TypeAliasDeclaration_Serializable(
 * "TypeAliasDeclaration_Serializable": {"backCompat": false}
 */
 declare function get_current_TypeAliasDeclaration_Serializable():
-    TypeOnly<current.Serializable>;
+    TypeOnly<current.Serializable<any>>;
 declare function use_old_TypeAliasDeclaration_Serializable(
     use: TypeOnly<old.Serializable>): void;
 use_old_TypeAliasDeclaration_Serializable(

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -776,7 +776,7 @@ export const shortCodeMap = {
 	"0x4ad": "Should not be called when connection is already present!",
 	"0x4ae": "Connection should be disposed by now",
 	"0x4af": "Received message from user not in the audience",
-	"0x4b0": "Encoded timestamps should be an array of nummbers",
+	"0x4b0": "Encoded timestamps should be an array of numbers",
 	"0x4b1": "serialized attribution columns should have the same length",
 	"0x4b2": "new client has different payload from existing one",
 	"0x4b3": "have connection",

--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -141,7 +141,7 @@ describeCompat(
 		});
 
 		function getAndIncrementCellValue(
-			sharedMatrix: SharedMatrix,
+			sharedMatrix: SharedMatrix<string>,
 			row: number,
 			column: number,
 			initialValue?: string,

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -13,7 +13,11 @@ import { SharedString, SharedStringFactory } from "@fluidframework/sequence";
 import { benchmarkAll, IBenchmarkParameters } from "./DocumentCreator.js";
 
 function createLocalMatrix(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
-	return new SharedMatrix(dataStoreRuntime, "matrix1", SharedMatrixFactory.Attributes);
+	return new SharedMatrix<SharedString["handle"]>(
+		dataStoreRuntime,
+		"matrix1",
+		SharedMatrixFactory.Attributes,
+	);
 }
 
 function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
@@ -21,8 +25,6 @@ function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
 }
 
 describeCompat("PAS Test", "NoCompat", () => {
-	let matrix: SharedMatrix;
-	let containerRuntimeFactory: MockContainerRuntimeFactory;
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const rowSize = 6;
 	const columnSize = 5;
@@ -47,10 +49,10 @@ describeCompat("PAS Test", "NoCompat", () => {
 				this.matrix.insertCols(0, columnSize);
 				for (let i = 0; i < rowSize; i++) {
 					for (let j = 0; j < columnSize; j++) {
-						const id = j.toString() + i.toString();
+						const id = `${j},${i}`;
 						const sharedString: SharedString = createString(id, dataStoreRuntime);
 						sharedString.insertText(0, "testValue");
-						this.matrix.setCell(i, j, sharedString);
+						this.matrix.setCell(i, j, sharedString.handle);
 					}
 				}
 			}

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -311,7 +311,7 @@ describeCompat("SharedCell orderSequentially", "NoCompat", (getTestObjectProvide
 	let dataObject: ITestFluidObject;
 	let sharedCell: SharedCell;
 	let containerRuntime: ContainerRuntime;
-	let changedEventData: Serializable[];
+	let changedEventData: Serializable<unknown>[];
 
 	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
 		getRawConfig: (name: string): ConfigTypes => settings[name],

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -19,6 +19,7 @@ import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IValueChanged, SharedDirectory, SharedMap } from "@fluidframework/map";
 import { SharedCell } from "@fluidframework/cell";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
+import { Serializable } from "@fluidframework/datastore-definitions";
 
 const stringId = "sharedStringKey";
 const string2Id = "sharedString2Key";
@@ -50,7 +51,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 	let sharedDir: SharedDirectory;
 	let sharedCell: SharedCell;
 	let sharedMap: SharedMap;
-	let changedEventData: IValueChanged[];
+	let changedEventData: (IValueChanged | Serializable<unknown>)[];
 	let containerRuntime: ContainerRuntime;
 	let error: Error | undefined;
 
@@ -128,8 +129,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[0]}`,
 		);
 
-		assert.equal(changedEventData[1].key, "key1");
-		assert.equal(changedEventData[1].previousValue, undefined);
+		assert.deepEqual(changedEventData[1], { key: "key1", previousValue: undefined });
 
 		assert.equal(changedEventData[2], 2);
 
@@ -138,16 +138,14 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[3]}`,
 		);
 
-		assert.equal(changedEventData[4].key, "key1");
-		assert.equal(changedEventData[4].previousValue, 0);
+		assert.deepEqual(changedEventData[4], { key: "key1", previousValue: 0 });
 
 		assert.equal(changedEventData[5], undefined);
 
 		// rollback
 		assert.equal(changedEventData[6], 2);
 
-		assert.equal(changedEventData[7].key, "key1");
-		assert.equal(changedEventData[7].previousValue, undefined);
+		assert.deepEqual(changedEventData[7], { key: "key1", previousValue: undefined });
 
 		assert(
 			changedEventData[8] instanceof SequenceDeltaEvent,
@@ -197,8 +195,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[0]}`,
 		);
 
-		assert.equal(changedEventData[1].key, "key1");
-		assert.equal(changedEventData[1].previousValue, undefined);
+		assert.deepEqual(changedEventData[1], { key: "key1", previousValue: undefined });
 
 		assert(
 			changedEventData[2] instanceof SequenceDeltaEvent,
@@ -207,8 +204,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 
 		assert.equal(changedEventData[3], 2);
 
-		assert.equal(changedEventData[4].key, "key1");
-		assert.equal(changedEventData[4].previousValue, 0);
+		assert.deepEqual(changedEventData[4], { key: "key1", previousValue: 0 });
 
 		assert(
 			changedEventData[5] instanceof SequenceDeltaEvent,
@@ -252,8 +248,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[15]}`,
 		);
 
-		assert.equal(changedEventData[16].key, "key1");
-		assert.equal(changedEventData[16].previousValue, 3);
+		assert.deepEqual(changedEventData[16], { key: "key1", previousValue: 3 });
 	});
 
 	it("Should handle rollback on multiple instances of the same DDS type", () => {
@@ -288,16 +283,14 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[0]}`,
 		);
 
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, undefined);
+		assert.deepEqual(changedEventData[1], { key: "key", previousValue: undefined });
 
 		assert(
 			changedEventData[2] instanceof SequenceDeltaEvent,
 			`Unexpected event type - ${typeof changedEventData[2]}`,
 		);
 
-		assert.equal(changedEventData[3].key, "key");
-		assert.equal(changedEventData[3].previousValue, 1);
+		assert.deepEqual(changedEventData[3], { key: "key", previousValue: 1 });
 
 		assert(
 			changedEventData[4] instanceof SequenceDeltaEvent,
@@ -320,8 +313,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[7]}`,
 		);
 
-		assert.equal(changedEventData[8].key, "key");
-		assert.equal(changedEventData[8].previousValue, undefined);
+		assert.deepEqual(changedEventData[8], { key: "key", previousValue: undefined });
 	});
 
 	it("Should handle nested calls to orderSequentially", () => {
@@ -361,11 +353,9 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[0]}`,
 		);
 
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, undefined);
+		assert.deepEqual(changedEventData[1], { key: "key", previousValue: undefined });
 
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, 1);
+		assert.deepEqual(changedEventData[2], { key: "key", previousValue: 1 });
 
 		assert(
 			changedEventData[3] instanceof SequenceDeltaEvent,
@@ -378,14 +368,11 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			`Unexpected event type - ${typeof changedEventData[4]}`,
 		);
 
-		assert.equal(changedEventData[5].key, "key");
-		assert.equal(changedEventData[5].previousValue, 0);
+		assert.deepEqual(changedEventData[5], { key: "key", previousValue: 0 });
 
 		// rollback - outer orderSequentially call
-		assert.equal(changedEventData[6].key, "key");
-		assert.equal(changedEventData[6].previousValue, undefined);
+		assert.deepEqual(changedEventData[6], { key: "key", previousValue: undefined });
 
-		assert.equal(changedEventData[7].key, "key");
-		assert.equal(changedEventData[7].previousValue, 0);
+		assert.deepEqual(changedEventData[7], { key: "key", previousValue: 0 });
 	});
 });

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -442,7 +442,7 @@ export interface MessageLoggingOptions {
 }
 
 // @internal
-export type Primitive = bigint | number | boolean | null | string | symbol | undefined;
+export type Primitive = number | boolean | null | string | undefined;
 
 // @internal
 export namespace RootDataVisualizations {

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -133,6 +133,42 @@
 			},
 			"InterfaceDeclaration_FluidDevtoolsProps": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_FluidHandleNode": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_FluidObjectNodeBase": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_TreeNodeBase": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_UnknownObjectNode": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_ValueNodeBase": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_VisualNodeBase": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_VisualTreeNode": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_VisualValueNode": {
+				"forwardCompat": false
+			},
+			"TypeAliasDeclaration_Primitive": {
+				"forwardCompat": false
+			},
+			"TypeAliasDeclaration_RootHandleNode": {
+				"forwardCompat": false
+			},
+			"TypeAliasDeclaration_VisualChildNode": {
+				"forwardCompat": false
+			},
+			"TypeAliasDeclaration_VisualNode": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/tools/devtools/devtools-core/src/data-visualization/VisualTree.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/VisualTree.ts
@@ -33,14 +33,14 @@ export enum VisualNodeKind {
 }
 
 /**
- * Type union representing TypeScript primitives.
+ * Type union representing TypeScript primitives supported in DDSes.
  *
  * @remarks Used for data / metadata in {@link VisualNodeBase}s.
  *
  * @internal
  */
 // eslint-disable-next-line @rushstack/no-new-null
-export type Primitive = bigint | number | boolean | null | string | symbol | undefined;
+export type Primitive = number | boolean | null | string | undefined;
 
 /**
  * Base interface for all {@link VisualNode}s.

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -1545,6 +1545,7 @@ declare function get_old_InterfaceDeclaration_FluidHandleNode():
 declare function use_current_InterfaceDeclaration_FluidHandleNode(
     use: TypeOnly<current.FluidHandleNode>): void;
 use_current_InterfaceDeclaration_FluidHandleNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_FluidHandleNode());
 
 /*
@@ -1617,6 +1618,7 @@ declare function get_old_InterfaceDeclaration_FluidObjectNodeBase():
 declare function use_current_InterfaceDeclaration_FluidObjectNodeBase(
     use: TypeOnly<current.FluidObjectNodeBase>): void;
 use_current_InterfaceDeclaration_FluidObjectNodeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_FluidObjectNodeBase());
 
 /*
@@ -2697,6 +2699,7 @@ declare function get_old_TypeAliasDeclaration_Primitive():
 declare function use_current_TypeAliasDeclaration_Primitive(
     use: TypeOnly<current.Primitive>): void;
 use_current_TypeAliasDeclaration_Primitive(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_Primitive());
 
 /*
@@ -2817,6 +2820,7 @@ declare function get_old_TypeAliasDeclaration_RootHandleNode():
 declare function use_current_TypeAliasDeclaration_RootHandleNode(
     use: TypeOnly<current.RootHandleNode>): void;
 use_current_TypeAliasDeclaration_RootHandleNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_RootHandleNode());
 
 /*
@@ -3081,6 +3085,7 @@ declare function get_old_InterfaceDeclaration_TreeNodeBase():
 declare function use_current_InterfaceDeclaration_TreeNodeBase(
     use: TypeOnly<current.TreeNodeBase>): void;
 use_current_InterfaceDeclaration_TreeNodeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_TreeNodeBase());
 
 /*
@@ -3105,6 +3110,7 @@ declare function get_old_InterfaceDeclaration_UnknownObjectNode():
 declare function use_current_InterfaceDeclaration_UnknownObjectNode(
     use: TypeOnly<current.UnknownObjectNode>): void;
 use_current_InterfaceDeclaration_UnknownObjectNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_UnknownObjectNode());
 
 /*
@@ -3129,6 +3135,7 @@ declare function get_old_InterfaceDeclaration_ValueNodeBase():
 declare function use_current_InterfaceDeclaration_ValueNodeBase(
     use: TypeOnly<current.ValueNodeBase>): void;
 use_current_InterfaceDeclaration_ValueNodeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ValueNodeBase());
 
 /*
@@ -3153,6 +3160,7 @@ declare function get_old_TypeAliasDeclaration_VisualChildNode():
 declare function use_current_TypeAliasDeclaration_VisualChildNode(
     use: TypeOnly<current.VisualChildNode>): void;
 use_current_TypeAliasDeclaration_VisualChildNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_VisualChildNode());
 
 /*
@@ -3177,6 +3185,7 @@ declare function get_old_TypeAliasDeclaration_VisualNode():
 declare function use_current_TypeAliasDeclaration_VisualNode(
     use: TypeOnly<current.VisualNode>): void;
 use_current_TypeAliasDeclaration_VisualNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_VisualNode());
 
 /*
@@ -3201,6 +3210,7 @@ declare function get_old_InterfaceDeclaration_VisualNodeBase():
 declare function use_current_InterfaceDeclaration_VisualNodeBase(
     use: TypeOnly<current.VisualNodeBase>): void;
 use_current_InterfaceDeclaration_VisualNodeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_VisualNodeBase());
 
 /*
@@ -3249,6 +3259,7 @@ declare function get_old_InterfaceDeclaration_VisualTreeNode():
 declare function use_current_InterfaceDeclaration_VisualTreeNode(
     use: TypeOnly<current.VisualTreeNode>): void;
 use_current_InterfaceDeclaration_VisualTreeNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_VisualTreeNode());
 
 /*
@@ -3273,6 +3284,7 @@ declare function get_old_InterfaceDeclaration_VisualValueNode():
 declare function use_current_InterfaceDeclaration_VisualValueNode(
     use: TypeOnly<current.VisualValueNode>): void;
 use_current_InterfaceDeclaration_VisualValueNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_VisualValueNode());
 
 /*

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/CommonInterfaces.ts
@@ -36,5 +36,5 @@ export interface DataVisualizationTreeProps<TNode extends VisualNodeBase = Visua
  * TODO
  */
 export interface CanSupplyEdit {
-	edit(newValue: Serializable<unknown>);
+	edit<T>(newValue: Serializable<T>);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2946,6 +2946,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@tiny-calc/micro': 0.0.0-alpha.5
+      '@tiny-calc/nano': 0.0.0-alpha.5
       '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       copyfiles: ^2.4.1
@@ -2974,6 +2975,7 @@ importers:
       '@fluidframework/sequence': link:../../../packages/dds/sequence
       '@fluidframework/view-interfaces': link:../../../packages/framework/view-interfaces
       '@tiny-calc/micro': 0.0.0-alpha.5
+      '@tiny-calc/nano': 0.0.0-alpha.5
       react: 17.0.2
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader


### PR DESCRIPTION
## Breaking Changes

### Alpha

Require first generic parameter for `Jsonable` and `Serializable` types that was previously `any` and resulted in `any`.
Additionally alter types to use new `JsonableTypeWith<>` as result when `any` or `unknown` is specified such that some constraint is actually produced.

### Internal

devtools-core types were broadly broken as its `Primitive` type was updated to respect primitives supported by `Jsonable`.

## Notes

This is a type only product change. Some tests were altered beyond type changes to respect the new constraints.

Some deprecated and experimental uses of [unqualified] `Jsonable` or `Serializable` have been replaced by `any`.
Other uses have been updated to specify a generic parameter, which may be `unknown` and now use `JsonableTypeWith` typing.

Due to recursive `TypeOnly` filter used in type tests, the definition for `JsonableTypeWith` uses interfaces where there is nested typing, which limits recursion. This may cause complications like imprecise typing in the future and need to be switch to pure type alias recursion.
Which means the type test generation will need to be updated to handle such types.