### PR TITLE
fix(check:policy): Exclude scripts that use tsc --watch from "check phase", not just "resolve phase"

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -472,6 +472,8 @@ export const handlers: Handler[] = [
 					// This clause ensures we don't match commands that are prefixed with "tsc", like "tsc-multi". The exception
 					// is when the whole command is "tsc".
 					(command.startsWith("tsc ") || command === "tsc") &&
+					// tsc --watch tasks are long-running processes and don't need the standard task deps
+					!command.includes("--watch") &&
 					!ignore.has(script)
 				) {
 					try {

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -531,7 +531,11 @@ export const handlers: Handler[] = [
  * @param tasksToIgnore - List of fluid-build tasks (usually npm scripts) that should be ignored.
  * @returns
  */
-function shouldProcessScriptForTsc(script: string, command: string, tasksToIgnore: Set<string>): boolean {
+function shouldProcessScriptForTsc(
+	script: string,
+	command: string,
+	tasksToIgnore: Set<string>,
+): boolean {
 	return (
 		// This clause ensures we don't match commands that are prefixed with "tsc", like "tsc-multi". The exception
 		// is when the whole command is "tsc".

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -528,7 +528,7 @@ export const handlers: Handler[] = [
  * Helper to determine if a script/command should be processed by the handler for tsc fluid-build tasks.
  * @param script - The name of the npm script in package.json.
  * @param command - The command that the npm script executes.
- * @param tasksToIgnore - List of fluid build tasks (usually npm scripts) that should be ignored.
+ * @param tasksToIgnore - List of fluid-build tasks (usually npm scripts) that should be ignored.
  * @returns
  */
 function shouldProcessScriptForTsc(script: string, command: string, tasksToIgnore: Set<string>): boolean {

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -468,14 +468,7 @@ export const handlers: Handler[] = [
 			for (const script in json.scripts) {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const command = json.scripts[script]!;
-				if (
-					// This clause ensures we don't match commands that are prefixed with "tsc", like "tsc-multi". The exception
-					// is when the whole command is "tsc".
-					(command.startsWith("tsc ") || command === "tsc") &&
-					// tsc --watch tasks are long-running processes and don't need the standard task deps
-					!command.includes("--watch") &&
-					!ignore.has(script)
-				) {
+				if (shouldProcessScriptForTsc(script, command, ignore)) {
 					try {
 						const checkDeps = getTscCommandDependencies(
 							packageDir,
@@ -509,12 +502,7 @@ export const handlers: Handler[] = [
 				for (const script in json.scripts) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					const command = json.scripts[script]!;
-					if (
-						command.startsWith("tsc") &&
-						// tsc --watch tasks are long-running processes and don't need the standard task deps
-						!command.includes("--watch") &&
-						!ignore.has(script)
-					) {
+					if (shouldProcessScriptForTsc(script, command, ignore)) {
 						try {
 							const checkDeps = getTscCommandDependencies(
 								packageDir,
@@ -535,3 +523,21 @@ export const handlers: Handler[] = [
 		},
 	},
 ];
+
+/**
+ * Helper to determine if a script/command should be processed by the handler for tsc fluid-build tasks.
+ * @param script - The name of the npm script in package.json.
+ * @param command - The command that the npm script executes.
+ * @param tasksToIgnore - List of fluid build tasks (usually npm scripts) that should be ignored.
+ * @returns
+ */
+function shouldProcessScriptForTsc(script: string, command: string, tasksToIgnore: Set<string>): boolean {
+	return (
+		// This clause ensures we don't match commands that are prefixed with "tsc", like "tsc-multi". The exception
+		// is when the whole command is "tsc".
+		(command.startsWith("tsc ") || command === "tsc") &&
+		// tsc --watch tasks are long-running processes and don't need the standard task deps
+		!command.includes("--watch") &&
+		!tasksToIgnore.has(script)
+	);
+}


### PR DESCRIPTION
## Description

We thought we had fixed this [before](https://github.com/microsoft/FluidFramework/pull/18104) but only applied the new condition in the resolvers and missed this part. I confirmed locally that with this change, policy check now doesn't flag [these scripts](https://github.com/microsoft/FluidFramework/blob/main/packages/tools/devtools/devtools-example/package.json#L37-L39) as failing policy after I removed them from the [exclusions list](https://github.com/microsoft/FluidFramework/blob/main/fluidBuild.config.cjs#L336-L340). Will need to publish a version of build-tools with this fix and consume it in the client release group to actually remove those exclusions though.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
