### PR TITLE
LTS: Disable ODSP-DF Service Load Tests

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -37,6 +37,8 @@ stages:
   # stress tests odsp
   - stage:
     displayName:  Stress tests - Odsp
+    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
+    condition: "false"
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
@@ -58,6 +60,8 @@ stages:
   # stress tests odsp dogfood
   - stage:
     displayName:  Stress tests - Odspdf
+    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
+    condition: "false"
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -37,8 +37,6 @@ stages:
   # stress tests odsp
   - stage:
     displayName:  Stress tests - Odsp
-    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
-    condition: "false"
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -124,8 +124,6 @@ stages:
   - stage:
     displayName:  e2e - odsp
     dependsOn: []
-    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
-    condition: "false"
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
     - group: e2e-odsp-lock

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -124,7 +124,7 @@ stages:
   - stage:
     displayName:  e2e - odsp
     dependsOn: []
-    # the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
+    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
     condition: "false"
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -124,6 +124,8 @@ stages:
   - stage:
     displayName:  e2e - odsp
     dependsOn: []
+    # the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
+    condition: "false"
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
     - group: e2e-odsp-lock


### PR DESCRIPTION
the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."