### PR TITLE
tree2: Remove concept of primitive types

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -243,7 +243,7 @@ infer Head,
 export type ContextuallyTypedFieldData = ContextuallyTypedNodeData | undefined;
 
 // @alpha
-export type ContextuallyTypedNodeData = ContextuallyTypedNodeDataObject | PrimitiveValue | readonly ContextuallyTypedNodeData[] | MarkedArrayLike<ContextuallyTypedNodeData>;
+export type ContextuallyTypedNodeData = ContextuallyTypedNodeDataObject | number | string | boolean | null | readonly ContextuallyTypedNodeData[] | MarkedArrayLike<ContextuallyTypedNodeData>;
 
 // @alpha
 export interface ContextuallyTypedNodeDataObject {
@@ -1575,9 +1575,6 @@ export function prefixFieldPath(prefix: PathRootPrefix | undefined, path: FieldU
 
 // @alpha
 export function prefixPath(prefix: PathRootPrefix | undefined, path: UpPath | undefined): UpPath | undefined;
-
-// @alpha @deprecated (undocumented)
-export type PrimitiveValue = string | boolean | number;
 
 // @alpha
 type ProtoNode = ITreeCursorSynchronous;

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -44,9 +44,8 @@ export {
 export {
 	typeNameSymbol,
 	valueSymbol,
-	isPrimitiveValue,
+	isTreeValue,
 	getPrimaryField,
-	PrimitiveValue,
 	ContextuallyTypedNodeDataObject,
 	ContextuallyTypedNodeData,
 	MarkedArrayLike,

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -146,7 +146,6 @@ export {
 	isContextuallyTypedNodeDataObject,
 	defaultSchemaPolicy,
 	jsonableTreeFromCursor,
-	PrimitiveValue,
 	StableNodeKey,
 	LocalNodeKey,
 	compareLocalNodeKeys,

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -19,7 +19,7 @@ import { FieldKinds, TreeFieldSchema, jsonableTreeFromCursor } from "../../featu
 import { leaf, SchemaBuilder } from "../../domains";
 
 describe("ContextuallyTyped", () => {
-	it("isPrimitiveValue", () => {
+	it("isTreeValue", () => {
 		assert(isTreeValue(0));
 		assert(isTreeValue(0.001));
 		assert(isTreeValue(NaN));

--- a/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -8,7 +8,7 @@ import { MockHandle } from "@fluidframework/test-runtime-utils";
 import { EmptyKey, MapTree } from "../../core";
 
 import {
-	isPrimitiveValue,
+	isTreeValue,
 	applyTypesFromContext,
 	ContextuallyTypedNodeDataObject,
 	cursorFromContextualData,
@@ -20,17 +20,17 @@ import { leaf, SchemaBuilder } from "../../domains";
 
 describe("ContextuallyTyped", () => {
 	it("isPrimitiveValue", () => {
-		assert(isPrimitiveValue(0));
-		assert(isPrimitiveValue(0.001));
-		assert(isPrimitiveValue(NaN));
-		assert(isPrimitiveValue(true));
-		assert(isPrimitiveValue(false));
-		assert(isPrimitiveValue(""));
-		assert(!isPrimitiveValue({}));
-		assert(!isPrimitiveValue(undefined));
-		assert(!isPrimitiveValue(null));
-		assert(!isPrimitiveValue([]));
-		assert(!isPrimitiveValue(new MockHandle(5)));
+		assert(isTreeValue(0));
+		assert(isTreeValue(0.001));
+		assert(isTreeValue(NaN));
+		assert(isTreeValue(true));
+		assert(isTreeValue(false));
+		assert(isTreeValue(""));
+		assert(!isTreeValue({}));
+		assert(!isTreeValue(undefined));
+		assert(isTreeValue(null));
+		assert(!isTreeValue([]));
+		assert(isTreeValue(new MockHandle(5)));
 	});
 
 	it("applyTypesFromContext omits empty fields", () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
@@ -18,8 +18,7 @@ import {
 } from "../../../feature-libraries/flex-tree/lazyNode";
 import {
 	Any,
-	PrimitiveValue,
-	isPrimitiveValue,
+	isTreeValue,
 	jsonableTreeFromCursor,
 	cursorForMapTreeNode,
 	FlexTreeField,
@@ -599,7 +598,7 @@ function checkPropertyInvariants(root: FlexTreeEntity): void {
 	]);
 
 	const visited: Set<unknown> = new Set([root]);
-	const primitivesAndValues = new Map<PrimitiveValue | TreeValue, number>();
+	const primitivesAndValues = new Map<TreeValue, number>();
 	// TODO: add cycle handler to not error on Fluid handles.
 	visitOwnPropertiesRecursive(root, (parent, key, child): Skip | void => {
 		assert(typeof child !== "function");
@@ -620,7 +619,7 @@ function checkPropertyInvariants(root: FlexTreeEntity): void {
 				const prototypeInner = Object.getPrototypeOf(prototype);
 				assert(prototypeInner === LazyObjectNode.prototype);
 			}
-		} else if (isPrimitiveValue(child) || child === null) {
+		} else if (isTreeValue(child)) {
 			// TODO: more robust check for schema names
 			if (key === "type") {
 				assert(typeof child === "string");


### PR DESCRIPTION
## Description

Remove concept of "primitive" types as separate from TreeValue types.
This distinction was based on the default unwrapping policies of the previous editable-tree API and is no longer relevant.

## Breaking Changes

isPrimitive has been removed from the package API.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
