### PR TITLE
Fix flaky prefetch snapshot tests in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
@@ -325,7 +325,8 @@ describe("Tests for prefetching snapshot", () => {
 					),
 			);
 
-			mockFetchSingle(
+			// This will store the response with wrong epoch in the cache
+			await mockFetchSingle(
 				async () =>
 					prefetchLatestSnapshot(
 						resolved,
@@ -347,18 +348,26 @@ describe("Tests for prefetching snapshot", () => {
 					),
 			);
 
-			let errorOccurred = false;
-			const version = await service.getVersions(null, 1).catch((err) => {
-				errorOccurred = true;
-				return undefined;
-			});
+			await mockFetchSingle(
+				async () => service.getVersions(null, 1),
+				async () =>
+					createResponse(
+						{ "x-fluid-epoch": "epoch1", "content-type": "application/json" },
+						odspSnapshot,
+						200,
+					),
+			);
 
-			assert.deepStrictEqual(version, undefined, "incorrect version");
-			assert.deepStrictEqual(errorOccurred, true, "error didn't occur");
-			assert(
-				mockLogger.events.filter((event) =>
-					event.eventName.includes("PrefetchSnapshotError"),
-				).length === 1,
+			mockLogger.assertMatchAny(
+				[
+					{
+						error: "Epoch mismatch",
+						errorType: "fileOverwrittenInStorage",
+						serverEpoch: "epoch2",
+						clientEpoch: "epoch1",
+						fetchType: "treesLatest",
+					},
+				],
 				"Snapshot prefetch has different epoch",
 			);
 		});
@@ -374,7 +383,9 @@ describe("Tests for prefetching snapshot", () => {
 						200,
 					),
 			);
-			mockFetchSingle(
+
+			// This will store the response with wrong epoch in the cache
+			await mockFetchSingle(
 				async () =>
 					prefetchLatestSnapshot(
 						resolved,
@@ -396,20 +407,26 @@ describe("Tests for prefetching snapshot", () => {
 					),
 			);
 
-			let errorOccurred = false;
-			const version = await service
-				.getVersions(null, 1, undefined, FetchSource.noCache)
-				.catch((err) => {
-					errorOccurred = true;
-					return undefined;
-				});
+			await mockFetchSingle(
+				async () => service.getVersions(null, 1, FetchSource.noCache),
+				async () =>
+					createResponse(
+						{ "x-fluid-epoch": "epoch1", "content-type": "application/json" },
+						odspSnapshot,
+						200,
+					),
+			);
 
-			assert.deepStrictEqual(version, undefined, "incorrect version");
-			assert.deepStrictEqual(errorOccurred, true, "error didn't occur");
-			assert(
-				mockLogger.events.filter((event) =>
-					event.eventName.includes("PrefetchSnapshotError"),
-				).length === 1,
+			mockLogger.assertMatchAny(
+				[
+					{
+						error: "Epoch mismatch",
+						errorType: "fileOverwrittenInStorage",
+						serverEpoch: "epoch2",
+						clientEpoch: "epoch1",
+						fetchType: "treesLatest",
+					},
+				],
 				"Snapshot prefetch has different epoch",
 			);
 		});
@@ -456,7 +473,9 @@ describe("Tests for prefetching snapshot", () => {
 						200,
 					),
 			);
-			mockFetchSingle(
+
+			// This will store the response with wrong epoch in the cache
+			await mockFetchSingle(
 				async () =>
 					prefetchLatestSnapshot(
 						resolved,
@@ -478,19 +497,26 @@ describe("Tests for prefetching snapshot", () => {
 					),
 			);
 
-			let errorOccurred = false;
-			const version = await service.getVersions(null, 1, undefined).catch((err) => {
-				errorOccurred = true;
-				return undefined;
-			});
+			await mockFetchSingle(
+				async () => service.getVersions(null, 1, undefined),
+				async () =>
+					createResponse(
+						{ "x-fluid-epoch": "epoch1", "content-type": "application/json" },
+						odspSnapshot,
+						200,
+					),
+			);
 
-			assert.deepStrictEqual(version, undefined, "incorrect version");
-			assert.deepStrictEqual(errorOccurred, true, "error didn't occur");
-
-			assert(
-				mockLogger.events.filter((event) =>
-					event.eventName.includes("PrefetchSnapshotError"),
-				).length === 1,
+			mockLogger.assertMatchAny(
+				[
+					{
+						error: "Epoch mismatch",
+						errorType: "fileOverwrittenInStorage",
+						serverEpoch: "epoch2",
+						clientEpoch: "epoch1",
+						fetchType: "treesLatest",
+					},
+				],
 				"Snapshot prefetch has different epoch",
 			);
 		});


### PR DESCRIPTION
## Description

These tests were ending up making an actual network call which was causing the timeout. Fixed and refactored the tests.