### PR TITLE
refactor(azure-client): Move re-exports to `index.ts`

### DIFF
--- a/azure/packages/azure-client/src/index.ts
+++ b/azure/packages/azure-client/src/index.ts
@@ -24,10 +24,11 @@ export type {
 	AzureRemoteConnectionConfig,
 	AzureUser,
 	IAzureAudience,
-	ITelemetryBaseEvent,
-	ITelemetryBaseLogger,
 } from "./interfaces";
 
 export type { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 export type { ITokenClaims, IUser } from "@fluidframework/protocol-definitions";
 export { ScopeType } from "@fluidframework/protocol-definitions";
+
+// Re-export so developers can build loggers without pulling in core-interfaces
+export type { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -9,9 +9,6 @@ import { type ITokenProvider } from "@fluidframework/routerlicious-driver";
 import { type IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { type ICompressionStorageConfig } from "@fluidframework/driver-utils";
 
-// Re-export so developers can build loggers without pulling in core-interfaces
-export type { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-
 /**
  * Props for initializing a new AzureClient instance
  *


### PR DESCRIPTION
The package was re-exporting members of `core-interfaces` via an internal module (`interfaces.ts`) while all its other re-exports live in the root `index.ts` module (which is the more standard pattern). This PR moves the `core-interfaces` re-exports to the root exports module.