### PR TITLE
Fix bad import in sparsematrix

### DIFF
--- a/packages/dds/sequence/src/sparsematrix.ts
+++ b/packages/dds/sequence/src/sparsematrix.ts
@@ -22,7 +22,8 @@ import {
 } from "@fluidframework/datastore-definitions";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 import { pkgVersion } from "./packageVersion";
-import { SharedSegmentSequence, SubSequence } from "./";
+import { SharedSegmentSequence } from "./sequence";
+import { SubSequence } from "./sharedSequence";
 
 /**
  * An empty segment that occupies 'cachedLength' positions.  SparseMatrix uses PaddingSegment


### PR DESCRIPTION
## Description

Some partners have reported issues using FF 1.0 APIs in certain contexts due to circular dependencies in this file. This should fix that problem.