### PR TITLE
(tree2) Move DiscriminatedUnionDispatcher to a more shared location

### DIFF
--- a/experimental/dds/tree2/src/codec/discriminatedUnions.ts
+++ b/experimental/dds/tree2/src/codec/discriminatedUnions.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { ObjectOptions } from "@sinclair/typebox";
+import { assert } from "@fluidframework/core-utils";
+import { _InlineTrick, fail, objectToMap } from "../util";
+
+/**
+ * This module contains utilities for an encoding of a discriminated union that is efficient to validate using
+ * a JSON schema validator.
+ * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
+ */
+
+/**
+ * Options to configure a TypeBox schema as a discriminated union that is simple to validate data against.
+ *
+ * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
+ */
+export const unionOptions: ObjectOptions = {
+	additionalProperties: false,
+	minProperties: 1,
+	maxProperties: 1,
+};
+
+/**
+ * Applies a function to the content of a [discriminated union](https://en.wikipedia.org/wiki/Tagged_union)
+ * where the function to apply depends on the which value from the union it holds.
+ *
+ * This uses a rather non-standard encoding of the union where it is an object with many differently named optional fields,
+ * and which of the fields is populated determines the content type.
+ * This union encoding has the advantage that schema validation (such as that implemented by TypeBox) can validate the data efficiently.
+ * Other encodings--such as using an untagged union, then tagging the content types with a marker enum--require the schema validator to disambiguate the union members.
+ * Most JSON validator implementations fail to recognize the marker enum determines which component of the discriminated union the data must be,
+ * and end up checking against all candidate members of the union.
+ *
+ * @example
+ *
+ * The following union:
+ * ```typescript
+ * type Operation = Add | Subtract | Multiply | Divide;
+ *
+ * interface BinaryOperation {
+ *     readonly left: number;
+ *     readonly right: number;
+ * }
+ *
+ * interface Add extends BinaryOperation {
+ *     readonly type: "add";
+ * }
+ *
+ * interface Subtract extends BinaryOperation {
+ *     readonly type: "subtract";
+ * }
+ *
+ * interface Multiply extends BinaryOperation {
+ *     readonly type: "multiply";
+ * }
+ *
+ * interface Divide extends BinaryOperation {
+ *     readonly type: "divide";
+ * }
+ *
+ * ```
+ * Would be encoded using this strategy as:
+ * ```typescript
+ * interface EncodedBinaryOperation {
+ *     readonly left: number;
+ *     readonly right: number;
+ * }
+ *
+ * interface EncodedOperation {
+ *     add?: EncodedBinaryOperation;
+ *     subtract?: EncodedBinaryOperation;
+ *     multiply?: EncodedBinaryOperation;
+ *     divide?: EncodedBinaryOperation;
+ * }
+ * ```
+ * where only a single property of `EncodedOperation` is populated for a given encoded value.
+ */
+export class DiscriminatedUnionDispatcher<TUnion extends object, TArgs extends any[], TResult> {
+	private readonly library: ReadonlyMap<
+		keyof TUnion,
+		(value: unknown, ...args: TArgs) => TResult
+	>;
+
+	public constructor(
+		library: [
+			{
+				readonly [Property in keyof TUnion]-?: (
+					value: Required<TUnion>[Property],
+					...args: TArgs
+				) => TResult;
+			},
+		][_InlineTrick],
+	) {
+		this.library = objectToMap(
+			library as Record<keyof TUnion, (value: unknown, ...args: TArgs) => TResult>,
+		);
+	}
+
+	public dispatch(union: TUnion, ...args: TArgs): TResult {
+		const keys = Reflect.ownKeys(union);
+		assert(
+			keys.length === 1,
+			0x733 /* discriminated union type should have exactly one member */,
+		);
+		const key: keyof TUnion = keys[0] as keyof TUnion;
+		const value = union[key];
+		const factory = this.library.get(key) ?? fail("missing function for union member");
+		const result = factory(value, ...args);
+		return result;
+	}
+}

--- a/experimental/dds/tree2/src/codec/discriminatedUnions.ts
+++ b/experimental/dds/tree2/src/codec/discriminatedUnions.ts
@@ -25,7 +25,7 @@ export const unionOptions: ObjectOptions = {
 
 /**
  * Applies a function to the content of a [discriminated union](https://en.wikipedia.org/wiki/Tagged_union)
- * where the function to apply depends on the which value from the union it holds.
+ * where the function to apply depends on which value from the union it holds.
  *
  * This uses a rather non-standard encoding of the union where it is an object with many differently named optional fields,
  * and which of the fields is populated determines the content type.

--- a/experimental/dds/tree2/src/codec/index.ts
+++ b/experimental/dds/tree2/src/codec/index.ts
@@ -18,4 +18,5 @@ export {
 	withDefaultBinaryEncoding,
 	withSchemaValidation,
 } from "./codec";
+export { DiscriminatedUnionDispatcher, unionOptions } from "./discriminatedUnions";
 export { noopValidator } from "./noopValidator";

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { _InlineTrick, assertValidIndex, fail, objectToMap } from "../../../util";
+import { assertValidIndex } from "../../../util";
 import { TreeChunk } from "../chunk";
 import { FluidSerializableReadOnly, assertAllowedValue } from "../../valueUtilities";
 import { TreeValue } from "../../../core";
@@ -177,49 +177,4 @@ export interface ChunkDecoder {
 	 * This chunk is allowed to reference/take ownership of content it reads from the stream.
 	 */
 	decode(decoders: readonly ChunkDecoder[], stream: StreamCursor): TreeChunk;
-}
-
-/**
- * Applies a function to the content of a [discriminated union](https://en.wikipedia.org/wiki/Tagged_union)
- * where the function to apply depends on the which value from the union it holds.
- *
- * This uses a rather non-standard encoding of the union where it is an object with many differently named optional fields,
- * and which of the fields is populated determines the content type.
- * This union encoding has the advantage that schema validation (such as that implemented by TypeBox) can validate the data.
- * Other encodings, such as an untagged-union, then tagging the content types with a marker enum require the schema validator to disambiguate the union members,
- * inferring that the enum can be use to differentiate them.
- */
-export class DiscriminatedUnionDispatcher<TUnion extends object, TArgs extends any[], TResult> {
-	private readonly library: ReadonlyMap<
-		keyof TUnion,
-		(value: unknown, ...args: TArgs) => TResult
-	>;
-
-	public constructor(
-		library: [
-			{
-				readonly [Property in keyof TUnion]-?: (
-					value: Required<TUnion>[Property],
-					...args: TArgs
-				) => TResult;
-			},
-		][_InlineTrick],
-	) {
-		this.library = objectToMap(
-			library as Record<keyof TUnion, (value: unknown, ...args: TArgs) => TResult>,
-		);
-	}
-
-	public dispatch(union: TUnion, ...args: TArgs): TResult {
-		const keys = Reflect.ownKeys(union);
-		assert(
-			keys.length === 1,
-			0x733 /* discriminated union type should have exactly one member */,
-		);
-		const key: keyof TUnion = keys[0] as keyof TUnion;
-		const value = union[key];
-		const factory = this.library.get(key) ?? fail("missing function for union member");
-		const result = factory(value, ...args);
-		return result;
-	}
 }

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -6,6 +6,7 @@
 import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { assertValidIndex } from "../../../util";
 import { FieldKey, TreeNodeSchemaIdentifier, Value } from "../../../core";
+import { DiscriminatedUnionDispatcher } from "../../../codec";
 import { TreeChunk } from "../chunk";
 import { BasicChunk } from "../basicChunk";
 import { SequenceChunk } from "../sequenceChunk";
@@ -21,7 +22,6 @@ import {
 } from "./format";
 import {
 	ChunkDecoder,
-	DiscriminatedUnionDispatcher,
 	StreamCursor,
 	getChecked,
 	readStream,

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
@@ -5,15 +5,10 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { BrandedType } from "../../../util";
+import { DiscriminatedUnionDispatcher } from "../../../codec";
 import { TreeChunk } from "../chunk";
 import { EncodedChunkGeneric, IdentifierOrIndex } from "./formatGeneric";
-import {
-	ChunkDecoder,
-	DiscriminatedUnionDispatcher,
-	StreamCursor,
-	getChecked,
-	readStream,
-} from "./chunkCodecUtilities";
+import { ChunkDecoder, StreamCursor, getChecked, readStream } from "./chunkCodecUtilities";
 
 /**
  * General purpose shape based tree decoder which gets its support for specific shapes from the caller.

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/format.ts
@@ -4,13 +4,8 @@
  */
 
 import { Static, Type } from "@sinclair/typebox";
-import {
-	EncodedChunkGeneric,
-	IdentifierOrIndex,
-	ShapeIndex,
-	unionOptions,
-	Count,
-} from "./formatGeneric";
+import { unionOptions } from "../../../codec";
+import { EncodedChunkGeneric, IdentifierOrIndex, ShapeIndex, Count } from "./formatGeneric";
 
 // TODO: Versions from here and schemaIndexFormat.ts should eventually be deduplicated into one version.
 export const version = 1.0;

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/formatGeneric.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/formatGeneric.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ObjectOptions, Static, TSchema, Type } from "@sinclair/typebox";
+import { Static, TSchema, Type } from "@sinclair/typebox";
 
 /**
  * Identifier OR Index of an identifier in the identifier list.
@@ -23,17 +23,6 @@ export const ShapeIndex = Type.Number({ multipleOf: 1, minimum: 0 });
 export type ShapeIndex = Static<typeof ShapeIndex>;
 
 export const Count = Type.Number({ multipleOf: 1, minimum: 0 });
-
-/**
- * Options to configure a TypeBox schema as a discriminated union that is simple to validate data against.
- *
- * See DiscriminatedUnionDispatcher for more information on this pattern.
- */
-export const unionOptions: ObjectOptions = {
-	additionalProperties: false,
-	minProperties: 1,
-	maxProperties: 1,
-};
 
 const EncodedChunkBase = Type.Object(
 	{

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/chunkCodecUtilities.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/chunkCodecUtilities.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 
 import {
 	Counter,
-	DiscriminatedUnionDispatcher,
 	getChecked,
 	jsonMinimizingFilter,
 	readStream,
@@ -15,6 +14,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/chunkCodecUtilities";
 import { makeArray } from "../../../../util";
+import { DiscriminatedUnionDispatcher } from "../../../../codec";
 
 describe("chunkEncodingUtilities", () => {
 	describe("counter", () => {

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -15,12 +15,10 @@ import {
 
 import {
 	EncodedChunkGeneric,
-	unionOptions,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/formatGeneric";
 import {
 	ChunkDecoder,
-	DiscriminatedUnionDispatcher,
 	StreamCursor,
 	getChecked,
 	readStreamNumber,
@@ -30,6 +28,7 @@ import { ReferenceCountedBase } from "../../../../util";
 import { TreeChunk } from "../../../../feature-libraries";
 // eslint-disable-next-line import/no-internal-modules
 import { ChunkedCursor } from "../../../../feature-libraries/chunked-forest/chunk";
+import { DiscriminatedUnionDispatcher, unionOptions } from "../../../../codec";
 
 const Constant = Type.Literal(0);
 const StringShape = Type.String();

--- a/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.spec.ts
@@ -14,14 +14,11 @@ import {
 } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric";
 
 import {
-	unionOptions,
-	// eslint-disable-next-line import/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/formatGeneric";
-import {
 	Counter,
 	DeduplicationTable,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/chunkCodecUtilities";
+import { unionOptions } from "../../../../codec";
 
 export const Constant = Type.Literal(0);
 


### PR DESCRIPTION
## Description

Moves DiscriminatedUnionDispatcher into a common location for usage in other codecs.
This PR only moves types around and updates documentation.
