### PR TITLE
build(PropertyDDS): Remove unused API-Extractor configs

### DIFF
--- a/experimental/PropertyDDS/packages/property-properties/api-extractor.json
+++ b/experimental/PropertyDDS/packages/property-properties/api-extractor.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.json"
-}

--- a/experimental/PropertyDDS/packages/property-proxy/api-extractor.json
+++ b/experimental/PropertyDDS/packages/property-proxy/api-extractor.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.json"
-}

--- a/experimental/PropertyDDS/packages/property-query/api-extractor.json
+++ b/experimental/PropertyDDS/packages/property-query/api-extractor.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.json"
-}


### PR DESCRIPTION
These 3 configs live in packages that don't use API-Extractor and can be safely removed.