### PR TITLE
When inserting into a SharedTree, only hydrate proxies, not plain objects

### DIFF
--- a/experimental/dds/tree2/src/simple-tree/proxies.ts
+++ b/experimental/dds/tree2/src/simple-tree/proxies.ts
@@ -993,7 +993,13 @@ function extractContentObject<T extends object>(input: T): ExtractedFactoryConte
 				editNode !== undefined,
 				0x7fa /* Expected edit node to be defined when hydrating object */,
 			);
-			setEditNode(input as TreeObjectNode<ObjectNodeSchema>, editNode as FlexTreeObjectNode); // This makes the input proxy usable and updates the proxy cache
+			if (rawEditNode !== undefined) {
+				// This makes the input proxy usable and updates the proxy cache
+				setEditNode(
+					input as TreeObjectNode<ObjectNodeSchema>,
+					editNode as FlexTreeObjectNode,
+				);
+			}
 			assert(
 				schemaIsObjectNode(editNode.schema),
 				0x7fb /* Expected object node when hydrating object content */,


### PR DESCRIPTION
## Description

There is currently a bug when inserting "plain" JavaScript objects (as opposed to "raw" proxies created with content factories/constructors). The plain object will undergo "hydration", which is something only applicable to proxies. This causes the plain object to be associated with the contents of the tree, and thus subsequent reads of the tree will produce that content object rather than creating a new proxy. This PR adjusts the logic to only hydrate objects which are indeed already thirsty proxies.
