### PR TITLE
Clean up typing around entryPoint

### DIFF
--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -307,13 +307,11 @@ export class AzureClient {
 	}
 
 	private async getContainerEntryPoint(container: IContainer): Promise<IRootDataObject> {
-		const rootDataObject: FluidObject<IRootDataObject> | undefined =
-			await container.getEntryPoint();
-		assert(rootDataObject !== undefined, "entryPoint must exist");
-		// ! This "if" is needed for back-compat (older instances of IRootDataObject may not have the IRootDataObject property)
-		if (rootDataObject.IRootDataObject === undefined) {
-			return rootDataObject as IRootDataObject;
-		}
+		const rootDataObject: FluidObject<IRootDataObject> = await container.getEntryPoint();
+		assert(
+			rootDataObject.IRootDataObject !== undefined,
+			"entryPoint must be of type IRootDataObject",
+		);
 		return rootDataObject.IRootDataObject;
 	}
 	// #endregion

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -140,7 +140,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
     // @alpha
     forceReadonly?(readonly: boolean): any;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-    getEntryPoint(): Promise<FluidObject | undefined>;
+    getEntryPoint(): Promise<FluidObject>;
     getLoadedCodeDetails(): IFluidCodeDetails | undefined;
     getQuorum(): IQuorumClients;
     getSpecifiedCodeDetails(): IFluidCodeDetails | undefined;
@@ -446,7 +446,7 @@ export interface IResolvedFluidCodeDetails extends IFluidCodeDetails {
 // @public
 export interface IRuntime extends IDisposable {
     createSummary(blobRedirectTable?: Map<string, string>): ISummaryTree;
-    getEntryPoint(): Promise<FluidObject | undefined>;
+    getEntryPoint(): Promise<FluidObject>;
     // @alpha
     getPendingLocalState(props?: IGetPendingLocalStateProps): unknown;
     notifyOpReplay?(message: ISequencedDocumentMessage): Promise<void>;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -463,7 +463,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 * Exposes the entryPoint for the container.
 	 * Use this as the primary way of getting access to the user-defined logic within the container.
 	 */
-	getEntryPoint(): Promise<FluidObject | undefined>;
+	getEntryPoint(): Promise<FluidObject>;
 }
 
 /**

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -104,7 +104,7 @@ export interface IRuntime extends IDisposable {
 	 *
 	 * @see {@link IContainer.getEntryPoint}
 	 */
-	getEntryPoint(): Promise<FluidObject | undefined>;
+	getEntryPoint(): Promise<FluidObject>;
 }
 
 /**

--- a/packages/framework/fluid-static/api-report/fluid-static.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.api.md
@@ -87,7 +87,7 @@ export type InitialObjects<T extends ContainerSchema> = {
 // @public (undocumented)
 export interface IProvideRootDataObject {
     // (undocumented)
-    readonly IRootDataObject?: IRootDataObject;
+    readonly IRootDataObject: IRootDataObject;
 }
 
 // @public

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -136,6 +136,9 @@
 			"RemovedClassDeclaration_ServiceAudience": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IRootDataObject": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -199,6 +199,7 @@ declare function get_old_InterfaceDeclaration_IRootDataObject():
 declare function use_current_InterfaceDeclaration_IRootDataObject(
     use: TypeOnly<current.IRootDataObject>): void;
 use_current_InterfaceDeclaration_IRootDataObject(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRootDataObject());
 
 /*

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -97,7 +97,7 @@ export interface ContainerSchema {
 }
 
 export interface IProvideRootDataObject {
-	readonly IRootDataObject?: IRootDataObject;
+	readonly IRootDataObject: IRootDataObject;
 }
 
 /**

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -171,13 +171,11 @@ export class TinyliciousClient {
 	}
 
 	private async getContainerEntryPoint(container: IContainer): Promise<IRootDataObject> {
-		const rootDataObject: FluidObject<IRootDataObject> | undefined =
-			await container.getEntryPoint();
-		assert(rootDataObject !== undefined, "entryPoint must exist");
-		// ! This "if" is needed for back-compat (older instances of IRootDataObject may not have the IRootDataObject property)
-		if (rootDataObject.IRootDataObject === undefined) {
-			return rootDataObject as IRootDataObject;
-		}
+		const rootDataObject: FluidObject<IRootDataObject> = await container.getEntryPoint();
+		assert(
+			rootDataObject.IRootDataObject !== undefined,
+			"entryPoint must be of type IRootDataObject",
+		);
 		return rootDataObject.IRootDataObject;
 	}
 	// #endregion

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -705,14 +705,14 @@ export class Container
 	/**
 	 * {@inheritDoc @fluidframework/container-definitions#IContainer.entryPoint}
 	 */
-	public async getEntryPoint(): Promise<FluidObject | undefined> {
+	public async getEntryPoint(): Promise<FluidObject> {
 		if (this._disposed) {
 			throw new UsageError("The context is already disposed");
 		}
 		if (this._runtime !== undefined) {
 			return this._runtime.getEntryPoint?.();
 		}
-		return new Promise<FluidObject | undefined>((resolve, reject) => {
+		return new Promise<FluidObject>((resolve, reject) => {
 			const runtimeInstantiatedHandler = () => {
 				assert(
 					this._runtime !== undefined,

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -193,13 +193,11 @@ export class OdspClient {
 	}
 
 	private async getContainerEntryPoint(container: IContainer): Promise<IRootDataObject> {
-		const rootDataObject: FluidObject<IRootDataObject> | undefined =
-			await container.getEntryPoint();
-		assert(rootDataObject !== undefined, "entryPoint must exist");
-		// ! This "if" is needed for back-compat (older instances of IRootDataObject may not have the IRootDataObject property)
-		if (rootDataObject.IRootDataObject === undefined) {
-			return rootDataObject as IRootDataObject;
-		}
+		const rootDataObject: FluidObject<IRootDataObject> = await container.getEntryPoint();
+		assert(
+			rootDataObject.IRootDataObject !== undefined,
+			"entryPoint must be of type IRootDataObject",
+		);
 		return rootDataObject.IRootDataObject;
 	}
 }


### PR DESCRIPTION
The following cleanup was done:
- IRuntime.getEntryPoint() can no longer return undefined
- make the `IRootDataObject` prop required for `IProvideRootDataObject`

[AB#6341](https://dev.azure.com/fluidframework/internal/_workitems/edit/6341)