### PR TITLE
tree2: Port migration shim to class based schema

### DIFF
--- a/examples/version-migration/tree-shim/src/model/inventoryList.ts
+++ b/examples/version-migration/tree-shim/src/model/inventoryList.ts
@@ -12,12 +12,7 @@ import {
 } from "@fluid-experimental/tree";
 // eslint-disable-next-line import/no-internal-modules
 import { EditLog } from "@fluid-experimental/tree/dist/EditLog";
-import {
-	ForestType,
-	ISharedTree,
-	SharedTreeFactory,
-	typeboxValidator,
-} from "@fluid-experimental/tree2";
+import { ForestType, ITree, TreeFactory, typeboxValidator } from "@fluid-experimental/tree2";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 
@@ -31,13 +26,13 @@ const treeKey = "tree";
 // Set to true to artificially slow down the migration.
 const DEBUG_migrateSlowly = false;
 
-const newTreeFactory = new SharedTreeFactory({
+const newTreeFactory = new TreeFactory({
 	jsonValidator: typeboxValidator,
 	// For now, ignore the forest argument - I think it's probably going away once the optimized one is ready anyway?  AB#6013
 	forest: ForestType.Reference,
 });
 
-function migrate(legacyTree: LegacySharedTree, newTree: ISharedTree) {
+function migrate(legacyTree: LegacySharedTree, newTree: ITree) {
 	// Revert local edits - otherwise we will be eventually inconsistent
 	const edits = legacyTree.edits as EditLog;
 	const localEdits = [...edits.getLocalEdits()].reverse();
@@ -162,7 +157,7 @@ export class InventoryList extends DataObject implements IInventoryList, IMigrat
 					.catch(console.error);
 			});
 		} else {
-			const tree = this.shim.currentTree as ISharedTree;
+			const tree = this.shim.currentTree as ITree;
 			this._model = new NewTreeInventoryListController(tree);
 		}
 

--- a/examples/version-migration/tree-shim/src/model/newTreeInventoryListController.ts
+++ b/examples/version-migration/tree-shim/src/model/newTreeInventoryListController.ts
@@ -6,7 +6,7 @@
 import EventEmitter from "events";
 
 import {
-	ISharedTree,
+	ITree,
 	NodeFromSchema,
 	SchemaFactory,
 	Tree,
@@ -100,7 +100,7 @@ class NewTreeInventoryItem extends TypedEmitter<IInventoryItemEvents> implements
 export class NewTreeInventoryListController extends EventEmitter implements IInventoryList {
 	// TODO: See note in inventoryList.ts for why this duplicative schematizeView call is here.
 	// TODO: initial tree type - and revisit if we get separate schematize/initialize calls
-	public static initializeTree(tree: ISharedTree, initialTree?: any): void {
+	public static initializeTree(tree: ITree, initialTree?: any): void {
 		const view = tree.schematize(treeConfiguration);
 
 		// This is required because schematizing the tree twice will result in an error
@@ -112,7 +112,7 @@ export class NewTreeInventoryListController extends EventEmitter implements IInv
 	private readonly _inventoryItemList: InventoryItemList;
 	private readonly _inventoryItems = new Map<string, NewTreeInventoryItem>();
 
-	public constructor(private readonly _tree: ISharedTree) {
+	public constructor(private readonly _tree: ITree) {
 		super();
 		// Note that although we always pass initialTree, it's only actually used on the first load and
 		// is ignored on subsequent loads.  AB#5974

--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -20,15 +20,15 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
-import { ISharedTree } from '@fluid-experimental/tree2';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { ITelemetryProperties } from '@fluidframework/core-interfaces';
+import { ITree } from '@fluid-experimental/tree2';
 import type { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
-import { SharedTreeFactory as SharedTreeFactory_2 } from '@fluid-experimental/tree2';
+import { TreeFactory } from '@fluid-experimental/tree2';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @public
@@ -558,7 +558,7 @@ export interface IShim extends IChannel {
     // (undocumented)
     create(): void;
     // (undocumented)
-    currentTree: ISharedTree | SharedTree;
+    currentTree: ITree | SharedTree;
     // (undocumented)
     load(channelServices: IChannelServices): Promise<void>;
 }
@@ -621,7 +621,7 @@ export interface MergeHealthStats {
 
 // @internal
 export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent> implements IShim {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, legacyTreeFactory: SharedTreeFactory, newTreeFactory: SharedTreeFactory_2, populateNewSharedObjectFn: (legacyTree: SharedTree, newTree: ISharedTree) => void);
+    constructor(id: string, runtime: IFluidDataStoreRuntime, legacyTreeFactory: SharedTreeFactory, newTreeFactory: TreeFactory, populateNewSharedObjectFn: (legacyTree: SharedTree, newTree: ITree) => void);
     // (undocumented)
     get attributes(): IChannelAttributes;
     // (undocumented)
@@ -629,7 +629,7 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
     // (undocumented)
     create(): void;
     // (undocumented)
-    get currentTree(): SharedTree | ISharedTree;
+    get currentTree(): SharedTree | ITree;
     // (undocumented)
     getAttachSummary(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
     // (undocumented)
@@ -652,7 +652,7 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
 
 // @internal @sealed
 export class MigrationShimFactory implements IChannelFactory {
-    constructor(oldFactory: SharedTreeFactory, newFactory: SharedTreeFactory_2, populateNewChannelFn: (oldChannel: SharedTree, newChannel: ISharedTree) => void);
+    constructor(oldFactory: SharedTreeFactory, newFactory: TreeFactory, populateNewChannelFn: (oldChannel: SharedTree, newChannel: ITree) => void);
     get attributes(): IChannelAttributes;
     create(runtime: IFluidDataStoreRuntime, id: string): MigrationShim;
     load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<MigrationShim>;
@@ -1029,7 +1029,7 @@ export interface SharedTreeOptions_0_1_1 {
 
 // @internal
 export class SharedTreeShim implements IShim {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, sharedTreeFactory: SharedTreeFactory_2);
+    constructor(id: string, runtime: IFluidDataStoreRuntime, sharedTreeFactory: TreeFactory);
     // (undocumented)
     get attributes(): IChannelAttributes;
     // (undocumented)
@@ -1037,7 +1037,7 @@ export class SharedTreeShim implements IShim {
     // (undocumented)
     create(): void;
     // (undocumented)
-    get currentTree(): ISharedTree;
+    get currentTree(): ITree;
     // (undocumented)
     getAttachSummary(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
     // (undocumented)
@@ -1055,14 +1055,14 @@ export class SharedTreeShim implements IShim {
     // (undocumented)
     readonly runtime: IFluidDataStoreRuntime;
     // (undocumented)
-    readonly sharedTreeFactory: SharedTreeFactory_2;
+    readonly sharedTreeFactory: TreeFactory;
     // (undocumented)
     summarize(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined): Promise<ISummaryTreeWithStats>;
 }
 
 // @internal @sealed
 export class SharedTreeShimFactory implements IChannelFactory {
-    constructor(factory: SharedTreeFactory_2);
+    constructor(factory: TreeFactory);
     get attributes(): IChannelAttributes;
     create(runtime: IFluidDataStoreRuntime, id: string): SharedTreeShim;
     load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<SharedTreeShim>;

--- a/experimental/dds/tree/src/migration-shim/migrationShim.ts
+++ b/experimental/dds/tree/src/migration-shim/migrationShim.ts
@@ -15,7 +15,7 @@ import {
 	type ITelemetryContext,
 	type ISummaryTreeWithStats,
 } from '@fluidframework/runtime-definitions';
-import { type SharedTreeFactory, type ISharedTree } from '@fluid-experimental/tree2';
+import { type TreeFactory, type ITree } from '@fluid-experimental/tree2';
 import { assert } from '@fluidframework/core-utils';
 import { MessageType, type ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { type EventEmitterEventType } from '@fluid-internal/client-utils';
@@ -79,8 +79,8 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
 		public readonly id: string,
 		private readonly runtime: IFluidDataStoreRuntime,
 		private readonly legacyTreeFactory: LegacySharedTreeFactory,
-		private readonly newTreeFactory: SharedTreeFactory,
-		private readonly populateNewSharedObjectFn: (legacyTree: LegacySharedTree, newTree: ISharedTree) => void
+		private readonly newTreeFactory: TreeFactory,
+		private readonly populateNewSharedObjectFn: (legacyTree: LegacySharedTree, newTree: ITree) => void
 	) {
 		super((event: EventEmitterEventType, e: unknown) => this.eventListenerErrorHandler(event, e));
 		// TODO: consider flattening this class
@@ -121,7 +121,7 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
 		return this._legacyTree;
 	}
 
-	private newTree: ISharedTree | undefined;
+	private newTree: ITree | undefined;
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.closeError}
@@ -180,7 +180,7 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
 		this.submitLocalMessage(migrateOp);
 	}
 
-	public get currentTree(): LegacySharedTree | ISharedTree {
+	public get currentTree(): LegacySharedTree | ITree {
 		return this.newTree ?? this.legacyTree;
 	}
 

--- a/experimental/dds/tree/src/migration-shim/migrationShimFactory.ts
+++ b/experimental/dds/tree/src/migration-shim/migrationShimFactory.ts
@@ -10,7 +10,7 @@ import {
 	type IChannelServices,
 	type IChannelFactory,
 } from '@fluidframework/datastore-definitions';
-import { type SharedTreeFactory, type ISharedTree } from '@fluid-experimental/tree2';
+import { type TreeFactory, type ITree } from '@fluid-experimental/tree2';
 import { type SharedTreeFactory as LegacySharedTreeFactory, type SharedTree as LegacySharedTree } from '../SharedTree';
 import { MigrationShim } from './migrationShim.js';
 import { attributesMatch } from './utils.js';
@@ -30,8 +30,8 @@ import { attributesMatch } from './utils.js';
 export class MigrationShimFactory implements IChannelFactory {
 	public constructor(
 		private readonly oldFactory: LegacySharedTreeFactory,
-		private readonly newFactory: SharedTreeFactory,
-		private readonly populateNewChannelFn: (oldChannel: LegacySharedTree, newChannel: ISharedTree) => void
+		private readonly newFactory: TreeFactory,
+		private readonly populateNewChannelFn: (oldChannel: LegacySharedTree, newChannel: ITree) => void
 	) {}
 
 	/**

--- a/experimental/dds/tree/src/migration-shim/sharedTreeShim.ts
+++ b/experimental/dds/tree/src/migration-shim/sharedTreeShim.ts
@@ -14,7 +14,7 @@ import {
 	type ITelemetryContext,
 	type ISummaryTreeWithStats,
 } from '@fluidframework/runtime-definitions';
-import { type ISharedTree, type SharedTreeFactory } from '@fluid-experimental/tree2';
+import { type ITree, type TreeFactory } from '@fluid-experimental/tree2';
 import { AttachState } from '@fluidframework/container-definitions';
 import { assert } from '@fluidframework/core-utils';
 import { type IShimChannelServices, NoDeltasChannelServices } from './shimChannelServices.js';
@@ -38,7 +38,7 @@ export class SharedTreeShim implements IShim {
 	public constructor(
 		public readonly id: string,
 		public readonly runtime: IFluidDataStoreRuntime,
-		public readonly sharedTreeFactory: SharedTreeFactory
+		public readonly sharedTreeFactory: TreeFactory
 	) {
 		this.newTreeShimDeltaHandler = new SharedTreeShimDeltaHandler(sharedTreeFactory.attributes);
 		this.handle = new ShimHandle<SharedTreeShim>(this);
@@ -46,8 +46,8 @@ export class SharedTreeShim implements IShim {
 
 	private readonly newTreeShimDeltaHandler: SharedTreeShimDeltaHandler;
 	private services?: IChannelServices;
-	private _currentTree?: ISharedTree;
-	public get currentTree(): ISharedTree {
+	private _currentTree?: ITree;
+	public get currentTree(): ITree {
 		assert(this._currentTree !== undefined, 0x7ed /* No current tree initialized */);
 		return this._currentTree;
 	}

--- a/experimental/dds/tree/src/migration-shim/sharedTreeShimFactory.ts
+++ b/experimental/dds/tree/src/migration-shim/sharedTreeShimFactory.ts
@@ -11,7 +11,7 @@ import {
 	type IChannelFactory,
 } from '@fluidframework/datastore-definitions';
 
-import { type SharedTreeFactory } from '@fluid-experimental/tree2';
+import { type TreeFactory } from '@fluid-experimental/tree2';
 import { SharedTreeShim } from './sharedTreeShim.js';
 import { attributesMatch } from './utils.js';
 
@@ -29,7 +29,7 @@ import { attributesMatch } from './utils.js';
  * @internal
  */
 export class SharedTreeShimFactory implements IChannelFactory {
-	public constructor(private readonly factory: SharedTreeFactory) {}
+	public constructor(private readonly factory: TreeFactory) {}
 
 	/**
 	 * Can only load the new SharedTree - this allows our snapshots to be simple. We do not have to consider any new

--- a/experimental/dds/tree/src/migration-shim/types.ts
+++ b/experimental/dds/tree/src/migration-shim/types.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type ISharedTree } from '@fluid-experimental/tree2';
+import { type ITree } from '@fluid-experimental/tree2';
 import {
 	type IChannel,
 	type IChannelAttributes,
@@ -72,5 +72,5 @@ export type IOpContents = IStampedContents | IUnstampedContents | IMigrationOp;
 export interface IShim extends IChannel {
 	create(): void;
 	load(channelServices: IChannelServices): Promise<void>;
-	currentTree: ISharedTree | LegacySharedTree;
+	currentTree: ITree | LegacySharedTree;
 }

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/dataMigration.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/dataMigration.spec.ts
@@ -17,13 +17,12 @@ import {
 	type TraitLabel,
 } from "@fluid-experimental/tree";
 import {
-	AllowedUpdateType,
-	type ISharedTree,
-	SchemaBuilder,
-	SharedTreeFactory,
+	type ITree,
+	TreeFactory,
 	disposeSymbol,
 	type TreeView,
-	type TreeField,
+	TreeConfiguration,
+	SchemaFactory,
 } from "@fluid-experimental/tree2";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import {
@@ -98,24 +97,18 @@ class TestDataObject extends DataObject {
 	}
 }
 
-const builder = new SchemaBuilder({ scope: "test" });
+const builder = new SchemaFactory("test");
 // For now this is the schema of the view.root
-const inventorySchema = builder.object("abcInventory", {
+class InventorySchema extends builder.object("abcInventory", {
 	quantity: builder.number,
-});
+}) {}
 
-// This is some schema to be updated later
-const inventoryFieldSchema = SchemaBuilder.required(inventorySchema);
-const schema = builder.intoSchema(inventoryFieldSchema);
-
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof inventoryFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
+function getNewTreeView(tree: ITree): TreeView<InventorySchema> {
+	return tree.schematize(
+		new TreeConfiguration(InventorySchema, () => ({
 			quantity: 0,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+		})),
+	);
 }
 
 describeNoCompat("HotSwap", (getTestObjectProvider) => {
@@ -146,12 +139,12 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 
 	// V2 of the registry (the migration registry) -----------------------------------------
 	// V2 of the code: Registry setup to migrate the document
-	const legacySharedTreeFactory = LegacySharedTree.getFactory();
-	const newSharedTreeFactory = new SharedTreeFactory();
+	const legacyTreeFactory = LegacySharedTree.getFactory();
+	const newTreeFactory = new TreeFactory({});
 
 	const migrationShimFactory = new MigrationShimFactory(
-		legacySharedTreeFactory,
-		newSharedTreeFactory,
+		legacyTreeFactory,
+		newTreeFactory,
 		(legacyTree, newTree) => {
 			// Migration code that the customer writes
 			const rootNode = legacyTree.currentView.getViewNode(legacyTree.currentView.root);
@@ -161,23 +154,21 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const quantity = legacyNode.payload.quantity as number;
 			newTree
-				.schematizeInternal({
-					initialTree: {
+				.schematize(
+					new TreeConfiguration(InventorySchema, () => ({
 						quantity,
-					},
-					allowedSchemaModifications: AllowedUpdateType.None,
-					schema,
-				})
+					})),
+				)
 				[disposeSymbol]();
 		},
 	);
 
-	const sharedTreeShimFactory = new SharedTreeShimFactory(newSharedTreeFactory);
+	const sharedTreeShimFactory = new SharedTreeShimFactory(newTreeFactory);
 
 	const dataObjectFactory2 = new DataObjectFactory(
 		"TestDataObject",
 		TestDataObject,
-		[migrationShimFactory, sharedTreeShimFactory], // Use the migrationShimFactory instead of the LegacySharedTreeFactory
+		[migrationShimFactory, sharedTreeShimFactory], // Use the migrationShimFactory instead of the LegacyTreeFactory
 		{},
 	);
 
@@ -222,11 +213,11 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
 		const shim2 = testObj2.getTree<MigrationShim>();
 		assert(
-			shim1.currentTree.attributes.type === legacySharedTreeFactory.type,
+			shim1.currentTree.attributes.type === legacyTreeFactory.type,
 			"shim1.currentTree is not legacy tree",
 		);
 		assert(
-			shim2.currentTree.attributes.type === legacySharedTreeFactory.type,
+			shim2.currentTree.attributes.type === legacyTreeFactory.type,
 			"shim2.currentTree is not legacy tree",
 		);
 
@@ -257,18 +248,12 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 		);
 
 		// Verify that the trees have been swapped by checking the attributes type
-		assert(
-			shim1.currentTree.attributes.type === newSharedTreeFactory.type,
-			"should have migrated",
-		);
-		assert(
-			shim2.currentTree.attributes.type === newSharedTreeFactory.type,
-			"should have migrated",
-		);
+		assert(shim1.currentTree.attributes.type === newTreeFactory.type, "should have migrated");
+		assert(shim2.currentTree.attributes.type === newTreeFactory.type, "should have migrated");
 
 		// Get the migrated values from the new tree
-		const tree1 = shim1.currentTree as ISharedTree;
-		const tree2 = shim2.currentTree as ISharedTree;
+		const tree1 = shim1.currentTree as ITree;
+		const tree2 = shim2.currentTree as ITree;
 
 		const view1 = getNewTreeView(tree1);
 		const view2 = getNewTreeView(tree2);
@@ -322,12 +307,12 @@ describeNoCompat("HotSwap", (getTestObjectProvider) => {
 
 		// Validate that we loaded a shared tree immediately
 		assert(
-			shim2.currentTree.attributes.type === newSharedTreeFactory.type,
+			shim2.currentTree.attributes.type === newTreeFactory.type,
 			"should have loaded migrated shim",
 		);
 
 		// Get the migrated values from the new tree
-		const tree1 = shim1.currentTree as ISharedTree;
+		const tree1 = shim1.currentTree as ITree;
 		const view1 = getNewTreeView(tree1);
 		const treeNode1 = view1.root;
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
@@ -18,14 +18,12 @@ import {
 	type NodeId,
 } from "@fluid-experimental/tree";
 import {
-	AllowedUpdateType,
-	type ISharedTree,
+	type ITree,
 	type TreeView,
-	SchemaBuilder,
-	SharedTreeFactory,
-	type TypedNode,
+	TreeFactory,
 	disposeSymbol,
-	type TreeField,
+	SchemaFactory,
+	TreeConfiguration,
 } from "@fluid-experimental/tree2";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import {
@@ -61,30 +59,25 @@ class TestDataObject extends DataObject {
 }
 
 // New tree schema
-const builder = new SchemaBuilder({ scope: "test" });
-const rootType = builder.object("abc", {
+const builder = new SchemaFactory("test");
+class RootType extends builder.object("abc", {
 	quantity: builder.number,
-});
-const schema = builder.intoSchema(rootType);
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof schema.rootFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
+}) {}
+function getNewTreeView(tree: ITree): TreeView<RootType> {
+	return tree.schematize(
+		new TreeConfiguration(RootType, () => ({
 			quantity: 0,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+		})),
+	);
 }
-const migrate = (legacyTree: LegacySharedTree, newTree: ISharedTree): void => {
+const migrate = (legacyTree: LegacySharedTree, newTree: ITree): void => {
 	const quantity = getQuantity(legacyTree);
 	newTree
-		.schematizeOld({
-			initialTree: {
+		.schematize(
+			new TreeConfiguration(RootType, () => ({
 				quantity,
-			},
-			allowedSchemaModifications: AllowedUpdateType.None,
-			schema,
-		})
+			})),
+		)
 		[disposeSymbol]();
 };
 
@@ -124,7 +117,7 @@ describeNoCompat("MigrationShim", (getTestObjectProvider) => {
 	// V2 of the registry (the migration registry) -----------------------------------------
 	// V2 of the code: Registry setup to migrate the document
 	const legacyTreeFactory = LegacySharedTree.getFactory();
-	const newSharedTreeFactory = new SharedTreeFactory();
+	const newSharedTreeFactory = new TreeFactory({});
 	const migrationShimFactory = new MigrationShimFactory(
 		legacyTreeFactory,
 		newSharedTreeFactory,
@@ -268,9 +261,9 @@ describeNoCompat("MigrationShim", (getTestObjectProvider) => {
 		await provider.ensureSynchronized();
 		await promise;
 
-		const newTree1 = shim1.currentTree as ISharedTree;
+		const newTree1 = shim1.currentTree as ITree;
 		const view1 = getNewTreeView(newTree1);
-		const rootNode1: TypedNode<typeof rootType> = view1.root;
+		const rootNode1: RootType = view1.root;
 
 		// Summarize
 		const { summarizer } = await createSummarizerFromFactory(
@@ -288,9 +281,9 @@ describeNoCompat("MigrationShim", (getTestObjectProvider) => {
 
 		const testObj3 = (await container3.getEntryPoint()) as TestDataObject;
 		const shim3 = await testObj3.getShim();
-		const tree3 = shim3.currentTree as ISharedTree;
+		const tree3 = shim3.currentTree as ITree;
 		const view3 = getNewTreeView(tree3);
-		const rootNode3: TypedNode<typeof rootType> = view3.root;
+		const rootNode3: RootType = view3.root;
 
 		// Verify that the value loaded from the summary matches the one loaded from a different summary
 		await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
@@ -18,11 +18,12 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/dist/EditLog.js";
 import {
-	AllowedUpdateType,
 	type ISharedTree,
-	SchemaBuilder,
-	SharedTreeFactory,
+	TreeFactory,
 	disposeSymbol,
+	SchemaFactory,
+	TreeConfiguration,
+	ITree,
 } from "@fluid-experimental/tree2";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import {
@@ -112,22 +113,15 @@ class TestDataObject extends DataObject {
 	}
 }
 
-const builder = new SchemaBuilder({ scope: "test" });
+const builder = new SchemaFactory("test");
 // For now this is the schema of the view.root
-const quantityType = builder.object("quantityObj", {
+class QuantityType extends builder.object("quantityObj", {
 	quantity: builder.number,
-});
-const schema = builder.intoSchema(quantityType);
+}) {}
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function getNewTreeView(tree: ISharedTree) {
-	return tree.schematizeOld({
-		initialTree: {
-			quantity: 0,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+function getNewTreeView(tree: ITree) {
+	return tree.schematize(new TreeConfiguration(QuantityType, () => ({ quantity: 0 })));
 }
 
 describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
@@ -159,7 +153,7 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 	// V2 of the registry (the migration registry) -----------------------------------------
 	// V2 of the code: Registry setup to migrate the document
 	const legacySharedTreeFactory = LegacySharedTree.getFactory();
-	const newSharedTreeFactory = new SharedTreeFactory();
+	const newSharedTreeFactory = new TreeFactory({});
 
 	const migrationShimFactory = new MigrationShimFactory(
 		legacySharedTreeFactory,
@@ -175,13 +169,11 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 			// migrate data
 			const quantity = getQuantity(legacyTree);
 			newTree
-				.schematizeOld({
-					initialTree: {
+				.schematize(
+					new TreeConfiguration(QuantityType, () => ({
 						quantity,
-					},
-					allowedSchemaModifications: AllowedUpdateType.None,
-					schema,
-				})
+					})),
+				)
 				[disposeSymbol]();
 		},
 	);

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
@@ -7,13 +7,11 @@ import { strict as assert } from "assert";
 
 import { type SharedTreeShim, SharedTreeShimFactory } from "@fluid-experimental/tree";
 import {
-	AllowedUpdateType,
-	type ISharedTree,
-	SchemaBuilder,
-	SharedTreeFactory,
+	type ITree,
+	TreeFactory,
 	type TreeView,
-	type TypedNode,
-	type TreeField,
+	SchemaFactory,
+	TreeConfiguration,
 } from "@fluid-experimental/tree2";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import {
@@ -49,20 +47,13 @@ class TestDataObject extends DataObject {
 }
 
 // New tree schema
-const builder = new SchemaBuilder({ scope: "test" });
-const rootType = builder.object("abc", {
+const builder = new SchemaFactory("test");
+class RootType extends builder.object("abc", {
 	quantity: builder.number,
-});
-const schema = builder.intoSchema(rootType);
+}) {}
 
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof schema.rootFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
-			quantity: 0,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+function getNewTreeView(tree: ITree): TreeView<RootType> {
+	return tree.schematize(new TreeConfiguration(RootType, () => ({ quantity: 0 })));
 }
 
 const testValue = 5;
@@ -79,7 +70,7 @@ describeNoCompat("SharedTreeShim", (getTestObjectProvider) => {
 
 	// V2 of the registry (the migration registry) -----------------------------------------
 	// V2 of the code: Registry setup to migrate the document
-	const newSharedTreeFactory = new SharedTreeFactory();
+	const newSharedTreeFactory = new TreeFactory({});
 	const sharedTreeShimFactory = new SharedTreeShimFactory(newSharedTreeFactory);
 
 	const dataObjectFactory = new DataObjectFactory(
@@ -127,8 +118,8 @@ describeNoCompat("SharedTreeShim", (getTestObjectProvider) => {
 		await provider.ensureSynchronized();
 
 		// This does some typing and gives us the root node.
-		const rootNode1: TypedNode<typeof rootType> = view1.root;
-		const rootNode2: TypedNode<typeof rootType> = view2.root;
+		const rootNode1: RootType = view1.root;
+		const rootNode2: RootType = view2.root;
 
 		// Test that we can modify/send ops with the new Shared Tree
 		rootNode1.quantity = testValue;
@@ -154,7 +145,7 @@ describeNoCompat("SharedTreeShim", (getTestObjectProvider) => {
 		const shim3 = await testObj3.getTree();
 		const tree3 = shim3.currentTree;
 		const view3 = getNewTreeView(tree3);
-		const rootNode3: TypedNode<typeof rootType> = view3.root;
+		const rootNode3: RootType = view3.root;
 
 		// Verify that it matches the previous node
 		await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
@@ -19,13 +19,12 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/dist/EditLog.js";
 import {
-	AllowedUpdateType,
-	type ISharedTree,
-	SchemaBuilder,
-	SharedTreeFactory,
+	type ITree,
+	TreeFactory,
 	type TreeView,
 	disposeSymbol,
-	type TreeField,
+	SchemaFactory,
+	TreeConfiguration,
 } from "@fluid-experimental/tree2";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import {
@@ -115,21 +114,14 @@ class TestDataObject extends DataObject {
 	}
 }
 
-const builder = new SchemaBuilder({ scope: "test" });
+const builder = new SchemaFactory("test");
 // For now this is the schema of the view.root
-const quantityType = builder.object("quantityObj", {
+class QuantityType extends builder.object("quantityObj", {
 	quantity: builder.number,
-});
-const schema = builder.intoSchema(quantityType);
+}) {}
 
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof schema.rootFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
-			quantity: 0,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+function getNewTreeView(tree: ITree): TreeView<QuantityType> {
+	return tree.schematize(new TreeConfiguration(QuantityType, () => ({ quantity: 0 })));
 }
 
 describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
@@ -161,7 +153,7 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 	// V2 of the registry (the migration registry) -----------------------------------------
 	// V2 of the code: Registry setup to migrate the document
 	const legacySharedTreeFactory = LegacySharedTree.getFactory();
-	const newSharedTreeFactory = new SharedTreeFactory();
+	const newSharedTreeFactory = new TreeFactory({});
 
 	const migrationShimFactory = new MigrationShimFactory(
 		legacySharedTreeFactory,
@@ -177,13 +169,11 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 			// migrate data
 			const quantity = getQuantity(legacyTree);
 			newTree
-				.schematizeOld({
-					initialTree: {
+				.schematize(
+					new TreeConfiguration(QuantityType, () => ({
 						quantity,
-					},
-					allowedSchemaModifications: AllowedUpdateType.None,
-					schema,
-				})
+					})),
+				)
 				[disposeSymbol]();
 		},
 	);
@@ -255,8 +245,8 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 		await promise2;
 		await provider.ensureSynchronized();
 
-		const newTree1 = shim1.currentTree as ISharedTree;
-		const newTree2 = shim2.currentTree as ISharedTree;
+		const newTree1 = shim1.currentTree as ITree;
+		const newTree2 = shim2.currentTree as ITree;
 		const view1 = getNewTreeView(newTree1);
 		const view2 = getNewTreeView(newTree2);
 		const node1 = view1.root;
@@ -320,7 +310,7 @@ describeNoCompat("Stamped v2 ops", (getTestObjectProvider) => {
 			"Should have loaded a SharedTreeShim",
 		);
 
-		const newTree1 = shim1.currentTree as ISharedTree;
+		const newTree1 = shim1.currentTree as ITree;
 		const newTree2 = shim2.currentTree;
 		const view1 = getNewTreeView(newTree1);
 		const view2 = getNewTreeView(newTree2);

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandles.spec.ts
@@ -19,13 +19,12 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/dist/EditLog.js";
 import {
-	AllowedUpdateType,
-	type ISharedTree,
+	type ITree,
 	type TreeView,
-	SchemaBuilder,
-	SharedTreeFactory,
 	disposeSymbol,
-	type TreeField,
+	SchemaFactory,
+	TreeConfiguration,
+	TreeFactory,
 } from "@fluid-experimental/tree2";
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
@@ -135,21 +134,18 @@ class TestDataObject extends DataObject {
 	}
 }
 
-const builder = new SchemaBuilder({ scope: "test" });
+const builder = new SchemaFactory("test");
 // For now this is the schema of the view.root
-const handleType = builder.object("handleObj", {
+class HandleType extends builder.object("handleObj", {
 	handle: builder.optional(builder.handle),
-});
-const schema = builder.intoSchema(handleType);
+}) {}
 
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof schema.rootFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
+function getNewTreeView(tree: ITree): TreeView<HandleType> {
+	return tree.schematize(
+		new TreeConfiguration(HandleType, () => ({
 			handle: undefined,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+		})),
+	);
 }
 
 describeNoCompat("Storing handles", (getTestObjectProvider) => {
@@ -181,7 +177,7 @@ describeNoCompat("Storing handles", (getTestObjectProvider) => {
 	// V2 of the registry (the migration registry) -----------------------------------------
 	// V2 of the code: Registry setup to migrate the document
 	const legacySharedTreeFactory = LegacySharedTree.getFactory();
-	const newSharedTreeFactory = new SharedTreeFactory();
+	const newSharedTreeFactory = new TreeFactory({});
 
 	const migrationShimFactory = new MigrationShimFactory(
 		legacySharedTreeFactory,
@@ -197,13 +193,11 @@ describeNoCompat("Storing handles", (getTestObjectProvider) => {
 			// migrate data
 			const handle = getHandle(legacyTree);
 			newTree
-				.schematizeOld({
-					initialTree: {
+				.schematize(
+					new TreeConfiguration(HandleType, () => ({
 						handle,
-					},
-					allowedSchemaModifications: AllowedUpdateType.None,
-					schema,
-				})
+					})),
+				)
 				[disposeSymbol]();
 		},
 	);
@@ -277,8 +271,8 @@ describeNoCompat("Storing handles", (getTestObjectProvider) => {
 		await provider.ensureSynchronized();
 		await promise1;
 
-		const newTree1 = shim1.currentTree as ISharedTree;
-		const newTree2 = shim2.currentTree as ISharedTree;
+		const newTree1 = shim1.currentTree as ITree;
+		const newTree2 = shim2.currentTree as ITree;
 		const view1 = getNewTreeView(newTree1);
 		const view2 = getNewTreeView(newTree2);
 		const node1 = view1.root;
@@ -315,7 +309,7 @@ describeNoCompat("Storing handles", (getTestObjectProvider) => {
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
 		const shim2 = testObj2.getTree<SharedTreeShim>();
 
-		const newTree1 = shim1.currentTree as ISharedTree;
+		const newTree1 = shim1.currentTree as ITree;
 		const newTree2 = shim2.currentTree;
 		const view1 = getNewTreeView(newTree1);
 		const view2 = getNewTreeView(newTree2);

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
@@ -7,12 +7,11 @@ import { strict as assert } from "assert";
 
 import { type SharedTreeShim, SharedTreeShimFactory } from "@fluid-experimental/tree";
 import {
-	AllowedUpdateType,
-	type ISharedTree,
+	type ITree,
 	type TreeView,
-	SchemaBuilder,
-	SharedTreeFactory,
-	type TreeField,
+	TreeFactory,
+	SchemaFactory,
+	TreeConfiguration,
 } from "@fluid-experimental/tree2";
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
@@ -29,22 +28,19 @@ import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type IChannel } from "@fluidframework/datastore-definitions";
 import { waitForContainerConnection, type ITestObjectProvider } from "@fluidframework/test-utils";
 
-const newSharedTreeFactory = new SharedTreeFactory();
-const builder = new SchemaBuilder({ scope: "test" });
+const newSharedTreeFactory = new TreeFactory({});
+const builder = new SchemaFactory("test");
 // For now this is the schema of the view.root
-const handleType = builder.object("handleObj", {
+class HandleType extends builder.object("handleObj", {
 	handle: builder.optional(builder.handle),
-});
-const schema = builder.intoSchema(handleType);
+}) {}
 
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof schema.rootFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
+function getNewTreeView(tree: ITree): TreeView<HandleType> {
+	return tree.schematize(
+		new TreeConfiguration(HandleType, () => ({
 			handle: undefined,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
+		})),
+	);
 }
 // A Test Data Object that exposes some basic functionality.
 class TestDataObject extends DataObject {


### PR DESCRIPTION
## Description

Update migration shim to use class based schema.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

