### PR TITLE
ci: Run lint in ci for client build

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -11,7 +11,7 @@ const tscDependsOn = ["^tsc", "^api", "build:genver"];
 module.exports = {
 	tasks: {
 		"ci:build": {
-			dependsOn: ["compile", "eslint", "ci:build:docs", "build:manifest", "build:readme"],
+			dependsOn: ["compile", "lint", "ci:build:docs", "build:manifest", "build:readme"],
 			script: false,
 		},
 		"full": {

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -129,7 +129,7 @@ extends:
     poolBuild: NewLarge
     checkoutSubmodules: true
     taskBundleAnalysis: true
-    taskLint: false
+    taskLint: false # Linting is captured by `ci:build` via fluid-build
     taskBuildDocs: true
     publishDocs: true
     # We only care about pipeline run telemetry for the CI runs on the internal project, not for PR runs in the public


### PR DESCRIPTION
#15874 intended to bundle all of linting into `ci:build`, but only ended up enabling `eslint`. This PR restores all linting functionality to CI builds.